### PR TITLE
terminal: Don't print header for blank lines

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -268,7 +268,7 @@ static void print_msg_on_terminal(struct mp_log *log, int lev, char *text)
         set_msg_color(stream, lev);
 
     do {
-        if (header) {
+        if (header && text[0] != '\n') {
             if (root->show_time)
                 fprintf(stream, "[%" PRId64 "] ", mp_time_us());
 


### PR DESCRIPTION
When there is only a newline character to print don't include the header (prefix and/or timestamp).

So instead of looking like this:

```
   cplayer: Playing: Horzi & Alchemiist - Reckoning Fear [16bit Master].wav
     demux: Detected file format: WAV / WAVE (Waveform Audio) (libavformat)
     demux: File tags:
     demux:  title: horzi & alchemiist_uusi polkka_2
     demux:  encoder: FL Studio 7
   cplayer: [stream] Audio (+) --aid=1 (pcm_s16le)
   cplayer: Video: no video
        ad: Selected audio codec: PCM signed 16-bit little-endian [lavc:pcm_s16le]
   cplayer: AO: [pulse] 44100Hz stereo 2ch s16
statusline: A: 00:00:03 / 00:07:57 (0%)
   cplayer:
   cplayer:
   cplayer: Exiting... (Quit)
```

It will look like this

```
   cplayer: Playing: Horzi & Alchemiist - Reckoning Fear [16bit Master].wav
     demux: Detected file format: WAV / WAVE (Waveform Audio) (libavformat)
     demux: File tags:
     demux:  title: horzi & alchemiist_uusi polkka_2
     demux:  encoder: FL Studio 7
   cplayer: [stream] Audio (+) --aid=1 (pcm_s16le)
   cplayer: Video: no video
        ad: Selected audio codec: PCM signed 16-bit little-endian [lavc:pcm_s16le]
   cplayer: AO: [pulse] 44100Hz stereo 2ch s16
statusline: A: 00:00:03 / 00:07:57 (0%)


   cplayer: Exiting... (Quit)
```
