### PR TITLE
manpage: fix typo in vd-lavc-o example

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -865,7 +865,7 @@ Video
 
     .. admonition:: Example
 
-        ``--vd--lavc-o=debug=pict``
+        ``--vd-lavc-o=debug=pict``
 
 ``--vd-lavc-show-all=<yes|no>``
     Show even broken/corrupt frames (default: no). If this option is set to


### PR DESCRIPTION
`--vd--lavc-o becomes --vd-lavc-o`