### PR TITLE
build: avoid conflicts with other packages

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -478,7 +478,7 @@ def build(ctx):
         # This assumes all examples are single-file (as examples should be)
         for f in ["simple"]:
             ctx(
-                target       = f,
+                target       = f + "_mpv",
                 source       = "DOCS/client_api_examples/" + f + ".c",
                 includes     = [ctx.bldnode.abspath(), ctx.srcnode.abspath()],
                 use          = "mpv",


### PR DESCRIPTION
`/usr/bin/simple` is too generic and non unique path.
