### PR TITLE
Wasapi default change

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -281,7 +281,7 @@ static int init(struct ao *ao)
     struct wasapi_state *state = ao->priv;
     state->log = ao->log;
 
-    state->deviceID = find_deviceID(ao);
+    state->deviceID = wasapi_find_deviceID(ao);
     if (!state->deviceID) {
         uninit(ao);
         return -1;

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -120,7 +120,7 @@ char *mp_PKEY_to_str_buf(char *buf, size_t buf_size, const PROPERTYKEY *pkey);
 
 void wasapi_list_devs(struct ao *ao, struct ao_device_list *list);
 bstr wasapi_get_specified_device_string(struct ao *ao);
-LPWSTR find_deviceID(struct ao *ao);
+LPWSTR wasapi_find_deviceID(struct ao *ao);
 
 void wasapi_dispatch(struct ao *ao);
 HRESULT wasapi_thread_init(struct ao *ao);

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -119,6 +119,7 @@ char *mp_PKEY_to_str_buf(char *buf, size_t buf_size, const PROPERTYKEY *pkey);
 #define mp_PKEY_to_str(pkey) mp_PKEY_to_str_buf((char[42]){0}, 42, (pkey))
 
 void wasapi_list_devs(struct ao *ao, struct ao_device_list *list);
+bstr wasapi_get_specified_device_string(struct ao *ao);
 LPWSTR find_deviceID(struct ao *ao);
 
 void wasapi_dispatch(struct ao *ao);

--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -122,7 +122,6 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDefaultDeviceChanged(
 {
     change_notify *change = (change_notify *)This;
     struct ao *ao = change->ao;
-    struct wasapi_state *state = ao->priv;
 
     // don't care about "eCapture" or non-"eMultimedia" roles
     if (flow == eCapture || role != eMultimedia) return S_OK;
@@ -133,9 +132,10 @@ static HRESULT STDMETHODCALLTYPE sIMMNotificationClient_OnDefaultDeviceChanged(
         ao_hotplug_event(ao);
     } else {
         // stay on the device the user specified
-        if (state->opt_device) {
+        bstr device = wasapi_get_specified_device_string(ao);
+        if (device.len) {
             MP_VERBOSE(ao, "OnDefaultDeviceChanged triggered: "
-                       "staying on specified device %s\n", state->opt_device);
+                       "staying on specified device %.*s\n", BSTR_P(device));
             return S_OK;
         }
 

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -858,14 +858,19 @@ static LPWSTR select_device(struct mp_log *l, struct device_desc *d)
                          (wcslen(d->deviceID) + 1) * sizeof(wchar_t));
 }
 
-LPWSTR find_deviceID(struct ao *ao)
+bstr wasapi_get_specified_device_string(struct ao *ao)
 {
-    LPWSTR deviceID = NULL;
     struct wasapi_state *state = ao->priv;
     bstr device = bstr_strip(bstr0(state->opt_device));
     if (!device.len)
         device = bstr_strip(bstr0(ao->device));
+    return device;
+}
 
+LPWSTR find_deviceID(struct ao *ao)
+{
+    LPWSTR deviceID = NULL;
+    bstr device = wasapi_get_specified_device_string(ao);
     MP_DBG(ao, "Find device \'%.*s\'\n", BSTR_P(device));
 
     struct device_desc *d = NULL;

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -909,7 +909,7 @@ LPWSTR find_deviceID(struct ao *ao)
         }
 
         if (bstrcmp(device, bstr_strip(bstr0(d->name))) == 0) {
-            if (!state->deviceID) {
+            if (!deviceID) {
                 MP_VERBOSE(ao, "Selecting device by name: \'%.*s\'\n", BSTR_P(device));
                 deviceID = select_device(ao->log, d);
             } else {

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -867,7 +867,7 @@ bstr wasapi_get_specified_device_string(struct ao *ao)
     return device;
 }
 
-LPWSTR find_deviceID(struct ao *ao)
+LPWSTR wasapi_find_deviceID(struct ao *ao)
 {
     LPWSTR deviceID = NULL;
     bstr device = wasapi_get_specified_device_string(ao);


### PR DESCRIPTION
the main thing here is that this more correctly avoids an ao-reload when the default device is changed (usually via windows control panel), but the user has already told mpv to use a specific ```audio-device``` independent of the system default. The other two commits are minor fixups.