### PR TITLE
vo_drm: zero screen buffers in reconfig function.

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -476,9 +476,8 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     mp_image_set_params(p->cur_frame, &p->sws->dst);
 
     struct modeset_buf *buf=p->dev->bufs;
-    int stride=p->device_w*4;
-    memset_pic(buf[0].map,0,stride,p->device_h,stride);
-    memset_pic(buf[1].map,0,stride,p->device_h,stride);
+    memset(buf[0].map,0,buf[0].size);
+    memset(buf[1].map,0,buf[0].size);
 
     if (mp_sws_reinit(p->sws) < 0)
         return -1;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -475,6 +475,11 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     mp_image_params_guess_csp(&p->sws->dst);
     mp_image_set_params(p->cur_frame, &p->sws->dst);
 
+    struct modeset_buf *buf=p->dev->bufs;
+    int stride=p->device_w*4;
+    memset_pic(buf[0].map,0,stride,p->device_h,stride);
+    memset_pic(buf[1].map,0,stride,p->device_h,stride);
+
     if (mp_sws_reinit(p->sws) < 0)
         return -1;
 

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -475,9 +475,9 @@ static int reconfig(struct vo *vo, struct mp_image_params *params, int flags)
     mp_image_params_guess_csp(&p->sws->dst);
     mp_image_set_params(p->cur_frame, &p->sws->dst);
 
-    struct modeset_buf *buf=p->dev->bufs;
-    memset(buf[0].map,0,buf[0].size);
-    memset(buf[1].map,0,buf[0].size);
+    struct modeset_buf *buf = p->dev->bufs;
+    memset(buf[0].map, 0, buf[0].size);
+    memset(buf[1].map, 0, buf[1].size);
 
     if (mp_sws_reinit(p->sws) < 0)
         return -1;


### PR DESCRIPTION
Before it would not clear the screen when switching files, causing parts of last frame from last file to remain on-screen.