### PR TITLE
Remove some XP-isms

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -188,25 +188,3 @@ a pthreads wrapper or you want to build mpv without one, configure with:
 ```bash
 ./waf configure --enable-win32-internal-pthreads
 ```
-
-libwaio
--------
-
-If you want to use ``--input-file``, you need libwaio. It's available from
-git://midipix.org/waio
-
-To compile libwaio in MSYS2, run:
-
-```bash
-git clone git://midipix.org/waio && cd waio
-
-# 32-bit build, run from mingw32_shell.bat
-./build-mingw-nt32 lib-static CC=gcc AR=ar
-cp -r include/waio /mingw32/include
-cp lib32/libwaio.a /mingw32/lib
-
-# 64-bit build, run from mingw64_shell.bat
-./build-mingw-nt64 lib-static CC=gcc AR=ar
-cp -r include/waio /mingw64/include
-cp lib64/libwaio.a /mingw64/lib
-```

--- a/TOOLS/old-configure
+++ b/TOOLS/old-configure
@@ -954,7 +954,6 @@ cat > $TMPC << EOF
 #define HAVE_GLOB 1
 #define HAVE_NANOSLEEP 1
 #define HAVE_SDL1 0
-#define HAVE_WAIO 0
 #define HAVE_POSIX_SPAWN 1
 #define HAVE_GLIBC_THREAD_NAME (!!__GLIBC__)
 #define HAVE_OSX_THREAD_NAME 0

--- a/input/input.c
+++ b/input/input.c
@@ -1265,11 +1265,7 @@ void mp_input_load(struct input_ctx *ictx)
 
 #if defined(__MINGW32__)
     if (ictx->global->opts->input_file && *ictx->global->opts->input_file)
-#if HAVE_WAIO
         mp_input_pipe_add(ictx, ictx->global->opts->input_file);
-#else
-        MP_ERR(ictx, "Pipes not available.\n");
-#endif
 #endif
 }
 

--- a/input/pipe-win32.c
+++ b/input/pipe-win32.c
@@ -1,98 +1,107 @@
-#include <pthread.h>
-#include <stdio.h>
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <windows.h>
 #include <io.h>
 
-#include <stdint.h>
-#include <waio/waio.h>
-
 #include "common/msg.h"
+#include "osdep/atomics.h"
 #include "osdep/io.h"
 #include "input.h"
 
