### PR TITLE
Add DVB-S2 and (partial) vdr-style channel-lists support

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3119,6 +3119,12 @@ DVB
     in the mpv configuration directory (usually ``~/.config/mpv``) with the
     filename ``channels.conf.{sat,ter,cbl,atsc}`` (based on your card type) or
     ``channels.conf`` as a last resort.
+    For DVB-S/2 cards, a VDR 1.7.x format channel list is recommended
+    as it allows tuning to DVB-S2 channels, enabling subtitles and
+    decoding the PMT (which largely improves the demuxing).
+    Classic mplayer format channel lists are still supported (without
+    these improvements), and for other card types, only limited VDR
+    format channel list support is implemented (patches welcome).
 
 ``--dvbin-timeout=<1-30>``
     Maximum number of seconds to wait when trying to tune a frequency before

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3125,11 +3125,22 @@ DVB
     Classic mplayer format channel lists are still supported (without
     these improvements), and for other card types, only limited VDR
     format channel list support is implemented (patches welcome).
+    For channels with dynamic PID switching or incomplete
+    ``channels.conf``, ``--dvbin-full-transponder`` or the magic PID
+    ``8192`` are recommended.
 
 ``--dvbin-timeout=<1-30>``
     Maximum number of seconds to wait when trying to tune a frequency before
     giving up (default: 30).
 
+``--dvbin-full-transponder=<yes|no>``
+    Apply no filters on program PIDs, only tune to frequency and pass full
+    transponder to demuxer. This is useful to record multiple programs
+    on a single transponder, or to work around issues in the ``channels.conf``.
+    It is also recommended to use this for channels which switch PIDs
+    on-the-fly, e.g. for regional news.
+
+    Default: ``no``
 
 PVR
 ---

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -187,6 +187,74 @@ int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pesty
         return 1;
 }
 
+int dvb_get_pmt_pid(dvb_priv_t *priv, int card, int service_id) {
+  /* We need special filters on the demux, 
+     so open one locally, and close also here. */
+  char demux_dev[32];
+  sprintf(demux_dev, "/dev/dvb/adapter%d/demux0", card);
+  
+  struct dmx_sct_filter_params fparams;
+  
+  memset(&fparams, 0, sizeof(fparams));
+  fparams.pid = 0;
+  fparams.filter.filter[0] = 0x00;
+  fparams.filter.mask[0] = 0xff;
+  fparams.timeout = 0;
+  fparams.flags = DMX_IMMEDIATE_START | DMX_CHECK_CRC;
+
+  int pat_fd;
+  if ((pat_fd = open(demux_dev, O_RDWR)) < 0) {
+    MP_ERR(priv, "Opening PAT DEMUX failed, error: %d", errno);
+    return -1;
+  }
+  
+  if (ioctl(pat_fd, DMX_SET_FILTER, &fparams) == -1) {
+    MP_ERR(priv, "ioctl DMX_SET_FILTER failed, error: %d", errno);
+    close(pat_fd);
+    return -1;
+  }
+    
+  int bytes_read;
+  int section_length;
+  unsigned char buft[4096];
+  unsigned char *bufptr = buft;
+
+  int pmt_pid = -1;
+
+  bool pat_read = false;
+  while (!pat_read) {
+    if (((bytes_read = read(pat_fd, bufptr, sizeof(buft))) < 0) && errno == EOVERFLOW)
+      bytes_read = read(pat_fd, bufptr, sizeof(buft));
+    if (bytes_read < 0) {
+      MP_ERR(priv, "PAT: read_sections: read error: %d", errno);
+      close(pat_fd);
+      return -1;
+    }
+    
+    section_length = ((bufptr[1] & 0x0f) << 8) | bufptr[2];
+    if (bytes_read != section_length + 3) {
+      continue;
+    }
+    
+    bufptr += 8;
+    section_length -= 8;
+    
+    /* assumes one section contains the whole pat */
+    pat_read = true; 
+    while (section_length > 0) {
+      int this_service_id = (bufptr[0] << 8) | bufptr[1];
+      if (this_service_id == service_id) {
+        pmt_pid = ((bufptr[2] & 0x1f) << 8) | bufptr[3];
+        section_length = 0;
+      }
+      bufptr += 4;
+      section_length -= 4;
+    }
+  }
+  close(pat_fd);
+  
+  return pmt_pid;
+}
 
 int dvb_demux_stop(int fd)
 {

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -324,8 +324,8 @@ static int do_diseqc(int secfd, int sat_no, int polv, int hi_lo)
 }
 
 static int tune_it(dvb_priv_t *priv, int fd_frontend, int fd_sec, unsigned int freq, unsigned int srate, char pol, int tone,
-                   bool is_dvb_s2, fe_spectral_inversion_t specInv, unsigned int diseqc, fe_modulation_t modulation, fe_code_rate_t HP_CodeRate,
-                   fe_transmit_mode_t TransmissionMode, fe_guard_interval_t guardInterval, fe_bandwidth_t bandwidth,
+                   bool is_dvb_s2, int stream_id, fe_spectral_inversion_t specInv, unsigned int diseqc, fe_modulation_t modulation,
+                   fe_code_rate_t HP_CodeRate, fe_transmit_mode_t TransmissionMode, fe_guard_interval_t guardInterval, fe_bandwidth_t bandwidth,
                    fe_code_rate_t LP_CodeRate, fe_hierarchy_t hier, int timeout)
 {
   int hi_lo = 0, dfd;
@@ -424,7 +424,6 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, int fd_sec, unsigned int f
         delsys = SYS_DVBS2;
       }
       fe_rolloff_t rolloff = ROLLOFF_AUTO;
