### PR TITLE
fix --loop=<number> off-by-one

### DIFF
--- a/mpvcore/mplayer.c
+++ b/mpvcore/mplayer.c
@@ -4736,9 +4736,9 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
             if (mpctx->opts->shuffle)
                 playlist_shuffle(mpctx->playlist);
             next = mpctx->playlist->first;
-            if (next && mpctx->opts->loop_times > 0) {
+            if (next && mpctx->opts->loop_times > 1) {
                 mpctx->opts->loop_times--;
-                if (mpctx->opts->loop_times == 0)
+                if (mpctx->opts->loop_times == 1)
                     mpctx->opts->loop_times = -1;
             }
         } else {

--- a/mpvcore/options.c
+++ b/mpvcore/options.c
@@ -681,8 +681,8 @@ const m_option_t mp_opts[] = {
     {"lircconf", &lirc_configfile, CONF_TYPE_STRING, CONF_GLOBAL, 0, 0, NULL},
 #endif
 
-    OPT_CHOICE_OR_INT("loop", loop_times, M_OPT_GLOBAL, 1, 10000,
-                      ({"no", -1}, {"0", -1},
+    OPT_CHOICE_OR_INT("loop", loop_times, M_OPT_GLOBAL, 2, 10000,
+                      ({"no", -1}, {"0", -1}, {"1", -1},
                        {"inf", 0})),
 
     OPT_FLAG("resume-playback", position_resume, 0),


### PR DESCRIPTION
Currently `--loop=5` will play the file/playlist 6 times. I'd expect it to play only 5 times (mplayer2 does as I expect). I just realized that mpv's behavior might have been changed intentionally; if so, feel free to close. But to me it makes more sense to specify directly how many times you want stuff played.
