### PR TITLE
build: bump required libpostproc version

### DIFF
--- a/wscript
+++ b/wscript
@@ -380,7 +380,7 @@ Libav libraries ({0}). Aborting.".format(" ".join(libav_pkg_config_checks))
     }, {
         'name': '--libpostproc',
         'desc': 'libpostproc',
-        'func': check_pkg_config('libpostproc', '>= 52.0.0'),
+        'func': check_pkg_config('libpostproc', '>= 52.2.100'),
     }, {
         'name': 'avcodec-metadata-update-side-data',
         'desc': 'libavcodec AV_PKT_DATA_METADATA_UPDATE side data type',


### PR DESCRIPTION
The CPU autodetect feature was added in 52.2.100 and is lacking from the
stand-alone version at http://git.videolan.org/?p=libpostproc.git
