### PR TITLE
OSC: exit tick immediately if disabled.

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1895,6 +1895,8 @@ end
 
 -- called by mpv on every frame
 function tick()
+    if (not state.enabled) then return end
+
     if (state.idle) then
 
         -- render idle message


### PR DESCRIPTION
Even after it has been disabled with the `disable-osc` message, the OSC continues to run the tick function. Completely preventing tick from being called is impractical since there are several different places that it's called in the code, so just make it immediately return if the OSC has been disabled.

This prevents the OSC from continuing the clear the OSD on every tick, allowing other scripts to disable it so that they may draw to the OSD.