### PR TITLE
wayland: Fallback to any GL version if 3.0 is not supported

### DIFF
--- a/video/out/gl_wayland.c
+++ b/video/out/gl_wayland.c
@@ -154,8 +154,17 @@ static bool egl_create_context(struct vo_wayland_state *wl,
                                         egl_ctx->egl.conf,
                                         EGL_NO_CONTEXT,
                                         context_attribs);
-    if (!egl_ctx->egl.ctx)
-        return false;
+    if (!egl_ctx->egl.ctx) {
+        /* fallback to any GL version */
+        context_attribs[0] = EGL_NONE;
+        egl_ctx->egl.ctx = eglCreateContext(egl_ctx->egl.dpy,
+                                            egl_ctx->egl.conf,
+                                            EGL_NO_CONTEXT,
+                                            context_attribs);
+
+        if (!egl_ctx->egl.ctx)
+            return false;
+    }
 
     eglMakeCurrent(egl_ctx->egl.dpy, NULL, NULL, egl_ctx->egl.ctx);
 


### PR DESCRIPTION
This fixes playback on Wayland with older GPUs.
