### PR TITLE
options: fix for compilation when encoding disabled

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -506,7 +506,7 @@ const m_option_t mp_opts[] = {
     OPT_PRINT("version", print_version),
     OPT_PRINT("V", print_version),
 
-#ifdef HAVE_ENCODING
+#if HAVE_ENCODING
     OPT_SUBSTRUCT("", encode_opts, encode_config, 0),
 #endif
 


### PR DESCRIPTION
HAVE_\* flags are always defined so ifdef will never work.
They should be checked with their values.
