### PR TITLE
manpage: add note about field dominance applicability

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -761,6 +761,13 @@ Video
     :top:     top field first
     :bottom:  bottom field first
 
+    .. note::
+
+        This option only changes the field dominance, leaving the interlaced flag
+        untouched. Therefore it may not have the intended effect if the
+        underlying stream is incorrectly labelled progressive. For these cases,
+        you may want to use ``--vf=lavfi=[setfield=bff]`` (or ``tff``) instead.
+
 ``--frames=<number>``
     Play/convert only first ``<number>`` video frames, then quit.
 


### PR DESCRIPTION
Addresses #2289. 

This seems to be a case of bad encoding / source material, so just add a note warning that the option might not always do what you expect in such circumstances.