### PR TITLE
wayland: don't schedule resize if going fullscreen

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1120,7 +1120,6 @@ int vo_wayland_control (struct vo *vo, int *events, int request, void *arg)
         return VO_TRUE;
     case VOCTRL_FULLSCREEN:
         vo_wayland_fullscreen(vo);
-        *events |= VO_EVENT_RESIZE;
         return VO_TRUE;
     case VOCTRL_ONTOP:
         vo_wayland_ontop(vo);


### PR DESCRIPTION
mpv was resizing to the same size before it went to fullscreen, we don't need to schedule a resize because the compositor will send a configure event with the new dimentions and thats when we should do it.
