### PR TITLE
Specify the encode type for subtitles

### DIFF
--- a/etc/example.conf
+++ b/etc/example.conf
@@ -83,7 +83,7 @@
 # Play Finnish audio if available, fall back to English otherwise.
 #alang = fi,en
 
-# Specify the encode type for subtitles. For arabic subtitles use 'cp1256'.
+# Change subtitles encoding. For Arabic subtitles use 'cp1256'.
 #subcp=cp1256
 
 # Enable hardware decoding if available. Often, this requires using an certain


### PR DESCRIPTION
Specify the encode type for subtitles. For arabic subtitles use 'cp1256'.
