### PR TITLE
encode_lavc: copy metadata to output file

### DIFF
--- a/common/encode.h
+++ b/common/encode.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+#include "demux/demux.h"
+
 struct mpv_global;
 struct mp_log;
 struct encode_lavc_context;
@@ -17,6 +19,8 @@ void encode_lavc_discontinuity(struct encode_lavc_context *ctx);
 bool encode_lavc_showhelp(struct mp_log *log, struct encode_output_conf *options);
 int encode_lavc_getstatus(struct encode_lavc_context *ctx, char *buf, int bufsize, float relative_position);
 void encode_lavc_expect_stream(struct encode_lavc_context *ctx, int mt);
+void encode_lavc_set_metadata(struct encode_lavc_context *ctx,
+                              struct mp_tags *metadata);
 void encode_lavc_set_video_fps(struct encode_lavc_context *ctx, float fps);
 void encode_lavc_set_audio_pts(struct encode_lavc_context *ctx, double pts);
 bool encode_lavc_didfail(struct encode_lavc_context *ctx); // check if encoding failed

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -244,6 +244,12 @@ struct encode_lavc_context *encode_lavc_init(struct encode_output_conf *options,
     return ctx;
 }
 
+void encode_lavc_set_metadata(struct encode_lavc_context *ctx,
+                              struct mp_tags *metadata)
+{
+    ctx->metadata = metadata;
+}
+
 int encode_lavc_start(struct encode_lavc_context *ctx)
 {
     AVDictionaryEntry *de;
@@ -295,6 +301,12 @@ int encode_lavc_start(struct encode_lavc_context *ctx)
 
     MP_INFO(ctx, "Opening muxer: %s [%s]\n",
             ctx->avc->oformat->long_name, ctx->avc->oformat->name);
+
+    if (ctx->metadata) {
+        for (int i = 0; i < ctx->metadata->num_keys; i++)
+            av_dict_set(&ctx->avc->metadata,
+                ctx->metadata->keys[i], ctx->metadata->values[i], 0);
+    }
 
     if (avformat_write_header(ctx->avc, &ctx->foptions) < 0) {
         encode_lavc_fail(ctx, "could not write header\n");

--- a/common/encode_lavc.h
+++ b/common/encode_lavc.h
@@ -38,6 +38,7 @@ struct encode_lavc_context {
     struct mpv_global *global;
     struct encode_output_conf *options;
     struct mp_log *log;
+    struct mp_tags *metadata;
 
     // All entry points must be guarded with the lock. Functions called by
     // the playback core lock this automatically, but ao_lavc.c and vo_lavc.c

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1272,6 +1272,9 @@ goto_reopen_demuxer: ;
         encode_lavc_expect_stream(mpctx->encode_lavc_ctx, AVMEDIA_TYPE_VIDEO);
     if (mpctx->encode_lavc_ctx && mpctx->current_track[0][STREAM_AUDIO])
         encode_lavc_expect_stream(mpctx->encode_lavc_ctx, AVMEDIA_TYPE_AUDIO);
+    if (mpctx->encode_lavc_ctx)
+        encode_lavc_set_metadata(mpctx->encode_lavc_ctx,
+                                 mpctx->demuxer->metadata);
 #endif
 
     reinit_video_chain(mpctx);


### PR DESCRIPTION
As per #684. I'm not sure if this is the best way to do this though, but it seems to work (I've only tried with audio files though).

A nice followup could be adding a "--metadata" option to make it possible for users to set custom metadata, but I don't need this so I left it out for now.
