### PR TITLE
vo_opengl: Simplify, clarify and update color management

### DIFF
--- a/DOCS/man/en/vo.rst
+++ b/DOCS/man/en/vo.rst
@@ -317,18 +317,14 @@ Available video output drivers are:
             by very few OpenGL cards.
 
     ``srgb``
-        Enable gamma-correct scaling by working in linear light. This
-        makes use of sRGB textures and framebuffers.
-        This option forces the options ``indirect`` and ``gamma``.
+        Convert and color correct the output to sRGB before displaying it on
+        the screen. This option enables linear light scaling. It also forces
+        the options ``indirect`` and ``gamma``.
 
-        .. note::
-
-            for YUV colorspaces, gamma 1/0.45 (2.222) is assumed. RGB input is
-            always assumed to be in sRGB.
-
-        This option is not really useful, as gamma-correct scaling has not much
-        influence on typical video playback. Most visible effect comes from
-        slightly different gamma.
+        This option is equivalent to using ``icc-profile`` with an sRGB ICC
+        profile, but it is implemented without a 3DLUT and does not require
+        LittleCMS 2. If both ``srgb`` and ``icc-profile`` are present, the
+        latter takes precedence, as they are somewhat redundant.
 
     ``pbo``
         Enable use of PBOs. This is slightly faster, but can sometimes lead to
@@ -449,7 +445,9 @@ Available video output drivers are:
 
     ``icc-profile=<file>``
         Load an ICC profile and use it to transform linear RGB to screen output.
-        Needs LittleCMS2 support compiled in.
+        Needs LittleCMS2 support compiled in. This option overrides the ``srgb``
+        property, as using both is somewhat redundant. It also enables linear
+        light scaling.
 
     ``icc-cache=<file>``
         Store and load the 3D LUT created from the ICC profile in this file.
@@ -467,13 +465,15 @@ Available video output drivers are:
         3
             absolute colorimetric
 
-    ``icc-approx-gamma``
+    ``approx-gamma``
         Approximate the actual BT.709 gamma function as a pure power curve of
         1.95. A number of video editing programs and studios apparently use this
         for mastering instead of the true curve. Most notably, anything in the
         Apple ecosystem uses this approximation - including all programs
         compatible with it. It's a sound idea to try enabling this flag first
         when watching movies and shows to see if things look better that way.
+
+        This only affects the output when using either ``icc-profile`` or``srgb``.
 
     ``3dlut-size=<r>x<g>x<b>``
         Size of the 3D LUT generated from the ICC profile in each dimension.

--- a/video/out/gl_lcms.h
+++ b/video/out/gl_lcms.h
@@ -8,7 +8,6 @@ struct mp_icc_opts {
     char *cache;
     char *size_str;
     int intent;
-    int approx;
 };
 
 struct lut3d;

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -33,6 +33,7 @@ struct gl_video_opts {
     int indirect;
     float gamma;
     int srgb;
+    int approx_gamma;
     int scale_sep;
     int fancy_downscaling;
     int scaler_resizes_only;


### PR DESCRIPTION
This commit:
- Changes some of the variable names for clarification and adds comments
  where appropriate
- Unifies :srgb and :icc-profile, making them fit into the same step of
  the decoding process and removing the weird interactions between both
  of them.
- Makes :srgb and :icc-profile mutually exclusive. When both are used, a
  warning is shown and :icc-profile takes precedence.
- Moves BT709 decompanding (approximate or actual) to the shader in all
  cases, making it happen before upscaling (instead of the old 0.45
  gamma function). This is the simpler and more proper way to do it.
- Enables the approx gamma function to work with :srgb as well as with
  :icc-profile as a result of these changes (since they share the gamma
  expansion code now).
- Renames :icc-approx-gamma to :approx-gamma since it is no longer tied
  to the ICC options or LittleCMS.
- Uses gamma 2.4 as input space for the actual 3DLUT, this is now a
  pretty arbitrary factor but I picked 2.4 mainly because a higher pure
  power value here seems to produce visually better results with wide
  gamut profiles, rather than the previous 1.95 or BT.709.
- Adds the input gamma curve to the 3dlut cache header in case we change
  it more in the future, or even make it user customizable (though I
  don't see why the latter would really be necessary)
- Fixes the OSD's gamma when using :srgb, which was previously using the
  old (0.45) approximation in all cases.
- Updates documentation on :srgb and :icc-profile and :approx-gamma to
  reflect their new usage and behavior. In particular, :srgb was still
  referencing behavior from over a year ago.
- Updates gl_check_features to check for the presence of the correct
  extensions, up to date with the new :srgb and :icc-profile feature
  dependencies.

This commit should serve to make the CMS code somewhat more accessible
and less confusing/error-prone, and simultaneously also improve the
appearance of 3DLUTs with wide gamut color spaces. It might also
positively impact performance when using :srgb due to less intermediate
conversion steps.

I would have liked to make it more modular but almost all of these
changes are interdependent, save for the documentation updates.

Note: I'm not sure how well this works together with real-world
subtitles that may need to be color corrected as well. I'm not sure
whether :approx-gamma needs to apply to subtitles as well. I'll need to
test this on proper files later.
