### PR TITLE
vo_opengl: fix boundary check for polar filters

### DIFF
--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -139,7 +139,7 @@ void pass_sample_polar(struct gl_shader_cache *sc, struct scaler *scaler)
                 continue;
             GLSLF("d = length(vec2(%d.0, %d.0) - fcoord)/%f;\n", x, y, radius);
             // Check for samples that might be skippable
-            if (dmax >= radius - 1)
+            if (dmax >= radius - M_SQRT2)
                 GLSLF("if (d < 1.0) {\n");
             if (scaler->gl_target == GL_TEXTURE_1D) {
                 GLSL(w = texture1D(lut, d).r;)
@@ -153,7 +153,7 @@ void pass_sample_polar(struct gl_shader_cache *sc, struct scaler *scaler)
                 GLSL(lo = min(lo, c);)
                 GLSL(hi = max(hi, c);)
             }
-            if (dmax >= radius -1)
+            if (dmax >= radius - M_SQRT2)
                 GLSLF("}\n");
         }
     }


### PR DESCRIPTION
If the sampling point is placed diagonally, the radius difference
could be as large as sqrt(2.0). And a loosened check with (radius - 1)
would potentially include pixels out of the range.