+struct priv {
+    atomic_bool cancel_requested;
+    int fd;
+    bool close_fd;
+    HANDLE file;
+    HANDLE thread;
+};
+
 static void request_cancel(struct mp_input_src *src)
 {
-    HANDLE terminate = src->priv;
+    struct priv *p = src->priv;
 
     MP_VERBOSE(src, "Exiting...\n");
-    SetEvent(terminate);
+    atomic_store(&p->cancel_requested, true);
+
+    // The thread might not be peforming I/O at the exact moment when
+    // CancelIoEx is called, so call it in a loop until it succeeds or the
+    // thread exits
+    do {
+        if (CancelIoEx(p->file, NULL))
+            break;
+    } while (WaitForSingleObject(p->thread, 1) != WAIT_OBJECT_0);
 }
 
 static void uninit(struct mp_input_src *src)
 {
-    HANDLE terminate = src->priv;
+    struct priv *p = src->priv;
 
-    CloseHandle(terminate);
+    CloseHandle(p->thread);
+    if (p->close_fd)
+        close(p->fd);
+
     MP_VERBOSE(src, "Exited.\n");
 }
 
 static void read_pipe_thread(struct mp_input_src *src, void *param)
 {
     char *filename = talloc_strdup(src, param);
+    struct priv *p = talloc_zero(src, struct priv);
 
-    struct waio_cx_interface *waio = NULL;
-    int mode = O_RDONLY;
-    int fd = -1;
-    bool close_fd = true;
+    p->fd = -1;
+    p->close_fd = true;
     if (strcmp(filename, "/dev/stdin") == 0) { // for symmetry with unix
-        fd = STDIN_FILENO;
-        close_fd = false;
+        p->fd = STDIN_FILENO;
+        p->close_fd = false;
     }
-    if (fd < 0)
-        fd = open(filename, mode);
-    if (fd < 0) {
+    if (p->fd < 0)
+        p->fd = open(filename, O_RDONLY);
+    if (p->fd < 0) {
         MP_ERR(src, "Can't open %s.\n", filename);
-        goto done;
+        return;
     }
 
-    // If we're reading from stdin, unset it. All I/O on synchronous handles is
-    // serialized, so stupid DLLs that call GetFileType on stdin can hang the
-    // process if they do it while we're reading from it. At least, the
-    // VirtualBox OpenGL ICD is affected by this, but only on Windows XP.
-    // GetFileType works differently in later versions of Windows. See:
-    // https://support.microsoft.com/kb/2009703
-    // http://blogs.msdn.com/b/oldnewthing/archive/2011/12/02/10243553.aspx
-    if ((void*)_get_osfhandle(fd) == GetStdHandle(STD_INPUT_HANDLE))
-        SetStdHandle(STD_INPUT_HANDLE, NULL);
-
-    waio = waio_alloc((void *)_get_osfhandle(fd), 0, NULL, NULL);
-    if (!waio) {
-        MP_ERR(src, "Can't initialize win32 file reader.\n");
-        goto done;
+    p->file = (HANDLE)_get_osfhandle(p->fd);
+    if (!p->file || p->file == INVALID_HANDLE_VALUE) {
+        MP_ERR(src, "Can't open %s.\n", filename);
+        return;
     }
 
-    HANDLE terminate = CreateEvent(NULL, TRUE, FALSE, NULL);
-    if (!terminate)
-        goto done;
+    atomic_store(&p->cancel_requested, false);
+    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+        GetCurrentProcess(), &p->thread, SYNCHRONIZE, FALSE, 0))
+        return;
 
-    src->priv = terminate;
+    src->priv = p;
     src->cancel = request_cancel;
     src->uninit = uninit;
     mp_input_src_init_done(src);
 
-    char buffer[128];
-    struct waio_aiocb cb = {
-        .aio_buf = buffer,
-        .aio_nbytes = sizeof(buffer),
-        .hsignal = terminate,
-    };
-    while (1) {
-        if (waio_read(waio, &cb)) {
-            MP_ERR(src, "Read operation failed.\n");
+    char buffer[4096];
+    while (!atomic_load(&p->cancel_requested)) {
+        DWORD r;
+        if (!ReadFile(p->file, buffer, 4096, &r, NULL)) {
+            if (GetLastError() != ERROR_OPERATION_ABORTED)
+                MP_ERR(src, "Read operation failed.\n");
             break;
         }
-        if (waio_suspend(waio, (const struct waio_aiocb *[]){&cb}, 1, NULL))
-            break;
-        ssize_t r = waio_return(waio, &cb);
-        if (r <= 0)
-            break; // EOF or error
         mp_input_src_feed_cmd_text(src, buffer, r);
     }
-
-done:
-    waio_free(waio);
-    if (close_fd)
-        close(fd);
 }
 
 void mp_input_pipe_add(struct input_ctx *ictx, const char *filename)

--- a/osdep/main-fn-win.c
+++ b/osdep/main-fn-win.c
@@ -38,15 +38,12 @@ static void microsoft_nonsense(void)
     HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
 
     HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
-    WINBOOL (WINAPI *pSetDllDirectory)(LPCWSTR lpPathName) =
-        (WINBOOL (WINAPI *)(LPCWSTR))GetProcAddress(kernel32, "SetDllDirectoryW");
     WINBOOL (WINAPI *pSetSearchPathMode)(DWORD Flags) =
         (WINBOOL (WINAPI *)(DWORD))GetProcAddress(kernel32, "SetSearchPathMode");
 
     // Always use safe search paths for DLLs and other files, ie. never use the
     // current directory
-    if (pSetSearchPathMode)
-        pSetDllDirectory(L"");
+    SetDllDirectoryW(L"");
     if (pSetSearchPathMode)
         pSetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE);
 }

--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -24,6 +24,8 @@
     </trustInfo>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
             <!-- Windows 8 -->

--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -17,6 +17,7 @@
 
 #include <windows.h>
 #include <shlobj.h>
+#include <knownfolders.h>
 #include <pthread.h>
 
 #include "osdep/path.h"
@@ -52,20 +53,21 @@ static char *mp_get_win_exe_subdir(void *ta_ctx, const char *name)
     return talloc_asprintf(ta_ctx, "%s/%s", mp_get_win_exe_dir(ta_ctx), name);
 }
 
