### PR TITLE
configure: fix typo

### DIFF
--- a/wscript
+++ b/wscript
@@ -11,7 +11,7 @@ from waftools.checks.custom import *
 build_options = [
     {
         'name': '--shared',
-        'desc': 'enable shared library',
+        'desc': 'shared library',
         'default': 'disable',
         'func': check_true
     }, {


### PR DESCRIPTION
When using help, the output for --enable-shared was :
`--enable-shared       enable enable shared library [disable]`
