### PR TITLE
core: do not store build time

### DIFF
--- a/core/mp_common.h
+++ b/core/mp_common.h
@@ -42,7 +42,6 @@
 #define CONTROL_NA -3
 
 extern const char *mplayer_version;
-extern const char *mplayer_builddate;
 
 char *mp_format_time(double time, bool fractions);
 

--- a/core/mplayer.c
+++ b/core/mplayer.c
@@ -4526,7 +4526,7 @@ void mp_set_playlist_entry(struct MPContext *mpctx, struct playlist_entry *e)
 void mp_print_version(int always)
 {
     mp_msg(MSGT_CPLAYER, always ? MSGL_INFO : MSGL_V,
-           "%s (C) 2000-2013 mpv/MPlayer/mplayer2 projects\n built on %s\n", mplayer_version, mplayer_builddate);
+           "%s (C) 2000-2013 mpv/MPlayer/mplayer2 projects\n", mplayer_version);
 }
 
 static bool handle_help_options(struct MPContext *mpctx)

--- a/core/version.c
+++ b/core/version.c
@@ -19,4 +19,3 @@
 #include "version.h"
 
 const char *mplayer_version  = "mpv " VERSION;
-const char *mplayer_builddate = BUILDDATE;


### PR DESCRIPTION
Now md5sum of /usr/bin/mpv does not change if you rebuild same commit.