-static char *mp_get_win_shell_dir(void *talloc_ctx, int folder)
+static char *mp_get_win_shell_dir(void *talloc_ctx, REFKNOWNFOLDERID folder)
 {
-    wchar_t w_appdir[MAX_PATH + 1] = {0};
+    wchar_t *w_appdir = NULL;
 
-    if (SHGetFolderPathW(NULL, folder|CSIDL_FLAG_CREATE, NULL,
-        SHGFP_TYPE_CURRENT, w_appdir) != S_OK)
+    if (FAILED(SHGetKnownFolderPath(folder, KF_FLAG_CREATE, NULL, &w_appdir)))
         return NULL;
 
-    return mp_to_utf8(talloc_ctx, w_appdir);
+    char *appdir = mp_to_utf8(talloc_ctx, w_appdir);
+    CoTaskMemFree(w_appdir);
+    return appdir;
 }
 
 static char *mp_get_win_app_dir(void *talloc_ctx)
 {
-    char *path = mp_get_win_shell_dir(talloc_ctx, CSIDL_APPDATA);
+    char *path = mp_get_win_shell_dir(talloc_ctx, &FOLDERID_RoamingAppData);
     return path ? mp_path_join(talloc_ctx, path, "mpv") : NULL;
 }
 
@@ -95,6 +97,6 @@ const char *mp_get_platform_path_win(void *talloc_ctx, const char *type)
             return mp_get_win_exe_subdir(talloc_ctx, "mpv");
     }
     if (strcmp(type, "desktop") == 0)
-        return mp_get_win_shell_dir(talloc_ctx, CSIDL_DESKTOPDIRECTORY);
+        return mp_get_win_shell_dir(talloc_ctx, &FOLDERID_Desktop);
     return NULL;
 }

--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -118,7 +118,8 @@ static int create_overlapped_pipe(HANDLE *read, HANDLE *write)
     // overlapped pipes, so instead, use a named pipe with a unique name
     *read = CreateNamedPipeW(buf, PIPE_ACCESS_INBOUND |
         FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
-        PIPE_TYPE_BYTE | PIPE_WAIT, 1, 0, 4096, 0, NULL);
+        PIPE_TYPE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+        1, 0, 4096, 0, NULL);
     if (*read == INVALID_HANDLE_VALUE)
         goto error;
 

--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -137,15 +137,7 @@ error:
 static void delete_handle_list(void *p)
 {
     LPPROC_THREAD_ATTRIBUTE_LIST list = p;
-    VOID (WINAPI *pDeleteProcThreadAttributeList)(LPPROC_THREAD_ATTRIBUTE_LIST);
-
-    HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
-    pDeleteProcThreadAttributeList =
-        (VOID (WINAPI*)(LPPROC_THREAD_ATTRIBUTE_LIST))
-        GetProcAddress(kernel32, "DeleteProcThreadAttributeList");
-
-    if (pDeleteProcThreadAttributeList)
-        pDeleteProcThreadAttributeList(list);
+    DeleteProcThreadAttributeList(list);
 }
 
 // Create a PROC_THREAD_ATTRIBUTE_LIST that specifies exactly which handles are
