### PR TITLE
stream_dvd/stream_dvdnav: make disc-title for DVDs start from 0

### DIFF
--- a/stream/stream_dvd.c
+++ b/stream/stream_dvd.c
@@ -749,7 +749,7 @@ static int open_s(stream_t *stream, int mode)
   dvd_priv_t *d = stream->priv;
 
   MP_VERBOSE(stream, "URL: %s\n", stream->url);
-  dvd_title = d->cfg_title+1;
+  dvd_title = d->cfg_title + 1;
   if(1){
     //int ret,ret2;
     int ttn,pgc_id,pgn;

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -712,7 +712,7 @@ static int open_s(stream_t *stream, int mode)
 
     if (p->track >= 0) {
         priv->title = p->track;
-        if (dvdnav_title_play(priv->dvdnav, p->track+1) != DVDNAV_STATUS_OK) {
+        if (dvdnav_title_play(priv->dvdnav, p->track + 1) != DVDNAV_STATUS_OK) {
             MP_FATAL(stream, "dvdnav_stream, couldn't select title %d, error '%s'\n",
                    p->track, dvdnav_err_to_string(priv->dvdnav));
             return STREAM_UNSUPPORTED;


### PR DESCRIPTION
This commit makes 'disc-title' properties for DVDs start from 0.
There was an inconsistency around 'disc-title' property between DVDs (from 1) and Blu-rays (from 0).
This fixes #648.
