### PR TITLE
vo_vdpau: ensure timestamps are correct

### DIFF
--- a/video/out/vo_vdpau.c
+++ b/video/out/vo_vdpau.c
@@ -176,6 +176,9 @@ static int change_vdptime_sync(struct vo *vo, int64_t *t)
             vdp_time -= (t2 - t1) * 1000ULL;
         else
             vdp_time = old;
+    } else if (!vdp_time) {
+        /* Some drivers do not return timestamps. */
+        vdp_time = old;
     }
     MP_DBG(vo, "adjusting VdpTime offset by %f µs\n",
            (int64_t)(vdp_time - old) / 1000.);


### PR DESCRIPTION
Make sure conversion to vdptime does not convert negative difference and
adjust last_queue_time when adjusting vdpau time.

Found with nouveau vdpau from mesa 10.0.2.
