### PR TITLE
gitignore: ignore waf directory on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 /DOCS/man/mpv.toc
 
 /waf
+/waf-*
+/waf3-*
 /build
 /.waf*
 /.lock-waf_*


### PR DESCRIPTION
Not sure why I didn't encounter this before. I must have been using MSYS2 Python for everything, instead of the native one.
