### PR TITLE
vo_opengl: implement debanding (and remove source-shader)

### DIFF
--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -578,6 +578,14 @@ void gl_sc_hadd(struct gl_shader_cache *sc, const char *text)
     sc->header_text = talloc_strdup_append(sc->header_text, text);
 }
 
+void gl_sc_haddf(struct gl_shader_cache *sc, const char *textf, ...)
+{
+    va_list ap;
+    va_start(ap, textf);
+    ta_xvasprintf_append(&sc->header_text, textf, ap);
+    va_end(ap);
+}
+
 const char *gl_sc_loadfile(struct gl_shader_cache *sc, const char *path)
 {
     if (!path || !path[0] || !sc->global)

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -125,6 +125,7 @@ void gl_sc_destroy(struct gl_shader_cache *sc);
 void gl_sc_add(struct gl_shader_cache *sc, const char *text);
 void gl_sc_addf(struct gl_shader_cache *sc, const char *textf, ...);
 void gl_sc_hadd(struct gl_shader_cache *sc, const char *text);
+void gl_sc_haddf(struct gl_shader_cache *sc, const char *textf, ...);
 const char *gl_sc_loadfile(struct gl_shader_cache *sc, const char *path);
 void gl_sc_uniform_sampler(struct gl_shader_cache *sc, char *name, GLenum target,
                            int unit);

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -67,6 +67,14 @@ struct scaler {
     struct filter_kernel kernel_storage;
 };
 
+struct deband_opts {
+    int enabled;
+    int iterations;
+    float threshold;
+    float range;
+    float grain;
+};
+
 struct gl_video_opts {
     int dumb_mode;
     struct scaler_config scaler[4];
@@ -97,6 +105,8 @@ struct gl_video_opts {
     char *scale_shader;
     char **pre_shaders;
     char **post_shaders;
+    int deband;
+    struct deband_opts *deband_opts;
 };
 
 extern const struct m_sub_options gl_video_conf;

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -23,9 +23,14 @@
 #ifndef MP_GL_VIDEO_SHADERS_H
 #define MP_GL_VIDEO_SHADERS_H
 
+#include <libavutil/lfg.h>
+
 #include "common.h"
 #include "utils.h"
 #include "video.h"
+
+extern const struct deband_opts deband_opts_def;
+extern const struct m_sub_options deband_conf;
 
 void sampler_prelude(struct gl_shader_cache *sc, int tex_num);
 void pass_sample_separated_gen(struct gl_shader_cache *sc, struct scaler *scaler,
@@ -39,5 +44,9 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
 
 void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
+
+void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
+                        int tex_num, float tex_mul, float img_w, float img_h,
+                        AVLFG *lfg);
 
 #endif


### PR DESCRIPTION
The removal of source-shader is a side effect, since this effectively
replaces it - and the video-reading code has been significantly
restructured to make more sense and be more readable.

This means users no longer have to constantly download and maintain a
separate deband.glsl installation alongside mpv, which was the only real
use case for source-shader that we found either way.