### PR TITLE
OSD: implement multiple OSD_EXTERNALs.

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -943,13 +943,32 @@ static int script_command_native(lua_State *L)
     return 2;
 }
 
+static int script_osd_add_external(lua_State *L)
+{
+    struct MPContext *mpctx = get_mpctx(L);
+    osd_add_external(mpctx->osd);
+    return 0;
+}
+
+static int script_osd_set_external(lua_State *L)
+{
+    struct MPContext *mpctx = get_mpctx(L);
+    int layer = luaL_checkinteger(L, 1);
+    int res_x = luaL_checkinteger(L, 2);
+    int res_y = luaL_checkinteger(L, 3);
+    const char *text = luaL_checkstring(L, 4);
+    osd_set_external(mpctx->osd, layer, res_x, res_y, (char *)text);
+    mp_input_wakeup(mpctx->input);
+    return 0;
+}
+
 static int script_set_osd_ass(lua_State *L)
 {
     struct MPContext *mpctx = get_mpctx(L);
     int res_x = luaL_checkinteger(L, 1);
     int res_y = luaL_checkinteger(L, 2);
     const char *text = luaL_checkstring(L, 3);
-    osd_set_external(mpctx->osd, res_x, res_y, (char *)text);
+    osd_set_external(mpctx->osd, 0, res_x, res_y, (char *)text);
     mp_input_wakeup(mpctx->input);
     return 0;
 }
@@ -1278,6 +1297,8 @@ static const struct fn_entry main_fns[] = {
     FN_ENTRY(set_property_native),
     FN_ENTRY(raw_observe_property),
     FN_ENTRY(raw_unobserve_property),
+    FN_ENTRY(osd_add_external),
+    FN_ENTRY(osd_set_external),
     FN_ENTRY(set_osd_ass),
     FN_ENTRY(get_osd_resolution),
     FN_ENTRY(get_screen_size),

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -457,6 +457,44 @@ function mp.dispatch_events(allow_wait)
 end
 
 -- additional helpers
+local osds = {}
+function mp.add_osd_layer(layer)
+    -- find the actual index corresponding to the osd layer
+    local osd_index = 0
+    for i = 1, #osds do
+        if osds[i].layer > layer then
+            osd_index = i
+            break
+        end
+    end
+    if osd_index == 0 then
+        osd_index = #osds + 1
+    end
+
+    -- create a new osd object
+    local new_osd = {
+        layer = layer,
+        index = osd_index,
+        res_x = 0,
+        res_y = 0,
+        text  = "",
+    }
+    -- rearrange all osds following the new insert.
+    table.insert(osds, osd_index, new_osd)
+    mp.osd_add_external()
+    for i = osd_index, #osds do
+        local osd = osds[i]
+        osd.index = i
+        mp.osd_set_external(osd.index, osd.res_x, osd.res_y, osd.text)
+    end
+
+    -- return a closure for updating the osd
+    return function(res_x, res_y, text)
+        new_osd.res_x, new_osd.res_y, new_osd.text = res_x, res_y, text
+        mp.osd_set_external(new_osd.index, res_x, res_y, text)
+    end
+end
+
 
 function mp.osd_message(text, duration)
     if not duration then

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -460,6 +460,11 @@ end
 local osds = {}
 function mp.add_osd_layer(layer)
     -- find the actual index corresponding to the osd layer
+    if #osds == 7 then
+        mp.msg.warn("All OSD layers are in use.")
+        return function() end
+    end
+
     local osd_index = 0
     for i = 1, #osds do
         if osds[i].layer > layer then
@@ -479,9 +484,9 @@ function mp.add_osd_layer(layer)
         res_y = 0,
         text  = "",
     }
+
     -- rearrange all osds following the new insert.
     table.insert(osds, osd_index, new_osd)
-    mp.osd_add_external()
     for i = osd_index, #osds do
         local osd = osds[i]
         osd.index = i
@@ -490,8 +495,8 @@ function mp.add_osd_layer(layer)
 
     -- return a closure for updating the osd
     return function(res_x, res_y, text)
-        new_osd.res_x, new_osd.res_y, new_osd.text = res_x, res_y, text
         mp.osd_set_external(new_osd.index, res_x, res_y, text)
