### PR TITLE
vo_opengl: Add :icc-approx-gamma suboption to approximate BT.709 gamma

### DIFF
--- a/DOCS/man/en/vo.rst
+++ b/DOCS/man/en/vo.rst
@@ -462,6 +462,14 @@ Available video output drivers are:
         3
             absolute colorimetric (default)
 
+    ``icc-approx-gamma``
+        Approximate the actual BT.709 gamma function as a pure power curve of
+        1.95. This is not quite correct, but it was historically used as a
+        faster version of the actual function, and seems to still be used by
+        many video editing programs and perhaps even studios. If you find your
+        videos displaying ever so slightly slightly brighter than you'd expect
+        them to, try enabling this option.
+
     ``3dlut-size=<r>x<g>x<b>``
         Size of the 3D LUT generated from the ICC profile in each dimension.
         Default is 128x256x64.

--- a/video/out/gl_lcms.h
+++ b/video/out/gl_lcms.h
@@ -8,6 +8,7 @@ struct mp_icc_opts {
     char *cache;
     char *size_str;
     int intent;
+    int approx;
 };
 
 struct lut3d;


### PR DESCRIPTION
This uses the value of 1.95 as an approximation for the exact gamma
curve, which replicates the behavior of popular video software including
anything in the Apple ecosystem, as per issue #534.
