### PR TITLE
Fix broken libmpv property/option functions

### DIFF
--- a/options/m_property.c
+++ b/options/m_property.c
@@ -216,6 +216,8 @@ int m_property_do(struct mp_log *log, const m_option_t *prop_list,
         if ((r = do_action(prop_list, name, M_PROPERTY_SET_NODE, arg, ctx)) !=
             M_PROPERTY_NOT_IMPLEMENTED)
             return r;
+         if ((r = do_action(prop_list, name, M_PROPERTY_SET, &val, ctx)) <= 0)
+             return r;
         struct mpv_node *node = arg;
         int err = m_option_set_node(&opt, &val, node);
         if (err == M_OPT_UNKNOWN) {

--- a/player/client.c
+++ b/player/client.c
@@ -510,7 +510,7 @@ int mpv_set_option(mpv_handle *ctx, const char *name, mpv_format format,
     if (ctx->mpctx->initialized) {
         char prop[100];
         snprintf(prop, sizeof(prop), "options/%s", name);
-        int err = mpv_set_property(ctx, name, format, data);
+        int err = mpv_set_property(ctx, prop, format, data);
         switch (err) {
         case MPV_ERROR_PROPERTY_UNAVAILABLE:
         case MPV_ERROR_PROPERTY_ERROR:
@@ -725,7 +725,7 @@ int mpv_set_property(mpv_handle *ctx, const char *name, mpv_format format,
         .mpctx = ctx->mpctx,
         .name = name,
         .format = format,
-        .data = *(char **)data,
+        .data = data,
     };
     run_locked(ctx, setproperty_fn, &req);
     return req.status;
@@ -821,7 +821,8 @@ static void getproperty_fn(void *arg)
                 break;
             node.format = MPV_FORMAT_STRING;
             node.u.string = s;
-        }
+        } else if (err <= 0)
+            break;
         if (req->format == MPV_FORMAT_NODE) {
             *(struct mpv_node *)data = node;
         } else {


### PR DESCRIPTION
With changes around native property formats, libmpv's property functions are totally broken.
I think most of them are just oversights when change functionalities.
The order of next list corresponds to display order of file changes in github.
1. Cannot set property with native format: after fix 3., mpv_set_property always returns error. I found asymmetry between M_PROPERTY_SET_NODE/M_PROPERTY_GET_NODE and made a fix.
2. Cannot set option after initialized: it seems that this bug has existed since libmpv was introduced first. Maybe just a typo.
3. Crash when set property with native format: mpv_set_property just causes crash when native format is used. I found an invalid casting and fixed it.
4. Wrong error value for mpv_get_property: when an error occurred, mpv_get_property always returns wrong format error because every error for property except M_PROPERTY_NOT_IMPLEMENTED is just ignored.
