### PR TITLE
DXVA2: Copy the image parameters

### DIFF
--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -321,6 +321,7 @@ static struct mp_image *dxva2_retrieve_image(struct lavc_ctx *s,
     }
 
     ctx->copy_nv12(sw_img, LockedRect.pBits, LockedRect.Pitch, surfaceDesc.Height);
+    mp_image_copy_attributes(sw_img, img);
 
     IDirect3DSurface9_UnlockRect(surface);
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -358,6 +358,7 @@ void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
     dst->pict_type = src->pict_type;
     dst->fields = src->fields;
     dst->pts = src->pts;
+    dst->params.rotate = src->params.rotate;
     dst->params.stereo_in = src->params.stereo_in;
     dst->params.stereo_out = src->params.stereo_out;
     if (dst->w == src->w && dst->h == src->h) {
@@ -369,6 +370,7 @@ void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
         dst->params.colorlevels = src->params.colorlevels;
         dst->params.primaries = src->params.primaries;
         dst->params.chroma_location = src->params.chroma_location;
+        dst->params.outputlevels = src->params.outputlevels;
     }
     if ((dst->fmt.flags & MP_IMGFLAG_PAL) && (src->fmt.flags & MP_IMGFLAG_PAL)) {
         if (dst->planes[1] && src->planes[1])


### PR DESCRIPTION
I was watching a video with rotation metadata and it wasn't rotated with --hwdec=dxva2-copy. It seems like this stuff should be copied onto the software image.

I'm not sure if I've done this the right way. I had a look at mp_image_copy_attributes, but it didn't copy the rotation field. Should mp_image_copy_attributes be augmented and used instead? Also, should this be done with vaapi-copy as well?