### PR TITLE
check for lua52

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -55,6 +55,7 @@ def check_lua(ctx, dependency_identifier):
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
         ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
         ( '52',     'lua >= 5.2.0 lua < 5.3.0' ),
+        ( '52arch', 'lua52 >= 5.2.0'), # Arch
         ( '52deb',  'lua5.2 >= 5.2.0'), # debian
         ( '52fbsd', 'lua-5.2 >= 5.2.0'), # FreeBSD
         ( 'luajit', 'luajit >= 2.0.0' ),


### PR DESCRIPTION
Arch linux is about to update to lua 5.3.x, but lua 5.2.x will be
provided by package lua52, which contains pkg-config file lua52.pc.