### PR TITLE
gl_wayland: Don't try to resize the egl_window before it exists

### DIFF
--- a/video/out/gl_wayland.c
+++ b/video/out/gl_wayland.c
@@ -26,6 +26,9 @@ static void egl_resize(struct vo_wayland_state *wl)
     int32_t width = wl->window.sh_width;
     int32_t height = wl->window.sh_height;
 
+    if (!wl->egl_context.egl_window)
+        return;
+
     // get the real size of the window
     // this improves moving the window while resizing it
     wl_egl_window_get_attached_size(wl->egl_context.egl_window,


### PR DESCRIPTION
If the compositor sends a configure event immediately after a window is
created (for example, if it implements tiling window management), mpv
will attempt to call wl_egl_window_resize before it has actually created
the egl_window, causing a crash.
