### PR TITLE
Switch to uniform float[] for ewa_lanczos

### DIFF
--- a/video/out/gl_common.c
+++ b/video/out/gl_common.c
@@ -56,7 +56,6 @@ static const struct feature features[] = {
     {MPGL_CAP_FLOAT_TEX,        "Float textures"},
     {MPGL_CAP_TEX_RG,           "RG textures"},
     {MPGL_CAP_1ST_CLASS_ARRAYS, "1st class shader arrays"},
-    {MPGL_CAP_1D_TEX,           "1D textures"},
     {MPGL_CAP_3D_TEX,           "3D textures"},
     {MPGL_CAP_DEBUG,            "debugging extensions"},
     {MPGL_CAP_SW,               "suspected software renderer"},
@@ -169,8 +168,7 @@ static const struct gl_functions gl_functions[] = {
     // GL 2.1+ desktop only (and GLSL 120 shaders)
     {
         .ver_core = 210,
-        .provides = MPGL_CAP_ROW_LENGTH | MPGL_CAP_1D_TEX | MPGL_CAP_3D_TEX |
-                    MPGL_CAP_1ST_CLASS_ARRAYS,
+        .provides = MPGL_CAP_ROW_LENGTH | MPGL_CAP_3D_TEX | MPGL_CAP_1ST_CLASS_ARRAYS,
         .functions = (const struct gl_function[]) {
             DEF_FN(DrawBuffer),
             DEF_FN(GetTexLevelParameteriv),

--- a/video/out/gl_common.c
+++ b/video/out/gl_common.c
@@ -157,6 +157,7 @@ static const struct gl_functions gl_functions[] = {
             DEF_FN(Uniform2f),
             DEF_FN(Uniform3f),
             DEF_FN(Uniform1i),
+            DEF_FN(Uniform1fv),
             DEF_FN(UniformMatrix2fv),
             DEF_FN(UniformMatrix3fv),
             DEF_FN(UseProgram),

--- a/video/out/gl_common.h
+++ b/video/out/gl_common.h
@@ -234,6 +234,7 @@ struct GL {
     void (GLAPIENTRY *Uniform3f)(GLint, GLfloat, GLfloat, GLfloat);
     void (GLAPIENTRY *Uniform4f)(GLint, GLfloat, GLfloat, GLfloat, GLfloat);
     void (GLAPIENTRY *Uniform1i)(GLint, GLint);
+    void (GLAPIENTRY *Uniform1fv)(GLint, GLsizei, const GLfloat *);
     void (GLAPIENTRY *UniformMatrix2fv)(GLint, GLsizei, GLboolean,
                                         const GLfloat *);
     void (GLAPIENTRY *UniformMatrix3fv)(GLint, GLsizei, GLboolean,

--- a/video/out/gl_common.h
+++ b/video/out/gl_common.h
@@ -62,9 +62,8 @@ enum {
     MPGL_CAP_VDPAU              = (1 << 11),    // GL_NV_vdpau_interop
     MPGL_CAP_APPLE_RGB_422      = (1 << 12),    // GL_APPLE_rgb_422
     MPGL_CAP_1ST_CLASS_ARRAYS   = (1 << 13),
-    MPGL_CAP_1D_TEX             = (1 << 14),
-    MPGL_CAP_3D_TEX             = (1 << 15),
-    MPGL_CAP_DEBUG              = (1 << 16),
+    MPGL_CAP_3D_TEX             = (1 << 14),
+    MPGL_CAP_DEBUG              = (1 << 15),
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };
 

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -46,8 +46,9 @@ static const char vo_opengl_shaders[] =
 #include "video/out/gl_video_shaders.h"
 ;
 
-// Pixel width of 1D lookup textures.
+// Pixel width of lookup tables.
 #define LOOKUP_TEXTURE_SIZE 256
+#define LOOKUP_ARRAY_SIZE 64
 
 // Texture units 0-3 are used by the video, with unit 0 for free use.
 // Units 4-5 are used for scaler LUTs.
@@ -108,6 +109,9 @@ struct scaler {
     GLuint gl_lut;
     const char *lut_name;
     bool insufficient;
+
+    // lookup table for 1D scalers
+    float table[LOOKUP_ARRAY_SIZE];
 
     // kernel points here
     struct filter_kernel kernel_storage;
@@ -645,9 +649,15 @@ static void update_uniforms(struct gl_video *p, GLuint program)
 
     for (int n = 0; n < 2; n++) {
         const char *lut = p->scalers[n].lut_name;
-        if (lut)
-            gl->Uniform1i(gl->GetUniformLocation(program, lut),
-                          TEXUNIT_SCALERS + n);
+        if (lut) {
+            loc = gl->GetUniformLocation(program, lut);
+            float *table = p->scalers[n].table;
+            if (*table != 0.0) {
+                gl->Uniform1fv(loc, LOOKUP_ARRAY_SIZE, table);
+            } else {
+                gl->Uniform1i(loc, TEXUNIT_SCALERS + n);
+            }
+        }
     }
 
     gl->Uniform1i(gl->GetUniformLocation(program, "dither"), TEXUNIT_DITHER);
@@ -900,9 +910,11 @@ static void compile_shaders(struct gl_video *p)
                              "#define HAVE_1DTEX %d\n"
                              "#define HAVE_3DTEX %d\n"
                              "#define HAVE_ARRAYS %d\n"
+                             "#define LOOKUP_ARRAY_SIZE %d\n"
                              "%s%s",
                              gl->glsl_version, gl->es >= 300 ? " es" : "",
-                             rg, tex1d, tex3d, arrays, shader_prelude, PRELUDE_END);
+                             rg, tex1d, tex3d, arrays, LOOKUP_ARRAY_SIZE,
+                             shader_prelude, PRELUDE_END);
 
     bool use_cms = p->opts.srgb || p->use_lut_3d;
     // 3DLUT overrides sRGB
@@ -1192,6 +1204,7 @@ static void init_scaler(struct gl_video *p, struct scaler *scaler)
 
     assert(scaler->name);
 
+    scaler->table[0] = 0;
     scaler->kernel = NULL;
     scaler->insufficient = false;
 
@@ -1214,6 +1227,14 @@ static void init_scaler(struct gl_video *p, struct scaler *scaler)
 
     update_scale_factor(p, scaler);
 
+    if (scaler->kernel->polar) {
+        scaler->lut_name = scaler->index == 0 ? "lut_1d_l" : "lut_1d_c";
+        mp_compute_lut(scaler->kernel, LOOKUP_ARRAY_SIZE, scaler->table);
+        return;
+    }
+
+    scaler->lut_name = scaler->index == 0 ? "lut_2d_l" : "lut_2d_c";
+
     int size = scaler->kernel->size;
     int elems_per_pixel = 4;
     if (size == 1) {
@@ -1226,41 +1247,26 @@ static void init_scaler(struct gl_video *p, struct scaler *scaler)
     int width = size / elems_per_pixel;
     assert(size == width * elems_per_pixel);
     const struct fmt_entry *fmt = &gl_float16_formats[elems_per_pixel - 1];
-    int target;
-
-    if (scaler->kernel->polar) {
-        target = GL_TEXTURE_1D;
-        scaler->lut_name = scaler->index == 0 ? "lut_1d_l" : "lut_1d_c";
-    } else {
-        target = GL_TEXTURE_2D;
-        scaler->lut_name = scaler->index == 0 ? "lut_2d_l" : "lut_2d_c";
-    }
 
     gl->ActiveTexture(GL_TEXTURE0 + TEXUNIT_SCALERS + scaler->index);
 
     if (!scaler->gl_lut)
         gl->GenTextures(1, &scaler->gl_lut);
 
-    gl->BindTexture(target, scaler->gl_lut);
+    gl->BindTexture(GL_TEXTURE_2D, scaler->gl_lut);
 
     float *weights = talloc_array(NULL, float, LOOKUP_TEXTURE_SIZE * size);
     mp_compute_lut(scaler->kernel, LOOKUP_TEXTURE_SIZE, weights);
 
-    if (target == GL_TEXTURE_1D) {
-        gl->TexImage1D(target, 0, fmt->internal_format, LOOKUP_TEXTURE_SIZE,
-                       0, fmt->format, GL_FLOAT, weights);
-    } else {
-        gl->TexImage2D(target, 0, fmt->internal_format, width, LOOKUP_TEXTURE_SIZE,
-                       0, fmt->format, GL_FLOAT, weights);
-    }
+    gl->TexImage2D(GL_TEXTURE_2D, 0, fmt->internal_format, width, LOOKUP_TEXTURE_SIZE,
+                   0, fmt->format, GL_FLOAT, weights);
 
     talloc_free(weights);
 
-    gl->TexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    gl->TexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    gl->TexParameteri(target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    if (target != GL_TEXTURE_1D)
-        gl->TexParameteri(target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     gl->ActiveTexture(GL_TEXTURE0);
 


### PR DESCRIPTION
Pull request for publicity.

On my hardware, this improves rendering times for high resolution content *significantly*, since it decouples LUT fetches from source frame fetches, allowing for a speedup of something like 50% at radius 4.0 (possibly more at a higher radius).

However, I'm not sure how controversial it is. I haven't tested AMD hardware, where I have a feeling it might degrade performance (based on previous experience). I also haven't tested the potential loss of image quality. (LUT precision was decreased from 256 to 64, and we also use nearest neighbour sampling instead of linear interpolation)

Feedback would be greatly appreciated.