### PR TITLE
Fix compilation with sdl/sdl2 after 02bbd87b removed autodetection.

### DIFF
--- a/configure
+++ b/configure
@@ -2198,7 +2198,7 @@ fi #if win32; then
 
 
 echocheck "SDL 2.0"
-if test "$_sdl2" = auto ; then
+if test "$_sdl2" = yes ; then
   pkg_config_add 'sdl2' && _sdl2=yes
 fi
 if test "$_sdl2" = yes ; then
@@ -2212,7 +2212,7 @@ else
   def_sdl2='#undef CONFIG_SDL2'
   echores "$_sdl2"
   echocheck "SDL"
-  if test "$_sdl" = auto ; then
+  if test "$_sdl" = yes ; then
     pkg_config_add 'sdl' && _sdl=yes
   fi
   if test "$_sdl" = yes ; then


### PR DESCRIPTION
The pkg-config routine to add the relevant headers still expected
'auto', which meant that it wouldn't add them at all even if
--enable-sdl/sdl2 was used, leading to ao_sdl.c and vo_sdl.c not
finding SDL.h.