+        new_osd.res_x, new_osd.res_y, new_osd.text = res_x, res_y, text
     end
 end
 

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -121,6 +121,7 @@ struct osd_state *osd_create(struct mpv_global *global)
             .type = n,
             .text = talloc_strdup(obj, ""),
             .progbar_state = {.type = -1},
+            .next = NULL,
         };
         for (int i = 0; i < OSD_CONV_CACHE_MAX; i++)
             obj->cache[i] = talloc_steal(obj, osd_conv_cache_new());
@@ -132,6 +133,45 @@ struct osd_state *osd_create(struct mpv_global *global)
 
     osd_init_backend(osd);
     return osd;
+}
+
+// it gets worse
+void osd_add_external(struct osd_state *osd)
+{
+    // move to the top of the linked list (bad)
+    struct osd_object *old_top = osd->objs[OSDTYPE_EXTERNAL];
+    while (old_top->next) {
+        old_top = old_top->next;
+    }
+    struct osd_object *new_obj = talloc(osd, struct osd_object);
+    *new_obj = (struct osd_object) {
+        .type = OSDTYPE_EXTERNAL,
+        .text = talloc_strdup(new_obj, ""),
+        .progbar_state = {.type = -1},
+        .next = NULL,
+    };
+    for (int i = 0; i < OSD_CONV_CACHE_MAX; i++)
+        new_obj->cache[i] = talloc_steal(new_obj, osd_conv_cache_new());
+
+    old_top->next = new_obj;
+}
+
+// bad
+void osd_remove_external(struct osd_state *osd, int idx)
+{
+    if (idx < 1)
+        return;
+
+    struct osd_object *prev = osd->objs[OSDTYPE_EXTERNAL];
+    for (int i = 0; i < idx-1; i++) {
+        prev = prev->next;
+        if (prev == NULL)
+            return;
+    }
+
+    struct osd_object *next = prev->next->next;
+    talloc_free(prev->next);
+    prev->next = next;
 }
 
 void osd_free(struct osd_state *osd)
@@ -199,10 +239,15 @@ void osd_set_progbar(struct osd_state *osd, struct osd_progbar_state *s)
     pthread_mutex_unlock(&osd->lock);
 }
 
-void osd_set_external(struct osd_state *osd, int res_x, int res_y, char *text)
+void osd_set_external(struct osd_state *osd, int layer, int res_x, int res_y, char *text)
 {
     pthread_mutex_lock(&osd->lock);
     struct osd_object *osd_obj = osd->objs[OSDTYPE_EXTERNAL];
+    for (int i = 0; i < layer; i++) {
+        osd_obj = osd_obj->next;
+        if (!osd_obj)
+            return;
+    }
     if (strcmp(osd_obj->text, text) != 0 ||
         osd_obj->external_res_x != res_x ||
         osd_obj->external_res_y != res_y)
@@ -211,7 +256,9 @@ void osd_set_external(struct osd_state *osd, int res_x, int res_y, char *text)
         osd_obj->text = talloc_strdup(osd_obj, text);
         osd_obj->external_res_x = res_x;
         osd_obj->external_res_y = res_y;
-        osd_changed_unlocked(osd, osd_obj->type);
+        // osd_changed_unlocked(osd, osd_obj->type);
+        osd_obj->force_redraw = true;
+        osd->want_redraw = true;
     }
     pthread_mutex_unlock(&osd->lock);
 }
@@ -312,6 +359,22 @@ static void render_object(struct osd_state *osd, struct osd_object *obj,
         obj->cached = *out_imgs;
 }
 
