### PR TITLE
stream_dvdnav: properly set 'suspended_read' even if the requested title was not found

### DIFF
--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -443,7 +443,6 @@ static int fill_buffer(stream_t *s, char *buf, int max_len)
                 if (priv->title > 0 && tit != priv->title) {
                     priv->next_event |= 1 << MP_NAV_EVENT_EOF;;
                     MP_WARN(s, "Requested title not found\n");
-                    return 0;
                 }
             }
             if (priv->nav_enabled)


### PR DESCRIPTION
Yet another weird dvdnav bug, yay! So. dvdnav has this annoying habit of showing the menu after each track is played (this also seems to happen with vlc, so it's not an mpv problem). This I guess is to emulate what dvd players do or whatever.

The problem is that with some DVDs (those that I tried anyway), mpv prints "Requested title not found" and then shuts down the video (the window closes) but it still plays the menu audio track if there's any. The menu normally (e.g. with dvd://menu) works well though.

With this patch the video track of the menu is played as well. I really didn't know what to put in the commit message, not sure if it makes any sense.
