### PR TITLE
ao_oss: fallback from float to s32 or s24 if available

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -299,12 +299,28 @@ ac3_retry:
     if (oss_format == -1) {
         MP_VERBOSE(ao, "Unknown/not supported internal format: %s\n",
                    af_fmt_to_str(ao->format));
+#if defined(AFMT_S32_LE) && defined(AFMT_S32_BE)
+#if BYTE_ORDER == BIG_ENDIAN
+        oss_format = AFMT_S32_BE;
+#else
+        oss_format = AFMT_S32_LE;
+#endif
+        ao->format = AF_FORMAT_S32;
+#elif defined(AFMT_S24_LE) && defined(AFMT_S24_BE)
+#if BYTE_ORDER == BIG_ENDIAN
+        oss_format = AFMT_S24_BE;
+#else
+        oss_format = AFMT_S24_LE;
+#endif
+        ao->format = AF_FORMAT_S24;
+#else
 #if BYTE_ORDER == BIG_ENDIAN
         oss_format = AFMT_S16_BE;
 #else
         oss_format = AFMT_S16_LE;
 #endif
         ao->format = AF_FORMAT_S16;
+#endif
     }
     if (ioctl(p->audio_fd, SNDCTL_DSP_SETFMT, &oss_format) < 0 ||
         oss_format != format2oss(ao->format))


### PR DESCRIPTION
Prefer largest bit depth when falling back. The behavior is similar to alsa 'plug' converter selecting next best.  s32 and s24 are tried only on DragonFly, FreeBSD, Solaris, 4Front OSS. 

In case S24 and S32 aren't supported by underlying hardware the following code would attempt S16 again.

``` c
ac3_retry:
    if (AF_FORMAT_IS_AC3(ao->format))
        ao->format = AF_FORMAT_AC3;
    oss_format = format2oss(ao->format);
...
    if (ioctl(p->audio_fd, SNDCTL_DSP_SETFMT, &oss_format) < 0 ||
        oss_format != format2oss(ao->format))
    {
        MP_WARN(ao, "Can't set audio device %s to %s output, trying %s...\n",
                p->dsp, af_fmt_to_str(ao->format),
                af_fmt_to_str(AF_FORMAT_S16));
        ao->format = AF_FORMAT_S16;
        goto ac3_retry;
    }
```

plug behavior with oss

```
$ aplay -v foo.wav
Playing WAVE 'foo.wav' : Float 32 bit Little Endian, Rate 48000 Hz, Channels 6
Plug PCM: Linear Integer <-> Linear Float conversion PCM (S32_LE)
Its setup is:
  stream       : PLAYBACK
  access       : RW_INTERLEAVED
  format       : FLOAT_LE
  subformat    : STD
  channels     : 6
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 32
  buffer_size  : 5461
  period_size  : 1365
  period_time  : 28442
  tstamp_mode  : NONE
  period_step  : 1
  avail_min    : 1365
  period_event : 0
  start_threshold  : 5461
  stop_threshold   : 5461
  silence_threshold: 0
  silence_size : 0
  boundary     : 6148539391267569664
Slave: ALSA <-> OSS PCM I/O Plugin
Its setup is:
  stream       : PLAYBACK
  access       : MMAP_INTERLEAVED
  format       : S32_LE
  subformat    : STD
  channels     : 6
  rate         : 48000
  exact rate   : 48000 (48000/1)
  msbits       : 32
  buffer_size  : 5461
  period_size  : 1365
  period_time  : 28442
  tstamp_mode  : NONE
  period_step  : 1
  avail_min    : 1365
  period_event : 0
  start_threshold  : 5461
  stop_threshold   : 5461
  silence_threshold: 0
  silence_size : 0
  boundary     : 6148539391267569664
^CAborted by signal Interrupt...
```

mpv now

```
$ mpv --channels 6 --msglevel all=-1:ao=6 foo.wav
[ao] Trying preferred audio driver 'oss'
[ao/oss] requested format: 48000 Hz, 5.1 channels, floatp
[ao/oss] using '/dev/dsp' dsp device
[ao/oss] using '/dev/mixer' mixer device
[ao/oss] using 'pcm' mixer device
[ao/oss] Unknown/not supported internal format: float
[ao/oss] sample format: s16
[ao/oss] using 6 channels (requested: 6)
[ao/oss] using 48000 Hz samplerate
[ao/oss] frags:  32/32  (4092 bytes/frag)  free: 130944
```

mpv after merge

```
$ mpv --channels 6 --msglevel all=-1:ao=6 foo.wav
[ao] Trying preferred audio driver 'oss'
[ao/oss] requested format: 48000 Hz, 5.1 channels, floatp
[ao/oss] using '/dev/dsp' dsp device
[ao/oss] using '/dev/mixer' mixer device
[ao/oss] using 'pcm' mixer device
[ao/oss] Unknown/not supported internal format: float
[ao/oss] sample format: s32
[ao/oss] using 6 channels (requested: 6)
[ao/oss] using 48000 Hz samplerate
[ao/oss] frags:  32/32  (4080 bytes/frag)  free: 130560
```
