### PR TITLE
Revert "vo_wayland: define opaque region"

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -795,15 +795,6 @@ static void schedule_resize(struct vo_wayland_state *wl,
     wl->window.events |= VO_EVENT_RESIZE;
     wl->vo->dwidth = width;
     wl->vo->dheight = height;
-
-    struct wl_region *region = wl_compositor_create_region(wl->display.compositor);
-
-    if (region) {
-        wl_region_add(region, x, y, width, height);
-        wl_surface_set_opaque_region(wl->window.video_surface, region);
-        wl_surface_commit(wl->window.video_surface);
-        wl_region_destroy(region);
-    }
 }
 
 static void frame_callback(void *data,


### PR DESCRIPTION
This reverts commit c10fb4ce9fcd3dbbf69741eb8499c4cfabbf5412.

This is already done in vo_wayland.c:resize,324 doing it here makes the window bigger before the video resizes showing a black area while dragging the border.