### PR TITLE
Avoiding conditional directives that split up parts of statements.

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -226,17 +226,19 @@ char *mp_splitext(const char *path, bstr *root)
 
 char *mp_path_join_bstr(void *talloc_ctx, struct bstr p1, struct bstr p2)
 {
+    bool test;
     if (p1.len == 0)
         return bstrdup0(talloc_ctx, p2);
     if (p2.len == 0)
         return bstrdup0(talloc_ctx, p1);
 
 #if HAVE_DOS_PATHS
-    if ((p2.len >= 2 && p2.start[1] == ':')
-        || p2.start[0] == '\\' || p2.start[0] == '/')
+    test = (p2.len >= 2 && p2.start[1] == ':')
+        || p2.start[0] == '\\' || p2.start[0] == '/';
 #else
-    if (p2.start[0] == '/')
+    test = p2.start[0] == '/';
 #endif
+    if (test)
         return bstrdup0(talloc_ctx, p2);   // absolute path
 
     bool have_separator;


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.