### PR TITLE
Relative percent seeking

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -86,7 +86,7 @@ List of Input Commands
     disabling default bindings, without disabling all bindings with
     ``--no-input-default-bindings``.
 
-``seek <seconds> [relative|absolute|absolute-percent|exact|keyframes]``
+``seek <seconds> [relative|absolute|absolute-percent|relative-percent|exact|keyframes]``
     Change the playback position. By default, seeks by a relative amount of
     seconds.
 
@@ -98,6 +98,8 @@ List of Input Commands
         Seek to a given time.
     absolute-percent
         Seek to a given percent position.
+    relative-percent
+        Seek relative to current position in percent.
     keyframes
         Always restart playback at keyframe boundaries (fast).
     exact

--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -63,6 +63,7 @@ const struct mp_cmd_def mp_cmds[] = {
       OARG_FLAGS(4|0, ({"relative", 4|0}, {"-", 4|0},
                        {"absolute-percent", 4|1},
                        {"absolute", 4|2},
+                       {"relative-percent", 4|3},
                        {"keyframes", 32|8},
                        {"exact", 32|16})),
       // backwards compatibility only

--- a/player/command.c
+++ b/player/command.c
@@ -4118,6 +4118,11 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             queue_seek(mpctx, MPSEEK_ABSOLUTE, v, precision, false);
             set_osd_function(mpctx,
                              v > get_current_time(mpctx) ? OSD_FFW : OSD_REW);
+        } else if (abs == 3) {   // Relative seeking by percentage
+            queue_seek(mpctx, MPSEEK_FACTOR,
+                              get_current_pos_ratio(mpctx, false) + v / 100.0,
+                              precision, false);
+            set_osd_function(mpctx, v > 0 ? OSD_FFW : OSD_REW);
         } else if (abs) {           /* Absolute seek by percentage */
             queue_seek(mpctx, MPSEEK_FACTOR, v / 100.0, precision, false);
             set_osd_function(mpctx, OSD_FFW); // Direction isn't set correctly

--- a/player/command.c
+++ b/player/command.c
@@ -4123,7 +4123,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
                               get_current_pos_ratio(mpctx, false) + v / 100.0,
                               precision, false);
             set_osd_function(mpctx, v > 0 ? OSD_FFW : OSD_REW);
-        } else if (abs) {           /* Absolute seek by percentage */
+        } else if (abs) {           // Absolute seek by percentage
             queue_seek(mpctx, MPSEEK_FACTOR, v / 100.0, precision, false);
             set_osd_function(mpctx, OSD_FFW); // Direction isn't set correctly
         } else {


### PR DESCRIPTION
Only absolute percentage seeking was permitted first. It is now also
possible to seek by relative percentage.

MPSEEK_FACTOR is used as seek_type.

Related feature request:
#1950 

Also made the comment style in player.c more consistent. 

Edit: Made pull request title better