### PR TITLE
Add more verbose exit reasons.

### DIFF
--- a/core/command.c
+++ b/core/command.c
@@ -2154,7 +2154,8 @@ void run_command(MPContext *mpctx, mp_cmd_t *cmd)
 
     case MP_CMD_QUIT:
         mpctx->stop_play = PT_QUIT;
-        mpctx->quit_player_rc = cmd->args[0].v.i;
+        mpctx->quit_custom_rc = cmd->args[0].v.i;
+        mpctx->has_quit_custom_rc = true;
         break;
 
     case MP_CMD_QUIT_WATCH_LATER:

--- a/core/mp_core.h
+++ b/core/mp_core.h
@@ -52,8 +52,10 @@ enum stop_play_reason {
 enum exit_reason {
   EXIT_NONE,
   EXIT_QUIT,
-  EXIT_EOF,
-  EXIT_ERROR
+  EXIT_PLAYED,
+  EXIT_ERROR,
+  EXIT_NOTPLAYED,
+  EXIT_SOMENOTPLAYED
 };
 
 struct timeline_part {
@@ -135,7 +137,10 @@ typedef struct MPContext {
     unsigned int initialized_flags;  // which subsystems have been initialized
 
     // Return code to use with PT_QUIT
-    int quit_player_rc;
+    enum exit_reason quit_player_rc;
+    int quit_custom_rc;
+    bool has_quit_custom_rc;
+    bool error_playing;
 
     struct demuxer **sources;
     int num_sources;


### PR DESCRIPTION
Expands EOF into:

```
   PLAYED, SOMENOTPLAYED, and NOTPLAYED
```

A file not being found for an example, no longer exits with an end
of file message.

Fixes #112
