### PR TITLE
Cocoa: update mouse position after going full screen.

### DIFF
--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -125,6 +125,9 @@
                                      userInfo:nil] autorelease];
 
     [self addTrackingArea:self.tracker];
+
+    if (![self containsMouseLocation])
+        [self.adapter putKey:MP_KEY_MOUSE_LEAVE withModifiers:0];
 }
 
 - (NSPoint)mouseLocation

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -80,6 +80,8 @@
 
         [self enterFullScreenMode:[self.adapter fsScreen]
                                   withOptions:fsopts];
+
+        [self signalMousePosition];
     }
 
     if (!willBeFullscreen && [self isInFullScreenMode]) {


### PR DESCRIPTION
When going full screen, the call to signalMousePosition in setFrameSize
does not return the correct mouse coordinates, so the mouse position
needs to be updated again after the transition to full screen is
finished.