### PR TITLE
DOCS/man: Fix errors

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -902,7 +902,7 @@ Property list
     always exactly known, so this is an estimate.
 
 ``playtime-remaining``
-    ``time-remaining`` scaled by the the current ``speed``.
+    ``time-remaining`` scaled by the current ``speed``.
 
 ``playback-time``
     Return the playback time, which is the time difference between start PTS and current PTS.
@@ -1211,7 +1211,7 @@ Property list
 ``balance`` (RW)
     Audio channel balance. (The implementation of this feature is rather odd.
     It doesn't change the volumes of each channel, but instead sets up a pan
-    matrix to mix the the left and right channels.)
+    matrix to mix the left and right channels.)
 
 ``fullscreen`` (RW)
     See ``--fullscreen``.

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -99,7 +99,7 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     functions.
 
     Unlike ``mp.command``, this will not use OSD by default either (except
-    for some OSd-specific commands).
+    for some OSD-specific commands).
 
 ``mp.command_native(table [,def])``
     Similar to ``mp.commandv``, but pass the argument list as table. This has

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -280,7 +280,7 @@ spaces or characters like ``,`` or ``:``, you need to quote them:
     ``mpv '--vo=opengl:icc-profile="file with spaces.icc",xv'``
 
 Shells may actually strip some quotes from the string passed to the commandline,
-so the example quotes the string twice, ensuring that mpv recieves the ``"``
+so the example quotes the string twice, ensuring that mpv receives the ``"``
 quotes.
 
 The ``[...]`` form of quotes wraps everything between ``[`` and ``]``. It's

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -457,7 +457,7 @@ Program Behavior
     (Default: ``best``)
 
 ``--ytdl-raw-options=<key>=<value>[,<key>=<value>[,...]]``
-    Pass arbitraty options to youtube-dl. Parameter and argument should be
+    Pass arbitrary options to youtube-dl. Parameter and argument should be
     passed as a key-value pair. Options without argument must include ``=``.
 
     There is no sanity checking so it's possible to break things (i.e.
@@ -528,7 +528,7 @@ Video
         Old, decoder-based framedrop mode. (This is the same as ``--framedrop=yes``
         in mpv 0.5.x and before.) This tells the decoder to skip frames (unless
         they are needed to decode future frames). May help with slow systems,
-        but can produce unwatchably choppy output, or even freeze the display
+        but can produce unwatchable choppy output, or even freeze the display
         completely. Not recommended.
         The ``--vd-lavc-framedrop`` option controls what frames to drop.
     <decoder+vo>
@@ -1156,7 +1156,7 @@ Subtitles
     the top of the screen) alongside the normal subtitle, and provides a way
     to render two subtitles at once.
 
-    there are some caveats associated with this feature. For example, bitmap
+    There are some caveats associated with this feature. For example, bitmap
     subtitles will always be rendered in their usual position, so selecting a
     bitmap subtitle as secondary subtitle will result in overlapping subtitles.
     Secondary subtitles are never shown on the terminal if video is disabled.
@@ -1871,7 +1871,7 @@ Window
     ``intptr_t``. mpv will create its own window, and set the wid window as
     parent, like with X11.
 
-    On OSX/Cocoa. the ID is interpreted as ``NSView*``. Pass it as value cast
+    On OSX/Cocoa, the ID is interpreted as ``NSView*``. Pass it as value cast
     to ``intptr_t``. mpv will creates its own sub-view. Because OSX does not
     support window embedding of foreign processes, this works only with libmpv,
     and will crash when used from the command line.
@@ -1965,7 +1965,7 @@ Disc Devices
     (Never) accept imperfect data reconstruction.
 
 ``--cdda-cdtext=<yes|no>``
-    Print CD text. This is disabled by default, because it ruins perfomance
+    Print CD text. This is disabled by default, because it ruins performance
     with CD-ROM drives for unknown reasons.
 
 ``--dvd-speed=<speed>``
@@ -2096,7 +2096,7 @@ Demuxer
     seeks only.
 
     You can use the ``--demuxer-mkv-subtitle-preroll-secs`` option to specify
-    how mach data the demuxer should pre-read at most in order to find subtitle
+    how much data the demuxer should pre-read at most in order to find subtitle
     packets that may overlap. Setting this to 0 will effectively disable this
     preroll mechanism. Setting a very large value can make seeking very slow,
     and an extremely large value would completely reread the entire file from

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -5,7 +5,7 @@ The On Screen Controller (short: OSC) is a minimal GUI integrated with mpv to
 offer basic mouse-controllability. It is intended to make interaction easier
 for new users and to enable precise and direct seeking.
 
-The OSC is enabled by default if mpv was compiled with lua support. It can be
+The OSC is enabled by default if mpv was compiled with Lua support. It can be
 disabled entirely using the ``--osc=no`` option.
 
 Using the OSC

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -780,7 +780,7 @@ Available filters are:
 ``vapoursynth-lazy``
     The same as ``vapoursynth``, but doesn't load Python scripts. Instead, a
     custom backend using Lua and the raw VapourSynth API is used. The syntax
-    is completely different, and absolutely no conveniencve features are
+    is completely different, and absolutely no convenience features are
     provided. There's no type checking either, and you can trigger crashes.
 
     .. admonition:: Example:


### PR DESCRIPTION
Fixed some errors in the man pages by spell checking them. Most of them
were typos.