### PR TITLE
Wasapi dev cleanup2

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -455,10 +455,7 @@ static void audio_resume(struct ao *ao)
 static void hotplug_uninit(struct ao *ao)
 {
     MP_DBG(ao, "Hotplug uninit\n");
-    struct wasapi_state *state = ao->priv;
     wasapi_change_uninit(ao);
-    SAFE_RELEASE(state->pEnumerator,
-                 IMMDeviceEnumerator_Release(state->pEnumerator));
     CoUninitialize();
 }
 
@@ -468,11 +465,7 @@ static int hotplug_init(struct ao *ao)
     struct wasapi_state *state = ao->priv;
     state->log = ao->log;
     CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator,
-                                  (void **)&state->pEnumerator);
-    EXIT_ON_ERROR(hr);
-    hr = wasapi_change_init(ao, true);
+    HRESULT hr = wasapi_change_init(ao, true);
     EXIT_ON_ERROR(hr);
 
     return 0;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -63,6 +63,8 @@ typedef struct wasapi_state {
     // for setting the audio thread priority
     HANDLE hTask;
 
+    // ID of the device to use
+    LPWSTR deviceID;
     // WASAPI object handles owned and used by audio thread
     IMMDevice *pDevice;
     IAudioClient *pAudioClient;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -30,6 +30,7 @@
 
 typedef struct change_notify {
     IMMNotificationClient client; // this must be first in the structure!
+    IMMDeviceEnumerator *pEnumerator; // object where client is registered
     LPWSTR monitored; // Monitored device
     bool is_hotplug;
     struct ao *ao;
@@ -69,7 +70,6 @@ typedef struct wasapi_state {
     IMMDevice *pDevice;
     IAudioClient *pAudioClient;
     IAudioRenderClient *pRenderClient;
-    IMMDeviceEnumerator *pEnumerator;
 
     // WASAPI internal clock information, for estimating delay
     IAudioClock *pAudioClock;

--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -226,8 +226,7 @@ HRESULT wasapi_change_init(struct ao *ao, bool is_hotplug)
         MP_DBG(ao, "Monitoring for hotplug events\n");
     } else {
         // Get the device string to compare with the pwstrDeviceId
-        hr = IMMDevice_GetId(state->pDevice, &change->monitored);
-        EXIT_ON_ERROR(hr);
+        change->monitored = state->deviceID;
         MP_VERBOSE(ao, "Monitoring changes in device %S\n", change->monitored);
     }
 
@@ -249,6 +248,5 @@ void wasapi_change_uninit(struct ao *ao)
             change->pEnumerator, (IMMNotificationClient *)change);
     }
 
-    if (change->monitored) CoTaskMemFree(change->monitored);
     SAFE_RELEASE(change->pEnumerator, IMMDeviceEnumerator_Release(change->pEnumerator));
 }

--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -187,7 +187,7 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnPropertyValueChanged(
     return S_OK;
 }
 
-static CONST_VTBL IMMNotificationClientVtbl sIMMDeviceEnumeratorVtbl_vtbl = {
+static CONST_VTBL IMMNotificationClientVtbl sIMMNotificationClientVtbl = {
     .QueryInterface = sIMMNotificationClient_QueryInterface,
     .AddRef = sIMMNotificationClient_AddRef,
     .Release = sIMMNotificationClient_Release,
@@ -209,7 +209,7 @@ HRESULT wasapi_change_init(struct ao *ao, bool is_hotplug)
     EXIT_ON_ERROR(hr);
 
     // COM voodoo to emulate c++ class
-    change->client.lpVtbl = &sIMMDeviceEnumeratorVtbl_vtbl;
+    change->client.lpVtbl = &sIMMNotificationClientVtbl;
 
     // register the change notification client
     hr = IMMDeviceEnumerator_RegisterEndpointNotificationCallback(

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -1101,13 +1101,7 @@ HRESULT wasapi_thread_init(struct ao *ao)
     MP_DBG(ao, "Init wasapi thread\n");
     int64_t retry_wait = 1;
 retry: ;
-
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
-                                  &IID_IMMDeviceEnumerator,
-                                  (void **)&state->pEnumerator);
-    EXIT_ON_ERROR(hr);
-
-    hr = find_device(ao);
+    HRESULT hr = find_device(ao);
     EXIT_ON_ERROR(hr);
 
     hr = load_device(ao->log, &state->pDevice, state->deviceID);
@@ -1170,7 +1164,6 @@ void wasapi_thread_uninit(struct ao *ao)
     SAFE_RELEASE(state->pAudioClient,    IAudioClient_Release(state->pAudioClient));
     SAFE_RELEASE(state->pDevice,         IMMDevice_Release(state->pDevice));
     SAFE_RELEASE(state->deviceID,        talloc_free(state->deviceID));
-    SAFE_RELEASE(state->pEnumerator,     IMMDeviceEnumerator_Release(state->pEnumerator));
     SAFE_RELEASE(state->hTask,           AvRevertMmThreadCharacteristics(state->hTask));
     MP_DBG(ao, "Thread uninit done\n");
 }


### PR DESCRIPTION
This is a second attempt at #2648 which does not create an internal device list, but instead isolates the messy wasapi enumerator code to be reused by both listing and selecting.

closes #2648
