### PR TITLE
Lua: add unpack shim for Lua 5.2/5.3 compatibility.

### DIFF
--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -1,3 +1,5 @@
+-- Compatibility shim for lua 5.2/5.3
+unpack = unpack or table.unpack
 
 -- these are used internally by lua.c
 mp.UNKNOWN_TYPE.info = "this value is inserted if the C type is not supported"


### PR DESCRIPTION
The global `unpack` function got moved to `table.unpack` in Lua 5.2, and it's only available as the global if 5.2 is built with compatibility enabled (the default). Lua 5.3 does not build with 5.1 compatibility by default.

See #1648.