### PR TITLE
some zsh completion fixes

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -15,7 +15,9 @@ my @vo = parse_opts("$mpv --vo=help", '^  ([^\s\:]*)\s*: (.*)');
 my @af = parse_opts("$mpv --af=help", '^  ([^\s\:]*)\s*: (.*)');
 my @vf = parse_opts("$mpv --vf=help", '^  ([^\s\:]*)\s*: (.*)');
 
-my ($opts_str, $ao_str, $vo_str, $af_str, $vf_str);
+my @protos = parse_opts("$mpv --list-protocols", '^ ([^\s]*)');
+
+my ($opts_str, $ao_str, $vo_str, $af_str, $vf_str, $protos_str);
 
 $opts_str .= qq{  '$_' \\\n} foreach (@opts);
 chomp $opts_str;
@@ -31,6 +33,9 @@ chomp $af_str;
 
 $vf_str .= qq{      '$_' \\\n} foreach (@vf);
 chomp $vf_str;
+
+$protos_str .= qq{$_ } foreach (@protos);
+chomp $protos_str;
 
 my $tmpl = <<"EOS";
 #compdef mpv
@@ -86,7 +91,7 @@ $vf_str
       if _requested urls; then
         while _next_label urls expl URL; do
           _urls "\$expl[@]" && ret=0
-          compadd -S '' "\$expl[@]" \{dvd,vcd,cdda,cddb,tv\}:// && ret=0
+          compadd -S '' "\$expl[@]" $protos_str && ret=0
         done
       fi
       (( ret )) || return 0


### PR DESCRIPTION
The first one is very simple. The replacement of colons in option descriptions needs to be global, because some descriptions have multiple colons. Otherwise the script will error out when completing for an option like that.

The second makes the script more aware of the type of each option. Previously, argument-less options would still be completed as if they took arguments, so you couldn't complete anything in the word after such an option. Also, the custom completed options like `--ao` claimed to take two arguments, for a similar effect. I also made it use `--opt=value` instead of `--opt value` by default.

I was planning to also implement generation of `--no-opt` for Flag options and completion of values for Choice options, but I figured I should send these first because the current script is actually broken. I'll probably do the other stuff another day.
