### PR TITLE
detect v4l2 input on freebsd

### DIFF
--- a/configure
+++ b/configure
@@ -2955,6 +2955,8 @@ if test "$_tv_v4l2" = auto ; then
   _tv_v4l2=no
   if test "$_tv" = yes && linux ; then
     header_check_broken sys/time.h linux/videodev2.h && _tv_v4l2=yes
+  elif test "$_tv" = yes && freebsd ; then
+    header_check linux/videodev2.h && _tv_v4l2=yes
   elif test "$_tv" = yes && test "$sys_videoio_h" = "yes" ; then
     _tv_v4l2=yes
   fi
@@ -3009,7 +3011,7 @@ echores "$_radio_capture"
 echocheck "Video 4 Linux 2 Radio interface"
 if test "$_radio_v4l2" = auto ; then
   _radio_v4l2=no
-  if test "$_radio" = yes && linux ; then
+  if test "$_radio" = yes && (linux || freebsd) ; then
     header_check linux/videodev2.h && _radio_v4l2=yes
   fi
 fi
@@ -3028,7 +3030,7 @@ fi
 echocheck "Video 4 Linux 2 MPEG PVR interface"
 if test "$_pvr" = auto ; then
  _pvr=no
- if test "$_tv_v4l2" = yes && linux ; then
+ if test "$_tv_v4l2" = yes ; then
   cat > $TMPC <<EOF
 #include <sys/time.h>
 #include <linux/videodev2.h>

--- a/stream/stream_pvr.c
+++ b/stream/stream_pvr.c
@@ -37,7 +37,9 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <poll.h>
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 #include <linux/videodev2.h>
 
 #include <libavutil/common.h>

--- a/stream/stream_radio.c
+++ b/stream/stream_radio.c
@@ -35,7 +35,9 @@
 #include <errno.h>
 #include <unistd.h>
 
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 
 #if HAVE_RADIO_V4L2
 #include <linux/videodev2.h>

--- a/stream/tvi_v4l2.c
+++ b/stream/tvi_v4l2.c
@@ -52,7 +52,9 @@ known issues:
 #if HAVE_SYS_VIDEOIO_H
 #include <sys/videoio.h>
 #else
+#ifdef __linux__
 #include <linux/types.h>
+#endif
 #include <linux/videodev2.h>
 #endif
 #if HAVE_LIBV4L2


### PR DESCRIPTION
On FreeBSD there's multimedia/webcamd port that provides a bunch of linux kernel drivers in userland. Many of them are for webcams and some don't support pixel formats that mpv understands e.g., V4L2_PIX_FMT_JPEG-only cams.

webcamd also supports a few PVR and Radio drivers.

http://www.freshports.org/multimedia/webcamd
http://web.archiveorange.com/archive/v/JZyvuczivPuypyze5Rhd (history)

It's an attempt to upstream this patch:

http://svnweb.freebsd.org/ports/head/multimedia/mpv/files/patch-stream-tvi_v4l2.c
http://svnweb.freebsd.org/ports/head/multimedia/mplayer2/files/patch-stream-tvi_v4l2.c
http://svnweb.freebsd.org/ports/head/multimedia/mplayer/files/patch-stream-tvi_v4l2.c
