### PR TITLE
Changed default encoding detection behavior to try uchardet if ENCA failed

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1438,10 +1438,11 @@ Subtitles
 
 ``--sub-codepage=<codepage>``
     If your system supports ``iconv(3)``, you can use this option to specify
-    the subtitle codepage. By default, ENCA will be used to guess the charset.
-    If mpv is not compiled with ENCA, ``UTF-8:UTF-8-BROKEN`` is the default,
-    which means it will try to use UTF-8, otherwise the ``UTF-8-BROKEN``
-    pseudo codepage (see below).
+    the subtitle codepage. By default, uchardet will be used to guess the
+    charset. If mpv is not compiled with uchardet, enca will be used.
+    If mpv is compiled with neither uchardet nor enca, ``UTF-8:UTF-8-BROKEN``
+    is the default, which means it will try to use UTF-8, otherwise the
+    ``UTF-8-BROKEN`` pseudo codepage (see below).
 
     The default value for this option is ``auto``, whose actual effect depends
     on whether ENCA is compiled.

--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -193,7 +193,9 @@ const char *mp_charset_guess(void *talloc_ctx, struct mp_log *log, bstr buf,
 
     bool use_auto = strcasecmp(user_cp, "auto") == 0;
     if (use_auto) {
-#if HAVE_ENCA
+#if HAVE_UCHARDET
+        user_cp = "uchardet";
+#elif HAVE_ENCA
         user_cp = "enca";
 #else
         user_cp = "UTF-8:UTF-8-BROKEN";


### PR DESCRIPTION
Hi,

I understand that ENCA should still stay the default detection algorithm for the time being (even with uchardet built now in #908).
And actually checking the list of encoding supported by ENCA, even though has much more, there still seems to be some not supported by uchardet (for instance I can't find CP1257/Windows-1257 in uchardet list, unless it has other naming).

But I propose this improvement with the default detection: if ENCA fails, then uchardet is tried.
I tried with some Korean subtitle and it worked great: ENCA not being able to recognize the encoding, it returned NULL and uchardet took the relay, and got the right encoding! :-)