### PR TITLE
Wasapi wine

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -290,7 +290,7 @@ static int init(struct ao *ao)
         return -1;
     }
 
-    wasapi_setup_proxies(state);
+    wasapi_receive_proxies(state);
     MP_DBG(ao, "Init wasapi done\n");
     return 0;
 }

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -284,92 +284,111 @@ static int init(struct ao *ao)
     return 0;
 }
 
+static int control_exclusive(struct ao *ao, enum aocontrol cmd, void *arg)
+{
+    struct wasapi_state *state = ao->priv;
+
+    switch (cmd) {
+    case AOCONTROL_GET_VOLUME:
+    case AOCONTROL_SET_VOLUME:
+        if (!state->pEndpointVolumeProxy ||
+            !(state->vol_hw_support & ENDPOINT_HARDWARE_SUPPORT_VOLUME)) {
+            return CONTROL_FALSE;
+        }
+
+        float volume;
+        switch (cmd) {
+        case AOCONTROL_GET_VOLUME:
+            IAudioEndpointVolume_GetMasterVolumeLevelScalar(
+                state->pEndpointVolumeProxy,
+                &volume);
+            *(ao_control_vol_t *)arg = (ao_control_vol_t){
+                .left  = 100.0f * volume,
+                .right = 100.0f * volume,
+            };
+            return CONTROL_OK;
+        case AOCONTROL_SET_VOLUME:
+            volume = ((ao_control_vol_t *)arg)->left / 100.f;
+            IAudioEndpointVolume_SetMasterVolumeLevelScalar(
+                state->pEndpointVolumeProxy,
+                volume, NULL);
+            return CONTROL_OK;
+        }
+    case AOCONTROL_GET_MUTE:
+    case AOCONTROL_SET_MUTE:
+        if (!state->pEndpointVolumeProxy ||
+            !(state->vol_hw_support & ENDPOINT_HARDWARE_SUPPORT_MUTE)) {
+            return CONTROL_FALSE;
+        }
+
+        BOOL mute;
+        switch (cmd) {
+        case AOCONTROL_GET_MUTE:
+            IAudioEndpointVolume_GetMute(state->pEndpointVolumeProxy,
+                                         &mute);
+            *(bool *)arg = mute;
+            return CONTROL_OK;
+        case AOCONTROL_SET_MUTE:
+            mute = *(bool *)arg;
+            IAudioEndpointVolume_SetMute(state->pEndpointVolumeProxy,
+                                         mute, NULL);
+            return CONTROL_OK;
+        }
+    case AOCONTROL_HAS_PER_APP_VOLUME:
+        return CONTROL_FALSE;
+    default:
+        return CONTROL_UNKNOWN;
+    }
+}
+
+static int control_shared(struct ao *ao, enum aocontrol cmd, void *arg)
+{
+    struct wasapi_state *state = ao->priv;
+
+    switch (cmd) {
+    case AOCONTROL_GET_VOLUME:
+    case AOCONTROL_SET_VOLUME:
+    case AOCONTROL_GET_MUTE:
+    case AOCONTROL_SET_MUTE:
+    case AOCONTROL_HAS_PER_APP_VOLUME:
+        if (!state->pAudioVolumeProxy)
+            return CONTROL_FALSE;
+
+        float volume;
+        BOOL mute;
+        switch(cmd) {
+        case AOCONTROL_GET_VOLUME:
+            ISimpleAudioVolume_GetMasterVolume(state->pAudioVolumeProxy,
+                                               &volume);
+            *(ao_control_vol_t *)arg = (ao_control_vol_t){
+                .left  = 100.0f * volume,
+                .right = 100.0f * volume,
+            };
+            return CONTROL_OK;
+        case AOCONTROL_SET_VOLUME:
+            volume = ((ao_control_vol_t *)arg)->left / 100.f;
+            ISimpleAudioVolume_SetMasterVolume(state->pAudioVolumeProxy,
+                                               volume, NULL);
+            return CONTROL_OK;
+        case AOCONTROL_GET_MUTE:
+            ISimpleAudioVolume_GetMute(state->pAudioVolumeProxy, &mute);
+            *(bool *)arg = mute;
+            return CONTROL_OK;
+        case AOCONTROL_SET_MUTE:
+            mute = *(bool *)arg;
+            ISimpleAudioVolume_SetMute(state->pAudioVolumeProxy, mute, NULL);
+            return CONTROL_OK;
+        case AOCONTROL_HAS_PER_APP_VOLUME:
+            return CONTROL_TRUE;
+        }
+    default:
+        return CONTROL_UNKNOWN;
+    }
+}
+
 static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 {
     struct wasapi_state *state = ao->priv;
-    float volume;
-    BOOL mute;
-
-    if (state->opt_exclusive) {
-        // exclusive-specific
-        switch (cmd) {
-        case AOCONTROL_GET_VOLUME:
-        case AOCONTROL_SET_VOLUME:
-            if (!state->pEndpointVolumeProxy ||
-                !(state->vol_hw_support & ENDPOINT_HARDWARE_SUPPORT_VOLUME)) {
-                return CONTROL_FALSE;
-            }
-            switch (cmd) {
-            case AOCONTROL_GET_VOLUME:
-                IAudioEndpointVolume_GetMasterVolumeLevelScalar(state->pEndpointVolumeProxy,
-                                                                &volume);
-                *(ao_control_vol_t *)arg = (ao_control_vol_t){
-                    .left  = 100.0f * volume,
-                    .right = 100.0f * volume,
-                };
-                return CONTROL_OK;
-            case AOCONTROL_SET_VOLUME:
-                volume = ((ao_control_vol_t *)arg)->left / 100.f;
-                IAudioEndpointVolume_SetMasterVolumeLevelScalar(state->pEndpointVolumeProxy,
-                                                                volume, NULL);
-                return CONTROL_OK;
-            }
-        case AOCONTROL_GET_MUTE:
-        case AOCONTROL_SET_MUTE:
-            if (!state->pEndpointVolumeProxy ||
-                !(state->vol_hw_support & ENDPOINT_HARDWARE_SUPPORT_MUTE)) {
-                return CONTROL_FALSE;
-            }
-            switch (cmd) {
-            case AOCONTROL_GET_MUTE:
-                IAudioEndpointVolume_GetMute(state->pEndpointVolumeProxy, &mute);
-                *(bool *)arg = mute;
-                return CONTROL_OK;
-            case AOCONTROL_SET_MUTE:
-                mute = *(bool *)arg;
-                IAudioEndpointVolume_SetMute(state->pEndpointVolumeProxy, mute, NULL);
-                return CONTROL_OK;
-            }
-        case AOCONTROL_HAS_PER_APP_VOLUME:
-            return CONTROL_FALSE;
-        }
-    } else {
-        // shared-specific
-        switch (cmd) {
-        case AOCONTROL_GET_VOLUME:
-        case AOCONTROL_SET_VOLUME:
-        case AOCONTROL_GET_MUTE:
-        case AOCONTROL_SET_MUTE:
-        case AOCONTROL_HAS_PER_APP_VOLUME:
-            if (!state->pAudioVolumeProxy)
-                return CONTROL_FALSE;
-            switch(cmd) {
-            case AOCONTROL_GET_VOLUME:
-                ISimpleAudioVolume_GetMasterVolume(state->pAudioVolumeProxy,
-                                                   &volume);
-                *(ao_control_vol_t *)arg = (ao_control_vol_t){
-                    .left  = 100.0f * volume,
-                    .right = 100.0f * volume,
-                };
-                return CONTROL_OK;
-            case AOCONTROL_SET_VOLUME:
-                volume = ((ao_control_vol_t *)arg)->left / 100.f;
-                ISimpleAudioVolume_SetMasterVolume(state->pAudioVolumeProxy,
-                                                   volume, NULL);
-                return CONTROL_OK;
-            case AOCONTROL_GET_MUTE:
-                ISimpleAudioVolume_GetMute(state->pAudioVolumeProxy, &mute);
-                *(bool *)arg = mute;
-                return CONTROL_OK;
-            case AOCONTROL_SET_MUTE:
-                mute = *(bool *)arg;
-                ISimpleAudioVolume_SetMute(state->pAudioVolumeProxy, mute, NULL);
-                return CONTROL_OK;
-            case AOCONTROL_HAS_PER_APP_VOLUME:
-                return CONTROL_TRUE;
-            }
-        }
-    }
 
     // common to exclusive and shared
     switch (cmd) {
@@ -395,9 +414,10 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
         talloc_free(title);
 
         return CONTROL_OK;
-    default:
-        return CONTROL_UNKNOWN;
     }
+
+    return state->opt_exclusive ?
+        control_exclusive(ao, cmd, arg) : control_shared(ao, cmd, arg);
 }
 
 static void audio_reset(struct ao *ao)

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -39,8 +39,9 @@ static HRESULT get_device_delay(struct wasapi_state *state, double *delay) {
     HRESULT hr;
 
     hr = IAudioClock_GetPosition(state->pAudioClock, &position, &qpc_position);
-    /* GetPosition succeeded, but the result may be inaccurate due to the length of the call */
-    /* http://msdn.microsoft.com/en-us/library/windows/desktop/dd370889%28v=vs.85%29.aspx */
+    // GetPosition succeeded, but the result may be
+    // inaccurate due to the length of the call
+    // http://msdn.microsoft.com/en-us/library/windows/desktop/dd370889%28v=vs.85%29.aspx
     if (hr == S_FALSE) {
         MP_DBG(state, "Possibly inaccurate device position.\n");
         hr = S_OK;
@@ -49,12 +50,14 @@ static HRESULT get_device_delay(struct wasapi_state *state, double *delay) {
 
     LARGE_INTEGER qpc_count;
     QueryPerformanceCounter(&qpc_count);
-    double qpc_diff = (qpc_count.QuadPart * 1e7 / state->qpc_frequency.QuadPart) - qpc_position;
+    double qpc_diff = (qpc_count.QuadPart * 1e7 / state->qpc_frequency.QuadPart)
+                      - qpc_position;
 
     position += state->clock_frequency * (uint64_t) (qpc_diff / 1e7);
 
-    /* convert position to the same base as sample_count */
-    position = position * state->format.Format.nSamplesPerSec / state->clock_frequency;
+    // convert position to the same base as sample_count
+    position = position * state->format.Format.nSamplesPerSec
+               / state->clock_frequency;
 
     double diff = sample_count - position;
     *delay = diff / state->format.Format.nSamplesPerSec;
@@ -80,7 +83,8 @@ static void thread_feed(struct ao *ao)
         EXIT_ON_ERROR(hr);
 
         frame_count -= padding;
-        MP_TRACE(ao, "Frame to fill: %"PRIu32". Padding: %"PRIu32"\n", frame_count, padding);
+        MP_TRACE(ao, "Frame to fill: %"PRIu32". Padding: %"PRIu32"\n",
+                 frame_count, padding);
     }
     double delay;
     hr = get_device_delay(state, &delay);
@@ -124,17 +128,21 @@ static void thread_resume(struct ao *ao)
                mp_HRESULT_to_str(hr));
     }
 
