### PR TITLE
Alsa format fail fix

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -483,9 +483,11 @@ static int init_device(struct ao *ao, bool second_try)
     af_get_best_sample_formats(ao->format, try_formats);
     for (int n = 0; try_formats[n]; n++) {
         p->alsa_fmt = find_alsa_format(try_formats[n]);
+        MP_DBG(ao, "Trying format %s\n", af_fmt_to_str(try_formats[n]));
         if (snd_pcm_hw_params_test_format(p->alsa, alsa_hwparams, p->alsa_fmt) >= 0) {
             ao->format = try_formats[n];
             found_format = true;
+            MP_DBG(ao, "Selectedformat %s\n", af_fmt_to_str(ao->format));
             break;
         }
     }

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -478,16 +478,19 @@ static int init_device(struct ao *ao, bool second_try)
     err = snd_pcm_hw_params_any(p->alsa, alsa_hwparams);
     CHECK_ALSA_ERROR("Unable to get initial parameters");
 
+    bool found_format = false;
     int try_formats[AF_FORMAT_COUNT];
     af_get_best_sample_formats(ao->format, try_formats);
     for (int n = 0; try_formats[n]; n++) {
-        ao->format = try_formats[n];
-        p->alsa_fmt = find_alsa_format(ao->format);
-        if (snd_pcm_hw_params_test_format(p->alsa, alsa_hwparams, p->alsa_fmt) >= 0)
+        p->alsa_fmt = find_alsa_format(try_formats[n]);
+        if (snd_pcm_hw_params_test_format(p->alsa, alsa_hwparams, p->alsa_fmt) >= 0) {
+            ao->format = try_formats[n];
+            found_format = true;
             break;
+        }
     }
 
-    if (!ao->format) {
+    if (!found_format) {
         MP_ERR(ao, "Can't find appropriate sample format.\n");
         goto alsa_error;
     }


### PR DESCRIPTION
Set format to invalid after each failed test. This way the final check
for valid format will actually fail if no formats work.

Also add some debug messages indicating what formats are being tried and which is finally selected.
