### PR TITLE
Fix --cache-file=TMP on Windows

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1650,7 +1650,7 @@ Window
     .. note::
 
         This does not affect the normal screensaver operation in any way.
-        
+
 ``--no-keepaspect``, ``--keepaspect``
     ``--no-keepaspect`` will always stretch the video to window size, and will
     disable the window manager hints that force the window aspect ratio.
@@ -2819,8 +2819,7 @@ Cache
        Instead, an invisible temporary file is created. It depends on your
        C library where this file is created (usually ``/tmp/``), and whether
        filename is visible (the ``tmpfile()`` function is used). On some
-       systems, automatic deletion of the cache file might not be guaranteed
-       (like on MS Windows).
+       systems, automatic deletion of the cache file might not be guaranteed.
 
        If you want to use a file cache, this mode is recommended, because it
        doesn't break ordered chapters or ``--audio-file``. These modes open

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -310,6 +310,41 @@ int mp_mkdir(const char *path, int mode)
     return res;
 }
 
+FILE *mp_tmpfile(void)
+{
+    // Reserve a file name in the format %TMP%\mpvXXXX.TMP
+    wchar_t tmp_path[MAX_PATH + 1];
+    if (!GetTempPathW(MAX_PATH + 1, tmp_path))
+        return NULL;
+    wchar_t tmp_name[MAX_PATH + 1];
+    if (!GetTempFileNameW(tmp_path, L"mpv", 0, tmp_name))
+        return NULL;
+
+    // Create the file. FILE_ATTRIBUTE_TEMPORARY indicates the file will be
+    // short-lived. Windows should avoid flushing it to disk while there is
+    // sufficient cache.
+    HANDLE file = CreateFileW(tmp_name, GENERIC_READ | GENERIC_WRITE | DELETE,
+        FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, CREATE_ALWAYS,
+        FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+    if (file == INVALID_HANDLE_VALUE) {
+        DeleteFileW(tmp_name);
+        return NULL;
+    }
+
+    int fd = _open_osfhandle((intptr_t)file, 0);
+    if (fd < 0) {
+        CloseHandle(file);
+        return NULL;
+    }
+    FILE *fp = fdopen(fd, "w+b");
+    if (!fp) {
+        close(fd);
+        return NULL;
+    }
+
+    return fp;
+}
+
 static char **utf8_environ;
 static void *utf8_environ_ctx;
 

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -75,6 +75,7 @@ DIR *mp_opendir(const char *path);
 struct dirent *mp_readdir(DIR *dir);
 int mp_closedir(DIR *dir);
 int mp_mkdir(const char *path, int mode);
+FILE *mp_tmpfile(void);
 char *mp_getenv(const char *name);
 
 typedef struct {
@@ -101,6 +102,7 @@ void mp_globfree(mp_glob_t *pglob);
 #define readdir(...) mp_readdir(__VA_ARGS__)
 #define closedir(...) mp_closedir(__VA_ARGS__)
 #define mkdir(...) mp_mkdir(__VA_ARGS__)
+#define tmpfile(...) mp_tmpfile(__VA_ARGS__)
 #define getenv(...) mp_getenv(__VA_ARGS__)
 
 #ifndef GLOB_NOMATCH


### PR DESCRIPTION
tmpfile() is pretty broken on Windows. It tries to create the file in the root directory, so it almost always fails due to lack of permissions on Vista and up. It will also try to create the cache on a network drive when that's the current drive. I always get `[file-cache] can't open cache file 'TMP'`.
