### PR TITLE
build: dvdnav needs dvdread

### DIFF
--- a/wscript
+++ b/wscript
@@ -254,6 +254,7 @@ If you really mean to compile without libass support use --disable-libass."
     }, {
         'name': '--dvdnav',
         'desc': 'dvdnav support',
+        'deps': [ 'dvdread' ],
         'func': check_pkg_config('dvdnav', '>= 4.2.0'),
     }, {
         'name': '--cdda',


### PR DESCRIPTION
Fixes this build fail:

```
[224/224] linking -> build/mpv
11:41:11 runner ['x86_64-pc-linux-gnu-gcc', '-Wl,--hash-style=gnu', '-Wl,-O1', '-Wl,--as-needed', '-Wl,--hash-style=gnu', '-Wl,-O1', '-Wl,--as-needed', '-Wl,-z,noexecstack', 'audio/audio.c.10.o', 'audio/audio_buffer.c.10.o', 'audio/chmap.c.10.o', 'audio/chmap_sel.c.10.o', 'audio/fmt-conversion.c.10.o', 'audio/format.c.10.o', 'audio/mixer.c.10.o', 'audio/reorder_ch.c.10.o', 'audio/decode/ad_lavc.c.10.o', 'audio/decode/ad_spdif.c.10.o', 'audio/decode/dec_audio.c.10.o', 'audio/filter/af.c.10.o', 'audio/filter/af_center.c.10.o', 'audio/filter/af_channels.c.10.o', 'audio/filter/af_convert24.c.10.o', 'audio/filter/af_convertsignendian.c.10.o', 'audio/filter/af_delay.c.10.o', 'audio/filter/af_drc.c.10.o', 'audio/filter/af_dummy.c.10.o', 'audio/filter/af_equalizer.c.10.o', 'audio/filter/af_export.c.10.o', 'audio/filter/af_extrastereo.c.10.o', 'audio/filter/af_format.c.10.o', 'audio/filter/af_hrtf.c.10.o', 'audio/filter/af_karaoke.c.10.o', 'audio/filter/af_lavcac3enc.c.10.o', 'audio/filter/af_lavrresample.c.10.o', 'audio/filter/af_pan.c.10.o', 'audio/filter/af_scaletempo.c.10.o', 'audio/filter/af_sinesuppress.c.10.o', 'audio/filter/af_sub.c.10.o', 'audio/filter/af_surround.c.10.o', 'audio/filter/af_sweep.c.10.o', 'audio/filter/af_volume.c.10.o', 'audio/filter/filter.c.10.o', 'audio/filter/tools.c.10.o', 'audio/filter/window.c.10.o', 'audio/out/ao.c.10.o', 'audio/out/ao_alsa.c.10.o', 'audio/out/ao_null.c.10.o', 'audio/out/ao_pcm.c.10.o', 'mpvcore/input/input.c.10.o', 'mpvcore/player/audio.c.10.o', 'mpvcore/player/command.c.10.o', 'mpvcore/player/configfiles.c.10.o', 'mpvcore/player/dvdnav.c.10.o', 'mpvcore/player/loadfile.c.10.o', 'mpvcore/player/main.c.10.o', 'mpvcore/player/misc.c.10.o', 'mpvcore/player/osd.c.10.o', 'mpvcore/player/playloop.c.10.o', 'mpvcore/player/screenshot.c.10.o', 'mpvcore/player/sub.c.10.o', 'mpvcore/player/timeline/tl_cue.c.10.o', 'mpvcore/player/timeline/tl_mpv_edl.c.10.o', 'mpvcore/player/timeline/tl_matroska.c.10.o', 'mpvcore/player/video.c.10.o', 'mpvcore/asxparser.c.10.o', 'mpvcore/av_common.c.10.o', 'mpvcore/av_log.c.10.o', 'mpvcore/av_opts.c.10.o', 'mpvcore/bstr.c.10.o', 'mpvcore/charset_conv.c.10.o', 'mpvcore/codecs.c.10.o', 'mpvcore/cpudetect.c.10.o', 'mpvcore/m_config.c.10.o', 'mpvcore/m_option.c.10.o', 'mpvcore/m_property.c.10.o', 'mpvcore/mp_common.c.10.o', 'mpvcore/mp_msg.c.10.o', 'mpvcore/mp_ring.c.10.o', 'mpvcore/options.c.10.o', 'mpvcore/parser-cfg.c.10.o', 'mpvcore/parser-mpcmd.c.10.o', 'mpvcore/path.c.10.o', 'mpvcore/playlist.c.10.o', 'mpvcore/playlist_parser.c.10.o', 'mpvcore/resolve_quvi.c.10.o', 'mpvcore/version.c.10.o', 'demux/codec_tags.c.10.o', 'demux/demux.c.10.o', 'demux/demux_cue.c.10.o', 'demux/demux_edl.c.10.o', 'demux/demux_lavf.c.10.o', 'demux/demux_libass.c.10.o', 'demux/demux_mf.c.10.o', 'demux/demux_mkv.c.10.o', 'demux/demux_playlist.c.10.o', 'demux/demux_raw.c.10.o', 'demux/demux_subreader.c.10.o', 'demux/ebml.c.10.o', 'demux/mf.c.10.o', 'stream/ai_alsa1x.c.10.o', 'stream/audio_in.c.10.o', 'stream/cache.c.10.o', 'stream/cookies.c.10.o', 'stream/frequencies.c.10.o', 'stream/rar.c.10.o', 'stream/stream.c.10.o', 'stream/stream_avdevice.c.10.o', 'stream/stream_bluray.c.10.o', 'stream/stream_dvdnav.c.10.o', 'stream/stream_edl.c.10.o', 'stream/stream_file.c.10.o', 'stream/stream_lavf.c.10.o', 'stream/stream_memory.c.10.o', 'stream/stream_mf.c.10.o', 'stream/stream_null.c.10.o', 'stream/stream_rar.c.10.o', 'stream/stream_tv.c.10.o', 'stream/tv.c.10.o', 'stream/tvi_dummy.c.10.o', 'stream/tvi_v4l2.c.10.o', 'sub/ass_mp.c.10.o', 'sub/dec_sub.c.10.o', 'sub/draw_bmp.c.10.o', 'sub/find_subfiles.c.10.o', 'sub/img_convert.c.10.o', 'sub/osd.c.10.o', 'sub/osd_libass.c.10.o', 'sub/sd_ass.c.10.o', 'sub/sd_lavc.c.10.o', 'sub/sd_lavc_conv.c.10.o', 'sub/sd_lavf_srt.c.10.o', 'sub/sd_microdvd.c.10.o', 'sub/sd_movtext.c.10.o', 'sub/sd_spu.c.10.o', 'sub/sd_srt.c.10.o', 'sub/spudec.c.10.o', 'video/csputils.c.10.o', 'video/fmt-conversion.c.10.o', 'video/image_writer.c.10.o', 'video/img_format.c.10.o', 'video/mp_image.c.10.o', 'video/mp_image_pool.c.10.o', 'video/sws_utils.c.10.o', 'video/decode/dec_video.c.10.o', 'video/decode/lavc_dr1.c.10.o', 'video/decode/vd_lavc.c.10.o', 'video/filter/pullup.c.10.o', 'video/filter/vf.c.10.o', 'video/filter/vf_crop.c.10.o', 'video/filter/vf_delogo.c.10.o', 'video/filter/vf_divtc.c.10.o', 'video/filter/vf_dlopen.c.10.o', 'video/filter/vf_dsize.c.10.o', 'video/filter/vf_eq.c.10.o', 'video/filter/vf_expand.c.10.o', 'video/filter/vf_flip.c.10.o', 'video/filter/vf_format.c.10.o', 'video/filter/vf_gradfun.c.10.o', 'video/filter/vf_hqdn3d.c.10.o', 'video/filter/vf_ilpack.c.10.o', 'video/filter/vf_mirror.c.10.o', 'video/filter/vf_noformat.c.10.o', 'video/filter/vf_noise.c.10.o', 'video/filter/vf_phase.c.10.o', 'video/filter/vf_pp.c.10.o', 'video/filter/vf_pullup.c.10.o', 'video/filter/vf_rotate.c.10.o', 'video/filter/vf_scale.c.10.o', 'video/filter/vf_screenshot.c.10.o', 'video/filter/vf_softpulldown.c.10.o', 'video/filter/vf_stereo3d.c.10.o', 'video/filter/vf_sub.c.10.o', 'video/filter/vf_swapuv.c.10.o', 'video/filter/vf_unsharp.c.10.o', 'video/filter/vf_yadif.c.10.o', 'video/out/aspect.c.10.o', 'video/out/bitmap_packer.c.10.o', 'video/out/dither.c.10.o', 'video/out/filter_kernels.c.10.o', 'video/out/gl_common.c.10.o', 'video/out/gl_lcms.c.10.o', 'video/out/gl_osd.c.10.o', 'video/out/gl_video.c.10.o', 'video/out/gl_x11.c.10.o', 'video/out/pnm_loader.c.10.o', 'video/out/vo.c.10.o', 'video/out/vo_image.c.10.o', 'video/out/vo_null.c.10.o', 'video/out/vo_opengl.c.10.o', 'video/out/vo_opengl_old.c.10.o', 'video/out/vo_x11.c.10.o', 'video/out/vo_xv.c.10.o', 'video/out/x11_common.c.10.o', 'osdep/getch2.c.10.o', 'osdep/io.c.10.o', 'osdep/numcores.c.10.o', 'osdep/timer.c.10.o', 'osdep/timer-linux.c.10.o', 'osdep/threads.c.10.o', 'ta/ta.c.10.o', 'ta/ta_talloc.c.10.o', 'ta/ta_utils.c.10.o', '-o', '/var/package-manager/tmp/portage/media-video/mpv-9999/work/mpv-9999/build/mpv', '-Wl,-Bstatic', '-Wl,-Bdynamic', '-ldvdnav', '-lpthread', '-lenca', '-llcms2', '-lXxf86vm', '-lavutil', '-lavcodec', '-lavformat', '-lswscale', '-lXv', '-lv4l2', '-lrt', '-lavfilter', '-lquvi', '-lGL', '-lpostproc', '-lasound', '-lavresample', '-lm', '-lXinerama', '-ldl', '-lpthread', '-lbluray', '-lXss', '-lz', '-lXext', '-lncurses', '-lX11', '-lass']
mpvcore/options.c.10.o:(.data.rel.ro+0x6c8): undefined reference to `dvd_speed'
mpvcore/options.c.10.o:(.data.rel.ro+0x710): undefined reference to `dvd_angle'
stream/stream_dvdnav.c.10.o: In function `open_s':
stream_dvdnav.c:(.text+0x47): undefined reference to `dvd_speed'
stream_dvdnav.c:(.text+0x51): undefined reference to `dvd_set_speed'
stream_dvdnav.c:(.text+0xff): undefined reference to `dvd_angle'
stream/stream_dvdnav.c.10.o: In function `fill_buffer':
stream_dvdnav.c:(.text+0x138c): undefined reference to `mp_dvdtimetomsec'
stream_dvdnav.c:(.text+0x13f5): undefined reference to `mp_dvdtimetomsec'
stream/stream_dvdnav.c.10.o: In function `stream_dvdnav_close':
stream_dvdnav.c:(.text+0x317): undefined reference to `dvd_set_speed'
collect2: error: ld returned 1 exit status
```
