### PR TITLE
ao/wasapi: add ao hotplug

### DIFF
--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -20,6 +20,7 @@
 #ifndef MP_AO_WASAPI_H_
 #define MP_AO_WASAPI_H_
 
+#include <stdbool.h>
 #include <audioclient.h>
 #include <audiopolicy.h>
 #include <mmdeviceapi.h>
@@ -30,10 +31,11 @@
 typedef struct change_notify {
     IMMNotificationClient client; /* this must be first in the structure! */
     LPWSTR monitored; /* Monitored device */
+    bool is_hotplug;
     struct ao *ao;
 } change_notify;
 
-HRESULT wasapi_change_init(struct ao* ao);
+HRESULT wasapi_change_init(struct ao* ao, bool is_hotplug);
 void wasapi_change_uninit(struct ao* ao);
 
 #define EXIT_ON_ERROR(hres)  \

--- a/audio/out/ao_wasapi_utils.h
+++ b/audio/out/ao_wasapi_utils.h
@@ -47,6 +47,9 @@ void wasapi_dispatch(void);
 HRESULT wasapi_thread_init(struct ao *ao);
 void wasapi_thread_uninit(struct ao *ao);
 
+HRESULT wasapi_hotplug_init(struct ao *ao);
+void wasapi_hotplug_uninit(struct ao *ao);
+
 HRESULT wasapi_setup_proxies(wasapi_state *state);
 void wasapi_release_proxies(wasapi_state *state);
 


### PR DESCRIPTION
Create a second copy of the change_notify structure for the hotplug
ao. The hotplug change_notify is distinguished by not having its
"monitored" member set since it does not watch a single device.