### PR TITLE
demux_mkv: Support playing Opus streams in Matroska

### DIFF
--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -97,6 +97,7 @@ static const struct mp_codec_tag mp_audio_codec_tags[] = {
     {MKTAG('s', 'a', 'm', 'r'), "amr_nb"},
     {MKTAG('s', 'a', 'w', 'b'), "amr_wb"},
     {MKTAG('v', 'r', 'b', 's'), "vorbis"},
+    {MKTAG('O', 'p', 'u', 's'), "opus"},
     // Special cased in ad_lavc:
     {0                        , "pcm"},
     {0x1                      , "pcm"}, // lavf: pcm_s16le

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1314,6 +1314,8 @@ static struct mkv_audio_tag {
     { MKV_A_AAC_4LTP,  0, mmioFOURCC('M', 'P', '4', 'A') },
     { MKV_A_AAC,       0, mmioFOURCC('M', 'P', '4', 'A') },
     { MKV_A_VORBIS,    0, mmioFOURCC('v', 'r', 'b', 's') },
+    { MKV_A_OPUS,      0, mmioFOURCC('O', 'p', 'u', 's') },
+    { MKV_A_OPUS_EXP,  0, mmioFOURCC('O', 'p', 'u', 's') },
     { MKV_A_QDMC,      0, mmioFOURCC('Q', 'D', 'M', 'C') },
     { MKV_A_QDMC2,     0, mmioFOURCC('Q', 'D', 'M', '2') },
     { MKV_A_WAVPACK,   0, mmioFOURCC('W', 'V', 'P', 'K') },
@@ -1462,6 +1464,9 @@ static int demux_mkv_open_audio(demuxer_t *demuxer, mkv_track_t *track,
             memcpy((unsigned char *) (sh_a->wf + 1), track->private_data,
                    sh_a->wf->cbSize);
         }
+    } else if (!strcmp(track->codec_id, MKV_A_OPUS)
+               || !strcmp(track->codec_id, MKV_A_OPUS_EXP)) {
+        sh_a->format = mmioFOURCC('O', 'p', 'u', 's');
     } else if (!strncmp(track->codec_id, MKV_A_REALATRC, 7)) {
         if (track->private_size < RAPROPERTIES4_SIZE)
             goto error;

--- a/demux/matroska.h
+++ b/demux/matroska.h
@@ -41,6 +41,8 @@
 #define MKV_A_PCM        "A_PCM/INT/LIT"
 #define MKV_A_PCM_BE     "A_PCM/INT/BIG"
 #define MKV_A_VORBIS     "A_VORBIS"
+#define MKV_A_OPUS       "A_OPUS"
+#define MKV_A_OPUS_EXP   "A_OPUS/EXPERIMENTAL"
 #define MKV_A_ACM        "A_MS/ACM"
 #define MKV_A_REAL28     "A_REAL/28_8"
 #define MKV_A_REALATRC   "A_REAL/ATRC"


### PR DESCRIPTION
FFmpeg recently changed how it writes Opus-in-Matroska to match
the A_OPUS/EXPERIMENTAL name that mkvmerge uses, with the caveat
that things will change and compatibility with old files can get
worked out when the spec is finalized.

This adds both A_OPUS and A_OPUS/EXPERIMENTAL so that _hopefully_
it can play both the newer files that use A_OPUS/EXPERIMENTAL, and
older ones muxed by FFmpeg that were simply A_OPUS, since this is
also what FFmpeg seems to be doing to handle the situation.

The only thing I'm [highly] unsure of is the private data stuff, which doesn't do a whole lot at all, just enough to make sure it can play the files.
