### PR TITLE
OSX/mpv.app/mpv.conf: Use pseudo-gui

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/Resources/mpv.conf
+++ b/TOOLS/osxbundle/mpv.app/Contents/Resources/mpv.conf
@@ -1,3 +1,2 @@
 screenshot-template=~/Desktop/shot%n
-quiet
-idle=once
+profile=pseudo-gui


### PR DESCRIPTION
The player is now forced to use the pseudo-gui in OSX, when opened with mpv.app. This will solve these issues:

https://github.com/mpv-player/mpv/issues/1808
https://github.com/mpv-player/mpv/issues/1754