### PR TITLE
Register both alt keys on Mac

### DIFF
--- a/DOCS/man/en/input.rst
+++ b/DOCS/man/en/input.rst
@@ -31,6 +31,10 @@ General Input Command Syntax
 
 ``[Shift+][Ctrl+][Alt+][Meta+]<key> [{<section>}] [<prefixes>] <command> (<argument>)* [; <command>]``
 
+Note that by default, the right Alt key can be used to create special
+characters, and thus does not register as a modifier. The option
+``--no-right-alt-gr`` changes this behavior.
+
 Newlines always start a new binding. ``#`` starts a comment (outside of quoted
 string arguments). To bind commands to the ``#`` key, ``SHARP`` can be used.
 

--- a/DOCS/man/en/options.rst
+++ b/DOCS/man/en/options.rst
@@ -1823,6 +1823,10 @@ OPTIONS
         - ``--reset-on-next-file=""``
           Do not reset pause mode.
 
+``--right-alt-gr``, ``--no-right-alt-gr``
+    Use the right Alt key as Alt Gr to produce special characters. If disabled,
+    count the right Alt as an Alt modifier key. Enabled by default.
+
 ``--rtsp-transport=<lavf|udp|tcp|http>``
     Select RTSP transport method (default: tcp). This selects the underlying
     network transport when playing ``rtsp://...`` URLs. The value ``lavf``

--- a/mpvcore/input/input.c
+++ b/mpvcore/input/input.c
@@ -550,6 +550,7 @@ struct input_ctx {
     pthread_mutex_t mutex;
     struct mp_log *log;
 
+    bool using_alt_gr;
     bool using_ar;
     bool using_cocoa_media_keys;
 
@@ -634,6 +635,7 @@ const m_option_t mp_input_opts[] = {
     OPT_FLAG("joystick", input.use_joystick, CONF_GLOBAL),
     OPT_FLAG("lirc", input.use_lirc, CONF_GLOBAL),
     OPT_FLAG("lircc", input.use_lircc, CONF_GLOBAL),
+    OPT_FLAG("right-alt-gr", input.use_alt_gr, CONF_GLOBAL),
 #if HAVE_COCOA
     OPT_FLAG("ar", input.use_ar, CONF_GLOBAL),
     OPT_FLAG("media-keys", input.use_media_keys, CONF_GLOBAL),
@@ -2371,6 +2373,10 @@ struct input_ctx *mp_input_init(struct mpv_global *global)
     }
 #endif
 
+    if (input_conf->use_alt_gr) {
+        ictx->using_alt_gr = true;
+    }
+
 #if HAVE_COCOA
     if (input_conf->use_ar) {
         cocoa_init_apple_remote();
@@ -2511,4 +2517,9 @@ unsigned int mp_input_get_mouse_event_counter(struct input_ctx *ictx)
     int ret = ictx->mouse_event_counter;
     input_unlock(ictx);
     return ret;
+}
+
+bool mp_input_use_alt_gr(struct input_ctx *ictx)
+{
+    return ictx->using_alt_gr;
 }

--- a/mpvcore/input/input.h
+++ b/mpvcore/input/input.h
@@ -287,6 +287,10 @@ void mp_input_wakeup(struct input_ctx *ictx);
 // Interruptible usleep:  (used by demux)
 int mp_input_check_interrupt(struct input_ctx *ictx, int time);
 
+// If this returns true, use Right Alt key as Alt Gr to produce special
+// characters. If false, count Right Alt as the modifier Alt key.
+bool mp_input_use_alt_gr(struct input_ctx *ictx);
+
 extern int async_quit_request;
 
 #endif /* MPLAYER_INPUT_H */

--- a/mpvcore/options.c
+++ b/mpvcore/options.c
@@ -873,6 +873,7 @@ const struct MPOpts mp_default_opts = {
         .use_joystick = 1,
         .use_lirc = 1,
         .use_lircc = 1,
+        .use_alt_gr = 1,
 #if HAVE_COCOA
         .use_ar = 1,
         .use_media_keys = 1,

--- a/mpvcore/options.h
+++ b/mpvcore/options.h
@@ -251,6 +251,7 @@ typedef struct MPOpts {
         int use_joystick;
         int use_lirc;
         int use_lircc;
+        int use_alt_gr;
         int use_ar;
         int use_media_keys;
         int default_bindings;

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -287,7 +287,9 @@ void cocoa_put_key_with_modifiers(int keycode, int modifiers)
         mask |= MP_KEY_MODIFIER_SHIFT;
     if (cocoaModifiers & NSControlKeyMask)
         mask |= MP_KEY_MODIFIER_CTRL;
-    if (LeftAltPressed(cocoaModifiers))
+    if (LeftAltPressed(cocoaModifiers) || 
+            (!mp_input_use_alt_gr(mpv_shared_app().inputContext) &&
+                RightAltPressed(cocoaModifiers)))
         mask |= MP_KEY_MODIFIER_ALT;
     if (cocoaModifiers & NSCommandKeyMask)
         mask |= MP_KEY_MODIFIER_META;
@@ -333,7 +335,8 @@ void cocoa_put_key_with_modifiers(int keycode, int modifiers)
 
     NSString *chars;
 
-    if (RightAltPressed([event modifierFlags]))
+    if (mp_input_use_alt_gr(mpv_shared_app().inputContext) &&
+            RightAltPressed([event modifierFlags]))
         chars = [event characters];
     else
         chars = [event charactersIgnoringModifiers];

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -495,11 +495,13 @@ static void check_events(struct vo *vo)
         case SDL_TEXTINPUT: {
             int sdl_mod = SDL_GetModState();
             int mpv_mod = 0;
-            // we ignore KMOD_LSHIFT, KMOD_RSHIFT and KMOD_RALT because
-            // these are already factored into ev.text.text
+            // we ignore KMOD_LSHIFT, KMOD_RSHIFT and KMOD_RALT (if
+            // mp_input_use_alt_gr() is true) because these are already
+            // factored into ev.text.text
             if (sdl_mod & (KMOD_LCTRL | KMOD_RCTRL))
                 mpv_mod |= MP_KEY_MODIFIER_CTRL;
-            if (sdl_mod & KMOD_LALT)
+            if ((sdl_mod & KMOD_LALT) ||
+                    (!mp_input_use_alt_gr(vo->input_ctx) && (sdl_mod & KMOD_RALT))
                 mpv_mod |= MP_KEY_MODIFIER_ALT;
             if (sdl_mod & (KMOD_LGUI | KMOD_RGUI))
                 mpv_mod |= MP_KEY_MODIFIER_META;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -203,7 +203,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             // Windows enables Ctrl+Alt when AltGr (VK_RMENU) is pressed.
             // E.g. AltGr+9 on a German keyboard would yield Ctrl+Alt+[
             // Warning: wine handles this differently. Don't test this on wine!
-            if (key_state(vo, VK_RMENU))
+            if (mp_input_use_alt_gr(vo->input_ctx) && key_state(vo, VK_RMENU))
                 mods &= ~(MP_KEY_MODIFIER_CTRL | MP_KEY_MODIFIER_ALT);
             // Apparently Ctrl+A to Ctrl+Z is special cased, and produces
             // character codes from 1-26. Work it around.


### PR DESCRIPTION
Previously only the left alt would count as the alt modifier key to mpv.

If the old behavior was intentional, I would love to know the reasoning behind it.

WARNING: I have not tested this change, although I'm pretty sure it will work. Compiling mpv is too much work to do right now. :)
