### PR TITLE
command: demuxer-ahead-duration property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1077,6 +1077,12 @@ Property list
     guess is very unreliable, and often the property will not be available
     at all, even if data is buffered.
 
+``demuxer-ahead-duration``
+    Approximate aheaded duration in demuxer buffer, in seconds. This is similar
+    with ``demuxer-cache-duration`` but returns duration measured from current
+    ``time-pos``. Also, this property returns remaining time after bufferred
+    data in demuxer reach end-of-file.
+
 ``demuxer-cache-idle``
     Returns ``yes`` if the demuxer is idle, which means the demuxer cache is
     filled to the requested amount, and is currently not reading more data.

--- a/player/command.c
+++ b/player/command.c
@@ -1383,6 +1383,29 @@ static int mp_property_demuxer_cache_duration(void *ctx, struct m_property *prop
     return m_property_double_ro(action, arg, s.ts_duration);
 }
 
+static int mp_property_demuxer_ahead_duration(void *ctx, struct m_property *prop,
+                                          int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    if (!mpctx->demuxer)
+        return M_PROPERTY_UNAVAILABLE;
+
+    struct demux_ctrl_reader_state s;
+    if (demux_control(mpctx->demuxer, DEMUXER_CTRL_GET_READER_STATE, &s) < 1)
+        return M_PROPERTY_UNAVAILABLE;
+
+    if (!s.eof && s.ts_range[1] == MP_NOPTS_VALUE)
+        return M_PROPERTY_UNAVAILABLE;
+    double ts = -1;
+    if (!s.eof) {
+        double time = get_current_time(mpctx);
+        if (time < 0)
+            return M_PROPERTY_UNAVAILABLE;
+        ts = s.ts_range[1] - time;
+    }
+    return m_property_double_ro(action, arg, ts);
+}
+
 static int mp_property_demuxer_cache_idle(void *ctx, struct m_property *prop,
                                           int action, void *arg)
 {
@@ -3283,6 +3306,7 @@ static const struct m_property mp_properties[] = {
     {"cache-size", mp_property_cache_size},
     {"cache-idle", mp_property_cache_idle},
     {"demuxer-cache-duration", mp_property_demuxer_cache_duration},
+    {"demuxer-ahead-duration", mp_property_demuxer_ahead_duration},
     {"demuxer-cache-idle", mp_property_demuxer_cache_idle},
     {"cache-buffering-state", mp_property_cache_buffering},
     {"paused-for-cache", mp_property_paused_for_cache},
@@ -3473,7 +3497,9 @@ static const char *const *const mp_event_property_change[] = {
     E(MPV_EVENT_METADATA_UPDATE, "metadata", "filtered-metadata", "media-title"),
     E(MPV_EVENT_CHAPTER_CHANGE, "chapter", "chapter-metadata"),
     E(MP_EVENT_CACHE_UPDATE, "cache", "cache-free", "cache-used", "cache-idle",
-      "demuxer-cache-duration", "demuxer-cache-idle", "paused-for-cache"),
+      "demuxer-cache-duration", "demuxer-cache-idle", "paused-for-cache",
+      "demuxer-ahead-time"
+    ),
     E(MP_EVENT_WIN_RESIZE, "window-scale"),
     E(MP_EVENT_WIN_STATE, "window-minimized", "display-names", "display-fps"),
     E(MP_EVENT_AUDIO_DEVICES, "audio-device-list"),

--- a/player/command.c
+++ b/player/command.c
@@ -3498,7 +3498,7 @@ static const char *const *const mp_event_property_change[] = {
     E(MPV_EVENT_CHAPTER_CHANGE, "chapter", "chapter-metadata"),
     E(MP_EVENT_CACHE_UPDATE, "cache", "cache-free", "cache-used", "cache-idle",
       "demuxer-cache-duration", "demuxer-cache-idle", "paused-for-cache",
-      "demuxer-ahead-time"
+      "demuxer-ahead-duration"
     ),
     E(MP_EVENT_WIN_RESIZE, "window-scale"),
     E(MP_EVENT_WIN_STATE, "window-minimized", "display-names", "display-fps"),

--- a/player/core.h
+++ b/player/core.h
@@ -328,7 +328,7 @@ typedef struct MPContext {
     int max_frames;
     bool playing_msg_shown;
 
-    bool paused_for_cache;
+    bool paused_for_cache, cache_eof;
     double cache_stop_time, cache_wait_time;
 
     // Set after showing warning about decoding being too slow for realtime

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1018,6 +1018,7 @@ static void play_current_file(struct MPContext *mpctx)
     mpctx->last_chapter = -2;
     mpctx->paused = false;
     mpctx->paused_for_cache = false;
+    mpctx->cache_eof = false;
     mpctx->playing_msg_shown = false;
     mpctx->backstep_active = false;
     mpctx->max_frames = -1;

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -545,6 +545,11 @@ static void handle_pause_on_low_cache(struct MPContext *mpctx)
     struct demux_ctrl_reader_state s = {.idle = true, .ts_duration = -1};
     demux_control(mpctx->demuxer, DEMUXER_CTRL_GET_READER_STATE, &s);
 
+    if (mpctx->cache_eof != s.eof) {
+        mpctx->cache_eof = s.eof;
+        mp_notify(mpctx, MP_EVENT_CACHE_UPDATE, NULL);
+    }
+
     if (mpctx->restart_complete && idle != -1) {
         if (mpctx->paused && mpctx->paused_for_cache) {
             if (!opts->cache_pausing || s.ts_duration >= mpctx->cache_wait_time


### PR DESCRIPTION
Approximate aheaded time in demuxer, in seconds. This is similar with
`demuxer-cache-duration` but returns duration measured from current
`time-pos`. Also, this property returns remaining time after bufferred
data in demuxer reach end-of-file.

The problem of `demuxer-cache-duration` is there's no way to figure out where the reported timestamp starts from. Also, once cache reaches eof, `demuxer-cache-duration` just returns 0.
This property is useful, for instance, to indicate current filled demuxer time in time slider in GUI.