### PR TITLE
Scale osd’s time remaining by the current speed

### DIFF
--- a/DOCS/man/en/input.rst
+++ b/DOCS/man/en/input.rst
@@ -536,6 +536,7 @@ Name                            W Comment
 ``ratio-pos``                   x position in current file (0.0-1.0)
 ``time-pos``                    x position in current file in seconds
 ``time-remaining``                estimated remaining length of the file in seconds
+``playtime-remaining``            ``time-remaining`` scaled by the the current ``speed``
 ``chapter``                     x current chapter number
 ``edition``                     x current MKV edition number
 ``titles``                        number of DVD titles

--- a/mpvcore/player/command.c
+++ b/mpvcore/player/command.c
@@ -382,17 +382,38 @@ static int mp_property_time_pos(m_option_t *prop, int action,
     return property_time(prop, action, arg, get_current_time(mpctx));
 }
 
+static double time_remaining(MPContext *mpctx, double *len)
+{
+    *len = get_time_length(mpctx);
+    double pos = get_current_time(mpctx);
+    double start = get_start_time(mpctx);
+
+    return *len - (pos - start);
+}
+
 static int mp_property_remaining(m_option_t *prop, int action,
                                  void *arg, MPContext *mpctx)
 {
-    double len = get_time_length(mpctx);
-    double pos = get_current_time(mpctx);
-    double start = get_start_time(mpctx);
+    double len;
+    double remaining = time_remaining(mpctx, &len);
 
     if (!(int)len)
         return M_PROPERTY_UNAVAILABLE;
 
-    return property_time(prop, action, arg, len - (pos - start));
+    return property_time(prop, action, arg, remaining);
+}
+
+static int mp_property_playtime_remaining(m_option_t *prop, int action,
+                                      void *arg, MPContext *mpctx)
+{
+    double len;
+    double remaining = time_remaining(mpctx, &len);
+
+    if (!(int)len)
+        return M_PROPERTY_UNAVAILABLE;
+
+    double speed = mpctx->opts->playback_speed;
+    return property_time(prop, action, arg, remaining / speed);
 }
 
 /// Current chapter (RW)
@@ -1881,6 +1902,7 @@ static const m_option_t mp_properties[] = {
     { "time-pos", mp_property_time_pos, CONF_TYPE_TIME,
       M_OPT_MIN, 0, 0, NULL },
     { "time-remaining", mp_property_remaining, CONF_TYPE_TIME },
+    { "playtime-remaining", mp_property_playtime_remaining, CONF_TYPE_TIME },
     { "chapter", mp_property_chapter, CONF_TYPE_INT,
       M_OPT_MIN, -1, 0, NULL },
     M_OPTION_PROPERTY_CUSTOM("edition", mp_property_edition),

--- a/mpvcore/player/lua/osc.lua
+++ b/mpvcore/player/lua/osc.lua
@@ -1020,9 +1020,9 @@ function osc_init()
     local contentF = function (ass)
         if state.rightTC_trem == true then
             if state.tc_ms then
-                ass:append("-" .. mp.property_get_string("time-remaining/full"))
+                ass:append("-" .. mp.property_get_string("playtime-remaining/full"))
             else
-                ass:append("-" .. mp.property_get_string("time-remaining"))
+                ass:append("-" .. mp.property_get_string("playtime-remaining"))
             end
         else
             if state.tc_ms then


### PR DESCRIPTION
Another small commit. I think this makes sense because the actual time remaining to complete a video depends on the current speed.
