### PR TITLE
vo_opengl: fix precision loss of fruit dithering matrix

### DIFF
--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1741,9 +1741,16 @@ static void pass_dither(struct gl_video *p)
                 p->last_dither_matrix_size = size;
             }
 
+            const struct fmt_entry *fmt = find_tex_format(gl, 2, 1);
             tex_size = size;
-            tex_iformat = gl_float16_formats[0].internal_format;
-            tex_format = gl_float16_formats[0].format;
+            // Prefer R16 texture since they provide higher precision.
+            if (fmt->internal_format) {
+                tex_iformat = fmt->internal_format;
+                tex_format = fmt->format;
+            } else {
+                tex_iformat = gl_float16_formats[0].internal_format;
+                tex_format = gl_float16_formats[0].format;
+            }
             tex_type = GL_FLOAT;
             tex_data = p->last_dither_matrix;
         } else {


### PR DESCRIPTION
With default setting, the matrix for fruit dithering requires 12 bits
precision (values from 0/4096 to 4095/4096). But 16-bit float
provides only 10 bits. In addition, when `dither-size-fruit=8` is
set, 16 bits are required from the texture format.

Fix this by attempting to use 16 bit integer texture first. This is
still not precise, but should be better than using a half float.


For testing, `mpv --vo opengl-hq:dither-depth=1:dither=fruit av://lavfi:color=c=black` will produce white pixels without this fix.