### PR TITLE
Fix compilation failure in vo.c when vaapi is enabled and x11 disabled

### DIFF
--- a/video/out/opengl/hwdec_vaegl.c
+++ b/video/out/opengl/hwdec_vaegl.c
@@ -88,7 +88,6 @@ struct priv {
     struct mp_log *log;
     struct mp_vaapi_ctx *ctx;
     VADisplay *display;
-    Display *xdisplay;
     GLuint gl_textures[4];
     EGLImageKHR images[4];
     VAImage current_image;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -89,7 +89,7 @@ const struct vo_driver *const video_out_drivers[] =
 #if HAVE_SDL2
     &video_out_sdl,
 #endif
-#if HAVE_VAAPI
+#if HAVE_VAAPI_X11
     &video_out_vaapi,
 #endif
 #if HAVE_X11


### PR DESCRIPTION
This was previously trying to use the `video_output_vaapi` symbol despite vo_vaapi.c being guarded by the vaapi-x11 option.