### PR TITLE
vo_opengl: simplify routines to enable GLSL extensions

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -324,6 +324,12 @@ static const struct gl_functions gl_functions[] = {
             {0}
         },
     },
+    // Extension to encode float in bits, required by NNEDI3.
+    {
+        .ver_core = 330,
+        .extension = "GL_ARB_shader_bit_encoding",
+        .provides = MPGL_CAP_FLOAT_BIT_ENC,
+    },
 };
 
 #undef FN_OFFS

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -63,6 +63,7 @@ enum {
     MPGL_CAP_1D_TEX             = (1 << 14),
     MPGL_CAP_3D_TEX             = (1 << 15),
     MPGL_CAP_DEBUG              = (1 << 16),
+    MPGL_CAP_FLOAT_BIT_ENC      = (1 << 17),    // GL_ARB_shader_bit_encoding
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };
 

--- a/video/out/opengl/nnedi3.c
+++ b/video/out/opengl/nnedi3.c
@@ -80,7 +80,7 @@ const float* get_nnedi3_weights(const struct nnedi3_opts *conf, int *size)
     return (const float*)(nnedi3_weights + offset * 4);
 }
 
-void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int planes, int tex_num,
+void pass_nnedi3(struct gl_shader_cache *sc, int planes, int tex_num,
                  int step, const struct nnedi3_opts *conf,
                  struct gl_transform *transform)
 {
@@ -108,8 +108,6 @@ void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int planes, int tex_num,
         snprintf(buf, sizeof(buf), "vec4 weights[%d];",
                  neurons * (sample_count * 2 + 1));
         gl_sc_uniform_buffer(sc, "NNEDI3_WEIGHTS", buf, 0);
-        if (gl->glsl_version < 140)
-            gl_sc_enable_extension(sc, "GL_ARB_uniform_buffer_object");
     } else if (conf->upload == NNEDI3_UPLOAD_SHADER) {
         // Somehow necessary for hard coding approach.
         GLSLH(#pragma optionNV(fastprecision on))

--- a/video/out/opengl/nnedi3.h
+++ b/video/out/opengl/nnedi3.h
@@ -40,7 +40,7 @@ extern const struct m_sub_options nnedi3_conf;
 
 const float* get_nnedi3_weights(const struct nnedi3_opts *conf, int *size);
 
-void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int planes, int tex_num,
+void pass_nnedi3(struct gl_shader_cache *sc, int planes, int tex_num,
                  int step, const struct nnedi3_opts *conf,
                  struct gl_transform *transform);
 

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -865,6 +865,7 @@ void gl_sc_gen_shader_and_reset(struct gl_shader_cache *sc)
     // set up shader text (header + uniforms + body)
     char *header = talloc_asprintf(tmp, "#version %d%s\n", gl->glsl_version,
                                    gl->es >= 300 ? " es" : "");
+    ADD(header, "#extension all : warn\n");
     if (gl->es)
         ADD(header, "precision mediump float;\n");
     char *vert_in = gl->glsl_version >= 130 ? "in" : "attribute";

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -513,9 +513,8 @@ struct gl_shader_cache {
     struct mp_log *log;
 
     // this is modified during use (gl_sc_add() etc.)
-    char *prelude_text;
-    char *header_text;
     char *text;
+    char *header_text;
     struct gl_vao *vao;
 
     struct sc_entry entries[SC_ENTRIES];
@@ -531,18 +530,16 @@ struct gl_shader_cache *gl_sc_create(GL *gl, struct mp_log *log)
     *sc = (struct gl_shader_cache){
         .gl = gl,
         .log = log,
-        .prelude_text = talloc_strdup(sc, ""),
-        .header_text = talloc_strdup(sc, ""),
         .text = talloc_strdup(sc, ""),
+        .header_text = talloc_strdup(sc, ""),
     };
     return sc;
 }
 
 void gl_sc_reset(struct gl_shader_cache *sc)
 {
-    sc->prelude_text[0] = '\0';
-    sc->header_text[0] = '\0';
     sc->text[0] = '\0';
+    sc->header_text[0] = '\0';
     for (int n = 0; n < sc->num_uniforms; n++) {
         talloc_free(sc->uniforms[n].name);
         if (sc->uniforms[n].type == UT_buffer)
@@ -568,12 +565,6 @@ void gl_sc_destroy(struct gl_shader_cache *sc)
     gl_sc_reset(sc);
     sc_flush_cache(sc);
     talloc_free(sc);
-}
-
-void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name)
-{
-    sc->prelude_text = talloc_asprintf_append(sc->prelude_text,
-                                              "#extension %s : enable\n", name);
 }
 
 void gl_sc_add(struct gl_shader_cache *sc, const char *text)
@@ -876,7 +867,6 @@ void gl_sc_gen_shader_and_reset(struct gl_shader_cache *sc)
                                    gl->es >= 300 ? " es" : "");
     if (gl->es)
         ADD(header, "precision mediump float;\n");
-    ADD(header, "%s", sc->prelude_text);
     char *vert_in = gl->glsl_version >= 130 ? "in" : "attribute";
     char *vert_out = gl->glsl_version >= 130 ? "out" : "varying";
     char *frag_in = gl->glsl_version >= 130 ? "in" : "varying";

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -142,7 +142,6 @@ void gl_sc_uniform_mat3(struct gl_shader_cache *sc, char *name,
 void gl_sc_uniform_buffer(struct gl_shader_cache *sc, char *name,
                           const char *text, int binding);
 void gl_sc_set_vao(struct gl_shader_cache *sc, struct gl_vao *vao);
-void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name);
 void gl_sc_gen_shader_and_reset(struct gl_shader_cache *sc);
 void gl_sc_reset(struct gl_shader_cache *sc);
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2347,6 +2347,7 @@ static void check_gl_features(struct gl_video *p)
     bool have_1d_tex = gl->mpgl_caps & MPGL_CAP_1D_TEX;
     bool have_3d_tex = gl->mpgl_caps & MPGL_CAP_3D_TEX;
     bool have_mix = gl->glsl_version >= 130;
+    bool have_float_bits_enc = gl->mpgl_caps & MPGL_CAP_FLOAT_BIT_ENC;
 
     if (gl->es && p->opts.pbo) {
         p->opts.pbo = 0;
@@ -2432,7 +2433,7 @@ static void check_gl_features(struct gl_video *p)
             }
         } else if (p->opts.nnedi3_opts->upload == NNEDI3_UPLOAD_SHADER) {
             // Check features for hard coding approach.
-            if (p->gl->glsl_version < 330) {
+            if (!have_float_bits_enc) {
                 MP_WARN(p, "Disabling NNEDI3 (OpenGL 3.3 required).\n");
                 p->opts.prescale = 0;
             }

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1213,7 +1213,7 @@ static void pass_prescale(struct gl_video *p, int src_tex_num, int dst_tex_num,
                               p->opts.superxbr_opts, &transform);
                 break;
             case 2:
-                pass_nnedi3(p->gl, p->sc, planes, tex_num, step,
+                pass_nnedi3(p->sc, planes, tex_num, step,
                             p->opts.nnedi3_opts, &transform);
                 break;
             default:


### PR DESCRIPTION
Use term "require" to state that the corresponding GLSL extensions
will surely be used. In this way we don't have to check GLSL version
explicitly.

Also enable "GL_ARB_shader_bit_encoding" for low GLSL version.