### PR TITLE
Don't free NULL libwaio pointer

### DIFF
--- a/input/pipe-win32.c
+++ b/input/pipe-win32.c
@@ -80,7 +80,8 @@ static void read_pipe_thread(struct mp_input_src *src, void *param)
     }
 
 done:
-    waio_free(waio);
+    if (waio)
+        waio_free(waio);
     if (close_fd)
         close(fd);
 }


### PR DESCRIPTION
It seems waio_alloc can fail when the input handle is a console. waio_free crashes if given a NULL pointer, so check for NULL before freeing.
