### PR TITLE
[ytdl_hook] Add the ability to control ytdl subs

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -97,7 +97,7 @@ mp.add_hook("on_load", 10, function ()
         local raw_options = mp.get_property_native("options/ytdl-raw-options")
 
         local command = {
-            ytdl.path, "--no-warnings", "-J", "--flat-playlist", "--all-subs",
+            ytdl.path, "--no-warnings", "-J", "--flat-playlist",
             "--sub-format", "ass/srt/best", "--no-playlist"
         }
 


### PR DESCRIPTION
it will allow the possibility to control the youtube-dl subs in diffrent ways.
the default is to not fetch any sub if most of the videos are in languages that he understand.
to fetch all subs:
ytdl-raw-options=all-subs=
to fetch only a specefic language:
ytdl-raw-options=sub-lang=lang1,write-sub=
to fetch only multiple languages:
ytdl-raw-options=sub-lang="lang1,lang2,...",write-sub=