### PR TITLE
Remove deprecation warning on OS X 10.9

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -415,30 +415,32 @@ static void macosx_redirect_output_to_logfile(const char *filename)
 
 static void get_system_version(int* major, int* minor, int* bugfix)
 {
-	static dispatch_once_t onceToken;
-	static int mMajor = 10;
-	static int mMinor = 8;
-	static int mBugfix = 0;
-	dispatch_once(&onceToken, ^{
-		NSString* versionString = [[NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"] objectForKey:@"ProductVersion"];
-		NSArray* versions = [versionString componentsSeparatedByString:@"."];
-		int count = [versions count];
-		if (count >= 1)
-			mMajor = [[versions objectAtIndex:0] intValue];
-		if (count >= 2)
-			mMinor = [[versions objectAtIndex:1] intValue];
-		if (count >= 3)
-			mBugfix = [[versions objectAtIndex:2] intValue];
-	});
-	*major = mMajor;
-	*minor = mMinor;
-	*bugfix = mBugfix;
+    static dispatch_once_t once_token;
+    static int s_major = 0;
+    static int s_minor = 0;
+    static int s_bugfix = 0;
+    dispatch_once(&once_token, ^{
+        NSString* version_string =
+		[NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"]
+		 [@"ProductVersion"];
+        NSArray* versions = [version_string componentsSeparatedByString:@"."];
+        int count = [versions count];
+        if (count >= 1)
+            s_major = [versions[0] intValue];
+        if (count >= 2)
+            s_minor = [versions[1] intValue];
+        if (count >= 3)
+            s_bugfix = [versions[2] intValue];
+    });
+    *major = s_major;
+    *minor = s_minor;
+    *bugfix = s_bugfix;
 }
 
 static bool bundle_started_from_finder(int argc, char **argv)
 {
-	bool bundle_detected = ([[NSBundle mainBundle] bundleIdentifier] != nil);
-	int major = 10, minor = 8, bugfix = 0;
+	bool bundle_detected = [[NSBundle mainBundle] bundleIdentifier];
+	int major = 0, minor = 0, bugfix = 0;
 	get_system_version(&major, &minor, &bugfix);
 	bool args = ((major == 10) && (minor >= 9)) ? argc==1 : argc==2;
 	return bundle_detected && args;


### PR DESCRIPTION
GetCurrentProcess() is deprecated on 10.9.
So make a universal solution by checking OS version number.
get_system_version() function is the recommended Apple way of getting the OS version, since Gestalt is also deprecated (and does pretty much the same thing anyway)

Updating HIDRemote.m to use a similar function would allow to get rid of the 2 other warnings.
