### PR TITLE
vo_opengl: treat non-blended subtitles as sRGB

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -663,8 +663,12 @@ Available video output drivers are:
         visible portion of the video, so you can't have subtitles exist in the
         black margins below a video (for example).
 
-        .. warning:: This mangles colors in an incorrect way, but is on the
-                     other hand needed if an icc-profile is used.
+        .. warning:: This changes the way subtitle colors are handled. Normally,
+                     subtitle colors are assumed to be in sRGB and color managed
+                     as such. Enabling this makes them treated as being in the
+                     video's color space instead. This is good if you want
+                     things like softsubbed ASS signs to match the video colors,
+                     but may cause SRT subtitles or similar to look slightly off.
 
     ``alpha=<blend|yes|no>``
         Decides what to do if the input has an alpha component (default: blend).


### PR DESCRIPTION
Currently, the code just skipped CMS completely. This commit treats them
as sRGB by default, instead.

This also refactors much of the color management code to make it more
generalized and re-usable.