### PR TITLE
vo_drm: fix releasing VT if received signal twice

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -339,6 +339,7 @@ end:
 static int setup_vo_crtc(struct vo *vo)
 {
     struct priv *p = vo->priv;
+    if (p->active) return;
     p->old_crtc = drmModeGetCrtc(p->fd, p->dev->crtc);
     int ret = drmModeSetCrtc(p->fd, p->dev->crtc,
                           p->dev->bufs[p->dev->front_buf + BUF_COUNT - 1].fb,
@@ -350,6 +351,7 @@ static int setup_vo_crtc(struct vo *vo)
 static void release_vo_crtc(struct vo *vo)
 {
     struct priv *p = vo->priv;
+    if (!p->active) return;
     p->active = false;
     if (p->old_crtc) {
         drmModeSetCrtc(p->fd,
@@ -361,6 +363,7 @@ static void release_vo_crtc(struct vo *vo)
                        1,
                        &p->dev->mode);
         drmModeFreeCrtc(p->old_crtc);
+        p->old_crtc = NULL;
     }
 }
 


### PR DESCRIPTION
If user switched terminals frantically, mpv could get SIGUSR1 twice in a row, which, up until now, resulted in destroying CRTC twice. This caused it to segfault. After this fix, double SIGUSR1 should be ignored, as well as double SIGUSR2 (which I haven't observed).