### PR TITLE
drm: fix setting up connectors

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -194,7 +194,7 @@ bool kms_setup(struct kms *kms, const char *device_path, int connector_id, int m
         return false;
     }
 
-    if (!setup_connector(kms, res, mode_id))
+    if (!setup_connector(kms, res, connector_id))
         return false;
     if (!setup_crtc(kms, res))
         return false;


### PR DESCRIPTION
Fixes regression from 67caea357c23443cf583ad401a38bbaae19e3df8 reported in #2469.