### PR TITLE
Fix build on OS X 10.9

### DIFF
--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -20,6 +20,9 @@
 #import <Cocoa/Cocoa.h>
 #import <CoreServices/CoreServices.h> // for CGDisplayHideCursor
 #import <IOKit/pwr_mgt/IOPMLib.h>
+#ifdef __MAC_10_9
+#import <OpenGL/gl.h>
+#endif
 #include <dlfcn.h>
 
 #include "cocoa_common.h"


### PR DESCRIPTION
Since commit (https://github.com/mpv-player/mpv/commit/0ab9634eb3f3005c37a0346d9035dbc4d4abd144) build fails on 10.9 with error:
'implicit declaration of function glClearColor() and glClear()'

Adding import of OpenGL/gl.h fix the problem.
