### PR TITLE
Prevent the machine from going to sleep when a video-only stream is played

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1316,7 +1316,8 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         return VO_TRUE;
     case VOCTRL_KILL_SCREENSAVER:
         w32->disable_screensaver = true;
-        SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED);
+        SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED |
+                                ES_DISPLAY_REQUIRED);
         return VO_TRUE;
     case VOCTRL_RESTORE_SCREENSAVER:
         w32->disable_screensaver = false;


### PR DESCRIPTION
VLC and MPC-HC also make a power request like this while playing. This _shouldn't_ be necessary for audio-only streams because it seems like the audio stack makes its own request, however I'm not sure if this is the case for all drivers.