### PR TITLE
Implement 3 new properties

### DIFF
--- a/DOCS/man/en/input.rst
+++ b/DOCS/man/en/input.rst
@@ -602,6 +602,14 @@ Property list
     Last A/V synchronization difference. Unavailable if audio or video is
     disabled.
 
+``total-avsync-change``
+    Total A-V sync correction done. Unavailable if audio or video is
+    disabled.
+
+``drop-frame-count``
+    Frames dropped because they arrived to late. Unavailable if video
+    is disabled
+
 ``percent-pos`` (RW)
     Position in current file (0-100). The advantage over using this instead of
     calculating it out of other properties is that it properly falls back to
@@ -749,6 +757,9 @@ Property list
     old cache is still allocated.
 
     Don't use this when playing DVD or Bluray.
+
+``paused-for-cache``
+    Returns ``yes`` when playback is paused because of waiting for the cache.
 
 ``pts-association-mode`` (RW)
     See ``--pts-association-mode``.

--- a/player/command.c
+++ b/player/command.c
@@ -355,6 +355,27 @@ static int mp_property_avsync(m_option_t *prop, int action, void *arg,
     return m_property_double_ro(prop, action, arg, mpctx->last_av_difference);
 }
 
+static int mp_property_total_avsync_change(m_option_t *prop, int action, void *arg,
+                              MPContext *mpctx)
+{
+    if (!mpctx->d_audio || !mpctx->d_video)
+        return M_PROPERTY_UNAVAILABLE;
+    if (mpctx->total_avsync_change == MP_NOPTS_VALUE)
+        return M_PROPERTY_UNAVAILABLE;
+    return m_property_double_ro(prop, action, arg, mpctx->total_avsync_change);
+}
+
+
+/// Late frames
+static int mp_property_drop_frame_cnt(m_option_t *prop, int action, void *arg,
+                                   MPContext *mpctx)
+{
+     if (!mpctx->d_video)
+        return M_PROPERTY_UNAVAILABLE;
+
+    return m_property_int_ro(prop, action, arg, mpctx->drop_frame_cnt);
+}
+
 /// Current position in percent (RW)
 static int mp_property_percent_pos(m_option_t *prop, int action,
                                    void *arg, MPContext *mpctx)
@@ -965,6 +986,12 @@ static int mp_property_cache_size(m_option_t *prop, int action, void *arg,
     }
     }
     return M_PROPERTY_NOT_IMPLEMENTED;
+}
+
+static int mp_property_paused_for_cache(m_option_t *prop, int action, void *arg,
+                            MPContext *mpctx)
+{
+    return m_property_int_ro(prop, action, arg, mpctx->paused_for_cache);
 }
 
 static int mp_property_clock(m_option_t *prop, int action, void *arg,
@@ -2155,6 +2182,10 @@ static const m_option_t mp_properties[] = {
     { "length", mp_property_length, CONF_TYPE_TIME,
       M_OPT_MIN, 0, 0, NULL },
     { "avsync", mp_property_avsync, CONF_TYPE_DOUBLE },
+    { "total-avsync-change", mp_property_total_avsync_change,
+      CONF_TYPE_DOUBLE },
+    { "drop-frame-count", mp_property_drop_frame_cnt, CONF_TYPE_INT,
+      0, 0, 0, NULL },
     { "percent-pos", mp_property_percent_pos, CONF_TYPE_DOUBLE,
       M_OPT_RANGE, 0, 100, NULL },
     { "time-start", mp_property_time_start, CONF_TYPE_TIME,
@@ -2179,6 +2210,8 @@ static const m_option_t mp_properties[] = {
     M_OPTION_PROPERTY_CUSTOM("pause", mp_property_pause),
     { "cache", mp_property_cache, CONF_TYPE_INT },
     { "cache-size", mp_property_cache_size, CONF_TYPE_INT, M_OPT_MIN, 0 },
+    { "paused-for-cache", mp_property_paused_for_cache, CONF_TYPE_FLAG,
+      M_OPT_RANGE, 0, 1, NULL },
     M_OPTION_PROPERTY("pts-association-mode"),
     M_OPTION_PROPERTY("hr-seek"),
     { "clock", mp_property_clock, CONF_TYPE_STRING,


### PR DESCRIPTION
implements paused-for-cache, total-avsync-change and drop-frame-cnt properties

This is needed if you want to reimplement the status line in lua

I could only test drop-frame-cnt because I didn't find an easy way to
trigger paused-for-cache and total-avsync-change
