### PR TITLE
Fix breaking in C99 compilers.

### DIFF
--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -192,7 +192,7 @@ void mp_ass_render_frame(ASS_Renderer *renderer, ASS_Track *track, double time,
         struct sub_bitmap *p = &res->parts[res->num_parts];
         p->bitmap = img->bitmap;
         p->stride = img->stride;
-        p->libass.color = img->color;
+        p->data.libass.color = img->color;
         p->dw = p->w = img->w;
         p->dh = p->h = img->h;
         p->x = img->dst_x;

--- a/sub/draw_bmp.c
+++ b/sub/draw_bmp.c
@@ -300,10 +300,10 @@ static void draw_ass(struct mp_draw_sub_cache *cache, struct mp_rect bb,
         if (!get_sub_area(bb, temp, sb, &dst, &src_x, &src_y))
             continue;
 
-        int r = (sb->libass.color >> 24) & 0xFF;
-        int g = (sb->libass.color >> 16) & 0xFF;
-        int b = (sb->libass.color >> 8) & 0xFF;
-        int a = 255 - (sb->libass.color & 0xFF);
+        int r = (sb->data.libass.color >> 24) & 0xFF;
+        int g = (sb->data.libass.color >> 16) & 0xFF;
+        int b = (sb->data.libass.color >> 8) & 0xFF;
+        int a = 255 - (sb->data.libass.color & 0xFF);
         int color_yuv[3] = {r, g, b};
         if (dst.flags & MP_IMGFLAG_YUV) {
             mp_map_int_color(rgb2yuv, bits, color_yuv);

--- a/sub/img_convert.c
+++ b/sub/img_convert.c
@@ -300,7 +300,7 @@ bool osd_conv_ass_to_rgba(struct osd_conv_cache *c, struct sub_bitmaps *imgs)
             draw_ass_rgba(s->bitmap, s->w, s->h, s->stride,
                           bmp->bitmap, bmp->stride,
                           s->x - bb.x0, s->y - bb.y0,
-                          s->libass.color);
+                          s->data.libass.color);
         }
     }
 

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -56,7 +56,7 @@ struct sub_bitmap {
         struct {
             uint32_t color;
         } libass;
-    };
+    } data;
 };
 
 struct sub_bitmaps {

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -442,7 +442,7 @@ static void mangle_colors(struct sd *sd, struct sub_bitmaps *parts)
 
     for (int n = 0; n < parts->num_parts; n++) {
         struct sub_bitmap *sb = &parts->parts[n];
-        uint32_t color = sb->libass.color;
+        uint32_t color = sb->data.libass.color;
         int r = (color >> 24u) & 0xff;
         int g = (color >> 16u) & 0xff;
         int b = (color >>  8u) & 0xff;
@@ -450,6 +450,6 @@ static void mangle_colors(struct sd *sd, struct sub_bitmaps *parts)
         int c[3] = {r, g, b};
         mp_map_int_color(vs_rgb2yuv, 8, c);
         mp_map_int_color(vs2rgb, 8, c);
-        sb->libass.color = (c[0] << 24u) | (c[1] << 16) | (c[2] << 8) | a;
+        sb->data.libass.color = (c[0] << 24u) | (c[1] << 16) | (c[2] << 8) | a;
     }
 }

--- a/video/out/gl_osd.c
+++ b/video/out/gl_osd.c
@@ -325,7 +325,7 @@ static void draw_legacy_cb(void *pctx, struct sub_bitmaps *imgs)
             struct pos p = osd->packer->result[n];
 
             uint32_t c = imgs->format == SUBBITMAP_LIBASS
-                         ? b->libass.color : 0xFFFFFF00;
+                         ? b->data.libass.color : 0xFFFFFF00;
             uint8_t color[4] = { c >> 24, (c >> 16) & 0xff,
                                  (c >> 8) & 0xff, 255 - (c & 0xff) };
 

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -1810,7 +1810,7 @@ static void draw_osd_cb(void *ctx, struct mpgl_osd_part *osd,
 
             // NOTE: the blend color is used with SUBBITMAP_LIBASS only, so it
             //       doesn't matter that we upload garbage for the other formats
-            uint32_t c = b->libass.color;
+            uint32_t c = b->data.libass.color;
             uint8_t color[4] = { c >> 24, (c >> 16) & 0xff,
                                 (c >> 8) & 0xff, 255 - (c & 0xff) };
 

--- a/video/out/vo_direct3d.c
+++ b/video/out/vo_direct3d.c
@@ -1622,7 +1622,7 @@ static void draw_osd_cb(void *ctx, struct sub_bitmaps *imgs)
             struct pos p = osd->packer->result[n];
 
             D3DCOLOR color = imgs->format == SUBBITMAP_LIBASS
-                             ? ass_to_d3d_color(b->libass.color)
+                             ? ass_to_d3d_color(b->data.libass.color)
                              : D3DCOLOR_ARGB(255, 255, 255, 255);
 
             float x0 = b->x;

--- a/video/out/vo_vdpau.c
+++ b/video/out/vo_vdpau.c
@@ -908,7 +908,7 @@ osd_skip_upload:
         target->dest = (VdpRect){b->x, b->y, b->x + b->dw, b->y + b->dh};
         target->color = (VdpColor){1, 1, 1, 1};
         if (imgs->format == SUBBITMAP_LIBASS) {
-            uint32_t color = b->libass.color;
+            uint32_t color = b->data.libass.color;
             target->color.alpha = 1.0 - ((color >> 0) & 0xff) / 255.0;
             target->color.blue  = ((color >>  8) & 0xff) / 255.0;
             target->color.green = ((color >> 16) & 0xff) / 255.0;


### PR DESCRIPTION
http://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html are not supported in C99 and will break in old gcc (4.2 on openbsd).  Looks like those kids are mostly using clang anyway, but since we claim to be C99 we should fix it.
