### PR TITLE
[RFC] options: add --list-protocols option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1313,6 +1313,9 @@ OPTIONS
 ``--list-properties``
     Print a list of the available properties.
 
+``--list-protocols``
+    Print a list of the supported protocols.
+
 ``--load-scripts=<yes|no>``
     If set to ``no``, don't auto-load scripts from ``~/.mpv/lua/``.
     (Default: ``yes``)

--- a/options/options.c
+++ b/options/options.c
@@ -46,6 +46,7 @@
 #include "audio/decode/dec_audio.h"
 #include "player/core.h"
 #include "player/command.h"
+#include "stream/stream.h"
 
 extern const char mp_help_text[];
 
@@ -515,6 +516,7 @@ const m_option_t mp_opts[] = {
     OPT_SUBSTRUCT("input", input_opts, input_config, 0),
 
     OPT_PRINT("list-properties", property_print_help),
+    OPT_PRINT("list-protocols", stream_print_proto_list),
     OPT_PRINT("help", print_help),
     OPT_PRINT("h", print_help),
     OPT_PRINT("version", print_version),

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -972,3 +972,25 @@ bool stream_manages_timeline(struct stream *s)
 {
     return stream_control(s, STREAM_CTRL_MANAGES_TIMELINE, NULL) == STREAM_OK;
 }
+
+void stream_print_proto_list(struct mp_log *log)
+{
+    int count = 0;
+
+    mp_info(log, "Protocols:\n\n");
+    for (int i = 0; stream_list[i]; i++) {
+        const stream_info_t *stream_info = stream_list[i];
+
+        if (!stream_info->protocols)
+            continue;
+
+        for (int j = 0; stream_info->protocols[j]; j++) {
+            if (*stream_info->protocols[j] == '\0')
+               continue;
+
+            mp_info(log, " %s://\n", stream_info->protocols[j]);
+            count++;
+        }
+    }
+    mp_info(log, "\nTotal: %d protocols\n", count);
+}

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -251,4 +251,6 @@ char *mp_url_escape(void *talloc_ctx, const char *s, const char *ok);
 // stream_file.c
 char *mp_file_url_to_filename(void *talloc_ctx, bstr url);
 
+void stream_print_proto_list(struct mp_log *log);
+
 #endif /* MPLAYER_STREAM_H */


### PR DESCRIPTION
Related to #883, this simply prints all the supported protocols with `--list-protocols`. I'm not completely happy about the output format though, and it's also kinda messy because it's not sorted but I'm not sure how to fix that.
