### PR TITLE
-achans option

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1570,6 +1570,10 @@ Property list
     ``track-list/N/lang``
         Track language as identified by the file. Not always available.
 
+    ``track-list/N/channels``
+        For audio tracks, the number of audio channels in the audio stream.
+        Not always accurate. Not always available.
+
     ``track-list/N/albumart``
         ``yes`` if this is a video track that consists of a single picture,
         ``no`` or unavailable otherwise. This is used for video tracks that are
@@ -1618,6 +1622,7 @@ Property list
                 "src-id"            MPV_FORMAT_INT64
                 "title"             MPV_FORMAT_STRING
                 "lang"              MPV_FORMAT_STRING
+                "channels"          MPV_FORMAT_INT64
                 "albumart"          MPV_FORMAT_FLAG
                 "default"           MPV_FORMAT_FLAG
                 "forced"            MPV_FORMAT_FLAG

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -31,6 +31,18 @@ Track Selection
         - ``mpv --slang=jpn example.mkv`` plays a Matroska file with Japanese
           subtitles.
 
+``--achans=<channels[,channels,...]>``
+    Specify a priority list of number of audio channels to use.
+    ``--alang`` takes priority over this.
+
+    .. admonition:: Examples
+
+        ``mpv dvd://1 --achans=2,6``
+            Chooses the audio track with 2 channels on a DVD and falls back
+            on one with 6 channels if one with 2 channels is not available.
+        ``mpv --achans=2 example.mkv``
+            Plays a Matroska file choosing the audio track with 2 channels.
+
 ``--aid=<ID|auto|no>``
     Select audio track. ``auto`` selects the default, ``no`` disables audio.
     See also ``--alang``. mpv normally prints available audio tracks on the

--- a/etc/example.conf
+++ b/etc/example.conf
@@ -97,6 +97,10 @@
 # Play Finnish audio if available, fall back to English otherwise.
 #alang=fi,en
 
+# Play the audio track with 2 channels if available, fall back to an audio
+# track with 6 channels otherwise.
+#achans=2,6
+
 # Change subtitle encoding. For Arabic subtitles use 'cp1256'.
 # If the file seems to be valid UTF-8, prefer UTF-8.
 #sub-codepage=utf8:cp1256

--- a/options/options.c
+++ b/options/options.c
@@ -206,6 +206,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG_STORE("no-audio", stream_id[0][STREAM_AUDIO], 0, -2),
     OPT_STRINGLIST("alang", stream_lang[STREAM_AUDIO], 0),
     OPT_STRINGLIST("slang", stream_lang[STREAM_SUB], 0),
+    OPT_STRINGLIST("achans", stream_achans, 0),
 
     OPT_CHOICE("audio-display", audio_display, 0,
                ({"no", 0}, {"attachment", 1})),

