### PR TITLE
DOCS/mplayer-changes.rst: Eleborate on joystick input

### DIFF
--- a/DOCS/mplayer-changes.rst
+++ b/DOCS/mplayer-changes.rst
@@ -49,6 +49,8 @@ Input
 * Classic LIRC support was removed. Install remotes as input devices instead.
   This way they will send X11 key events to the mpv window, which can be bound
   using the normal ``input.conf``.
+* Joystick support was removed. It was considered useless and was the cause
+  of some problems (e.g. a laptop's accelerator being recognized as joystick).
 
 Audio
 ~~~~~


### PR DESCRIPTION
Since joystick support was removed and is a difference from mplayer, it should be included in the document with the mplayer changes. It will help new users who were using mplayer's joystick support to seek alternatives when switching to mpv. It will also be helpful for people that had problems with the joystick support in mplayer (for example, by incorrectly recognizing other input devices as joystick) to know that those problems won't persist in mpv.