### PR TITLE
vo_opengl: add blend-subtitles-res

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -710,6 +710,17 @@ Available video output drivers are:
                      things like softsubbed ASS signs to match the video colors,
                      but may cause SRT subtitles or similar to look slightly off.
 
+    ``blend-subtitles-res=<display|video>``
+        The resolution at which subtitles get drawn if ``blend-subtitles`` is
+        enabled (default: display). In the absence of ``blend-subtitles``,
+        subtitles are always drawn at the window's size, together with the OSD.
+
+        display
+            Subs are drawn directly at the window's size.
+        video
+            Subs are drawn at the video's native resolution, and scaled along
+            with the video.
+
     ``alpha=<blend|yes|no>``
         Decides what to do if the input has an alpha component (default: blend).
 

--- a/video/out/gl_video.h
+++ b/video/out/gl_video.h
@@ -66,6 +66,7 @@ struct gl_video_opts {
     struct m_color background;
     int interpolation;
     int blend_subs;
+    int blend_subs_res;
 };
 
 extern const struct m_sub_options gl_video_conf;


### PR DESCRIPTION
This can be used to draw the subtitles at the video's native res, which
can make them look more natural and increases performance.