### PR TITLE
demux_mkv: skip EBML void elements

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2609,7 +2609,7 @@ static int read_next_block(demuxer_t *demuxer, struct block_info *block)
             }
             // For the sake of robustness, consider even unknown level 1
             // elements the same as unknown/broken IDs.
-            if (!ebml_is_mkv_level1_id(id) ||
+            if ((!ebml_is_mkv_level1_id(id) && id != EBML_ID_VOID) ||
                 ebml_read_skip(demuxer->log, -1, s) != 0)
             {
                 ebml_resync_cluster(demuxer->log, s);


### PR DESCRIPTION
EBML_ID_VOID might occur at any level, see [spec](https://github.com/Matroska-Org/ebml-specification/blob/master/specification.markdown). This change prevents `Corrupt file detected` errors on completely valid files.

[Test file.](https://dump.bitcheese.net/files/ubimiry/void.webm)

```
$ hexdump -C void.webm | tail
00000b00  7b 27 38 7b 27 38 7b 27  38 7b 27 38 7b 27 38 7b  |{'8{'8{'8{'8{'8{|
00000b10  27 38 7b 27 38 7b 27 38  7b 27 38 7b 27 38 7b 27  |'8{'8{'8{'8{'8{'|
00000b20  38 7b 27 38 7b 27 38 7b  27 38 7b 27 38 7b 27 38  |8{'8{'8{'8{'8{'8|
00000b30  7b 27 38 7b 27 38 7b 27  38 7b 27 38 7b 27 38 7b  |{'8{'8{'8{'8{'8{|
00000b40  27 38 7b 27 38 7b 27 38  7b 27 38 7b 27 38 7b 27  |'8{'8{'8{'8{'8{'|
00000b50  38 7b 27 38 7b 27 38 7b  27 38 7b 27 38 7b 27 37  |8{'8{'8{'8{'8{'7|
00000b60  80 fe ff ba 83 00 1c 53  bb 6b 01 00 00 00 00 00  |.......S.k......|
00000b70  00 11 bb 8f b3 81 00 b7  8a f7 81 01 f1 82 01 87  |................|
00000b80  f0 81 03 ec 86 31 32 33  34 35 36                 |.....123456|
00000b8b
```

(`0xEC` = `EBML_ID_VOID`, `0x80 | 6 (length)` = `0x86`, 6 ASCII symbols)

mpv output on this file:

```
$ mpv --no-config void.webm 
Playing: void.webm
 (+) Video --vid=1 (*) (vp8)
[vo/opengl/x11] Disabling screensaver failed (-1). Make sure the xdg-screensaver script is installed.
[mkv] Corrupt file detected. Trying to resync starting from position 2948...
VO: [opengl] 640x360 yuv420p
[osd/libass] fontconfig: cannot find font 'sans-serif', falling back to 'Liberation Sans'
V: 00:00:00 / 00:00:01 (0%)


Exiting... (End of file)
```

`--demuxer=lavf` also doesn't report any errors.