### PR TITLE
Use the correct icon in the title bar

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -826,17 +826,14 @@ int vo_w32_init(struct vo *vo)
 
     HINSTANCE hInstance = GetModuleHandleW(NULL);
 
-    HICON mplayerIcon = LoadIconW(hInstance, L"IDI_ICON1");
-
     WNDCLASSEXW wcex = {
         .cbSize = sizeof wcex,
         .style = CS_OWNDC | CS_HREDRAW | CS_VREDRAW,
         .lpfnWndProc = WndProc,
         .hInstance = hInstance,
-        .hIcon = mplayerIcon,
+        .hIcon = LoadIconW(hInstance, L"IDI_ICON1"),
         .hCursor = LoadCursor(NULL, IDC_ARROW),
         .lpszClassName = classname,
-        .hIconSm = mplayerIcon,
     };
 
     if (!RegisterClassExW(&wcex)) {


### PR DESCRIPTION
I just noticed the video window uses the wrong icon on Windows. It loads the 32x32 icon and scales it down instead of using the 16x16 icon:
![icon-before](https://f.cloud.github.com/assets/162837/2180086/ea4cbffa-96f6-11e3-89a0-c5c164b04ddd.png)

If `hIconSm` is left unset on the window class, Windows will choose the correct size from `hIcon`:
![icon-after](https://f.cloud.github.com/assets/162837/2180087/ee03c53a-96f6-11e3-949a-28ebff9cce76.png)

It's a pretty small detail, but it's easy enough to fix :)
