### PR TITLE
waf: use print_function for Python 2

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -2,19 +2,20 @@
 
 # This script simply downloads waf to the current directory
 
-WAFRELEASE = "waf-1.7.13"
-SHA256HASH = "03cc750049350ee01cdbc584b70924e333fcc17ba4a2d04648dab1535538a873"
+from __future__ import print_function
+import os, sys, stat, hashlib
 
 try:
     from urllib.request import urlopen
 except:
     from urllib2 import urlopen
 
-import os, sys, stat, hashlib
+WAFRELEASE = "waf-1.7.13"
+SHA256HASH = "03cc750049350ee01cdbc584b70924e333fcc17ba4a2d04648dab1535538a873"
 
-waf = urlopen("http://waf.googlecode.com/files/" + WAFRELEASE).read()
+waf = urlopen("https://waf.googlecode.com/files/" + WAFRELEASE).read()
 
-if (SHA256HASH == hashlib.sha256(waf).hexdigest()):
+if SHA256HASH == hashlib.sha256(waf).hexdigest():
     with open("waf", "wb") as wf:
         wf.write(waf)
 


### PR DESCRIPTION
Also HTTPS for downloading waf, though Python 2 does not verify the
certificate.
