### PR TITLE
command: change OSD symbol for absolute perc. seek

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -4124,8 +4124,10 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
                               precision, false);
             set_osd_function(mpctx, v > 0 ? OSD_FFW : OSD_REW);
         } else if (abs) {           // Absolute seek by percentage
-            queue_seek(mpctx, MPSEEK_FACTOR, v / 100.0, precision, false);
-            set_osd_function(mpctx, OSD_FFW); // Direction isn't set correctly
+            double ratio = v / 100.0;
+            double cur_pos = get_current_pos_ratio(mpctx, false);
+            queue_seek(mpctx, MPSEEK_FACTOR, ratio, precision, false);
+            set_osd_function(mpctx, cur_pos < ratio ? OSD_FFW : OSD_REW);
         } else {
             queue_seek(mpctx, MPSEEK_RELATIVE, v, precision, false);
             set_osd_function(mpctx, (v > 0) ? OSD_FFW : OSD_REW);


### PR DESCRIPTION
The OSD symbol for seeking to an absolute percentage was always OSD_FFW,
even when it should be OSD_REW. It uses the correct OSD symbols now, by
checking the current position ratio.

Note: The symbol is still incorrectly given when the absolute percentage
is very close to the current position ratio. Fortunately, that's a rare
use case.