### PR TITLE
stream_dvb (FreeBSD)

### DIFF
--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -37,11 +37,11 @@
 #ifndef DTV_STREAM_ID
 #define DTV_STREAM_ID DTV_ISDBS_TS_ID
 #endif
+#endif
 
 // This is only defined, for convenience, since API 5.8.
 #ifndef NO_STREAM_ID_FILTER
 #define NO_STREAM_ID_FILTER (~0U)
-#endif
 #endif
 
 #if (DVB_API_VERSION == 3 && DVB_API_VERSION_MINOR >= 1) || DVB_API_VERSION == 5

--- a/waftools/fragments/dvb.c
+++ b/waftools/fragments/dvb.c
@@ -7,4 +7,4 @@
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/video.h>
 #include <linux/dvb/audio.h>
-int main(void) {int a = NO_STREAM_ID_FILTER; return 0;}
+int main(void) {return 0;}


### PR DESCRIPTION
I just saw 64456488b3b6bbbcbc4d3c96aab1b45cbd215439 , this should be the correct fix. Essentially, NO_STREAM_ID_FILTER is coming from the DVB-API but I use it for initialization of the corresponding parameter in the channel list. 
Again, it's not there for all kernel headers, so now it's just always defined if missing. 