### PR TITLE
vf_stereo3d: fix "auto" input format with libav

### DIFF
--- a/video/filter/vf_stereo3d.c
+++ b/video/filter/vf_stereo3d.c
@@ -542,7 +542,7 @@ static int vf_open(vf_instance_t *vf)
         vf->priv->auto_in = 1;
 
     if (vf->priv->in.fmt == STEREO_AUTO &&
-        vf_lw_set_graph(vf, vf->priv->lw_opts, NULL, "null") >= 0)
+        vf_lw_set_graph(vf, vf->priv->lw_opts, "stereo3d", "null") >= 0)
     {
         vf_lw_set_reconfig_cb(vf, lavfi_reconfig);
         return 1;


### PR DESCRIPTION
I'm not 100% sure the fix is correct (i.e. if the `NULL` was on purpose), but it seems to work.

Also, maybe the two ifs can be merged like so:

``` diff
diff --git a/video/filter/vf_stereo3d.c b/video/filter/vf_stereo3d.c
index e5a84f4..e572476 100644
--- a/video/filter/vf_stereo3d.c
+++ b/video/filter/vf_stereo3d.c
@@ -541,17 +541,14 @@ static int vf_open(vf_instance_t *vf)
     if (vf->priv->in.fmt == STEREO_AUTO)
         vf->priv->auto_in = 1;

-    if (vf->priv->in.fmt == STEREO_AUTO &&
-        vf_lw_set_graph(vf, vf->priv->lw_opts, "stereo3d", "null") >= 0)
-    {
-        vf_lw_set_reconfig_cb(vf, lavfi_reconfig);
-        return 1;
-    }
-
     if (vf_lw_set_graph(vf, vf->priv->lw_opts, "stereo3d", "%s:%s",
                         rev_map_name(vf->priv->in.fmt),
                         rev_map_name(vf->priv->out.fmt)) >= 0)
+    {
+        if (vf->priv->in.fmt == STEREO_AUTO)
+            vf_lw_set_reconfig_cb(vf, lavfi_reconfig);
         return 1;
+    }

     return 1;
 }
```

but I haven't tested if this works with ffmpeg.
