### PR TITLE
vo_drm: add KMS/DRM renderer support

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -58,6 +58,7 @@ extern const struct vo_driver video_out_null;
 extern const struct vo_driver video_out_image;
 extern const struct vo_driver video_out_lavc;
 extern const struct vo_driver video_out_caca;
+extern const struct vo_driver video_out_drm;
 extern const struct vo_driver video_out_direct3d;
 extern const struct vo_driver video_out_direct3d_shaders;
 extern const struct vo_driver video_out_sdl;
@@ -97,6 +98,9 @@ const struct vo_driver *const video_out_drivers[] =
         &video_out_image,
 #if HAVE_CACA
         &video_out_caca,
+#endif
+#if HAVE_DRM
+        &video_out_drm,
 #endif
 #if HAVE_ENCODING
         &video_out_lavc,

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -446,7 +446,7 @@ static int preinit(struct vo *vo)
     if (ret)
         return ret;
 
-    assert(p->dev != NULL);
+    assert(p->dev);
     p->device_w = p->dev->bufs[0].width;
     p->device_h = p->dev->bufs[0].height;
 
@@ -467,8 +467,8 @@ static void uninit(struct vo *vo)
 {
     struct priv *p = vo->priv;
 
-    if (p->dev != NULL) {
-        if (p->old_crtc != NULL) {
+    if (p->dev) {
+        if (p->old_crtc) {
             drmModeSetCrtc(p->fd,
                            p->old_crtc->crtc_id,
                            p->old_crtc->buffer_id,

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -327,22 +327,13 @@ end:
 static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
 {
     struct priv *p = vo->priv;
-    float device_ar = p->device_w / (float)p->device_h;
 
+    vo->dwidth = p->device_w;
+    vo->dheight = p->device_h;
     vo_get_src_dst_rects(vo, &p->src, &p->dst, &p->osd);
-    int32_t video_w = (p->dst.x1 - p->dst.x0);
-    int32_t video_h = (p->dst.y1 - p->dst.y0);
-    float video_ar = video_w / (float)video_h;
-    int32_t w, h;
-    if (device_ar > video_ar) {
-        w = p->device_h * video_ar;
-        h = p->device_h;
-    } else {
-        w = p->device_w;
-        h = p->device_w * video_ar;
-    }
-    if (w > p->device_w) w = p->device_w;
-    if (h > p->device_h) h = p->device_h;
+
+    int32_t w = p->dst.x1 - p->dst.x0;
+    int32_t h = p->dst.y1 - p->dst.y0;
 
     // p->osd contains the parameters assuming OSD rendering in window
     // coordinates, but OSD can only be rendered in the intersection

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -372,7 +372,7 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
 
     osd_draw_on_image(vo->osd, p->osd, mpi ? mpi->pts : 0, 0, &img);
 
-    memcpy(front_buf->map, p->buf, p->device_w * p->device_h * 4);
+    memmove(front_buf->map, p->buf, p->device_w * p->device_h * 4);
 }
 
 static void flip_page(struct vo *vo)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -220,7 +220,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     }
 
     if (conn_id < 0 || conn_id >= res->count_connectors) {
-        MP_ERR(vo, "Bad DRM connector ID. Max valid DRM connector ID = %u",
+        MP_ERR(vo, "Bad DRM connector ID. Max valid DRM connector ID = %u\n",
                res->count_connectors);
         ret = -ENODEV;
         goto end;
@@ -273,7 +273,8 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
             for (j = 0; j < i; j ++) {
                 modeset_destroy_fb(fd, &dev->bufs[j]);
             }
-            MP_ERR(vo, "Cannot create framebuffer for DRM connector %u\n", conn_id);
+            MP_ERR(vo, "Cannot create framebuffer for DRM connector %u\n",
+                   conn_id);
             return ret;
         }
     }

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -304,7 +304,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
             for (unsigned int j = 0; j < i; j++) {
                 modeset_destroy_fb(fd, &dev->bufs[j]);
             }
-            return ret;
+            goto end;
         }
     }
 
@@ -439,6 +439,7 @@ static int preinit(struct vo *vo)
     if (ret) {
         MP_ERR(vo, "Cannot set CRTC for connector %u: %s\n", p->connector_id,
                mp_strerror(errno));
+        return -1;
     }
 
     return 0;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -78,8 +78,7 @@ static int modeset_open(struct vo *vo, int *out, const char *node)
     uint64_t has_dumb;
     fd = open(node, O_RDWR | O_CLOEXEC);
     if (fd < 0) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot open \"%s\": %s.\n", node, errstr);
+        MP_ERR(vo, "Cannot open \"%s\": %s.\n", node, mp_strerror(errno));
         return -errno;
     }
     if (drmGetCap(fd, DRM_CAP_DUMB_BUFFER, &has_dumb) < 0) {
@@ -104,8 +103,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     creq.bpp = 32;
     ret = drmIoctl(fd, DRM_IOCTL_MODE_CREATE_DUMB, &creq);
     if (ret < 0) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot create dumb buffer: %s\n", errstr);
+        MP_ERR(vo, "Cannot create dumb buffer: %s\n", mp_strerror(errno));
         return -errno;
     }
     buf->stride = creq.pitch;
@@ -116,8 +114,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     ret = drmModeAddFB(fd, buf->width, buf->height, 24, 32, buf->stride,
                        buf->handle, &buf->fb);
     if (ret) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot create framebuffer: %s\n", errstr);
+        MP_ERR(vo, "Cannot create framebuffer: %s\n", mp_strerror(errno));
         ret = -errno;
         goto err_destroy;
     }
