### PR TITLE
Cue fixes

### DIFF
--- a/demux/cue.c
+++ b/demux/cue.c
@@ -218,3 +218,18 @@ struct cue_file *mp_parse_cue(struct bstr data)
 
     return f;
 }
+
+int mp_check_embedded_cue(struct cue_file *f)
+{
+    char *fn0 = f->tracks[0].filename;
+    for (int n = 1; n < f->num_tracks; n++) {
+        char *fn = f->tracks[n].filename;
+        // both filenames have the same address (including NULL)
+        if (fn0 == fn)
+            continue;
+        // only one filename is NULL, or the strings don't match
+        if (!fn0 || !fn || strcmp(fn0, fn) != 0)
+            return -1;
+    }
+    return 0;
+}

--- a/demux/cue.h
+++ b/demux/cue.h
@@ -38,5 +38,6 @@ struct cue_track {
 
 bool mp_probe_cue(struct bstr data);
 struct cue_file *mp_parse_cue(struct bstr data);
+int mp_check_embedded_cue(struct cue_file *f);
 
 #endif

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -926,10 +926,15 @@ static void demux_init_cuesheet(struct demuxer *demuxer)
     if (cue && !demuxer->num_chapters) {
         struct cue_file *f = mp_parse_cue(bstr0(cue));
         if (f) {
-            for (int n = 0; n < f->num_tracks; n++) {
-                struct cue_track *t = &f->tracks[n];
-                int idx = demuxer_add_chapter(demuxer, "", t->start, -1);
-                mp_tags_merge(demuxer->chapters[idx].metadata, t->tags);
+            if (mp_check_embedded_cue(f) < 0) {
+                MP_WARN(demuxer, "Embedded cue sheet references more than one file. "
+                        "Ignoring it.\n");
+            } else {
+                for (int n = 0; n < f->num_tracks; n++) {
+                    struct cue_track *t = &f->tracks[n];
+                    int idx = demuxer_add_chapter(demuxer, "", t->start, -1);
+                    mp_tags_merge(demuxer->chapters[idx].metadata, t->tags);
+                }
             }
         }
         talloc_free(f);

--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -150,8 +150,18 @@ static void build_timeline(struct timeline *tl)
 
     add_source(tl, tl->demuxer);
 
-    struct cue_track *tracks = p->f->tracks;
-    size_t track_count = p->f->num_tracks;
+    struct cue_track *tracks = NULL;
+    size_t track_count = 0;
+
+    for (size_t n = 0; n < p->f->num_tracks; n++) {
+        struct cue_track *track = &p->f->tracks[n];
+        if (track->filename) {
+            MP_TARRAY_APPEND(ctx, tracks, track_count, *track);
+        } else {
+            MP_WARN(tl->demuxer, "No file specified for track entry %zd. "
+                    "It will be removed\n", n + 1);
+        }
+    }
 
     if (track_count == 0) {
         MP_ERR(tl, "CUE: no tracks found!\n");


### PR DESCRIPTION
Do some error checking on the parsed cue structure. The demux_cue commit fixes a segfault
for EAC files seen in the wild. 