### PR TITLE
vdpau: correctly mark invalid mixer as such on vdp_video_mixer_create() failure

### DIFF
--- a/video/vdpau_mixer.c
+++ b/video/vdpau_mixer.c
@@ -170,6 +170,9 @@ static int create_vdp_mixer(struct mp_vdpau_mixer *mixer)
                                      VDP_NUM_MIXER_PARAMETER,
                                      parameters, parameter_values,
                                      &mixer->video_mixer);
+    if (vdp_st != VDP_STATUS_OK)
+        mixer->video_mixer = VDP_INVALID_HANDLE;
+
     CHECK_VDP_ERROR(mixer, "Error when calling vdp_video_mixer_create");
 
     mixer->initialized = true;


### PR DESCRIPTION
Otherwise vdp_video_mixer_destroy() would later fail when called on an invalid
video mixer handle. With mesa r600 vdpau driver, this would cause a segfault.

This may just be a mesa thing idk, but e.g. vlc does basically the same thing. Now mpv doesn't segfaults anymore, but it keeps showing "Error when calling vdp_video_mixer_create: An invalid/unsupported value was supplied" with no video displayed (but the audio works). Should it just die or is this ok?
