### PR TITLE
Drag and drop playlist append

### DIFF
--- a/input/event.c
+++ b/input/event.c
@@ -20,7 +20,8 @@
 #include "common/msg.h"
 #include "sub/find_subfiles.h"
 
-void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files)
+void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files,
+                         bool append)
 {
     bool all_sub = true;
     for (int i = 0; i < num_files; i++)
@@ -42,8 +43,9 @@ void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files)
                 "osd-auto",
                 "loadfile",
                 files[i],
-                /* Start playing the dropped files right away */
-                (i == 0) ? "replace" : "append",
+                /* Either start playing the dropped files right away
+                   or add them to the end of the current playlist */
+                (i == 0) ? (append ? "append-play" : "replace") : "append",
                 NULL
             };
             mp_input_run_cmd(ictx, cmd);
@@ -52,7 +54,7 @@ void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files)
 }
 
 int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,
-                            bstr data)
+                            bstr data, bool append)
 {
     // X11 and Wayland file list format.
     if (strcmp(mime_type, "text/uri-list") == 0) {
@@ -67,7 +69,7 @@ int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,
             char *s = bstrto0(tmp, line);
             MP_TARRAY_APPEND(tmp, files, num_files, s);
         }
-        mp_event_drop_files(ictx, num_files, files);
+        mp_event_drop_files(ictx, num_files, files, append);
         talloc_free(tmp);
         return num_files > 0;
     } else {

--- a/input/event.h
+++ b/input/event.h
@@ -20,9 +20,10 @@
 struct input_ctx;
 
 // Enqueue files for playback after drag and drop
-void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files);
+void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files,
+                         bool append);
 
 // Drop data in a specific format (identified by the mimetype).
 // Returns <0 on error, ==0 if data was ok but empty, >0 on success.
 int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,
-                            bstr data);
+                            bstr data, bool append);

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -472,7 +472,7 @@ void cocoa_set_input_context(struct input_ctx *input_context)
     }];
     [_input_lock lock];
     if (_inputContext)
-        mp_event_drop_files(_inputContext, num_files, files_utf8);
+        mp_event_drop_files(_inputContext, num_files, files_utf8, false);
     [_input_lock unlock];
     talloc_free(files_utf8);
 }

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1972,6 +1972,7 @@ validate_user_opts()
 
 mp.register_event("start-file", request_init)
 mp.register_event("tracks-changed", request_init)
+mp.observe_property("playlist", nil, request_init)
 
 mp.register_script_message("enable-osc", function() enable_osc(true) end)
 mp.register_script_message("disable-osc", function() enable_osc(false) end)

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -253,7 +253,7 @@ static HRESULT STDMETHODCALLTYPE DropTarget_Drop(IDropTarget* This,
             }
 
             GlobalUnlock(medium.hGlobal);
-            mp_event_drop_files(t->w32->input_ctx, nrecvd_files, files);
+            mp_event_drop_files(t->w32->input_ctx, nrecvd_files, files, false);
 
             talloc_free(files);
         }
@@ -265,7 +265,7 @@ static HRESULT STDMETHODCALLTYPE DropTarget_Drop(IDropTarget* This,
         char* url = (char*)GlobalLock(medium.hGlobal);
         if (url != NULL) {
             if (mp_event_drop_mime_data(t->w32->input_ctx, "text/uri-list",
-                                        bstr0(url)) > 0) {
+                                        bstr0(url), false) > 0) {
                 MP_VERBOSE(t->w32, "received dropped URL: %s\n", url);
             } else {
                 MP_ERR(t->w32, "error getting dropped URL\n");

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1176,7 +1176,7 @@ static int vo_wayland_check_events (struct vo *vo)
                         buffer[str_len] = 0;
                         struct bstr file_list = bstr0(buffer);
                         mp_event_drop_mime_data(vo->input_ctx, "text/uri-list",
-                                                file_list);
+                                                file_list, false);
                         break;
                     }
                 }

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -793,6 +793,8 @@ static void vo_x11_dnd_handle_message(struct vo *vo, XClientMessageEvent *ce)
             dnd_select_format(x11, args, 3);
         }
     } else if (ce->message_type == XA(x11, XdndPosition)) {
+        x11->dnd_requested_action = ce->data.l[4];
+
         Window src = ce->data.l[0];
         XEvent xev;
 
@@ -836,9 +838,10 @@ static void vo_x11_dnd_handle_selection(struct vo *vo, XSelectionEvent *se)
         void *prop = x11_get_property(x11, x11->window, XAs(x11, DND_PROPERTY),
                                       x11->dnd_requested_format, 8, &nitems);
         if (prop) {
+            bool append = x11->dnd_requested_action != XA(x11, XdndActionCopy);
             // No idea if this is guaranteed to be \0-padded, so use bstr.
             success = mp_event_drop_mime_data(vo->input_ctx, "text/uri-list",
-                                              (bstr){prop, nitems}, false) > 0;
+                                              (bstr){prop, nitems}, append) > 0;
             XFree(prop);
         }
     }

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -838,7 +838,7 @@ static void vo_x11_dnd_handle_selection(struct vo *vo, XSelectionEvent *se)
         if (prop) {
             // No idea if this is guaranteed to be \0-padded, so use bstr.
             success = mp_event_drop_mime_data(vo->input_ctx, "text/uri-list",
-                                              (bstr){prop, nitems}) > 0;
+                                              (bstr){prop, nitems}, false) > 0;
             XFree(prop);
         }
     }

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -112,6 +112,7 @@ struct vo_x11_state {
 
     /* drag and drop */
     Atom dnd_requested_format;
+    Atom dnd_requested_action;
     Window dnd_src_window;
 
     /* dragging the window */


### PR DESCRIPTION
As per #2166, this adds append to playlist functionality through a modified drag and drop.

I have started with just x11. In this PR all other platforms preserve the existing "replace" behaviour for now. 

The only way I could find to achieve this is to use the Action member in the XdndPosition client message. This is typically XdndActionCopy, however Thunar, Nautilus and Dolphin change this to XdndActionMove if you press the shift key. Dolphin will additionally send XdndActionLink if you press alt. Therefore, XdndActionCopy corresponds to the existing "replace" behaviour, while anything else is considered "append".

This seems kind of hackish to me, but I can't figure out any way to determine the modifier keys at drop time directly since the mpv window does not have focus and none of the above file managers appear to send this information along in the XdndPosition as they are supposed to according to http://jjlindal.net/jafl/xdnd/.