### PR TITLE
vo_drm: Fix resolution not restored after exiting

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -385,7 +385,7 @@ static void release_vo_crtc(struct vo *vo)
                        p->old_crtc->y,
                        &p->dev->conn,
                        1,
-                       &p->dev->mode);
+                       &p->old_crtc->mode);
         drmModeFreeCrtc(p->old_crtc);
         p->old_crtc = NULL;
     }


### PR DESCRIPTION
If the mode used by mpv had resolution different from the virtual terminal it was executed in, it wouldn't be restored correctly and user would need to switch to another VT and back after finished playback. It also affected terminal switching. This commit should properly restore the video resolution after playback.