### PR TITLE
Cocoa adapter consolidation

### DIFF
--- a/video/out/cocoa/adapter.h
+++ b/video/out/cocoa/adapter.h
@@ -1,5 +1,5 @@
 /*
- * Cocoa OpenGL Backend
+ * Cocoa OpenGL Adapter
  *
  * This file is part of mpv.
  *
@@ -10,21 +10,38 @@
  *
  * mpv is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MPLAYER_COCOA_COMMON_H
-#define MPLAYER_COCOA_COMMON_H
+#ifndef MPLAYER_COCOA_ADAPTER_H
+#define MPLAYER_COCOA_ADAPTER_H
 
-#include "vo.h"
+#include "video/out/vo.h"
+
+#ifdef __OBJC__
+#import <Cocoa/Cocoa.h>
+@interface MpvCocoaAdapter : NSObject
+- (void)setNeedsResize;
+- (void)signalMouseMovement:(NSPoint)point;
+- (void)putKey:(int)mpkey withModifiers:(int)modifiers;
+- (void)putAxis:(int)mpkey delta:(float)delta;
+- (void)putCommand:(char*)cmd;
+- (void)performAsyncResize:(NSSize)size;
+- (void)handleFilesArray:(NSArray *)files;
+- (void)didChangeWindowedScreenProfile:(NSScreen *)screen;
+
+- (BOOL)isInFullScreenMode;
+- (NSScreen *)fsScreen;
+@property(nonatomic, assign) struct vo *vout;
+
+@end
+#endif /* __OBJC__ */
 
 struct vo_cocoa_state;
-
-void *vo_cocoa_glgetaddr(const char *s);
 
 int vo_cocoa_init(struct vo *vo);
 void vo_cocoa_uninit(struct vo *vo);
