### PR TITLE
filter_kernels: improve the gaussian function

### DIFF
--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -289,7 +289,7 @@ static double spline64(params *p, double x)
 
 static double gaussian(params *p, double x)
 {
-    return exp(-2.0 * x * x) * sqrt(2.0 / M_PI);
+    return exp(-2.0 * x * x / p->params[0]);
 }
 
 static double sinc(params *p, double x)
@@ -326,7 +326,7 @@ const struct filter_window mp_filter_windows[] = {
     {"welch",          1,   welch},
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
     {"blackman",       1,   blackman, .params = {0.16, NAN} },
-    {"gaussian",       2,   gaussian},
+    {"gaussian",       2,   gaussian, .params = {1.00, NAN} },
     {"sinc",           1,   sinc},
     {"jinc",           1.2196698912665045, jinc},
     {"sphinx",         1.4302966531242027, sphinx},


### PR DESCRIPTION
Commit 3909e4cd ended up losing the ability to tune the gaussian window,
which this commit trivially reintroduces.

The constant scaling factor (present in the code copied from glumpy)
also goes against filter_kernels.c conventions, which is that f(0.0) = 1
(and the invoking code takes care of normalization), and has been
removed.

The values of this new gaussian function corresponds to different
functions when compared against the old version. To translate the old
values p1 to the new values p2 requires solving 2^(e/p1) = e^(2/p2) or
p2 = p1 * 2/(e * ln(2)) ≈ p1 * 1.0615

In other words, to get the old default in the new function requires
setting scale-param1 to 1.0615. (The new function is *slightly* sharper
by default)

(Though most users should probably not notice the change)