### PR TITLE
vo_opengl: separate kernel and window

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -396,6 +396,19 @@ Available video output drivers are:
         Defaults to the filter's preferred window if unset. Use
         ``scale-window=help`` to get a list of supported windowing functions.
 
+    ``scale-wparam=<window>``
+        (Advanced users only) Configure the parameter for the window function
+        given by ``scale-window``. Ignored if the window is not tunable.
+        Currently, this affects the following window parameters:
+
+        kaiser
+            Window parameter (alpha). Defaults to 6.33.
+        blackman
+            Window parameter (alpha). Defaults to 0.16.
+        gaussian
+            Scale parameter (t). Increasing this makes the window wider.
+            Defaults to 1.
+
     ``scaler-resizes-only``
         Disable the scaler if the video image is not resized. In that case,
         ``bilinear`` is used instead whatever is set with ``scale``. Bilinear

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -348,18 +348,18 @@ Available video output drivers are:
         Set filter parameters. Ignored if the filter is not tunable.
         Currently, this affects the following filter parameters:
 
-        ``bcspline``
+        bcspline
             Spline parameters (``B`` and ``C``). Defaults to 0.5 for both.
 
-        ``gaussian``
+        gaussian
             Scale parameter (``t``). Increasing this makes the result blurrier.
             Defaults to 1.
 
-        ``sharpen3``, ``sharpen5``
+        sharpen3, sharpen5
             Sharpening strength. Increasing this makes the image sharper but
             adds more ringing and aliasing. Defaults to 0.5.
 
-        ``oversample``
+        oversample
             Minimum distance to an edge before interpolation is used. Setting
             this to 0 will always interpolate edges, whereas setting it to 0.5
             will never interpolate, thus behaving as if the regular nearest

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -308,11 +308,15 @@ Available video output drivers are:
             This filter corresponds to the old ``lanczos3`` alias if the default
             radius is used, while ``lanczos2`` corresponds to a radius of 2.
 
+            (This filter is an alias for ``sinc``-windowed ``sinc``)
+
         ``ewa_lanczos``
             Elliptic weighted average Lanczos scaling. Also known as Jinc.
             Relatively slow, but very good quality. The radius can be
             controlled with ``scale-radius``. Increasing the radius makes the
             filter sharper but adds more ringing.
+
+            (This filter is an alias for ``jinc``-windowed ``jinc``)
 
         ``ewa_lanczossharp``
             A slightly sharpened version of ewa_lanczos, preconfigured to use
@@ -344,21 +348,12 @@ Available video output drivers are:
         Set filter parameters. Ignored if the filter is not tunable.
         Currently, this affects the following filter parameters:
 
-        ``kaiser``
-            Window parameter (``alpha``). Defaults to 6.33.
-
-        ``mitchell``
-            Spline parameters (``B`` and ``C``). Defaults to 1/3 for both.
+        ``bcspline``
+            Spline parameters (``B`` and ``C``). Defaults to 0.5 for both.
 
         ``gaussian``
             Scale parameter (``t``). Increasing this makes the result blurrier.
             Defaults to 1.
-
-        ``ewa_lanczos``, ``ewa_ginseng``, ``ewa_hanning``
-            Jinc function scaling factor (also known as a blur factor).
-            Decreasing this makes the result sharper, increasing it makes it
-            blurrier. Defaults to 1. Note that setting this too low (eg. 0.5)
-            leads to bad results. It's recommended to stay between 0.9 and 1.1.
 
         ``sharpen3``, ``sharpen5``
             Sharpening strength. Increasing this makes the image sharper but
@@ -370,11 +365,18 @@ Available video output drivers are:
             will never interpolate, thus behaving as if the regular nearest
             neighbour algorithm was used. Defaults to 0.0.
 
-    ``scale-radius=<r>``
+    ``scale-blur=<value>``
+        Kernel scaling factor (also known as a blur factor). Decreasing this
+        makes the result sharper, increasing it makes it blurrier (default 0).
+        If set to 0, the kernel's preferred blur factor is used. Note that
+        setting this too low (eg. 0.5) leads to bad results. It's generally
+        recommended to stick to values between 0.8 and 1.2.
+
+    ``scale-radius=<value>``
         Set radius for filters listed below, must be a float number between 1.0
         and 16.0. Defaults to be 3.0 if not specified.
 
-            ``sinc``, ``lanczos``, ``blackman``, ``gaussian`` and all EWA filters (eg. ``ewa_lanczos``)
+            ``sinc`` and derivatives, ``jinc`` and derivatives, ``gaussian``, ``box`` and ``triangle``
 
         Note that depending on filter implementation details and video scaling
         ratio, the radius that actually being used might be different
@@ -388,6 +390,11 @@ Available video output drivers are:
 
         Note that this doesn't affect the special filters ``bilinear``,
         ``bicubic_fast`` or ``sharpen``.
+
+    ``scale-window=<window>``
+        (Advanced users only) Choose a custom windowing function for the kernel.
+        Defaults to the filter's preferred window if unset. Use
+        ``scale-window=help`` to get a list of supported windowing functions.
 
     ``scaler-resizes-only``
         Disable the scaler if the video image is not resized. In that case,
@@ -469,25 +476,25 @@ Available video output drivers are:
 
     ``scale-down=<filter>``
         Like ``scale``, but apply these filters on downscaling instead. If this
-        option is unset, the filter implied by ``scale`` will be applied.
+        option is unset, the filter implied by ``scale`` will be applied. Note
+        that this is also affected by the other options related to ``scale``,
+        ie. there is no ``scale-down-param1`` or similar.
 
-    ``cscale-param1``, ``cscale-param2``, ``cscale-radius``, ``cscale-antiring``
-        Set filter parameters and radius for ``cscale``.
-
-        See ``scale-param1``, ``scale-param2``, ``scale-radius`` and
-        ``scale-antiring``.
-
-    ``tscale=<filter>``, ``tscale-param1``, ``tscale-param2``, ``tscale-antiring``
+    ``tscale=<filter>``
         The filter used for interpolating the temporal axis (frames). This is
         only used if ``interpolation`` is enabled. The only valid choices
         for ``tscale`` are separable convolution filters (use ``tscale=help``
-        to get a list). The other options (``tscale-param1`` etc.) are
-        analogous to their ``scale`` counterparts. The default is ``oversample``.
+        to get a list). The default is ``oversample``.
 
         Note that the maximum supported filter radius is currently 3, and that
         using filters with larger radius may introduce issues when pausing or
         framestepping, proportional to the radius used. It is recommended to
         stick to a radius of 1 or 2.
+
+    ``cscale-radius``, ``tscale-radius``, ``cscale-blur``, ``tscale-blur``, etc.
+        Set filter parameters for ``cscale`` and ``tscale``, respectively.
+
+        See the corresponding options for ``scale``.
 
     ``linear-scaling``
         Scale in linear light. This is automatically enabled if

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -329,7 +329,7 @@ Available video output drivers are:
         ``mitchell``
             Mitchell-Netravali. The ``B`` and ``C`` parameters can be set with
             ``scale-param1`` and ``scale-param2``. This filter is very good at
-            downscaling (see ``scale-down``).
+            downscaling (see ``dscale``).
 
         ``oversample``
             A version of nearest neighbour that (naively) oversamples pixels,
@@ -373,8 +373,8 @@ Available video output drivers are:
         recommended to stick to values between 0.8 and 1.2.
 
     ``scale-radius=<value>``
-        Set radius for filters listed below, must be a float number between 1.0
-        and 16.0. Defaults to be 3.0 if not specified.
+        Set radius for filters listed below, must be a float number between 0.5
+        and 16.0. Defaults to the filter's preferred radius if not specified.
 
             ``sinc`` and derivatives, ``jinc`` and derivatives, ``gaussian``, ``box`` and ``triangle``
 
@@ -470,15 +470,13 @@ Available video output drivers are:
         also lead to bad results, as can missing or incorrect display FPS
         information (see ``--display-fps``).
 
+    ``dscale=<filter>``
+        Like ``scale``, but apply these filters on downscaling instead. If this
+        option is unset, the filter implied by ``scale`` will be applied.
+
     ``cscale=<filter>``
         As ``scale``, but for interpolating chroma information. If the image
         is not subsampled, this option is ignored entirely.
-
-    ``scale-down=<filter>``
-        Like ``scale``, but apply these filters on downscaling instead. If this
-        option is unset, the filter implied by ``scale`` will be applied. Note
-        that this is also affected by the other options related to ``scale``,
-        ie. there is no ``scale-down-param1`` or similar.
 
     ``tscale=<filter>``
         The filter used for interpolating the temporal axis (frames). This is
@@ -491,8 +489,9 @@ Available video output drivers are:
         framestepping, proportional to the radius used. It is recommended to
         stick to a radius of 1 or 2.
 
-    ``cscale-radius``, ``tscale-radius``, ``cscale-blur``, ``tscale-blur``, etc.
-        Set filter parameters for ``cscale`` and ``tscale``, respectively.
+    ``dscale-radius``, ``cscale-radius``, ``tscale-radius``, etc.
+        Set filter parameters for ``dscale``, ``cscale`` and ``tscale``,
+        respectively.
 
         See the corresponding options for ``scale``.
 
@@ -703,7 +702,7 @@ Available video output drivers are:
 
     This is equivalent to::
 
