### PR TITLE
Don't show the Windows taskbar progress indicator in idle mode

### DIFF
--- a/player/misc.c
+++ b/player/misc.c
@@ -141,11 +141,13 @@ void update_vo_playback_state(struct MPContext *mpctx)
     if (mpctx->video_out) {
         struct voctrl_playback_state oldstate = mpctx->vo_playback_state;
         struct voctrl_playback_state newstate = {
+            .playing = mpctx->playing,
             .paused = mpctx->paused,
             .percent_pos = get_percent_pos(mpctx),
         };
 
-        if (oldstate.paused != newstate.paused ||
+        if (oldstate.playing != newstate.playing ||
+            oldstate.paused != newstate.paused ||
             oldstate.percent_pos != newstate.percent_pos) {
             vo_control(mpctx->video_out,
                        VOCTRL_UPDATE_PLAYBACK_STATE, &newstate);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -133,6 +133,7 @@ struct voctrl_get_equalizer_args {
 
 // VOCTRL_UPDATE_PLAYBACK_STATE
 struct voctrl_playback_state {
+    bool playing;
     bool paused;
     int percent_pos;
 };

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1376,13 +1376,20 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         struct voctrl_playback_state *pstate =
             (struct voctrl_playback_state *)arg;
 
-        if (w32->taskbar_list3 && w32->tbtnCreated) {
-            ITaskbarList3_SetProgressValue(w32->taskbar_list3, w32->window,
-                                           pstate->percent_pos, 100);
+        if (!w32->taskbar_list3 || !w32->tbtnCreated)
+            return VO_TRUE;
+
+        if (!pstate->playing) {
             ITaskbarList3_SetProgressState(w32->taskbar_list3, w32->window,
-                                           pstate->paused ? TBPF_PAUSED :
-                                                            TBPF_NORMAL);
+                                           TBPF_NOPROGRESS);
+            return VO_TRUE;
         }
+
+        ITaskbarList3_SetProgressValue(w32->taskbar_list3, w32->window,
+                                       pstate->percent_pos, 100);
+        ITaskbarList3_SetProgressState(w32->taskbar_list3, w32->window,
+                                       pstate->paused ? TBPF_PAUSED :
+                                                        TBPF_NORMAL);
         return VO_TRUE;
     }
     case VOCTRL_GET_DISPLAY_FPS:


### PR DESCRIPTION
This also shuffles around some logic in the VOCTRL handler to save horizontal space (rather than adding an extra level of indentation.)