### PR TITLE
gl_video.c: invalidate image_params in uninit_video()

### DIFF
--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -1643,6 +1643,10 @@ static void uninit_video(struct gl_video *p)
 
     fbotex_uninit(p, &p->indirect_fbo);
     fbotex_uninit(p, &p->scale_sep_fbo);
+    
+    // Invalidate image_params to ensure that gl_video_config() will call
+    // init_video() on uninitialized gl_video.
+    p->image_params = (struct mp_image_params){0};
 }
 
 static void change_dither_trafo(struct gl_video *p)


### PR DESCRIPTION
When the given `mp_image_params` does not match with that of `gl_video`, `gl_video_config()` always calls `uninit_video()` but calls `init_video()` only if valid format is given.

Since `uninit_video()` does not change `image_params` of `gl_video`, when the same params as the previous one is given to `gl_video_config()` after `gl_video` is unitialized with invalid format, `gl_video_config()` never calls `init_video()`.

To prevent this, invalidate `image_params` of `gl_video` in `uninit_video()`.