### PR TITLE
stream_dvb: Fixes for multi-delivery type DVB-cards

### DIFF
--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -102,7 +102,9 @@ int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
         mp_err(log, "FE_GET_INFO error: %d, FD: %d\n\n", errno, fe_fd);
         return 0;
     }
-  
+
+    mp_verbose(log, "Queried tuner type of device named '%s', FD: %d\n",
+               fe_info.name, fe_fd);
     switch (fe_info.type) {
     case FE_OFDM:
         mp_verbose(log, "Tuner type seems to be DVB-T\n");

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -69,25 +69,29 @@ int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
          DVB-S2 is treated in the DVB-S branch already. */
       switch (delsys) {
       case SYS_DVBT:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-T\n");
+        mp_verbose(log, "Tuner type seems to be DVB-T\n");
         (*tuner_types)[supported_tuners++] = TUNER_TER;
         break;
       case SYS_DVBC_ANNEX_AC:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-C\n");
+        mp_verbose(log, "Tuner type seems to be DVB-C\n");
         (*tuner_types)[supported_tuners++] = TUNER_CBL;
         break;
       case SYS_DVBS:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-S\n");
+        mp_verbose(log, "Tuner type seems to be DVB-S\n");
         (*tuner_types)[supported_tuners++] = TUNER_SAT;
         break;
 #ifdef DVB_ATSC
       case SYS_ATSC:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-ATSC\n");
+        mp_verbose(log, "Tuner type seems to be DVB-ATSC\n");
         (*tuner_types)[supported_tuners++] = TUNER_ATSC;
         break;
 #endif
+      case SYS_DVBS2:
+        // We actually handle that in the DVB-S branch, ok to ignore here.
+        mp_verbose(log, "Tuner supports DVB-S2\n");
+        break;
       default:
-        mp_err(log, "UNKNOWN TUNER TYPE\n");
+        mp_err(log, "Unhandled tuner type: %d\n", delsys);
       }
     }
     return supported_tuners;
@@ -101,29 +105,29 @@ int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
   
     switch (fe_info.type) {
     case FE_OFDM:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-T\n");
+        mp_verbose(log, "Tuner type seems to be DVB-T\n");
         *tuner_types = talloc_array(NULL, int, 1);
         (*tuner_types)[0] = TUNER_TER;
         return 1;
     case FE_QPSK:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-S\n");
+        mp_verbose(log, "Tuner type seems to be DVB-S\n");
         *tuner_types = talloc_array(NULL, int, 1);
         (*tuner_types)[0] = TUNER_SAT;
         return 1;
     case FE_QAM:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-C\n");
+        mp_verbose(log, "Tuner type seems to be DVB-C\n");
         *tuner_types = talloc_array(NULL, int, 1);
         (*tuner_types)[0] = TUNER_CBL;
         return 1;
 #ifdef DVB_ATSC
     case FE_ATSC:
-        mp_verbose(log, "TUNER TYPE SEEMS TO BE DVB-ATSC\n");
+        mp_verbose(log, "Tuner type seems to be DVB-ATSC\n");
         *tuner_types = talloc_array(NULL, int, 1);
         (*tuner_types)[0] = TUNER_ATSC;
         return 1;
 #endif
     default:
-        mp_err(log, "UNKNOWN TUNER TYPE\n");
+        mp_err(log, "Unknown tuner type: %d\n", fe_info.type);
         return 0;
     }
 #endif

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -23,7 +23,7 @@
 
 struct mp_log;
 
-int dvb_get_tuner_type(int fe_fd, struct mp_log *log);
+int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types);
 int dvb_open_devices(dvb_priv_t *priv, int n, int demux_cnt);
 int dvb_fix_demuxes(dvb_priv_t *priv, int cnt);
 int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pestype);


### PR DESCRIPTION
This confirmedly fixes https://github.com/mpv-player/mpv/issues/2727 thanks to all the testing performed by @adrian5 . 
It also drops a duplicated `ioctl` on each channel switch (and initial tuning) and improves verbose output during the tuner detection a bit. 
For DVB-T / DVB-ATSC tuning with devices which support an additional delivery system, further changes might be needed - here we'll have to wait until somebody with the hardware shows up and complains. Since multi-standard devices are now queried correctly since this changeset, this would only need small changes in the inner "tuning" part then. 
For now, the old (hopefully tested) tuning code carried over from mplayer stays in place for these delivery systems since I have no way to test anything new. This may change later this year in case I get my hands on DVB-T2 hardware when T2 is rolled out in Germany. 