### PR TITLE
player: use exit code 0 by default for quit, 4 for signals, etc.

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -808,7 +808,8 @@ If errors happen, the following exit codes can be returned:
         immediately after initialization.
     :3: There were some files that could be played, and some files which
         couldn't (using the definition of success from above).
-    :4: The ``quit`` command was issued (default exit code).
+    :4: Quit due to a signal, Ctrl+c in a VO window (by default), or from the
+        default quit key bindings in encoding mode.
 
 Note that quitting the player manually will always lead to exit code 0,
 overriding the exit code that would be returned normally. Also, the ``quit``

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -69,9 +69,9 @@
 #BS set speed 1.0                       # reset speed to normal
 #q quit
 #Q quit-watch-later
-#q {encode} quit
+#q {encode} quit 4
 #ESC set fullscreen no
-#ESC {encode} quit
+#ESC {encode} quit 4
 #p cycle pause                          # toggle pause/playback mode
 #. frame-step                           # advance one frame and pause
 #, frame-back-step                      # go back by one frame and pause
@@ -138,11 +138,11 @@
 #VOLUME_DOWN add volume -2
 #MUTE cycle mute
 #CLOSE_WIN quit
-#CLOSE_WIN {encode} quit
+#CLOSE_WIN {encode} quit 4
 #E cycle edition                        # next edition
 #l ab_loop                              # Set/clear A-B loop points
 #L cycle-values loop "inf" "no"         # toggle infinite looping
-#ctrl+c quit
+#ctrl+c quit 4
 
 # Apple Remote section
 #AR_PLAY cycle pause

--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -76,8 +76,8 @@ const struct mp_cmd_def mp_cmds[] = {
   { MP_CMD_REVERT_SEEK, "revert-seek", {
       OARG_FLAGS(0, ({"mark", 1})),
   }},
-  { MP_CMD_QUIT, "quit", { OARG_INT(4) } },
-  { MP_CMD_QUIT_WATCH_LATER, "quit-watch-later", { OARG_INT(4) } },
+  { MP_CMD_QUIT, "quit", { OARG_INT(0) } },
+  { MP_CMD_QUIT_WATCH_LATER, "quit-watch-later", { OARG_INT(0) } },
   { MP_CMD_STOP, "stop", },
   { MP_CMD_FRAME_STEP, "frame-step", .allow_auto_repeat = true,
     .on_updown = true },

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -399,7 +399,7 @@ static void *terminal_thread(void *ptr)
             stdin_ok = getch2(input_ctx);
     }
     // Important if we received SIGTERM, rather than regular quit.
-    struct mp_cmd *cmd = mp_input_parse_cmd(input_ctx, bstr0("quit"), "");
+    struct mp_cmd *cmd = mp_input_parse_cmd(input_ctx, bstr0("quit 4"), "");
     if (cmd)
         mp_input_queue_cmd(input_ctx, cmd);
     return NULL;


### PR DESCRIPTION
Default key bindings in encoding mode also use code 4, because scripts will probably want to fail if encoding is aborted (leaving an incomplete file).

Ref. #2029 