### PR TITLE
TOOLS/zsh.pl: only check the actual exit code when calling mpv

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -232,8 +232,8 @@ sub call_mpv {
     my $output = `"$mpv" --no-config $cmd`;
     if ($? == -1) {
         die "Could not run mpv: $!";
-    } elsif ($? != 0) {
-        die "mpv returned " . ($? >> 8) . " with output:\n$output";
+    } elsif ((my $exit_code = $? >> 8) != 0) {
+        die "mpv returned $exit_code with output:\n$output";
     }
     return split /\n/, $output;
 }


### PR DESCRIPTION
A user of the mpv-git AUR package had their build fail because some low bit in `$?` was set even though mpv ran fine.