### PR TITLE
WIP: stream: implement cdda:// support through libavdevice

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -208,7 +208,7 @@ const m_option_t mp_opts[] = {
     OPT_CHOICE("hls-bitrate", hls_bitrate, M_OPT_FIXED,
                ({"no", 0}, {"min", 1}, {"max", 2})),
 
-#if HAVE_CDDA
+#if HAVE_CDDA || HAVE_CDDA_LIBAV
     OPT_SUBSTRUCT("cdda", stream_cdda_opts, stream_cdda_conf, 0),
     OPT_STRING("cdrom-device", cdrom_device, M_OPT_FILE),
 #endif

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -72,7 +72,7 @@ extern const stream_info_t stream_info_rar_entry;
 extern const stream_info_t stream_info_edl;
 
 static const stream_info_t *const stream_list[] = {
-#if HAVE_CDDA
+#if HAVE_CDDA || HAVE_CDDA_LIBAV
     &stream_info_cdda,
 #endif
     &stream_info_ffmpeg,

--- a/stream/stream_cdda_libav.c
+++ b/stream/stream_cdda_libav.c
@@ -1,0 +1,77 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+
+#include "stream.h"
+#include "options/m_option.h"
+#include "options/m_config.h"
+#include "options/options.h"
+
+typedef struct cdda_params {
+    char *device;
+} cdda_priv;
+
+#define OPT_BASE_STRUCT struct cdda_params
+
+static const m_option_t cdda_params_fields[] = {
+    OPT_STRING("device", device, 0),
+    {0}
+};
+
+const struct m_sub_options stream_cdda_conf = {
+    .opts = (const m_option_t[]) {
+        OPT_STRING("device", device, 0),
+        {0}
+    },
+    .size = sizeof(struct cdda_params),
+};
+
+static int open_f(stream_t *stream)
+{
+    cdda_priv *priv = stream->priv;
+    cdda_priv *p = priv;
+
+    stream->type = STREAMTYPE_AVDEVICE;
+    stream->demuxer = "lavf";
+
+    if (!p->device || !p->device[0]) {
+        talloc_free(p->device);
+        if (stream->opts->cdrom_device && stream->opts->cdrom_device[0])
+            p->device = talloc_strdup(stream, stream->opts->cdrom_device);
+        else
+            p->device = talloc_strdup(stream, DEFAULT_CDROM_DEVICE);
+    }
+
+    stream->url = talloc_asprintf(stream, "libcdio:%s", p->device);
+
+    return STREAM_OK;
+}
+
+const stream_info_t stream_info_cdda = {
+    .name = "cdda",
+    .open = open_f,
+    .protocols = (const char*const[]){"cdda", NULL },
+    .priv_size = sizeof(cdda_priv),
+    .options = cdda_params_fields,
+    .url_options = (const char*const[]){
+        "port=speed",
+        "filename=device",
+        NULL
+    },
+};

--- a/wscript
+++ b/wscript
@@ -421,6 +421,12 @@ Libav libraries ({0}). Aborting.".format(" ".join(libav_pkg_config_checks))
         'desc': 'libavdevice',
         'func': check_pkg_config('libavdevice', '>= 54.0.0'),
     }, {
+        'name': '--cdda-libav',
+        'desc': 'cdda support (libav)',
+        'deps': [ 'libavdevice' ],
+        'deps_neg': [ 'cdda' ],
+        'func': check_true,
+    }, {
         'name': '--libpostproc',
         'desc': 'libpostproc',
         'func': check_pkg_config('libpostproc', '>= 52.2.100'),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -247,6 +247,7 @@ def build(ctx):
         ( "stream/stream_avdevice.c" ),
         ( "stream/stream_bluray.c",              "libbluray" ),
         ( "stream/stream_cdda.c",                "cdda" ),
+        ( "stream/stream_cdda_libav.c",          "cdda-libav" ),
         ( "stream/stream_dvb.c",                 "dvbin" ),
         ( "stream/stream_dvd.c",                 "dvdread" ),
         ( "stream/stream_dvd_common.c",          "dvdread" ),


### PR DESCRIPTION
This implements cdda:// stream support by proxying the cdda:// URL and --cdda-*
options to libavdevice. This is only enabled if the native cdda support is
disabled (default).

So, this is just a proof-of-concept and there may be a better way to do this. I created the new stream_cdda_libav.c file to avoid cluttering stream_cdda.c with ifdefs, however there's some code overlap. Also, right now it doesn't pass any of the --cdda-\* options to libavdevice, because it's not very clear to me if that's even possible given the "av://format:filename" syntax. So, yeah, if you have a better idea that'd be nice.
