### PR TITLE
[TOOLS/autoload] Don't run if playlist is loaded

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -47,6 +47,10 @@ function find_and_add_entries()
     if #dir == 0 then
         return
     end
+    local isplaylist = mp.get_property("playlist-count")
+    if #isplaylist > 1 then
+        return
+    end
 
     local files = mputils.readdir(dir, "files")
     if files == nil then


### PR DESCRIPTION
This assumes people run autoload.lua automatically and wouldn't want their playlist messed up by the script.

Example: this is useful when opening a single file in a directory with other videos, but if you open several with the same command or an actual playlist, then you probably don't want autoload.lua to open files that aren't in that command or playlist.