### PR TITLE
charset_conv: remove custom UTF-8 detection.

### DIFF
--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -202,12 +202,6 @@ const char *mp_charset_guess(void *talloc_ctx, struct mp_log *log, bstr buf,
 #endif
     }
 
-    // Do our own UTF-8 detection, because at least ENCA seems to get it
-    // wrong sometimes (suggested by divVerent).
-    int r = bstr_validate_utf8(buf);
-    if (r >= 0 || (r > -8 && (flags & MP_ICONV_ALLOW_CUTOFF)))
-        return "UTF-8";
-
     bstr params[3] = {{0}};
     split_colon(user_cp, 3, params);
 


### PR DESCRIPTION
I was testing a little more and this time with a Japanese subtitle in ISO-2022-JP.
MPV would detect it as UTF-8 because of the custom UTF-8 validation in current mpv code: bstr_validate_utf8().

The comment says that ENCA sometimes get it wrong. Well now ENCA is not the default anymore, so that's good. Also obviously this custom code also gets it wrong sometimes.
If needed for anyone wanting to validate, I can send a copy of the subtitle file in ISO-2022-JP (github does not even accept attachments other than images. I will never understand this for a bug tracker!).

My commit does not remove the implementation of bstr_validate_utf8() itself, even though I see it is used nowhere else, since maybe you were still planning to improve it or use it elsewhere. But I can remove it if you don't care.
