### PR TITLE
vo_opengl: Change the default icc-intent to relative colorimetric

### DIFF
--- a/DOCS/man/en/vo.rst
+++ b/DOCS/man/en/vo.rst
@@ -456,11 +456,11 @@ Available video output drivers are:
         0
             perceptual
         1
-            relative colorimetric
+            relative colorimetric (default)
         2
             saturation
         3
-            absolute colorimetric (default)
+            absolute colorimetric
 
     ``icc-approx-gamma``
         Approximate the actual BT.709 gamma function as a pure power curve of

--- a/video/out/gl_lcms.c
+++ b/video/out/gl_lcms.c
@@ -80,7 +80,7 @@ const struct m_sub_options mp_icc_conf = {
     .size = sizeof(struct mp_icc_opts),
     .defaults = &(const struct mp_icc_opts) {
         .size_str = "128x256x64",
-        .intent = INTENT_ABSOLUTE_COLORIMETRIC,
+        .intent = INTENT_RELATIVE_COLORIMETRIC,
     },
 };
 


### PR DESCRIPTION
This used to be absolute colorimetric, but relative colorimetric is a
saner default due to the arguments presented in issue #595.

A short summary: In general it doesn't affect much because our eyes
adapt to the white point either way, but if running in windowed mode it
would make the whites seem inconsistent/tinted. For fullscreen
projection it's also undesirable since it reduces the dynamic range
without much benefit (again, since our eyes adapt either way) and it
also breaks calibration against ambient lighting.

This shouldn't change much, since most profile types that aren't 3DLUTs
aren't capable of either of those transforms, and most displays are
calibrated against D65 (same as BT.709 source) either way.
