### PR TITLE
Check ALSA PCM state before pause and resume.

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -565,9 +565,11 @@ static void audio_pause(struct ao *ao)
     int err;
 
     if (p->can_pause) {
-        p->delay_before_pause = get_delay(ao);
-        err = snd_pcm_pause(p->alsa, 1);
-        CHECK_ALSA_ERROR("pcm pause error");
+        if (snd_pcm_state(p->alsa) == SND_PCM_STATE_RUNNING) {
+            p->delay_before_pause = get_delay(ao);
+            err = snd_pcm_pause(p->alsa, 1);
+            CHECK_ALSA_ERROR("pcm pause error");
+        }
     } else {
         MP_VERBOSE(ao, "pause not supported by hardware\n");
         if (snd_pcm_delay(p->alsa, &p->prepause_frames) < 0
@@ -595,8 +597,10 @@ static void audio_resume(struct ao *ao)
     }
 
     if (p->can_pause) {
-        err = snd_pcm_pause(p->alsa, 0);
-        CHECK_ALSA_ERROR("pcm resume error");
+        if (snd_pcm_state(p->alsa) == SND_PCM_STATE_PAUSED) {
+            err = snd_pcm_pause(p->alsa, 0);
+            CHECK_ALSA_ERROR("pcm resume error");
+        }
     } else {
         MP_VERBOSE(ao, "resume not supported by hardware\n");
         err = snd_pcm_prepare(p->alsa);


### PR DESCRIPTION
It is possible to have ao->reset() called between ao->pause() and
ao->resume() when seeking during the pause. If the underlying PCM
supports pausing, resuming an already reset PCM will produce an error.
Avoid that by explicitly checking PCM state before calling
snd_pcm_pause().
