### PR TITLE
Use the w32_common keymaps in terminal-win

### DIFF
--- a/old-makefile
+++ b/old-makefile
@@ -60,7 +60,8 @@ SOURCES-$(MPG123)               += audio/decode/ad_mpg123.c
 
 SOURCES-$(NEED_GETTIMEOFDAY)    += osdep/gettimeofday.c
 SOURCES-$(NEED_GLOB)            += osdep/glob-win.c
-SOURCES-$(WIN32)                += osdep/path-win.c
+SOURCES-$(WIN32)                += osdep/path-win.c \
+                                   osdep/w32_keyboard.c
 
 SOURCES-$(PRIORITY)             += osdep/priority.c
 SOURCES-$(PVR)                  += stream/stream_pvr.c

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -33,6 +33,7 @@
 #include "input/keycodes.h"
 #include "input/input.h"
 #include "terminal.h"
+#include "osdep/w32_keyboard.h"
 
 int screen_width = 79;
 int screen_height = 24;
@@ -121,52 +122,24 @@ static int getch2_internal(void)
     /*filter out keyevents*/
     for (i = 0; i < retval; i++) {
         switch (eventbuffer[i].EventType) {
-        case KEY_EVENT:
+        case KEY_EVENT: {
+            KEY_EVENT_RECORD *record = &eventbuffer[i].Event.KeyEvent;
+
             /*only a pressed key is interresting for us*/
-            if (eventbuffer[i].Event.KeyEvent.bKeyDown == TRUE) {
-                /*check for special keys*/
-                switch (eventbuffer[i].Event.KeyEvent.wVirtualKeyCode) {
-                case VK_HOME:
-                    return MP_KEY_HOME;
-                case VK_END:
-                    return MP_KEY_END;
-                case VK_DELETE:
-                    return MP_KEY_DEL;
-                case VK_INSERT:
-                    return MP_KEY_INS;
-                case VK_BACK:
-                    return MP_KEY_BS;
-                case VK_PRIOR:
-                    return MP_KEY_PGUP;
-                case VK_NEXT:
-                    return MP_KEY_PGDWN;
-                case VK_RETURN:
-                    return MP_KEY_ENTER;
-                case VK_ESCAPE:
-                    return MP_KEY_ESC;
-                case VK_LEFT:
-                    return MP_KEY_LEFT;
-                case VK_UP:
-                    return MP_KEY_UP;
-                case VK_RIGHT:
-                    return MP_KEY_RIGHT;
-                case VK_DOWN:
-                    return MP_KEY_DOWN;
-                case VK_SHIFT:
-                    continue;
-                }
-                /*check for function keys*/
-                if (0x87 >= eventbuffer[i].Event.KeyEvent.wVirtualKeyCode &&
-                    eventbuffer[i].Event.KeyEvent.wVirtualKeyCode >= 0x70)
-                    return MP_KEY_F + 1 +
-                           eventbuffer[i].Event.KeyEvent.wVirtualKeyCode - 0x70;
+            if (record->bKeyDown) {
+                UINT vkey = record->wVirtualKeyCode;
+                bool ext = record->dwControlKeyState & ENHANCED_KEY;
+
+                int mpkey = mp_w32_vkey_to_mpkey(vkey, ext);
+                if (mpkey)
+                    return mpkey;
 
                 /*only characters should be remaining*/
                 //printf("getch2: YOU PRESSED \"%c\" \n",eventbuffer[i].Event.KeyEvent.uChar.AsciiChar);
-                return eventbuffer[i].Event.KeyEvent.uChar.AsciiChar;
+                return eventbuffer[i].Event.KeyEvent.uChar.UnicodeChar;
             }
             break;
-
+        }
         case MOUSE_EVENT:
         case WINDOW_BUFFER_SIZE_EVENT:
         case FOCUS_EVENT:

--- a/osdep/w32_keyboard.c
+++ b/osdep/w32_keyboard.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <windows.h>
+#include "osdep/w32_keyboard.h"
+#include "input/keycodes.h"
+
+struct keymap {
+    int from;
+    int to;
+};
+
+static const struct keymap vk_map_ext[] = {
+    // cursor keys
+    {VK_LEFT, MP_KEY_LEFT}, {VK_UP, MP_KEY_UP}, {VK_RIGHT, MP_KEY_RIGHT},
+    {VK_DOWN, MP_KEY_DOWN},
+
+    // navigation block
+    {VK_INSERT, MP_KEY_INSERT}, {VK_DELETE, MP_KEY_DELETE},
+    {VK_HOME, MP_KEY_HOME}, {VK_END, MP_KEY_END}, {VK_PRIOR, MP_KEY_PAGE_UP},
+    {VK_NEXT, MP_KEY_PAGE_DOWN},
+
+    // numpad independent of numlock
+    {VK_RETURN, MP_KEY_KPENTER},
+
+    {0, 0}
+};
+
+static const struct keymap vk_map[] = {
+    // special keys
+    {VK_ESCAPE, MP_KEY_ESC}, {VK_BACK, MP_KEY_BS}, {VK_TAB, MP_KEY_TAB},
+    {VK_RETURN, MP_KEY_ENTER}, {VK_PAUSE, MP_KEY_PAUSE},
+    {VK_SNAPSHOT, MP_KEY_PRINT}, {VK_APPS, MP_KEY_MENU},
+
+    // F-keys
+    {VK_F1, MP_KEY_F+1}, {VK_F2, MP_KEY_F+2}, {VK_F3, MP_KEY_F+3},
+    {VK_F4, MP_KEY_F+4}, {VK_F5, MP_KEY_F+5}, {VK_F6, MP_KEY_F+6},
+    {VK_F7, MP_KEY_F+7}, {VK_F8, MP_KEY_F+8}, {VK_F9, MP_KEY_F+9},
+    {VK_F10, MP_KEY_F+10}, {VK_F11, MP_KEY_F+11}, {VK_F12, MP_KEY_F+12},
+
+    // numpad with numlock
+    {VK_NUMPAD0, MP_KEY_KP0}, {VK_NUMPAD1, MP_KEY_KP1},
+    {VK_NUMPAD2, MP_KEY_KP2}, {VK_NUMPAD3, MP_KEY_KP3},
+    {VK_NUMPAD4, MP_KEY_KP4}, {VK_NUMPAD5, MP_KEY_KP5},
+    {VK_NUMPAD6, MP_KEY_KP6}, {VK_NUMPAD7, MP_KEY_KP7},
+    {VK_NUMPAD8, MP_KEY_KP8}, {VK_NUMPAD9, MP_KEY_KP9},
+    {VK_DECIMAL, MP_KEY_KPDEC},
+
+    // numpad without numlock
+    {VK_INSERT, MP_KEY_KPINS}, {VK_END, MP_KEY_KP1}, {VK_DOWN, MP_KEY_KP2},
+    {VK_NEXT, MP_KEY_KP3}, {VK_LEFT, MP_KEY_KP4}, {VK_CLEAR, MP_KEY_KP5},
+    {VK_RIGHT, MP_KEY_KP6}, {VK_HOME, MP_KEY_KP7}, {VK_UP, MP_KEY_KP8},
+    {VK_PRIOR, MP_KEY_KP9}, {VK_DELETE, MP_KEY_KPDEL},
+
+    {0, 0}
+};
+
+static int lookup_keymap(const struct keymap *map, int key)
+{
+    while (map->from && map->from != key) map++;
+    return map->to;
+}
+
+int mp_w32_vkey_to_mpkey(UINT vkey, bool extended)
+{
+    // The extended flag is set for the navigation cluster and the arrow keys,
+    // so it can be used to differentiate between them and the numpad. The
+    // numpad enter key also has this flag set.
+    int mpkey = lookup_keymap(extended ? vk_map_ext : vk_map, vkey);
+
+    // If we got the extended flag for a key we don't recognize, search the
+    // normal keymap before giving up
+    if (extended && !mpkey)
+        mpkey = lookup_keymap(vk_map, vkey);
+
+    return mpkey;
+}

--- a/osdep/w32_keyboard.h
+++ b/osdep/w32_keyboard.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MP_W32_KEYBOARD
+#define MP_W32_KEYBOARD
+
+#include <stdbool.h>
+
+/* Convert a Windows virtual key code to an mpv key */
+int mp_w32_vkey_to_mpkey(UINT vkey, bool extended);
+
+#endif

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -33,6 +33,7 @@
 #include "aspect.h"
 #include "w32_common.h"
 #include "osdep/io.h"
+#include "osdep/w32_keyboard.h"
 #include "talloc.h"
 
 #define WIN_ID_TO_HWND(x) ((HWND)(intptr_t)(x))
@@ -41,51 +42,6 @@ static const wchar_t classname[] = L"mpv";
 
 enum mp_messages {
     MPM_PUTKEY = WM_USER,
-};
-
-static const struct mp_keymap vk_map_ext[] = {
-    // cursor keys
-    {VK_LEFT, MP_KEY_LEFT}, {VK_UP, MP_KEY_UP}, {VK_RIGHT, MP_KEY_RIGHT},
-    {VK_DOWN, MP_KEY_DOWN},
-
-    // navigation block
-    {VK_INSERT, MP_KEY_INSERT}, {VK_DELETE, MP_KEY_DELETE},
-    {VK_HOME, MP_KEY_HOME}, {VK_END, MP_KEY_END}, {VK_PRIOR, MP_KEY_PAGE_UP},
-    {VK_NEXT, MP_KEY_PAGE_DOWN},
-
-    // numpad independent of numlock
-    {VK_RETURN, MP_KEY_KPENTER},
-
-    {0, 0}
-};
-
-static const struct mp_keymap vk_map[] = {
-    // special keys
-    {VK_ESCAPE, MP_KEY_ESC}, {VK_BACK, MP_KEY_BS}, {VK_TAB, MP_KEY_TAB},
-    {VK_RETURN, MP_KEY_ENTER}, {VK_PAUSE, MP_KEY_PAUSE},
-    {VK_SNAPSHOT, MP_KEY_PRINT}, {VK_APPS, MP_KEY_MENU},
-
-    // F-keys
-    {VK_F1, MP_KEY_F+1}, {VK_F2, MP_KEY_F+2}, {VK_F3, MP_KEY_F+3},
-    {VK_F4, MP_KEY_F+4}, {VK_F5, MP_KEY_F+5}, {VK_F6, MP_KEY_F+6},
-    {VK_F7, MP_KEY_F+7}, {VK_F8, MP_KEY_F+8}, {VK_F9, MP_KEY_F+9},
-    {VK_F10, MP_KEY_F+10}, {VK_F11, MP_KEY_F+11}, {VK_F12, MP_KEY_F+12},
-
-    // numpad with numlock
-    {VK_NUMPAD0, MP_KEY_KP0}, {VK_NUMPAD1, MP_KEY_KP1},
-    {VK_NUMPAD2, MP_KEY_KP2}, {VK_NUMPAD3, MP_KEY_KP3},
-    {VK_NUMPAD4, MP_KEY_KP4}, {VK_NUMPAD5, MP_KEY_KP5},
-    {VK_NUMPAD6, MP_KEY_KP6}, {VK_NUMPAD7, MP_KEY_KP7},
-    {VK_NUMPAD8, MP_KEY_KP8}, {VK_NUMPAD9, MP_KEY_KP9},
-    {VK_DECIMAL, MP_KEY_KPDEC},
-
-    // numpad without numlock
-    {VK_INSERT, MP_KEY_KPINS}, {VK_END, MP_KEY_KP1}, {VK_DOWN, MP_KEY_KP2},
-    {VK_NEXT, MP_KEY_KP3}, {VK_LEFT, MP_KEY_KP4}, {VK_CLEAR, MP_KEY_KP5},
-    {VK_RIGHT, MP_KEY_KP6}, {VK_HOME, MP_KEY_KP7}, {VK_UP, MP_KEY_KP8},
-    {VK_PRIOR, MP_KEY_KP9}, {VK_DELETE, MP_KEY_KPDEL},
-
-    {0, 0}
 };
 
 typedef struct tagDropTarget {
@@ -520,20 +476,11 @@ static bool translate_key_input(MSG *msg)
         msg->message != WM_KEYUP && msg->message != WM_SYSKEYUP)
         return false;
 
-    bool ext = msg->lParam & (1 << 24);
+    bool ext = msg->lParam & KF_EXTENDED;
+    int mpkey = mp_w32_vkey_to_mpkey(msg->wParam, ext);
 
-    // The extended flag is set for the navigation cluster and the arrow keys,
-    // so it can be used to differentiate between them and the numpad. The
-    // numpad enter key also has this flag set.
-    int mpkey = lookup_keymap_table(ext ? vk_map_ext : vk_map, msg->wParam);
-
-    // If we got the extended flag for a key we don't recognize, search the
-    // normal keymap before giving up
-    if (ext && !mpkey)
-        mpkey = lookup_keymap_table(vk_map, msg->wParam);
-
-    // Finally, if we really don't want the key, return false so
-    // TranslateMessage can convert it to Unicode
+    // If we don't want the key, return false so TranslateMessage can convert
+    // it to Unicode
     if (!mpkey)
         return false;
 

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -378,6 +378,8 @@ def build(ctx):
         ( "osdep/path-win.c",                    "os-cygwin" ),
         ( "osdep/glob-win.c",                    "glob-win32-replacement" ),
         ( "osdep/priority.c",                    "priority" ),
+        ( "osdep/w32_keyboard.c",                "os-win32" ),
+        ( "osdep/w32_keyboard.c",                "os-cygwin" ),
         ( "osdep/mpv.rc",                        "win32-executable" ),
 
         ## tree_allocator


### PR DESCRIPTION
This should fix #476, and hopefully any other inconsistencies in how the terminal handles keystrokes, compared to how the video windows handle them.

It's a bit ugly, since `lookup_keymap_table` is in vo.c, so I had to copy it here. I'm not sure if there's a better solution, though maybe `lookup_keymap_table` and `mp_keymap` can be moved to input.h/c.
