### PR TITLE
Fix WAF & unicode issue.

### DIFF
--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -6,7 +6,7 @@ def __get_version__(ctx):
                                cwd=ctx.srcnode.abspath())
     process.wait()
     (version, err) = process.communicate()
-    return version.strip().decode("utf-8")
+    return version.strip().decode('utf-8').encode('ascii', 'ignore')
 
 def __get_build_date__():
     import time


### PR DESCRIPTION
As per https://code.google.com/p/waf/issues/detail?id=1420, WAF does not play nice with unicode.
This directly fixes the "CFVersion" key in the .app bundle plist, which currently gets mangled.

(I assume the existing explicit conversion to the unicode type was somehow necessary, which is why I went for ".decode('utf-8').encode('ascii', 'ignore')" instead of just deleting ".decode('utf-8')")
