### PR TITLE
Ignore modifiers when releasing keys

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -548,9 +548,9 @@ static void release_down_cmd(struct input_ctx *ictx, bool drop_current)
 
 static int find_key_down(struct input_ctx *ictx, int code)
 {
-    code &= ~(MP_KEY_STATE_UP | MP_KEY_STATE_DOWN);
+    code &= ~(MP_KEY_STATE_UP | MP_KEY_STATE_DOWN | MP_KEY_MODIFIER_MASK);
     for (int j = 0; j < ictx->num_key_down; j++) {
-        if (ictx->key_down[j] == code)
+        if ((ictx->key_down[j] & ~MP_KEY_MODIFIER_MASK) == code)
             return j;
     }
     return -1;


### PR DESCRIPTION
If a key is pressed with a modifier and then released without that modifier (ie. ctrl+mouse2 is pressed, ctrl is released, then mouse2 is released) mpv doesn't process the key release event correctly and it thinks that the original key (with modifier) is still pressed:

```
[input] key code=0x34a000a2 'Ctrl+MOUSE_BTN2' down
[input] key 'Ctrl+MOUSE_BTN2' -> 'seek 5' in 'default'
[input] key code=0x382000a2 'MOUSE_BTN2' up
[input] key code=0x61 'a'
[input] key 'Ctrl+MOUSE_BTN2-a' -> 'cycle angle' in 'default'
```

This is reproducible on Windows. I tested with Linux/X11, but it seems to send `MP_INPUT_RELEASE_ALL` on every key up event, so the issue didn't really affect anything.
