### PR TITLE
Fix the build on OpenBSD and FreeBSD

### DIFF
--- a/wscript
+++ b/wscript
@@ -798,7 +798,7 @@ def configure(ctx):
     ctx.load('detections.devices')
 
     if ctx.env.DEST_OS in ('freebsd', 'openbsd'):
-        ctx.env.CFLAGS += ['-I/usr/local/include']
+        ctx.env.CFLAGS += ['-I.', '-I..', '-I/usr/local/include']
         ctx.env.LINKFLAGS += ['-L/usr/local/lib']
 
     if ctx.env.DEST_OS == 'netbsd':


### PR DESCRIPTION
Without this change, the compiler uses by default the "talloc.h" file installed by the package libtalloc within /usr/local/include. Found and tested on OpenBSD but FreeBSD has the same patch on its ports tree.
