### PR TITLE
build: version string as native str type for each Python version

### DIFF
--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -4,9 +4,11 @@ def __get_version__(ctx):
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
                                cwd=ctx.srcnode.abspath())
-    process.wait()
     (version, err) = process.communicate()
-    return version.strip().decode('utf-8').encode('ascii', 'ignore')
+    version = version.strip()
+    if not isinstance(version, str):
+        version = version.decode('utf-8')
+    return version
 
 def __get_build_date__():
     import time


### PR DESCRIPTION
The output we get from the version script is a byte string in either version of Python. On Python 3, using this directly will result in the "mpv b'...'" issue, so we want to convert it to unicode. However, on Python 2, you want to keep it as a byte string, or else you get [some issue on OS X](https://code.google.com/p/waf/issues/detail?id=1420), apparently.

This patch ensures that we use the native str type on whatever Python happens to be running, so it'll be decoded on Python 3, but not 2.

I also removed the process.wait(), because communicate() already waits for the process to terminate.
