### PR TITLE
stream_smb: increase to 128k read_chuuk from default 2k

### DIFF
--- a/stream/stream_smb.c
+++ b/stream/stream_smb.c
@@ -140,6 +140,7 @@ static int open_f (stream_t *stream, int mode)
   stream->write_buffer = write_buffer;
   stream->close = close_f;
   stream->control = control;
+  stream->read_chunk = 128 * 1024;
 
   return STREAM_OK;
 }


### PR DESCRIPTION
Previous to this commit, read_chunk was not set in stream_smb. It
therefore fell back to the generic default of 2K. This resulted in
poor performance when compared to, for example, smbnetfs on the same
network. The value of 128k is chosen both because it is emperically
the "levelling off point" for performance in mpv, and because it is
the value chosen by smbnetfs when serving smb shares to mpv.
