### PR TITLE
cocoa: sort files opened from Finder the same way Finder does

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -264,7 +264,7 @@ Application *mpv_shared_app(void)
         }
     }];
 
-    self.files = [filesToOpen sortedArrayUsingSelector:@selector(compare:)];
+    self.files = [filesToOpen sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
     if (self.willStopOnOpenEvent) {
         self.willStopOnOpenEvent = NO;
         cocoa_stop_runloop();


### PR DESCRIPTION
This means if you have the files in Finder

```
3 - 9.mp4
3 - 10.mp4
```

and you select then click to open them using the mpv binary. They will played in the same order.
