### PR TITLE
Disable --keep-open when encoding

### DIFF
--- a/player/main.c
+++ b/player/main.c
@@ -393,6 +393,7 @@ int mp_initialize(struct MPContext *mpctx)
         m_config_set_option0(mpctx->mconfig, "vo", "lavc");
         m_config_set_option0(mpctx->mconfig, "ao", "lavc");
         m_config_set_option0(mpctx->mconfig, "fixed-vo", "yes");
+        m_config_set_option0(mpctx->mconfig, "keep-open", "no");
         m_config_set_option0(mpctx->mconfig, "force-window", "no");
         m_config_set_option0(mpctx->mconfig, "gapless-audio", "yes");
         mp_input_enable_section(mpctx->input, "encode", MP_INPUT_EXCLUSIVE);


### PR DESCRIPTION
keep-open doesn't seem useful for encoding. All my scripts have to start with `--no-keep-open`.

I wonder if it's worth adding any other options (hr-seek or demuxer-mkv-subtitle-preroll?)
