### PR TITLE
posix: use STD*_FILENO constants

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -437,8 +437,8 @@ void mp_msg_update_msglevels(struct mpv_global *global)
     root->use_terminal = opts->use_terminal;
     root->show_time = opts->msg_time;
     if (root->use_terminal) {
-        root->color = opts->msg_color && isatty(fileno(stdout));
-        root->termosd = isatty(fileno(stderr));
+        root->color = opts->msg_color && isatty(STDOUT_FILENO);
+        root->termosd = isatty(STDERR_FILENO);
     }
 
     talloc_free(root->msglevels);

--- a/input/pipe.c
+++ b/input/pipe.c
@@ -41,7 +41,7 @@ static void *reader_thread(void *ctx)
     int fd = -1;
     bool close_fd = true;
     if (strcmp(p->filename, "/dev/stdin") == 0) { // mainly for win32
-        fd = fileno(stdin);
+        fd = STDIN_FILENO;
         close_fd = false;
     }
     if (fd < 0)

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -264,7 +264,7 @@ static void load_termcap(void)
 
 static void enable_kx(bool enable)
 {
-    if (isatty(1)) {
+    if (isatty(STDOUT_FILENO)) {
         char *cmd = enable ? "\033=" : "\033>";
         printf("%s", cmd);
         fflush(stdout);
@@ -664,7 +664,7 @@ void terminal_setup_getch(struct input_ctx *ictx)
 
 static void do_activate_getch2(void)
 {
-    if (getch2_active || !isatty(1))
+    if (getch2_active || !isatty(STDOUT_FILENO))
         return;
 
     enable_kx(true);
@@ -798,7 +798,7 @@ void terminal_uninit(void)
 
 bool terminal_in_background(void)
 {
-    return isatty(2) && tcgetpgrp(2) != getpgrp();
+    return isatty(STDERR_FILENO) && tcgetpgrp(STDERR_FILENO) != getpgrp();
 }
 
 void terminal_get_size(int *w, int *h)
@@ -813,7 +813,7 @@ void terminal_get_size(int *w, int *h)
 
 int terminal_init(void)
 {
-    if (isatty(1))
+    if (isatty(STDOUT_FILENO))
         load_termcap();
     getch2_enable();
     return 0;


### PR DESCRIPTION
Rather than "magic" numbers, use meaningful constant names provided by
unistd.h.
