### PR TITLE
Fix the install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,9 +414,9 @@ osdep/mpv-rc.o: osdep/mpv.exe.manifest
 check_rst2man:
 	@which $(RST2MAN) > /dev/null 2>&1 || (printf "\n\trst2man not found. You need the docutils (>= 0.7) to generate the manpages. Alternatively you can use 'install-no-man' rule.\n\n" && exit 1)
 
-install: $(INSTALL_TARGETS-yes)
+install: $(INSTALL_TARGETS)
 
-install-no-man: $(INSTALL_NO_MAN_TARGETS-yes)
+install-no-man: $(INSTALL_NO_MAN_TARGETS)
 
 install-dirs:
 	if test ! -d $(BINDIR) ; then $(INSTALL) -d $(BINDIR) ; fi


### PR DESCRIPTION
INSTALL_TARGETS-yes is a leftover from INSTALL_TARGETS-$(MPLAYER), which
was removed in 4873b32c5959c988af1769529ff72e3fd62fba82.
