### PR TITLE
Use the cache for remote files on Windows

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -39,6 +39,10 @@
 #include <sys/mount.h>
 #endif
 
+#ifdef __MINGW32__
+#include <windows.h>
+#endif
+
 struct priv {
     int fd;
     bool close;
@@ -125,6 +129,19 @@ static bool check_stream_network(stream_t *stream)
                 return true;
     return false;
 
+}
+#elif defined(__MINGW32__)
+static bool check_stream_network(stream_t *stream)
+{
+    wchar_t volume[MAX_PATH];
+    wchar_t *path = mp_from_utf8(NULL, stream->path);
+    bool remote = false;
+
+    if (GetVolumePathNameW(path, volume, MAX_PATH))
+        remote = GetDriveTypeW(volume) == DRIVE_REMOTE;
+
+    talloc_free(path);
+    return remote;
 }
 #else
 static bool check_stream_network(stream_t *stream)


### PR DESCRIPTION
A solution to #558 for Windows. It successfully activates the cache for me when playing files through a UNC path or a mapped network drive.