@@ -127,8 +124,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     mreq.handle = buf->handle;
     ret = drmIoctl(fd, DRM_IOCTL_MODE_MAP_DUMB, &mreq);
     if (ret) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot map dumb buffer: %s\n", errstr);
+        MP_ERR(vo, "Cannot map dumb buffer: %s\n", mp_strerror(errno));
         ret = -errno;
         goto err_fb;
     }
@@ -137,8 +133,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     buf->map = mmap(0, buf->size, PROT_READ | PROT_WRITE, MAP_SHARED,
                     fd, mreq.offset);
     if (buf->map == MAP_FAILED) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot map dumb buffer: %s\n", errstr);
+        MP_ERR(vo, "Cannot map dumb buffer: %s\n", mp_strerror(errno));
         ret = -errno;
         goto err_fb;
     }
@@ -165,9 +160,8 @@ static int modeset_find_crtc(struct vo *vo, int fd, drmModeRes *res,
     for (i = 0; i < conn->count_encoders; ++i) {
         enc = drmModeGetEncoder(fd, conn->encoders[i]);
         if (!enc) {
-            char *errstr = mp_strerror(errno);
             MP_WARN(vo, "Cannot retrieve encoder %u:%u: %s\n",
-                    i, conn->encoders[i], errstr);
+                    i, conn->encoders[i], mp_strerror(errno));
             continue;
         }
 
@@ -207,8 +201,8 @@ static bool is_connector_valid(struct vo *vo, int conn_id,
 {
     if (!conn) {
         if (!silent) {
-            char *errstr = mp_strerror(errno);
-            MP_ERR(vo, "Cannot get connector %d: %s\n", conn_id, errstr);
+            MP_ERR(vo, "Cannot get connector %d: %s\n", conn_id,
+                   mp_strerror(errno));
         }
         return false;
     }
@@ -242,8 +236,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
 
     res = drmModeGetResources(fd);
     if (!res) {
-        char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot retrieve DRM resources: %s\n", errstr);
+        MP_ERR(vo, "Cannot retrieve DRM resources: %s\n", mp_strerror(errno));
         ret = -errno;
         goto end;
     }
@@ -455,9 +448,8 @@ static int preinit(struct vo *vo)
                          p->dev->bufs[p->dev->front_buf + BUF_COUNT - 1].fb,
                          0, 0, &p->dev->conn, 1, &p->dev->mode);
     if (ret) {
-        char *errstr = mp_strerror(errno);
         MP_ERR(vo, "Cannot set CRTC for connector %u: %s\n", p->connector_id,
-               errstr);
+               mp_strerror(errno));
     }
 
     return 0;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -274,7 +274,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
         goto end;
     }
 
-    dev = talloc_size(vo->priv, sizeof(*dev));
+    dev = talloc_zero(vo->priv, struct modeset_dev);
     dev->conn = conn->connector_id;
     dev->front_buf = 0;
     dev->mode = conn->modes[0];

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -393,6 +393,8 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
                p->device_h,
                p->device_w * 4,
                p->curframe->stride[0]);
