### PR TITLE
Windows: Make mpv DPI-aware

### DIFF
--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -7,13 +7,31 @@
         type="win32"
     />
     <description>mpv - The Movie Player</description>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+            <ws:dpiAware>True/PM</ws:dpiAware>
+        </windowsSettings>
+    </application>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>
             <requestedPrivileges>
                 <requestedExecutionLevel
                     level="asInvoker"
+                    uiAccess="false"
                 />
             </requestedPrivileges>
         </security>
     </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        </application>
+    </compatibility>
 </assembly>


### PR DESCRIPTION
The difference is fairly obvious :)

![hidpi mpv](https://f.cloud.github.com/assets/162837/794113/4e095f5c-ec71-11e2-8c2d-6d76d86d524f.png)

I've tested this a little bit and I'm fairly sure it doesn't bring up any weird bugs. Since mpv is pretty much resolution independent, it should be fine.

This also has some less important changes to the manifest, adding a compatibility section to avoid AppCompat stuff and putting the missing uiAccess attribute in the trustInfo section. The manifest is now pretty similar to the one here:
http://msdn.microsoft.com/en-us/library/windows/desktop/dn302074(v=vs.85).aspx
