### PR TITLE
Fix WASAPI format selection for unsupported formats in shared mode

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -324,8 +324,7 @@ static bool try_format(struct ao *ao,
                        ao->channels.num, af_fmt_to_str(ao->format), ao->samplerate);
             return true;
         }
-    } if (hr == S_OK || (!state->opt_exclusive && hr == AUDCLNT_E_UNSUPPORTED_FORMAT)) {
-        // AUDCLNT_E_UNSUPPORTED_FORMAT here means "works in shared, doesn't in exclusive"
+    } else if (hr == S_OK) {
         if (set_ao_format(ao, &wformat.Format)) {
             MP_VERBOSE(ao, "%dch %s @ %dhz accepted\n",
                        ao->channels.num, af_fmt_to_str(ao->format), samplerate);


### PR DESCRIPTION
I've been having trouble with ao_wasapi on my work laptop (Windows 7, SigmaTel STAC9228 sound card.) It would only successfully select a format when the sample rate of the file matched the mix format. With other sample rates, it would try to select a matching format and fail init ([log][1].)

I think this was happening because the old code misinterpreted the docs and treated AUDCLNT_E_UNSUPPORTED_FORMAT as success instead of failure in shared mode (see the commit message.) This patch fixes it for me by treating that return code as failure, so it will fall back to the mix format.

Interestingly, none of my machines at home have this problem because they never fail in IsFormatSupported and always return the mix format in ``closestMatch``.

[1]: https://gist.github.com/rossy/60169dedf80883968519