### PR TITLE
matroska: clear ordered chapter if ordered chapters aren't used

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -832,6 +832,9 @@ static int demux_mkv_read_chapters(struct demuxer *demuxer)
         m_chapters = talloc_array_ptrtype(demuxer, m_chapters, count);
         demuxer->matroska_data.ordered_chapters = m_chapters;
         demuxer->matroska_data.num_ordered_chapters = count;
+    } else {
+        demuxer->matroska_data.ordered_chapters = NULL;
+        demuxer->matroska_data.num_ordered_chapters = 0;
     }
 
     for (int idx = 0; idx < num_editions; idx++) {


### PR DESCRIPTION
It seems these were never initialized, so were invalid when check_file
(from tl_matroska.c) tried to check the ordered chapters for further
segment references. This likely only occurs when an ordered edition
references a non-ordered edition which contains chapters (not exactly
sure though).

Speculative fix for #306.
