### PR TITLE
support mpv directory for config on Windows again

### DIFF
--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -59,7 +59,11 @@ char *mp_get_win_config_path(const char *filename)
         res = mp_path_join(NULL, bstr0(temp), bstr0(filename));
         if (!mp_path_exists(res) || mp_path_isdir(res)) {
             talloc_free(res);
-            res = NULL;
+            res = mp_path_join(NULL, bstr0(dir), bstr0(filename));
+            if (!mp_path_exists(res) || mp_path_isdir(res)) {
+                talloc_free(res);
+                res = NULL;
+            }
         }
     }
 


### PR DESCRIPTION
Same rationale as https://github.com/mpv-player/mpv/commit/b2c2fe7a3782c1c47ba3bee6481b0c2f8d41ef22 but updated to work with path-win.c
