### PR TITLE
ytdl_hook: Allow loading youtube-dl.py on Windows

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -23,7 +23,8 @@ mp.add_hook("on_load", 10, function ()
         if (ytdl.vercheck == nil) then
 
              -- check for youtube-dl in mpv's config dir
-            local ytdl_mcd = mp.find_config_file("youtube-dl") or mp.find_config_file("youtube-dl.py")
+            local ytdl_mcd = mp.find_config_file("youtube-dl")
+                          or mp.find_config_file("youtube-dl.py")
             if not (ytdl_mcd == nil) then
                 msg.verbose("found youtube-dl at: " .. ytdl_mcd)
                 ytdl.path = ytdl_mcd


### PR DESCRIPTION
I'm not sure about actually using 0 and 1 for the values of pyscript, but I was getting too many warnings/errors when I tried setting it up with other values.  I've never done any Lua scripting before, so it can probably be simplified over what I did.

I'm also not sure if it tries using both when both youtube-dl.exe and youtube-dl.py are present and available for use, or if it only uses one of them.  That scenario should be rare, though.

Searching the %PATH% doesn't work for youtube-dl.py because Python doesn't support that, apparently (unless I'm missing something obvious).  So it has to be in mpv's root directory or symlinked there.
