### PR TITLE
demux_disc: resync after open

### DIFF
--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -299,6 +299,8 @@ static int d_open(demuxer_t *demuxer, enum demux_check check)
     add_streams(demuxer);
     add_stream_chapters(demuxer);
 
+    demux_control(p->slave, DEMUXER_CTRL_RESYNC, NULL);
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes #926

No idea what it does or why it's needed, but it seems to work.
