### PR TITLE
player: write file name to the watch later config file

### DIFF
--- a/DOCS/man/en/options.rst
+++ b/DOCS/man/en/options.rst
@@ -1832,6 +1832,15 @@ OPTIONS
     This behavior is disabled by default, but is always available when quitting
     the player with Shift+Q.
 
+``--write-filename-in-watch-later-config``
+    Prepend the watch later config files with the name of the file they refer
+    to. This is simply written as comment on the top of the file.
+
+    .. warning::
+
+        This option may expose privacy-sensitive information and is thus
+        disabled by default.
+
 ``--screen=<default|0-32>``
     In multi-monitor configurations (i.e. a single desktop that spans across
     multiple displays), this option tells mpv which screen to display the

--- a/options/options.c
+++ b/options/options.c
@@ -559,6 +559,7 @@ const m_option_t mp_opts[] = {
 
     OPT_FLAG("resume-playback", position_resume, 0),
     OPT_FLAG("save-position-on-quit", position_save_on_quit, 0),
+    OPT_FLAG("write-filename-in-watch-later-config", write_filename_in_watch_later_config, 0),
 
     OPT_FLAG("ordered-chapters", ordered_chapters, 0),
     OPT_STRING("ordered-chapters-files", ordered_chapters_files, 0),

--- a/options/options.h
+++ b/options/options.h
@@ -153,6 +153,7 @@ typedef struct MPOpts {
     double step_sec;
     int position_resume;
     int position_save_on_quit;
+    int write_filename_in_watch_later_config;
     int pause;
     int keep_open;
     int audio_id;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -298,6 +298,8 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     FILE *file = fopen(conffile, "wb");
     if (!file)
         goto exit;
+    if (mpctx->opts->write_filename_in_watch_later_config)
+        fprintf(file, "# %s\n", mpctx->filename);
     fprintf(file, "start=%f\n", pos);
     for (int i = 0; backup_properties[i]; i++) {
         const char *pname = backup_properties[i];


### PR DESCRIPTION
This simply writes the file name as a comment to the top of the watch later
config file.

It can be useful to the user for determining whether a watch later config file
can be manually removed (e.g. in case the corresponding media file has been
deleted) or not.
