### PR TITLE
Set subtitle resolution to video resolution when avctx->width and avctx->height are zeros.

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -91,6 +91,10 @@ static void get_resolution(struct sd *sd, int wh[2])
     struct sd_lavc_priv *priv = sd->priv;
     wh[0] = priv->avctx->width;
     wh[1] = priv->avctx->height;
+    if (wh[0] <= 0 || wh[1] <= 0) {
+        wh[0] = priv->video_params.w;
+        wh[1] = priv->video_params.h;
+    }
     guess_resolution(priv->avctx->codec_id, &wh[0], &wh[1]);
 }
 


### PR DESCRIPTION
Recently, I've got a report that a video file whose subtitle is not displayed in CMPlayer and mpv while mplayer shows it properly.
http://www.file-upload.net/download-8617894/00001.mkv.html
It's a HDres mkv file and with some debugging, I found that avctx in sd_lavc did not provide proper size.
When play the file, avctx->width and avctx->height are always set to zero, so guess_resolution() just sets the resolution to standrad DVD size because, of course, zero is smaller than 720.

This patch copies the video resolution to subtitle resolution when avctx does not include non-zero width/height. Although I'm not sure this is a ffmpeg bug or mpv bug, I think this solution(or workaround) is harmless and can fix the problem.
