### PR TITLE
Add one-based OSD formating for playlist-pos

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2492,11 +2492,16 @@ static int mp_property_playlist_pos(void *ctx, struct m_property *prop,
         return M_PROPERTY_UNAVAILABLE;
 
     switch (action) {
-    case M_PROPERTY_GET: {
+    case M_PROPERTY_GET
+    case M_PROPERTY_PRINT: {
         int pos = playlist_entry_to_index(pl, pl->current);
         if (pos < 0)
             return M_PROPERTY_UNAVAILABLE;
-        *(int *)arg = pos;
+
+        if (action == M_PROPERTY_GET)
+            *(int *)arg = pos;
+        else
+            *(char **)arg = talloc_asprintf(NULL, "%d", pos + 1);
         return M_PROPERTY_OK;
     }
     case M_PROPERTY_SET: {
@@ -2514,13 +2519,6 @@ static int mp_property_playlist_pos(void *ctx, struct m_property *prop,
             .max = playlist_entry_count(pl) - 1,
         };
         *(struct m_option *)arg = opt;
-        return M_PROPERTY_OK;
-    }
-    case M_PROPERTY_PRINT: {
-        int pos = playlist_entry_to_index(pl, pl->current);
-        if (pos < 0)
-            return M_PROPERTY_UNAVAILABLE;
-        *(char **)arg = talloc_asprintf(NULL, "%d", pos + 1);
         return M_PROPERTY_OK;
     }
     }


### PR DESCRIPTION
_I remember some conversation going on about something similar to this some time ago._

Add an OSD formatted mode (?) to `playlist-pos` that indexes entries from one.
My main reason for wanting this is for use in `screenshot-template`.

Of course, other than what is displayed, nothing else is changed so command line arguments etc, are all still zero-based. This could potentially be unexpected to users.

I mostly just copied the code. I guess I could refactor it a bit...
EDIT: Did a bit of it.
