### PR TITLE
format_bitrate: fix conversion to kbits and mbits

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -106,9 +106,9 @@ static void mark_seek(struct MPContext *mpctx)
 static char *format_bitrate(int rate)
 {
     if (rate < 1024 * 1024)
-        return talloc_asprintf(NULL, "%.3f kbps", rate * 8.0 / 1000.0);
+        return talloc_asprintf(NULL, "%.3f kbps", rate / 1000.0);
 
-    return talloc_asprintf(NULL, "%.3f mbps", rate * 8.0 / 1000000.0);
+    return talloc_asprintf(NULL, "%.3f mbps", rate / 1000000.0);
 }
 
 static char *format_file_size(int64_t size)


### PR DESCRIPTION
Bitrates are now expressed in bits/second. This commit fixes conversions
which assumed it was still in bytes/second.
