### PR TITLE
build: make opengl-old video output optional

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -86,7 +86,7 @@ const struct vo_driver *video_out_drivers[] =
 #if HAVE_SDL2
         &video_out_sdl,
 #endif
-#if HAVE_GL
+#if HAVE_GL_OLD
         &video_out_opengl_old,
 #endif
 #if HAVE_VAAPI

--- a/wscript
+++ b/wscript
@@ -579,6 +579,11 @@ video_output_features = [
         'deps_any': [ 'gl-cocoa', 'gl-x11', 'gl-win32', 'gl-wayland' ],
         'func': check_true
     } , {
+        'name': '--gl-old',
+        'desc': 'legacy OpenGL video output',
+        'deps': [ 'gl' ],
+        'func': check_true
+    } , {
         'name': '--corevideo',
         'desc': 'CoreVideo',
         'deps': [ 'gl', 'gl-cocoa' ],

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -365,7 +365,7 @@ def build(ctx):
         ( "video/out/vo_lavc.c",                 "encoding" ),
         ( "video/out/vo_null.c" ),
         ( "video/out/vo_opengl.c",               "gl" ),
-        ( "video/out/vo_opengl_old.c",           "gl" ),
+        ( "video/out/vo_opengl_old.c",           "gl-old" ),
         ( "video/out/vo_sdl.c",                  "sdl2" ),
         ( "video/out/vo_vaapi.c",                "vaapi" ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),


### PR DESCRIPTION
All my systems have new enough mesa: opengl VO works fine with both r600 and nouveau drivers. So i would like to disable opengl-old VO at build time.

```
# time USE='opengl-old' MAKEOPTS="-j1" emerge -1vb --nodeps mpv;du -s /usr/bin/mpv 
'build' finished successfully (4m25.780s)
real    6m15.809s
user    5m44.179s
sys     0m40.105s
1345    /usr/bin/mpv

# time USE='-opengl-old' MAKEOPTS="-j1" emerge -1vb --nodeps mpv;du -s /usr/bin/mpv
'build' finished successfully (4m15.652s)
real    6m4.894s
user    5m34.077s
sys     0m39.904s
1308    /usr/bin/mpv
```
