### PR TITLE
options: remove the period at the end of "No file."

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -676,7 +676,7 @@ const struct MPOpts mp_default_opts = {
         .window_scale = 1.0,
     },
     .allow_win_drag = 1,
-    .wintitle = "${?media-title:${media-title}}${!media-title:No file.} - mpv",
+    .wintitle = "${?media-title:${media-title}}${!media-title:No file} - mpv",
     .heartbeat_interval = 30.0,
     .stop_screensaver = 1,
     .cursor_autohide_delay = 1000,


### PR DESCRIPTION
Since we're on the topic of consistency, I've seen multiple users
complain about the presence of this period, which does not really match
other programs' behavior.