### PR TITLE
Cocoa: Allow drag and drop directly from a web browser

### DIFF
--- a/video/out/cocoa/view.h
+++ b/video/out/cocoa/view.h
@@ -20,7 +20,6 @@
 
 @interface MpvVideoView : NSView <NSDraggingDestination> {
     BOOL hasMouseDown;
-    BOOL draggingTypeURL;
 }
 @property(nonatomic, retain) MpvCocoaAdapter *adapter;
 @property(nonatomic, retain) NSTrackingArea *tracker;


### PR DESCRIPTION
by registering for NSURLPboardType we can handle files directly from the web browser by saving them to a temp folder.

Also returns different dragged types to improve visual feedback to the user (arrow/plus icons in the mouse cursor)
