### PR TITLE
Detect Lua on FreeBSD

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -52,10 +52,12 @@ def check_lua(ctx, dependency_identifier):
     lua_versions = [
         ( '51',     'lua >= 5.1.0 lua < 5.2.0'),
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
+        ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
         ( 'luajit', 'luajit >= 2.0.0' ),
         # assume all our dependencies (libquvi in particular) link with 5.1
         ( '52',     'lua >= 5.2.0' ),
         ( '52deb',  'lua5.2 >= 5.2.0'), # debian
+        ( '52fbsd', 'lua-5.2 >= 5.2.0'), # FreeBSD
     ]
 
     if ctx.options.LUA_VER:

--- a/wscript
+++ b/wscript
@@ -765,7 +765,7 @@ def options(opt):
     group.add_option('--lua',
         type    = 'string',
         dest    = 'LUA_VER',
-        help    = "select Lua package which should be autodetected. Choices: 51 51deb 52 52deb luajit")
+        help    = "select Lua package which should be autodetected. Choices: 51 51deb 51fbsd 52 52deb 52fbsd luajit")
 
 @conf
 def is_debug_build(ctx):


### PR DESCRIPTION
On FreeBSD pkg-config data for Lua is stored in lua-5.1.pc and lua-5.2.pc files.
