### PR TITLE
Fixes linking issue on OS X 10.7

### DIFF
--- a/wscript
+++ b/wscript
@@ -453,7 +453,7 @@ audio_output_features = [
         'desc': 'CoreAudio audio output',
         'func': check_cc(
             fragment=load_fragment('coreaudio.c'),
-            framework_name=['CoreAudio', 'AudioUnit', 'AudioToolbox'])
+            framework_name=['CoreFoundation', 'CoreAudio', 'AudioUnit', 'AudioToolbox'])
     }, {
         'name': '--dsound',
         'desc': 'DirectSound audio output',


### PR DESCRIPTION
This fixes the following linking issue on OS X 10.7.

```
Undefined symbols for architecture x86_64:
  "_CFRelease", referenced from:
      _ca_get_str in ao_coreaudio_properties.c.10.o
  "_CFStringGetCString", referenced from:
      _ca_get_str in ao_coreaudio_properties.c.10.o
  "_CFStringGetLength", referenced from:
      _ca_get_str in ao_coreaudio_properties.c.10.o
  "_CFStringGetMaximumSizeForEncoding", referenced from:
      _ca_get_str in ao_coreaudio_properties.c.10.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
