### PR TITLE
x11: get *current* XRandR screen configuration

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -364,7 +364,7 @@ static void xrandr_read(struct vo_x11_state *x11)
                        RRCrtcChangeNotifyMask | RROutputChangeNotifyMask);
     }
 
-    XRRScreenResources *r = XRRGetScreenResources(x11->display, x11->rootwin);
+    XRRScreenResources *r = XRRGetScreenResourcesCurrent(x11->display, x11->rootwin);
     if (!r) {
         MP_VERBOSE(x11, "Xrandr doesn't work.\n");
         return;


### PR DESCRIPTION
Only request the current screen configuration instead of polling for new screens, too. We're not interested in detecting any new screens as we're merely enumerating what is currently connected and configured.

On some hardware (like mine) calling XRRGetScreenResources will stall X11 for about 10 to 20 seconds. This has annoyed me for a few months now and almost made me switch to VLC ;)