@@ -42,10 +59,8 @@ void vo_cocoa_register_resize_callback(struct vo *vo,
 void vo_cocoa_register_gl_clear_callback(struct vo *vo, void *ctx,
                                          void (*cb)(void *ctx));
 
-void *vo_cocoa_cgl_context(struct vo *vo);
-void *vo_cocoa_cgl_pixel_format(struct vo *vo);
-
 void vo_cocoa_create_nsgl_ctx(struct vo *vo, void *ctx);
 void vo_cocoa_release_nsgl_ctx(struct vo *vo);
+void *vo_cocoa_get_nsgl_ctx(struct vo *vo);
 
-#endif /* MPLAYER_COCOA_COMMON_H */
+#endif /* MPLAYER_COCOA_ADAPTER_H */

--- a/video/out/cocoa/adapter.m
+++ b/video/out/cocoa/adapter.m
@@ -1,6 +1,4 @@
 /*
- * Cocoa OpenGL Backend
- *
  * This file is part of mpv.
  *
  * mpv is free software; you can redistribute it and/or modify
@@ -20,12 +18,10 @@
 #import <Cocoa/Cocoa.h>
 #import <CoreServices/CoreServices.h> // for CGDisplayHideCursor
 #import <IOKit/pwr_mgt/IOPMLib.h>
-#include <dlfcn.h>
 
-#include "cocoa_common.h"
-#include "video/out/cocoa/window.h"
-#include "video/out/cocoa/view.h"
-#import "video/out/cocoa/mpvadapter.h"
+#import "adapter.h"
+#import "window.h"
+#import "view.h"
 
 #include "osdep/macosx_compat.h"
 #include "osdep/macosx_events_objc.h"
@@ -39,7 +35,7 @@
 
 #include "options/options.h"
 #include "video/out/vo.h"
-#include "win_state.h"
+#include "video/out/win_state.h"
 
 #include "input/input.h"
 #include "talloc.h"
@@ -98,19 +94,6 @@ static void dispatch_on_main_thread(struct vo *vo, void(^block)(void))
     } else {
         block();
     }
-}
-
-void *vo_cocoa_glgetaddr(const char *s)
-{
-    void *ret = NULL;
-    void *handle = dlopen(
-        "/System/Library/Frameworks/OpenGL.framework/OpenGL",
-        RTLD_LAZY | RTLD_LOCAL);
-    if (!handle)
-        return NULL;
-    ret = dlsym(handle, s);
-    dlclose(handle);
-    return ret;
 }
 
 static void enable_power_management(struct vo *vo)
@@ -411,6 +394,12 @@ void vo_cocoa_release_nsgl_ctx(struct vo *vo)
     s->gl_ctx = nil;
 }
 
+void *vo_cocoa_get_nsgl_ctx(struct vo *vo)
+{
+    struct vo_cocoa_state *s = vo->cocoa;
+    return s->gl_ctx;
+}
+
 int vo_cocoa_config_window(struct vo *vo, uint32_t flags, void *gl_ctx)
 {
     struct vo_cocoa_state *s = vo->cocoa;
@@ -689,17 +678,6 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
         return VO_TRUE;
     }
     return VO_NOTIMPL;
-}
-
-void *vo_cocoa_cgl_context(struct vo *vo)
-{
-    struct vo_cocoa_state *s = vo->cocoa;
-    return [s->gl_ctx CGLContextObj];
-}
-
-void *vo_cocoa_cgl_pixel_format(struct vo *vo)
-{
-    return CGLGetPixelFormat(vo_cocoa_cgl_context(vo));
 }
 
 @implementation MpvCocoaAdapter

--- a/video/out/cocoa/view.h
+++ b/video/out/cocoa/view.h
@@ -16,7 +16,8 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import "video/out/cocoa/mpvadapter.h"
+
+@class MpvCocoaAdapter;
 
 @interface MpvVideoView : NSView <NSDraggingDestination> {
     BOOL hasMouseDown;

--- a/video/out/cocoa/view.m
+++ b/video/out/cocoa/view.m
@@ -21,10 +21,10 @@
 #include "input/keycodes.h"
 
 #include "osdep/macosx_compat.h"
-#include "video/out/cocoa_common.h"
-#import  "video/out/cocoa/additions.h"
 
-#include "view.h"
+#import "adapter.h"
+#import "additions.h"
+#import "view.h"
 
 @implementation MpvVideoView
 @synthesize adapter = _adapter;

--- a/video/out/cocoa/window.h
+++ b/video/out/cocoa/window.h
@@ -16,7 +16,8 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import "video/out/cocoa/mpvadapter.h"
+
+@class MpvCocoaAdapter;
 
 @interface MpvVideoWindow : NSWindow <NSWindowDelegate>
 @property(nonatomic, retain) MpvCocoaAdapter *adapter;

--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -22,10 +22,9 @@
 #include "osdep/macosx_events.h"
 #include "osdep/macosx_compat.h"
 
-#include "video/out/cocoa/additions.h"
-#include "video/out/cocoa_common.h"
-
-#include "window.h"
+#import "additions.h"
+#import "adapter.h"
+#import "window.h"
 
 @implementation MpvVideoWindow {
     NSSize _queued_video_size;

--- a/video/out/cocoa_common.h
+++ b/video/out/cocoa_common.h
@@ -1,4 +1,6 @@
 /*
+ * Cocoa OpenGL common backend bits
+ *
  * This file is part of mpv.
  *
  * mpv is free software; you can redistribute it and/or modify
@@ -15,20 +17,14 @@
  * with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#import <Cocoa/Cocoa.h>
-#include "video/out/vo.h"
+#ifndef MPLAYER_COCOA_COMMON_H
+#define MPLAYER_COCOA_COMMON_H
 
-@interface MpvCocoaAdapter : NSObject
-- (void)setNeedsResize;
-- (void)signalMouseMovement:(NSPoint)point;
-- (void)putKey:(int)mpkey withModifiers:(int)modifiers;
-- (void)putAxis:(int)mpkey delta:(float)delta;
-- (void)putCommand:(char*)cmd;
-- (void)performAsyncResize:(NSSize)size;
-- (void)handleFilesArray:(NSArray *)files;
-- (void)didChangeWindowedScreenProfile:(NSScreen *)screen;
+struct vo;
 
-- (BOOL)isInFullScreenMode;
-- (NSScreen *)fsScreen;
-@property(nonatomic, assign) struct vo *vout;
-@end
+void *vo_cocoa_glgetaddr(const char *s);
+
+void *vo_cocoa_cgl_context(struct vo *vo);
+void *vo_cocoa_cgl_pixel_format(struct vo *vo);
+
+#endif

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -1,0 +1,44 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cocoa_common.h"
+#include "cocoa/adapter.h"
+#include <dlfcn.h>
+
+void *vo_cocoa_glgetaddr(const char *s)
+{
+    void *ret = NULL;
+    void *handle = dlopen(
+                          "/System/Library/Frameworks/OpenGL.framework/OpenGL",
+                          RTLD_LAZY | RTLD_LOCAL);
+    if (!handle)
+        return NULL;
+    ret = dlsym(handle, s);
+    dlclose(handle);
+    return ret;
+}
+
+void *vo_cocoa_cgl_context(struct vo *vo)
+{
+    NSOpenGLContext *gl_ctx = vo_cocoa_get_nsgl_ctx(vo);
+    return [gl_ctx CGLContextObj];
+}
+
+void *vo_cocoa_cgl_pixel_format(struct vo *vo)
+{
+    return CGLGetPixelFormat(vo_cocoa_cgl_context(vo));
+}

--- a/video/out/gl_cocoa.c
+++ b/video/out/gl_cocoa.c
@@ -20,6 +20,7 @@
  */
 
 #include <OpenGL/OpenGL.h>
+#include "cocoa/adapter.h"
 #include "cocoa_common.h"
 #include "osdep/macosx_versions.h"
 #include "gl_common.h"

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -335,6 +335,7 @@ def build(ctx):
         ( "video/filter/vf_yadif.c" ),
         ( "video/out/aspect.c" ),
         ( "video/out/bitmap_packer.c" ),
+        ( "video/out/cocoa/adapter.m",           "cocoa" ),
         ( "video/out/cocoa/additions.m",         "cocoa" ),
         ( "video/out/cocoa/view.m",              "cocoa" ),
         ( "video/out/cocoa/window.m",            "cocoa" ),


### PR DESCRIPTION
This is in preparation for some kind of more general mpgl backend that allows passing an IOSurface or shared GL texture through the client API. I needed a common_cocoa.h that didn't involve the existing MPV adapter code, and ended up moving some things around. Just soliciting opinions on whether this reorg makes sense.
