### PR TITLE
ao_wasapi: simplify hotplug

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -829,20 +829,15 @@ end:
     return found;
 }
 
-HRESULT wasapi_enumerate_devices(struct ao *ao,
-                                 struct ao_device_list *list)
+void wasapi_list_devs(struct ao *ao, struct ao_device_list *list)
 {
-    IMMDeviceEnumerator *pEnumerator = NULL;
+    struct wasapi_state *state = (struct wasapi_state *)ao->priv;
     IMMDeviceCollection *pDevices = NULL;
     IMMDevice *pDevice = NULL;
     char *name = NULL, *id = NULL;
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator,
-                                  (void **)&pEnumerator);
-    EXIT_ON_ERROR(hr);
 
-    hr = IMMDeviceEnumerator_EnumAudioEndpoints(pEnumerator, eRender,
-                                                DEVICE_STATE_ACTIVE, &pDevices);
+    HRESULT hr = IMMDeviceEnumerator_EnumAudioEndpoints(state->pEnumerator, eRender,
+                                                        DEVICE_STATE_ACTIVE, &pDevices);
     EXIT_ON_ERROR(hr);
 
     int count;
@@ -871,9 +866,8 @@ HRESULT wasapi_enumerate_devices(struct ao *ao,
         SAFE_RELEASE(pDevice, IMMDevice_Release(pDevice));
     }
     SAFE_RELEASE(pDevices, IMMDeviceCollection_Release(pDevices));
-    SAFE_RELEASE(pEnumerator, IMMDeviceEnumerator_Release(pEnumerator));
 
-    return S_OK;
+    return;
 exit_label:
     MP_ERR(ao, "Error enumerating devices: %s (0x%"PRIx32")\n",
            wasapi_explain_err(hr), (uint32_t) hr);
@@ -881,8 +875,7 @@ exit_label:
     talloc_free(id);
     SAFE_RELEASE(pDevice, IMMDevice_Release(pDevice));
     SAFE_RELEASE(pDevices, IMMDeviceCollection_Release(pDevices));
-    SAFE_RELEASE(pEnumerator, IMMDeviceEnumerator_Release(pEnumerator));
-    return hr;
+    return;
 }
 
 static HRESULT load_default_device(struct ao *ao, IMMDeviceEnumerator* pEnumerator,
@@ -1167,30 +1160,6 @@ exit_label:
     MP_ERR(state, "Error setting up audio thread: %s (0x%"PRIx32")\n",
            wasapi_explain_err(hr), (uint32_t) hr);
     return hr;
-}
-
-HRESULT wasapi_hotplug_init(struct ao *ao)
-{
-    struct wasapi_state *state = (struct wasapi_state *)ao->priv;
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator, (void **)&state->pEnumerator);
-    EXIT_ON_ERROR(hr);
-
-    hr = wasapi_change_init(ao, true);
-    EXIT_ON_ERROR(hr);
-
-    return S_OK;
-exit_label:
-    MP_ERR(state, "Error setting up audio hotplug: %s (0x%"PRIx32")\n",
-           wasapi_explain_err(hr), (uint32_t) hr);
-    return hr;
-}
-
-void wasapi_hotplug_uninit(struct ao *ao)
-{
-    struct wasapi_state *state = (struct wasapi_state *)ao->priv;
-    wasapi_change_uninit(ao);
-    SAFE_RELEASE(state->pEnumerator, IMMDeviceEnumerator_Release(state->pEnumerator));
 }
 
 void wasapi_thread_uninit(struct ao *ao)

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -875,7 +875,6 @@ exit_label:
     talloc_free(id);
     SAFE_RELEASE(pDevice, IMMDevice_Release(pDevice));
     SAFE_RELEASE(pDevices, IMMDeviceCollection_Release(pDevices));
-    return;
 }
 
 static HRESULT load_default_device(struct ao *ao, IMMDeviceEnumerator* pEnumerator,

--- a/audio/out/ao_wasapi_utils.h
+++ b/audio/out/ao_wasapi_utils.h
@@ -36,15 +36,11 @@ bool wasapi_fill_VistaBlob(wasapi_state *state);
 
 const char *wasapi_explain_err(const HRESULT hr);
 
-HRESULT wasapi_enumerate_devices(struct ao *ao,
-                                 struct ao_device_list *list);
+void wasapi_list_devs(struct ao *ao, struct ao_device_list *list);
 
 void wasapi_dispatch(void);
 HRESULT wasapi_thread_init(struct ao *ao);
 void wasapi_thread_uninit(struct ao *ao);
-
-HRESULT wasapi_hotplug_init(struct ao *ao);
-void wasapi_hotplug_uninit(struct ao *ao);
 
 HRESULT wasapi_setup_proxies(wasapi_state *state);
 void wasapi_release_proxies(wasapi_state *state);


### PR DESCRIPTION
Take advantage of the fact that list_devs is called with a
hotplug_inited ao. Also eliminate unnecessary nested function
abstraction of hotplug_(un)init and list_devs. However, keep list_devs
in ao_wasapi_utils.c since it uses the private functions get_device_id,
get_device_name and exposing these would require including headers for
IMMDevice in ao_wasapi_utils.h.