-      int stream_id = NO_STREAM_ID_FILTER;
       
       struct dtv_property p[] = {
            { .cmd = DTV_DELIVERY_SYSTEM,   .u.data = delsys },
@@ -495,7 +494,7 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, int fd_sec, unsigned int f
 
 
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc, int tone,
-             bool is_dvb_s2, fe_spectral_inversion_t specInv, fe_modulation_t modulation, fe_guard_interval_t guardInterval,
+             bool is_dvb_s2, int stream_id, fe_spectral_inversion_t specInv, fe_modulation_t modulation, fe_guard_interval_t guardInterval,
              fe_transmit_mode_t TransmissionMode, fe_bandwidth_t bandWidth, fe_code_rate_t HP_CodeRate,
              fe_code_rate_t LP_CodeRate, fe_hierarchy_t hier, int timeout)
 {
@@ -503,7 +502,7 @@ int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc, int to
 
         MP_INFO(priv, "dvb_tune Freq: %lu\n", (long unsigned int) freq);
 
-        ris = tune_it(priv, priv->fe_fd, priv->sec_fd, freq, srate, pol, tone, is_dvb_s2, specInv, diseqc, modulation, HP_CodeRate, TransmissionMode, guardInterval, bandWidth, LP_CodeRate, hier, timeout);
+        ris = tune_it(priv, priv->fe_fd, priv->sec_fd, freq, srate, pol, tone, is_dvb_s2, stream_id, specInv, diseqc, modulation, HP_CodeRate, TransmissionMode, guardInterval, bandWidth, LP_CodeRate, hier, timeout);
 
         if(ris != 0)
                 MP_INFO(priv, "dvb_tune, TUNING FAILED\n");

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -30,7 +30,7 @@ int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pesty
 int dvb_demux_stop(int fd);
 int dvb_demux_start(int fd);
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
-             int tone, fe_spectral_inversion_t specInv,
+             int tone, bool is_dvb_s2, fe_spectral_inversion_t specInv,
              fe_modulation_t modulation, fe_guard_interval_t guardInterval,
              fe_transmit_mode_t TransmissionMode, fe_bandwidth_t bandWidth,
              fe_code_rate_t HP_CodeRate, fe_code_rate_t LP_CodeRate,

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -27,6 +27,7 @@ int dvb_get_tuner_type(int fe_fd, struct mp_log *log);
 int dvb_open_devices(dvb_priv_t *priv, int n, int demux_cnt);
 int dvb_fix_demuxes(dvb_priv_t *priv, int cnt);
 int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pestype);
