### PR TITLE
command: play the correct entry with loadfile ... append-play

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -4064,7 +4064,7 @@ int run_command(MPContext *mpctx, mp_cmd_t *cmd)
         if (!append || (append == 2 && !mpctx->playlist->current)) {
             if (opts->position_save_on_quit) // requested in issue #1148
                 mp_write_watch_later_conf(mpctx);
-            mp_set_playlist_entry(mpctx, mpctx->playlist->first);
+            mp_set_playlist_entry(mpctx, entry);
         }
         break;
     }


### PR DESCRIPTION
The playlist may be non-empty even if the player is idle. Instead of playing the
first entry, play the entry that was just added.

(again, I don't know if the current behavior was on purpose, but I think it makes more sense this way, and it would make some hairy parts in grooved, and probably other projects using libmpv, much simpler. I also think it wouldn't conflict with the original use case in #950, since the guy explicitly mentioned an empty playlist).
