### PR TITLE
ytdl: Include Referer header as well

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -27,9 +27,12 @@ local function set_http_headers(http_headers)
     if useragent and not option_was_set("user-agent") then
         mp.set_property("file-local-options/user-agent", useragent)
     end
-    local cookies = http_headers["Cookie"]
-    if cookies then
-        headers[#headers + 1] = "Cookie: " .. cookies
+    local additional_fields = {"Cookie", "Referer"}
+    for idx, item in pairs(additional_fields) do
+        local field_value = http_headers[item]
+        if field_value then
+            headers[#headers + 1] = item .. ": " .. field_value
+        end
     end
     if #headers > 0 and not option_was_set("http-header-fields") then
         mp.set_property_native("file-local-options/http-header-fields", headers)


### PR DESCRIPTION
Some videos require correct Referer header for downloading, or 403
Forbidden is thrown.

Here's an example:
```
$ ./build/mpv http://www.tudou.com/programs/view/9OolTOJefuA
Playing: http://www.tudou.com/programs/view/9OolTOJefuA
[ffmpeg] http: HTTP error 403 Forbidden
Failed to open http://58.205.218.10/f4v/7/218341407.h264_4_seg_0.0400150200549A7100D68C8C4AC35C81F28CB9-C00C-3655-EE3C-000272368785.f4v?key=51f5e2da744e730124d757569250630040908c9f9a&qrs=182111546&p=9236836334092993650&playtype=15&tk=142762898739378463710707756&brt=15&bc=0&xid=0400150200549A7100D68C8C4AC35C81F28CB9-C00C-3655-EE3C-000272368785&nt=0&nw=1&bs=0&ispid=2013&rc=200&inf=12&si=un&npc=1173&pp=-1&ul=0&mt=0&sid=0&pc=0&cip=140.112.230.216&id=tudou&hf=0&hd=0&sta=0&ssid=0&cvid=&itemid=272368785&fi=0&sz=27299571.
EDL: Could not open source file 'http://58.205.218.10/f4v/7/218341407.h264_4_seg_0.0400150200549A7100D68C8C4AC35C81F28CB9-C00C-3655-EE3C-000272368785.f4v?key=51f5e2da744e730124d757569250630040908c9f9a&qrs=182111546&p=9236836334092993650&playtype=15&tk=142762898739378463710707756&brt=15&bc=0&xid=0400150200549A7100D68C8C4AC35C81F28CB9-C00C-3655-EE3C-000272368785&nt=0&nw=1&bs=0&ispid=2013&rc=200&inf=12&si=un&npc=1173&pp=-1&ul=0&mt=0&sid=0&pc=0&cip=140.112.230.216&id=tudou&hf=0&hd=0&sta=0&ssid=0&cvid=&itemid=272368785&fi=0&sz=27299571'.
No video or audio streams selected.


Exiting... (Errors when loading file)
```

By including Referer as well, the video can be played:
```
$ ./build/mpv http://www.tudou.com/programs/view/9OolTOJefuA
Playing: http://www.tudou.com/programs/view/9OolTOJefuA
[ffmpeg/audio] aac: element type mismatch 1 != 0
 (+) Video --vid=1 (h264)
 (+) Audio --aid=1 (aac)
libEGL warning: DRI2: failed to authenticate
[vo/opengl] Suspected software renderer or indirect context.
[vo/opengl] Suspected software renderer or indirect context.
[vo/vdpau] Error when calling vdp_device_create_x11: 1
AO: [pulse] 44100Hz stereo 2ch float
VO: [xv] 1280x720 yuv420p
AV: 00:00:05 / 00:06:09 (1%) A-V:  0.000 Cache: 10s+3MB


Exiting... (Quit)
```