### PR TITLE
make mpv_opengl_cb_render() return left frames

### DIFF
--- a/libmpv/opengl_cb.h
+++ b/libmpv/opengl_cb.h
@@ -191,7 +191,7 @@ int mpv_opengl_cb_init_gl(mpv_opengl_cb_context *ctx, const char *exts,
  *           image - the renderer will flip it before setting the viewport
  *           (typically you want to flip the image if you are rendering
  *           directly to the main framebuffer).
- * @return error code
+ * @return the number of left frames in the internal queue to be rendered
  */
 int mpv_opengl_cb_render(mpv_opengl_cb_context *ctx, int fbo, int vp[4]);
 

--- a/video/out/vo_opengl_cb.c
+++ b/video/out/vo_opengl_cb.c
@@ -343,11 +343,12 @@ int mpv_opengl_cb_render(struct mpv_opengl_cb_context *ctx, int fbo, int vp[4])
     gl_video_unset_gl_state(ctx->renderer);
 
     pthread_mutex_lock(&ctx->lock);
-    if (vo && ctx->queued_frames > 0)
+    const int left = ctx->queued_frames;
+    if (vo && left > 0)
         update(vo->priv);
     pthread_mutex_unlock(&ctx->lock);
 
-    return 0;
+    return left;
 }
 
 static void draw_image(struct vo *vo, mp_image_t *mpi)


### PR DESCRIPTION
Instead of error code which was not helpful because it's always 0, mpv_opengl_cb_render() returns the number of left frames in the frame queue by this commit.