### PR TITLE
vo_drm: Expose mode ID option to users

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1013,3 +1013,7 @@ Available video output drivers are:
     ``devpath=<filename>``
         Path to graphic card device.
         (default: /dev/dri/card0)
+
+    ``mode=<number>``
+        Mode ID to use (resolution, bit depth and frame rate).
+        (default: 0)


### PR DESCRIPTION
Until now `vo_drm` had assumed the best mode ID to be the first one reported by user's device. This might not be true for every device, and besides, user might want to play movies at lower resolution for performance reasons. Therefore, exposing an option to arbitrarily control mode ID makes sense.