### PR TITLE
quvi: Add option to not fetch subtitles.

### DIFF
--- a/DOCS/man/en/options.rst
+++ b/DOCS/man/en/options.rst
@@ -1743,6 +1743,13 @@ OPTIONS
 
     Also see ``--really-quiet`` and ``--msglevel``.
 
+``--quvi-fetch-subtitles=<yes|no>``
+    Toggles fetching of subtitles from streaming sites with libquvi.
+
+    Supported in libquvi 0.9.x.
+
+    Enabled by default
+
 ``--quvi-format=<best|default|...>``
     Video format/quality that is directly passed to libquvi (default: ``best``).
     This is used when opening links to streaming sites like YouTube. The

--- a/options/options.c
+++ b/options/options.c
@@ -316,6 +316,7 @@ const m_option_t mp_opts[] = {
                ({"no", 0}, {"attachment", 1})),
 
     OPT_STRING("quvi-format", quvi_format, 0),
+    OPT_FLAG("quvi-fetch-subtitles", quvi_fetch_subtitles, 0),
 
 #if HAVE_CDDA
     { "cdda", (void *)&cdda_opts, CONF_TYPE_SUBCONFIG, 0, 0, 0, NULL},
@@ -718,6 +719,7 @@ const struct MPOpts mp_default_opts = {
     .sub_visibility = 1,
     .sub_pos = 100,
     .sub_speed = 1.0,
+    .quvi_fetch_subtitles = 1,
     .audio_output_channels = MP_CHMAP_INIT_STEREO,
     .audio_output_format = 0,  // AF_FORMAT_UNKNOWN
     .playback_speed = 1.,

--- a/options/options.h
+++ b/options/options.h
@@ -158,6 +158,7 @@ typedef struct MPOpts {
     int forced_subs_only;
     int stretch_dvd_subs;
     char *quvi_format;
+    int quvi_fetch_subtitles;
 
     // subreader.c
     int suboverlap_enabled;

--- a/stream/resolve/resolve_quvi9.c
+++ b/stream/resolve/resolve_quvi9.c
@@ -111,7 +111,7 @@ struct mp_resolve_result *mp_resolve_quvi(const char *url,
         quvi_media_free(media);
     }
 
-    if (quvi_supports(q, url, mode, QUVI_SUPPORTS_TYPE_SUBTITLE)) {
+    if (opts->quvi_fetch_subtitles && quvi_supports(q, url, mode, QUVI_SUPPORTS_TYPE_SUBTITLE)) {
         mp_info(log, "Getting subtitles...\n");
         quvi_subtitle_t qsub = quvi_subtitle_new(q, url);
         if (mp_quvi_ok(q, log)) {


### PR DESCRIPTION
Subtitle fetching can be very slow at times, add a flag to disable it.  Still leaves it enabled by default
