### PR TITLE
input, player: new command for mouse event

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -374,6 +374,23 @@ List of Input Commands
     essentially like ``quit``. Useful for the client API: playback can be
     stopped without terminating the player.
 
+``mouse <x> <y> [<button> [single|double]]``
+    Send a mouse event with given coordinate (``<x>``, ``<y>``).
+
+    Second argument:
+
+    <button>
+        The button number of clicked mouse button. This should be one of 0-19.
+        If ``<button>`` is omitted, only the position will be updated.
+
+    Third argument:
+
+    <single> (default)
+        The mouse event represents regular single click.
+
+    <double>
+        The mouse event represents double-click.
+
 
 Input Commands that are Possibly Subject to Change
 --------------------------------------------------

--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -186,6 +186,13 @@ const struct mp_cmd_def mp_cmds[] = {
   { MP_CMD_HOOK_ADD, "hook_add", { ARG_STRING, ARG_INT, ARG_INT } },
   { MP_CMD_HOOK_ACK, "hook_ack", { ARG_STRING } },
 
+  { MP_CMD_MOUSE, "mouse", {
+      ARG_INT, ARG_INT, // coordinate (x, y)
+      OARG_INT(-1),     // button number
+      OARG_CHOICE(0, ({"single", 0},
+                      {"double", 1})),
+  }},
+
   {0}
 };
 

--- a/input/cmd_list.h
+++ b/input/cmd_list.h
@@ -83,6 +83,8 @@ enum mp_command_type {
 
     MP_CMD_DROP_BUFFERS,
 
+    MP_CMD_MOUSE,
+
     /// Audio Filter commands
     MP_CMD_AF,
     MP_CMD_AO_RELOAD,

--- a/player/command.c
+++ b/player/command.c
@@ -39,6 +39,7 @@
 #include "osdep/timer.h"
 #include "common/common.h"
 #include "input/input.h"
+#include "input/keycodes.h"
 #include "stream/stream.h"
 #include "demux/demux.h"
 #include "demux/stheader.h"
@@ -4710,6 +4711,24 @@ int run_command(MPContext *mpctx, mp_cmd_t *cmd)
         }
         mp_hook_run(mpctx, cmd->sender, cmd->args[0].v.s);
         break;
+
+    case MP_CMD_MOUSE: {
+        const int x = cmd->args[0].v.i, y = cmd->args[1].v.i;
+        int button = cmd->args[2].v.i;
+        if (button == -1) {// no button
+            mp_input_set_mouse_pos(mpctx->input, x, y);
+            break;
+        }
+        if (button < 0 || button >= 20) {// invalid button
+            MP_ERR(mpctx, "%d is not a valid mouse button number.\n", button);
+            return -1;
+        }
+        const bool dbc = cmd->args[3].v.i;
+        button += dbc ? MP_MOUSE_BASE_DBL : MP_MOUSE_BASE;
+        mp_input_set_mouse_pos(mpctx->input, x, y);
+        mp_input_put_key(mpctx->input, button);
+        break;
+    }
 
     default:
         MP_VERBOSE(mpctx, "Received unknown cmd %s\n", cmd->name);


### PR DESCRIPTION
New command `mouse <x> <y> [<button> [single|double]]` is introduced.

This will update mouse position with given coordinate (`<x>`, `<y>`), and additionally, send single-click or double-click event if `<button>` is given.