### PR TITLE
Revamp Windows keyboard input

### DIFF
--- a/video/out/w32_common.h
+++ b/video/out/w32_common.h
@@ -55,6 +55,9 @@ struct vo_w32_state {
 
     int mouse_x;
     int mouse_y;
+
+    // UTF-16 decoding state for WM_CHAR and VK_PACKET
+    int high_surrogate;
 };
 
 struct vo;


### PR DESCRIPTION
This changes w32_common to call ToUnicode directly instead of relying on TranslateMessage, which gives mpv much more flexibility over how keyboard input is converted to unicode. As a result:
- Key up/down events are sent for all keys.
- Ctrl+_number_, Ctrl+_punctuation_ and Ctrl+Alt+_letter_ bindings work (they were broken before.)
- Dead keys produce their base character, so they can be bound as well.
- Normal, non-shifted characters are generated when `--no-right-alt-gr` is set, like in OS X.
- The translate_key_input/MP_PUTKEY hack can be removed.
- The hack in the WM_CHAR handler to translate control characters to normal characters can be removed.

[mintty](https://code.google.com/p/mintty/source/browse/trunk/wininput.c) uses ToUnicode instead of TranslateMessage for similar reasons.

To simplify the implementation and to match the behaviour of other VOs, it sends a RELEASE_ALL on keyup instead of trying to figure out which keys were released, although these changes should make it easier to relate keyup events with their corresponding keydown events if it ever becomes necessary.

Additionally, this adds proper UTF-16 decoding. I don't think there are any real Windows keyboard layouts that use supplementary plane characters yet, but it works for the Win8 touch emoji keyboard.

One potential disadvantage of this change is that input commands can no longer be bound to dead key combinations, since for example, pressing '^' and 'A' on a US international keyboard will generate '^' and 'a', not 'â'. I'm not sure what kind of impact this change will make, since I don't use a keyboard layout with dead keys, but I doubt such bindings are in common use, and it frees up the base key '^' to be used instead.
