### PR TITLE
stream_bluray: fix for significant memory leak

### DIFF
--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -196,6 +196,7 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
             return STREAM_UNSUPPORTED;
 
         *((double *) arg) = BD_TIME_TO_MP(ti->duration);
+        bd_free_title_info(ti);
         return STREAM_OK;
     }
 


### PR DESCRIPTION
It's obvious but, since STREAM_CTRL_GET_TIME_LENGTH is called frequently, the amount of leaked memory here is quite big.
