### PR TITLE
stream_file: network file system detection for Linux

### DIFF
--- a/wscript
+++ b/wscript
@@ -202,6 +202,11 @@ iconv support use --disable-iconv.",
         'func': check_statement(['sys/param.h', 'sys/mount.h'],
                                 'struct statfs fs; fstatfs(0, &fs)')
     }, {
+        'name': 'linux-fstatfs',
+        'desc': "Linux's fstatfs()",
+        'func': check_statement('sys/vfs.h',
+                                'struct statfs fs; fstatfs(0, &fs); fs.f_namelen')
+    }, {
         'name': 'sys-sysinfo-h',
         'desc': 'sys/sysinfo.h',
         'func': check_statement('sys/sysinfo.h',


### PR DESCRIPTION
Addresses issue #558 on Linux systems.

It looks pretty ugly, I know, but I looked around for a while and couldn't find a better way to do it. This is how it's done in coreutils (and this is basically the inverse of is_local_fs_type there).
