### PR TITLE
vo_opengl: custom shader support

### DIFF
--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -395,6 +395,7 @@ const struct m_sub_options gl_video_conf = {
                     {"blend", 2})),
         OPT_FLAG("rectangle-textures", use_rectangle, 0),
         OPT_COLOR("background", background, 0),
+        OPT_STRING("custom-shader", custom_shader, 0),
         {0}
     },
     .size = sizeof(struct gl_video_opts),
@@ -1128,6 +1129,10 @@ static void compile_shaders(struct gl_video *p)
         shader_def(&header_conv, "USE_ALPHA_PLANE", "3");
     if (p->opts.alpha_mode == 2 && p->has_alpha)
         shader_def(&header_conv, "USE_ALPHA_BLEND", "1");
+    if (p->opts.custom_shader && strlen(p->opts.custom_shader)) {
+        shader_def_opt(&header_conv, "USE_CUSTOM_SHADER", true);
+        header_conv = talloc_asprintf_append(header_conv, "%s\n", p->opts.custom_shader);
+    }
 
     shader_def_opt(&header_final, "USE_GAMMA_POW", p->opts.gamma > 0);
     shader_def_opt(&header_final, "USE_CMS_MATRIX", use_cms_matrix);

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -51,6 +51,7 @@ struct gl_video_opts {
     int chroma_location;
     int use_rectangle;
     struct m_color background;
+    char *custom_shader;
 };
 
 extern const struct m_sub_options gl_video_conf;

--- a/video/out/gl_video_shaders.glsl
+++ b/video/out/gl_video_shaders.glsl
@@ -480,4 +480,7 @@ void main() {
 #else
     out_color = vec4(color, 1.0);
 #endif
+#ifdef USE_CUSTOM_SHADER
+    out_color = custom_shader(out_color);
+#endif
 }


### PR DESCRIPTION
This commit adds custom shader support for opengl vo.
The prototype for custom_shader is
```
vec3 custom_shader(vec3 color)
```
where the `color` argument is converted rgb color.

Example
```
mpv --vo=opengl-hq:custom-shader='"vec3 custom_shader(vec3 c) { float v = (c.r+c.g+c.b)/3.; return vec3(v, v, v); }"' video.mkv
```
will produce gray scaled video.