-        --vo=opengl:scale=spline36:cscale=spline36:scale-down=mitchell:dither-depth=auto:fbo-format=rgba16:fancy-downscaling:sigmoid-upscaling
+        --vo=opengl:scale=spline36:cscale=spline36:dscale=mitchell:dither-depth=auto:fbo-format=rgba16:fancy-downscaling:sigmoid-upscaling
 
     Note that some cheaper LCDs do dithering that gravely interferes with
     ``opengl``'s dithering. Disabling dithering with ``dither-depth=no`` helps.

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -45,7 +45,6 @@ const struct filter_window *mp_find_filter_window(const char *name)
 {
     if (!name)
         return NULL;
-
     for (const struct filter_window *w = mp_filter_windows; w->name; w++) {
         if (strcmp(w->name, name) == 0)
             return w;
@@ -55,6 +54,8 @@ const struct filter_window *mp_find_filter_window(const char *name)
 
 const struct filter_kernel *mp_find_filter_kernel(const char *name)
 {
+    if (!name)
+        return NULL;
     for (const struct filter_kernel *k = mp_filter_kernels; k->f.name; k++) {
         if (strcmp(k->f.name, name) == 0)
             return k;
@@ -313,7 +314,7 @@ const struct filter_window mp_filter_windows[] = {
     {"quadric",        1.5, quadric},
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
     {"hermite",        1,   cubic_bc, .params = {0.0, 0.0} },
-    {"gaussian",       -1,  gaussian, .params = {1.0, NAN} },
+    {"gaussian",       2,   gaussian, .params = {1.0, NAN} },
     {"sinc",           1,   sinc},
     {"jinc",           1.2196698912665045, jinc},
     {"sphinx",         1.4302966531242027, sphinx},
@@ -326,14 +327,14 @@ const struct filter_kernel mp_filter_kernels[] = {
     {{"spline36",       3,   spline36}},
     {{"spline64",       4,   spline64}},
     // Sinc filters
-    {{"sinc",           -1,  sinc}},
-    {{"lanczos",        -1,  sinc}, .window = "sinc"},
-    {{"ginseng",        -1,  sinc}, .window = "jinc"},
+    {{"sinc",           2,  sinc, .resizable = true}},
+    {{"lanczos",        3,  sinc, .resizable = true}, .window = "sinc"},
+    {{"ginseng",        3,  sinc, .resizable = true}, .window = "jinc"},
     // Jinc filters
-    {{"jinc",           -1,  jinc}, .polar = true},
-    {{"ewa_lanczos",    -1,  jinc}, .polar = true, .window = "jinc"},
-    {{"ewa_hanning",    -1,  jinc}, .polar = true, .window = "hanning" },
-    {{"ewa_ginseng",    -1,  jinc}, .polar = true, .window = "sinc"},
+    {{"jinc",           3,  jinc, .resizable = true}, .polar = true},
+    {{"ewa_lanczos",    3,  jinc, .resizable = true}, .polar = true, .window = "jinc"},
+    {{"ewa_hanning",    3,  jinc, .resizable = true}, .polar = true, .window = "hanning" },
+    {{"ewa_ginseng",    3,  jinc, .resizable = true}, .polar = true, .window = "sinc"},
     // Radius is based on the true jinc radius, slightly sharpened as per
     // calculations by Nicolas Robidoux. Source: Imagemagick's magick/resize.c
     {{"ewa_lanczossharp", 3.2383154841662362, jinc, .blur = 0.9812505644269356},
@@ -350,10 +351,9 @@ const struct filter_kernel mp_filter_kernels[] = {
     {{"robidoux",       2,   cubic_bc, .params = {0.3782, 0.3109}}, .polar = true},
     {{"robidouxsharp",  2,   cubic_bc, .params = {0.2620, 0.3690}}, .polar = true},
     // Miscalleaneous filters
-    {{"box",            -1,  box}},
+    {{"box",            1,   box, .resizable = true}},
     {{"nearest",        0.5, box}},
-    {{"triangle",       -1,  triangle}},
-    {{"bilinear_slow",  1,   triangle}},
-    {{"gaussian",       -1,  gaussian, .params = {1.0, NAN} }},
+    {{"triangle",       1,   triangle, .resizable = true}},
+    {{"gaussian",       2,   gaussian, .params = {1.0, NAN}, .resizable = true}},
     {{0}}
 };

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -39,13 +39,24 @@
 
 #include "filter_kernels.h"
 
-// NOTE: all filters are separable, symmetric, and are intended for use with
-//       a lookup table/texture.
+// NOTE: all filters are designed for discrete convolution
+
+const struct filter_window *mp_find_filter_window(const char *name)
+{
+    if (!name)
+        return NULL;
+
+    for (const struct filter_window *w = mp_filter_windows; w->name; w++) {
+        if (strcmp(w->name, name) == 0)
+            return w;
+    }
+    return NULL;
+}
 
 const struct filter_kernel *mp_find_filter_kernel(const char *name)
 {
-    for (const struct filter_kernel *k = mp_filter_kernels; k->name; k++) {
-        if (strcmp(k->name, name) == 0)
+    for (const struct filter_kernel *k = mp_filter_kernels; k->f.name; k++) {
+        if (strcmp(k->f.name, name) == 0)
             return k;
     }
     return NULL;
@@ -56,16 +67,22 @@ const struct filter_kernel *mp_find_filter_kernel(const char *name)
 bool mp_init_filter(struct filter_kernel *filter, const int *sizes,
                     double inv_scale)
 {
-    assert(filter->radius > 0);
-    // polar filters are dependent only on the radius
+    assert(filter->f.radius > 0);
+    // Only downscaling requires widening the filter
+    filter->inv_scale = inv_scale >= 1.0 ? inv_scale : 1.0;
+    filter->f.radius *= filter->inv_scale;
+    // Polar filters are dependent solely on the radius
     if (filter->polar) {
+        filter->f.radius = fmin(filter->f.radius, 16.0);
         filter->size = 1;
+        // Safety precaution to avoid generating a gigantic shader
+        if (filter->f.radius > 16.0) {
+            filter->f.radius = 16.0;
+            return false;
+        }
         return true;
     }
-    // only downscaling requires widening the filter
-    filter->inv_scale = inv_scale >= 1.0 ? inv_scale : 1.0;
-    double support = filter->radius * filter->inv_scale;
-    int size = ceil(2.0 * support);
+    int size = ceil(2.0 * filter->f.radius);
     // round up to smallest available size that's still large enough
     if (size < sizes[0])
         size = sizes[0];
@@ -80,27 +97,42 @@ bool mp_init_filter(struct filter_kernel *filter, const int *sizes,
         // largest filter available. This is incorrect, but better than refusing
         // to do anything.
         filter->size = cursize[-1];
-        filter->inv_scale = filter->size / 2.0 / filter->radius;
+        filter->inv_scale *= (filter->size/2.0) / filter->f.radius;
         return false;
     }
+}
+
+// Sample from the blurred, windowed kernel. Note: The window is always
+// stretched to the true radius, regardless of the filter blur/scale.
+static double sample_filter(struct filter_kernel *filter,
+                            struct filter_window *window, double x)
+{
+    double bk = filter->f.blur > 0.0 ? filter->f.blur : 1.0;
+    double bw = window->blur > 0.0 ? window->blur : 1.0;
+    double c = fabs(x) / (filter->inv_scale * bk);
+    double w = window->weight ? window->weight(window, x/bw * window->radius
+                                                            / filter->f.radius)
+                              : 1.0;
+    return c < filter->f.radius ? w * filter->f.weight(&filter->f, c) : 0.0;
 }
 
 // Calculate the 1D filtering kernel for N sample points.
 // N = number of samples, which is filter->size
 // The weights will be stored in out_w[0] to out_w[N - 1]
 // f = x0 - abs(x0), subpixel position in the range [0,1) or [0,1].
-void mp_compute_weights(struct filter_kernel *filter, double f, float *out_w)
+static void mp_compute_weights(struct filter_kernel *filter,
+                               struct filter_window *window,
+                               double f, float *out_w)
 {
     assert(filter->size > 0);
     double sum = 0;
     for (int n = 0; n < filter->size; n++) {
         double x = f - (n - filter->size / 2 + 1);
-        double c = fabs(x) / filter->inv_scale;
-        double w = c <= filter->radius ? filter->weight(filter, c) : 0;
+        double w = sample_filter(filter, window, x);
         out_w[n] = w;
         sum += w;
     }
-    //normalize
+    // Normalize to preserve energy
     for (int n = 0; n < filter->size; n++)
         out_w[n] /= sum;
 }
@@ -109,47 +141,47 @@ void mp_compute_weights(struct filter_kernel *filter, double f, float *out_w)
 // interpreted as rectangular array of count * filter->size items.
 void mp_compute_lut(struct filter_kernel *filter, int count, float *out_array)
 {
+    struct filter_window *window = &filter->w;
     if (filter->polar) {
         // Compute a 1D array indexed by radius
-        assert(filter->radius > 0);
         for (int x = 0; x < count; x++) {
-            double r = x * filter->radius / (count - 1);
-            out_array[x] = r <= filter->radius ? filter->weight(filter, r) : 0;
+            double r = x * filter->f.radius / (count - 1);
+            out_array[x] = sample_filter(filter, window, r);
         }
     } else {
         // Compute a 2D array indexed by subpixel position
         for (int n = 0; n < count; n++) {
-            mp_compute_weights(filter, n / (double)(count - 1),
+            mp_compute_weights(filter, window,  n / (double)(count - 1),
                                out_array + filter->size * n);
         }
     }
 }
 
-typedef struct filter_kernel kernel;
+typedef struct filter_window params;
 
-static double nearest(kernel *k, double x)
+static double box(params *p, double x)
 {
-    return x > 0.5 ? 0.0 : 1.0;
+    // This is mathematically 1.0 everywhere, the clipping is done implicitly
+    // based on the radius.
+    return 1.0;
 }
 
-static double triangle(kernel *k, double x)
+static double triangle(params *p, double x)
 {
-    if (fabs(x) > 1.0)
-        return 0.0;
-    return 1.0 - fabs(x);
+    return fmax(0.0, 1.0 - fabs(x / p->radius));
 }
 
-static double hanning(kernel *k, double x)
+static double hanning(params *p, double x)
 {
     return 0.5 + 0.5 * cos(M_PI * x);
 }
 
-static double hamming(kernel *k, double x)
+static double hamming(params *p, double x)
 {
     return 0.54 + 0.46 * cos(M_PI * x);
 }
 
-static double quadric(kernel *k, double x)
+static double quadric(params *p, double x)
 {
     // NOTE: glumpy uses 0.75, AGG uses 0.5
     if (x < 0.5)
@@ -164,7 +196,7 @@ static double bc_pow3(double x)
     return (x <= 0) ? 0 : x * x * x;
 }
 
-static double bicubic(kernel *k, double x)
+static double bicubic(params *p, double x)
 {
     return (1.0/6.0) * (      bc_pow3(x + 2)
                         - 4 * bc_pow3(x + 1)
@@ -184,19 +216,19 @@ static double bessel_i0(double epsilon, double x)
     return sum;
 }
 
-static double kaiser(kernel *k, double x)
+static double kaiser(params *p, double x)
 {
-    double a = k->params[0];
+    double a = p->params[0];
     double epsilon = 1e-12;
     double i0a = 1 / bessel_i0(epsilon, a);
     return bessel_i0(epsilon, a * sqrt(1 - x * x)) * i0a;
 }
 
 // Family of cubic B/C splines
-static double cubic_bc(kernel *k, double x)
+static double cubic_bc(params *p, double x)
 {
-    double b = k->params[0];
-    double c = k->params[1];
+    double b = p->params[0];
+    double c = p->params[1];
     double
         p0 = (6.0 - 2.0 * b) / 6.0,
         p2 = (-18.0 + 12.0 * b + 6.0 * c) / 6.0,
@@ -212,14 +244,14 @@ static double cubic_bc(kernel *k, double x)
     return 0;
 }
 
-static double spline16(kernel *k, double x)
+static double spline16(params *p, double x)
 {
     if (x < 1.0)
         return ((x - 9.0/5.0 ) * x - 1.0/5.0 ) * x + 1.0;
     return ((-1.0/3.0 * (x-1) + 4.0/5.0) * (x-1) - 7.0/15.0 ) * (x-1);
 }
 
-static double spline36(kernel *k, double x)
+static double spline36(params *p, double x)
 {
     if(x < 1.0)
         return ((13.0/11.0 * x - 453.0/209.0) * x - 3.0/209.0) * x + 1.0;
@@ -230,7 +262,7 @@ static double spline36(kernel *k, double x)
            * (x - 2);
 }
 
-static double spline64(kernel *k, double x)
+static double spline64(params *p, double x)
 {
     if (x < 1.0)
         return ((49.0 / 41.0 * x - 6387.0 / 2911.0) * x - 3.0 / 2911.0) * x + 1.0;
@@ -244,107 +276,84 @@ static double spline64(kernel *k, double x)
            * (x - 3);
 }
 
-static double gaussian(kernel *k, double x)
+static double gaussian(params *p, double x)
 {
-    double p = k->params[0];
-    return pow(2.0, -(M_E / p) * x * x);
+    return pow(2.0, -(M_E / p->params[0]) * x * x);
 }
 
-static double sinc(kernel *k, double x)
+static double sinc(params *p, double x)
 {
-    if (x == 0.0)
+    if (fabs(x) < 1e-8)
         return 1.0;
     double pix = M_PI * x;
     return sin(pix) / pix;
 }
 
-static double jinc(kernel *k, double x)
+static double jinc(params *p, double x)
 {
     if (fabs(x) < 1e-8)
         return 1.0;
-    double pix = M_PI * x / k->params[0]; // blur factor
+    double pix = M_PI * x;
     return 2.0 * j1(pix) / pix;
 }
 
-static double lanczos(kernel *k, double x)
+static double sphinx(params *p, double x)
 {
-    double radius = k->size / 2;
-    if (x < -radius || x > radius)
-        return 0;
-    if (x == 0)
-        return 1;
-    double pix = M_PI * x;
-    return radius * sin(pix) * sin(pix / radius) / (pix * pix);
-}
-
-static double ewa_ginseng(kernel *k, double x)
-{
-    // Note: This is EWA ginseng, aka sinc-windowed jinc.
-    // Not to be confused with tensor ginseng, aka jinc-windowed sinc.
-    double radius = k->radius;
-    if (fabs(x) >= radius)
-        return 0.0;
-    return jinc(k, x) * sinc(k, x / radius);
-}
-
-static double ewa_lanczos(kernel *k, double x)
-{
-    double radius = k->radius;
-    if (fabs(x) >= radius)
-        return 0.0;
-    // First zero of the jinc function. We simply scale it to fit into the
-    // given radius.
-    double jinc_zero = 1.2196698912665045;
-    return jinc(k, x) * jinc(k, x * jinc_zero / radius);
-}
-
-static double ewa_hanning(kernel *k, double x)
-{
-    double radius = k->radius;
-    if (fabs(x) >= radius)
-        return 0.0;
-    // Jinc windowed by the hanning window
-    return jinc(k, x) * hanning(k, x / radius);
-}
-
-static double blackman(kernel *k, double x)
-{
-    double radius = k->size / 2;
-    if (x == 0.0)
+    if (fabs(x) < 1e-8)
         return 1.0;
-    if (x > radius)
-        return 0.0;
-    x *= M_PI;
-    double xr = x / radius;
-    return (sin(x) / x) * (0.42 + 0.5 * cos(xr) + 0.08 * cos(2 * xr));
+    double pix = M_PI * x;
+    return 3.0 * (sin(pix) - pix * cos(pix)) / (pix * pix * pix);
 }
 
-const struct filter_kernel mp_filter_kernels[] = {
-    {"nearest",        0.5, nearest},
+const struct filter_window mp_filter_windows[] = {
+    {"box",            1,   box},
     {"triangle",       1,   triangle},
     {"hanning",        1,   hanning},
     {"hamming",        1,   hamming},
     {"quadric",        1.5, quadric},
-    {"bicubic",        2,   bicubic},
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
-    {"catmull_rom",    2,   cubic_bc, .params = {0.0, 0.5} },
-    {"mitchell",       2,   cubic_bc, .params = {1.0/3.0, 1.0/3.0} },
     {"hermite",        1,   cubic_bc, .params = {0.0, 0.0} },
-    {"robidoux",       2,   cubic_bc, .params = {0.3782, 0.3109}, .polar = true},
-    {"robidouxsharp",  2,   cubic_bc, .params = {0.2620, 0.3690}, .polar = true},
-    {"spline16",       2,   spline16},
-    {"spline36",       3,   spline36},
-    {"spline64",       4,   spline64},
     {"gaussian",       -1,  gaussian, .params = {1.0, NAN} },
-    {"sinc",           -1,  sinc},
-    {"ewa_lanczos",    -1,  ewa_lanczos, .params = {1.0, NAN}, .polar = true},
-    {"ewa_hanning",    -1,  ewa_hanning, .params = {1.0, NAN}, .polar = true},
-    {"ewa_ginseng",    -1,  ewa_ginseng, .params = {1.0, NAN}, .polar = true},
+    {"sinc",           1,   sinc},
+    {"jinc",           1.2196698912665045, jinc},
+    {"sphinx",         1.4302966531242027, sphinx},
+    {0}
+};
+
+const struct filter_kernel mp_filter_kernels[] = {
+    // Spline filters
+    {{"spline16",       2,   spline16}},
+    {{"spline36",       3,   spline36}},
+    {{"spline64",       4,   spline64}},
+    // Sinc filters
+    {{"sinc",           -1,  sinc}},
+    {{"lanczos",        -1,  sinc}, .window = "sinc"},
+    {{"ginseng",        -1,  sinc}, .window = "jinc"},
+    // Jinc filters
+    {{"jinc",           -1,  jinc}, .polar = true},
+    {{"ewa_lanczos",    -1,  jinc}, .polar = true, .window = "jinc"},
+    {{"ewa_hanning",    -1,  jinc}, .polar = true, .window = "hanning" },
+    {{"ewa_ginseng",    -1,  jinc}, .polar = true, .window = "sinc"},
     // Radius is based on the true jinc radius, slightly sharpened as per
     // calculations by Nicolas Robidoux. Source: Imagemagick's magick/resize.c
-    {"ewa_lanczossharp", 3.2383154841662362, ewa_lanczos,
-                         .params = {0.9812505644269356, NAN}, .polar = true},
-    {"lanczos",        -1,  lanczos},
-    {"blackman",       -1,  blackman},
-    {0}
+    {{"ewa_lanczossharp", 3.2383154841662362, jinc, .blur = 0.9812505644269356},
+          .polar = true, .window = "jinc"},
+    // Similar to the above, but softened instead. This one makes hash patterns
+    // disappear completely. Blur determined by trial and error.
+    {{"ewa_lanczossoft", 3.2383154841662362, jinc, .blur = 1.015},
+          .polar = true, .window = "jinc"},
+    // Cubic filters
+    {{"bicubic",        2,   bicubic}},
+    {{"bcspline",       2,   cubic_bc, .params = {0.5, 0.5} }},
+    {{"catmull_rom",    2,   cubic_bc, .params = {0.0, 0.5} }},
+    {{"mitchell",       2,   cubic_bc, .params = {1.0/3.0, 1.0/3.0} }},
+    {{"robidoux",       2,   cubic_bc, .params = {0.3782, 0.3109}}, .polar = true},
+    {{"robidouxsharp",  2,   cubic_bc, .params = {0.2620, 0.3690}}, .polar = true},
+    // Miscalleaneous filters
+    {{"box",            -1,  box}},
+    {{"nearest",        0.5, box}},
+    {{"triangle",       -1,  triangle}},
+    {{"bilinear_slow",  1,   triangle}},
+    {{"gaussian",       -1,  gaussian, .params = {1.0, NAN} }},
+    {{0}}
 };

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -225,6 +225,19 @@ static double kaiser(params *p, double x)
     return bessel_i0(epsilon, a * sqrt(1 - x * x)) * i0a;
 }
 
+static double blackman(params *p, double x)
+{
+    double a = p->params[0];
+    double a0 = (1-a)/2.0, a1 = 1/2.0, a2 = a/2.0;
+    double pix = M_PI * x;
+    return a0 + a1*cos(pix) + a2*cos(2 * pix);
+}
+
+static double welch(params *p, double x)
+{
+    return 1.0 - x*x;
+}
+
 // Family of cubic B/C splines
 static double cubic_bc(params *p, double x)
 {
@@ -312,9 +325,11 @@ const struct filter_window mp_filter_windows[] = {
     {"hanning",        1,   hanning},
     {"hamming",        1,   hamming},
     {"quadric",        1.5, quadric},
+    {"welch",          1,   welch},
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
     {"hermite",        1,   cubic_bc, .params = {0.0, 0.0} },
-    {"gaussian",       2,   gaussian, .params = {1.0, NAN} },
+    {"blackman",       1,   blackman, .params = {0.16, NAN} },
+    {"gaussian",       2,   gaussian, .params = {1.0,  NAN} },
     {"sinc",           1,   sinc},
     {"jinc",           1.2196698912665045, jinc},
     {"sphinx",         1.4302966531242027, sphinx},

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -357,6 +357,10 @@ const struct filter_kernel mp_filter_kernels[] = {
     // disappear completely. Blur determined by trial and error.
     {{"ewa_lanczossoft", 3.2383154841662362, jinc, .blur = 1.015},
           .polar = true, .window = "jinc"},
+    // Very soft (blurred) hanning-windowed jinc; removes almost all aliasing.
+    // Blur paramater picked to match orthogonal and diagonal contributions
+    {{"haasnsoft", 3.2383154841662362, jinc, .blur = 1.11}, .polar = true,
+          .window = "hanning"},
     // Cubic filters
     {{"bicubic",        2,   bicubic}},
     {{"bcspline",       2,   cubic_bc, .params = {0.5, 0.5} }},

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -327,7 +327,6 @@ const struct filter_window mp_filter_windows[] = {
     {"quadric",        1.5, quadric},
     {"welch",          1,   welch},
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
-    {"hermite",        1,   cubic_bc, .params = {0.0, 0.0} },
     {"blackman",       1,   blackman, .params = {0.16, NAN} },
     {"gaussian",       2,   gaussian, .params = {1.0,  NAN} },
     {"sinc",           1,   sinc},

--- a/video/out/filter_kernels.h
+++ b/video/out/filter_kernels.h
@@ -21,26 +21,34 @@
 
 #include <stdbool.h>
 
-struct filter_kernel {
+struct filter_window {
     const char *name;
-    double radius;  // A negative value will use user specified radius instead.
-    double (*weight)(struct filter_kernel *kernel, double x);
+    double radius; // A negative value will use user specified radius instead.
+    double (*weight)(struct filter_window *k, double x);
+    double params[2]; // User-defined custom filter parameters. Not used by
+                      // all filters
+    double blur; // Blur coefficient (sharpens or widens the filter)
+};
 
-    // The filter params can be changed at runtime. Only used by some filters.
-    float params[2];
-    // Whether or not the filter uses polar coordinates
-    bool polar;
+struct filter_kernel {
+    struct filter_window f; // the kernel itself
+    struct filter_window w; // window storage
+    // Constant values
+    const char *window; // default window
+    bool polar;         // whether or not the filter uses polar coordinates
     // The following values are set by mp_init_filter() at runtime.
     int size;           // number of coefficients (may depend on radius)
     double inv_scale;   // scale factor (<1.0 is upscale, >1.0 downscale)
 };
 
+extern const struct filter_window mp_filter_windows[];
 extern const struct filter_kernel mp_filter_kernels[];
 
+const struct filter_window *mp_find_filter_window(const char *name);
 const struct filter_kernel *mp_find_filter_kernel(const char *name);
+
 bool mp_init_filter(struct filter_kernel *filter, const int *sizes,
                     double scale);
-void mp_compute_weights(struct filter_kernel *filter, double f, float *out_w);
 void mp_compute_lut(struct filter_kernel *filter, int count, float *out_array);
 
 #endif /* MPLAYER_FILTER_KERNELS_H */

--- a/video/out/filter_kernels.h
+++ b/video/out/filter_kernels.h
@@ -23,8 +23,9 @@
 
 struct filter_window {
     const char *name;
-    double radius; // A negative value will use user specified radius instead.
+    double radius; // Preferred radius, should only be changed if resizable
     double (*weight)(struct filter_window *k, double x);
+    bool resizable; // Filter supports any given radius
     double params[2]; // User-defined custom filter parameters. Not used by
                       // all filters
     double blur; // Blur coefficient (sharpens or widens the filter)

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -324,10 +324,10 @@ const struct gl_video_opts gl_video_opts_def = {
     .sigmoid_center = 0.75,
     .sigmoid_slope = 6.5,
     .scaler = {
-        {{"bilinear",   .params={NAN, NAN}}}, // scale
-        {{NULL,         .params={NAN, NAN}}}, // dscale (defaults to scale)
-        {{"bilinear",   .params={NAN, NAN}}}, // cscale
-        {{"oversample", .params={NAN, NAN}}}  // tscale
+        {{"bilinear",   .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // scale
+        {{NULL,         .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // dscale
+        {{"bilinear",   .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // cscale
+        {{"oversample", .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // tscale
     },
     .alpha_mode = 2,
     .background = {0, 0, 0, 255},
@@ -344,10 +344,10 @@ const struct gl_video_opts gl_video_opts_hq_def = {
     .sigmoid_slope = 6.5,
     .sigmoid_upscaling = 1,
     .scaler = {
-        {{"spline36",   .params={NAN, NAN}}}, // scale
-        {{"mitchell",   .params={NAN, NAN}}}, // dscale
-        {{"spline36",   .params={NAN, NAN}}}, // cscale
-        {{"oversample", .params={NAN, NAN}}}  // tscale
+        {{"spline36",   .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // scale
+        {{"mitchell",   .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // dscale
+        {{"spline36",   .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // cscale
+        {{"oversample", .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // tscale
     },
     .alpha_mode = 2,
     .background = {0, 0, 0, 255},
@@ -401,6 +401,10 @@ const struct m_sub_options gl_video_conf = {
         OPT_STRING_VALIDATE("dscale-window", scaler[1].window.name, 0, validate_window_opt),
         OPT_STRING_VALIDATE("cscale-window", scaler[2].window.name, 0, validate_window_opt),
         OPT_STRING_VALIDATE("tscale-window", scaler[3].window.name, 0, validate_window_opt),
+        OPT_FLOAT("scale-wparam",  scaler[0].window.params[0], 0),
+        OPT_FLOAT("dscale-wparam", scaler[1].window.params[0], 0),
+        OPT_FLOAT("cscale-wparam", scaler[2].window.params[0], 0),
+        OPT_FLOAT("tscale-wparam", scaler[3].window.params[0], 0),
         OPT_FLOATRANGE("scale-radius",  scaler[0].radius, 0, 0.5, 16.0),
         OPT_FLOATRANGE("dscale-radius", scaler[1].radius, 0, 0.5, 16.0),
         OPT_FLOATRANGE("cscale-radius", scaler[2].radius, 0, 0.5, 16.0),

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -357,6 +357,9 @@ const struct gl_video_opts gl_video_opts_hq_def = {
 static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
                                struct bstr name, struct bstr param);
 
+static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
+                               struct bstr name, struct bstr param);
+
 #define OPT_BASE_STRUCT struct gl_video_opts
 const struct m_sub_options gl_video_conf = {
     .opts = (const m_option_t[]) {
@@ -387,6 +390,12 @@ const struct m_sub_options gl_video_conf = {
         OPT_FLOAT("cscale-param2", scaler_params[1][1], 0),
         OPT_FLOAT("tscale-param1", scaler_params[2][0], 0),
         OPT_FLOAT("tscale-param2", scaler_params[2][1], 0),
+        OPT_FLOAT("scale-blur", scaler_blur[0], 0),
+        OPT_FLOAT("cscale-blur", scaler_blur[1], 0),
+        OPT_FLOAT("tscale-blur", scaler_blur[2], 0),
+        OPT_STRING_VALIDATE("scale-window", scaler_window[0], 0, validate_window_opt),
+        OPT_STRING_VALIDATE("cscale-window", scaler_window[1], 0, validate_window_opt),
+        OPT_STRING_VALIDATE("tscale-window", scaler_window[2], 0, validate_window_opt),
         OPT_FLOATRANGE("scale-radius", scaler_radius[0], 0, 1.0, 16.0),
         OPT_FLOATRANGE("cscale-radius", scaler_radius[1], 0, 1.0, 16.0),
         OPT_FLOATRANGE("tscale-radius", scaler_radius[2], 0, 1.0, 3.0),
@@ -900,6 +909,7 @@ static void reinit_scaler(struct gl_video *p, int scaler_unit, const char *name,
 
     for (int n = 0; n < 2; n++)
         scaler->params[n] = p->opts.scaler_params[scaler->index][n];
+    scaler->antiring = p->opts.scaler_antiring[scaler->index];
 
     const struct filter_kernel *t_kernel = mp_find_filter_kernel(scaler->name);
     if (!t_kernel)
@@ -908,15 +918,24 @@ static void reinit_scaler(struct gl_video *p, int scaler_unit, const char *name,
     scaler->kernel_storage = *t_kernel;
     scaler->kernel = &scaler->kernel_storage;
 
+    const char *win = p->opts.scaler_window[scaler->index];
+    if (!win || !win[0])
+        win = t_kernel->window;
+    const struct filter_window *t_window = mp_find_filter_window(win);
+    if (t_window)
+        scaler->kernel->w = *t_window;
+
     for (int n = 0; n < 2; n++) {
         if (!isnan(scaler->params[n]))
-            scaler->kernel->params[n] = scaler->params[n];
+            scaler->kernel->f.params[n] = scaler->params[n];
     }
 
-    scaler->antiring = p->opts.scaler_antiring[scaler->index];
+    float blur = p->opts.scaler_blur[scaler->index];
+    if (blur > 0.0)
+        scaler->kernel->f.blur = blur;
 
-    if (scaler->kernel->radius < 0)
-        scaler->kernel->radius = p->opts.scaler_radius[scaler->index];
+    if (scaler->kernel->f.radius < 0)
+        scaler->kernel->f.radius = p->opts.scaler_radius[scaler->index];
 
     scaler->insufficient = !mp_init_filter(scaler->kernel, sizes, scale_factor);
 
@@ -1071,7 +1090,7 @@ static void pass_sample_separated(struct gl_video *p, int src_tex,
 
 static void pass_sample_polar(struct gl_video *p, struct scaler *scaler)
 {
-    double radius = scaler->kernel->radius;
+    double radius = scaler->kernel->f.radius;
     int bound = (int)ceil(radius);
     bool use_ar = scaler->antiring > 0;
     GLSL(vec4 color = vec4(0.0);)
@@ -2486,7 +2505,7 @@ static const char *handle_scaler_opt(const char *name, bool tscale)
     if (name && name[0]) {
         const struct filter_kernel *kernel = mp_find_filter_kernel(name);
         if (kernel && (!tscale || !kernel->polar))
-                return kernel->name;
+                return kernel->f.name;
 
         for (const char *const *filter = tscale ? fixed_tscale_filters
                                                 : fixed_scale_filters;
@@ -2515,7 +2534,7 @@ void gl_video_set_options(struct gl_video *p, struct gl_video_opts *opts,
     if (queue_size && p->opts.interpolation && p->opts.scalers[2]) {
         const struct filter_kernel *kernel = mp_find_filter_kernel(p->opts.scalers[2]);
         if (kernel) {
-            double radius = kernel->radius;
+            double radius = kernel->f.radius;
             radius = radius > 0 ? radius : p->opts.scaler_radius[2];
            *queue_size = 50e3 * ceil(radius);
         }
@@ -2561,15 +2580,39 @@ static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
              *filter; filter++) {
             mp_info(log, "    %s\n", *filter);
         }
-        for (int n = 0; mp_filter_kernels[n].name; n++) {
+        for (int n = 0; mp_filter_kernels[n].f.name; n++) {
             if (!tscale || !mp_filter_kernels[n].polar)
-                mp_info(log, "    %s\n", mp_filter_kernels[n].name);
+                mp_info(log, "    %s\n", mp_filter_kernels[n].f.name);
         }
         if (s[0])
             mp_fatal(log, "No scaler named '%s' found!\n", s);
     }
     return r;
 }
+
+static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
+                               struct bstr name, struct bstr param)
+{
+    char s[20] = {0};
+    int r = 1;
+    if (bstr_equals0(param, "help")) {
+        r = M_OPT_EXIT - 1;
+    } else {
+        snprintf(s, sizeof(s), "%.*s", BSTR_P(param));
+        const struct filter_window *window = mp_find_filter_window(s);
+        if (!window)
+            r = M_OPT_INVALID;
+    }
+    if (r < 1) {
+        mp_info(log, "Available windows:\n");
+        for (int n = 0; mp_filter_windows[n].name; n++)
+            mp_info(log, "    %s\n", mp_filter_windows[n].name);
+        if (s[0])
+            mp_fatal(log, "No window named '%s' found!\n", s);
+    }
+    return r;
+}
+
 
 // Resize and redraw the contents of the window without further configuration.
 // Intended to be used in situations where the frontend can't really be

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -48,7 +48,7 @@
 
 // Other texture units are reserved for specific purposes
 #define TEXUNIT_SCALERS  TEXUNIT_VIDEO_NUM
-#define TEXUNIT_3DLUT    (TEXUNIT_SCALERS+3)
+#define TEXUNIT_3DLUT    (TEXUNIT_SCALERS+4)
 #define TEXUNIT_DITHER   (TEXUNIT_3DLUT+1)
 
 // scale/cscale arguments that map directly to shader filter routines.
@@ -112,11 +112,8 @@ struct video_image {
 
 struct scaler {
     int index;
-    const char *name;
+    struct scaler_config conf;
     double scale_factor;
-    float params[2];
-    float antiring;
-
     bool initialized;
     struct filter_kernel *kernel;
     GLuint gl_lut;
@@ -190,8 +187,8 @@ struct gl_video {
     int surface_now;
     bool is_interpolated;
 
-    // state for luma (0), chroma (1) and temporal (2) scalers
-    struct scaler scalers[3];
+    // state for luma (0), luma-down(1), chroma (2) and temporal (3) scalers
+    struct scaler scaler[4];
 
     struct mp_csp_equalizer video_eq;
 
@@ -326,10 +323,12 @@ const struct gl_video_opts gl_video_opts_def = {
     .fbo_format = GL_RGBA,
     .sigmoid_center = 0.75,
     .sigmoid_slope = 6.5,
-    .scalers = { "bilinear", "bilinear", "oversample" },
-    .dscaler = "bilinear",
-    .scaler_params = {{NAN, NAN}, {NAN, NAN}, {NAN, NAN}},
-    .scaler_radius = {3, 3, 3},
+    .scaler = {
+        {{"bilinear",   .params={NAN, NAN}}}, // scale
+        {{NULL,         .params={NAN, NAN}}}, // dscale (defaults to scale)
+        {{"bilinear",   .params={NAN, NAN}}}, // cscale
+        {{"oversample", .params={NAN, NAN}}}  // tscale
+    },
     .alpha_mode = 2,
     .background = {0, 0, 0, 255},
     .gamma = 1.0f,
@@ -344,10 +343,12 @@ const struct gl_video_opts gl_video_opts_hq_def = {
     .sigmoid_center = 0.75,
     .sigmoid_slope = 6.5,
     .sigmoid_upscaling = 1,
-    .scalers = { "spline36", "spline36", "oversample" },
-    .dscaler = "mitchell",
-    .scaler_params = {{NAN, NAN}, {NAN, NAN}, {NAN, NAN}},
-    .scaler_radius = {3, 3, 3},
+    .scaler = {
+        {{"spline36",   .params={NAN, NAN}}}, // scale
+        {{"mitchell",   .params={NAN, NAN}}}, // dscale
+        {{"spline36",   .params={NAN, NAN}}}, // cscale
+        {{"oversample", .params={NAN, NAN}}}  // tscale
+    },
     .alpha_mode = 2,
     .background = {0, 0, 0, 255},
     .gamma = 1.0f,
@@ -380,28 +381,34 @@ const struct m_sub_options gl_video_conf = {
                     {"gamma22", MP_CSP_TRC_GAMMA22})),
         OPT_FLAG("npot", npot, 0),
         OPT_FLAG("pbo", pbo, 0),
-        OPT_STRING_VALIDATE("scale", scalers[0], 0, validate_scaler_opt),
-        OPT_STRING_VALIDATE("cscale", scalers[1], 0, validate_scaler_opt),
-        OPT_STRING_VALIDATE("tscale", scalers[2], 0, validate_scaler_opt),
-        OPT_STRING_VALIDATE("scale-down", dscaler, 0, validate_scaler_opt),
-        OPT_FLOAT("scale-param1", scaler_params[0][0], 0),
-        OPT_FLOAT("scale-param2", scaler_params[0][1], 0),
-        OPT_FLOAT("cscale-param1", scaler_params[1][0], 0),
-        OPT_FLOAT("cscale-param2", scaler_params[1][1], 0),
-        OPT_FLOAT("tscale-param1", scaler_params[2][0], 0),
-        OPT_FLOAT("tscale-param2", scaler_params[2][1], 0),
-        OPT_FLOAT("scale-blur", scaler_blur[0], 0),
-        OPT_FLOAT("cscale-blur", scaler_blur[1], 0),
-        OPT_FLOAT("tscale-blur", scaler_blur[2], 0),
-        OPT_STRING_VALIDATE("scale-window", scaler_window[0], 0, validate_window_opt),
-        OPT_STRING_VALIDATE("cscale-window", scaler_window[1], 0, validate_window_opt),
-        OPT_STRING_VALIDATE("tscale-window", scaler_window[2], 0, validate_window_opt),
-        OPT_FLOATRANGE("scale-radius", scaler_radius[0], 0, 1.0, 16.0),
-        OPT_FLOATRANGE("cscale-radius", scaler_radius[1], 0, 1.0, 16.0),
-        OPT_FLOATRANGE("tscale-radius", scaler_radius[2], 0, 1.0, 3.0),
-        OPT_FLOATRANGE("scale-antiring", scaler_antiring[0], 0, 0.0, 1.0),
-        OPT_FLOATRANGE("cscale-antiring", scaler_antiring[1], 0, 0.0, 1.0),
-        OPT_FLOATRANGE("tscale-antiring", scaler_antiring[2], 0, 0.0, 1.0),
+        OPT_STRING_VALIDATE("scale",  scaler[0].kernel.name, 0, validate_scaler_opt),
+        OPT_STRING_VALIDATE("dscale", scaler[1].kernel.name, 0, validate_scaler_opt),
+        OPT_STRING_VALIDATE("cscale", scaler[2].kernel.name, 0, validate_scaler_opt),
+        OPT_STRING_VALIDATE("tscale", scaler[3].kernel.name, 0, validate_scaler_opt),
+        OPT_FLOAT("scale-param1", scaler[0].kernel.params[0], 0),
+        OPT_FLOAT("scale-param2", scaler[0].kernel.params[1], 0),
+        OPT_FLOAT("dscale-param1", scaler[1].kernel.params[0], 0),
+        OPT_FLOAT("dscale-param2", scaler[1].kernel.params[1], 0),
+        OPT_FLOAT("cscale-param1", scaler[2].kernel.params[0], 0),
+        OPT_FLOAT("cscale-param2", scaler[2].kernel.params[1], 0),
+        OPT_FLOAT("tscale-param1", scaler[3].kernel.params[0], 0),
+        OPT_FLOAT("tscale-param2", scaler[3].kernel.params[1], 0),
+        OPT_FLOAT("scale-blur",  scaler[0].kernel.blur, 0),
+        OPT_FLOAT("dscale-blur", scaler[1].kernel.blur, 0),
+        OPT_FLOAT("cscale-blur", scaler[2].kernel.blur, 0),
+        OPT_FLOAT("tscale-blur", scaler[3].kernel.blur, 0),
+        OPT_STRING_VALIDATE("scale-window",  scaler[0].window.name, 0, validate_window_opt),
+        OPT_STRING_VALIDATE("dscale-window", scaler[1].window.name, 0, validate_window_opt),
+        OPT_STRING_VALIDATE("cscale-window", scaler[2].window.name, 0, validate_window_opt),
+        OPT_STRING_VALIDATE("tscale-window", scaler[3].window.name, 0, validate_window_opt),
+        OPT_FLOATRANGE("scale-radius",  scaler[0].radius, 0, 0.5, 16.0),
+        OPT_FLOATRANGE("dscale-radius", scaler[1].radius, 0, 0.5, 16.0),
+        OPT_FLOATRANGE("cscale-radius", scaler[2].radius, 0, 0.5, 16.0),
+        OPT_FLOATRANGE("tscale-radius", scaler[3].radius, 0, 0.5, 3.0),
+        OPT_FLOATRANGE("scale-antiring",  scaler[0].antiring, 0, 0.0, 1.0),
+        OPT_FLOATRANGE("dscale-antiring", scaler[1].antiring, 0, 0.0, 1.0),
+        OPT_FLOATRANGE("cscale-antiring", scaler[2].antiring, 0, 0.0, 1.0),
+        OPT_FLOATRANGE("tscale-antiring", scaler[3].antiring, 0, 0.0, 1.0),
         OPT_FLAG("scaler-resizes-only", scaler_resizes_only, 0),
         OPT_FLAG("linear-scaling", linear_scaling, 0),
         OPT_FLAG("fancy-downscaling", fancy_downscaling, 0),
@@ -458,6 +465,7 @@ const struct m_sub_options gl_video_conf = {
         OPT_REPLACED("cantiring", "cscale-antiring"),
         OPT_REPLACED("smoothmotion", "interpolation"),
         OPT_REPLACED("smoothmotion-threshold", "tscale-param1"),
+        OPT_REPLACED("scale-down", "dscale"),
 
         {0}
     },
@@ -466,7 +474,7 @@ const struct m_sub_options gl_video_conf = {
 };
 
 static void uninit_rendering(struct gl_video *p);
-static void uninit_scaler(struct gl_video *p, int scaler_unit);
+static void uninit_scaler(struct gl_video *p, struct scaler *scaler);
 static void check_gl_features(struct gl_video *p);
 static bool init_format(int fmt, struct gl_video *init);
 
@@ -545,8 +553,8 @@ static void uninit_rendering(struct gl_video *p)
 {
     GL *gl = p->gl;
 
-    for (int n = 0; n < 3; n++)
-        uninit_scaler(p, n);
+    for (int n = 0; n < 4; n++)
+        uninit_scaler(p, &p->scaler[n]);
 
     gl->DeleteTextures(1, &p->dither_texture);
     p->dither_texture = 0;
@@ -877,11 +885,9 @@ static void finish_pass_fbo(struct gl_video *p, struct fbotex *dst_fbo,
     pass_load_fbotex(p, dst_fbo, tex, w, h);
 }
 
-static void uninit_scaler(struct gl_video *p, int scaler_unit)
+static void uninit_scaler(struct gl_video *p, struct scaler *scaler)
 {
     GL *gl = p->gl;
-    struct scaler *scaler = &p->scalers[scaler_unit];
-
     fbotex_uninit(&scaler->sep_fbo);
     gl->DeleteTextures(1, &scaler->gl_lut);
     scaler->gl_lut = 0;
@@ -889,53 +895,72 @@ static void uninit_scaler(struct gl_video *p, int scaler_unit)
     scaler->initialized = false;
 }
 
-static void reinit_scaler(struct gl_video *p, int scaler_unit, const char *name,
-                          double scale_factor, int sizes[])
+static bool scaler_fun_eq(struct scaler_fun a, struct scaler_fun b)
+{
+    if ((a.name && !b.name) || (b.name && !a.name))
+        return false;
+
+    return ((!a.name && !b.name) || strcmp(a.name, b.name) == 0) &&
+           a.params[0] == b.params[0] && a.params[1] == b.params[1] &&
+           a.blur == b.blur;
+}
+
+static bool scaler_conf_eq(struct scaler_config a, struct scaler_config b)
+{
+    // Note: antiring isn't compared because it doesn't affect LUT
+    // generation
+    return scaler_fun_eq(a.kernel, b.kernel) &&
+           scaler_fun_eq(a.window, b.window) &&
+           a.radius == b.radius;
+}
+
+static void reinit_scaler(struct gl_video *p, struct scaler *scaler,
+                          const struct scaler_config *conf,
+                          double scale_factor,
+                          int sizes[])
 {
     GL *gl = p->gl;
-    struct scaler *scaler = &p->scalers[scaler_unit];
 
-    if (scaler->name && strcmp(scaler->name, name) == 0 &&
+    if (scaler_conf_eq(scaler->conf, *conf) &&
         scaler->scale_factor == scale_factor &&
         scaler->initialized)
         return;
 
-    uninit_scaler(p, scaler_unit);
+    uninit_scaler(p, scaler);
 
-    scaler->name = name;
+    scaler->conf = *conf;
     scaler->scale_factor = scale_factor;
     scaler->insufficient = false;
     scaler->initialized = true;
 
-    for (int n = 0; n < 2; n++)
-        scaler->params[n] = p->opts.scaler_params[scaler->index][n];
-    scaler->antiring = p->opts.scaler_antiring[scaler->index];
-
-    const struct filter_kernel *t_kernel = mp_find_filter_kernel(scaler->name);
+    const struct filter_kernel *t_kernel = mp_find_filter_kernel(conf->kernel.name);
     if (!t_kernel)
         return;
 
     scaler->kernel_storage = *t_kernel;
     scaler->kernel = &scaler->kernel_storage;
 
-    const char *win = p->opts.scaler_window[scaler->index];
+    const char *win = conf->window.name;
     if (!win || !win[0])
-        win = t_kernel->window;
+        win = t_kernel->window; // fall back to the scaler's default window
     const struct filter_window *t_window = mp_find_filter_window(win);
     if (t_window)
         scaler->kernel->w = *t_window;
 
     for (int n = 0; n < 2; n++) {
-        if (!isnan(scaler->params[n]))
-            scaler->kernel->f.params[n] = scaler->params[n];
+        if (!isnan(conf->kernel.params[n]))
+            scaler->kernel->f.params[n] = conf->kernel.params[n];
+        if (!isnan(conf->window.params[n]))
+            scaler->kernel->w.params[n] = conf->window.params[n];
     }
 
-    float blur = p->opts.scaler_blur[scaler->index];
-    if (blur > 0.0)
-        scaler->kernel->f.blur = blur;
+    if (conf->kernel.blur > 0.0)
+        scaler->kernel->f.blur = conf->kernel.blur;
+    if (conf->window.blur > 0.0)
+        scaler->kernel->w.blur = conf->window.blur;
 
-    if (scaler->kernel->f.radius < 0)
-        scaler->kernel->f.radius = p->opts.scaler_radius[scaler->index];
+    if (scaler->kernel->f.resizable && conf->radius > 0.0)
+        scaler->kernel->f.radius = conf->radius;
 
     scaler->insufficient = !mp_init_filter(scaler->kernel, sizes, scale_factor);
 
@@ -1033,7 +1058,7 @@ static void pass_sample_separated_gen(struct gl_video *p, struct scaler *scaler,
                                       int d_x, int d_y)
 {
     int N = scaler->kernel->size;
-    bool use_ar = scaler->antiring > 0;
+    bool use_ar = scaler->conf.antiring > 0;
     bool planar = d_x == 0 && d_y == 0;
     GLSL(vec4 color = vec4(0.0);)
     GLSLF("{\n");
@@ -1063,7 +1088,8 @@ static void pass_sample_separated_gen(struct gl_video *p, struct scaler *scaler,
         }
     }
     if (use_ar)
-        GLSLF("color = mix(color, clamp(color, lo, hi), %f);\n", scaler->antiring);
+        GLSLF("color = mix(color, clamp(color, lo, hi), %f);\n",
+              scaler->conf.antiring);
     GLSLF("}\n");
 }
 
@@ -1092,7 +1118,7 @@ static void pass_sample_polar(struct gl_video *p, struct scaler *scaler)
 {
     double radius = scaler->kernel->f.radius;
     int bound = (int)ceil(radius);
-    bool use_ar = scaler->antiring > 0;
+    bool use_ar = scaler->conf.antiring > 0;
     GLSL(vec4 color = vec4(0.0);)
     GLSLF("{\n");
     GLSL(vec2 fcoord = fract(pos * size - vec2(0.5));)
@@ -1134,7 +1160,8 @@ static void pass_sample_polar(struct gl_video *p, struct scaler *scaler)
     }
     GLSL(color = color / vec4(wsum);)
     if (use_ar)
-        GLSLF("color = mix(color, clamp(color, lo, hi), %f);\n", scaler->antiring);
+        GLSLF("color = mix(color, clamp(color, lo, hi), %f);\n",
+              scaler->conf.antiring);
     GLSLF("}\n");
 }
 
@@ -1188,7 +1215,8 @@ static void pass_sample_sharpen3(struct gl_video *p, struct scaler *scaler)
                   + texture(tex, pos + st * vec2(+1, -1))
                   + texture(tex, pos + st * vec2(-1, +1))
                   + texture(tex, pos + st * vec2(-1, -1));)
-    double param = isnan(scaler->params[0]) ? 0.5 : scaler->params[0];
+    float param = scaler->conf.kernel.params[0];
+    param = isnan(param) ? 0.5 : param;
     GLSLF("color = p + (p - 0.25 * sum) * %f;\n", param);
     GLSLF("}\n");
 }
@@ -1209,7 +1237,8 @@ static void pass_sample_sharpen5(struct gl_video *p, struct scaler *scaler)
                    + texture(tex, pos + st2 * vec2(-1,  0))
                    + texture(tex, pos + st2 * vec2( 0, -1));)
     GLSL(vec4 t = p * 0.859375 + sum2 * -0.1171875 + sum1 * -0.09765625;)
-    double param = isnan(scaler->params[0]) ? 0.5 : scaler->params[0];
+    float param = scaler->conf.kernel.params[0];
+    param = isnan(param) ? 0.5 : param;
     GLSLF("color = p + t * %f;\n", param);
     GLSLF("}\n");
 }
@@ -1231,11 +1260,12 @@ static void pass_sample_oversample(struct gl_video *p, struct scaler *scaler,
     gl_sc_uniform_vec2(p->sc, "output_size", (float[2]){w, h});
     GLSL(vec2 coeff = vec2((baseSE - pos) * output_size);)
     GLSL(coeff = clamp(coeff, 0.0, 1.0);)
-    if (scaler->params[0] > 0) { // also rules out NAN
+    float threshold = scaler->conf.kernel.params[0];
+    if (threshold > 0) { // also rules out NAN
         GLSLF("coeff = mix(coeff, vec2(0.0), "
-              "lessThanEqual(coeff, vec2(%f)));\n", scaler->params[0]);
+              "lessThanEqual(coeff, vec2(%f)));\n", threshold);
         GLSLF("coeff = mix(coeff, vec2(1.0), "
-              "greaterThanEqual(coeff, vec2(%f)));\n", scaler->params[0]);
+              "greaterThanEqual(coeff, vec2(%f)));\n", threshold);
     }
     // Compute the right blend of colors
     GLSL(vec4 left = mix(texture(tex, baseSW),
@@ -1257,12 +1287,11 @@ static void pass_sample_oversample(struct gl_video *p, struct scaler *scaler,
 // This will declare "vec4 color;", which contains the scaled contents.
 // The scaler unit is initialized by this function; in order to avoid cache
 // thrashing, the scaler unit should usually use the same parameters.
-static void pass_sample(struct gl_video *p, int src_tex,
-                        int scaler_unit, const char *name, double scale_factor,
+static void pass_sample(struct gl_video *p, int src_tex, struct scaler *scaler,
+                        const struct scaler_config *conf, double scale_factor,
                         int w, int h, struct gl_transform transform)
 {
-    struct scaler *scaler = &p->scalers[scaler_unit];
-    reinit_scaler(p, scaler_unit, name, scale_factor, filter_sizes);
+    reinit_scaler(p, scaler, conf, scale_factor, filter_sizes);
     sampler_prelude(p, src_tex);
 
     // Set up the transformation for everything other than separated scaling
@@ -1270,15 +1299,16 @@ static void pass_sample(struct gl_video *p, int src_tex,
         gl_transform_rect(transform, &p->pass_tex[src_tex].src);
 
     // Dispatch the scaler. They're all wildly different.
-    if (strcmp(scaler->name, "bilinear") == 0) {
+    const char *name = scaler->conf.kernel.name;
+    if (strcmp(name, "bilinear") == 0) {
         GLSL(vec4 color = texture(tex, pos);)
-    } else if (strcmp(scaler->name, "bicubic_fast") == 0) {
+    } else if (strcmp(name, "bicubic_fast") == 0) {
         pass_sample_bicubic_fast(p);
-    } else if (strcmp(scaler->name, "sharpen3") == 0) {
+    } else if (strcmp(name, "sharpen3") == 0) {
         pass_sample_sharpen3(p, scaler);
-    } else if (strcmp(scaler->name, "sharpen5") == 0) {
+    } else if (strcmp(name, "sharpen5") == 0) {
         pass_sample_sharpen5(p, scaler);
-    } else if (strcmp(scaler->name, "oversample") == 0) {
+    } else if (strcmp(name, "oversample") == 0) {
         pass_sample_oversample(p, scaler, w, h);
     } else if (scaler->kernel && scaler->kernel->polar) {
         pass_sample_polar(p, scaler);
@@ -1305,9 +1335,9 @@ static void pass_read_video(struct gl_video *p)
         return;
     }
 
-    const char *cscale = p->opts.scalers[1];
+    const struct scaler_config *cscale = &p->opts.scaler[2];
     if (p->image_desc.flags & MP_IMGFLAG_SUBSAMPLED &&
-            strcmp(cscale, "bilinear") != 0) {
+            strcmp(cscale->kernel.name, "bilinear") != 0) {
         struct src_tex luma = p->pass_tex[0];
         if (p->plane_count > 2) {
             // For simplicity and performance, we merge the chroma planes
@@ -1324,7 +1354,8 @@ static void pass_read_video(struct gl_video *p)
             finish_pass_fbo(p, &p->chroma_merge_fbo, c_w, c_h, 1, 0);
         }
         GLSLF("// chroma scaling\n");
-        pass_sample(p, 1, 1, cscale, 1.0, p->image_w, p->image_h, chromafix);
+        pass_sample(p, 1, &p->scaler[2], cscale, 1.0, p->image_w, p->image_h,
+                    chromafix);
         GLSL(vec2 chroma = color.rg;)
         // Always force rendering to a FBO before main scaling, or we would
         // scale chroma incorrectly.
@@ -1469,11 +1500,14 @@ static void pass_scale_main(struct gl_video *p)
     bool upscaling = !downscaling && (xy[0] > 1.0 || xy[1] > 1.0);
     double scale_factor = 1.0;
 
-    char *scaler = p->opts.scalers[0];
+    struct scaler *scaler = &p->scaler[0];
+    struct scaler_config scaler_conf = p->opts.scaler[0];
     if (p->opts.scaler_resizes_only && !downscaling && !upscaling)
-        scaler = "bilinear";
-    if (downscaling)
-        scaler = p->opts.dscaler;
+        scaler_conf.kernel.name = "bilinear";
+    if (downscaling && p->opts.scaler[1].kernel.name) {
+        scaler_conf = p->opts.scaler[1];
+        scaler = &p->scaler[1];
+    }
 
     double f = MPMIN(xy[0], xy[1]);
     if (p->opts.fancy_downscaling && f < 1.0 &&
@@ -1530,7 +1564,7 @@ static void pass_scale_main(struct gl_video *p)
     }
 
     GLSLF("// main scaling\n");
-    if (!p->use_indirect && strcmp(scaler, "bilinear") == 0) {
+    if (!p->use_indirect && strcmp(scaler_conf.kernel.name, "bilinear") == 0) {
         // implicitly scale in pass_video_to_screen, but set up the textures
         // manually (for cropping etc.). Special care has to be taken for the
         // chroma planes (everything except luma=tex0), to make sure the offset
@@ -1544,7 +1578,8 @@ static void pass_scale_main(struct gl_video *p)
             gl_transform_rect(n > 0 ? tchroma : transform, &p->pass_tex[n].src);
     } else {
         finish_pass_fbo(p, &p->indirect_fbo, p->image_w, p->image_h, 0, 0);
-        pass_sample(p, 0, 0, scaler, scale_factor, vp_w, vp_h, transform);
+        pass_sample(p, 0, scaler, &scaler_conf, scale_factor, vp_w, vp_h,
+                    transform);
     }
 
     GLSLF("// scaler post-conversion\n");
@@ -1829,9 +1864,9 @@ static void gl_video_interpolate_frame(struct gl_video *p, int fbo,
     // look like this: _ A [B] C D _
     // A is surface_bse, B is surface_now, C is surface_nxt and D is
     // surface_end.
-    struct scaler *tscale = &p->scalers[2];
-    reinit_scaler(p, 2, p->opts.scalers[2], 1, tscale_sizes);
-    bool oversample = strcmp(tscale->name, "oversample") == 0;
+    struct scaler *tscale = &p->scaler[3];
+    reinit_scaler(p, tscale, &p->opts.scaler[3], 1, tscale_sizes);
+    bool oversample = strcmp(tscale->conf.kernel.name, "oversample") == 0;
     int size;
     if (oversample) {
         size = 2;
@@ -1905,7 +1940,8 @@ static void gl_video_interpolate_frame(struct gl_video *p, int fbo,
         double fscale = pts_nxt - pts_now, mix;
         if (oversample) {
             double vsync_interval = t->next_vsync - t->prev_vsync,
-                   threshold = isnan(tscale->params[0]) ? 0 : tscale->params[0];
+                   threshold = tscale->conf.kernel.params[0];
+            threshold = isnan(threshold) ? 0.0 : threshold;
             mix = (pts_nxt - t->next_vsync) / vsync_interval;
             mix = mix <= 0 + threshold ? 0 : mix;
             mix = mix >= 1 - threshold ? 1 : mix;
@@ -2128,8 +2164,9 @@ static void check_gl_features(struct gl_video *p)
     // because they will be slow (not critically slow, but still slower).
     // Without FP textures, we must always disable them.
     // I don't know if luminance alpha float textures exist, so disregard them.
-    for (int n = 0; n < 2; n++) {
-        const struct filter_kernel *kernel = mp_find_filter_kernel(p->opts.scalers[n]);
+    for (int n = 0; n < 4; n++) {
+        const struct filter_kernel *kernel =
+            mp_find_filter_kernel(p->opts.scaler[n].kernel.name);
         if (kernel) {
             char *reason = NULL;
             if (!test_fbo(p, &have_fbo))
@@ -2139,7 +2176,7 @@ static void check_gl_features(struct gl_video *p)
             if (!have_1d_tex && kernel->polar)
                 reason = "scaler (1D tex.)";
             if (reason) {
-                p->opts.scalers[n] = "bilinear";
+                p->opts.scaler[n].kernel.name = "bilinear";
                 disabled[n_disabled++] = reason;
             }
         }
@@ -2485,11 +2522,7 @@ struct gl_video *gl_video_init(GL *gl, struct mp_log *log)
         .opts = gl_video_opts_def,
         .gl_target = GL_TEXTURE_2D,
         .texture_16bit_depth = 16,
-        .scalers = {
-            { .index = 0, .name = "bilinear" },
-            { .index = 1, .name = "bilinear" },
-            { .index = 2, .name = "oversample" },
-        },
+        .scaler = {{.index = 0}, {.index = 1}, {.index = 2}, {.index = 3}},
         .sc = gl_sc_create(gl, log),
     };
     gl_video_set_debug(p, true);
@@ -2523,19 +2556,21 @@ void gl_video_set_options(struct gl_video *p, struct gl_video_opts *opts,
                           int *queue_size)
 {
     p->opts = *opts;
-    for (int n = 0; n < 3; n++)
-        p->opts.scalers[n] = (char *)handle_scaler_opt(p->opts.scalers[n], n==2);
-    p->opts.dscaler = (char *)handle_scaler_opt(p->opts.dscaler, false);
+    for (int n = 0; n < 4; n++) {
+        p->opts.scaler[n].kernel.name =
+            (char *)handle_scaler_opt(p->opts.scaler[n].kernel.name, n==3);
+    }
 
     // Figure out an adequate size for the interpolation queue. The larger
     // the radius, the earlier we need to queue frames. This rough heuristic
     // seems to work for now, but ideally we want to rework the pause/unpause
     // logic to make larger queue sizes the default.
-    if (queue_size && p->opts.interpolation && p->opts.scalers[2]) {
-        const struct filter_kernel *kernel = mp_find_filter_kernel(p->opts.scalers[2]);
+    if (queue_size && p->opts.interpolation) {
+        const struct filter_kernel *kernel =
+            mp_find_filter_kernel(p->opts.scaler[3].kernel.name);
         if (kernel) {
             double radius = kernel->f.radius;
-            radius = radius > 0 ? radius : p->opts.scaler_radius[2];
+            radius = radius > 0 ? radius : p->opts.scaler[3].radius;
            *queue_size = 50e3 * ceil(radius);
         }
     }

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -28,18 +28,25 @@ struct lut3d {
     int size[3];
 };
 
+struct scaler_fun {
+    char *name;
+    float params[2];
+    float blur;
+};
+
+struct scaler_config {
+    struct scaler_fun kernel;
+    struct scaler_fun window;
+    float radius;
+    float antiring;
+};
+
 struct gl_video_opts {
-    char *scalers[3];
-    char *dscaler;
+    struct scaler_config scaler[4];
     float gamma;
     int gamma_auto;
     int target_prim;
     int target_trc;
-    float scaler_params[3][2];
-    float scaler_blur[3];
-    float scaler_radius[3];
-    float scaler_antiring[3];
-    char *scaler_window[3];
     int linear_scaling;
     int fancy_downscaling;
     int sigmoid_upscaling;

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -36,8 +36,10 @@ struct gl_video_opts {
     int target_prim;
     int target_trc;
     float scaler_params[3][2];
+    float scaler_blur[3];
     float scaler_radius[3];
     float scaler_antiring[3];
+    char *scaler_window[3];
     int linear_scaling;
     int fancy_downscaling;
     int sigmoid_upscaling;


### PR DESCRIPTION
This makes the core much more elegant, reusable, reconfigurable and also
allows us to more easily add aliases for specific configurations.

Furthermore, this lets us apply a generic blur factor / window function
to arbitrary filters, so we can finally "mix and match" in order to
fine-tune windowing functions.

A few notes are in order:

1. The current system for configuring scalers is ugly and rapidly
   getting unwieldy. I modified the man page to make it a bit more
   bearable, but long-term we have to do something about it; especially
   since..

2. There's currently no way to affect the blur factor or parameters of
   the window functions themselves. For example, I can't actually
   fine-tune the kaiser window's param1, since there's simply no way to
   do so in the current API - even though filter_kernels.c supports it
   just fine!

3. This removes some lesser used filters (especially those which are
   purely window functions to begin with). If anybody asks, you can get
   eg. the old behavior of scale=hanning by using
   scale=box:scale-window=hanning:scale-radius=1 (and yes, the result is
   just as terrible as that sounds - which is why nobody should have
   been using them in the first place).

4. This changes the semantics of the "triangle" scaler slightly - it now
   has an arbitrary radius. This can possibly produce weird results for
   people who were previously using scale-down=triangle, especially if
   in combination with scale-radius (for the usual upscaling). The
   correct fix for this is to use scale-down=bilinear_slow instead,
   which is an alias for triangle at radius 1.

In regards to the last point, in future I want to make it so that
filters have a filter-specific "preferred radius" (for the ones that
are arbitrarily tunable), once the configuration system for filters has
been redesigned (in particular in a way that will let us separate scale
and scale-down cleanly). That way, "triangle" can simply have the
preferred radius of 1 by default, while still being tunable. (Rather
than the default radius being hard-coded to 3 always)