### PR TITLE
vo_opengl: fancy-downscaling: enable also for anamorphic clips

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -520,9 +520,9 @@ Available video output drivers are:
         When using convolution based filters, extend the filter size
         when downscaling. Trades quality for reduced downscaling performance.
 
-        This is automatically disabled for anamorphic video, because this
-        feature doesn't work correctly with different scale factors in
-        different directions.
+        This will perform slightly sub-optimally for anamorphic video (but still
+        better than without it) since it will extend the size to match only the
+        milder of the scale factors between the axes.
 
     ``source-shader=<file>``, ``scale-shader=<file>``, ``pre-shaders=<files>``, ``post-shaders=<files>``
         Custom GLSL fragment shaders.

--- a/video/out/gl_video.c
+++ b/video/out/gl_video.c
@@ -1707,11 +1707,16 @@ static void pass_scale_main(struct gl_video *p)
         scaler = &p->scaler[1];
     }
 
-    double f = MPMIN(xy[0], xy[1]);
-    if (p->opts.fancy_downscaling && f < 1.0 &&
-        fabs(xy[0] - f) < 0.01 && fabs(xy[1] - f) < 0.01)
+    // When requesting fancy-downscaling and the clip is anamorphic, and because
+    // only a single fancy scale factor is used for both axes, enable fancy only
+    // when both axes are downscaled, and use the milder of the factors to not
+    // end up with too much blur on one axis (even if we end up with sub-optimal
+    // fancy factor on the other axis).
+    // This is better than not respecting fancy at all for anamorphic clips.
+    double f = MPMAX(xy[0], xy[1]);
+    if (p->opts.fancy_downscaling && f < 1.0)
     {
-        scale_factor = FFMAX(1.0, 1.0 / f);
+        scale_factor = 1.0 / f;
     }
 
     // Pre-conversion, like linear light/sigmoidization


### PR DESCRIPTION
Sub optimal, but since it only improves on the original kernel and never regresses the scaling, it's better than not respecting `fancy-downscaling` at all for anamorphic clips.