+int dvb_get_pmt_pid(dvb_priv_t *priv, int card, int service_id);
 int dvb_demux_stop(int fd);
 int dvb_demux_start(int fd);
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -30,7 +30,7 @@ int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pesty
 int dvb_demux_stop(int fd);
 int dvb_demux_start(int fd);
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
-             int tone, bool is_dvb_s2, fe_spectral_inversion_t specInv,
+             int tone, bool is_dvb_s2, int stream_id, fe_spectral_inversion_t specInv,
              fe_modulation_t modulation, fe_guard_interval_t guardInterval,
              fe_transmit_mode_t TransmissionMode, fe_bandwidth_t bandWidth,
              fe_code_rate_t HP_CodeRate, fe_code_rate_t LP_CodeRate,

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -55,7 +55,7 @@
 #define DVB_CHANNEL_HIGHER 1
 
 #ifndef DMX_FILTER_SIZE
-#define DMX_FILTER_SIZE 16
+#define DMX_FILTER_SIZE 32
 #endif
 
 typedef struct {

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -25,8 +25,24 @@
 
 /* kernel headers >=2.6.28 have version 5.
  *
- * FIXME: are there any real differences between 3.1 and 5?
+ * Version 5 is also called S2API, it adds support for tuning to S2 channels
+ * and is extensible for future delivery systems. Old API is deprecated. 
+ * StreamID-implementation only supported since API >=5.2. 
  */
+
+#if (DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 2)
+#define DVB_USE_S2API 1
+
+// This had a different name until API 5.8. 
+#ifndef DTV_STREAM_ID
+#define DTV_STREAM_ID DTV_ISDBS_TS_ID
+#endif
+
+// This is only defined, for convenience, since API 5.8.
+#ifndef NO_STREAM_ID_FILTER
+#define NO_STREAM_ID_FILTER (~0U)
+#endif
+#endif
 
 #if (DVB_API_VERSION == 3 && DVB_API_VERSION_MINOR >= 1) || DVB_API_VERSION == 5
 #define DVB_ATSC 1

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -63,6 +63,7 @@ typedef struct {
         int                             freq, srate, diseqc, tone;
         char                            pol;
         int                             tpid, dpid1, dpid2, progid, ca, pids[DMX_FILTER_SIZE], pids_cnt;
+        bool                            is_dvb_s2;
         fe_spectral_inversion_t         inv;
         fe_modulation_t                 mod;
         fe_transmit_mode_t              trans;

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -115,6 +115,8 @@ typedef struct dvb_params {
         int cfg_card;
         int cfg_timeout;
         char *cfg_file;
+
+        int cfg_full_transponder;
 } dvb_priv_t;
 
 

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -64,6 +64,7 @@ typedef struct {
         char                            pol;
         int                             tpid, dpid1, dpid2, progid, ca, pids[DMX_FILTER_SIZE], pids_cnt;
         bool                            is_dvb_s2;
+        int                             stream_id;
         fe_spectral_inversion_t         inv;
         fe_modulation_t                 mod;
         fe_transmit_mode_t              trans;

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -65,6 +65,7 @@ typedef struct {
         int                             tpid, dpid1, dpid2, progid, ca, pids[DMX_FILTER_SIZE], pids_cnt;
         bool                            is_dvb_s2;
         int                             stream_id;
+        int                             service_id;
         fe_spectral_inversion_t         inv;
         fe_modulation_t                 mod;
         fe_transmit_mode_t              trans;

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -369,29 +369,6 @@ static dvb_channels_list *dvb_get_channels(struct mp_log *log, int cfg_full_tran
                 if((fields < 2) || (ptr->pids_cnt <= 0) || (ptr->freq == 0) || (strlen(ptr->name) == 0))
                   continue;
 
-                has8192 = has0 = 0;
-                for(cnt = 0; cnt < ptr->pids_cnt; cnt++)
-                {
-                        if(ptr->pids[cnt] == 8192)
-                                has8192 = 1;
-                        if(ptr->pids[cnt] == 0)
-                                has0 = 1;
-                }
-                /* 8192 is the pseudo-PID for full TP dump, 
-                   enforce that if requested. */
-                if (!has8192 && cfg_full_transponder) {
-                  has8192 = 1;
-                }
-                if(has8192) {
-                        ptr->pids[0] = 8192;
-                        ptr->pids_cnt = 1;
-                }
-                else if(! has0)
-                {
-                        ptr->pids[ptr->pids_cnt] = 0;   //PID 0 is the PAT
-                        ptr->pids_cnt++;
-                }
-
                 /* Add some PIDs which are mandatory in DVB, 
                  * and contain human-readable helpful data. */
                 
@@ -414,6 +391,28 @@ static dvb_channels_list *dvb_get_channels(struct mp_log *log, int cfg_full_tran
                   ptr->pids_cnt++;
                 }
                 
+                has8192 = has0 = 0;
+                for(cnt = 0; cnt < ptr->pids_cnt; cnt++)
+                {
+                        if(ptr->pids[cnt] == 8192)
+                                has8192 = 1;
+                        if(ptr->pids[cnt] == 0)
+                                has0 = 1;
+                }
+                
+                /* 8192 is the pseudo-PID for full TP dump, 
+                   enforce that if requested. */
+                if (!has8192 && cfg_full_transponder) {
+                  has8192 = 1;
+                }
+                if (has8192) {
+                        ptr->pids[0] = 8192;
+                        ptr->pids_cnt = 1;
+                } else if (!has0) {
+                        ptr->pids[ptr->pids_cnt] = 0;   //PID 0 is the PAT
+                        ptr->pids_cnt++;
+                }
+
                 mp_verbose(log, " PIDS: ");
                 for(cnt = 0; cnt < ptr->pids_cnt; cnt++)
                         mp_verbose(log, " %d ", ptr->pids[cnt]);

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -901,6 +901,7 @@ static int dvb_open(stream_t *stream)
         stream->fill_buffer = dvb_streaming_read;
         stream->close = dvbin_close;
         stream->control = dvbin_stream_control;
+        stream->streaming = true;
 
         stream->demuxer = "lavf";
         stream->lavf_type = "mpegts";

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -387,6 +387,20 @@ static dvb_channels_list *dvb_get_channels(struct mp_log *log, char *filename, i
                         ptr->pids_cnt++;
                 }
 
+                /* Add some PIDs which are mandatory in DVB, 
+                 * and contain human-readable helpful data. */
+                
+                /* This is the STD, the service description table. 
+                 * It contains service names and such, ffmpeg decodes it. */
+                ptr->pids[ptr->pids_cnt] = 0x0011;
+                ptr->pids_cnt++;
+
+                /* This is the EIT, which contains EPG data. 
+                 * ffmpeg can not decode it (yet), but e.g. VLC 
+                 * shows what was recorded. */
+                ptr->pids[ptr->pids_cnt] = 0x0012;
+                ptr->pids_cnt++;
+
                 if (ptr->service_id != -1) {
                   /* We have the PMT-PID in addition. 
                      This will be found later, when we tune to the channel.


### PR DESCRIPTION
With this changeset, mpv: 
* Can read VDR-style channel-lists (and, at least for DVB-S, extract all information as before). 
* Uses S2API (DVB-API v. 5, since 2.6.28 the older API is deprecated) for tuning, for DVB-S tuners. 

The new API allows to tune to DVB-S2 channels, and as the classic mplayer-styles "channels.conf" do not contain a "DVB-S2" flag, I added vdr-style channel-list support. With this, mpv can now tune to most FullHD-broadcasts via satellite using a vdr-style channel.conf e.g. created with w_scan. 

I tried to be as non-invasive as possible: 
* S2API is only used if DVB-API >= 5.x, and for DVB-S devices. 
* On channel.conf reading, it is tested with a sscanf-pattern whether the line matches the VDR-style format (see http://www.vdr-wiki.de/wiki/index.php/Channels.conf , sadly german only). If not, classic parsing is done. 

I also fixed a broken ifdef (which meant that ATSC should not have worked since a while) and cleaned up some debug-output. The commits are fine-grained and hopefully contain enough commentary to explain what I changed. 

Disclaimer: The non-DVB-S-code paths should function as before, but I only have DVB-S(2) hardware here, and some DVB-T stick with bad reception floating around. I only tested all changes with DVB-S on old and new channel-config-files, DVB-S and DVB-S2 channels, but not on pre-2.6.28 kernels (there are many DVB-S drivers missing there...). 
The VDR-style channel.confs contain a lot more information usable for non-DVB-S cards (e.g. FEC, ROLLOFF etc.). I do not parse this, since I have no hardware to test whether it works as expected, so VDR-style config files will probably not work with this hardware (but not much is missing). As a fallback to the classic config format is in, no old setup should be broken. 

As this is my first (planned) contribution to mpv, feel free to RTFM me or teach me how to better agree with the coding guidelines (I mostly do C++ in real life). 