### PR TITLE
Fix several issues with wayland code

### DIFF
--- a/video/out/gl_common.h
+++ b/video/out/gl_common.h
@@ -109,6 +109,10 @@ typedef struct MPGLContext {
     void (*register_resize_callback)(struct vo *vo,
                                      void (*cb)(struct vo *vo, int w, int h));
 
+    // Optional activity state of context.
+    // If false, OpenGL renderers should not draw anything.
+    bool (*is_active)(struct MPGLContext *);
+
     // For free use by the backend.
     void *priv;
 } MPGLContext;

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -1968,6 +1968,13 @@ static bool get_image(struct gl_video *p, struct mp_image *mpi)
     return true;
 }
 
+void gl_video_skip_image(struct gl_video *p, struct mp_image *mpi)
+{
+    struct video_image *vimg = &p->image;
+    talloc_free(vimg->mpi);
+    vimg->mpi = mpi;
+}
+
 void gl_video_upload_image(struct gl_video *p, struct mp_image *mpi)
 {
     GL *gl = p->gl;

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -72,6 +72,7 @@ bool gl_video_check_format(struct gl_video *p, int mp_format);
 void gl_video_config(struct gl_video *p, struct mp_image_params *params);
 void gl_video_set_output_depth(struct gl_video *p, int r, int g, int b);
 void gl_video_set_lut3d(struct gl_video *p, struct lut3d *lut3d);
+void gl_video_skip_image(struct gl_video *p, struct mp_image *mpi);
 void gl_video_upload_image(struct gl_video *p, struct mp_image *img);
 void gl_video_render_frame(struct gl_video *p, int fbo, struct frame_timing *t);
 void gl_video_resize(struct gl_video *p, int vp_w, int vp_h,

--- a/video/out/gl_wayland.c
+++ b/video/out/gl_wayland.c
@@ -196,7 +196,12 @@ static void releaseGlContext_wayland(MPGLContext *ctx)
 static void swapGlBuffers_wayland(MPGLContext *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wayland;
+
+    if (!wl->frame.pending)
+        return;
+
     eglSwapBuffers(wl->egl_context.egl.dpy, wl->egl_context.egl_surface);
+    wl->frame.pending = false;
 }
 
 static int control(struct vo *vo, int *events, int request, void *data)

--- a/video/out/gl_wayland.c
+++ b/video/out/gl_wayland.c
@@ -215,6 +215,12 @@ static int control(struct vo *vo, int *events, int request, void *data)
     return r;
 }
 
+static bool is_active(struct MPGLContext *ctx)
+{
+    struct vo_wayland_state *wl = ctx->vo->wayland;
+    return wl->frame.pending;
+}
+
 void mpgl_set_backend_wayland(MPGLContext *ctx)
 {
     ctx->config_window = config_window_wayland;
@@ -223,4 +229,5 @@ void mpgl_set_backend_wayland(MPGLContext *ctx)
     ctx->vo_control = control;
     ctx->vo_init = vo_wayland_init;
     ctx->vo_uninit = vo_wayland_uninit;
+    ctx->is_active = is_active;
 }

--- a/video/out/vo_opengl.c
+++ b/video/out/vo_opengl.c
@@ -122,6 +122,9 @@ static void flip_page(struct vo *vo)
     struct gl_priv *p = vo->priv;
     GL *gl = p->gl;
 
+    if (p->glctx->is_active && !p->glctx->is_active(p->glctx))
+        return;
+
     mpgl_lock(p->glctx);
 
     p->glctx->swapGlBuffers(p->glctx);
@@ -159,6 +162,12 @@ static void draw_image_timed(struct vo *vo, mp_image_t *mpi,
 {
     struct gl_priv *p = vo->priv;
     GL *gl = p->gl;
+
+    if (p->glctx->is_active && !p->glctx->is_active(p->glctx)) {
+        if (mpi)
+            gl_video_skip_image(p->renderer, mpi);
+        return;
+    }
 
     if (p->vo_flipped)
         mp_image_vflip(mpi);
@@ -376,6 +385,9 @@ static int control(struct vo *vo, uint32_t request, void *data)
         request_hwdec_api(p, data);
         return true;
     case VOCTRL_REDRAW_FRAME:
+        if (p->glctx->is_active && !p->glctx->is_active(p->glctx))
+            return true;
+
         mpgl_lock(p->glctx);
         gl_video_render_frame(p->renderer, 0, NULL);
         mpgl_unlock(p->glctx);

--- a/video/out/vo_wayland.c
+++ b/video/out/vo_wayland.c
@@ -268,7 +268,7 @@ static bool resize(struct priv *p)
 {
     struct vo_wayland_state *wl = p->wl;
 
-    if (SHM_BUFFER_IS_BUSY(p->video_bufpool.back_buffer))
+    if (!p->video_bufpool.back_buffer || SHM_BUFFER_IS_BUSY(p->video_bufpool.back_buffer))
         return false; // skip resizing if we can't garantuee pixel perfectness!
 
     int32_t x = wl->window.sh_x;

--- a/video/out/vo_wayland.c
+++ b/video/out/vo_wayland.c
@@ -41,7 +41,6 @@
 static void draw_image(struct vo *vo, mp_image_t *mpi);
 static void draw_osd(struct vo *vo);
 
-static const struct wl_callback_listener frame_listener;
 static const struct wl_buffer_listener buffer_listener;
 
 // TODO: pay attention to the reported subpixel order
@@ -118,8 +117,6 @@ struct priv {
 
     struct mp_sws_context *sws;
     struct mp_image_params in_format;
-
-    struct wl_callback *redraw_callback;
 
     struct buffer_pool video_bufpool;
 
@@ -359,34 +356,6 @@ static const struct wl_buffer_listener buffer_listener = {
     buffer_handle_release
 };
 
-static void frame_handle_redraw(void *data,
-                                struct wl_callback *callback,
-                                uint32_t time)
-{
-    struct priv *p = data;
-    struct vo_wayland_state *wl = p->wl;
-    shm_buffer_t *buf = buffer_pool_get_front(&p->video_bufpool);
-
-    wl_surface_attach(wl->window.video_surface, buf->buffer, p->x, p->y);
-    wl_surface_damage(wl->window.video_surface, 0, 0, p->dst_w, p->dst_h);
-
-    if (callback)
-        wl_callback_destroy(callback);
-
-    p->redraw_callback = wl_surface_frame(wl->window.video_surface);
-    wl_callback_add_listener(p->redraw_callback, &frame_listener, p);
-    wl_surface_commit(wl->window.video_surface);
-    buffer_finalise_front(buf);
-
-    p->x = 0;
-    p->y = 0;
-    p->recent_flip_time = mp_time_us();
-}
-
-static const struct wl_callback_listener frame_listener = {
-    frame_handle_redraw
-};
-
 static void shm_handle_format(void *data,
                               struct wl_shm *wl_shm,
                               uint32_t format)
@@ -414,12 +383,16 @@ static const struct wl_shm_listener shm_listener = {
 static void draw_image(struct vo *vo, mp_image_t *mpi)
 {
     struct priv *p = vo->priv;
-    shm_buffer_t *buf = buffer_pool_get_back(&p->video_bufpool);
 
     if (mpi) {
         talloc_free(p->original_image);
         p->original_image = mpi;
     }
+
+    if (!p->wl->frame.pending)
+        return;
+
+    shm_buffer_t *buf = buffer_pool_get_back(&p->video_bufpool);
 
     if (!buf) {
         // TODO: use similar handling of busy buffers as the osd buffers
@@ -535,12 +508,21 @@ static void flip_page(struct vo *vo)
 {
     struct priv *p = vo->priv;
 
+    if (!p->wl->frame.pending)
+        return;
+
     buffer_pool_swap(&p->video_bufpool);
 
-    if (!p->redraw_callback) {
-        MP_DBG(p->wl, "restart frame callback\n");
-        frame_handle_redraw(p, NULL, 0);
-    }
+    shm_buffer_t *buf = buffer_pool_get_front(&p->video_bufpool);
+    wl_surface_attach(p->wl->window.video_surface, buf->buffer, p->x, p->y);
+    wl_surface_damage(p->wl->window.video_surface, 0, 0, p->dst_w, p->dst_h);
+    wl_surface_commit(p->wl->window.video_surface);
+    buffer_finalise_front(buf);
+
+    p->x = 0;
+    p->y = 0;
+    p->recent_flip_time = mp_time_us();
+    p->wl->frame.pending = false;
 }
 
 static int query_format(struct vo *vo, int format)
@@ -611,9 +593,6 @@ static void uninit(struct vo *vo)
 {
     struct priv *p = vo->priv;
     buffer_pool_destroy(&p->video_bufpool);
-
-    if (p->redraw_callback)
-        wl_callback_destroy(p->redraw_callback);
 
     talloc_free(p->original_image);
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -795,6 +795,15 @@ static void schedule_resize(struct vo_wayland_state *wl,
     wl->window.events |= VO_EVENT_RESIZE;
     wl->vo->dwidth = width;
     wl->vo->dheight = height;
+
+    struct wl_region *region = wl_compositor_create_region(wl->display.compositor);
+
+    if (region) {
+        wl_region_add(region, x, y, width, height);
+        wl_surface_set_opaque_region(wl->window.video_surface, region);
+        wl_surface_commit(wl->window.video_surface);
+        wl_region_destroy(region);
+    }
 }
 
 static void frame_callback(void *data,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -59,6 +59,8 @@ static void schedule_resize(struct vo_wayland_state *wl,
 
 static void vo_wayland_fullscreen (struct vo *vo);
 
+static const struct wl_callback_listener frame_listener;
+
 static const struct mp_keymap keymap[] = {
     // special keys
     {XKB_KEY_Pause,     MP_KEY_PAUSE}, {XKB_KEY_Escape, MP_KEY_ESC},
@@ -795,6 +797,30 @@ static void schedule_resize(struct vo_wayland_state *wl,
     wl->vo->dheight = height;
 }
 
+static void frame_callback(void *data,
+                           struct wl_callback *callback,
+                           uint32_t time)
+{
+    struct vo_wayland_state *wl = data;
+
+    if (callback)
+        wl_callback_destroy(callback);
+
+    wl->frame.callback = wl_surface_frame(wl->window.video_surface);
+
+    if (!wl->frame.callback) {
+        MP_ERR(wl, "wl_surface_frame failed\n");
+        return;
+    }
+
+    wl_callback_add_listener(wl->frame.callback, &frame_listener, wl);
+    wl->frame.pending = true;
+}
+
+static const struct wl_callback_listener frame_listener = {
+    frame_callback
+};
+
 static bool create_display (struct vo_wayland_state *wl)
 {
     if (wl->vo->probing && !getenv("XDG_RUNTIME_DIR"))
@@ -878,6 +904,7 @@ static bool create_window (struct vo_wayland_state *wl)
         wl_shell_surface_set_class(wl->window.shell_surface, "mpv");
     }
 
+    frame_callback(wl, NULL, 0);
     return true;
 }
 
@@ -888,6 +915,9 @@ static void destroy_window (struct vo_wayland_state *wl)
 
     if (wl->window.video_surface)
         wl_surface_destroy(wl->window.video_surface);
+
+    if (wl->frame.callback)
+        wl_callback_destroy(wl->frame.callback);
 }
 
 static bool create_cursor (struct vo_wayland_state *wl)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -52,6 +52,11 @@ struct vo_wayland_state {
     struct vo *vo;
     struct mp_log* log;
 
+    struct {
+        struct wl_callback *callback;
+        bool pending;
+    } frame;
+
 #if HAVE_GL_WAYLAND
     struct {
         EGLSurface egl_surface;


### PR DESCRIPTION
Moves frame callbacks to wayland common and uses them in OpenGL vo as well, this times blitting with compositor.

Define mpv surface as opaque. This allows compositor to optimize drawing behind the mpv window.

Add optional is_active() function to glctx interface, that allows OpenGL vo to skip drawing when compositor hasn't yet responded with frame callback, or when window is not visible.
(This fixes #249)

Fix null dereference in vo_wayland.