### PR TITLE
Show a window when launched from Explorer

### DIFF
--- a/player/main.c
+++ b/player/main.c
@@ -476,6 +476,13 @@ int mp_initialize(struct MPContext *mpctx)
     return 0;
 }
 
+#ifdef __MINGW32__
+static bool is_valid_handle(HANDLE h)
+{
+    return h != NULL && h != INVALID_HANDLE_VALUE;
+}
+#endif
+
 int mpv_main(int argc, char *argv[])
 {
     osdep_preinit(&argc, &argv);
@@ -518,6 +525,23 @@ int mpv_main(int argc, char *argv[])
 
     if (handle_help_options(mpctx))
         exit_player(mpctx, EXIT_NONE);
+
+#ifdef __MINGW32__
+    // If the .exe is launched directly from Explorer or the Start Menu, show
+    // some UI so files can be dropped onto it. This test uses a heuristic to
+    // determine whether mpv was launched as a GUI program. If it has no input
+    // files, no command line arguments and no standard handles, it would
+    // normally do nothing, so force it to show a window instead.
+
+    if (argc == 1 && !mpctx->playlist->first && !opts->player_idle_mode &&
+        !is_valid_handle(GetStdHandle(STD_INPUT_HANDLE)) &&
+        !is_valid_handle(GetStdHandle(STD_OUTPUT_HANDLE)) &&
+        !is_valid_handle(GetStdHandle(STD_ERROR_HANDLE)))
+    {
+        m_config_set_option0(mpctx->mconfig, "idle", "yes");
+        m_config_set_option0(mpctx->mconfig, "force-window", "yes");
+    }
+#endif
 
     if (!mpctx->playlist->first && !opts->player_idle_mode) {
         mp_print_version(mpctx->log, true);


### PR DESCRIPTION
As discussed on IRC a little while back. I think it makes sense to do this when there is no console window on Windows, and it would hopefully prevent issues like #1308, #1083, #726, and #524.

I'd like to set ``--keep-open`` as well, since I think that's more natural for a GUI media player, but it would deviate from the behaviour of the OS X bundle.

Note this doesn't change the behaviour of mpv when it's launched as a file association, since argc will be 2. I think the best way to handle this case is to bundle mpv with a program or script that sets custom file associations. WIP batch script here: https://gist.github.com/rossy/b87272a6606b98f409fb