### PR TITLE
manpage: update mpv IRC channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ notifications:
   email: false
   irc:
     channels:
-      - "irc.freenode.org#mpv-player-dev"
+      - "irc.freenode.org#mpv-devel"
     on_success: change
     on_failure: always
 

--- a/DOCS/contribute.md
+++ b/DOCS/contribute.md
@@ -4,8 +4,8 @@ How to contribute
 General
 -------
 
-The main contact for mpv development is IRC, specifically #mpv-player
-and #mpv-player-dev on Freenode.
+The main contact for mpv development is IRC, specifically #mpv
+and #mpv-devel on Freenode.
 
 Sending patches
 ---------------

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Most activity happens on the IRC channel and the github issue tracker. The
 mailing lists are mostly unused.
 
  - **Github issue tracker**: [issue tracker][issue-tracker] (report bugs here)
- - **User IRC Channel**: `#mpv-player` on `irc.freenode.net`
- - **Developer IRC Channel**: `#mpv-player-dev` on `irc.freenode.net`
+ - **User IRC Channel**: `#mpv` on `irc.freenode.net`
+ - **Developer IRC Channel**: `#mpv-devel` on `irc.freenode.net`
  - **Users Mailing List**: `mpv-users@googlegroups.com` ([Archive / Subscribe][mpv-users]).
  - **Devel Mailing List**: `mpv-devel@googlegroups.com` ([Archive / Subscribe][mpv-devel])
 


### PR DESCRIPTION
Moved to #mpv and #mpv-devel, respectively. Travis details were also
updated.