### PR TITLE
ao_openal: fix virtual speaker positioning

### DIFF
--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -118,15 +118,15 @@ struct speaker {
 };
 
 static const struct speaker speaker_pos[] = {
-    {MP_SPEAKER_ID_FL,   {-0.575, 0,  0.819}}, //  -35 deg
-    {MP_SPEAKER_ID_FR,   { 0.575, 0,  0.819}}, //   35 deg
-    {MP_SPEAKER_ID_FC,   {     0, 0,      1}}, //    0 deg
-    {MP_SPEAKER_ID_LFE,  {     0, 1,      0}}, //    below
-    {MP_SPEAKER_ID_BL,   {-0.500, 0, -0.866}}, // -150 deg
-    {MP_SPEAKER_ID_BR,   { 0.500, 0, -0.866}}, //  150 deg
-    {MP_SPEAKER_ID_BC,   {     0, 0,     -1}}, //  180 deg
-    {MP_SPEAKER_ID_SL,   {-0.985, 0, -0.174}}, // -100 deg
-    {MP_SPEAKER_ID_SR,   { 0.985, 0, -0.174}}, //  100 deg
+    {MP_SPEAKER_ID_FL,   {-0.438,  0, -0.899}}, // -30 deg
+    {MP_SPEAKER_ID_FR,   { 0.438,  0, -0.899}}, //  30 deg
+    {MP_SPEAKER_ID_FC,   {     0,  0,     -1}}, //   0 deg
+    {MP_SPEAKER_ID_LFE,  {     0, -1,      0}}, //   below
+    {MP_SPEAKER_ID_BL,   {-0.655,  0,  0.793}}, // -142.5 deg
+    {MP_SPEAKER_ID_BR,   { 0.655,  0,  0.793}}, // -142.5 deg
+    {MP_SPEAKER_ID_BC,   {     0,  0,      1}}, //  180 deg
+    {MP_SPEAKER_ID_SL,   {-0.985,  0,  0.174}}, // -100 deg
+    {MP_SPEAKER_ID_SR,   { 0.985,  0,  0.174}}, //  100 deg
     {-1},
 };
 
@@ -162,7 +162,7 @@ static void uninit(struct ao *ao)
 static int init(struct ao *ao)
 {
     float position[3] = {0, 0, 0};
-    float direction[6] = {0, 0, 1, 0, -1, 0};
+    float direction[6] = {0, 0, -1, 0, 1, 0};
     ALCdevice *dev = NULL;
     ALCcontext *ctx = NULL;
     ALCint freq = 0;

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -118,12 +118,12 @@ struct speaker {
 };
 
 static const struct speaker speaker_pos[] = {
-    {MP_SPEAKER_ID_FL,   {-0.438,  0, -0.899}}, // -30 deg
-    {MP_SPEAKER_ID_FR,   { 0.438,  0, -0.899}}, //  30 deg
+    {MP_SPEAKER_ID_FL,   {-0.500,  0, -0.866}}, // -30 deg
+    {MP_SPEAKER_ID_FR,   { 0.500,  0, -0.866}}, //  30 deg
     {MP_SPEAKER_ID_FC,   {     0,  0,     -1}}, //   0 deg
     {MP_SPEAKER_ID_LFE,  {     0, -1,      0}}, //   below
-    {MP_SPEAKER_ID_BL,   {-0.655,  0,  0.793}}, // -142.5 deg
-    {MP_SPEAKER_ID_BR,   { 0.655,  0,  0.793}}, // -142.5 deg
+    {MP_SPEAKER_ID_BL,   {-0.609,  0,  0.793}}, // -142.5 deg
+    {MP_SPEAKER_ID_BR,   { 0.609,  0,  0.793}}, // -142.5 deg
     {MP_SPEAKER_ID_BC,   {     0,  0,      1}}, //  180 deg
     {MP_SPEAKER_ID_SL,   {-0.985,  0,  0.174}}, // -100 deg
     {MP_SPEAKER_ID_SR,   { 0.985,  0,  0.174}}, //  100 deg

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -118,15 +118,15 @@ struct speaker {
 };
 
 static const struct speaker speaker_pos[] = {
-    {MP_SPEAKER_ID_FL,   {-1, 0, 0.5}},
-    {MP_SPEAKER_ID_FR,   { 1, 0, 0.5}},
-    {MP_SPEAKER_ID_FC,   { 0, 0,   1}},
-    {MP_SPEAKER_ID_LFE,  { 0, 0, 0.1}},
-    {MP_SPEAKER_ID_BL,   {-1, 0,  -1}},
-    {MP_SPEAKER_ID_BR,   { 1, 0,  -1}},
-    {MP_SPEAKER_ID_BC,   { 0, 0,  -1}},
-    {MP_SPEAKER_ID_SL,   {-1, 0,   0}},
-    {MP_SPEAKER_ID_SR,   { 1, 0,   0}},
+    {MP_SPEAKER_ID_FL,   {-0.575, 0,  0.819}}, //  -35 deg
+    {MP_SPEAKER_ID_FR,   { 0.575, 0,  0.819}}, //   35 deg
+    {MP_SPEAKER_ID_FC,   {     0, 0,      1}}, //    0 deg
+    {MP_SPEAKER_ID_LFE,  {     0, 1,      0}}, //    below
+    {MP_SPEAKER_ID_BL,   {-0.500, 0, -0.866}}, // -150 deg
+    {MP_SPEAKER_ID_BR,   { 0.500, 0, -0.866}}, //  150 deg
+    {MP_SPEAKER_ID_BC,   {     0, 0,     -1}}, //  180 deg
+    {MP_SPEAKER_ID_SL,   {-0.985, 0, -0.174}}, // -100 deg
+    {MP_SPEAKER_ID_SR,   { 0.985, 0, -0.174}}, //  100 deg
     {-1},
 };
 


### PR DESCRIPTION
Place speakers in standard positions equidistant from the listener.

It makes a difference for HRTF, which is probably the only valid use case of ao_openal.