### PR TITLE
zsh completion: complete profiles and misc. fixes

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -72,6 +72,9 @@ my $tmpl = <<"EOS";
 
 # mpv zsh completion
 
+local curcontext="\$curcontext" state state_descr line
+typeset -A opt_args
+
 local rc=1
 
 _arguments -C -S \\
@@ -120,6 +123,7 @@ $profile_comp
   ;;
 
   mfiles)
+    local expl
     _tags files urls
     while _tags; do
       _requested files expl 'media file' _files -g \\


### PR DESCRIPTION
Only functional change from what I posted in the other thread is to use `$words[1]` instead of hardcoding mpv.

I made a separate heredoc and included it in the main one, because I thought trying to escape everything would be a nightmare to maintain.

Also fixed some stuff up. The ret/rc thing was causing a second tab press to delete the `//` at the end of a protocol. (Edit: Or so I thought. My change seemed to fix it on one machine, but not another...? Either way it should be changed, though.) I'm not aware of the global env pollution causing any actual bugs, but according to the zshcompsys manpage, we're supposed to make them local.
