### PR TITLE
reimplement mp_ring_read() in terms of mp_ring_read_cb()

### DIFF
--- a/mpvcore/mp_ring.c
+++ b/mpvcore/mp_ring.c
@@ -100,7 +100,7 @@ static void read_memcpy_cb(void *ctx, void *src, int len)
 
 int mp_ring_read(struct mp_ring *buffer, unsigned char *dest, int len)
 {
-    return mp_ring_read_cb(buffer, dest, len, read_memcpy_cb);
+    return mp_ring_read_cb(buffer, &dest, len, read_memcpy_cb);
 }
 
 int mp_ring_write(struct mp_ring *buffer, unsigned char *src, int len)


### PR DESCRIPTION
these two functions were nearly identical, so here's a way of factoring out some of the duplication.
submitted separately from the mp_ring_read_cb() fix in case you'd prefer just to merge that one.
