### PR TITLE
vo_opengl: disable drm_egl autopickup

### DIFF
--- a/video/out/opengl/drm_egl.c
+++ b/video/out/opengl/drm_egl.c
@@ -304,6 +304,10 @@ static void drm_egl_uninit(MPGLContext *ctx)
 
 static int drm_egl_init(struct MPGLContext *ctx, int flags)
 {
+    if (ctx->vo->probing) {
+        MP_VERBOSE(ctx->vo, "DRM EGL backend can be activated only manually.\n");
+        return -1;
+    }
     struct priv *p = ctx->priv;
     p->kms = NULL;
     p->old_crtc = NULL;


### PR DESCRIPTION
Tested with `-vo=opengl` from within X (works),  then `-vo=opengl` from within FB (doesn't work as intended) and finally `-vo=opengl:backend=drm_egl` from within FB (works.)

The message will be displayed only in verbose logs.