### PR TITLE
stream_vcd.c: fix compilation on win32

### DIFF
--- a/stream/stream_vcd.c
+++ b/stream/stream_vcd.c
@@ -53,6 +53,10 @@
 #include "vcd_read.h"
 #endif
 
+#ifndef vcd_close
+#define vcd_close(priv) (fclose(((mp_vcd_priv_t*)priv)->fd))
+#endif
+
 extern char *cdrom_device;
 
 static struct stream_priv_s {
@@ -95,9 +99,8 @@ static int seek(stream_t *s,int64_t newpos) {
 }
 
 static void close_s(stream_t *stream) {
-  mp_vcd_priv_t *p = stream->priv;
-  close(p->fd);
-  free(p);
+  vcd_close(stream->priv);
+  free(stream->priv);
 }
 
 static int open_s(stream_t *stream,int mode, void* opts)

--- a/stream/vcd_read_win32.h
+++ b/stream/vcd_read_win32.h
@@ -132,6 +132,8 @@ static mp_vcd_priv_t* vcd_read_toc(int fd)
     return vcd;
 }
 
+#define vcd_close(priv) (CloseHandle(((mp_vcd_priv_t*)priv)->hd))
+
 static int vcd_read(mp_vcd_priv_t* vcd, char *mem)
 {
     DWORD dwBytesReturned;


### PR DESCRIPTION
the mp_vcd_priv_t doesn't have a file descriptor but a file handle on
win32.
