### PR TITLE
Fix Windows build for the ewa_lanczos stuff

### DIFF
--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -48,7 +48,8 @@ def __add_clang_flags__(ctx):
                        "-Wno-tautological-constant-out-of-range-compare" ]
 
 def __add_mswin_flags__(ctx):
-    ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x600', '-DUNICODE', '-DCOBJMACROS']
+    ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x600', '-DUNICODE', '-DCOBJMACROS',
+                       '-U__STRICT_ANSI__']
 
 def __add_mingw_flags__(ctx):
     __add_mswin_flags__(ctx)
@@ -58,7 +59,6 @@ def __add_mingw_flags__(ctx):
 def __add_cygwin_flags__(ctx):
     __add_mswin_flags__(ctx)
     ctx.env.CFLAGS += ['-mwin32']
-    ctx.env.CFLAGS += ['-U__STRICT_ANSI__']
 
 __compiler_map__ = {
     '__GNUC__':  __add_gcc_flags__,


### PR DESCRIPTION
j1() isn't available when ``__STRICT_ANSI__`` is defined.

Related MinGW-w64 feature request:
https://sourceforge.net/p/mingw-w64/feature-requests/68/