### PR TITLE
demux_playlist: add mov RTSPtext tag parser

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -93,6 +93,23 @@ static int parse_ref_init(struct pl_parser *p)
     return 0;
 }
 
+static int parse_mov_rtsptext(struct pl_parser *p)
+{
+    bstr line = pl_get_line(p);
+    if (!bstr_eatstart(&line, bstr0("RTSPtext")))
+        return -1;
+    if (p->probing)
+        return 0;
+    line = bstr_strip(line);
+    do {
+	    if (bstr_case_startswith(line, bstr0("rtsp://"))) {
+            pl_add(p, line);
+            return 0;
+        }
+    } while (!pl_eof(p) && (line = bstr_strip(pl_get_line(p))).len);
+    return -1;
+}
+
 struct pl_format {
     const char *name;
     int (*parse)(struct pl_parser *p);
@@ -101,6 +118,7 @@ struct pl_format {
 static const struct pl_format formats[] = {
     {"m3u", parse_m3u},
     {"ini", parse_ref_init},
+    {"mov", parse_mov_rtsptext},
 };
 
 static const struct pl_format *probe_pl(struct pl_parser *p, bool force)


### PR DESCRIPTION
The quicktime html scripting guide suggests to wrap urls not
necesarly associated with quicktime in a .mov file.
(so that when <embed>ing videos quicktime would be forced.)
These mov files may contain several "Text Hacks".
One of these is RTSPtext.

The suggested/allowed format (as regex) is like:
  RTSPtext[ \r]RTSP://url
See also p.51 of:
https://developer.apple.com/library/mac/documentation/QuickTime/Conceptual/QTScripting_HTML/QTScripting_HTML.pdf
In reality there are also files like (e.g. zdfmediathek.de):
RTSPtext\nrtsp://url\n\n

Lets handle these files as a playlist with one element.
