### PR TITLE
Windows: Use the refresh rate of the current monitor

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -589,9 +589,13 @@ static double vo_w32_get_display_fps(struct vo_w32_state *w32)
     switch (dm.dmDisplayFrequency) {
         case  23:
         case  29:
+        case  47:
         case  59:
         case  71:
+        case  89:
+        case  95:
         case 119:
+        case 143:
             rv = (rv + 1) / 1.001;
     }
 

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -565,12 +565,15 @@ static void wakeup_gui_thread(void *ctx)
     PostMessage(w32->window, WM_USER, 0, 0);
 }
 
-static double vo_w32_get_display_fps(void)
+static double vo_w32_get_display_fps(struct vo_w32_state *w32)
 {
-    DEVMODE dm;
-    dm.dmSize = sizeof(DEVMODE);
-    dm.dmDriverExtra = 0;
-    if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dm))
+    // Get the device name of the monitor containing the window
+    HMONITOR mon = MonitorFromWindow(w32->window, MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFOEXW mi = { .cbSize = sizeof mi };
+    GetMonitorInfoW(mon, (MONITORINFO*)&mi);
+
+    DEVMODE dm = { .dmSize = sizeof dm };
+    if (!EnumDisplaySettingsW(mi.szDevice, ENUM_CURRENT_SETTINGS, &dm))
         return -1;
 
     // May return 0 or 1 which "represent the display hardware's default refresh rate"
@@ -595,11 +598,9 @@ static double vo_w32_get_display_fps(void)
     return rv;
 }
 
-static void update_display_fps(void *ctx)
+static void update_display_fps(struct vo_w32_state *w32)
 {
-    struct vo_w32_state *w32 = ctx;
-
-    double fps = vo_w32_get_display_fps();
+    double fps = vo_w32_get_display_fps(w32);
     if (fps != w32->display_fps) {
         w32->display_fps = fps;
         signal_events(w32, VO_EVENT_WIN_STATE);


### PR DESCRIPTION
The old code didn't work for multiple-monitors, so fix it by passing the device name of the monitor we want to EnumDisplaySettings.

This includes a commit to amend the list of "rounded down" frame rates to include all multiples of 24 and 30 under 144Hz. As suggested by @avih, but I think I added more frame rates than the ones he mentioned (up to 144Hz instead of 120Hz.)