### PR TITLE
WASAPI stops working after pause

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -1150,7 +1150,8 @@ static unsigned int __stdcall ThreadLoop(void *lpParameter)
             thread_play(state);
             break;
         case (WAIT_OBJECT_0 + 6): /* feed */
-            feedwatch = 1;
+            if (state->is_playing)
+                feedwatch = 1;
             thread_feed(state, 0);
             break;
         case WAIT_TIMEOUT: /* Did our feed die? */


### PR DESCRIPTION
With --ao=wasapi and --ao=wasapi:exclusive, pausing the video for more than a few seconds makes it impossible to un-pause. According to Process Explorer, it looks like the WASAPI event thread exits when paused for too long.

OS: Windows 8 64-bit
Audio: Realtek HDA 6.0.1.6772
