### PR TITLE
X11: Capitalize the first letter of the class name

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -697,7 +697,7 @@ static void vo_x11_classhint(struct vo *vo, Window window, const char *name)
     long pid = getpid();
 
     wmClass.res_name = opts->winname ? opts->winname : (char *)name;
-    wmClass.res_class = "mpv";
+    wmClass.res_class = "Mpv";
     XSetClassHint(x11->display, window, &wmClass);
     XChangeProperty(x11->display, window, XA(x11, _NET_WM_PID), XA_CARDINAL,
                     32, PropModeReplace, (unsigned char *) &pid, 1);


### PR DESCRIPTION
By convention, the class name should start with an uppercase letter.

(See the RESOURCES section of `man 7 X`.)