### PR TITLE
GNU HURD doesn't define PATH_MAX which is referenced unconditionally

### DIFF
--- a/osdep/io.h
+++ b/osdep/io.h
@@ -94,7 +94,13 @@ char *mp_getenv(const char *name);
 
 #else /* __MINGW32__ */
 
+//GNU HURD doesn't define PATH_MAX
+//http://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html
+#ifdef PATH_MAX
 #define MP_PATH_MAX PATH_MAX
+#else
+#define MP_PATH_MAX 4096
+#endif 
 
 #define mp_stat(...) stat(__VA_ARGS__)
 


### PR DESCRIPTION
in osdep/io.h. This is apparently a common problem: see
http://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html.

Use an #ifdef to detect whether PATH_MAX is there and if not
arbitrarily use 4096 (like linux). It seems that PATH_MAX properly
shouldn't be used at all, but this should work for now.
