### PR TITLE
vf.c, wscript_build.py: fix libavfilter dependency for vf_mirror

### DIFF
--- a/video/filter/vf.c
+++ b/video/filter/vf.c
@@ -73,9 +73,9 @@ static const vf_info_t *const filter_list[] = {
     &vf_info_format,
     &vf_info_noformat,
     &vf_info_flip,
-    &vf_info_mirror,
 
 #if HAVE_LIBAVFILTER
+    &vf_info_mirror,
     &vf_info_lavfi,
     &vf_info_rotate,
     &vf_info_noise,

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -305,7 +305,7 @@ def build(ctx):
         ( "video/filter/vf_gradfun.c",           "libavfilter"),
         ( "video/filter/vf_hqdn3d.c",            "libavfilter"),
         ( "video/filter/vf_lavfi.c",             "libavfilter"),
-        ( "video/filter/vf_mirror.c" ),
+        ( "video/filter/vf_mirror.c",            "libavfilter"),
         ( "video/filter/vf_noformat.c" ),
         ( "video/filter/vf_noise.c",             "libavfilter"),
         ( "video/filter/vf_pullup.c",            "libavfilter"),


### PR DESCRIPTION
Since e207c24b32a457859ab6e3a5b1f5f9eaeea36ed1, vf_mirror requires libavfilter.