### PR TITLE
vf_vdpaupp: Don't crash when evaluating interlacing of NULL mpi

### DIFF
--- a/video/filter/vf_vdpaupp.c
+++ b/video/filter/vf_vdpaupp.c
@@ -151,7 +151,7 @@ static int filter_ext(struct vf_instance *vf, struct mp_image *mpi)
         p->prev_pos += 2;
     }
 
-    bool deint = (mpi->fields & MP_IMGFIELD_INTERLACED) || !p->interlaced_only;
+    bool deint = (mpi && (mpi->fields & MP_IMGFIELD_INTERLACED)) || !p->interlaced_only;
 
     while (1) {
         int current = p->prev_pos - 1;


### PR DESCRIPTION
The interlaced frame test needs to be aware that the input mpi might be
NULL - this happens at the end of a stream when the input frames have
all been submitted but frames still need to be drained from the
decoder.