### PR TITLE
Added lua scripts youtube-starttime and ontop-playback to TOOLS/lua

### DIFF
--- a/TOOLS/lua/ontop-playback.lua
+++ b/TOOLS/lua/ontop-playback.lua
@@ -1,0 +1,19 @@
+--makes mpv disable ontop when pausing and re-enable it again when resuming playback
+--please note that this won't do anything if ontop was not enabled before pausing
+
+local was_ontop = false
+
+mp.observe_property("pause", "bool", function(name, value)
+    local ontop = mp.get_property_native("ontop")
+    if value then
+        if ontop then
+            mp.set_property_native("ontop", false)
+            was_ontop = true
+        end
+    else
+        if was_ontop and not ontop then
+            mp.set_property_native("ontop", true)
+        end
+        was_ontop = false
+    end
+end)

--- a/TOOLS/lua/youtube-starttime.lua
+++ b/TOOLS/lua/youtube-starttime.lua
@@ -1,0 +1,34 @@
+--sets the startime of a youtube video as specified in the "t=HHhMMmSSs" part of the url
+--NOTE: This might become obsolete once youtube-dl adds the functionality
+
+local msg = require 'mp.msg'
+
+function youtube_starttime()
+  url = mp.get_property("path", "")
+  start = 0
+
+  if string.find(url, "youtu%.?be") and
+    ((url:find("http://") == 1) or (url:find("https://") == 1)) then
+      time = string.match(url, "[#&%?]t=%d*h?%d*m?%d+s?m?h?")
+      --the time-string can start with #, & or ? followed by t= and the timing parameters
+      --at least one number needs to be present after t=, followed by h, m, s or nothing (>implies s)
+
+      if time then
+        for pos in string.gmatch(time,"%d+%a?") do
+          if string.match(pos,"%d+h") then            --find out multiplier for
+            multiplier = 60*60                        --hours
+          elseif string.match(pos,"%d+m") then
+            multiplier = 60                           --minutes
+          else multiplier = 1 end                     --seconds
+
+          start = start + (string.match(pos,"%d+") * multiplier)
+        end
+
+        msg.info("parsed '" .. time .. "' into '" .. start .. "' seconds")
+      end
+
+      mp.set_property("file-local-options/start",start)
+  end
+end
+
+mp.add_hook("on_load", 50, youtube_starttime)


### PR DESCRIPTION
Added two lua scripts to the TOOLS/lua folder
youtube-starttime for extracting and setting the **t=** portion of a youtube url and setting mpv's starttime accordingly (useful until youtube-dl implements this functionality)
ontop-playback for a *stay on top only during playback* mode, which automatically dis- and enables the ontop property when pausing/resuming playback