### PR TITLE
vo_opengl: fix 10-bit video prescaling

### DIFF
--- a/video/out/opengl/nnedi3.h
+++ b/video/out/opengl/nnedi3.h
@@ -41,7 +41,7 @@ extern const struct m_sub_options nnedi3_conf;
 const float* get_nnedi3_weights(const struct nnedi3_opts *conf, int *size);
 
 void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int planes, int tex_num,
-                 int step, const struct nnedi3_opts *conf,
+                 int step, float tex_mul, const struct nnedi3_opts *conf,
                  struct gl_transform *transform);
 
 #endif

--- a/video/out/opengl/superxbr.h
+++ b/video/out/opengl/superxbr.h
@@ -30,7 +30,7 @@ extern const struct superxbr_opts superxbr_opts_def;
 extern const struct m_sub_options superxbr_conf;
 
 void pass_superxbr(struct gl_shader_cache *sc, int planes, int tex_num,
-                   int step, const struct superxbr_opts *conf,
+                   int step, float tex_mul, const struct superxbr_opts *conf,
                    struct gl_transform *transform);
 
 #endif

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1210,20 +1210,17 @@ static void pass_prescale(struct gl_video *p, int src_tex_num, int dst_tex_num,
             switch(p->opts.prescale) {
             case 1:
                 pass_superxbr(p->sc, planes, tex_num, step,
-                              p->opts.superxbr_opts, &transform);
+                              tex_mul, p->opts.superxbr_opts, &transform);
                 break;
             case 2:
                 pass_nnedi3(p->gl, p->sc, planes, tex_num, step,
-                            p->opts.nnedi3_opts, &transform);
+                            tex_mul, p->opts.nnedi3_opts, &transform);
                 break;
             default:
                 abort();
             }
 
-            if (tex_mul != 1.0) {
-                GLSLF("color *= %f;\n", tex_mul);
-                tex_mul = 1.0;
-            }
+            tex_mul = 1.0;
 
             gl_transform_trans(transform, offset);
 


### PR DESCRIPTION
The nnedi3 prescaler requires a normalized range to work properly,
but the original implementation did the range normalization after
the first step of the first pass. This could lead to severe quality
degradation when debanding is not enabled for NNEDI3.

Fix this issue by passing `tex_mul` into the shader code.

Fixes #2464