### PR TITLE
DOCS/waf: Edit --enable-feature sentences

### DIFF
--- a/DOCS/waf-buildsystem.rst
+++ b/DOCS/waf-buildsystem.rst
@@ -20,8 +20,9 @@ shortcomings:
    part is this pieces are spread apart in the configure and copy pasted for
    any single case. That brings us to..
 
-2) --enable-feature has to override the user and help him understand that he
-   has libraries missing and should install them for the feature to be enabled.
+2) --enable-feature has to be overridden by the user and helps them understand that
+   they have libraries missing and should install them for the feature to be
+   enabled.
 
 3) Must be customizable, hackable, pleasant to the developer eyes and to work
    with in general.


### PR DESCRIPTION
The gender specific pronoun is changed, since we shouldn't assume the
gender of the user.

The sentence itself is also changed to be more correct in general.

This pull request is made because the previous one was incorrectly submitted, and was assumed to be a troll.

https://github.com/mpv-player/mpv/pull/1798