### PR TITLE
Lua: add mp.get_screen_margins().

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -971,6 +971,17 @@ static int script_get_screen_size(lua_State *L)
     return 3;
 }
 
+static int script_get_screen_margins(lua_State *L)
+{
+    struct MPContext *mpctx = get_mpctx(L);
+    struct mp_osd_res vo_res = osd_get_vo_res(mpctx->osd, OSDTYPE_EXTERNAL);
+    lua_pushnumber(L, vo_res.ml);
+    lua_pushnumber(L, vo_res.mt);
+    lua_pushnumber(L, vo_res.mr);
+    lua_pushnumber(L, vo_res.mb);
+    return 4;
+}
+
 static int script_get_mouse_pos(lua_State *L)
 {
     struct MPContext *mpctx = get_mpctx(L);
@@ -1280,6 +1291,7 @@ static const struct fn_entry main_fns[] = {
     FN_ENTRY(set_osd_ass),
     FN_ENTRY(get_osd_resolution),
     FN_ENTRY(get_screen_size),
+    FN_ENTRY(get_screen_margins),
     FN_ENTRY(get_mouse_pos),
     FN_ENTRY(get_time),
     FN_ENTRY(input_define_section),


### PR DESCRIPTION
When used with mp.get_screen_size(), mp.get_screen_margins() allows a Lua script to determine what portion of the mpv window actually has the video in it. Previously this information was not exposed to the Lua scripting interface.

Like get_screen_size, this is undocumented. Like get_screen_size, it would probably be better off being implemented as a property and properly documented. However, after spending some staring at the code, I'd need some guidance to implement it as a property. So here's this: not pretty, but functional.