### PR TITLE
vo_opengl_cb: introduce frame queue

### DIFF
--- a/libmpv/opengl_cb.h
+++ b/libmpv/opengl_cb.h
@@ -207,6 +207,12 @@ int mpv_opengl_cb_render(mpv_opengl_cb_context *ctx, int fbo, int vp[4]);
  */
 int mpv_opengl_cb_uninit_gl(mpv_opengl_cb_context *ctx);
 
+int mpv_opengl_cb_set_frame_queue_size(mpv_opengl_cb_context *ctx, int size);
+int mpv_opengl_cb_get_frame_queue_size(mpv_opengl_cb_context *ctx);
+int mpv_opengl_cb_get_queued_frames(mpv_opengl_cb_context *ctx);
+uint64_t mpv_opengl_cb_get_dropped_frames(mpv_opengl_cb_context *ctx);
+void mpv_opengl_cb_empty_frame_queue(mpv_opengl_cb_context *ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The previous implementation of opengl-cb kept only latest flipped frame. This can cause massive frame drops because rendering is done asynchronously and only the latest frame can be rendered. This commit introduces frame queue in opengl-cb and provide better way to handle this problem.

Next 5 functions are added:
```
* int mpv_opengl_cb_set_frame_queue_size(mpv_opengl_cb_context *ctx, int size);
* int mpv_opengl_cb_get_frame_queue_size(mpv_opengl_cb_context *ctx);
* int mpv_opengl_cb_get_queued_frames(mpv_opengl_cb_context *ctx);
* uint64_t mpv_opengl_cb_get_dropped_frames(mpv_opengl_cb_context *ctx);
* void mpv_opengl_cb_empty_frame_queue(mpv_opengl_cb_context *ctx);
```
Client can query the state of queue, for instance, client can know how many frames are delayed. Client can make a decision to schedule more frequent update to hurry into rendering next frame. If one thinks too many frames are delayed, he or she can drop all queued frames by emptying queue. Also, the total number of dropped frames by overflow of queue and emptying queue can be queried, too.