### PR TITLE
ao_oss with no -softvol

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -196,6 +196,10 @@ static int init(struct ao *ao)
     struct priv *p = ao->priv;
     int oss_format;
 
+#ifdef SNDCTL_DSP_GETPLAYVOL
+    ao->no_persistent_volume = true;
+#endif
+
     const char *mchan = NULL;
     if (p->cfg_oss_mixer_channel && p->cfg_oss_mixer_channel[0])
         mchan = p->cfg_oss_mixer_channel;


### PR DESCRIPTION
4Front OSS and FreeBSD OSS (but not DragonFly) support per-application volume. volume_oss4() already implements ability to control it within mpv.

4Front behavior:  the last app closing /dev/dsp sets default volume
FreeBSD behavior: default volume is set to hw.snd.vpc_0db (45 by default)
                  and depends on hw.snd.vpc_autoreset (1 by default)

sysctl() bloat can be removed if you think handling non-default configuration is unnecessary.
