### PR TITLE
Wasapi no vistablob

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -764,7 +764,7 @@ Video
     if supported.
 
     This behaves exactly like the ``deinterlace`` input property (usually
-    mapped to ``Shift+D``).
+    mapped to ``d``).
 
     ``auto`` is a technicality. Strictly speaking, the default for this option
     is deinterlacing disabled, but the ``auto`` case is needed if ``yadif`` was

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -464,16 +464,16 @@ Available filters are:
         :yes: Only deinterlace frames marked as interlaced (default if this
               filter is inserted via ``deinterlace`` property).
 
-    This filter, is automatically inserted when using the ``D`` key (or any
+    This filter, is automatically inserted when using the ``d`` key (or any
     other key that toggles the ``deinterlace`` property or when using the
     ``--deinterlace`` switch), assuming the video output does not have native
     deinterlacing support.
 
     If you just want to set the default mode, put this filter and its options
-    into ``--vf-defaults`` instead, and enable deinterlacing with ``D`` or
+    into ``--vf-defaults`` instead, and enable deinterlacing with ``d`` or
     ``--deinterlace``.
 
-    Also note that the ``D`` key is stupid enough to insert an interlacer twice
+    Also note that the ``d`` key is stupid enough to insert a deinterlacer twice
     when inserting yadif with ``--vf``, so using the above methods is
     recommended.
 
@@ -721,7 +721,7 @@ Available filters are:
 ``vavpp``
     VA-AP-API video post processing. Works with ``--vo=vaapi`` and ``--vo=opengl``
     only. Currently deinterlaces. This filter is automatically inserted if
-    deinterlacing is requested (either using the ``D`` key, by default mapped to
+    deinterlacing is requested (either using the ``d`` key, by default mapped to
     the command ``cycle deinterlace``, or the ``--deinterlace`` option).
 
     ``deint=<method>``
@@ -745,7 +745,7 @@ Available filters are:
 ``vdpaupp``
     VDPAU video post processing. Works with ``--vo=vdpau`` and ``--vo=opengl``
     only. This filter is automatically inserted if deinterlacing is requested
-    (either using the ``D`` key, by default mapped to the command
+    (either using the ``d`` key, by default mapped to the command
     ``cycle deinterlace``, or the ``--deinterlace`` option). When enabling
     deinterlacing, it is always preferred over software deinterlacer filters
     if the ``vdpau`` VO is used, and also if ``opengl`` is used and hardware

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -105,7 +105,7 @@ Available video output drivers are:
         Select deinterlacing mode (default: 0). In older versions (as well as
         MPlayer/mplayer2) you could use this option to enable deinterlacing.
         This doesn't work anymore, and deinterlacing is enabled with either
-        the ``D`` key (by default mapped to the command ``cycle deinterlace``),
+        the ``d`` key (by default mapped to the command ``cycle deinterlace``),
         or the ``--deinterlace`` option. Also, to select the default deint mode,
         you should use something like ``--vf-defaults=vdpaupp:deint-mode=temporal``
         instead of this sub-option.
@@ -1007,7 +1007,7 @@ Available video output drivers are:
 
     ``deint-mode=<mode>``
         Select deinterlacing algorithm. Note that by default deinterlacing is
-        initially always off, and needs to be enabled with the ``D`` key
+        initially always off, and needs to be enabled with the ``d`` key
         (default key binding for ``cycle deinterlace``).
 
         This option doesn't apply if libva supports video post processing (vpp).

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -237,8 +237,6 @@ static void uninit(struct ao *ao)
         MP_ERR(ao, "Audio loop thread refuses to abort\n");
         return;
     }
-    if (state->VistaBlob.hAvrt)
-        FreeLibrary(state->VistaBlob.hAvrt);
 
     SAFE_RELEASE(state->hInitDone,   CloseHandle(state->hInitDone));
     SAFE_RELEASE(state->hWake,       CloseHandle(state->hWake));
@@ -255,8 +253,6 @@ static int init(struct ao *ao)
 
     struct wasapi_state *state = ao->priv;
     state->log = ao->log;
-    if(!wasapi_fill_VistaBlob(state))
-        MP_WARN(ao, "Error loading thread priority functions\n");
 
     state->hInitDone = CreateEventW(NULL, FALSE, FALSE, NULL);
     state->hWake     = CreateEventW(NULL, FALSE, FALSE, NULL);

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -79,7 +79,6 @@ typedef struct wasapi_state {
 
     /* for setting the audio thread priority */
     HANDLE hTask; /* AV thread */
-    DWORD taskIndex; /* AV task ID */
 
     /* WASAPI proxy handles, for Single-Threaded Apartment communication.
        One is needed for each audio thread object that's accessed from the main thread. */
@@ -109,16 +108,6 @@ typedef struct wasapi_state {
     WAVEFORMATEXTENSIBLE format;
     size_t buffer_block_size; /* Size of each block in bytes */
     UINT32 bufferFrameCount; /* wasapi buffer block size, number of frames, frame size at format.nBlockAlign */
-
-    /* Don't use these functions directly in case
-       they are unimplemented for some reason.
-       (XP shouldn't be an issue since it doesn't support wasapi, maybe wine?)
-       Blob is owned by the main thread */
-    struct {
-        HMODULE hAvrt;
-        HANDLE (WINAPI *pAvSetMmThreadCharacteristicsW)(LPCWSTR, LPDWORD);
-        WINBOOL (WINAPI *pAvRevertMmThreadCharacteristics)(HANDLE);
-    } VistaBlob;
 
     change_notify change;
 } wasapi_state;

--- a/audio/out/ao_wasapi_utils.h
+++ b/audio/out/ao_wasapi_utils.h
@@ -33,6 +33,7 @@ char *mp_HRESULT_to_str_buf(char *buf, size_t buf_size, HRESULT hr);
 #define mp_GUID_to_str(guid) mp_GUID_to_str_buf((char[40]){0}, 40, (guid))
 #define mp_PKEY_to_str(pkey) mp_PKEY_to_str_buf((char[42]){0}, 42, (pkey))
 #define mp_HRESULT_to_str(hr) mp_HRESULT_to_str_buf((char[60]){0}, 60, (hr))
+#define mp_LastError_to_str() mp_HRESULT_to_str(HRESULT_FROM_WIN32(GetLastError()))
 
 bool wasapi_fill_VistaBlob(wasapi_state *state);
 


### PR DESCRIPTION
get rid of the vistablob in wasapi for setting AV thread priority. Now that we are Vista+, this should just always be available.