### PR TITLE
vo_opengl: Include :icc-approx-gamma option in the 3DLUT cache header

### DIFF
--- a/video/out/gl_lcms.c
+++ b/video/out/gl_lcms.c
@@ -129,8 +129,9 @@ struct lut3d *mp_load_icc(struct mp_icc_opts *opts, struct mp_log *log,
     if (!iccdata.len)
         goto error_exit;
 
-    char *cache_info = talloc_asprintf(tmp, "intent=%d, size=%dx%dx%d\n",
-                                       opts->intent, s_r, s_g, s_b);
+    char *cache_info =
+        talloc_asprintf(tmp, "intent=%d, size=%dx%dx%d, approx=%d\n",
+                        opts->intent, s_r, s_g, s_b, opts->approx);
 
     // check cache
     if (opts->cache) {


### PR DESCRIPTION
This makes sure the ICC cache is recomputed when the :icc-approx-gamma
option is changed, since it affects the output quite a lot.
