### PR TITLE
 Use /dev/cd0 as default cdrom device on FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -2360,7 +2360,7 @@ elif darwin ; then
 elif dragonfly ; then
   default_cdrom_device="/dev/cd0"
 elif freebsd ; then
-  default_cdrom_device="/dev/acd0"
+  default_cdrom_device="/dev/cd0"
 elif openbsd ; then
   default_cdrom_device="/dev/rcd0c"
 else


### PR DESCRIPTION
/dev/cd0 is the default cdrom device on recent FreeBSD releases.
More precise, /dev/cd0 is default cdrom when FreeBSD kernel is build with new (S)ATA driver, which appeared in FreeBSD 8 and is the default (S)ATA driver on FreeBSD 9.
