### PR TITLE
TOOLS/zsh.pl: add return 1 as a fall-through when no matches are found

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -98,6 +98,7 @@ $vf_str
     done
   ;;
 esac
+return 1
 EOS
 
 print $tmpl;


### PR DESCRIPTION
This allows zsh anchors to be used to generate matches during
completion.
