### PR TITLE
TOOLS/lua/autoload: fix adding more files at end of auto-playlist

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -47,9 +47,12 @@ function find_and_add_entries()
     if #dir == 0 then
         return
     end
-    local isplaylist = mp.get_property("playlist-count")
-    if #isplaylist > 1 then
+    local pl_count = mp.get_property_number("playlist-count", 1)
+    if (pl_count > 1 and autoload == nil) or
+       (pl_count == 1 and EXTENSIONS[string.lower(get_extension(filename))] == nil) then
         return
+    else
+        autoload = true
     end
 
     local files = mputils.readdir(dir, "files")


### PR DESCRIPTION
Fixes regression in dfd8a5f that made autoload not add more files at the end of the current playlist if playlist was made by the script.

This still prevents loading the script if more than one (media or playlist) file was manually added.

Fixes #2219 