### PR TITLE
Erase `add audio-delay` from `Not assigned by default` section.

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -183,8 +183,6 @@
 # ? sub-step +1                         #                     previous
 # ? cycle-values window-scale 0.5 2 1   # switch between 1/2, 2x, unresized window size
 # ? cycle colormatrix
-# ? add audio-delay 0.100               # this changes audio/video sync
-# ? add audio-delay -0.100
 # ? cycle angle                         # switch DVD/Bluray angle
 # ? add balance -0.1                    # adjust audio balance in favor of left
 # ? add balance 0.1                     #                                  right


### PR DESCRIPTION
`ctrl+ +`is assigned as `add audio-delay` by default.
Tested by running `mpv --input-test --force-window --idle`