### PR TITLE
Add a --dtshd option

### DIFF
--- a/DOCS/man/en/options.rst
+++ b/DOCS/man/en/options.rst
@@ -531,6 +531,13 @@
     Time in milliseconds to recognize two consecutive button presses as a
     double-click (default: 300).
 
+--dtshd, --no-dtshd
+    When using DTS passthrough, output any DTS-HD track as-is.
+    With ``--no-dts'' (the default) only the DTS Core parts will be output.
+
+    DTS-HD tracks can be sent over HDMI but not over the original
+    coax/toslink S/PDIF system.
+
 --dvbin=<options>
     Pass the following parameters to the DVB input module, in order to
     override the default ones:

--- a/core/cfg-mplayer.h
+++ b/core/cfg-mplayer.h
@@ -441,6 +441,7 @@ const m_option_t common_opts[] = {
 
     OPT_STRING("ad", audio_decoders, 0),
     OPT_STRING("vd", video_decoders, 0),
+    OPT_FLAG("dtshd", dtshd, 0),
 
     OPT_CHOICE("hwdec", hwdec_api, 0,
                ({"no", 0},

--- a/core/options.h
+++ b/core/options.h
@@ -109,6 +109,7 @@ typedef struct MPOpts {
 
     int audio_output_channels;
     int audio_output_format;
+    int dtshd;
     float playback_speed;
     float drc_level;
     struct m_obj_settings *vf_settings;


### PR DESCRIPTION
The spdif decoder was hardcoded to assume that the spdif output is
capable of accepting high (>1.5Mbps) bitrates. While this is true
for modern HDMI spdif interfaces, the original coax/toslink system
cannot deal with this and will fail to work.

This patch adds an option --dtshd which can be enabled if you use
a DTS-capable receiver behind a HDMI link.
