### PR TITLE
Add --ytdl-format option for selecting the format that youtube-dl extracts

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -435,6 +435,12 @@ Program Behavior
 
     (Note: this is the replacement for the now removed libquvi support.)
 
+``--ytdl-format=<best|worst|mp4|webm|...>``
+    Video format/quality that is directly passed to youtube-dl. The possible
+    values are specific to the website and the video, for a given url the
+    available formats can be found with the command
+    ``youtube-dl --list-formats URL``.
+
 Video
 -----
 

--- a/options/options.c
+++ b/options/options.c
@@ -131,6 +131,7 @@ const m_option_t mp_opts[] = {
     OPT_KEYVALUELIST("lua-opts", lua_opts, M_OPT_GLOBAL),
     OPT_FLAG("osc", lua_load_osc, CONF_GLOBAL),
     OPT_FLAG("ytdl", lua_load_ytdl, CONF_GLOBAL),
+    OPT_STRING("ytdl-format", lua_ytdl_format, CONF_GLOBAL),
     OPT_FLAG("load-scripts", auto_load_scripts, CONF_GLOBAL),
 #endif
 
@@ -612,6 +613,7 @@ const struct MPOpts mp_default_opts = {
 #if HAVE_LUA
     .lua_load_osc = 1,
     .lua_load_ytdl = 0,
+    .lua_ytdl_format = NULL,
 #endif
     .auto_load_scripts = 1,
     .loop_times = -1,

--- a/options/options.h
+++ b/options/options.h
@@ -62,6 +62,8 @@ typedef struct MPOpts {
     char **lua_opts;
     int lua_load_osc;
     int lua_load_ytdl;
+    char *lua_ytdl_format;
+
     int auto_load_scripts;
 
     struct m_obj_settings *audio_driver_list, *ao_defs;

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -55,16 +55,25 @@ mp.add_hook("on_load", 10, function ()
             url = url:sub(8)
         end
 
+        local format = mp.get_property("options/ytdl-format")
+
         -- subformat workaround
         local subformat = "srt"
         if url:find("crunchyroll.com") then
             subformat = "ass"
         end
 
-        local es, json = exec({
+        local command = {
             ytdl.path, "-J", "--flat-playlist", "--all-subs",
-            "--sub-format", subformat, "--no-playlist", "--", url
-            })
+            "--sub-format", subformat, "--no-playlist"
+        }
+        if (format ~= "") then
+            table.insert(command, "--format")
+            table.insert(command, format)
+        end
+        table.insert(command, "--")
+        table.insert(command, url)
+        local es, json = exec(command)
 
         if (es < 0) or (json == nil) or (json == "") then
             msg.warn("youtube-dl failed, trying to play URL directly ...")


### PR DESCRIPTION
The manpage message is adapated from the old `--quvi-format` option.

I haven't work with lua before, there may be a nicer way of building the youtube-dl command.
