### PR TITLE
Alsa sample format detection

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -215,6 +215,14 @@ static const int mp_to_alsa_format[][2] = {
 
 static int find_alsa_format(int af_format)
 {
+    if (af_fmt_is_spdif(af_format)) {
+        if (af_format == AF_FORMAT_S_MP3) {
+            return SND_PCM_FORMAT_MPEG;
+        } else {
+            return SND_PCM_FORMAT_S16;
+        }
+    }
+
     af_format = af_fmt_from_planar(af_format);
     for (int n = 0; mp_to_alsa_format[n][0] != AF_FORMAT_UNKNOWN; n++) {
         if (mp_to_alsa_format[n][0] == af_format)
@@ -453,15 +461,7 @@ static int init_device(struct ao *ao, bool second_try)
     err = snd_pcm_hw_params_any(p->alsa, alsa_hwparams);
     CHECK_ALSA_ERROR("Unable to get initial parameters");
 
-    if (af_fmt_is_spdif(ao->format)) {
-        if (ao->format == AF_FORMAT_S_MP3) {
-            p->alsa_fmt = SND_PCM_FORMAT_MPEG;
-        } else {
-            p->alsa_fmt = SND_PCM_FORMAT_S16;
-        }
-    } else {
-        p->alsa_fmt = find_alsa_format(ao->format);
-    }
+    p->alsa_fmt = find_alsa_format(ao->format);
     if (p->alsa_fmt == SND_PCM_FORMAT_UNKNOWN) {
         p->alsa_fmt = SND_PCM_FORMAT_S16;
         ao->format = AF_FORMAT_S16;

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -210,6 +210,7 @@ static const int mp_to_alsa_format[][2] = {
     {AF_FORMAT_S24,
             MP_SELECT_LE_BE(SND_PCM_FORMAT_S24_3LE, SND_PCM_FORMAT_S24_3BE)},
     {AF_FORMAT_FLOAT,       SND_PCM_FORMAT_FLOAT},
+    {AF_FORMAT_DOUBLE,      SND_PCM_FORMAT_FLOAT64},
     {AF_FORMAT_UNKNOWN,     SND_PCM_FORMAT_UNKNOWN},
 };
 


### PR DESCRIPTION
Use the new format selection algorithm for alsa. 

Also revise the conversion score as follows:
* (de)planarize -1
* pad 1 byte -8
* truncate 1 byte -1024
* float -> int 1048576 * (8 - dst_bytes)
* int -> float -512

Now the score is negative if and only if the conversion is lossy
(e.g. previously s24 -> float was given a negative (lossy) score),
However, int->float is still considered bad
(s16->float is worse than than s16->s32).

This penalizes any loss of precision more than performance / bandwidth hits.
For example, previously s24->s16p was considered equal to s24->u8.

Finally, we penalize padding more than (de)planarizing as this will
increase the output size for example with ao_lavc.

[sorted full list of conversion scores](http://sprunge.us/EMRa)