### PR TITLE
Allow accepting true/false and on/off for flag properties.

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -50,6 +50,24 @@
 #define OPTION_PATH_SEPARATOR ':'
 #endif
 
+static const char *true_flag_strings[] = {
+	"yes",
+	"true",
+	"on",
+	"enabled",
+	"1",
+	""
+};
+
+static const char *false_flag_strings[] = {
+	"no",
+	"false",
+	"off",
+	"disabled",
+	"0",
+	""
+};
+
 const char m_option_path_separator = OPTION_PATH_SEPARATOR;
 
 char *m_option_strerror(int code)
@@ -120,16 +138,34 @@ static int clamp_flag(const m_option_t *opt, void *val)
     return M_OPT_OUT_OF_RANGE;
 }
 
+static int flag_istrue(struct bstr flag) {
+	for(int i = 0; true_flag_strings[i][0] != '\0'; i++) {
+		if(!bstrcmp0(flag, true_flag_strings[i]))
+			return 1;
+	}
+
+	return 0;
+}
+
+static int flag_isfalse(struct bstr flag) {
+	for(int i = 0; false_flag_strings[i][0] != '\0'; i++) {
+		if(!bstrcmp0(flag, false_flag_strings[i]))
+			return 1;
+	}
+
+	return 0;
+}
+
 static int parse_flag(struct mp_log *log, const m_option_t *opt,
                       struct bstr name, struct bstr param, void *dst)
 {
     if (param.len) {
-        if (!bstrcmp0(param, "yes") || !bstrcmp0(param, "true") || !bstrcmp0(param, "on")) {
+        if (flag_istrue(param)) {
             if (dst)
                 VAL(dst) = opt->max;
             return 1;
         }
-        if (!bstrcmp0(param, "no") || !bstrcmp0(param, "false") || !bstrcmp0(param, "off")) {
+        if (flag_isfalse(param)) {
             if (dst)
                 VAL(dst) = opt->min;
             return 1;


### PR DESCRIPTION
I figured it'd be more intuitive to allow true/false as well as on/off
for flag properties in addition to yes/no, seeing as they're common
synonyms for boolean types and true/false was the first thing I tried
when messing with input.conf before looking up what the correct keywords
were.
