### PR TITLE
DOCS: add document describing the release policy and procedure

### DIFF
--- a/DOCS/release-policy.md
+++ b/DOCS/release-policy.md
@@ -1,0 +1,57 @@
+Release Policy
+==============
+
+Every few months, a new release is cut off of the master branch and is assigned
+a 0.X.0 version number.
+
+As part of the maintenance process, minor releases are made, which are assigned
+0.X.Y version numbers. Minor releases contain bug fixes only. They never merge
+the master branch, and no features are added to it. Only the latest release is
+maintained.
+
+The goal of releases is to provide stability and an unchanged base for the sake
+of Linux distributions. If you want the newest features, just use the master
+branch, which is stable most of the time, except sometimes, when it's not.
+
+Releases other than the latest release are unsupported and unmaintained.
+
+Release procedure
+-----------------
+
+- Create branch release/0.X or cherry-pick commits to the relevant branch.
+
+- Create and/or update the ``RELEASE_NOTES`` file.
+
+- Create and/or update the ``VERSION`` file.
+
+- Create tag v0.X.Y.
+
+- Push branch and tag to GitHub.
+
+- Create a new GitHub release using the content of ``RELEASE_NOTES``.
+
+Release notes template
+----------------------
+
+Here is a template that can be used for writing the ``RELEASE_NOTES`` file.
+
+```markdown
+Changes
+-------
+
+- List of changes.
+
+Bug fixes
+---------
+
+- List of bug fixes.
+
+New features
+------------
+
+- List of new features.
+
+This listing is not complete. There are many more bug fixes and changes. The
+complete change log can be viewed by running ``git log <start>..<end>`` in
+the git repository.
+```

--- a/README.md
+++ b/README.md
@@ -85,17 +85,21 @@ with FFmpeg only. See the [wiki article][ffmpeg_vs_libav] about the issue.
 Release cycle
 -------------
 
-Every few months, a new release is cut off of the master branch. Currently,
-these releases are assigned a version number ``0.X.0``. Only the latest release
-is maintained. As part of the maintenance process, minor releases are made,
-which are assigned ``0.X.Y`` version numbers. Minor releases contain bug fixes
-only. They never merge the master branch, and no features are added to it. The
-goal of releases is to provide stability and an unchanged base for the sake of
-Linux distributions. If you want the newest features, just use the master
-branch. (The master branch is stable most of the time, except sometimes, when
-it's not.)
+Every few months, a new release is cut off of the master branch and is assigned
+a 0.X.0 version number.
+
+As part of the maintenance process, minor releases are made, which are assigned
+0.X.Y version numbers. Minor releases contain bug fixes only. They never merge
+the master branch, and no features are added to it. Only the latest release is
+maintained.
+
+The goal of releases is to provide stability and an unchanged base for the sake
+of Linux distributions. If you want the newest features, just use the master
+branch, which is stable most of the time, except sometimes, when it's not.
 
 Releases other than the latest release are unsupported and unmaintained.
+
+See the [release policy document][release-policy] for more information.
 
 Bug reports
 -----------
@@ -132,3 +136,4 @@ To contact the `mpv` team in private write to `mpv-team@googlegroups.com`.
 [mpv-users]: https://groups.google.com/forum/?hl=en#!forum/mpv-users
 [mpv-devel]: https://groups.google.com/forum/?hl=en#!forum/mpv-devel
 [ffmpeg_vs_libav]: https://github.com/mpv-player/mpv/wiki/FFmpeg-versus-Libav
+[release-policy]: https://github.com/mpv-player/mpv/blob/master/release-policy.md


### PR DESCRIPTION
Related to #872. Not sure if the "release procedure" is complete.

I've also created a [release notes draft](https://gist.github.com/ghedo/1d157c54bdf3e591280c) for the 0.4.0 release. I tried to list the most visible user-facing changes, but I most likely missed a lot of things (particularly in the bug fixes section and for windows/mac os x related stuff), so suggestions are welcome.

I'd expect that with a release manager future releases will happen more frequently, so the release notes will probably be more manageable.