-    /* Fill the buffer before starting, but only if there is no audio queued to play. */
-    /* This prevents overfilling the buffer, which leads to problems in exclusive mode */
+    // Fill the buffer before starting, but only if there is no audio queued to
+    // play.  This prevents overfilling the buffer, which leads to problems in
+    // exclusive mode
     if (padding < (UINT32) state->bufferFrameCount)
         thread_feed(ao);
 
     // start feeding next wakeup if something else hasn't been requested
     int expected = WASAPI_THREAD_RESUME;
-    atomic_compare_exchange_strong(&state->thread_state, &expected, WASAPI_THREAD_FEED);
+    atomic_compare_exchange_strong(&state->thread_state, &expected,
+                                   WASAPI_THREAD_FEED);
     hr = IAudioClient_Start(state->pAudioClient);
-    if (hr != S_OK)
-        MP_ERR(state, "IAudioClient_Start returned %s\n", mp_HRESULT_to_str(hr));
+    if (hr != S_OK) {
+        MP_ERR(state, "IAudioClient_Start returned %s\n",
+               mp_HRESULT_to_str(hr));
+    }
 
     return;
 }
@@ -145,11 +153,11 @@ static void thread_reset(struct ao *ao)
     HRESULT hr;
     MP_DBG(state, "Thread Reset\n");
     hr = IAudioClient_Stop(state->pAudioClient);
-    /* we may get S_FALSE if the stream is already stopped */
+    // we may get S_FALSE if the stream is already stopped
     if (hr != S_OK && hr != S_FALSE)
         MP_ERR(state, "IAudioClient_Stop returned: %s\n", mp_HRESULT_to_str(hr));
 
-    /* we may get S_FALSE if the stream is already reset */
+    // we may get S_FALSE if the stream is already reset
     hr = IAudioClient_Reset(state->pAudioClient);
     if (hr != S_OK && hr != S_FALSE)
         MP_ERR(state, "IAudioClient_Reset returned: %s\n", mp_HRESULT_to_str(hr));
@@ -157,7 +165,8 @@ static void thread_reset(struct ao *ao)
     atomic_store(&state->sample_count, 0);
     // start feeding next wakeup if something else hasn't been requested
     int expected = WASAPI_THREAD_RESET;
-    atomic_compare_exchange_strong(&state->thread_state, &expected, WASAPI_THREAD_FEED);
+    atomic_compare_exchange_strong(&state->thread_state, &expected,
+                                   WASAPI_THREAD_FEED);
     return;
 }
 
@@ -173,11 +182,12 @@ static DWORD __stdcall AudioThread(void *lpParameter)
         goto exit_label;
 
     MP_DBG(ao, "Entering dispatch loop\n");
