### PR TITLE
ytdl: added "--ytdl-params" option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -454,15 +454,17 @@ Program Behavior
     ``bestvideo+bestaudio``.
     (Default: ``best``)
 
-``--ytdl-params==<key>=<value>[,<key>=<value>[,...]]``
-    Pass arbitraty options to youtube-dl.
-
+``--ytdl-raw-options=<key>=<value>[,<key>=<value>[,...]]``
+    Pass arbitraty options to youtube-dl. Parameter and argument should be
+    passed as a key-value pair. Options without argument must include ``=``.
+    
     There is no sanity checking so it's possible to break things (i.e.
     passing invalid parameters to youtube-dl).
 
     .. admonition:: Example
  
-        ``--ytdl-params=username=user,password=pass``
+        ``--ytdl-raw-options=username=user,password=pass``
+        ``--ytdl-raw-options=force-ipv6=``
 
 Video
 -----

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -454,6 +454,14 @@ Program Behavior
     ``bestvideo+bestaudio``.
     (Default: ``best``)
 
+``--ytdl-params=<youtube-dl options>``
+    This option allows the user to pass non-supported options directly to
+    youtube-dl, such as ``--proxy URL``, ``--username USERNAME`` and
+    ``--password PASSWORD``.
+
+    There is no sanity checking so it's possible to break things (i.e.
+    if you pass ``--version`` mpv exits with random JSON error).
+
 Video
 -----
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -454,13 +454,15 @@ Program Behavior
     ``bestvideo+bestaudio``.
     (Default: ``best``)
 
-``--ytdl-params=<youtube-dl options>``
-    This option allows the user to pass non-supported options directly to
-    youtube-dl, such as ``--proxy URL``, ``--username USERNAME`` and
-    ``--password PASSWORD``.
+``--ytdl-params==<key>=<value>[,<key>=<value>[,...]]``
+    Pass arbitraty options to youtube-dl.
 
     There is no sanity checking so it's possible to break things (i.e.
-    if you pass ``--version`` mpv exits with random JSON error).
+    passing invalid parameters to youtube-dl).
+
+    .. admonition:: Example
+ 
+        ``--ytdl-params=username=user,password=pass``
 
 Video
 -----

--- a/options/options.c
+++ b/options/options.c
@@ -133,7 +133,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("osc", lua_load_osc, CONF_GLOBAL),
     OPT_FLAG("ytdl", lua_load_ytdl, CONF_GLOBAL),
     OPT_STRING("ytdl-format", lua_ytdl_format, CONF_GLOBAL),
-    OPT_STRING("ytdl-params", lua_ytdl_params, CONF_GLOBAL),
+    OPT_KEYVALUELIST("ytdl-params", lua_ytdl_params, CONF_GLOBAL),
     OPT_FLAG("load-scripts", auto_load_scripts, CONF_GLOBAL),
 #endif
 

--- a/options/options.c
+++ b/options/options.c
@@ -133,6 +133,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("osc", lua_load_osc, CONF_GLOBAL),
     OPT_FLAG("ytdl", lua_load_ytdl, CONF_GLOBAL),
     OPT_STRING("ytdl-format", lua_ytdl_format, CONF_GLOBAL),
+    OPT_STRING("ytdl-params", lua_ytdl_params, CONF_GLOBAL),
     OPT_FLAG("load-scripts", auto_load_scripts, CONF_GLOBAL),
 #endif
 
