### PR TITLE
ao_openal: wipe out global context on init error

### DIFF
--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -236,6 +236,7 @@ static int init(struct ao *ao)
     return 0;
 
 err_out:
+    ao_data = NULL;
     return -1;
 }
 


### PR DESCRIPTION
Previously this would break all further attempts to init the driver after one
had failed.