### PR TITLE
Fix fd:// on Windows

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -654,9 +654,8 @@ PROTOCOLS
     absolute path.
 
 ``fd://123``
-    Read data from the given UNIX FD (for example 123). This is similar to
-    piping data to stdin via ``-``, but can use an arbitrary file descriptor.
-    Will not work correctly on MS Windows.
+    Read data from the given file descriptor (for example 123). This is similar
+    to piping data to stdin via ``-``, but can use an arbitrary file descriptor.
 
 ``edl://[edl specification as in edl-mpv.rst]``
     Stitch together parts of multiple files and play them.

--- a/osdep/win32-console-wrapper.c
+++ b/osdep/win32-console-wrapper.c
@@ -37,6 +37,7 @@ void cr_perror(const wchar_t *prefix)
 int cr_runproc(wchar_t *name, wchar_t *cmdline)
 {
     STARTUPINFO si;
+    STARTUPINFO our_si;
     PROCESS_INFORMATION pi;
     DWORD retval = 1;
 
@@ -46,6 +47,12 @@ int cr_runproc(wchar_t *name, wchar_t *cmdline)
     si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
     si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
     si.dwFlags |= STARTF_USESTDHANDLES;
+
+    // Copy the list of inherited CRT file descriptors to the new process
+    our_si.cb = sizeof(our_si);
+    GetStartupInfo(&our_si);
+    si.lpReserved2 = our_si.lpReserved2;
+    si.cbReserved2 = our_si.cbReserved2;
 
     ZeroMemory(&pi, sizeof(pi));
 

--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -262,9 +262,6 @@ static int open_f(stream_t *stream)
             MP_INFO(stream, "Writing to stdout...\n");
             p->fd = 1;
         }
-#ifdef __MINGW32__
-        setmode(p->fd, O_BINARY);
-#endif
         p->close = false;
     } else {
         mode_t openmode = S_IRUSR | S_IWUSR;
@@ -297,6 +294,10 @@ static int open_f(stream_t *stream)
         }
         p->close = true;
     }
+
+#ifdef __MINGW32__
+    setmode(p->fd, O_BINARY);
+#endif
 
     off_t len = lseek(p->fd, 0, SEEK_END);
     lseek(p->fd, 0, SEEK_SET);


### PR DESCRIPTION
msvcrt.dll programs can inherit fds from each other in Windows. libuv/node.js also supports MSVC-compatible fd inheritance.

Tested with these two programs:
```c
#include <io.h>
#include <fcntl.h>
#include <process.h>

int main()
{
	static const char exe[] = "C:\\path\\to\\mpv.com";
	static const char file[] = "C:\\path\\to\\some\\file.mkv";

	int fd = open(file, O_RDONLY | O_BINARY);
	dup2(fd, 7);

	return spawnl(P_WAIT, exe, exe, "fd://7", NULL);
}
```

```javascript
'use strict';
const fs = require('fs');
const spawn = require('child_process').spawn;

const exe = 'C:\\path\\to\\mpv.com';
const file = 'C:\\path\\to\\some\\file.mkv';

spawn(exe, ['fd://7'], {
	stdio: [0, 1, 2, null, null, null, null, fs.openSync(file, 'r')],
});
```