### PR TITLE
ao_wasapi: only report per-app volume in shared mode

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -341,7 +341,8 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 
         return CONTROL_OK;
     case AOCONTROL_HAS_PER_APP_VOLUME:
-        return CONTROL_TRUE;
+        return state->share_mode == AUDCLNT_SHAREMODE_SHARED ?
+            CONTROL_TRUE : CONTROL_FALSE;
     case AOCONTROL_UPDATE_STREAM_TITLE: {
         MP_VERBOSE(state, "Updating stream title to \"%s\"\n", (char*)arg);
         wchar_t *title = mp_from_utf8(NULL, (char*)arg);


### PR DESCRIPTION
otherwise we were incorrectly adjusting the hardware master volume
in exclusive mode with softvol=auto