### PR TITLE
video: don't send video-reconfig if video is not initialized

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -247,8 +247,8 @@ void uninit_video_chain(struct MPContext *mpctx)
         mpctx->video_status = STATUS_EOF;
         mpctx->sync_audio_to_video = false;
         reselect_demux_streams(mpctx);
+        mp_notify(mpctx, MPV_EVENT_VIDEO_RECONFIG, NULL);
     }
-    mp_notify(mpctx, MPV_EVENT_VIDEO_RECONFIG, NULL);
 }
 
 int reinit_video_chain(struct MPContext *mpctx)


### PR DESCRIPTION
When using --no-video clients would get flooded with video-reconfig events.

I don't know if leaving the mp_notify() call outside of the if was on purpose, but putting it inside fixes the problem above. Maybe there's another fix.

You can reproduce by running e.g. `mpv --input-unix-socket=... --no-video <file>` and then connecting to it using socat.