--- a/options/options.h
+++ b/options/options.h
@@ -175,6 +175,7 @@ typedef struct MPOpts {
     int stream_id[2][STREAM_TYPE_COUNT];
     int stream_id_ff[STREAM_TYPE_COUNT];
     char **stream_lang[STREAM_TYPE_COUNT];
+    char **stream_achans;
     int audio_display;
     char **display_tags;
     int sub_visibility;

--- a/player/command.c
+++ b/player/command.c
@@ -1853,6 +1853,15 @@ static int property_switch_track_ff(void *ctx, struct m_property *prop,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
+static int track_channels(struct track *track)
+{
+    if (track->type == STREAM_AUDIO)
+    {
+        return track->stream->audio->channels.num;
+    }
+    return 0;
+}
+
 static int get_track_entry(int item, int action, void *arg, void *ctx)
 {
     struct MPContext *mpctx = ctx;
@@ -1870,6 +1879,8 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
                         .unavailable = !track->title},
         {"lang",        SUB_PROP_STR(track->lang),
                         .unavailable = !track->lang},
+        {"channels",    SUB_PROP_INT(track_channels(track)),
+                        .unavailable = track_channels(track) <= 0},
         {"albumart",    SUB_PROP_FLAG(track->attached_picture)},
         {"default",     SUB_PROP_FLAG(track->default_track)},
         {"forced",      SUB_PROP_FLAG(track->forced_track)},

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -418,6 +418,15 @@ static int match_lang(char **langs, char *lang)
     return 0;
 }
 
+static int match_achans(char **achans, uint8_t tachans)
+{
+    for (int idx = 0; achans && achans[idx]; idx++) {
+        if (tachans && (uint8_t)atoi(achans[idx]) == tachans)
+            return INT_MAX - idx;
+    }
+    return 0;
+}
+
 /* Get the track wanted by the user.
  * tid is the track ID requested by the user (-2: deselect, -1: default)
  * lang is a string list, NULL is same as empty list
@@ -427,16 +436,18 @@ static int match_lang(char **langs, char *lang)
  * 1) track is external (no_default cancels this)
  * 1b) track was passed explicitly (is not an auto-loaded subtitle)
  * 2) earlier match in lang list
- * 3a) track is marked forced
- * 3b) track is marked default
- * 4) attached picture, HLS bitrate
- * 5) lower track number
- * If select_fallback is not set, 5) is only used to determine whether a
+ * 3) track is audio, earlier match in achans list
+ * 4a) track is marked forced
+ * 4b) track is marked default
+ * 5) attached picture, HLS bitrate
+ * 6) lower track number
+ * If select_fallback is not set, 6) is only used to determine whether a
  * matching track is preferred over another track. Otherwise, always pick a
  * track (if nothing else matches, return the track with lowest ID).
  */
 // Return whether t1 is preferred over t2
-static bool compare_track(struct track *t1, struct track *t2, char **langs,
+static bool compare_track(struct track *t1, struct track *t2,
+                          char **langs, char **achans,
                           struct MPOpts *opts)
 {
     bool ext1 = t1->is_external && !t1->no_default;
@@ -448,6 +459,12 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs,
     int l1 = match_lang(langs, t1->lang), l2 = match_lang(langs, t2->lang);
     if (l1 != l2)
         return l1 > l2;
+    if (t1->type == STREAM_AUDIO && t2->type == STREAM_AUDIO) {
+        int c1 = match_achans(achans, t1->stream->audio->channels.num);
+        int c2 = match_achans(achans, t2->stream->audio->channels.num);
+        if (c1 != c2)
+            return c1 > c2;
+    }
     if (t1->forced_track != t2->forced_track)
         return t1->forced_track;
     if (t1->default_track != t2->default_track)
@@ -468,6 +485,7 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
     int tid = opts->stream_id[order][type];
     int ffid = order == 0 ? opts->stream_id_ff[type] : -1;
     char **langs = order == 0 ? opts->stream_lang[type] : NULL;
+    char **achans = order == 0 ? opts->stream_achans : NULL;
     if (ffid != -1)
         tid = -1; // prefer selecting ffid
     if (tid == -2 || ffid == -2)
@@ -482,11 +500,13 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
             return track;
         if (track->ff_index == ffid)
             return track;
-        if (!pick || compare_track(track, pick, langs, mpctx->opts))
+        if (!pick || compare_track(track, pick, langs, achans, mpctx->opts))
             pick = track;
     }
     if (pick && !select_fallback && !(pick->is_external && !pick->no_default)
-        && !match_lang(langs, pick->lang) && !pick->default_track
+        && !match_lang(langs, pick->lang) && (type == STREAM_AUDIO
+            && !match_achans(achans, pick->stream->audio->channels.num))
+        && !pick->default_track
         && !pick->forced_track)
         pick = NULL;
     if (pick && pick->attached_picture && !mpctx->opts->audio_display)

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -242,13 +242,17 @@ function get_tracklist(type)
     else
         for n = 1, #tracks_osc[type] do
             local track = tracks_osc[type][n]
-            local lang, title, selected = "unknown", "", "○"
+            local lang, title, channels, selected = "unknown", "", "", "○"
             if not(track.lang == nil) then lang = track.lang end
             if not(track.title == nil) then title = track.title end
+            if not(track.channels == nil) then
+                channels = "-"..track.channels.."ch"
+            end
             if (track.id == tonumber(mp.get_property(type))) then
                 selected = "●"
             end
-            msg = msg.."\n"..selected.." "..n..": ["..lang.."] "..title
+            msg = msg.."\n"..selected.." "..n..
+                ": ["..lang..channels.."] "..title
         end
     end
     return msg


### PR DESCRIPTION
>Added the option to specify a priority list of the number of audio
>channels of the audio tracks. -alang takes priority over it.
>So for example "--alang=jpn --achans=2" would prioritize the Japanese
>audio track with 2 channels over, say, an English track with 2 channels
>and a Japanese one with 6 channels.

I've often had a problem with media files that offer multiple audio choices for each language and no clear indication of what is the difference between them (no title, same format).
Usually it's the classic 2.0 and 5.1 tracks, and time is lost trying to figure out which is which.
This pretty much solves it for me, since I can set it up on each machine depending on the audio equipment.
The implementation is pretty straightforward, since I basically copied what was done for -alang/-slang.