-    while (true) { /* watch events */
+    while (true) { // watch events
         HANDLE events[] = {state->hWake};
-        switch (MsgWaitForMultipleObjects(MP_ARRAY_SIZE(events), events, FALSE, INFINITE,
+        switch (MsgWaitForMultipleObjects(MP_ARRAY_SIZE(events), events,
+                                          FALSE, INFINITE,
                                           QS_POSTMESSAGE | QS_SENDMESSAGE)) {
-        /* AudioThread wakeup */
+        // AudioThread wakeup
         case WAIT_OBJECT_0:
             switch (atomic_load(&state->thread_state)) {
             case WASAPI_THREAD_FEED:
@@ -198,7 +208,7 @@ static DWORD __stdcall AudioThread(void *lpParameter)
                 goto exit_label;
             }
             break;
-        /* messages to dispatch (COM marshalling) */
+        // messages to dispatch (COM marshalling)
         case (WAIT_OBJECT_0 + MP_ARRAY_SIZE(events)):
             wasapi_dispatch(ao);
             break;
@@ -215,7 +225,8 @@ exit_label:
     return 0;
 }
 
-static void set_thread_state(struct ao *ao, enum wasapi_thread_state thread_state)
+static void set_thread_state(struct ao *ao,
+                             enum wasapi_thread_state thread_state)
 {
     struct wasapi_state *state = ao->priv;
     atomic_store(&state->thread_state, thread_state);
@@ -230,7 +241,7 @@ static void uninit(struct ao *ao)
     if (state->hWake)
         set_thread_state(ao, WASAPI_THREAD_SHUTDOWN);
 
-    /* wait up to 10 seconds */
+    // wait up to 10 seconds
     if (state->hAudioThread &&
         WaitForSingleObject(state->hAudioThread, 10000) == WAIT_TIMEOUT)
     {
@@ -270,7 +281,7 @@ static int init(struct ao *ao)
         return -1;
     }
 
-    WaitForSingleObject(state->hInitDone, INFINITE); /* wait on init complete */
+    WaitForSingleObject(state->hInitDone, INFINITE); // wait on init complete
     SAFE_RELEASE(state->hInitDone,CloseHandle(state->hInitDone));
     if (state->init_ret != S_OK) {
         if (!ao->probing)
@@ -396,23 +407,21 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
         if (!state->pSessionControlProxy)
             return CONTROL_FALSE;
 
-        MP_VERBOSE(state, "Updating stream title to \"%s\"\n", (char*)arg);
         wchar_t *title = mp_from_utf8(NULL, (char*)arg);
-
         wchar_t *tmp = NULL;
-
-        /* There is a weird race condition in the IAudioSessionControl itself --
-           it seems that *sometimes* the SetDisplayName does not take effect and it still shows
-           the old title. Use this loop to insist until it works. */
+        // There is a weird race condition in the IAudioSessionControl itself --
+        // it seems that *sometimes* the SetDisplayName does not take effect and
+        // it still shows the old title. Use this loop to insist until it works.
         do {
-            IAudioSessionControl_SetDisplayName(state->pSessionControlProxy, title, NULL);
+            IAudioSessionControl_SetDisplayName(state->pSessionControlProxy,
+                                                title, NULL);
 
             SAFE_RELEASE(tmp, CoTaskMemFree(tmp));
-            IAudioSessionControl_GetDisplayName(state->pSessionControlProxy, &tmp);
+            IAudioSessionControl_GetDisplayName(state->pSessionControlProxy,
+                                                &tmp);
         } while (lstrcmpW(title, tmp));
         SAFE_RELEASE(tmp, CoTaskMemFree(tmp));
         talloc_free(title);
-
         return CONTROL_OK;
     }
 
@@ -435,7 +444,8 @@ static void hotplug_uninit(struct ao *ao)
     MP_DBG(ao, "Hotplug uninit\n");
     struct wasapi_state *state = ao->priv;
     wasapi_change_uninit(ao);
-    SAFE_RELEASE(state->pEnumerator, IMMDeviceEnumerator_Release(state->pEnumerator));
+    SAFE_RELEASE(state->pEnumerator,
+                 IMMDeviceEnumerator_Release(state->pEnumerator));
     CoUninitialize();
 }
 
@@ -446,7 +456,8 @@ static int hotplug_init(struct ao *ao)
     state->log = ao->log;
     CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
     HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator, (void **)&state->pEnumerator);
+                                  &IID_IMMDeviceEnumerator,
+                                  (void **)&state->pEnumerator);
     EXIT_ON_ERROR(hr);
     hr = wasapi_change_init(ao, true);
     EXIT_ON_ERROR(hr);

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -29,8 +29,8 @@
 #include "osdep/atomics.h"
 
 typedef struct change_notify {
-    IMMNotificationClient client; /* this must be first in the structure! */
-    LPWSTR monitored; /* Monitored device */
+    IMMNotificationClient client; // this must be first in the structure!
+    LPWSTR monitored; // Monitored device
     bool is_hotplug;
     struct ao *ao;
 } change_notify;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -103,7 +103,6 @@ typedef struct wasapi_state {
 
     /* format info */
     WAVEFORMATEXTENSIBLE format;
-    size_t buffer_block_size; /* Size of each block in bytes */
     UINT32 bufferFrameCount; /* wasapi buffer block size, number of frames, frame size at format.nBlockAlign */
 
     change_notify change;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -73,7 +73,6 @@ typedef struct wasapi_state {
     IAudioClock *pAudioClock;
     atomic_ullong sample_count;  // samples per channel written by GetBuffer
     UINT64 clock_frequency;      // scale for position returned by GetPosition
-    LARGE_INTEGER qpc_frequency; // frequency of Windows' high resolution timer
 
     // WASAPI control (handles owned by audio thread but used by main thread)
     IAudioSessionControl *pSessionControl; // setting the stream title

--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -30,7 +30,7 @@
 static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_QueryInterface(
     IMMNotificationClient* This, REFIID riid, void **ppvObject)
 {
-    /* Compatible with IMMNotificationClient and IUnknown */
+    // Compatible with IMMNotificationClient and IUnknown
     if (IsEqualGUID(&IID_IMMNotificationClient, riid) ||
         IsEqualGUID(&IID_IUnknown, riid))
     {
@@ -42,14 +42,14 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_QueryInterface(
     }
 }
 
-/* these are required, but not actually used */
+// these are required, but not actually used
 static ULONG STDMETHODCALLTYPE sIMMNotificationClient_AddRef(
     IMMNotificationClient *This)
 {
     return 1;
 }
 
-/* MSDN says it should free itself, but we're static */
+// MSDN says it should free itself, but we're static
 static ULONG STDMETHODCALLTYPE sIMMNotificationClient_Release(
     IMMNotificationClient *This)
 {
@@ -65,7 +65,8 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDeviceStateChanged(
     struct ao *ao = change->ao;
 
     if (change->is_hotplug) {
-        MP_VERBOSE(ao, "OnDeviceStateChanged triggered: sending hotplug event\n");
+        MP_VERBOSE(ao,
+                   "OnDeviceStateChanged triggered: sending hotplug event\n");
         ao_hotplug_event(ao);
     } else if (pwstrDeviceId && !wcscmp(pwstrDeviceId, change->monitored)) {
         switch (dwNewState) {
@@ -99,7 +100,7 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDeviceAdded(
     return S_OK;
 }
 
-/* maybe MPV can go over to the prefered device once it is plugged in? */
+// maybe MPV can go over to the prefered device once it is plugged in?
 static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDeviceRemoved(
     IMMNotificationClient *This,
     LPCWSTR pwstrDeviceId)
@@ -129,29 +130,31 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDefaultDeviceChanged(
     struct ao *ao = change->ao;
     struct wasapi_state *state = ao->priv;
 
-    /* don't care about "eCapture" or non-"eMultimedia" roles  */
+    // don't care about "eCapture" or non-"eMultimedia" roles
     if (flow == eCapture || role != eMultimedia) return S_OK;
 
     if (change->is_hotplug) {
-        MP_VERBOSE(ao, "OnDefaultDeviceChanged triggered: sending hotplug event\n");
+        MP_VERBOSE(ao,
+                   "OnDefaultDeviceChanged triggered: sending hotplug event\n");
         ao_hotplug_event(ao);
     } else {
-        /* stay on the device the user specified */
+        // stay on the device the user specified
         if (state->opt_device) {
             MP_VERBOSE(ao, "OnDefaultDeviceChanged triggered: "
                        "staying on specified device %s\n", state->opt_device);
             return S_OK;
         }
 
-        /* don't reload if already on the new default */
+        // don't reload if already on the new default
         if (pwstrDeviceId && !wcscmp(pwstrDeviceId, change->monitored)) {
             MP_VERBOSE(ao, "OnDefaultDeviceChanged triggered: "
                        "already using default device, no reload required\n");
             return S_OK;
         }
 
-        /* if we got here, we need to reload */
-        MP_VERBOSE(ao, "OnDefaultDeviceChanged triggered: requesting ao reload\n");
+        // if we got here, we need to reload
+        MP_VERBOSE(ao,
+                   "OnDefaultDeviceChanged triggered: requesting ao reload\n");
         ao_request_reload(ao);
     }
 
@@ -201,24 +204,24 @@ HRESULT wasapi_change_init(struct ao *ao, bool is_hotplug)
     struct wasapi_state *state = ao->priv;
     struct change_notify *change = &state->change;
     HRESULT hr;
-    /* COM voodoo to emulate c++ class */
+    // COM voodoo to emulate c++ class
     change->client.lpVtbl = &sIMMDeviceEnumeratorVtbl_vtbl;
 
-    /* register the change notification client */
+    // register the change notification client
     hr = IMMDeviceEnumerator_RegisterEndpointNotificationCallback(
         state->pEnumerator, (IMMNotificationClient *)change);
     EXIT_ON_ERROR(hr);
 
-    /* so the callbacks can access the ao */
+    // so the callbacks can access the ao
     change->ao = ao;
 
-    /* whether or not this is the hotplug instance */
+    // whether or not this is the hotplug instance
     change->is_hotplug = is_hotplug;
 
     if (is_hotplug) {
         MP_DBG(ao, "Monitoring for hotplug events\n");
     } else {
-        /* Get the device string to compare with the pwstrDeviceId */
+        // Get the device string to compare with the pwstrDeviceId
         hr = IMMDevice_GetId(state->pDevice, &change->monitored);
         EXIT_ON_ERROR(hr);
         MP_VERBOSE(ao, "Monitoring changes in device %S\n", change->monitored);

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -694,9 +694,6 @@ reinit:
     EXIT_ON_ERROR(hr);
 
     ao->device_buffer = state->bufferFrameCount;
-    state->buffer_block_size = state->format.Format.nChannels *
-                               state->format.Format.wBitsPerSample / 8 *
-                               state->bufferFrameCount;
     bufferDuration =
         (REFERENCE_TIME) ((10000.0 * 1000 / state->format.Format.nSamplesPerSec *
                            state->bufferFrameCount) + 0.5);
@@ -714,9 +711,6 @@ reinit:
         MP_WARN(state, "Failed to set AV thread to Pro Audio: %s\n",
                 mp_LastError_to_str());
     }
-
-    MP_VERBOSE(state, "Format fixed. Using %lld byte buffer block size\n",
-               (long long) state->buffer_block_size);
 
     return S_OK;
 exit_label:

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -97,8 +97,8 @@ static const GUID *format_to_subtype(int format)
     return &KSDATAFORMAT_SUBTYPE_PCM;
 }
 
-// "solve" the under-determined inverse of format_to_subtype by
-// assuming the input subtype is "special" (i.e. IEC61937)
+// "solve" the under-determined inverse of format_to_subtype by assuming the
+// input subtype is "special" (i.e. IEC61937)
 static int special_subtype_to_format(const GUID *subtype) {
     for (int i = 0; wasapi_fmt_table[i].format; i++) {
         if (IsEqualGUID(subtype, wasapi_fmt_table[i].subtype))
@@ -123,7 +123,8 @@ char *mp_PKEY_to_str_buf(char *buf, size_t buf_size, const PROPERTYKEY *pkey)
 {
     buf = mp_GUID_to_str_buf(buf, buf_size, &pkey->fmtid);
     size_t guid_len = strnlen(buf, buf_size);
-    snprintf(buf + guid_len, buf_size - guid_len, ",%"PRIu32, (uint32_t) pkey->pid);
+    snprintf(buf + guid_len, buf_size - guid_len, ",%"PRIu32,
+             (uint32_t) pkey->pid);
     return buf;
 }
 
@@ -204,15 +205,15 @@ static void set_waveformat(WAVEFORMATEXTENSIBLE *wformat,
     wformat->Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
 
     wformat->SubFormat                   = *format_to_subtype(format);
-    wformat->Samples.wValidBitsPerSample = valid_bits ? valid_bits : wformat->Format.wBitsPerSample;
+    wformat->Samples.wValidBitsPerSample =
+        valid_bits ? valid_bits : wformat->Format.wBitsPerSample;
     wformat->dwChannelMask               = mp_chmap_to_waveext(channels);
     update_waveformat_datarate(wformat);
 }
 
-// This implicitly transforms all pcm formats to:
-// interleaved / signed (except 8-bit is unsigned) / waveext channel order.
-// "Special" formats should be exempt as they should already
-// satisfy these properties.
+// This implicitly transforms all pcm formats to: interleaved / signed (except
+// 8-bit is unsigned) / waveext channel order.  "Special" formats should be
+// exempt as they should already satisfy these properties.
 static void set_waveformat_with_ao(WAVEFORMATEXTENSIBLE *wformat, struct ao *ao)
 {
     struct mp_chmap channels = ao->channels;
@@ -257,7 +258,8 @@ static int format_from_waveformat(WAVEFORMATEX *wf)
         WAVEFORMATEXTENSIBLE *wformat = (WAVEFORMATEXTENSIBLE *)wf;
         if (IsEqualGUID(&wformat->SubFormat, &KSDATAFORMAT_SUBTYPE_PCM)) {
             format = wf->wBitsPerSample == 8 ? AF_FORMAT_U8 : AF_FORMAT_S32;
-        } else if (IsEqualGUID(&wformat->SubFormat, &KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)) {
+        } else if (IsEqualGUID(&wformat->SubFormat,
+                               &KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)) {
             format = AF_FORMAT_FLOAT;
         } else {
             format = special_subtype_to_format(&wformat->SubFormat);
@@ -275,16 +277,17 @@ static int format_from_waveformat(WAVEFORMATEX *wf)
     }
     // https://msdn.microsoft.com/en-us/library/windows/hardware/ff538802%28v=vs.85%29.aspx:
     // Since mpv doesn't have the notion of "valid bits", we just specify a
-    // format with the container size. The least significant, "invalid"
-    // bits will be excess precision ignored by wasapi.
-    // The change_bytes operations should be a no-op for properly
-    // configured "special" formats, otherwise it will return 0.
+    // format with the container size. The least significant, "invalid" bits
+    // will be excess precision ignored by wasapi.  The change_bytes operations
+    // should be a no-op for properly configured "special" formats, otherwise it
+    // will return 0.
     if (wf->wBitsPerSample % 8)
         return 0;
     return af_fmt_change_bytes(format, wf->wBitsPerSample / 8);
 }
 
-static bool chmap_from_waveformat(struct mp_chmap *channels, const WAVEFORMATEX *wf)
+static bool chmap_from_waveformat(struct mp_chmap *channels,
+                                  const WAVEFORMATEX *wf)
 {
     if (wf->wFormatTag == WAVE_FORMAT_EXTENSIBLE) {
         WAVEFORMATEXTENSIBLE *wformat = (WAVEFORMATEXTENSIBLE *)wf;
@@ -312,7 +315,8 @@ static char *waveformat_to_str_buf(char *buf, size_t buf_size, WAVEFORMATEX *wf)
         snprintf(validstr, sizeof(validstr), " (%u valid)", valid_bits);
 
     snprintf(buf, buf_size, "%s %s%s @ %uhz",
-             mp_chmap_to_str(&channels), af_fmt_to_str(format_from_waveformat(wf)),
+             mp_chmap_to_str(&channels),
+             af_fmt_to_str(format_from_waveformat(wf)),
              validstr, (unsigned) wf->nSamplesPerSec);
     return buf;
 }
@@ -327,7 +331,8 @@ static void waveformat_copy(WAVEFORMATEXTENSIBLE* dst, WAVEFORMATEX* src)
     }
 }
 
-static bool set_ao_format(struct ao *ao, WAVEFORMATEX *wf, AUDCLNT_SHAREMODE share_mode)
+static bool set_ao_format(struct ao *ao, WAVEFORMATEX *wf,
+                          AUDCLNT_SHAREMODE share_mode)
 {
     struct wasapi_state *state = ao->priv;
     int format = format_from_waveformat(wf);
@@ -337,7 +342,8 @@ static bool set_ao_format(struct ao *ao, WAVEFORMATEX *wf, AUDCLNT_SHAREMODE sha
         return false;
     }
 
-    // Do not touch the ao for passthrough, just assume that we set WAVEFORMATEX correctly.
+    // Do not touch the ao for passthrough, just assume that we set WAVEFORMATEX
+    // correctly.
     if (af_fmt_is_pcm(format)) {
         struct mp_chmap channels;
         if (!chmap_from_waveformat(&channels, wf)) {
@@ -357,7 +363,8 @@ static bool set_ao_format(struct ao *ao, WAVEFORMATEX *wf, AUDCLNT_SHAREMODE sha
 static bool try_format_exclusive(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat)
 {
     struct wasapi_state *state = ao->priv;
-    MP_VERBOSE(ao, "Trying %s (exclusive)\n", waveformat_to_str(&wformat->Format));
+    MP_VERBOSE(ao, "Trying %s (exclusive)\n",
+               waveformat_to_str(&wformat->Format));
     HRESULT hr = IAudioClient_IsFormatSupported(state->pAudioClient,
                                                 AUDCLNT_SHAREMODE_EXCLUSIVE,
                                                 &wformat->Format, NULL);
@@ -470,7 +477,8 @@ static bool search_channels(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat)
         if (!wformat->Format.nSamplesPerSec) {
             if (search_samplerates(ao, wformat, &entry)) {
                 mp_chmap_sel_add_map(&chmap_sel, &entry);
-                MP_VERBOSE(ao, "%s is supported\n", waveformat_to_str(&wformat->Format));
+                MP_VERBOSE(ao, "%s is supported\n",
+                           waveformat_to_str(&wformat->Format));
             }
         } else {
             change_waveformat_channels(wformat, &entry);
@@ -494,8 +502,8 @@ static bool find_formats_exclusive(struct ao *ao, bool do_search)
     WAVEFORMATEXTENSIBLE wformat;
     set_waveformat_with_ao(&wformat, ao);
 
-    // Try the requested format as is. If that doesn't work, and the
-    // do_search argument is set, do the pcm format search.
+    // Try the requested format as is. If that doesn't work, and the do_search
+    // argument is set, do the pcm format search.
     if (!try_format_exclusive_with_spdif_fallback(ao, &wformat) &&
         (!do_search || !search_channels(ao, &wformat)))
         return false;
@@ -550,7 +558,8 @@ static bool find_formats_shared(struct ao *ao)
                af_fmt_to_str(ao->format), ao->samplerate);
     return true;
 exit_label:
-    MP_ERR(state, "Error finding shared mode format: %s\n", mp_HRESULT_to_str(hr));
+    MP_ERR(state, "Error finding shared mode format: %s\n",
+           mp_HRESULT_to_str(hr));
     return false;
 }
 
@@ -587,7 +596,8 @@ static HRESULT init_clock(struct wasapi_state *state) {
 
     atomic_store(&state->sample_count, 0);
 
-    MP_VERBOSE(state, "IAudioClock::GetFrequency gave a frequency of %"PRIu64".\n",
+    MP_VERBOSE(state,
+               "IAudioClock::GetFrequency gave a frequency of %"PRIu64".\n",
                (uint64_t) state->clock_frequency);
 
     return S_OK;
@@ -608,7 +618,8 @@ static HRESULT init_session_display(struct wasapi_state *state) {
     GetModuleFileNameW(NULL, path, MAX_PATH);
     lstrcatW(path, L",-IDI_ICON1");
 
-    hr = IAudioSessionControl_SetDisplayName(state->pSessionControl, MIXER_DEFAULT_LABEL, NULL);
+    hr = IAudioSessionControl_SetDisplayName(state->pSessionControl,
+                                             MIXER_DEFAULT_LABEL, NULL);
     EXIT_ON_ERROR(hr);
     hr = IAudioSessionControl_SetIconPath(state->pSessionControl, path, NULL);
     EXIT_ON_ERROR(hr);
@@ -626,15 +637,18 @@ static HRESULT fix_format(struct ao *ao)
 
     REFERENCE_TIME devicePeriod, bufferDuration, bufferPeriod;
     MP_DBG(state, "IAudioClient::GetDevicePeriod\n");
-    HRESULT hr = IAudioClient_GetDevicePeriod(state->pAudioClient,&devicePeriod, NULL);
-    MP_VERBOSE(state, "Device period: %.2g ms\n", (double) devicePeriod / 10000.0 );
+    HRESULT hr = IAudioClient_GetDevicePeriod(state->pAudioClient,&devicePeriod,
+                                              NULL);
+    MP_VERBOSE(state, "Device period: %.2g ms\n",
+               (double) devicePeriod / 10000.0 );
 
-    /* integer multiple of device period close to 50ms */
-    bufferPeriod = bufferDuration = ceil(50.0 * 10000.0 / devicePeriod) * devicePeriod;
+    // integer multiple of device period close to 50ms
+    bufferPeriod = bufferDuration =
+                   ceil(50.0 * 10000.0 / devicePeriod) * devicePeriod;
 
-    /* handle unsupported buffer size */
-    /* hopefully this shouldn't happen because of the above integer device period */
-    /* http://msdn.microsoft.com/en-us/library/windows/desktop/dd370875%28v=vs.85%29.aspx */
+    // handle unsupported buffer size hopefully this shouldn't happen because of
+    // the above integer device period
+    // http://msdn.microsoft.com/en-us/library/windows/desktop/dd370875%28v=vs.85%29.aspx
     int retries=0;
 reinit:
     if (state->share_mode == AUDCLNT_SHAREMODE_SHARED)
@@ -648,20 +662,22 @@ reinit:
                                  bufferPeriod,
                                  &(state->format.Format),
                                  NULL);
-    /* something about buffer sizes on Win7 */
+    // something about buffer sizes on Win7
     if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
         if (retries > 0) {
             EXIT_ON_ERROR(hr);
         } else {
             retries ++;
         }
-        MP_VERBOSE(state, "IAudioClient::Initialize negotiation failed with %s, used %lld * 100ns\n",
+        MP_VERBOSE(state, "IAudioClient::Initialize negotiation failed with %s,"
+                   "used %lld * 100ns\n",
                    mp_HRESULT_to_str(hr), bufferDuration);
 
-        IAudioClient_GetBufferSize(state->pAudioClient, &state->bufferFrameCount);
-        bufferPeriod = bufferDuration =
-            (REFERENCE_TIME) ((10000.0 * 1000 / state->format.Format.nSamplesPerSec *
-                               state->bufferFrameCount) + 0.5);
+        IAudioClient_GetBufferSize(state->pAudioClient,
+                                   &state->bufferFrameCount);
+        bufferPeriod = bufferDuration = (REFERENCE_TIME) (0.5 +
+            (10000.0 * 1000 / state->format.Format.nSamplesPerSec
+             * state->bufferFrameCount));
 
         IAudioClient_Release(state->pAudioClient);
         state->pAudioClient = NULL;
@@ -694,9 +710,9 @@ reinit:
     EXIT_ON_ERROR(hr);
 
     ao->device_buffer = state->bufferFrameCount;
-    bufferDuration =
-        (REFERENCE_TIME) ((10000.0 * 1000 / state->format.Format.nSamplesPerSec *
-                           state->bufferFrameCount) + 0.5);
+    bufferDuration = (REFERENCE_TIME) (0.5 +
+        (10000.0 * 1000 / state->format.Format.nSamplesPerSec
+         * state->bufferFrameCount));
     MP_VERBOSE(state, "Buffer frame count: %"PRIu32" (%.2g ms)\n",
                state->bufferFrameCount, (double) bufferDuration / 10000.0 );
 
@@ -731,7 +747,8 @@ static char* get_device_id(IMMDevice *pDevice) {
     idstr = mp_to_utf8(NULL, devid);
 
     if (strstr(idstr, "{0.0.0.00000000}.")) {
-        char *stripped = talloc_strdup(NULL, idstr + strlen("{0.0.0.00000000}."));
+        char *stripped =
+            talloc_strdup(NULL, idstr + strlen("{0.0.0.00000000}."));
         talloc_free(idstr);
         idstr = stripped;
     }
@@ -754,7 +771,8 @@ static char* get_device_name(IMMDevice *pDevice) {
     PROPVARIANT devname;
     PropVariantInit(&devname);
 
-    hr = IPropertyStore_GetValue(pProps, &mp_PKEY_Device_FriendlyName, &devname);
+    hr = IPropertyStore_GetValue(pProps, &mp_PKEY_Device_FriendlyName,
+                                 &devname);
     EXIT_ON_ERROR(hr);
 
     namestr = mp_to_utf8(NULL, devname.pwszVal);
@@ -816,8 +834,9 @@ void wasapi_list_devs(struct ao *ao, struct ao_device_list *list)
     IMMDevice *pDevice = NULL;
     char *name = NULL, *id = NULL;
 
-    HRESULT hr = IMMDeviceEnumerator_EnumAudioEndpoints(state->pEnumerator, eRender,
-                                                        DEVICE_STATE_ACTIVE, &pDevices);
+    HRESULT hr =
+        IMMDeviceEnumerator_EnumAudioEndpoints(state->pEnumerator, eRender,
+                                               DEVICE_STATE_ACTIVE, &pDevices);
     EXIT_ON_ERROR(hr);
 
     int count;
@@ -856,12 +875,14 @@ exit_label:
     SAFE_RELEASE(pDevices, IMMDeviceCollection_Release(pDevices));
 }
 
-static HRESULT load_default_device(struct ao *ao, IMMDeviceEnumerator* pEnumerator,
+static HRESULT load_default_device(struct ao *ao,
+                                   IMMDeviceEnumerator* pEnumerator,
                                    IMMDevice **ppDevice)
 {
-    HRESULT hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(pEnumerator,
-                                                             eRender, eMultimedia,
-                                                             ppDevice);
+    HRESULT hr =
+        IMMDeviceEnumerator_GetDefaultAudioEndpoint(pEnumerator,
+                                                    eRender, eMultimedia,
+                                                    ppDevice);
     EXIT_ON_ERROR(hr);
 
     char *id = get_device_id(*ppDevice);
@@ -874,7 +895,8 @@ exit_label:
     return hr;
 }
 
-static HRESULT find_and_load_device(struct ao *ao, IMMDeviceEnumerator* pEnumerator,
+static HRESULT find_and_load_device(struct ao *ao,
+                                    IMMDeviceEnumerator* pEnumerator,
                                     IMMDevice **ppDevice, char *search)
 {
     HRESULT hr;
@@ -893,7 +915,8 @@ static HRESULT find_and_load_device(struct ao *ao, IMMDeviceEnumerator* pEnumera
 
     if (devid == NULL) {
         hr = IMMDeviceEnumerator_EnumAudioEndpoints(pEnumerator, eRender,
-                                                    DEVICE_STATE_ACTIVE, &pDevices);
+                                                    DEVICE_STATE_ACTIVE,
+                                                    &pDevices);
         EXIT_ON_ERROR(hr);
 
         int count;
@@ -913,7 +936,8 @@ static HRESULT find_and_load_device(struct ao *ao, IMMDeviceEnumerator* pEnumera
         }
     } else {
         hr = IMMDeviceEnumerator_EnumAudioEndpoints(pEnumerator, eRender,
-                                                    DEVICE_STATE_ACTIVE|DEVICE_STATE_UNPLUGGED,
+                                                    DEVICE_STATE_ACTIVE
+                                                    | DEVICE_STATE_UNPLUGGED,
                                                     &pDevices);
         EXIT_ON_ERROR(hr);
 
@@ -991,9 +1015,12 @@ HRESULT wasapi_setup_proxies(struct wasapi_state *state) {
     EXIT_ON_ERROR(hr);                                                    \
 } while (0)
 
-    UNMARSHAL(IID_ISimpleAudioVolume,   state->pAudioVolumeProxy,    state->sAudioVolume);
-    UNMARSHAL(IID_IAudioEndpointVolume, state->pEndpointVolumeProxy, state->sEndpointVolume);
-    UNMARSHAL(IID_IAudioSessionControl, state->pSessionControlProxy, state->sSessionControl);
+    UNMARSHAL(IID_ISimpleAudioVolume,   state->pAudioVolumeProxy,
+              state->sAudioVolume);
+    UNMARSHAL(IID_IAudioEndpointVolume, state->pEndpointVolumeProxy,
+              state->sEndpointVolume);
+    UNMARSHAL(IID_IAudioSessionControl, state->pSessionControlProxy,
+              state->sSessionControl);
 
 #undef UNMARSHAL
 
@@ -1004,9 +1031,12 @@ exit_label:
 }
 
 void wasapi_release_proxies(wasapi_state *state) {
-    SAFE_RELEASE(state->pAudioVolumeProxy,    ISimpleAudioVolume_Release(state->pAudioVolumeProxy));
-    SAFE_RELEASE(state->pEndpointVolumeProxy, IAudioEndpointVolume_Release(state->pEndpointVolumeProxy));
-    SAFE_RELEASE(state->pSessionControlProxy, IAudioSessionControl_Release(state->pSessionControlProxy));
+    SAFE_RELEASE(state->pAudioVolumeProxy,
+                 ISimpleAudioVolume_Release(state->pAudioVolumeProxy));
+    SAFE_RELEASE(state->pEndpointVolumeProxy,
+                 IAudioEndpointVolume_Release(state->pEndpointVolumeProxy));
+    SAFE_RELEASE(state->pSessionControlProxy,
+                 IAudioSessionControl_Release(state->pSessionControlProxy));
 }
 
 static HRESULT create_proxies(struct wasapi_state *state) {
@@ -1021,9 +1051,12 @@ static HRESULT create_proxies(struct wasapi_state *state) {
     EXIT_ON_ERROR(hr);                                             \
 } while (0)
 
-    MARSHAL(IID_ISimpleAudioVolume,   state->sAudioVolume,    state->pAudioVolume);
-    MARSHAL(IID_IAudioEndpointVolume, state->sEndpointVolume, state->pEndpointVolume);
-    MARSHAL(IID_IAudioSessionControl, state->sSessionControl, state->pSessionControl);
+    MARSHAL(IID_ISimpleAudioVolume,   state->sAudioVolume,
+            state->pAudioVolume);
+    MARSHAL(IID_IAudioEndpointVolume, state->sEndpointVolume,
+            state->pEndpointVolume);
+    MARSHAL(IID_IAudioSessionControl, state->sSessionControl,
+            state->pSessionControl);
 
     return S_OK;
 exit_label:
@@ -1032,15 +1065,18 @@ exit_label:
 }
 
 static void destroy_proxies(struct wasapi_state *state) {
-    SAFE_RELEASE(state->sAudioVolume,    IStream_Release(state->sAudioVolume));
-    SAFE_RELEASE(state->sEndpointVolume, IStream_Release(state->sEndpointVolume));
-    SAFE_RELEASE(state->sSessionControl, IStream_Release(state->sSessionControl));
+    SAFE_RELEASE(state->sAudioVolume,
+                 IStream_Release(state->sAudioVolume));
+    SAFE_RELEASE(state->sEndpointVolume,
+                 IStream_Release(state->sEndpointVolume));
+    SAFE_RELEASE(state->sSessionControl,
+                 IStream_Release(state->sSessionControl));
 }
 
 void wasapi_dispatch(struct ao *ao)
 {
     MP_DBG(ao, "Dispatch\n");
-    /* dispatch any possible pending messages */
+    // dispatch any possible pending messages
     MSG msg;
     while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         DispatchMessage(&msg);
@@ -1054,7 +1090,8 @@ HRESULT wasapi_thread_init(struct ao *ao)
 retry: ;
 
     HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator, (void **)&state->pEnumerator);
+                                  &IID_IMMDeviceEnumerator,
+                                  (void **)&state->pEnumerator);
     EXIT_ON_ERROR(hr);
 
     char *device = state->opt_device;
@@ -1065,7 +1102,8 @@ retry: ;
     if (!device || !device[0]) {
         hr = load_default_device(ao, state->pEnumerator, &state->pDevice);
     } else {
-        hr = find_and_load_device(ao, state->pEnumerator, &state->pDevice, device);
+        hr = find_and_load_device(ao, state->pEnumerator, &state->pDevice,
+                                  device);
     }
     EXIT_ON_ERROR(hr);
 
@@ -1075,7 +1113,8 @@ retry: ;
 
     MP_DBG(ao, "Activating pAudioClient interface\n");
     hr = IMMDeviceActivator_Activate(state->pDevice, &IID_IAudioClient,
-                                     CLSCTX_ALL, NULL, (void **)&state->pAudioClient);
+                                     CLSCTX_ALL, NULL,
+                                     (void **)&state->pAudioClient);
     EXIT_ON_ERROR(hr);
 
     MP_DBG(ao, "Activating pEndpointVolume interface\n");
@@ -1137,14 +1176,23 @@ void wasapi_thread_uninit(struct ao *ao)
     wasapi_change_uninit(ao);
     destroy_proxies(state);
 
-    SAFE_RELEASE(state->pRenderClient,   IAudioRenderClient_Release(state->pRenderClient));
-    SAFE_RELEASE(state->pAudioClock,     IAudioClock_Release(state->pAudioClock));
-    SAFE_RELEASE(state->pAudioVolume,    ISimpleAudioVolume_Release(state->pAudioVolume));
-    SAFE_RELEASE(state->pEndpointVolume, IAudioEndpointVolume_Release(state->pEndpointVolume));
-    SAFE_RELEASE(state->pSessionControl, IAudioSessionControl_Release(state->pSessionControl));
-    SAFE_RELEASE(state->pAudioClient,    IAudioClient_Release(state->pAudioClient));
-    SAFE_RELEASE(state->pDevice,         IMMDevice_Release(state->pDevice));
-    SAFE_RELEASE(state->pEnumerator,     IMMDeviceEnumerator_Release(state->pEnumerator));
-    SAFE_RELEASE(state->hTask,           AvRevertMmThreadCharacteristics(state->hTask));
+    SAFE_RELEASE(state->pRenderClient,
+                 IAudioRenderClient_Release(state->pRenderClient));
+    SAFE_RELEASE(state->pAudioClock,
+                 IAudioClock_Release(state->pAudioClock));
+    SAFE_RELEASE(state->pAudioVolume,
+                 ISimpleAudioVolume_Release(state->pAudioVolume));
+    SAFE_RELEASE(state->pEndpointVolume,
+                 IAudioEndpointVolume_Release(state->pEndpointVolume));
+    SAFE_RELEASE(state->pSessionControl,
+                 IAudioSessionControl_Release(state->pSessionControl));
+    SAFE_RELEASE(state->pAudioClient,
+                 IAudioClient_Release(state->pAudioClient));
+    SAFE_RELEASE(state->pDevice,
+                 IMMDevice_Release(state->pDevice));
+    SAFE_RELEASE(state->pEnumerator,
+                 IMMDeviceEnumerator_Release(state->pEnumerator));
+    SAFE_RELEASE(state->hTask,
+                 AvRevertMmThreadCharacteristics(state->hTask));
     MP_DBG(ao, "Thread uninit done\n");
 }

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -1006,28 +1006,27 @@ exit_label:
     return hr;
 }
 
-HRESULT wasapi_setup_proxies(struct wasapi_state *state) {
-    HRESULT hr;
-
-#define UNMARSHAL(type, to, from) do {                                    \
-    hr = CoGetInterfaceAndReleaseStream((from), &(type), (void **)&(to)); \
-    (from) = NULL;                                                        \
-    EXIT_ON_ERROR(hr);                                                    \
-} while (0)
-
-    UNMARSHAL(IID_ISimpleAudioVolume,   state->pAudioVolumeProxy,
-              state->sAudioVolume);
-    UNMARSHAL(IID_IAudioEndpointVolume, state->pEndpointVolumeProxy,
-              state->sEndpointVolume);
-    UNMARSHAL(IID_IAudioSessionControl, state->pSessionControlProxy,
-              state->sSessionControl);
-
-#undef UNMARSHAL
-
-    return S_OK;
+static void *unmarshal(struct wasapi_state *state, REFIID type, IStream **from)
+{
+    if (!*from)
+        return NULL;
+    void *to_proxy = NULL;
+    HRESULT hr = CoGetInterfaceAndReleaseStream(*from, type, &to_proxy);
+    *from = NULL; // the stream is released even on failure
+    EXIT_ON_ERROR(hr);
+    return to_proxy;
 exit_label:
-    MP_ERR(state, "Error reading COM proxy: %s\n", mp_HRESULT_to_str(hr));
-    return hr;
+    MP_WARN(state, "Error reading COM proxy: %s\n", mp_HRESULT_to_str(hr));
+    return to_proxy;
+}
+
+void wasapi_receive_proxies(struct wasapi_state *state) {
+    state->pAudioVolumeProxy    = unmarshal(state, &IID_ISimpleAudioVolume,
+                                             &state->sAudioVolume);
+    state->pEndpointVolumeProxy = unmarshal(state, &IID_IAudioEndpointVolume,
+                                             &state->sEndpointVolume);
+    state->pSessionControlProxy = unmarshal(state, &IID_IAudioSessionControl,
+                                             &state->sSessionControl);
 }
 
 void wasapi_release_proxies(wasapi_state *state) {
@@ -1039,38 +1038,50 @@ void wasapi_release_proxies(wasapi_state *state) {
                  IAudioSessionControl_Release(state->pSessionControlProxy));
 }
 
-static HRESULT create_proxies(struct wasapi_state *state) {
-    HRESULT hr;
+// Must call CoReleaseMarshalData to decrement marshalled object's reference
+// count.
+#define SAFE_RELEASE_INTERFACE_STREAM(stream) do { \
+        if ((stream) != NULL) {                    \
+            CoReleaseMarshalData((stream));        \
+            IStream_Release((stream));             \
+            (stream) = NULL;                       \
+        }                                          \
+    } while(0)
 
-#define MARSHAL(type, to, from) do {                               \
-    hr = CreateStreamOnHGlobal(NULL, TRUE, &(to));                 \
-    EXIT_ON_ERROR(hr);                                             \
-    hr = CoMarshalInterThreadInterfaceInStream(&(type),            \
-                                               (IUnknown *)(from), \
-                                               &(to));             \
-    EXIT_ON_ERROR(hr);                                             \
-} while (0)
-
-    MARSHAL(IID_ISimpleAudioVolume,   state->sAudioVolume,
-            state->pAudioVolume);
-    MARSHAL(IID_IAudioEndpointVolume, state->sEndpointVolume,
-            state->pEndpointVolume);
-    MARSHAL(IID_IAudioSessionControl, state->sSessionControl,
-            state->pSessionControl);
-
-    return S_OK;
+static IStream *marshal(struct wasapi_state *state,
+                         REFIID type, void *from_obj)
+{
+    if (!from_obj)
+        return NULL;
+    IStream *to;
+    HRESULT hr = CreateStreamOnHGlobal(NULL, TRUE, &to);
+    EXIT_ON_ERROR(hr);
+    hr = CoMarshalInterThreadInterfaceInStream(type, (IUnknown *)from_obj, &to);
+    EXIT_ON_ERROR(hr);
+    return to;
 exit_label:
-    MP_ERR(state, "Error creating COM proxy: %s\n", mp_HRESULT_to_str(hr));
-    return hr;
+    SAFE_RELEASE_INTERFACE_STREAM(to);
+    MP_WARN(state, "Error creating COM proxy stream: %s\n",
+            mp_HRESULT_to_str(hr));
+    return to;
 }
 
-static void destroy_proxies(struct wasapi_state *state) {
-    SAFE_RELEASE(state->sAudioVolume,
-                 IStream_Release(state->sAudioVolume));
-    SAFE_RELEASE(state->sEndpointVolume,
-                 IStream_Release(state->sEndpointVolume));
-    SAFE_RELEASE(state->sSessionControl,
-                 IStream_Release(state->sSessionControl));
+static void create_proxy_streams(struct wasapi_state *state) {
+    state->sAudioVolume    = marshal(state, &IID_ISimpleAudioVolume,
+                                     state->pAudioVolume);
+    state->sEndpointVolume = marshal(state, &IID_IAudioEndpointVolume,
+                                     state->pEndpointVolume);
+    state->sSessionControl = marshal(state, &IID_IAudioSessionControl,
+                                     state->pSessionControl);
+}
+
+static void destroy_proxy_streams(struct wasapi_state *state) {
+    // This is only to handle error conditions.
+    // During normal operation, these will already have been released by
+    // unmarshaling.
+    SAFE_RELEASE_INTERFACE_STREAM(state->sAudioVolume);
+    SAFE_RELEASE_INTERFACE_STREAM(state->sEndpointVolume);
+    SAFE_RELEASE_INTERFACE_STREAM(state->sSessionControl);
 }
 
 void wasapi_dispatch(struct ao *ao)
@@ -1152,8 +1163,7 @@ retry: ;
     EXIT_ON_ERROR(hr);
 
     MP_DBG(ao, "Creating proxies\n");
-    hr = create_proxies(state);
-    EXIT_ON_ERROR(hr);
+    create_proxy_streams(state);
 
     wasapi_change_init(ao, false);
 
@@ -1174,7 +1184,7 @@ void wasapi_thread_uninit(struct ao *ao)
         IAudioClient_Stop(state->pAudioClient);
 
     wasapi_change_uninit(ao);
-    destroy_proxies(state);
+    destroy_proxy_streams(state);
 
     SAFE_RELEASE(state->pRenderClient,
                  IAudioRenderClient_Release(state->pRenderClient));

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -635,6 +635,39 @@ exit_label:
     return;
 }
 
+static void init_volume_control(struct wasapi_state *state)
+{
+    HRESULT hr;
+    if (state->share_mode == AUDCLNT_SHAREMODE_EXCLUSIVE) {
+        MP_DBG(state, "Activating pEndpointVolume interface\n");
+        hr = IMMDeviceActivator_Activate(state->pDevice,
+                                         &IID_IAudioEndpointVolume,
+                                         CLSCTX_ALL, NULL,
+                                         (void **)&state->pEndpointVolume);
+        EXIT_ON_ERROR(hr);
+
+        MP_DBG(state, "IAudioEndpointVolume::QueryHardwareSupport\n");
+        hr = IAudioEndpointVolume_QueryHardwareSupport(state->pEndpointVolume,
+                                                       &state->vol_hw_support);
+        EXIT_ON_ERROR(hr);
+    } else {
+        MP_DBG(state, "IAudioClient::Initialize pAudioVolume\n");
+        hr = IAudioClient_GetService(state->pAudioClient,
+                                     &IID_ISimpleAudioVolume,
+                                     (void **)&state->pAudioVolume);
+        EXIT_ON_ERROR(hr);
+    }
+    return;
+exit_label:
+    state->vol_hw_support = 0;
+    SAFE_RELEASE(state->pEndpointVolume,
+                 IAudioEndpointVolume_Release(state->pEndpointVolume));
+    SAFE_RELEASE(state->pAudioVolume,
+                 ISimpleAudioVolume_Release(state->pAudioVolume));
+    MP_WARN(state, "Error setting up volume control: %s\n",
+            mp_HRESULT_to_str(hr));
+}
+
 static HRESULT fix_format(struct ao *ao)
 {
     struct wasapi_state *state = ao->priv;
@@ -698,12 +731,6 @@ reinit:
                                  (void **)&state->pRenderClient);
     EXIT_ON_ERROR(hr);
 
-    MP_DBG(state, "IAudioClient::Initialize pAudioVolume\n");
-    hr = IAudioClient_GetService(state->pAudioClient,
-                                 &IID_ISimpleAudioVolume,
-                                 (void **)&state->pAudioVolume);
-    EXIT_ON_ERROR(hr);
-
     MP_DBG(state, "IAudioClient::Initialize IAudioClient_SetEventHandle\n");
     hr = IAudioClient_SetEventHandle(state->pAudioClient, state->hWake);
     EXIT_ON_ERROR(hr);
@@ -724,6 +751,7 @@ reinit:
     EXIT_ON_ERROR(hr);
 
     init_session_display(state);
+    init_volume_control(state);
 
     state->hTask = AvSetMmThreadCharacteristics(L"Pro Audio", &(DWORD){0});
     if (!state->hTask) {
@@ -1130,21 +1158,6 @@ retry: ;
                                      CLSCTX_ALL, NULL,
                                      (void **)&state->pAudioClient);
     EXIT_ON_ERROR(hr);
-
-    MP_DBG(ao, "Activating pEndpointVolume interface\n");
-    hr = IMMDeviceActivator_Activate(state->pDevice, &IID_IAudioEndpointVolume,
-                                     CLSCTX_ALL, NULL,
-                                     (void **)&state->pEndpointVolume);
-    EXIT_ON_ERROR(hr);
-
-    MP_DBG(ao, "Query hardware volume support\n");
-    hr = IAudioEndpointVolume_QueryHardwareSupport(state->pEndpointVolume,
-                                                   &state->vol_hw_support);
-    if (hr != S_OK) {
-        MP_WARN(ao, "Error querying hardware volume control: %s\n",
-                mp_HRESULT_to_str(hr));
-        state->vol_hw_support = 0;
-    }
 
     MP_DBG(ao, "Probing formats\n");
     if (!find_formats(ao)) {

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -589,16 +589,15 @@ static HRESULT init_clock(struct wasapi_state *state) {
                                          &IID_IAudioClock,
                                          (void **)&state->pAudioClock);
     EXIT_ON_ERROR(hr);
+
     hr = IAudioClock_GetFrequency(state->pAudioClock, &state->clock_frequency);
     EXIT_ON_ERROR(hr);
-
-    QueryPerformanceFrequency(&state->qpc_frequency);
-
-    atomic_store(&state->sample_count, 0);
 
     MP_VERBOSE(state,
                "IAudioClock::GetFrequency gave a frequency of %"PRIu64".\n",
                (uint64_t) state->clock_frequency);
+
+    atomic_store(&state->sample_count, 0);
 
     return S_OK;
 exit_label:

--- a/audio/out/ao_wasapi_utils.h
+++ b/audio/out/ao_wasapi_utils.h
@@ -43,7 +43,7 @@ void wasapi_dispatch(struct ao *ao);
 HRESULT wasapi_thread_init(struct ao *ao);
 void wasapi_thread_uninit(struct ao *ao);
 
-HRESULT wasapi_setup_proxies(wasapi_state *state);
+void wasapi_receive_proxies(wasapi_state *state);
 void wasapi_release_proxies(wasapi_state *state);
 
 #endif


### PR DESCRIPTION
Get wasapi to actually work in wine. Two things were standing in the way of this: 

* wine doesn't seem to want to marshall wasapi interfaces
* the device delay calculation was totally screwed up

The first problem was solved by gracefully and non-fatally handling marshalling failure (which is possible since we are no longer marshalling anything of critical importance - only volume control and stream title display). 

The second problem had something to do with the weird second guessing of the position returned by IAudioClock_GetPosition, which we no longer do. 

Also some streamlining (i.e. only init the volume control interface we're actually going to use depending on exclusive/shared), and cosmetic cleanup. 