### PR TITLE
add support for client certificate authentication

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3278,6 +3278,13 @@ Network
     Verify peer certificates when using TLS (e.g. with ``https://...``).
     (Silently fails with older FFmpeg or Libav versions.)
 
+``--tls-cert-file``
+    A file containing a certificate to use in the handshake with the
+    peer.
+
+``--tls-key-file``
+    A file containing the private key for the certificate.
+
 ``--referrer=<string>``
     Specify a referrer path or URL for HTTP requests.
 

--- a/options/options.c
+++ b/options/options.c
@@ -185,6 +185,8 @@ const m_option_t mp_opts[] = {
                 {"http", 3})),
     OPT_FLAG("tls-verify", network_tls_verify, 0),
     OPT_STRING("tls-ca-file", network_tls_ca_file, M_OPT_FILE),
+    OPT_STRING("tls-cert-file", network_tls_cert_file, M_OPT_FILE),
+    OPT_STRING("tls-key-file", network_tls_key_file, M_OPT_FILE),
     OPT_DOUBLE("network-timeout", network_timeout, M_OPT_MIN, .min = 0),
 
 // ------------------------- demuxer options --------------------

--- a/options/options.h
+++ b/options/options.h
@@ -277,6 +277,8 @@ typedef struct MPOpts {
     char **network_http_header_fields;
     int network_tls_verify;
     char *network_tls_ca_file;
+    char *network_tls_cert_file;
+    char *network_tls_key_file;
     double network_timeout;
 
     struct tv_params *tv_params;

--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -168,6 +168,10 @@ void mp_setup_av_network_options(AVDictionary **dict, struct mpv_global *global,
     av_dict_set(dict, "tls_verify", opts->network_tls_verify ? "1" : "0", 0);
     if (opts->network_tls_ca_file)
         av_dict_set(dict, "ca_file", opts->network_tls_ca_file, 0);
+    if (opts->network_tls_cert_file)
+	av_dict_set(dict, "cert_file", opts->network_tls_cert_file, 0);
+    if (opts->network_tls_key_file)
+	av_dict_set(dict, "key_file", opts->network_tls_key_file, 0);
     char *cust_headers = talloc_strdup(temp, "");
     if (opts->network_referrer) {
         cust_headers = talloc_asprintf_append(cust_headers, "Referer: %s\r\n",


### PR DESCRIPTION
Client certificates are supported by ffmpeg as documented here:

  > https://www.ffmpeg.org/ffmpeg-protocols.html#tls