### PR TITLE
Add support for A/53 Closed Captions

### DIFF
--- a/demux/demux.h
+++ b/demux/demux.h
@@ -237,6 +237,7 @@ void free_demuxer(struct demuxer *demuxer);
 void free_demuxer_and_stream(struct demuxer *demuxer);
 
 void demux_add_packet(struct sh_stream *stream, demux_packet_t *dp);
+void demuxer_feed_caption(struct sh_stream *stream, demux_packet_t *dp);
 
 struct demux_packet *demux_read_packet(struct sh_stream *sh);
 int demux_read_packet_async(struct sh_stream *sh, struct demux_packet **out_pkt);

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -163,3 +163,17 @@ ASS_Library *mp_ass_init(struct mpv_global *global, struct mp_log *log)
     talloc_free(path);
     return priv;
 }
+
+void mp_ass_flush_old_events(ASS_Track *track, long long ts)
+{
+    int n = 0;
+    for (; n < track->n_events; n++) {
+        if ((track->events[n].Start + track->events[n].Duration) >= ts)
+            break;
+        ass_free_event(track, n);
+        track->n_events--;
+    }
+    for (int i = 0; n > 0 && i < track->n_events; i++) {
+        track->events[i] = track->events[i+n];
+    }
+}

--- a/sub/ass_mp.h
+++ b/sub/ass_mp.h
@@ -44,6 +44,7 @@ struct mpv_global;
 struct mp_osd_res;
 struct osd_style_opts;
 
+void mp_ass_flush_old_events(ASS_Track *track, long long ts);
 void mp_ass_set_style(ASS_Style *style, double res_y,
                       const struct osd_style_opts *opts);
 


### PR DESCRIPTION
This PR wires up `AV_FRAME_DATA_A53_CC` side data in mpeg2 frames to the `eia_608` decoder in ffmpeg using sd_ass.

The pipeline is working as expected, with side data getting enqueued as subtitle packets:

```
[lavf] packets=76, bytes=969015, active=1, more=0
[lavf] append packet to sub: size=60 pts=9.590611 dts=9.590611 pos=6334660 [num=1 size=60]
[cplayer] video_output_image: 2
[lavf] packets=77, bytes=969075, active=1, more=0
```

Then being read by the demuxer:

```
[lavf] reading packet for sub
[lavf] reading packet for sub
[cplayer] Sub: c_pts=9.507 s_pts=-59413.507 duration=-1.000 len=60
[lavf] packets=76, bytes=969015, active=1, more=0
```

And finally being decoded by libass in sd_ass:

```
[libass] Event: Dialogue: 0,-16:-30:-14.-89,-16:-30:-13.-51,Default,,0,0,0,,THAT THE COUNTRY'S\NGOTTEN SAFER
[libass]
[lavf] packets=75, bytes=967479, active=1, more=1
```

However, something's off with the pts which is causing the subtitles to not be displayed at the right time. I'm not sure what the issue is, but maybe someone else can spot it in the diff.

Notice how timestamps differ when appending video/audio/sub packets to the stream:

```
[lavf] append packet to video: size=7313 pts=59434.807078 dts=59434.807078 pos=7565684 [num=48 size=955675]
[lavf] append packet to audio: size=1536 pts=59433.977689 dts=59433.977689 pos=7550644 [num=32 size=49152]
[lavf] append packet to sub: size=60 pts=9.757444 dts=9.757444 pos=6410424 [num=1 size=60]
```

and how the timestamp on the subtitle packet itself changes between enqueue and dequeue, from `9.75` to `-59413.34`:

```
[lavf] append packet to sub: size=60 pts=9.757444 dts=9.757444 pos=6410424 [num=1 size=60]
[lavf] reading packet for sub
[lavf] reading packet for sub
[cplayer] Sub: c_pts=9.674 s_pts=-59413.340 duration=-1.000 len=60
```