### PR TITLE
ta: rename MP_TALLOC_ELEMS to MP_TARRAY_AVAILABLE

### DIFF
--- a/player/timeline/tl_matroska.c
+++ b/player/timeline/tl_matroska.c
@@ -281,7 +281,7 @@ static int find_ordered_chapter_sources(struct MPContext *mpctx,
             MP_INFO(mpctx, "Will scan other files in the "
                     "same directory to find referenced sources.\n");
             filenames = find_files(main_filename);
-            num_filenames = MP_TALLOC_ELEMS(filenames);
+            num_filenames = MP_TALLOC_AVAIL(filenames);
             talloc_steal(tmp, filenames);
         }
         // Possibly get further segments appended to the first segment

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -207,7 +207,7 @@ void mp_ass_render_frame(ASS_Renderer *renderer, ASS_Track *track, double time,
 
     res->parts = *parts;
     res->num_parts = 0;
-    int num_parts_alloc = MP_TALLOC_ELEMS(res->parts);
+    int num_parts_alloc = MP_TALLOC_AVAIL(res->parts);
     for (struct ass_image *img = imgs; img; img = img->next) {
         if (img->w == 0 || img->h == 0)
             continue;

--- a/ta/ta_talloc.h
+++ b/ta/ta_talloc.h
@@ -75,7 +75,7 @@ char *ta_talloc_asprintf_append_buffer(char *s, const char *fmt, ...) TA_PRF(2, 
 
 #define TA_EXPAND_ARGS(...) __VA_ARGS__
 
-#define MP_TALLOC_ELEMS(p) (talloc_get_size(p) / sizeof((p)[0]))
+#define MP_TALLOC_AVAIL(p) (talloc_get_size(p) / sizeof((p)[0]))
 
 #define MP_RESIZE_ARRAY(ctx, p, count)                          \
     do {                                                        \
@@ -86,7 +86,7 @@ char *ta_talloc_asprintf_append_buffer(char *s, const char *fmt, ...) TA_PRF(2, 
 #define MP_TARRAY_GROW(ctx, p, nextidx)             \
     do {                                            \
         size_t nextidx_ = (nextidx);                \
-        if (nextidx_ >= MP_TALLOC_ELEMS(p))         \
+        if (nextidx_ >= MP_TALLOC_AVAIL(p))         \
             MP_RESIZE_ARRAY(ctx, p, ta_calc_prealloc_elems(nextidx_)); \
     } while (0)
 

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -266,7 +266,7 @@ static void VS_CC vs_frame_done(void *userData, const VSFrameRef *f, int n,
 static bool locked_need_input(struct vf_instance *vf)
 {
     struct vf_priv_s *p = vf->priv;
-    return p->num_buffered < MP_TALLOC_ELEMS(p->buffered);
+    return p->num_buffered < MP_TALLOC_AVAIL(p->buffered);
 }
 
 // Return true if progress was made.
@@ -457,7 +457,7 @@ static const VSFrameRef *VS_CC infiltGetFrame(int frameno, int activationReason,
             p->vsapi->setFilterError(msg, frameCtx);
             break;
         }
-        if (frameno >= p->in_frameno + MP_TALLOC_ELEMS(p->buffered)) {
+        if (frameno >= p->in_frameno + MP_TALLOC_AVAIL(p->buffered)) {
             // Too far in the future. Remove frames, so that the main thread can
             // queue new frames.
             if (p->num_buffered) {


### PR DESCRIPTION
The macro is meant for arrays and actually returns the *available* space
in the array, not how much is actually filled in.

---
Some misuses due to the name may have been pointed out by this rename; will comment in those locations.