### PR TITLE
malloc+memset(0) to calloc

### DIFF
--- a/TOOLS/vf_dlopen/framestep.c
+++ b/TOOLS/vf_dlopen/framestep.c
@@ -90,8 +90,7 @@ int vf_dlopen_getcontext(struct vf_dlopen_context *ctx, int argc, const char **a
     if (argc != 1 && argc != 2)
         return -1;
 
-    framestep_data_t *framestep = malloc(sizeof(framestep_data_t));
-    memset(framestep, 0, sizeof(*framestep));
+    framestep_data_t *framestep = calloc(1,sizeof(framestep_data_t));
 
     framestep->step = atoi(argv[0]);
     framestep->pos = (argc >= 2) ? atoi(argv[1]) : 0;

--- a/TOOLS/vf_dlopen/ildetect.c
+++ b/TOOLS/vf_dlopen/ildetect.c
@@ -267,8 +267,7 @@ int vf_dlopen_getcontext(struct vf_dlopen_context *ctx, int argc, const char **a
     (void) argc;
     (void) argv;
 
-    ildetect_data_t *il = malloc(sizeof(ildetect_data_t));
-    memset(il, 0, sizeof(*il));
+    ildetect_data_t *il = calloc(1,sizeof(ildetect_data_t));
 
 #define A(i,d) ((argc>(i) && *argv[i]) ? atof(argv[i]) : (d))
     il->method = A(0, 0);

--- a/TOOLS/vf_dlopen/rectangle.c
+++ b/TOOLS/vf_dlopen/rectangle.c
@@ -348,8 +348,7 @@ int vf_dlopen_getcontext(struct vf_dlopen_context *ctx, int argc, const char **a
         { "yuv420p", "yuv420p" },
         { NULL, NULL }
     };
-    privdata *priv = malloc(sizeof(privdata));
-    memset(priv, 0, sizeof(*priv));
+    privdata *priv = calloc(1,sizeof(privdata));
     priv->step = 8;
     if(argc >= 1)
         priv->w = atoi(argv[0]);

--- a/TOOLS/vf_dlopen/telecine.c
+++ b/TOOLS/vf_dlopen/telecine.c
@@ -237,8 +237,7 @@ int vf_dlopen_getcontext(struct vf_dlopen_context *ctx, int argc, const char **a
     if (!a0[0] || a0[1] || !a1[0] || argc > 2)
         return -1;
 
-    tc_data_t *tc = malloc(sizeof(tc_data_t));
-    memset(tc, 0, sizeof(*tc));
+    tc_data_t *tc = calloc(1,sizeof(tc_data_t));
 
     if (a0[0] == 't')
         tc->firstfield = 0;

--- a/TOOLS/vf_dlopen/tile.c
+++ b/TOOLS/vf_dlopen/tile.c
@@ -150,8 +150,7 @@ int vf_dlopen_getcontext(struct vf_dlopen_context *ctx, int argc, const char **a
     if (argc != 2)
         return -1;
 
-    tile_data_t *tile = malloc(sizeof(tile_data_t));
-    memset(tile, 0, sizeof(*tile));
+    tile_data_t *tile = calloc(1,sizeof(tile_data_t));
 
     tile->cols = atoi(argv[0]);
     tile->rows = atoi(argv[1]);

--- a/video/out/dither.c
+++ b/video/out/dither.c
@@ -63,7 +63,6 @@ static void makegauss(struct ctx *k, unsigned int sizeb)
 {
     assert(sizeb >= 1 && sizeb <= MAX_SIZEB);
 
-    memset(k, 0, sizeof(*k));
     av_lfg_init(&k->avlfg, 123);
 
     k->sizeb = sizeb;
@@ -159,7 +158,7 @@ static void makeuniform(struct ctx *k)
 // out_matrix is a reactangular tsize * tsize array, where tsize = (1 << size).
 void mp_make_fruit_dither_matrix(float *out_matrix, int size)
 {
-    struct ctx *k = talloc(NULL, struct ctx);
+    struct ctx *k = talloc_zero(NULL, struct ctx);
     makegauss(k, size);
     makeuniform(k);
     float invscale = k->size2;
@@ -225,7 +224,7 @@ static void print(struct ctx *k)
 int main(void)
 {
     mp_time_init();
-    struct ctx *k = malloc(sizeof(struct ctx));
+    struct ctx *k = calloc(1,sizeof(struct ctx));
     int64_t s = mp_time_us();
     makegauss(k, 6);
     makeuniform(k);

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -212,12 +212,10 @@ shmemerror:
     p->myximage[foo] =
         XCreateImage(vo->x11->display, p->vinfo.visual, p->depth, ZPixmap,
                      0, NULL, p->image_width, p->image_height, 8, 0);
-    p->ImageDataOrig[foo] =
-        malloc(p->myximage[foo]->bytes_per_line * p->image_height + 32);
+    uint32_t sz = p->myximage[foo]->bytes_per_line * p->image_height +32 ;                
+    p->ImageDataOrig[foo] = calloc(1,sz);
     p->myximage[foo]->data = p->ImageDataOrig[foo] + 16
                            - ((long)p->ImageDataOrig & 15);
-    memset(p->myximage[foo]->data, 0, p->myximage[foo]->bytes_per_line
-                                      * p->image_height);
     p->ImageData[foo] = p->myximage[foo]->data;
 #if HAVE_SHM && HAVE_XEXT
 }


### PR DESCRIPTION
Hi, cleaned up.

 realloc thing was for the possibility of leak if the realloc fails and the copy is lost forever, so i leaved this out for now.

 Both av_malloc or av_mallocz in mem.c in ffmpeg was last changed in 2002. Libressl devs made a good case on practices of malloc calloc memset for both security and performance. 
