### PR TITLE
cocoa: update mouse coordinates when window is initialized.

### DIFF
--- a/video/out/cocoa/events_view.h
+++ b/video/out/cocoa/events_view.h
@@ -23,4 +23,5 @@
 - (void)setFullScreen:(BOOL)willBeFullscreen;
 - (void)clear;
 - (BOOL)canHideCursor;
+- (void)signalMousePosition;
 @end

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -209,6 +209,8 @@
 - (void)signalMousePosition
 {
     NSPoint p = [self convertPointToPixels:[self mouseLocation]];
+    p.x = MIN(MAX(p.x, 0), self.bounds.size.width-1);
+    p.y = MIN(MAX(p.y, 0), self.bounds.size.height-1);
     [self.adapter signalMouseMovement:p];
 }
 

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -28,7 +28,6 @@
 @property(nonatomic, assign) BOOL clearing;
 @property(nonatomic, assign) BOOL hasMouseDown;
 @property(nonatomic, retain) NSTrackingArea *tracker;
-- (void)signalMousePosition;
 - (BOOL)hasDock:(NSScreen*)screen;
 - (BOOL)hasMenubar:(NSScreen*)screen;
 - (int)mpvButtonNumber:(NSEvent*)event;

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -379,6 +379,8 @@ static void create_ui(struct vo *vo, struct mp_rect *win, int geo_flags)
     view.adapter = adapter;
     s->view = view;
     [parent addSubview:s->view];
+    // update the cursor position now that the view has been added.
+    [view signalMousePosition];
 
     // insert ourselves as the next key view so that clients can give key
     // focus to the mpv view by calling -[NSWindow selectNextKeyView:]
@@ -501,7 +503,7 @@ int vo_cocoa_config_window(struct vo *vo, uint32_t flags, void *gl_ctx)
         }
 
         // trigger a resize -> don't set vo->dwidth and vo->dheight directly
-        // since this block is executed asynchrolously to the video
+        // since this block is executed asynchronously to the video
         // reconfiguration code.
         s->pending_events |= VO_EVENT_RESIZE;
     });


### PR DESCRIPTION
Previously, `mp_input_get_mouse_pos` would return (0,0) from mpv launch until a mouse move event occurred. This commit explicitly updates the mouse position when the view is initialized.

Can result in coordinates outside of the frame that won't normally be encountered (due to not being filtered through the tracking area), but it doesn't seem to be a problem. I am curious how the other wm environments handle this.