### PR TITLE
build: point to directory with overriden tools

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -452,7 +452,7 @@ def build(ctx):
     if build_shared or build_static:
         if build_shared:
             import os
-            waftoolsdir = os.path.dirname(__file__) + os.sep + "waftools"
+            waftoolsdir = os.path.join(os.path.dirname(__file__), "waftools")
             ctx.load("syms", tooldir=waftoolsdir)
         vre = '^#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION\((.*), (.*)\)$'
         libmpv_header = ctx.path.find_node("libmpv/client.h").read()


### PR DESCRIPTION
mpv overrides waf tool "syms" found in "waftools" directory, but  when building with system waf, this overriden version is not picked up which results in error:

```
Build failed
Traceback (most recent call last):
  File "/usr/share/waf/waflib/Task.py", line 241, in process
    ret = self.run()
  File "/usr/share/waf/waflib/Task.py", line 85, in run
    return m1(self)
  File "/usr/share/waf/waflib/extras/syms.py", line 40, in run
    re_nm = re.compile(r'T\s+(' + self.generator.export_symbols_regex + r')\b')
AttributeError: 'task_gen' object has no attribute 'export_symbols_regex'
```

Error is only present when building with shared client lib enabled by --enable-libmpv-shared. Please apply patch which explicitly points to tool directory.
