### PR TITLE
Cocoa: use transparent cursor instead of CGDisplayHideCursor.

### DIFF
--- a/video/out/cocoa/events_view.h
+++ b/video/out/cocoa/events_view.h
@@ -21,6 +21,7 @@
 @interface MpvEventsView : NSView <NSDraggingDestination>
 @property(nonatomic, retain) MpvCocoaAdapter *adapter;
 - (void)setFullScreen:(BOOL)willBeFullscreen;
+- (void)setCursorVisible:(BOOL)visible;
 - (void)clear;
 - (BOOL)canHideCursor;
 - (void)signalMousePosition;

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -27,6 +27,8 @@
 @interface MpvEventsView()
 @property(nonatomic, assign) BOOL clearing;
 @property(nonatomic, assign) BOOL hasMouseDown;
+@property(nonatomic, retain) NSCursor *cursor;
+@property(nonatomic, assign) NSRect cursorRect;
 @property(nonatomic, retain) NSTrackingArea *tracker;
 - (BOOL)hasDock:(NSScreen*)screen;
 - (BOOL)hasMenubar:(NSScreen*)screen;
@@ -40,6 +42,8 @@
 @synthesize adapter = _adapter;
 @synthesize tracker = _tracker;
 @synthesize hasMouseDown = _mouse_down;
+@synthesize cursor = _cursor;
+@synthesize cursorRect = _cursorRect;
 
 - (id)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
@@ -47,6 +51,8 @@
         [self registerForDraggedTypes:@[NSFilenamesPboardType,
                                         NSURLPboardType]];
         [self setAutoresizingMask:NSViewWidthSizable|NSViewHeightSizable];
+        [self setCursor:[[NSCursor alloc] initWithImage:[[NSImage alloc] initWithSize:NSMakeSize(1,1)] hotSpot:NSMakePoint(0, 0)]];
+        [self setCursorRect:[self bounds]];
     }
     return self;
 }
@@ -140,6 +146,26 @@
     // clip bounds to current visibleFrame
     NSRect clippedBounds = CGRectIntersection([self bounds], vFV);
     return CGRectContainsPoint(clippedBounds, pt);
+}
+
+- (void)setCursorVisible:(BOOL)visible
+{
+    if (visible) {
+        [self discardCursorRects];
+        // For some reason removing the cursor rect does not update the
+        // cursor.
+        [[NSCursor arrowCursor] set];
+    } else {
+        [self addCursorRect:[self cursorRect] cursor:[self cursor]];
+        // For some reason there are also certain circumstances where
+        // adding the cursor rect does not update the cursor.
+        [[self cursor] set];
+    }
+}
+
+- (void)resetCursorRects
+{
+    [self setCursorRect:[self bounds]];
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)theEvent

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -257,9 +257,9 @@ static int vo_cocoa_set_cursor_visibility(struct vo *vo, bool *visible)
     MpvEventsView *v = (MpvEventsView *) s->view;
 
     if (*visible) {
-        CGDisplayShowCursor(kCGDirectMainDisplay);
+        [v setCursorVisible:YES];
     } else if ([v canHideCursor]) {
-        CGDisplayHideCursor(kCGDirectMainDisplay);
+        [v setCursorVisible:NO];
     } else {
         *visible = true;
     }


### PR DESCRIPTION
On Yosemite (and possibly older versions of OS X), there is a bug in the
cursor state handing where a hidden cursor is not shown when using
nonstandard methods to switch between applications (e.g. a global
hotkey). This bug will cause the cursor to stay hidden until the task
switcher is opened.

This commit sidesteps that issue entirely by simply using a transparent
cursor instead of trying to hide the cursor. This implementation relies
on cursor rects to maintain the cursor state when switching away from
and back to mpv. It also moves the cursor hiding implementation into
MpvEventsView.

Fixes #1651 for me. Hopefully someone else running into the bug can test it too.