### PR TITLE
mpvcore: fix build failure (typo) if HAVE_PTHREADS is undefined

### DIFF
--- a/mpvcore/input/input.c
+++ b/mpvcore/input/input.c
@@ -73,7 +73,7 @@ static pthread_mutex_t queue_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define queue_unlock() pthread_mutex_unlock(&queue_mutex)
 #else
 #define queue_lock() 0
-#define queue_lock() 0
+#define queue_unlock() 0
 #endif
 
 struct cmd_bind {


### PR DESCRIPTION
This fixes the following build failure if `HAVE_PTHREADS` is undefined.

```
mpvcore/input/input.c:670:5: error: implicit declaration of function 'queue_unlock' [-Werror=implicit-function-declaration]
```