+
+    talloc_free(mpi);
 }
 
 static void flip_page(struct vo *vo)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -283,17 +283,17 @@ end:
 
 static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
 {
-    //struct priv *priv = vo->priv;
-    //priv->image_height = params->h;
-    //priv->image_width  = params->w;
-    //priv->image_format = params->imgfmt;
+    //struct priv *p = vo->priv;
+    //p->image_height = params->h;
+    //p->image_width  = params->w;
+    //p->image_format = params->imgfmt;
     return 0;
 }
 
 static void draw_image(struct vo *vo, mp_image_t *mpi)
 {
-    struct priv *priv = vo->priv;
-    struct modeset_buf *front_buf = &priv->dev->bufs[priv->dev->front_buf];
+    struct priv *p = vo->priv;
+    struct modeset_buf *front_buf = &p->dev->bufs[p->dev->front_buf];
 
     //display random noise for now
     static int j = 0;
@@ -311,40 +311,40 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
 
 static void flip_page(struct vo *vo)
 {
-    struct priv *priv = vo->priv;
-    int ret = drmModeSetCrtc(priv->fd, priv->dev->crtc,
-                             priv->dev->bufs[priv->dev->front_buf].fb,
-                             0, 0, &priv->dev->conn, 1, &priv->dev->mode);
+    struct priv *p = vo->priv;
+    int ret = drmModeSetCrtc(p->fd, p->dev->crtc,
+                             p->dev->bufs[p->dev->front_buf].fb,
+                             0, 0, &p->dev->conn, 1, &p->dev->mode);
     if (ret) {
         MP_WARN(vo, "Cannot flip page for DRM connector\n");
     } else {
-        //priv->dev->front_buf ^= 1;
+        //p->dev->front_buf ^= 1;
     }
 }
 
 static int preinit(struct vo *vo)
 {
-    struct priv *priv = vo->priv;
-    priv->dev = NULL;
-    priv->fd = 0;
-    priv->old_crtc = NULL;
+    struct priv *p = vo->priv;
+    p->dev = NULL;
+    p->fd = 0;
+    p->old_crtc = NULL;
 
     int ret;
 
-    ret = modeset_open(vo, &priv->fd, path_to_device);
+    ret = modeset_open(vo, &p->fd, path_to_device);
     if (ret)
         return ret;
 
-    ret = modeset_prepare_dev(vo, priv->fd, connector_id, &priv->dev);
+    ret = modeset_prepare_dev(vo, p->fd, connector_id, &p->dev);
     if (ret)
         return ret;
 
-    assert(priv->dev != NULL);
+    assert(p->dev != NULL);
 
-    priv->old_crtc = drmModeGetCrtc(priv->fd, priv->dev->crtc);
-    ret = drmModeSetCrtc(priv->fd, priv->dev->crtc,
-                         priv->dev->bufs[priv->dev->front_buf ^ 1].fb,
-                         0, 0, &priv->dev->conn, 1, &priv->dev->mode);
+    p->old_crtc = drmModeGetCrtc(p->fd, p->dev->crtc);
+    ret = drmModeSetCrtc(p->fd, p->dev->crtc,
+                         p->dev->bufs[p->dev->front_buf ^ 1].fb,
+                         0, 0, &p->dev->conn, 1, &p->dev->mode);
     if (ret) {
         char *errstr = mp_strerror(errno);
         MP_ERR(vo, "Cannot set CRTC for connector %u: %s\n", connector_id,
@@ -356,26 +356,26 @@ static int preinit(struct vo *vo)
 
 static void uninit(struct vo *vo)
 {
-    struct priv *priv = vo->priv;
+    struct priv *p = vo->priv;
 
-    if (priv->dev != NULL) {
-        if (priv->old_crtc != NULL) {
-            drmModeSetCrtc(priv->fd,
-                    priv->old_crtc->crtc_id,
-                    priv->old_crtc->buffer_id,
-                    priv->old_crtc->x,
-                    priv->old_crtc->y,
-                    &priv->dev->conn,
+    if (p->dev != NULL) {
+        if (p->old_crtc != NULL) {
+            drmModeSetCrtc(p->fd,
+                    p->old_crtc->crtc_id,
+                    p->old_crtc->buffer_id,
+                    p->old_crtc->x,
+                    p->old_crtc->y,
+                    &p->dev->conn,
                     1,
-                    &priv->dev->mode);
-            drmModeFreeCrtc(priv->old_crtc);
+                    &p->dev->mode);
+            drmModeFreeCrtc(p->old_crtc);
         }
 
-        modeset_destroy_fb(priv->fd, &priv->dev->bufs[1]);
-        modeset_destroy_fb(priv->fd, &priv->dev->bufs[0]);
+        modeset_destroy_fb(p->fd, &p->dev->bufs[1]);
+        modeset_destroy_fb(p->fd, &p->dev->bufs[0]);
     }
 
-    talloc_free(priv->dev);
+    talloc_free(p->dev);
 }
 
 static int query_format(struct vo *vo, int format)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -472,9 +472,7 @@ static void uninit(struct vo *vo)
 
 static int query_format(struct vo *vo, int format)
 {
-    if (sws_isSupportedInput(imgfmt2pixfmt(format)))
-        return 1;
-    return format == IMGFMT_BGR0;
+    return sws_isSupportedInput(imgfmt2pixfmt(format));
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -250,7 +250,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
 
     if (conn_id == -1) {
         // get the first connected connector
-        for (int i = 0; i < res->count_connectors; i ++) {
+        for (int i = 0; i < res->count_connectors; i++) {
             conn = drmModeGetConnector(fd, res->connectors[i]);
             if (is_connector_valid(vo, i, conn, true)) {
                 conn_id = i;
@@ -300,12 +300,12 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     }
 
     unsigned int i, j;
-    for (i = 0; i < BUF_COUNT; i ++) {
+    for (i = 0; i < BUF_COUNT; i++) {
         ret = modeset_create_fb(vo, fd, &dev->bufs[i]);
         if (ret) {
             MP_ERR(vo, "Cannot create framebuffer for connector %d\n",
                    conn_id);
-            for (j = 0; j < i; j ++) {
+            for (j = 0; j < i; j++) {
                 modeset_destroy_fb(fd, &dev->bufs[j]);
             }
             return ret;
@@ -413,7 +413,7 @@ static void flip_page(struct vo *vo)
     if (ret) {
         MP_WARN(vo, "Cannot flip page for connector\n");
     } else {
-        p->dev->front_buf ++;
+        p->dev->front_buf++;
         p->dev->front_buf %= BUF_COUNT;
     }
 }

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -321,7 +321,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     mp_sws_set_from_cmdline(p->sws, vo->opts->sws_opts);
     p->sws->src = *params;
     p->sws->dst = (struct mp_image_params) {
-        .imgfmt = IMGFMT_BGR32,
+        .imgfmt = IMGFMT_BGR0,
         .w = w,
         .h = h,
         .d_w = w,
@@ -442,7 +442,7 @@ static void uninit(struct vo *vo)
 
 static int query_format(struct vo *vo, int format)
 {
-    return format == IMGFMT_BGR32;
+    return format == IMGFMT_BGR0;
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -101,8 +101,7 @@ static void modeset_destroy_fb(int fd, struct modeset_buf *buf)
         drmModeRmFB(fd, buf->fb);
     }
     if (buf->handle) {
-        struct drm_mode_destroy_dumb dreq =
-        {
+        struct drm_mode_destroy_dumb dreq = {
             .handle = buf->handle,
         };
         drmIoctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dreq);
@@ -116,8 +115,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     buf->handle = 0;
 
     // create dumb buffer
-    struct drm_mode_create_dumb creq =
-    {
+    struct drm_mode_create_dumb creq = {
         .width = buf->width,
         .height = buf->height,
         .bpp = 32,
@@ -142,8 +140,7 @@ static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
     }
 
     // prepare buffer for memory mapping
-    struct drm_mode_map_dumb mreq =
-    {
+    struct drm_mode_map_dumb mreq = {
         .handle = buf->handle,
     };
     ret = drmIoctl(fd, DRM_IOCTL_MODE_MAP_DUMB, &mreq);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -184,7 +184,7 @@ static int modeset_find_crtc(struct vo *vo, int fd, drmModeRes *res,
         drmModeFreeEncoder(enc);
     }
 
-    MP_ERR(vo, "DRM connector %u has no suitable CRTC\n", conn->connector_id);
+    MP_ERR(vo, "Connector %u has no suitable CRTC\n", conn->connector_id);
     return -ENOENT;
 }
 
@@ -220,7 +220,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     }
 
     if (conn_id < 0 || conn_id >= res->count_connectors) {
-        MP_ERR(vo, "Bad DRM connector ID. Max valid DRM connector ID = %u\n",
+        MP_ERR(vo, "Bad connector ID. Max valid connector ID = %u\n",
                res->count_connectors);
         ret = -ENODEV;
         goto end;
@@ -229,7 +229,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     conn = drmModeGetConnector(fd, res->connectors[conn_id]);
     if (!conn) {
         char *errstr = mp_strerror(errno);
-        MP_ERR(vo, "Cannot retrieve DRM connector %u:%u: %s\n",
+        MP_ERR(vo, "Cannot retrieve connector %u:%u: %s\n",
                conn_id, res->connectors[conn_id], errstr);
         ret = -errno;
         goto end;
@@ -240,13 +240,13 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     dev->front_buf = 0;
 
     if (conn->connection != DRM_MODE_CONNECTED) {
-        MP_ERR(vo, "DRM connector %u is disconnected\n", conn_id);
+        MP_ERR(vo, "Connector %u is disconnected\n", conn_id);
         ret = -ENODEV;
         goto end;
     }
 
     if (conn->count_modes == 0) {
-        MP_ERR(vo, "DRM connector %u has no valid modes\n", conn_id);
+        MP_ERR(vo, "Connector %u has no valid modes\n", conn_id);
         ret = -ENODEV;
         goto end;
     }
@@ -257,12 +257,12 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     dev->bufs[1].width = conn->modes[0].hdisplay;
     dev->bufs[1].height = conn->modes[0].vdisplay;
 
-    MP_INFO(vo, "DRM connector using mode %ux%u\n",
+    MP_INFO(vo, "Connector using mode %ux%u\n",
             dev->bufs[0].width, dev->bufs[0].height);
 
     ret = modeset_find_crtc(vo, fd, res, conn, dev);
     if (ret) {
-        MP_ERR(vo, "DRM connector %u has no valid CRTC\n", conn_id);
+        MP_ERR(vo, "Connector %d has no valid CRTC\n", conn_id);
         goto end;
     }
 
@@ -273,7 +273,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
             for (j = 0; j < i; j ++) {
                 modeset_destroy_fb(fd, &dev->bufs[j]);
             }
-            MP_ERR(vo, "Cannot create framebuffer for DRM connector %u\n",
+            MP_ERR(vo, "Cannot create framebuffer for connector %d\n",
                    conn_id);
             return ret;
         }
@@ -382,7 +382,7 @@ static void flip_page(struct vo *vo)
                              p->dev->bufs[p->dev->front_buf].fb,
                              0, 0, &p->dev->conn, 1, &p->dev->mode);
     if (ret) {
-        MP_WARN(vo, "Cannot flip page for DRM connector\n");
+        MP_WARN(vo, "Cannot flip page for connector\n");
     } else {
         p->dev->front_buf ++;
         p->dev->front_buf %= BUF_COUNT;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -313,6 +313,16 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     if (w > p->device_w) w = p->device_w;
     if (h > p->device_h) h = p->device_h;
 
+    // p->osd contains the parameters assuming OSD rendering in window
+    // coordinates, but OSD can only be rendered in the intersection
+    // between window and video rectangle (i.e. not into panscan borders).
+    p->osd.w = w;
+    p->osd.h = h;
+    p->osd.mt = MPMIN(0, p->osd.mt);
+    p->osd.mb = MPMIN(0, p->osd.mb);
+    p->osd.mr = MPMIN(0, p->osd.mr);
+    p->osd.ml = MPMIN(0, p->osd.ml);
+
     p->x = (p->device_w - w) >> 1;
     p->y = (p->device_h - h) >> 1;
     p->buf = (char*)talloc_size(vo, p->device_w * p->device_h * 4);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -367,7 +367,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     mp_image_set_params(p->curframe, &p->sws->dst);
 
     if (mp_sws_reinit(p->sws) < 0)
-        return 1;
+        return -1;
 
     vo->want_redraw = true;
     return 0;
@@ -422,11 +422,11 @@ static int preinit(struct vo *vo)
 
     ret = modeset_open(vo, &p->fd, p->device_path);
     if (ret)
-        return ret;
+        return -1;
 
     ret = modeset_prepare_dev(vo, p->fd, p->connector_id, &p->dev);
     if (ret)
-        return ret;
+        return -1;
 
     assert(p->dev);
     p->device_w = p->dev->bufs[0].width;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -392,7 +392,7 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
     memcpy_pic(front_buf->map + shift,
                p->cur_frame->planes[0],
                (p->dst.x1 - p->dst.x0) * 4,
-               p->device_h,
+               p->dst.y1 - p->dst.y0,
                p->device_w * 4,
                p->cur_frame->stride[0]);
 

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -369,12 +369,6 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
         .d_h = h,
     };
 
-    MP_INFO(vo, "resizing %dx%d -> %dx%d\n",
-            p->sws->src.w,
-            p->sws->src.h,
-            p->sws->dst.w,
-            p->sws->dst.h);
-
     mp_image_params_guess_csp(&p->sws->dst);
 
     if (mp_sws_reinit(p->sws) < 0)

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -20,18 +20,19 @@
  */
 
 #include <assert.h>
-#include <stdbool.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdbool.h>
 #include <libswscale/swscale.h>
 #include <sys/mman.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
 #include "common/msg.h"
+#include "sub/osd.h"
+#include "video/fmt-conversion.h"
 #include "video/mp_image.h"
 #include "video/sws_utils.h"
-#include "sub/osd.h"
 #include "vo.h"
 
 #define BUF_COUNT 2
@@ -471,6 +472,8 @@ static void uninit(struct vo *vo)
 
 static int query_format(struct vo *vo, int format)
 {
+    if (sws_isSupportedInput(imgfmt2pixfmt(format)))
+        return 1;
     return format == IMGFMT_BGR0;
 }
 

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -362,7 +362,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
         .d_h = h,
     };
 
-    if (p->cur_frame) talloc_free(p->cur_frame);
+    talloc_free(p->cur_frame);
     p->cur_frame = mp_image_alloc(IMGFMT_BGR0, p->device_w, p->device_h);
     mp_image_params_guess_csp(&p->sws->dst);
     mp_image_set_params(p->cur_frame, &p->sws->dst);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -1,0 +1,402 @@
+/*
+ * video output driver for libdrm
+ *
+ * by rr- <rr-@sakuya.pl>
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include "common/msg.h"
+#include "video/mp_image.h"
+#include "sub/osd.h"
+#include "vo.h"
+
+//TODO: change path_to_device to option
+//TODO: change modeset_dev to option
+const char *path_to_device = "/dev/dri/card0";
+const unsigned int connector_id = 0;
+
+struct modeset_buf {
+    uint32_t width;
+    uint32_t height;
+    uint32_t stride;
+    uint32_t size;
+    uint32_t handle;
+    uint8_t *map;
+    uint32_t fb;
+};
+
+struct modeset_dev {
+    struct modeset_buf bufs[2];
+    drmModeModeInfo mode;
+    uint32_t conn;
+    uint32_t crtc;
+    int front_buf;
+};
+
+struct priv {
+    int fd;
+    struct modeset_dev *dev;
+    drmModeCrtc *old_crtc;
+};
+
+static int modeset_open(struct vo *vo, int *out, const char *node)
+{
+    int fd;
+    uint64_t has_dumb;
+    fd = open(node, O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot open \"%s\": %s.\n", node, errstr);
+        return -errno;
+    }
+    if (drmGetCap(fd, DRM_CAP_DUMB_BUFFER, &has_dumb) < 0) {
+        MP_ERR(vo, "Device \"%s\" does not support dumb buffers.\n", node);
+        return -EOPNOTSUPP;
+    }
+    *out = fd;
+    return 0;
+}
+
+static int modeset_create_fb(struct vo *vo, int fd, struct modeset_buf *buf)
+{
+    struct drm_mode_create_dumb creq;
+    struct drm_mode_destroy_dumb dreq;
+    struct drm_mode_map_dumb mreq;
+    int ret;
+
+    // create dumb buffer
+    memset(&creq, 0, sizeof(creq));
+    creq.width = buf->width;
+    creq.height = buf->height;
+    creq.bpp = 32;
+    ret = drmIoctl(fd, DRM_IOCTL_MODE_CREATE_DUMB, &creq);
+    if (ret < 0) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot create dumb buffer: %s\n", errstr);
+        return -errno;
+    }
+    buf->stride = creq.pitch;
+    buf->size = creq.size;
+    buf->handle = creq.handle;
+
+    // create framebuffer object for the dumb-buffer
+    ret = drmModeAddFB(fd, buf->width, buf->height, 24, 32, buf->stride,
+               buf->handle, &buf->fb);
+    if (ret) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot create framebuffer: %s\n", errstr);
+        ret = -errno;
+        goto err_destroy;
+    }
+
+    // prepare buffer for memory mapping
+    memset(&mreq, 0, sizeof(mreq));
+    mreq.handle = buf->handle;
+    ret = drmIoctl(fd, DRM_IOCTL_MODE_MAP_DUMB, &mreq);
+    if (ret) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot map dumb buffer: %s\n", errstr);
+        ret = -errno;
+        goto err_fb;
+    }
+
+    // perform actual memory mapping
+    buf->map = mmap(0, buf->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                fd, mreq.offset);
+    if (buf->map == MAP_FAILED) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot map dumb buffer: %s\n", errstr);
+        ret = -errno;
+        goto err_fb;
+    }
+
+    memset(buf->map, 0, buf->size);
+
+    return 0;
+
+err_fb:
+    drmModeRmFB(fd, buf->fb);
+err_destroy:
+    memset(&dreq, 0, sizeof(dreq));
+    dreq.handle = buf->handle;
+    drmIoctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dreq);
+    return ret;
+}
+
+static int modeset_find_crtc(struct vo *vo, int fd, drmModeRes *res,
+                             drmModeConnector *conn, struct modeset_dev *dev)
+{
+    drmModeEncoder *enc;
+    unsigned int i, j;
+
+    for (i = 0; i < conn->count_encoders; ++i) {
+        enc = drmModeGetEncoder(fd, conn->encoders[i]);
+        if (!enc) {
+            char *errstr = mp_strerror(errno);
+            MP_WARN(vo, "Cannot retrieve encoder %u:%u: %s\n",
+                    i, conn->encoders[i], errstr);
+            continue;
+        }
+
+        // iterate all global CRTCs
+        for (j = 0; j < res->count_crtcs; ++j) {
+            // check whether this CRTC works with the encoder
+            if (!(enc->possible_crtcs & (1 << j)))
+                continue;
+
+            drmModeFreeEncoder(enc);
+            dev->crtc = res->crtcs[j];
+            return 0;
+        }
+
+        drmModeFreeEncoder(enc);
+    }
+
+    MP_ERR(vo, "DRM connector %u has no suitable CRTC\n", conn->connector_id);
+    return -ENOENT;
+}
+
+static void modeset_destroy_fb(int fd, struct modeset_buf *buf)
+{
+    struct drm_mode_destroy_dumb dreq;
+
+    munmap(buf->map, buf->size);
+
+    drmModeRmFB(fd, buf->fb);
+
+    memset(&dreq, 0, sizeof(dreq));
+    dreq.handle = buf->handle;
+    drmIoctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &dreq);
+}
+
+static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
+                               struct modeset_dev **out)
+{
+    struct modeset_dev *dev = NULL;
+    drmModeConnector *conn = NULL;
+    drmModeRes *res = NULL;
+    int ret = 0;
+
+    *out = NULL;
+
+    res = drmModeGetResources(fd);
+    if (!res) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot retrieve DRM resources: %s\n", errstr);
+        ret = -errno;
+        goto end;
+    }
+
+    if (conn_id < 0 || conn_id >= res->count_connectors) {
+        MP_ERR(vo, "Bad DRM connector ID. Max valid DRM connector ID = %u",
+               res->count_connectors);
+        ret = -ENODEV;
+        goto end;
+    }
+
+    conn = drmModeGetConnector(fd, res->connectors[conn_id]);
+    if (!conn) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot retrieve DRM connector %u:%u: %s\n",
+               conn_id, res->connectors[conn_id], errstr);
+        ret = -errno;
+        goto end;
+    }
+
+    dev = talloc_size(vo->priv, sizeof(*dev));
+    dev->conn = conn->connector_id;
+    dev->front_buf = 0;
+
+    if (conn->connection != DRM_MODE_CONNECTED) {
+        MP_ERR(vo, "DRM connector %u is disconnected\n", conn_id);
+        ret = -ENODEV;
+        goto end;
+    }
+
+    if (conn->count_modes == 0) {
+        MP_ERR(vo, "DRM connector %u has no valid modes\n", conn_id);
+        ret = -ENODEV;
+        goto end;
+    }
+
+    memcpy(&dev->mode, &conn->modes[0], sizeof(dev->mode));
+    dev->bufs[0].width = conn->modes[0].hdisplay;
+    dev->bufs[0].height = conn->modes[0].vdisplay;
+    dev->bufs[1].width = conn->modes[0].hdisplay;
+    dev->bufs[1].height = conn->modes[0].vdisplay;
+
+    MP_INFO(vo, "DRM connector using mode %ux%u\n",
+            dev->bufs[0].width, dev->bufs[0].height);
+
+    ret = modeset_find_crtc(vo, fd, res, conn, dev);
+    if (ret) {
+        MP_ERR(vo, "DRM connector %u has no valid CRTC\n", conn_id);
+        goto end;
+    }
+
+    ret = modeset_create_fb(vo, fd, &dev->bufs[0]);
+    if (ret) {
+        MP_ERR(vo, "Cannot create framebuffer for DRM connector %u\n", conn_id);
+        return ret;
+    }
+
+    ret = modeset_create_fb(vo, fd, &dev->bufs[1]);
+    if (ret) {
+        MP_ERR(vo, "Cannot create framebuffer for DRM connector %u\n", conn_id);
+        modeset_destroy_fb(fd, &dev->bufs[0]);
+        return ret;
+    }
+
+end:
+    if (conn) drmModeFreeConnector(conn);
+    if (res) drmModeFreeResources(res);
+    if (ret == 0) {
+        *out = dev;
+    } else {
+        talloc_free(dev);
+    }
+    return ret;
+}
+
+
+
+static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
+{
+    //struct priv *priv = vo->priv;
+    //priv->image_height = params->h;
+    //priv->image_width  = params->w;
+    //priv->image_format = params->imgfmt;
+    return 0;
+}
+
+static void draw_image(struct vo *vo, mp_image_t *mpi)
+{
+    struct priv *priv = vo->priv;
+    struct modeset_buf *front_buf = &priv->dev->bufs[priv->dev->front_buf];
+
+    //display random noise for now
+    static int j = 0;
+    srand(j);
+    j++ ;
+    int i;
+    for (i = 0;  i < 5000; i ++)
+    {
+        int x = rand() % front_buf->width;
+        int y = rand() % front_buf->height;
+        int off = front_buf->stride * y + x * 4;
+        *(uint32_t*)(&front_buf->map[off]) = rand();
+    }
+}
+
+static void flip_page(struct vo *vo)
+{
+    struct priv *priv = vo->priv;
+    int ret = drmModeSetCrtc(priv->fd, priv->dev->crtc,
+                             priv->dev->bufs[priv->dev->front_buf].fb,
+                             0, 0, &priv->dev->conn, 1, &priv->dev->mode);
+    if (ret) {
+        MP_WARN(vo, "Cannot flip page for DRM connector\n");
+    } else {
+        //priv->dev->front_buf ^= 1;
+    }
+}
+
+static int preinit(struct vo *vo)
+{
+    struct priv *priv = vo->priv;
+    priv->dev = NULL;
+    priv->fd = 0;
+    priv->old_crtc = NULL;
+
+    int ret;
+
+    ret = modeset_open(vo, &priv->fd, path_to_device);
+    if (ret)
+        return ret;
+
+    ret = modeset_prepare_dev(vo, priv->fd, connector_id, &priv->dev);
+    if (ret)
+        return ret;
+
+    assert(priv->dev != NULL);
+
+    priv->old_crtc = drmModeGetCrtc(priv->fd, priv->dev->crtc);
+    ret = drmModeSetCrtc(priv->fd, priv->dev->crtc,
+                         priv->dev->bufs[priv->dev->front_buf ^ 1].fb,
+                         0, 0, &priv->dev->conn, 1, &priv->dev->mode);
+    if (ret) {
+        char *errstr = mp_strerror(errno);
+        MP_ERR(vo, "Cannot set CRTC for connector %u: %s\n", connector_id,
+               errstr);
+    }
+
+    return 0;
+}
+
+static void uninit(struct vo *vo)
+{
+    struct priv *priv = vo->priv;
+
+    if (priv->dev != NULL) {
+        if (priv->old_crtc != NULL) {
+            drmModeSetCrtc(priv->fd,
+                    priv->old_crtc->crtc_id,
+                    priv->old_crtc->buffer_id,
+                    priv->old_crtc->x,
+                    priv->old_crtc->y,
+                    &priv->dev->conn,
+                    1,
+                    &priv->dev->mode);
+            drmModeFreeCrtc(priv->old_crtc);
+        }
+
+        modeset_destroy_fb(priv->fd, &priv->dev->bufs[1]);
+        modeset_destroy_fb(priv->fd, &priv->dev->bufs[0]);
+    }
+
+    talloc_free(priv->dev);
+}
+
+static int query_format(struct vo *vo, int format)
+{
+    return format == IMGFMT_BGR24;
+}
+
+static int control(struct vo *vo, uint32_t request, void *data)
+{
+    return VO_NOTIMPL;
+}
+
+const struct vo_driver video_out_drm = {
+    .name = "drm",
+    .description = "Direct Rendering Manager",
+    .preinit = preinit,
+    .query_format = query_format,
+    .reconfig = reconfig,
+    .control = control,
+    .draw_image = draw_image,
+    .flip_page = flip_page,
+    .uninit = uninit,
+    .priv_size = sizeof(struct priv),
+};

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -349,7 +349,7 @@ static void flip_page(struct vo *vo)
 {
     struct priv *p = vo->priv;
 
-    int ret = drmModePageFlip(p->fd, p->dev->crtc,
+    int ret = drmModeSetCrtc(p->fd, p->dev->crtc,
                              p->dev->bufs[p->dev->front_buf].fb,
                              0, 0, &p->dev->conn, 1, &p->dev->mode);
     if (ret) {

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -277,7 +277,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     dev = talloc_size(vo->priv, sizeof(*dev));
     dev->conn = conn->connector_id;
     dev->front_buf = 0;
-    memcpy(&dev->mode, &conn->modes[0], sizeof(dev->mode));
+    dev->mode = conn->modes[0];
     dev->bufs[0].width = conn->modes[0].hdisplay;
     dev->bufs[0].height = conn->modes[0].vdisplay;
     dev->bufs[1].width = conn->modes[0].hdisplay;

--- a/wscript
+++ b/wscript
@@ -632,6 +632,10 @@ video_output_features = [
         'desc': 'CACA',
         'func': check_pkg_config('caca', '>= 0.99.beta18'),
     }, {
+        'name': '--drm',
+        'desc': 'DRM',
+        'func': check_pkg_config('libdrm'),
+    }, {
         'name': '--jpeg',
         'desc': 'JPEG support',
         'func': check_cc(header_name=['stdio.h', 'jpeglib.h'],

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -340,6 +340,7 @@ def build(ctx):
         ( "video/out/gl_x11egl.c",               "egl-x11" ),
         ( "video/out/vo.c" ),
         ( "video/out/vo_caca.c",                 "caca" ),
+        ( "video/out/vo_drm.c",                  "drm" ),
         ( "video/out/vo_direct3d.c",             "direct3d" ),
         ( "video/out/vo_image.c" ),
         ( "video/out/vo_lavc.c",                 "encoding" ),


### PR DESCRIPTION
This pull request introduces new video output, `vo_drm`. It uses Direct Rendering Manager (DRM) and Kernel Mode Setting (KMS) to enable watching videos on Linux systems, where neither X window system nor wayland server are available. Its only dependency is `libdrm` (it doesn't even need OpenGL) and thus I draw a bold conclusion that in terms of dependencies, it is the most lightweight video renderer for Linux.

Because of this, it doesn't use hardware acceleration at all, and heavy videos / old hardware *will* experience performance problems. This was tested on a 5-year-old netbook equipped with AMD C-50 (1gHz) and Radeon 6250. Old movies were played acceptably, while 720p action videos with rich ass subtitles experienced massive frame drops. This behavior could be fixed to some extent with extreme `--vf=scale=-1:180 --sws-scaler=point`.

I have no idea how it performs on better hardware. I'm going to purchase a powerful computer within one month.

Additionally, I (eventually) plan to develop a renderer for DRM that utilizes hardware acceleration, but it will need `libegl` and almost surely `libgbm` that come with their own (remarkable) chain of dependencies. In my opinion, these dependencies are what makes `vo_drm` attractive.