### PR TITLE
Windows: Add numpad keys and VK_APPS

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -43,27 +43,47 @@ enum mp_messages {
     MPM_PUTKEY = WM_USER,
 };
 
+static const struct mp_keymap vk_map_ext[] = {
+    // cursor keys
+    {VK_LEFT, MP_KEY_LEFT}, {VK_UP, MP_KEY_UP}, {VK_RIGHT, MP_KEY_RIGHT},
+    {VK_DOWN, MP_KEY_DOWN},
+
+    // navigation block
+    {VK_INSERT, MP_KEY_INSERT}, {VK_DELETE, MP_KEY_DELETE},
+    {VK_HOME, MP_KEY_HOME}, {VK_END, MP_KEY_END}, {VK_PRIOR, MP_KEY_PAGE_UP},
+    {VK_NEXT, MP_KEY_PAGE_DOWN},
+
+    // numpad independent of numlock
+    {VK_RETURN, MP_KEY_KPENTER},
+
+    {0, 0}
+};
+
 static const struct mp_keymap vk_map[] = {
     // special keys
     {VK_ESCAPE, MP_KEY_ESC}, {VK_BACK, MP_KEY_BS}, {VK_TAB, MP_KEY_TAB},
-    {VK_RETURN, MP_KEY_ENTER}, {VK_PAUSE, MP_KEY_PAUSE}, {VK_SNAPSHOT, MP_KEY_PRINT},
-
-    // cursor keys
-    {VK_LEFT, MP_KEY_LEFT}, {VK_UP, MP_KEY_UP}, {VK_RIGHT, MP_KEY_RIGHT}, {VK_DOWN, MP_KEY_DOWN},
-
-    // navigation block
-    {VK_INSERT, MP_KEY_INSERT}, {VK_DELETE, MP_KEY_DELETE}, {VK_HOME, MP_KEY_HOME}, {VK_END, MP_KEY_END},
-    {VK_PRIOR, MP_KEY_PAGE_UP}, {VK_NEXT, MP_KEY_PAGE_DOWN},
+    {VK_RETURN, MP_KEY_ENTER}, {VK_PAUSE, MP_KEY_PAUSE},
+    {VK_SNAPSHOT, MP_KEY_PRINT}, {VK_APPS, MP_KEY_MENU},
 
     // F-keys
-    {VK_F1, MP_KEY_F+1}, {VK_F2, MP_KEY_F+2}, {VK_F3, MP_KEY_F+3}, {VK_F4, MP_KEY_F+4},
-    {VK_F5, MP_KEY_F+5}, {VK_F6, MP_KEY_F+6}, {VK_F7, MP_KEY_F+7}, {VK_F8, MP_KEY_F+8},
-    {VK_F9, MP_KEY_F+9}, {VK_F10, MP_KEY_F+10}, {VK_F11, MP_KEY_F+11}, {VK_F12, MP_KEY_F+12},
-    // numpad
-    {VK_NUMPAD0, MP_KEY_KP0}, {VK_NUMPAD1, MP_KEY_KP1}, {VK_NUMPAD2, MP_KEY_KP2},
-    {VK_NUMPAD3, MP_KEY_KP3}, {VK_NUMPAD4, MP_KEY_KP4}, {VK_NUMPAD5, MP_KEY_KP5},
-    {VK_NUMPAD6, MP_KEY_KP6}, {VK_NUMPAD7, MP_KEY_KP7}, {VK_NUMPAD8, MP_KEY_KP8},
-    {VK_NUMPAD9, MP_KEY_KP9}, {VK_DECIMAL, MP_KEY_KPDEC},
+    {VK_F1, MP_KEY_F+1}, {VK_F2, MP_KEY_F+2}, {VK_F3, MP_KEY_F+3},
+    {VK_F4, MP_KEY_F+4}, {VK_F5, MP_KEY_F+5}, {VK_F6, MP_KEY_F+6},
+    {VK_F7, MP_KEY_F+7}, {VK_F8, MP_KEY_F+8}, {VK_F9, MP_KEY_F+9},
+    {VK_F10, MP_KEY_F+10}, {VK_F11, MP_KEY_F+11}, {VK_F12, MP_KEY_F+12},
+
+    // numpad with numlock
+    {VK_NUMPAD0, MP_KEY_KP0}, {VK_NUMPAD1, MP_KEY_KP1},
+    {VK_NUMPAD2, MP_KEY_KP2}, {VK_NUMPAD3, MP_KEY_KP3},
+    {VK_NUMPAD4, MP_KEY_KP4}, {VK_NUMPAD5, MP_KEY_KP5},
+    {VK_NUMPAD6, MP_KEY_KP6}, {VK_NUMPAD7, MP_KEY_KP7},
+    {VK_NUMPAD8, MP_KEY_KP8}, {VK_NUMPAD9, MP_KEY_KP9},
+    {VK_DECIMAL, MP_KEY_KPDEC},
+
+    // numpad without numlock
+    {VK_INSERT, MP_KEY_KPINS}, {VK_END, MP_KEY_KP1}, {VK_DOWN, MP_KEY_KP2},
+    {VK_NEXT, MP_KEY_KP3}, {VK_LEFT, MP_KEY_KP4}, {VK_CLEAR, MP_KEY_KP5},
+    {VK_RIGHT, MP_KEY_KP6}, {VK_HOME, MP_KEY_KP7}, {VK_UP, MP_KEY_KP8},
+    {VK_PRIOR, MP_KEY_KP9}, {VK_DELETE, MP_KEY_KPDEL},
 
     {0, 0}
 };
@@ -500,16 +520,27 @@ static bool translate_key_input(MSG *msg)
         msg->message != WM_KEYUP && msg->message != WM_SYSKEYUP)
         return false;
 
-    int mpkey = lookup_keymap_table(vk_map, msg->wParam);
+    bool ext = msg->lParam & (1 << 24);
 
-    if (mpkey) {
-        if (msg->message == WM_KEYDOWN || msg->message == WM_SYSKEYDOWN)
-            SendMessageW(msg->hwnd, MPM_PUTKEY, mpkey, 0);
+    // The extended flag is set for the navigation cluster and the arrow keys,
+    // so it can be used to differentiate between them and the numpad. The
+    // numpad enter key also has this flag set.
+    int mpkey = lookup_keymap_table(ext ? vk_map_ext : vk_map, msg->wParam);
 
-        return true;
-    }
+    // If we got the extended flag for a key we don't recognize, search the
+    // normal keymap before giving up
+    if (ext && !mpkey)
+        mpkey = lookup_keymap_table(vk_map, msg->wParam);
 
-    return false;
+    // Finally, if we really don't want the key, return false so
+    // TranslateMessage can convert it to Unicode
+    if (!mpkey)
+        return false;
+
+    if (msg->message == WM_KEYDOWN || msg->message == WM_SYSKEYDOWN)
+        SendMessageW(msg->hwnd, MPM_PUTKEY, mpkey, 0);
+
+    return true;
 }
 
 /**


### PR DESCRIPTION
This brings Windows keyboard input up to speed with the other platforms. Instead of treating the navigation keys on the numpad the same as the navigation cluster, it uses the enhanced/extended flag in lParam to tell them apart. [According to MSDN,](http://msdn.microsoft.com/en-us/library/windows/desktop/ms646280.aspx) the numpad navigation/arrow keys have the extended flag clear and the numpad enter key has the extended flag set.

VK_APPS was also missing, probably because of the confusing name (it's the menu key, VK_MENU is Alt.)

This slightly reorders the logic in `translate_key_input`, but it think it looks a little better, now that there are (potentially) two calls to `lookup_keymap_table`.
