### PR TITLE
vo/x11_common: do not select motion events when --no-mouse-movements is set

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1614,7 +1614,7 @@ static void vo_x11_selectinput_witherr(struct vo *vo,
                                        long event_mask)
 {
     if (!vo->opts->enable_mouse_movements)
-        event_mask &= ~(ButtonPressMask | ButtonReleaseMask);
+        event_mask &= ~(PointerMotionMask | ButtonPressMask | ButtonReleaseMask);
 
     XSelectInput(display, w, NoEventMask);
 


### PR DESCRIPTION
I'm pretty sure this is the desired behavior for anyone using --no-mouse-movements.
