### PR TITLE
Fix ANGLE GLES3 mode

### DIFF
--- a/video/out/opengl/angle.c
+++ b/video/out/opengl/angle.c
@@ -83,7 +83,7 @@ static bool create_context_egl(MPGLContext *ctx, EGLConfig config,
     struct priv *p = ctx->priv;
 
     EGLint context_attributes[] = {
-        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_CONTEXT_CLIENT_VERSION, 3,
         EGL_NONE
     };
 

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -175,9 +175,16 @@ static const struct gl_functions gl_functions[] = {
             DEF_FN(BlitFramebuffer),
             DEF_FN(GetStringi),
             // for ES 3.0
-            DEF_FN(GetTexLevelParameteriv),
             DEF_FN(ReadBuffer),
             DEF_FN(UnmapBuffer),
+            {0}
+        },
+    },
+    // For ES 3.1 core
+    {
+        .ver_es_core = 310,
+        .functions = (const struct gl_function[]) {
+            DEF_FN(GetTexLevelParameteriv),
             {0}
         },
     },


### PR DESCRIPTION
Move [glGetTexLevelParameter][1] out of the ES 3.0 group and into one for ES 3.1.

[1]: http://docs.gl/es3/glGetTexLevelParameter