### PR TITLE
DOCS/client_api_examples: Qt: force qmake to use pkg-config on OSX.

### DIFF
--- a/DOCS/client_api_examples/qml/mpvtest.pro
+++ b/DOCS/client_api_examples/qml/mpvtest.pro
@@ -3,6 +3,7 @@ QT += qml quick
 HEADERS += main.h
 SOURCES += main.cpp
 
+QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig debug
 PKGCONFIG += mpv
 

--- a/DOCS/client_api_examples/qml_direct/mpvtest.pro
+++ b/DOCS/client_api_examples/qml_direct/mpvtest.pro
@@ -3,6 +3,7 @@ QT += qml quick
 HEADERS += main.h
 SOURCES += main.cpp
 
+QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig debug
 PKGCONFIG += mpv
 

--- a/DOCS/client_api_examples/qt/qtexample.pro
+++ b/DOCS/client_api_examples/qt/qtexample.pro
@@ -5,6 +5,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = qtexample
 TEMPLATE = app
 
+QT_CONFIG -= no-pkg-config
 CONFIG += link_pkgconfig debug
 PKGCONFIG += mpv
 


### PR DESCRIPTION
If pkg-config isn't installed, qmake just returns the same error it would without this line.