### PR TITLE
vo_drm: Fix stride problem for certain devices

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -505,7 +505,7 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
                    p->cur_frame->planes[0],
                    (p->dst.x1 - p->dst.x0) * 4,
                    p->dst.y1 - p->dst.y0,
-                   p->device_w * 4,
+                   front_buf->stride,
                    p->cur_frame->stride[0]);
     }
 


### PR DESCRIPTION
The stride was retrieved from the frame buffer correctly, but it was never actually used. Instead, the scaler always assumed that the stride is equal to display row width. This should fix #1979.