### PR TITLE
x11: query ICC profile based on center of window

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -95,6 +95,12 @@ void mp_rect_union(struct mp_rect *rc, const struct mp_rect *rc2)
     rc->y1 = FFMAX(rc->y1, rc2->y1);
 }
 
+// Returns whether or not a point is contained by rc
+bool mp_rect_contains(struct mp_rect *rc, int x, int y)
+{
+    return rc->x0 <= x && x < rc->x1 && rc->y0 <= y && y < rc->y1;
+}
+
 // Set rc to the intersection of rc and src.
 // Return false if the result is empty.
 bool mp_rect_intersection(struct mp_rect *rc, const struct mp_rect *rc2)

--- a/common/common.h
+++ b/common/common.h
@@ -75,6 +75,7 @@ struct mp_rect {
 
 void mp_rect_union(struct mp_rect *rc, const struct mp_rect *src);
 bool mp_rect_intersection(struct mp_rect *rc, const struct mp_rect *rc2);
+bool mp_rect_contains(struct mp_rect *rc, int x, int y);
 
 int mp_snprintf_cat(char *str, size_t size, const char *format, ...)
     PRINTF_ATTRIBUTE(3, 4);

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1752,10 +1752,12 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
     case VOCTRL_GET_ICC_PROFILE: {
         if (!x11->pseudo_mapped)
             return VO_NOTAVAIL;
+        int cx = x11->winrc.x0 + (x11->winrc.x1 - x11->winrc.x0)/2,
+            cy = x11->winrc.y0 + (x11->winrc.y1 - x11->winrc.y0)/2;
         int screen = 0; // xinerama screen number
         for (int n = 0; n < x11->num_displays; n++) {
             struct xrandr_display *disp = &x11->displays[n];
-            if (disp->overlaps) {
+            if (mp_rect_contains(&disp->rc, cx, cy)) {
                 screen = n;
                 break;
             }


### PR DESCRIPTION
Right now, the default behavior is to pick the numerically lowest screen
ID that overlaps the window in any way - but this means that mpv will
decide to pick an ICC profile in a pretty arbitrary way even if the
window only overlaps another screen by a single pixel.

The new behavior is to query it based on the center of the window
instead.