### PR TITLE
command: append entries to the end of the playlist with loadlist append

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -215,6 +215,15 @@ void playlist_transfer_entries(struct playlist *pl, struct playlist *source_pl)
     }
 }
 
+void playlist_append_entries(struct playlist *pl, struct playlist *source_pl)
+{
+    while (source_pl->first) {
+        struct playlist_entry *e = source_pl->first;
+        playlist_unlink(source_pl, e);
+        playlist_add(pl, e);
+    }
+}
+
 // Return number of entries between list start and e.
 // Return -1 if e is not on the list, or if e is NULL.
 int playlist_entry_to_index(struct playlist *pl, struct playlist_entry *e)

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -74,6 +74,7 @@ void playlist_shuffle(struct playlist *pl);
 struct playlist_entry *playlist_get_next(struct playlist *pl, int direction);
 void playlist_add_base_path(struct playlist *pl, bstr base_path);
 void playlist_transfer_entries(struct playlist *pl, struct playlist *source_pl);
+void playlist_append_entries(struct playlist *pl, struct playlist *source_pl);
 
 int playlist_entry_to_index(struct playlist *pl, struct playlist_entry *e);
 int playlist_entry_count(struct playlist *pl);

--- a/player/command.c
+++ b/player/command.c
@@ -3624,7 +3624,7 @@ int run_command(MPContext *mpctx, mp_cmd_t *cmd)
         if (pl) {
             if (!append)
                 playlist_clear(mpctx->playlist);
-            playlist_transfer_entries(mpctx->playlist, pl);
+            playlist_append_entries(mpctx->playlist, pl);
             talloc_free(pl);
 
             if (!append && mpctx->playlist->first) {


### PR DESCRIPTION
Currently entries are added after the current playlist element. This is kinda confusing, more so given that "loadfile append" appends at the end of the playlist.

Not sure if it'd be better to simply inline the while loop, since the new function is used only once.

Anyway, I've recently started using "loadlist append" quite frequently with grooved, and the "append after the end" is the behavior I expected but was quite confused when this didn't happen. Maybe the old behavior could be readded with a new option or something if needed.
