### PR TITLE
vo: Add a default color space for files with no video

### DIFF
--- a/video/csputils.c
+++ b/video/csputils.c
@@ -305,6 +305,9 @@ struct mp_csp_primaries mp_get_csp_primaries(enum mp_csp_prim spc)
                 .blue  = {0.150, 0.060},
                 .white = d65
             };
+        // This is the default assumption if no colorspace information could
+        // be determined, eg. for files which have no video channel.
+        case MP_CSP_PRIM_AUTO:
         case MP_CSP_PRIM_BT_709:
             return (struct mp_csp_primaries) {
                 .red   = {0.640, 0.330},


### PR DESCRIPTION
Usually mp_image_params_guess_csp takes care of finding _some_ default
for a video channel, but files with no video (or with extremely broken
configurations) end up leaving the colorspace information as
MP_CSP_PRIM_AUTO, which has no associated primaries.

As a result of this, color managed OSD messages could not display
because they were being color managed to match the (non-existing/absurd)
video channel. With this change, such non-spaces will have BT.709
primaries as far as color management and the OSD is concerned.

This fixes #961.
