### PR TITLE
Made borderless window resizable.

### DIFF
--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -267,7 +267,7 @@ static void create_window(struct vo *vo, uint32_t d_width, uint32_t d_height,
         window_mask = NSTitledWindowMask|NSClosableWindowMask|
                       NSMiniaturizableWindowMask|NSResizableWindowMask;
     } else {
-        window_mask = NSBorderlessWindowMask;
+        window_mask = NSBorderlessWindowMask|NSResizableWindowMask;
     }
 
     s->window =


### PR DESCRIPTION
Borderless window on OS X (flag `--no-border` or `--border=no`) is now resizable.
