### PR TITLE
command: disc-mouse-on-button property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -919,6 +919,10 @@ Property list
     a BD or DVD. Use the ``discnav menu`` command to actually enter or leave
     menu mode.
 
+``disc-mouse-on-button``
+    Return ``yes`` when the mouse cursor is located on a button, or ``no``
+    when cursor is outside of any button for disc navigation.
+
 ``chapters``
     Number of chapters.
 

--- a/player/command.c
+++ b/player/command.c
@@ -702,6 +702,14 @@ static int mp_property_disc_menu(void *ctx, struct m_property *prop,
     return m_property_flag_ro(action, arg, !!state);
 }
 
+static int mp_property_mouse_on_button(void *ctx, struct m_property *prop,
+                                       int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    bool on = mp_nav_mouse_on_button(mpctx);
+    return m_property_flag_ro(action, arg, on);
+}
+
 /// Current chapter (RW)
 static int mp_property_chapter(void *ctx, struct m_property *prop,
                                int action, void *arg)
@@ -3262,6 +3270,7 @@ static const struct m_property mp_properties[] = {
     {"playback-time", mp_property_playback_time},
     {"disc-title", mp_property_disc_title},
     {"disc-menu-active", mp_property_disc_menu},
+    {"disc-mouse-on-button", mp_property_mouse_on_button},
     {"chapter", mp_property_chapter},
     {"edition", mp_property_edition},
     {"disc-titles", mp_property_disc_titles},

--- a/player/core.h
+++ b/player/core.h
@@ -373,6 +373,7 @@ void mp_nav_destroy(struct MPContext *mpctx);
 void mp_nav_user_input(struct MPContext *mpctx, char *command);
 void mp_handle_nav(struct MPContext *mpctx);
 int mp_nav_in_menu(struct MPContext *mpctx);
+bool mp_nav_mouse_on_button(struct MPContext *mpctx);
 
 // loadfile.c
 void uninit_player(struct MPContext *mpctx, unsigned int mask);

--- a/stream/discnav.h
+++ b/stream/discnav.h
@@ -80,6 +80,7 @@ struct mp_nav_cmd {
             int x, y;
         } mouse_pos;
     } u;
+    bool mouse_on_button;
 };
 
 #endif /* MPLAYER_STREAM_DVDNAV_H */

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -455,7 +455,9 @@ static void handle_nav_command(stream_t *s, struct mp_nav_cmd *ev)
         bd_vk_key_e key = translate_nav_menu_action(action);
         if (key != BD_VK_NONE) {
             if (key == BD_VK_MOUSE_ACTIVATE)
-                bd_mouse_select(priv->bd, pts, priv->mousex, priv->mousey);
+                ev->mouse_on_button = bd_mouse_select(priv->bd, pts, 
+                                                      priv->mousex, 
+                                                      priv->mousey);
             bd_user_input(priv->bd, pts, key);
         } else if (strcmp(action, "menu") == 0) {
             if (priv->popup_enabled)
@@ -467,7 +469,9 @@ static void handle_nav_command(stream_t *s, struct mp_nav_cmd *ev)
     } case MP_NAV_CMD_MOUSE_POS:
         priv->mousex = ev->u.mouse_pos.x;
         priv->mousey = ev->u.mouse_pos.y;
-        bd_mouse_select(priv->bd, mp_time_us(), priv->mousex, priv->mousey);
+        ev->mouse_on_button = bd_mouse_select(priv->bd, mp_time_us(), 
+                                              priv->mousex, 
+                                              priv->mousey);
         break;
     case MP_NAV_CMD_SKIP_STILL:
         bd_read_skip_still(priv->bd);

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -202,18 +202,19 @@ static void handle_menu_input(stream_t *stream, const char *cmd)
     }
 }
 
-static void handle_mouse_pos(stream_t *stream, int x, int y)
+static dvdnav_status_t handle_mouse_pos(stream_t *stream, int x, int y)
 {
     struct priv *priv = stream->priv;
     dvdnav_t *nav = priv->dvdnav;
     pci_t *pci = dvdnav_get_current_nav_pci(nav);
 
     if (!pci)
-        return;
+        return DVDNAV_STATUS_ERR;
 
-    dvdnav_mouse_select(nav, pci, x, y);
+    dvdnav_status_t status = dvdnav_mouse_select(nav, pci, x, y);
     priv->mousex = x;
     priv->mousey = y;
+    return status;
 }
 
 /**
@@ -305,7 +306,7 @@ static void handle_cmd(stream_t *s, struct mp_nav_cmd *ev)
         handle_menu_input(s, ev->u.menu.action);
         break;
     case MP_NAV_CMD_MOUSE_POS:
-        handle_mouse_pos(s, ev->u.mouse_pos.x, ev->u.mouse_pos.y);
+        ev->mouse_on_button = handle_mouse_pos(s, ev->u.mouse_pos.x, ev->u.mouse_pos.y);
         break;
     }
 


### PR DESCRIPTION
This property indicates whether mouse cursor is located on button
or not for disc naviation.

This is useful for instance, not to override mouse button click with some other single click action for GUI.