### PR TITLE
manpage: fix indenting issue in vf_format

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -289,27 +289,27 @@ Available filters are:
         :prophoto:     ProPhoto RGB (ROMM)
         :cie1931:      CIE 1931 RGB
 
-     ``<gamma>``
-        Gamma function the source file was encoded with. Normally this should be set
-        in the file header, but when playing broken or mistagged files this can be
-        used to override the setting.
+    ``<gamma>``
+       Gamma function the source file was encoded with. Normally this should be set
+       in the file header, but when playing broken or mistagged files this can be
+       used to override the setting.
 
-        This option only affects video output drivers that perform color management.
+       This option only affects video output drivers that perform color management.
 
-        If this option is set to ``auto`` (which is the default), the gamma will
-        be set to BT.1886 for YCbCr content, sRGB for RGB content and Linear for
-        XYZ content.
+       If this option is set to ``auto`` (which is the default), the gamma will
+       be set to BT.1886 for YCbCr content, sRGB for RGB content and Linear for
+       XYZ content.
 
-        Available gamma functions are:
+       Available gamma functions are:
 
-        :auto:         automatic selection (default)
-        :bt.1886:      ITU-R BT.1886 (approximation of BT.601/BT.709/BT.2020 curve)
-        :srgb:         IEC 61966-2-4 (sRGB)
-        :linear:       Linear light
-        :gamma1.8:     Pure power curve (gamma 1.8)
-        :gamma2.2:     Pure power curve (gamma 2.2)
-        :gamma2.8:     Pure power curve (gamma 2.8)
-        :prophoto:     ProPhoto RGB (ROMM) curve
+       :auto:         automatic selection (default)
+       :bt.1886:      ITU-R BT.1886 (approximation of BT.601/BT.709/BT.2020 curve)
+       :srgb:         IEC 61966-2-4 (sRGB)
+       :linear:       Linear light
+       :gamma1.8:     Pure power curve (gamma 1.8)
+       :gamma2.2:     Pure power curve (gamma 2.2)
+       :gamma2.8:     Pure power curve (gamma 2.8)
+       :prophoto:     ProPhoto RGB (ROMM) curve
 
     ``<stereo-in>``
         Set the stereo mode the video is assumed to be encoded in. Takes the


### PR DESCRIPTION
This slightly broke the man page's appearance here.