### PR TITLE
path-win: include initguid.h

### DIFF
--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -17,6 +17,7 @@
 
 #include <windows.h>
 #include <shlobj.h>
+#include <initguid.h>
 #include <knownfolders.h>
 #include <pthread.h>
 


### PR DESCRIPTION
cygwin was giving undefined reference to `FOLDERID_Desktop' at link time