### PR TITLE
Mention that mp.commandv doesn't expand properties

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -74,6 +74,10 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     These two commands are equivalent, except that the first version breaks
     if the filename contains spaces or certain special characters.
 
+    Note that properties are *not* expanded.  You can use either ``mp.command``,
+    the ``expand-properties`` prefix, or the ``mp.get_property`` family of
+    functions.
+
 ``mp.get_property(name [,def])``
     Return the value of the given property as string. These are the same
     properties as used in input.conf. See `Properties`_ for a list of


### PR DESCRIPTION
The little lua snippet at #488 as well as the actual implementation seems to indicate that not expanding properties is indeed the correct behavior.  Document that.
