### PR TITLE
ao_pulse: Set the property media.role=video

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -297,11 +297,11 @@ static int init(struct ao *ao)
 
     if (!pa_sample_spec_valid(&ss)) {
         MP_ERR(ao, "Invalid sample spec\n");
-        goto fail;
+        goto unlock_and_fail;
     }
 
     if (!select_chmap(ao, &map))
-        goto fail;
+        goto unlock_and_fail;
 
     if (!(proplist = pa_proplist_new())) {
         MP_ERR(ao, "Failed to allocate proplist\n");


### PR DESCRIPTION
Tell PulseAudio we’re a video player so it can do the right thing when using e.g. module-role-cork or module-role-ducking.

Also fix an adjacent bug.
