### PR TITLE
waf: add "lua51" ("51obsd") to list of possible lua names

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -52,6 +52,7 @@ def check_iconv(ctx, dependency_identifier):
 def check_lua(ctx, dependency_identifier):
     lua_versions = [
         ( '51',     'lua >= 5.1.0 lua < 5.2.0'),
+        ( '51obsd', 'lua51 >= 5.1.0'), # OpenBSD
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
         ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
         ( '52',     'lua >= 5.2.0 lua < 5.3.0' ),


### PR DESCRIPTION
Lua 5.1 is still default on OpenBSD. With this patch it gets detected.