@@ -716,6 +717,7 @@ const struct MPOpts mp_default_opts = {
     .lua_load_osc = 1,
     .lua_load_ytdl = 1,
     .lua_ytdl_format = NULL,
+    .lua_ytdl_params = NULL,
 #endif
     .auto_load_scripts = 1,
     .loop_times = 1,

--- a/options/options.c
+++ b/options/options.c
@@ -133,7 +133,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("osc", lua_load_osc, CONF_GLOBAL),
     OPT_FLAG("ytdl", lua_load_ytdl, CONF_GLOBAL),
     OPT_STRING("ytdl-format", lua_ytdl_format, CONF_GLOBAL),
-    OPT_KEYVALUELIST("ytdl-params", lua_ytdl_params, CONF_GLOBAL),
+    OPT_KEYVALUELIST("ytdl-raw-options", lua_ytdl_raw_options, CONF_GLOBAL),
     OPT_FLAG("load-scripts", auto_load_scripts, CONF_GLOBAL),
 #endif
 
@@ -717,7 +717,7 @@ const struct MPOpts mp_default_opts = {
     .lua_load_osc = 1,
     .lua_load_ytdl = 1,
     .lua_ytdl_format = NULL,
-    .lua_ytdl_params = NULL,
+    .lua_ytdl_raw_options = NULL,
 #endif
     .auto_load_scripts = 1,
     .loop_times = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -68,7 +68,7 @@ typedef struct MPOpts {
     int lua_load_osc;
     int lua_load_ytdl;
     char *lua_ytdl_format;
-    char *lua_ytdl_params;
+    char **lua_ytdl_params;
 
     int auto_load_scripts;
 

--- a/options/options.h
+++ b/options/options.h
@@ -68,7 +68,7 @@ typedef struct MPOpts {
     int lua_load_osc;
     int lua_load_ytdl;
     char *lua_ytdl_format;
-    char **lua_ytdl_params;
+    char **lua_ytdl_raw_options;
 
     int auto_load_scripts;
 

--- a/options/options.h
+++ b/options/options.h
@@ -68,6 +68,7 @@ typedef struct MPOpts {
     int lua_load_osc;
     int lua_load_ytdl;
     char *lua_ytdl_format;
+    char *lua_ytdl_params;
 
     int auto_load_scripts;
 

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -80,7 +80,7 @@ mp.add_hook("on_load", 10, function ()
         end
 
         local format = mp.get_property("options/ytdl-format")
-        local params = mp.get_property_native("options/ytdl-params")
+        local raw_options = mp.get_property_native("options/ytdl-raw-options")
 
         -- subformat workaround
         local subformat = "srt"
@@ -96,7 +96,7 @@ mp.add_hook("on_load", 10, function ()
             table.insert(command, "--format")
             table.insert(command, format)
         end
-        for param, arg in pairs(params) do
+        for param, arg in pairs(raw_options) do
             table.insert(command, "--" .. param)
             table.insert(command, arg)
         end

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -97,8 +97,12 @@ mp.add_hook("on_load", 10, function ()
             table.insert(command, format)
         end
         for param, arg in pairs(raw_options) do
-            table.insert(command, "--" .. param)
-            table.insert(command, arg)
+            if (param ~= "") then
+                table.insert(command, "--" .. param)
+            end
+            if (arg ~= "") then
+                table.insert(command, arg)
+            end
         end
         table.insert(command, "--")
         table.insert(command, url)

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -80,7 +80,7 @@ mp.add_hook("on_load", 10, function ()
         end
 
         local format = mp.get_property("options/ytdl-format")
-        local params = mp.get_property("options/ytdl-params")
+        local params = mp.get_property_native("options/ytdl-params")
 
         -- subformat workaround
         local subformat = "srt"
@@ -96,10 +96,9 @@ mp.add_hook("on_load", 10, function ()
             table.insert(command, "--format")
             table.insert(command, format)
         end
-        if (params ~= "") then
-            for param in params:gmatch("%S+") do
-                table.insert(command, param)
-            end
+        for param, arg in pairs(params) do
+            table.insert(command, "--" .. param)
+            table.insert(command, arg)
         end
         table.insert(command, "--")
         table.insert(command, url)

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -80,6 +80,7 @@ mp.add_hook("on_load", 10, function ()
         end
 
         local format = mp.get_property("options/ytdl-format")
+        local params = mp.get_property("options/ytdl-params")
 
         -- subformat workaround
         local subformat = "srt"
@@ -94,6 +95,11 @@ mp.add_hook("on_load", 10, function ()
         if (format ~= "") then
             table.insert(command, "--format")
             table.insert(command, format)
+        end
+        if (params ~= "") then
+            for param in params:gmatch("%S+") do
+                table.insert(command, param)
+            end
         end
         table.insert(command, "--")
         table.insert(command, url)


### PR DESCRIPTION
This option allows the user to pass non-supported options directly to
youtube-dl, such as "--proxy URL", "--username USERNAME" and
'--password PASSWORD".

There is no sanity checking so it's possible to break things (i.e.
if you pass "--version" mpv exits with random JSON error).

Fix issue #1299 