### PR TITLE
osxbundle: fix recursion termination

### DIFF
--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -61,7 +61,7 @@ def lib_name(lib):
 def process_libraries(libs_dict, binary, processed = []):
     ls   = leafs(libs_dict, processed)
     diff = set(ls) - set(processed)
-    if diff == set():
+    if diff == set([binary]):
         return
 
     for src in diff:


### PR DESCRIPTION
Before this commit, `mpv` binary is copied to `mpv.app/Contents/MacOS/lib/`, but it isn't necessary.
Thanks in advance.
