### PR TITLE
Windows: Silence some warnings

### DIFF
--- a/core/input/input.c
+++ b/core/input/input.c
@@ -1154,12 +1154,14 @@ static int default_cmd_func(int fd, char *buf, int l)
     }
 }
 
+#ifndef __MINGW32__
 static int read_wakeup(void *ctx, int fd)
 {
     char buf[100];
     read(fd, buf, sizeof(buf));
     return MP_INPUT_NOTHING;
 }
+#endif
 
 static bool bind_matches_key(struct cmd_bind *bind, int n, const int *keys);
 

--- a/stream/cache.c
+++ b/stream/cache.c
@@ -134,7 +134,7 @@ static int cond_timed_wait(pthread_cond_t *cond, pthread_mutex_t *mutex,
                            double timeout)
 {
     struct timespec ts;
-#if _POSIX_TIMERS > 0
+#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
     clock_gettime(CLOCK_REALTIME, &ts);
 #else
     struct timeval tv;


### PR DESCRIPTION
With winsock gone and M_ST_MB_P kinda fixed, this silences the last two warnings I get when compiling with MinGW-w64 GCC 4.8.1.

Should clock_gettime be replaced with mp_raw_time_us?
