### PR TITLE
waf's check_oss() is horribly broken

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -98,8 +98,12 @@ def __check_oss_headers__(ctx, dependency_identifier):
         if os.path.exists(soundcard_h):
             osscflags = '-I{0}'.format(ossincdir)
 
-    real_oss = ctx.check_cc(fragment=load_fragment('oss_audio_header.c'),
-                            use='soundcard', cflags=osscflags)
+    try:
+        real_oss = ctx.check_cc(fragment=load_fragment('oss_audio_header.c'),
+                                use='soundcard', cflags=osscflags)
+    except Exception:
+        real_oss = False
+
     if real_oss:
         ctx.env.CFLAGS.append(osscflags)
 


### PR DESCRIPTION
On DragonFly and FreeBSD **check_oss_headers**() aborts configure. But installing audio/oss port (4Front impl.) and linking `/usr/local/etc/oss.conf` to `/etc/oss.conf` still wouldn't help.

```
../test.c:1:5: warning: 'HAVE_SOUNDCARD_H' is not defined, evaluates to 0 [-Wundef]
#if HAVE_SOUNDCARD_H
    ^
../test.c:12:2: error: Not the real thing
#error Not the real thing
 ^
1 warning and 1 error generated.

from /path/to/mpv: Test does not build: Traceback (most recent call last):
  File "/path/to/mpv/.waf-1.7.13-5a064c2686fe54de4e11018d22148cfc/waflib/Tools/c_config.py", line 459, in run_c_code
    bld.compile()
  File "/path/to/mpv/.waf-1.7.13-5a064c2686fe54de4e11018d22148cfc/waflib/Build.py", line 188, in compile
    raise Errors.BuildError(self.producer.error)
BuildError: Build failed
 -> task in 'testprog' failed (exit status 1): 
    {task 34462467424: c test.c -> test.c.1.o}
```

And **check_oss_bsd**() isn't suitable. -lossaudio is an OSS emulation layer for SunAudio (aka sys/audioio.h). It's used mostly by NetBSD because Solaris moved to Boomer (4Front OSS fork) while OpenBSD to -lsndio.
