### PR TITLE
DOCS/mplayer-changes: Add removal of X11 vo

### DIFF
--- a/DOCS/mplayer-changes.rst
+++ b/DOCS/mplayer-changes.rst
@@ -94,6 +94,8 @@ Video
 
 * Image subtitles (DVDs etc.) are rendered in color and use more correct
   positioning (color for image subs can be disabled with ``--sub-gray``).
+* Support for the X11 video output is removed, since it was considered
+  deprecated. SDL video output can still be used as a fallback.
 
 OSD and terminal
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The X11 video output was removed recently and is a difference
from mplayer. That's why it should be documented in the
mplayer-changes document.