### PR TITLE
vd_lavc: fix a deprecated warning

### DIFF
--- a/video/decode/lavc_dr1.c
+++ b/video/decode/lavc_dr1.c
@@ -93,7 +93,7 @@ static int alloc_buffer(FramePool *pool, AVCodecContext *s)
      */
     memset(buf->base[0], 128, ret);
 
-    avcodec_get_chroma_sub_sample(s->pix_fmt, &h_chroma_shift, &v_chroma_shift);
+    av_pix_fmt_get_chroma_sub_sample(s->pix_fmt, &h_chroma_shift, &v_chroma_shift);
     for (i = 0; i < FF_ARRAY_ELEMS(buf->data); i++) {
         const int h_shift = i==0 ? 0 : h_chroma_shift;
         const int v_shift = i==0 ? 0 : v_chroma_shift;


### PR DESCRIPTION
Make use of av_pix_fmt_get_chroma_sub_sample instead of
the old avcodec_get_chroma_sub_sample function.
