### PR TITLE
input: enable wakeup on LIRC socket

### DIFF
--- a/input/lirc.c
+++ b/input/lirc.c
@@ -71,7 +71,7 @@ int mp_input_lirc_init(struct input_ctx *ictx, struct mp_log *log,
       .log = log,
       .lirc_config = lirc_config,
   };
-  mp_input_add_fd(ictx, lirc_sock, 0, mp_input_lirc_read, NULL, mp_input_lirc_close, ctx);
+  mp_input_add_fd(ictx, lirc_sock, 1, mp_input_lirc_read, NULL, mp_input_lirc_close, ctx);
 
   return lirc_sock;
 }


### PR DESCRIPTION
Commit dc00b14 removed playloop polling. Enable wakeup on LIRC socket,
otherwise remote control doesn't work when paused.
