### PR TITLE
build: make zsh completion directory configurable

### DIFF
--- a/wscript
+++ b/wscript
@@ -768,6 +768,7 @@ _INSTALL_DIRS_LIST = [
     ('datadir', '${PREFIX}/share',    'data files'),
     ('mandir',  '${DATADIR}/man',     'man pages '),
     ('docdir',  '${DATADIR}/doc/mpv', 'documentation files'),
+    ('zshdir',  '${DATADIR}/zsh/site-functions', 'zsh completion functions'),
 ]
 
 def options(opt):

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -563,7 +563,7 @@ def build(ctx):
     if ctx.dependency_satisfied('zsh-comp'):
         ctx.zshcomp(target = "etc/_mpv")
         ctx.install_files(
-            ctx.env.DATADIR + '/zsh/vendor-completions',
+            ctx.env.ZSHDIR,
             ['etc/_mpv'])
 
     ctx.install_files(


### PR DESCRIPTION
See #1160.

I used site-functions as the default, so Debian would have to use `--zshdir='${DATADIR}/zsh/vendor-completions'`.

Ping @ghedo @Nikoli
