### PR TITLE
DOCS/man: Re-wrapped and fixed some spelling and punctuation errors.

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -561,7 +561,7 @@ Input Commands that are Possibly Subject to Change
     different memory region to prevent tearing).
 
     It is also possible to pass a raw memory address for use as bitmap memory
-    by passing a memory address as integer prefixed with a ``&`` character.
+    by passing a memory address as integer prefixed with an ``&`` character.
     Passing the wrong thing here will crash the player. This mode might be
     useful for use with libmpv. The ``offset`` parameter is simply added to the
     memory address (since mpv 0.8.0, ignored before).

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -309,7 +309,7 @@ Suboptions passed to the client API are also subject to escaping. Using
 command line (but without shell processing of the string). Some options
 support passing values in a more structured way instead of flat strings, and
 can avoid the suboption parsing mess. For example, ``--vf`` supports
-``MPV_FORMAT_NODE``, which let's you pass suboptions as a nested data structure
+``MPV_FORMAT_NODE``, which lets you pass suboptions as a nested data structure
 of maps and arrays. (``--vo`` supports this in the same way, although this
 fact is undocumented.)
 
@@ -536,7 +536,7 @@ listed.
   frame couldn't be displayed on time. (``vo-drop-frame-count`` property.)
   If the decoder drops frames, the number of decoder-dropped frames is appended
   to the display as well, e.g.: ``Dropped: 4/34``. This happens only if
-  decoder-framedropping is enabled with the ``--framedrop`` options.
+  decoder frame dropping is enabled with the ``--framedrop`` options.
   (``drop-frame-count`` property.)
 - Cache state, e.g. ``Cache:  2s+134KB``. Visible if the stream cache is enabled.
   The first value shows the amount of video buffered in the demuxer in seconds,

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -152,7 +152,7 @@ Available filters are:
     number (1.33). Alternatively, you may specify the exact display width and
     height desired. Note that this filter does *not* do any scaling itself; it
     just affects what later scalers (software or hardware) will do when
-    auto-scaling to correct aspect.
+    auto-scaling to the correct aspect.
 
     ``<w>,<h>``
         New display width and height.


### PR DESCRIPTION
Re-wrapped quite a lot of lines to 80 characters in the man-pages where
there were inconsistencies in line lengths. Also added some missing
punctuation (such as missing full stops) to several places and fixed one
or two spelling errors.