### PR TITLE
Move resume and reset into the wasapi audio thread

### DIFF
--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -72,8 +72,7 @@ typedef struct wasapi_state {
     IMMDeviceEnumerator *pEnumerator;
 
     HANDLE hFeed; /* wasapi event */
-    HANDLE hForceFeed; /* forces writing a buffer (e.g. before audio_resume) */
-    HANDLE hFeedDone; /* set only after a hForceFeed */
+    HANDLE hResume; /* signal audio thread to resume the stream */
     HANDLE hReset; /* signal audio thread to reset the stream */
     HANDLE hTask; /* AV thread */
     DWORD taskIndex; /* AV task ID */
@@ -81,7 +80,6 @@ typedef struct wasapi_state {
 
     /* WASAPI proxy handles, for Single-Threaded Apartment communication.
        One is needed for each object that's accessed by a different thread. */
-    IAudioClient *pAudioClientProxy;
     ISimpleAudioVolume *pAudioVolumeProxy;
     IAudioEndpointVolume *pEndpointVolumeProxy;
     IAudioSessionControl *pSessionControlProxy;
@@ -89,7 +87,6 @@ typedef struct wasapi_state {
     /* Streams used to marshal the proxy objects. The thread owning the actual objects
        needs to marshal proxy objects into these streams, and the thread that wants the
        proxies unmarshals them from here. */
-    IStream *sAudioClient;
     IStream *sAudioVolume;
     IStream *sEndpointVolume;
     IStream *sSessionControl;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -74,6 +74,7 @@ typedef struct wasapi_state {
     HANDLE hFeed; /* wasapi event */
     HANDLE hForceFeed; /* forces writing a buffer (e.g. before audio_resume) */
     HANDLE hFeedDone; /* set only after a hForceFeed */
+    HANDLE hReset; /* signal audio thread to reset the stream */
     HANDLE hTask; /* AV thread */
     DWORD taskIndex; /* AV task ID */
     WAVEFORMATEXTENSIBLE format;

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -958,7 +958,6 @@ HRESULT wasapi_setup_proxies(struct wasapi_state *state) {
     EXIT_ON_ERROR(hr);                                                    \
 } while (0)
 
-    UNMARSHAL(IID_IAudioClient,         state->pAudioClientProxy,    state->sAudioClient);
     UNMARSHAL(IID_ISimpleAudioVolume,   state->pAudioVolumeProxy,    state->sAudioVolume);
     UNMARSHAL(IID_IAudioEndpointVolume, state->pEndpointVolumeProxy, state->sEndpointVolume);
     UNMARSHAL(IID_IAudioSessionControl, state->pSessionControlProxy, state->sSessionControl);
@@ -973,7 +972,6 @@ exit_label:
 }
 
 void wasapi_release_proxies(wasapi_state *state) {
-    SAFE_RELEASE(state->pAudioClientProxy,    IUnknown_Release(state->pAudioClientProxy));
     SAFE_RELEASE(state->pAudioVolumeProxy,    IUnknown_Release(state->pAudioVolumeProxy));
     SAFE_RELEASE(state->pEndpointVolumeProxy, IUnknown_Release(state->pEndpointVolumeProxy));
     SAFE_RELEASE(state->pSessionControlProxy, IUnknown_Release(state->pSessionControlProxy));
@@ -991,7 +989,6 @@ static HRESULT create_proxies(struct wasapi_state *state) {
     EXIT_ON_ERROR(hr);                                             \
 } while (0)
 
-    MARSHAL(IID_IAudioClient,         state->sAudioClient,    state->pAudioClient);
     MARSHAL(IID_ISimpleAudioVolume,   state->sAudioVolume,    state->pAudioVolume);
     MARSHAL(IID_IAudioEndpointVolume, state->sEndpointVolume, state->pEndpointVolume);
     MARSHAL(IID_IAudioSessionControl, state->sSessionControl, state->pSessionControl);
@@ -1004,7 +1001,6 @@ exit_label:
 }
 
 static void destroy_proxies(struct wasapi_state *state) {
-    SAFE_RELEASE(state->sAudioClient,    IUnknown_Release(state->sAudioClient));
     SAFE_RELEASE(state->sAudioVolume,    IUnknown_Release(state->sAudioVolume));
     SAFE_RELEASE(state->sEndpointVolume, IUnknown_Release(state->sEndpointVolume));
     SAFE_RELEASE(state->sSessionControl, IUnknown_Release(state->sSessionControl));


### PR DESCRIPTION
Moving these operations to the audio thread ensures that these operations are never happening simultaneously with thread_feed, which makes life much simpler.

I also made the pre-filling of the buffer happen only if there is less than a full buffer of audio already waiting to be played. This seems to be the key to remove fixing #1529 for me. 
