### PR TITLE
vo_drm: fix logging problems with connectors

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -294,7 +294,7 @@ static int modeset_prepare_dev(struct vo *vo, int fd, int conn_id,
     }
 
     conn = drmModeGetConnector(fd, res->connectors[conn_id]);
-    if (!is_connector_valid(vo, conn_id, conn, true)) {
+    if (!is_connector_valid(vo, conn_id, conn, false)) {
         ret = -ENODEV;
         goto end;
     }


### PR DESCRIPTION
Logging was meant to be silenced only when user uses connector auto-detection feature. If user supplies connector ID manually, he should see exact reason why connecting to this specific connector
failed.