### PR TITLE
ao_wasapi: use share_mode value instead of raw option opt_exclusive

### DIFF
--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -236,6 +236,7 @@ static int init(struct ao *ao)
     return 0;
 
 err_out:
+    ao_data = NULL;
     return -1;
 }
 


### PR DESCRIPTION
Previously used opt_exclusive option to decide which volume control code to run.
The might not always reflect the actual state, for example if passthrough
is used. Admittedly, none of the volume controls will work anyway with
passthrough, but this is the right thing to do.