### PR TITLE
mpv on OpenBSD

### DIFF
--- a/old-configure
+++ b/old-configure
@@ -661,6 +661,8 @@ EOF
     _gl_wayland=yes
     libs_mplayer="$libs_mplayer -lGL -lEGL"
     test "$_gl_wayland" = yes && res_comment="$res_comment wayland"
+  else
+    _gl_wayland=no
   fi
   if test "$_x11" = yes && test "$_gl" = yes && pkg_config_add "egl"; then
     _gl_x11_egl=yes

--- a/old-configure
+++ b/old-configure
@@ -813,9 +813,11 @@ test_lua() {
 
 test_lua "lua >= 5.1.0 lua < 5.2.0"
 test_lua "lua5.1 >= 5.1.0" # debian
+test_lua "lua51 >= 5.1.0" # OpenBSD
 test_lua "luajit >= 2.0.0"
 test_lua "lua >= 5.2.0"
 test_lua "lua5.2 >= 5.2.0" # debian
+test_lua "lua52 >= 5.2.0" # OpenBSD
 
 test "$_lua" != yes && check_yes_no no LUA
 
@@ -929,8 +931,13 @@ cat > $TMPC << EOF
 #define HAVE_DXVA2_HWACCEL 0
 #define HAVE_FCHMOD 0
 
+#ifdef __OpenBSD__
+#define DEFAULT_CDROM_DEVICE "/dev/rcd0c"
+#define DEFAULT_DVD_DEVICE   "/dev/rcd0c"
+#else
 #define DEFAULT_CDROM_DEVICE "/dev/cdrom"
 #define DEFAULT_DVD_DEVICE   "/dev/dvd"
+#endif
 #define PATH_DEV_DSP "/dev/dsp"
 #define PATH_DEV_MIXER "/dev/mixer"
 

--- a/old-configure
+++ b/old-configure
@@ -324,7 +324,7 @@ test -z "$_bindir"  && _bindir="$_prefix/bin"
 test -z "$_mandir"  && _mandir="$_prefix/share/man"
 test -z "$_confdir" && _confdir="$_prefix/etc/mpv"
 
-mplayer_tmpdir=$(mktemp -d mpv-configure-XXXXXX)
+mplayer_tmpdir=$(mktemp -d -p ${TMPDIR:=/tmp} mpv-configure-XXXXXX)
 test -n "$mplayer_tmpdir" || die "Unable to create tmpdir."
 trap 'rm -rf "$mplayer_tmpdir"' EXIT
 

--- a/old-configure
+++ b/old-configure
@@ -324,7 +324,7 @@ test -z "$_bindir"  && _bindir="$_prefix/bin"
 test -z "$_mandir"  && _mandir="$_prefix/share/man"
 test -z "$_confdir" && _confdir="$_prefix/etc/mpv"
 
-mplayer_tmpdir=$(mktemp -d --tmpdir mpv-configure-XXXX)
+mplayer_tmpdir=$(mktemp -d mpv-configure-XXXXXX)
 test -n "$mplayer_tmpdir" || die "Unable to create tmpdir."
 trap 'rm -rf "$mplayer_tmpdir"' EXIT
 


### PR DESCRIPTION
Following changes are applied to `old-configure` in OpenBSD's ports. Basically they boil down to
* removal of `--tmpdir` flag of `mktemp`,
* disabling wayland GL backend if wayland isn't found,
* names of Lua binaries, and
* CD and DVD device names.