### PR TITLE
options: sub-file replaces subfile, instead of sub

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -629,7 +629,7 @@ const m_option_t mp_opts[] = {
     OPT_REPLACED("sub", "sub-file"),
     OPT_REPLACED("subcp", "sub-codepage"),
     OPT_REPLACED("subdelay", "sub-delay"),
-    OPT_REPLACED("subfile", "sub"),
+    OPT_REPLACED("subfile", "sub-file"),
     OPT_REPLACED("subfont-text-scale", "sub-scale"),
     OPT_REPLACED("subfont", "sub-text-font"),
     OPT_REPLACED("subfps", "sub-fps"),


### PR DESCRIPTION
Currently, using `--subfile` recommends using replacement `--sub`, 
but `--sub` has been replaced by `--sub-file`.

```
$ mpv ... --subfile=foo.srt
The --subfile option was renamed or replaced: --sub

$ mpv ... --sub=foo.srt
The --sub option was renamed or replaced: --sub-file

$ mpv ... --sub-file=foo.srt
```