### PR TITLE
mpvcore/playlist.c: Avoid NULL reference in playlist_add_base_path()

### DIFF
--- a/mpvcore/playlist.c
+++ b/mpvcore/playlist.c
@@ -178,7 +178,7 @@ struct playlist_entry *playlist_get_next(struct playlist *pl, int direction)
 
 void playlist_add_base_path(struct playlist *pl, bstr base_path)
 {
-    if (base_path.len == 0 || bstrcmp0(base_path, ".") == 0)
+    if (!pl || base_path.len == 0 || bstrcmp0(base_path, ".") == 0)
         return;
     for (struct playlist_entry *e = pl->first; e; e = e->next) {
         if (!mp_is_url(bstr0(e->filename))) {


### PR DESCRIPTION
Before this patch, those will cause a crash:

  mpv -playlist /dev/null
  mpv -playlist <(bla) # if the result of bla is empty

Signed-off-by: Mohammad Alsaleh CE.Mohammad.AlSaleh@gmail.com
