### PR TITLE
fix libass disabled issue

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -82,7 +82,7 @@ const demuxer_desc_t *const demuxer_list[] = {
 #ifdef CONFIG_TV
     &demuxer_desc_tv,
 #endif
-#ifdef CONFIG_LIBASS
+#ifdef CONFIG_ASS
     &demuxer_desc_libass,
 #endif
     &demuxer_desc_matroska,


### PR DESCRIPTION
libass was disabled due to a typo in f630ee15972a6ce967658441994824322d8f5136