@@ -153,38 +145,21 @@ static void delete_handle_list(void *p)
 static LPPROC_THREAD_ATTRIBUTE_LIST create_handle_list(void *ctx,
                                                        HANDLE *handles, int num)
 {
-    WINBOOL (WINAPI *pInitializeProcThreadAttributeList)(
-            LPPROC_THREAD_ATTRIBUTE_LIST, DWORD, DWORD, PSIZE_T);
-    WINBOOL (WINAPI *pUpdateProcThreadAttribute)(LPPROC_THREAD_ATTRIBUTE_LIST,
-            DWORD, DWORD_PTR, PVOID, SIZE_T, PVOID, PSIZE_T);
-
-    // Load Windows Vista functions, if available
-    HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
-    pInitializeProcThreadAttributeList =
-        (WINBOOL (WINAPI*)(LPPROC_THREAD_ATTRIBUTE_LIST, DWORD, DWORD, PSIZE_T))
-        GetProcAddress(kernel32, "InitializeProcThreadAttributeList");
-    pUpdateProcThreadAttribute =
-        (WINBOOL (WINAPI*)(LPPROC_THREAD_ATTRIBUTE_LIST, DWORD, DWORD_PTR,
-                           PVOID, SIZE_T, PVOID, PSIZE_T))
-        GetProcAddress(kernel32, "UpdateProcThreadAttribute");
-    if (!pInitializeProcThreadAttributeList || !pUpdateProcThreadAttribute)
-        return NULL;
-
     // Get required attribute list size
     SIZE_T size = 0;
-    if (!pInitializeProcThreadAttributeList(NULL, 1, 0, &size)) {
+    if (!InitializeProcThreadAttributeList(NULL, 1, 0, &size)) {
         if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
             return NULL;
     }
 
     // Allocate attribute list
     LPPROC_THREAD_ATTRIBUTE_LIST list = talloc_size(ctx, size);
-    if (!pInitializeProcThreadAttributeList(list, 1, 0, &size))
+    if (!InitializeProcThreadAttributeList(list, 1, 0, &size))
         goto error;
     talloc_set_destructor(list, delete_handle_list);
 
-    if (!pUpdateProcThreadAttribute(list, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-                                    handles, num * sizeof(HANDLE), NULL, NULL))
+    if (!UpdateProcThreadAttribute(list, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                   handles, num * sizeof(HANDLE), NULL, NULL))
         goto error;
 
     return list;
@@ -265,7 +240,7 @@ int mp_subprocess(char **args, struct mp_cancel *cancel, void *ctx,
     // Convert the args array to a UTF-16 Windows command-line string
     wchar_t *cmdline = write_cmdline(tmp, args);
 
-    DWORD flags = CREATE_UNICODE_ENVIRONMENT;
+    DWORD flags = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
     PROCESS_INFORMATION pi = {0};
     STARTUPINFOEXW si = {
         .StartupInfo = {
@@ -283,11 +258,6 @@ int mp_subprocess(char **args, struct mp_cancel *cancel, void *ctx,
         .lpAttributeList = create_handle_list(tmp,
                 (HANDLE[]){ pipes[0].write, pipes[1].write }, 2),
     };
-
-    // PROC_THREAD_ATTRIBUTE_LISTs are only supported in Vista and up. If not
-    // supported, create_handle_list will return NULL.
-    if (si.lpAttributeList)
-        flags |= EXTENDED_STARTUPINFO_PRESENT;
 
     // If we have a console, the subprocess will automatically attach to it so
     // it can receive Ctrl+C events. If we don't have a console, prevent the

--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -51,6 +51,8 @@ def __add_clang_flags__(ctx):
 def __add_mswin_flags__(ctx):
     ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x0601', '-DUNICODE', '-DCOBJMACROS',
                        '-U__STRICT_ANSI__']
+    ctx.env.LAST_LINKFLAGS += ['-Wl,--major-os-version=6,--minor-os-version=0',
+                 '-Wl,--major-subsystem-version=6,--minor-subsystem-version=0']
 
 def __add_mingw_flags__(ctx):
     __add_mswin_flags__(ctx)

--- a/wscript
+++ b/wscript
@@ -199,12 +199,6 @@ iconv support use --disable-iconv.",
         'deps_any': [ 'os-win32', 'os-cygwin' ],
         'func': check_true
     }, {
-        'name': '--waio',
-        'desc': 'libwaio for win32',
-        'deps': [ 'os-win32', 'mingw' ],
-        'func': check_libs(['waio'],
-                    check_statement('waio/waio.h', 'waio_alloc(0, 0, 0, 0)')),
-    }, {
         'name': '--termios',
         'desc': 'termios',
         'func': check_headers('termios.h', 'sys/termios.h'),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -180,7 +180,7 @@ def build(ctx):
         ( "input/input.c" ),
         ( "input/ipc.c",                         "!mingw" ),
         ( "input/keycodes.c" ),
-        ( "input/pipe-win32.c",                  "waio" ),
+        ( "input/pipe-win32.c",                  "mingw" ),
 
         ## Misc
         ( "misc/bstr.c" ),


### PR DESCRIPTION
This should remove most of the cruft that has been added to support Windows XP. All changes have been tested in a 32-bit Vista VM. The most notable change is probably in the last commit, which removes libwaio and replaces it with Vista's CancelIoEx.