### PR TITLE
Fix overflowing stream-cache buffer index (pos), add some err-output

### DIFF
--- a/stream/cache.c
+++ b/stream/cache.c
@@ -241,7 +241,7 @@ static bool cache_fill(struct priv *s)
     int64_t space = s->buffer_size - (newb + back);
 
     // offset into the buffer that maps to max_filepos
-    int pos = s->max_filepos - s->offset;
+    int64_t pos = s->max_filepos - s->offset;
     if (pos >= s->buffer_size)
         pos -= s->buffer_size; // wrap-around
 

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -621,6 +621,10 @@ static int dvb_streaming_read(stream_t *stream, char *buffer, int size)
         if ((rk = read(fd, &buffer[pos], rk)) > 0) {
             pos += rk;
             MP_TRACE(stream, "ret (%d) bytes\n", pos);
+        } else {
+          MP_ERR(stream, "dvb_streaming_read, poll ok but read failed with "
+                 "errno %d when reading %d bytes, size: %d, pos: %d\n",
+                 errno, size - pos, size, pos);
         }
     }
 


### PR DESCRIPTION
I found during dvb-watching, mpv ended in an endless loop after about 30-50 minutes (I use a large cache of ~ 4 GiB to allow for in-memory time-shifting). 
The issue was that we got locked in dvb_streaming_read: poll() worked fine, but the read()-syscall returned EFAULT, since &buffer[pos] was pointing to memory not belonging to us. I added an MP_ERR to make such issues visible in the future. 

Going back up, the issue is happening in stream/cache.c: pos needs to be int64_t, it is calculated from max_filepos and offset, both are int64_t. It overflowed for me at some point, thus creating an invalid buffer-ptr. 