### PR TITLE
CoreAudio output driver compillation error on OSX 10.7.5

### DIFF
--- a/audio/out/ao_coreaudio_properties.h
+++ b/audio/out/ao_coreaudio_properties.h
@@ -25,7 +25,7 @@
 #define ca_sel    AudioObjectPropertySelector
 #define ca_scope  AudioObjectPropertyScope
 #define CA_GLOBAL kAudioObjectPropertyScopeGlobal
-#define CA_OUTPUT kAudioObjectPropertyScopeOutput
+#define CA_OUTPUT kAudioDevicePropertyScopeOutput
 
 OSStatus ca_get(AudioObjectID id, ca_scope scope, ca_sel selector,
                 uint32_t size, void *data);


### PR DESCRIPTION
I've got the following compilation error on my system:

```
audio/out/ao_coreaudio.c:288:15: error: use of undeclared identifier 'kAudioObjectPropertyScopeOutput'; did you mean 'kAudioDevicePropertyScopeOutput'?
        err = CA_GET_ARY_O(selected_device,
              ^
./audio/out/ao_coreaudio_properties.h:47:20: note: expanded from macro 'CA_GET_ARY_O'
    ca_get_ary(id, CA_OUTPUT, sel, sizeof(**(data)), (void **)data, elements)
                   ^
./audio/out/ao_coreaudio_properties.h:29:19: note: expanded from macro 'CA_OUTPUT'
#define CA_OUTPUT kAudioObjectPropertyScopeOutput
                  ^
/System/Library/Frameworks/CoreAudio.framework/Headers/AudioHardware.h:1571:5: note: 'kAudioDevicePropertyScopeOutput' declared here
    kAudioDevicePropertyScopeOutput         = 'outp',
    ^
audio/out/ao_coreaudio.c:464:11: error: use of undeclared identifier 'kAudioObjectPropertyScopeOutput'; did you mean 'kAudioDevicePropertyScopeOutput'?
    err = CA_GET_ARY_O(p->device, kAudioDevicePropertyStreams,
          ^
./audio/out/ao_coreaudio_properties.h:47:20: note: expanded from macro 'CA_GET_ARY_O'
    ca_get_ary(id, CA_OUTPUT, sel, sizeof(**(data)), (void **)data, elements)
                   ^
./audio/out/ao_coreaudio_properties.h:29:19: note: expanded from macro 'CA_OUTPUT'
#define CA_OUTPUT kAudioObjectPropertyScopeOutput
                  ^
/System/Library/Frameworks/CoreAudio.framework/Headers/AudioHardware.h:1571:5: note: 'kAudioDevicePropertyScopeOutput' declared here
    kAudioDevicePropertyScopeOutput         = 'outp',
    ^
```

Official documentation remains silent about kAudioObjectPropertyScopeOutput, so I've replaced it with kAudioDevicePropertyScopeOutput and it worked. I also found patch 18777ecfe894ec9c7995a69e0786e56f45bc73f8, which contains implicit replacement of kAudioDevicePropertyScopeOutput with kAudioObjectPropertyScopeOutput. Maybe @pigoz can shed some light on this.
