### PR TITLE
dvb: Cleanup dvb_params struct, remove some unneeded fds.

### DIFF
--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -370,7 +370,7 @@ static int do_diseqc(int secfd, int sat_no, int polv, int hi_lo)
                            (sat_no / 4) % 2 ? SEC_MINI_B : SEC_MINI_A);
 }
 
-static int tune_it(dvb_priv_t *priv, int fd_frontend, int fd_sec,
+static int tune_it(dvb_priv_t *priv, int fd_frontend, 
                    unsigned int freq, unsigned int srate, char pol, int tone,
                    bool is_dvb_s2, int stream_id,
                    fe_spectral_inversion_t specInv, unsigned int diseqc,
@@ -386,8 +386,8 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, int fd_sec,
     struct dvb_frontend_parameters feparams;
     struct dvb_frontend_info fe_info;
 
-    MP_VERBOSE(priv, "TUNE_IT, fd_frontend %d, fd_sec %d\nfreq %lu, srate %lu, "
-               "pol %c, tone %i, diseqc %u\n", fd_frontend, fd_sec,
+    MP_VERBOSE(priv, "TUNE_IT, fd_frontend %d, freq %lu, srate %lu, "
+               "pol %c, tone %i, diseqc %u\n", fd_frontend, 
                (long unsigned int)freq, (long unsigned int)srate, pol,
                tone, diseqc);
 
@@ -548,7 +548,7 @@ int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
 {
     MP_INFO(priv, "dvb_tune Freq: %lu\n", (long unsigned int) freq);
 
-    int ris = tune_it(priv, priv->fe_fd, priv->sec_fd, freq, srate, pol, tone,
+    int ris = tune_it(priv, priv->fe_fd, freq, srate, pol, tone,
                       is_dvb_s2, stream_id, specInv, diseqc, modulation,
                       HP_CodeRate, TransmissionMode, guardInterval,
                       bandWidth, LP_CodeRate, hier, timeout);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -95,12 +95,10 @@ typedef struct {
 
 typedef struct dvb_params {
     struct mp_log *log;
-    int fd;
     int card;
     int fe_fd;
-    int sec_fd;
-    int demux_fd[3], demux_fds[DMX_FILTER_SIZE], demux_fds_cnt;
     int dvr_fd;
+    int demux_fd[3], demux_fds[DMX_FILTER_SIZE], demux_fds_cnt;
 
     dvb_config_t *config;
     dvb_channels_list *list;

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -604,7 +604,7 @@ static int dvb_streaming_read(stream_t *stream, char *buffer, int size)
 
     tries = priv->retry + 1;
 
-    fd = priv->fd;
+    fd = priv->dvr_fd;
     while (pos < size) {
         pfds[0].fd = fd;
         pfds[0].events = POLLIN | POLLPRI;
@@ -693,7 +693,6 @@ int dvb_set_channel(stream_t *stream, int card, int n)
     priv->list = new_list;
     priv->retry = 5;
     new_list->current = n;
-    priv->fd = priv->dvr_fd;
     MP_VERBOSE(stream, "DVB_SET_CHANNEL: new channel name=%s, card: %d, "
                "channel %d\n", channel->name, card, n);
 
@@ -799,7 +798,7 @@ static void dvbin_close(stream_t *stream)
     close(priv->dvr_fd);
 
     close(priv->fe_fd);
-    priv->fe_fd = priv->sec_fd = priv->dvr_fd = -1;
+    priv->fe_fd = priv->dvr_fd = -1;
 
     priv->is_on = 0;
     dvb_free_config(priv->config);
@@ -859,7 +858,7 @@ static int dvb_open(stream_t *stream)
     char *progname;
     int tuner_type = 0, i;
 
-    priv->fe_fd = priv->sec_fd = priv->dvr_fd = -1;
+    priv->fe_fd = priv->dvr_fd = -1;
     priv->config = dvb_get_config(stream);
     if (priv->config == NULL) {
         MP_ERR(stream, "DVB CONFIGURATION IS EMPTY, exit\n");


### PR DESCRIPTION
One was just used as an alias, the other one (sec_fd) was not used at all.

Time to remove some cruft before attacking #2568 . 