### PR TITLE
build: check for 64bit stdatomic.h operations too

### DIFF
--- a/old-configure
+++ b/old-configure
@@ -493,7 +493,8 @@ compile_check waftools/fragments/pthreads.c "$_ld_pthread" || die "Unable to fin
 echores "yes"
 
 check_statement_libs "support for stdatomic.h" auto STDATOMIC \
-    stdatomic.h '_Atomic int test = ATOMIC_VAR_INIT(123); int test2 = atomic_load(&test)'
+    stdatomic.h 'atomic_int_least64_t test = ATOMIC_VAR_INIT(123); int test2 = atomic_load(&test)' \
+    " " "-latomic"
 _stdatomic=$(defretval)
 
 _atomic=auto

--- a/wscript
+++ b/wscript
@@ -118,10 +118,10 @@ main_dependencies = [
     }, {
         'name': 'stdatomic',
         'desc': 'stdatomic.h',
-        'func':
+        'func': check_libs(['atomic'],
             check_statement('stdatomic.h',
-                '_Atomic int test = ATOMIC_VAR_INIT(123);'
-                'int test2 = atomic_load(&test)')
+                'atomic_int_least64_t test = ATOMIC_VAR_INIT(123);'
+                'int test2 = atomic_load(&test)'))
     }, {
         'name': 'atomic-builtins',
         'desc': 'compiler support for __atomic built-ins',


### PR DESCRIPTION
This fixes the build on platform where the atomic calls can't be turned into
lock-free instructions and thus need the external libatomic library (e.g. mips).

(Debian now defaults to GCC 4.9, so I missed this when I tested the original change since I used GCC 4.8 without stdatomic.h at the time)
