### PR TITLE
Support UTF-8 in write_json_str. Fixes #1874

### DIFF
--- a/misc/json.c
+++ b/misc/json.c
@@ -220,16 +220,27 @@ int json_parse(void *ta_parent, struct mpv_node *dst, char **src, int max_depth)
 
 static void write_json_str(bstr *b, char *str)
 {
+    struct bstr prev, in_str = bstr0(str);
+
     APPEND(b, "\"");
     while (1) {
-        char *cur = str;
-        while (cur[0] && cur[0] >= 32 && cur[0] != '"' && cur[0] != '\\')
-            cur++;
-        if (!cur[0])
+        unsigned char *copy_from = in_str.start;
+
+        int chr;
+        do {
+            prev = in_str;
+            chr = bstr_decode_utf8(prev, &in_str);
+            if (chr == -1) {
+                chr = in_str.start[0];
+                in_str.start++;
+                in_str.len--;
+            }
+        } while (chr >= 0x20 && chr <= 0x7f && chr != '"' && chr != '\\');
+
+        if (!prev.start[0])
             break;
-        bstr_xappend(NULL, b, (bstr){str, cur - str});
-        bstr_xappend_asprintf(NULL, b, "\\u%04x", (unsigned char)cur[0]);
-        str = cur + 1;
+        bstr_xappend(NULL, b, (bstr){copy_from, prev.start - copy_from});
+        bstr_xappend_asprintf(NULL, b, "\\u%04x", chr);
     }
     APPEND(b, str);
     APPEND(b, "\"");


### PR DESCRIPTION
Re-do of the goofed PR #1877 

Manual tests done:

Valid filename:
```
score@kirisame ~ % echo '{"command":["get_property_string","media-title"]}' | socat - unix:"$HOME/.config/mpv/mpv.sock"              
{"data":"\u6771\u65b9Vocal\u3000C83\u79c1\u7684\u826f\u66f2\u30e1\u30c9\u30ec\u30fc.mp4","error":"success"}
score@kirisame ~ % echo '{"command":["get_property_string","media-title"]}' | socat - unix:"$HOME/.config/mpv/mpv.sock" | jq -r .data
東方Vocal　C83私的良曲メドレー.mp4
```

Invalid filename (filename is "test\x52\xCD\x01\x99\x99\xDD\xFF.mp4"):
```
score@kirisame ~ % echo '{"command":["get_property_string","media-title"]}' | socat - unix:"$HOME/.config/mpv/mpv.sock"              
{"data":"testR\u00cd\u0001\u0099\u0099\u00dd\u00ff.mp4","error":"success"}
score@kirisame ~ % echo '{"command":["get_property_string","media-title"]}' | socat - unix:"$HOME/.config/mpv/mpv.sock" | jq -r .data
testRÍÝÿ.mp4
```