### PR TITLE
qtexample: Set the locale

### DIFF
--- a/DOCS/client_api_examples/qtexample.cpp
+++ b/DOCS/client_api_examples/qtexample.cpp
@@ -2,6 +2,7 @@
 
 // This example can be built with: qmake && make
 
+#include <clocale>
 #include <sstream>
 
 #include <QFileDialog>
@@ -152,6 +153,11 @@ MainWindow::~MainWindow()
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+
+    // Qt sets the locale in the QApplication constructor, but libmpv requires
+    // the LC_NUMERIC category to be set to "C", so change it back.
+    std::setlocale(LC_NUMERIC, "C");
+
     MainWindow w;
     w.show();
 


### PR DESCRIPTION
Going from the Qt and libmpv documentation, I think this is the right thing to do. This could be helpful for future Qt/libmpv developers to avoid locale issues.
