### PR TITLE
info.plist: add NSSupportsAutomaticGraphicsSwitching key

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -4,6 +4,8 @@
   <dict>
     <key>CFBundleDevelopmentRegion</key>
     <string>English</string>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
     <key>CFBundleDocumentTypes</key>
     <array>
       <dict>


### PR DESCRIPTION
Needed to support integrated / discrete GPU switching

Should fix #811, if not, we probably need to update NSOpenGLPixelFormatAttribute flags in cocoa_common.m
