### PR TITLE
vo_wayland: Fix stuttering playback

### DIFF
--- a/video/out/gl_common.h
+++ b/video/out/gl_common.h
@@ -136,11 +136,6 @@ typedef struct MPGLContext {
     // Resize the window, or create a new window if there isn't one yet.
     // On the first call, it creates a GL context.
     bool (*config_window)(struct MPGLContext *ctx, int flags);
-
-    // Optional callback on the beginning of a frame. The frame will be finished
-    // with swapGlBuffers(). This returns false if use of the OpenGL context
-    // should be avoided.
-    bool (*start_frame)(struct MPGLContext *);
 } MPGLContext;
 
 MPGLContext *mpgl_init(struct vo *vo, const char *backend_name, int vo_flags);

--- a/video/out/gl_wayland.c
+++ b/video/out/gl_wayland.c
@@ -210,6 +210,11 @@ static void swapGlBuffers_wayland(MPGLContext *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wayland;
 
+    if (!wl->frame.callback)
+        vo_wayland_request_frame(ctx->vo, NULL, NULL);
+
+    if (!vo_wayland_wait_frame(ctx->vo))
+        MP_DBG(wl, "discarding frame callback\n");
 
     eglSwapBuffers(wl->egl_context.egl.dpy, wl->egl_context.egl_surface);
 }

--- a/video/out/vo_opengl.c
+++ b/video/out/vo_opengl.c
@@ -169,9 +169,6 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     struct gl_priv *p = vo->priv;
     GL *gl = p->gl;
 
-    if (p->glctx->start_frame && !p->glctx->start_frame(p->glctx))
-        return;
-
     p->frame_started = true;
     gl_video_render_frame(p->renderer, frame, 0);
 

--- a/video/out/vo_wayland.c
+++ b/video/out/vo_wayland.c
@@ -389,14 +389,12 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
         p->original_image = mpi;
     }
 
-    if (!p->wl->frame.pending)
-        return;
+    if (!vo_wayland_wait_frame(vo))
+        MP_DBG(p->wl, "discarding frame callback\n");
 
     shm_buffer_t *buf = buffer_pool_get_back(&p->video_bufpool);
 
     if (!buf) {
-        // TODO: use similar handling of busy buffers as the osd buffers
-        // if the need arises
         MP_VERBOSE(p->wl, "can't draw, back buffer is busy\n");
         return;
     }
@@ -504,25 +502,31 @@ static void draw_osd(struct vo *vo)
     osd_draw(vo->osd, p->osd, pts, 0, osd_formats, draw_osd_cb, p);
 }
 
-static void flip_page(struct vo *vo)
+static void redraw(void *data, uint32_t time)
 {
-    struct priv *p = vo->priv;
-
-    if (!p->wl->frame.pending)
-        return;
-
-    buffer_pool_swap(&p->video_bufpool);
+    struct priv *p = data;
 
     shm_buffer_t *buf = buffer_pool_get_front(&p->video_bufpool);
     wl_surface_attach(p->wl->window.video_surface, buf->buffer, p->x, p->y);
     wl_surface_damage(p->wl->window.video_surface, 0, 0, p->dst_w, p->dst_h);
-    wl_surface_commit(p->wl->window.video_surface);
     buffer_finalise_front(buf);
 
     p->x = 0;
     p->y = 0;
     p->recent_flip_time = mp_time_us();
-    p->wl->frame.pending = false;
+}
+
+static void flip_page(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+
+    buffer_pool_swap(&p->video_bufpool);
+
+    if (!p->wl->frame.callback)
+        vo_wayland_request_frame(vo, p, redraw);
+
+    if (!vo_wayland_wait_frame(vo))
+        MP_DBG(p->wl, "discarding frame callback\n");
 }
 
 static int query_format(struct vo *vo, int format)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -47,14 +47,19 @@ struct vo_wayland_output {
     struct wl_list link;
 };
 
+typedef void (*vo_wayland_frame_cb)(void *data, uint32_t time);
 
 struct vo_wayland_state {
     struct vo *vo;
     struct mp_log* log;
 
     struct {
+        void *data;
+        vo_wayland_frame_cb function;
         struct wl_callback *callback;
+        uint64_t last_us;
         bool pending;
+        bool dropping;
     } frame;
 
 #if HAVE_GL_WAYLAND
@@ -144,6 +149,8 @@ int vo_wayland_init(struct vo *vo);
 void vo_wayland_uninit(struct vo *vo);
 bool vo_wayland_config(struct vo *vo, uint32_t flags);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
+void vo_wayland_request_frame(struct vo *vo, void *data, vo_wayland_frame_cb cb);
+bool vo_wayland_wait_frame(struct vo *vo);
 
 #endif /* MPLAYER_WAYLAND_COMMON_H */
 


### PR DESCRIPTION
Implements small api for vo_wayland to request and wait for frame callbacks.
Uses eglSwapInterval(0) in vo_opengl so we can avoid dropping frames and avoid refactoring rendering to be asynchronous. This effectively disables blocking for frame callback inside mesa and instead just makes compositor use more buffers (?). However we wait for frame callback ourself on gl_wayland as well, to avoid possible overhead to compositor.

- Fixes issue #2227 
- Reverts some changes done in #1711 that originally introduced this behaviour.

