### PR TITLE
bstr: check pointers before memcmp/strncasecmp

### DIFF
--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -33,7 +33,9 @@
 
 int bstrcmp(struct bstr str1, struct bstr str2)
 {
-    int ret = memcmp(str1.start, str2.start, FFMIN(str1.len, str2.len));
+    int ret = 0;
+    if (str1.len && str2.len)
+        ret = memcmp(str1.start, str2.start, FFMIN(str1.len, str2.len));
 
     if (!ret) {
         if (str1.len == str2.len)
@@ -48,7 +50,9 @@ int bstrcmp(struct bstr str1, struct bstr str2)
 
 int bstrcasecmp(struct bstr str1, struct bstr str2)
 {
-    int ret = strncasecmp(str1.start, str2.start, FFMIN(str1.len, str2.len));
+    int ret = 0;
+    if (str1.len && str2.len)
+        ret = strncasecmp(str1.start, str2.start, FFMIN(str1.len, str2.len));
 
     if (!ret) {
         if (str1.len == str2.len)


### PR DESCRIPTION
This fixes #1155 for me. I think it's the cause of all the invalid parameter errors.
