### PR TITLE
man: replace : with , in broken --lua-opts osc example

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -161,7 +161,7 @@ To avoid collisions with other scripts, all options need to be prefixed with
 
 Example::
 
-    --lua-opts=osc-optionA=value1:osc-optionB=value2
+    --lua-opts=osc-optionA=value1,osc-optionB=value2
 
 
 Configurable Options


### PR DESCRIPTION
--lua-opts is a key-value list, so the option parser accepts only commas.