+// this is very bad and should probably be done much better.
+static void join_sub_bitmaps(struct sub_bitmaps *group, struct sub_bitmaps *joiner)
+{
+    // destroy everything
+    group->format = joiner->format;
+    group->scaled = joiner->scaled;
+    // this is just mp_osdtype
+    group->render_index = joiner->render_index;
+    // leak tons of memory
+    group->parts = talloc_realloc(NULL, group->parts, struct sub_bitmap, group->num_parts + joiner->num_parts);
+    memcpy(group->parts + group->num_parts, joiner->parts, joiner->num_parts * sizeof(struct sub_bitmap));
+    group->num_parts += joiner->num_parts;
+    // I didn't want the cache to work anyway.
+    group->change_id += joiner->change_id;
+}
+
 // draw_flags is a bit field of OSD_DRAW_* constants
 void osd_draw(struct osd_state *osd, struct mp_osd_res res,
               double video_pts, int draw_flags,
@@ -324,22 +387,32 @@ void osd_draw(struct osd_state *osd, struct mp_osd_res res,
         draw_flags |= OSD_DRAW_SUB_ONLY;
 
     for (int n = 0; n < MAX_OSD_PARTS; n++) {
+        struct sub_bitmaps imgs = {0};
         struct osd_object *obj = osd->objs[n];
+        do {
 
-        // Object is drawn into the video frame itself; don't draw twice
-        if (osd->render_subs_in_filter && obj->is_sub &&
-            !(draw_flags & OSD_DRAW_SUB_FILTER))
-            continue;
-        if ((draw_flags & OSD_DRAW_SUB_ONLY) && !obj->is_sub)
-            continue;
-        if ((draw_flags & OSD_DRAW_OSD_ONLY) && obj->is_sub)
-            continue;
+            // Object is drawn into the video frame itself; don't draw twice
+            if (osd->render_subs_in_filter && obj->is_sub &&
+                !(draw_flags & OSD_DRAW_SUB_FILTER))
+                continue;
+            if ((draw_flags & OSD_DRAW_SUB_ONLY) && !obj->is_sub)
+                continue;
+            if ((draw_flags & OSD_DRAW_OSD_ONLY) && obj->is_sub)
+                continue;
 
-        if (obj->sub_state.dec_sub)
-            sub_lock(obj->sub_state.dec_sub);
+            if (obj->sub_state.dec_sub)
+                sub_lock(obj->sub_state.dec_sub);
 
-        struct sub_bitmaps imgs;
-        render_object(osd, obj, res, video_pts, formats, &imgs);
+            struct sub_bitmaps img;
+            render_object(osd, obj, res, video_pts, formats, &img);
+            join_sub_bitmaps( &imgs, &img );
+
+            if (obj->sub_state.dec_sub)
+                sub_unlock(obj->sub_state.dec_sub);
+
+            obj = obj->next;
+        } while ( obj );
+
         if (imgs.num_parts > 0) {
             if (formats[imgs.format]) {
                 cb(cb_ctx, &imgs);
@@ -348,9 +421,6 @@ void osd_draw(struct osd_state *osd, struct mp_osd_res res,
                        obj->type, imgs.format);
             }
         }
-
-        if (obj->sub_state.dec_sub)
-            sub_unlock(obj->sub_state.dec_sub);
     }
 
     pthread_mutex_unlock(&osd->lock);

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -171,7 +171,9 @@ struct osd_progbar_state {
 };
 void osd_set_progbar(struct osd_state *osd, struct osd_progbar_state *s);
 
-void osd_set_external(struct osd_state *osd, int res_x, int res_y, char *text);
+void osd_add_external(struct osd_state *osd);
+void osd_remove_external(struct osd_state *osd, int idx);
+void osd_set_external(struct osd_state *osd, int layer, int res_x, int res_y, char *text);
 
 void osd_set_external2(struct osd_state *osd, struct sub_bitmaps *imgs);
 

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -87,7 +87,17 @@ enum mp_osdtype {
     OSDTYPE_PROGBAR,
     OSDTYPE_OSD,
 
-    OSDTYPE_EXTERNAL,
+    // external ASS osd.
+    OSDTYPE_EXTERNAL_0,
+    OSDTYPE_EXTERNAL_1,
+    OSDTYPE_EXTERNAL_2,
+    OSDTYPE_EXTERNAL_3,
+    OSDTYPE_EXTERNAL_4,
+    OSDTYPE_EXTERNAL_5,
+    OSDTYPE_EXTERNAL_6,
+    OSDTYPE_EXTERNAL_7,
+
+    // external bitmap osd.
     OSDTYPE_EXTERNAL2,
 
     MAX_OSD_PARTS
@@ -171,9 +181,7 @@ struct osd_progbar_state {
 };
 void osd_set_progbar(struct osd_state *osd, struct osd_progbar_state *s);
 
-void osd_add_external(struct osd_state *osd);
-void osd_remove_external(struct osd_state *osd, int idx);
-void osd_set_external(struct osd_state *osd, int layer, int res_x, int res_y, char *text);
+void osd_set_external(struct osd_state *osd, unsigned layer, int res_x, int res_y, char *text);
 
 void osd_set_external2(struct osd_state *osd, struct sub_bitmaps *imgs);
 

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -458,7 +458,14 @@ static void update_object(struct osd_state *osd, struct osd_object *obj)
     case OSDTYPE_PROGBAR:
         update_progbar(osd, obj);
         break;
-    case OSDTYPE_EXTERNAL:
+    case OSDTYPE_EXTERNAL_0:
+    case OSDTYPE_EXTERNAL_1:
+    case OSDTYPE_EXTERNAL_2:
+    case OSDTYPE_EXTERNAL_3:
+    case OSDTYPE_EXTERNAL_4:
+    case OSDTYPE_EXTERNAL_5:
+    case OSDTYPE_EXTERNAL_6:
+    case OSDTYPE_EXTERNAL_7:
         update_external(osd, obj);
         break;
     }

--- a/sub/osd_state.h
+++ b/sub/osd_state.h
@@ -24,6 +24,8 @@ struct osd_object {
 
     // OSDTYPE_EXTERNAL
     int external_res_x, external_res_y;
+    // do a terrible linked list thing.
+    struct osd_object *next;
 
     // OSDTYPE_EXTERNAL2
     struct sub_bitmaps *external2;

--- a/sub/osd_state.h
+++ b/sub/osd_state.h
@@ -22,10 +22,8 @@ struct osd_object {
     // OSDTYPE_SUB/OSDTYPE_SUB2
     struct osd_sub_state sub_state;
 
-    // OSDTYPE_EXTERNAL
+    // OSDTYPE_EXTERNAL_n
     int external_res_x, external_res_y;
-    // do a terrible linked list thing.
-    struct osd_object *next;
 
     // OSDTYPE_EXTERNAL2
     struct sub_bitmaps *external2;


### PR DESCRIPTION
:warning: This really probably shouldn't be merged just yet.

#### Rationale
The (currently undocumented) Lua API function `mp.set_osd_ass` is very useful and powerful because it allows drawing in the mpv window with positioned and formatted text as well as vector graphic primitives. 
This makes it the most versatile way to display messages for the user and create interactive scripts. However, it's terribly limited because it is global. Any script that uses it will overwrite what any other script has drawn.

#### Possible Solutions
1. Concatenate all OSD draw calls in Lua.
  - Pros: easy to implement.
  - Cons: All scripts must share a virtual OSD resolution, which makes positioning and sizing troublesome.

2. Extend current OSD API to support a variable number of layers.
  - Pros: eliminates the need for shared virtual resolutions.
  - Cons: the entire OSD system is designed to work with a set number of OSDs, which causes a lot of trouble.

3. Implement a new API specifically for script OSDs.
  - Pros: solves the cons of the first two.
  - Cons: requires changing all the VO's to support the new API, more code to maintain.

#### This PR
I've implemented a very hacked-up version of solution 2. While I don't think this is ready for prime-time yet, I'm submitting it because I'm hoping to get some feedback. While I personally think that solution 3 is probably the best in the long run, I don't know enough about mpv's internals to do that well.

##### Details

The particular solution this patch employs is to turn all of the OSD types into linked lists. The only one that ends up having more than one element is `OSDTYPE_EXTERNAL`. When the OSDs are being rendered, the linked list is iterated through and all resulting bitmaps are joined into a single `sub_bitmaps` struct. This keeps each member of the linked list from overwriting the bitmaps of the previous members, but it also probably destroys the caching, because the cache is not designed to cope with this. I don't really understand the OSD cache, so I'm not sure what the best way to fix this is.

The actual layer ordering of the OSDs is controlled by Lua. The new Lua OSD API consists of a registration function that returns a closure to be used for actually updating the OSD. The function signature of the closure is the same as the old `mp.set_osd_ass` api.

Things to do:
- [ ] Play nicely with the OSD caches.
- [ ] Don't leak memory.
- [ ] Remove unnecessary comments.
- [ ] Increase code quality?
- [ ] Investigate alternate solutions.
- [ ] Make part of documented Lua API.
