### PR TITLE
build: fix version in mpv.pc

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -458,7 +458,7 @@ def build(ctx):
             PREFIX       = ctx.env.PREFIX,
             LIBDIR       = ctx.env.LIBDIR,
             INCDIR       = ctx.env.INCDIR,
-            vnum         = "0.0.0",
+            VERSION      = ctx.env.VERSION,
         )
 
         headers = ["client.h"]


### PR DESCRIPTION
This is a follow-up to #629 that fixes the version exported to the pc file.
