### PR TITLE
input: Ignore spurious mouse moves

### DIFF
--- a/core/input/input.c
+++ b/core/input/input.c
@@ -1536,6 +1536,10 @@ static void trigger_mouse_leave(struct input_ctx *ictx, char *new_section)
 
 void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y)
 {
+    // we're already there
+    if (ictx->mouse_vo_x == x && ictx->mouse_vo_y == y)
+        return;
+
     ictx->mouse_event_counter++;
     ictx->mouse_vo_x = x;
     ictx->mouse_vo_y = y;


### PR DESCRIPTION
Windows generates WM_MOUSEMOVE messages internally whenever the window
manager wants to know where the mouse is[1](http://blogs.msdn.com/b/oldnewthing/archive/2003/10/01/55108.aspx) and broadcasts that to
everyone; w32_common doesn't check whether the position is different
and just (indirectly) calls this.

Do the check on input.c since it's possible some other VO or frontend
also do the same thing.
