### PR TITLE
command: make 'disc-title' property writable

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -436,7 +436,7 @@ static int mp_property_playtime_remaining(m_option_t *prop, int action,
     return property_time(prop, action, arg, remaining / speed);
 }
 
-/// Current BD/DVD title (RO)
+/// Current BD/DVD title (RW)
 static int mp_property_disc_title(m_option_t *prop, int action, void *arg,
                                  MPContext *mpctx)
 {
@@ -449,7 +449,13 @@ static int mp_property_disc_title(m_option_t *prop, int action, void *arg,
     case M_PROPERTY_GET:
         if (stream_control(stream, STREAM_CTRL_GET_CURRENT_TITLE, &title) <= 0)
             return M_PROPERTY_UNAVAILABLE;
-        return m_property_int_ro(prop, action, arg, title);
+        *(int*)arg = title;
+        return M_PROPERTY_OK;
+    case M_PROPERTY_SET:
+        title = *(int*)arg;
+        if (stream_control(stream, STREAM_CTRL_SET_CURRENT_TITLE, &title) <= 0)
+            return M_PROPERTY_NOT_IMPLEMENTED;
+        return M_PROPERTY_OK;
     default:
         return M_PROPERTY_NOT_IMPLEMENTED;
     }

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -143,7 +143,14 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
         }
         return STREAM_ERROR;
     }
-
+    case STREAM_CTRL_SET_CURRENT_TITLE: {
+        const uint32_t title = *((unsigned int*)arg);
+        if (title < b->num_titles && bd_select_title(b->bd, title)) {
+            b->current_title = title;
+            return STREAM_OK;
+        }
+        return STREAM_ERROR;
+    }
     case STREAM_CTRL_GET_CURRENT_TITLE: {
         *((unsigned int *) arg) = b->current_title;
         return 1;


### PR DESCRIPTION
This commit makes 'disc-title' property writable using STREAM_CTRL_SET_CURRENT_TITLE.
This commit also contains implementation of STREAM_CTRL_SET_CURRENT_TITLE for stream_bluray.
Currently, 'disc-title' is writable for stream_dvdnav and stream_bluray and stream_dvd is not supported.

I couldn't find the way to implement STREAM_CTRL_SET_CURRENT_TITLE for stream_dvd.
