### PR TITLE
vf_vapoursynth: add display refresh rate property

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -653,6 +653,9 @@ Available filters are:
 
         Useful for some filters which insist on having a FPS.
 
+    ``display_fps``
+        Refresh rate of the current display. Note that this value can be 0.
+
 ``vapoursynth-lazy``
     The same as ``vapoursynth``, but doesn't load Python scripts. Instead, a
     custom backend using Lua and the raw VapourSynth API is used. The syntax

--- a/player/video.c
+++ b/player/video.c
@@ -180,6 +180,8 @@ static void recreate_video_filters(struct MPContext *mpctx)
     d_video->vfilter->wakeup_callback = wakeup_playloop;
     d_video->vfilter->wakeup_callback_ctx = mpctx;
     d_video->vfilter->container_fps = d_video->fps;
+    vo_control(mpctx->video_out, VOCTRL_GET_DISPLAY_FPS,
+        &d_video->vfilter->display_fps);
 
     vf_append_filter_list(d_video->vfilter, opts->vf_settings);
 

--- a/video/filter/vf.h
+++ b/video/filter/vf.h
@@ -122,6 +122,7 @@ struct vf_chain {
     uint8_t allowed_output_formats[IMGFMT_END - IMGFMT_START];
 
     double container_fps;
+    double display_fps;
 
     struct mp_log *log;
     struct MPOpts *opts;

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -592,6 +592,7 @@ static int reinit_vs(struct vf_instance *vf)
     p->vsapi->propSetInt(vars, "video_in_dw", p->fmt_in.d_w, 0);
     p->vsapi->propSetInt(vars, "video_in_dh", p->fmt_in.d_h, 0);
     p->vsapi->propSetFloat(vars, "container_fps", vf->chain->container_fps, 0);
+    p->vsapi->propSetFloat(vars, "display_fps", vf->chain->display_fps, 0);
 
     if (p->drv->load(vf, vars) < 0)
         goto error;


### PR DESCRIPTION
For me it seems to work quite reliably, at least I couldn't break it. 
`display_fps` is 0 in a VS script when there's not (yet) a refresh rate set by the back-end.