### PR TITLE
vdpau: simplify screenshot code for vdpau

### DIFF
--- a/video/vdpau.h
+++ b/video/vdpau.h
@@ -74,9 +74,6 @@ struct mp_vdpau_ctx {
         bool in_use;
         int64_t age;
     } video_surfaces[MAX_VIDEO_SURFACES];
-    struct mp_vdpau_mixer *getimg_mixer;
-    VdpOutputSurface getimg_surface;
-    int getimg_w, getimg_h;
 };
 
 struct mp_vdpau_ctx *mp_vdpau_create_device_x11(struct mp_log *log, Display *x11);


### PR DESCRIPTION
Instead of vdpau mixer, download YCbCr data directly.

One question: does `video_surface_get_bits_y_cb_cr()` convert data to given VdpYCbCrFormat if underlying format doesn't match?

For now, this code always requests VDP_YCBCR_FORMAT_YV12. If automatic conversion is not gauranteed, it's needed to add querying code to figure out what format supported using `VdpVideoSurfaceQueryGetPutBitsYCbCrCapabilities()`.
In that case, it could be not simplified anymore but I think it's still better code than using mixer because it does not require additional fields in vdpau context structure.