### PR TITLE
Windows: Always show the cursor when it's in the window border

### DIFF
--- a/video/out/w32_common.h
+++ b/video/out/w32_common.h
@@ -45,6 +45,7 @@ struct vo_w32_state {
     uint32_t o_dheight;
 
     bool disable_screensaver;
+    bool cursor_visible;
     int event_flags;
     int mon_cnt;
     int mon_id;


### PR DESCRIPTION
Makes it easier to use the window controls, since otherwise the cursor would hide after the timeout and not appear again.

This also uses SetCursor instead of ShowCursor to avoid having to remember the cursor's state.
