### PR TITLE
use pool for dxva2 hwdec surfaces 

### DIFF
--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -40,7 +40,7 @@
 #include "video/hwdec.h"
 #include "video/d3d.h"
 
-#define ADDTIONAL_SURFACES HWDEC_DELAY_QUEUE_COUNT
+#define ADDITIONAL_SURFACES (4 + HWDEC_DELAY_QUEUE_COUNT)
 
 // A minor evil.
 #ifndef FF_DXVA2_WORKAROUND_INTEL_CLEARVIDEO
@@ -575,14 +575,7 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
     else
         surface_alignment = 16;
 
-    /* 4 base work surfaces */
-    ctx->num_surfaces = 4 + ADDTIONAL_SURFACES;
-
-    /* add surfaces based on number of possible refs */
-    if (codec_id == AV_CODEC_ID_H264 || codec_id == AV_CODEC_ID_HEVC)
-        ctx->num_surfaces += 16;
-    else
-        ctx->num_surfaces += 2;
+    ctx->num_surfaces = hwdec_get_max_refs(s) + ADDITIONAL_SURFACES;
 
     ctx->surfaces      = av_mallocz(ctx->num_surfaces * sizeof(*ctx->surfaces));
     ctx->surface_infos = av_mallocz(ctx->num_surfaces * sizeof(*ctx->surface_infos));

--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -116,7 +116,6 @@ typedef struct DXVA2Context {
     IDirectXVideoDecoderService *decoder_service;
     IDirectXVideoDecoder        *decoder;
 
-    GUID                        decoder_guid;
     DXVA2_ConfigPictureDecode   decoder_config;
 
     LPDIRECT3DSURFACE9          *surfaces;
@@ -125,8 +124,6 @@ typedef struct DXVA2Context {
     uint64_t                    surface_age;
 
     struct mp_image_pool       *sw_pool;
-
-    struct dxva_context         *av_dxva_ctx;
 } DXVA2Context;
 
 typedef struct DXVA2SurfaceWrapper {
@@ -605,7 +602,6 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
         goto fail;
     }
 
-    ctx->decoder_guid   = device_guid;
     ctx->decoder_config = config;
 
     dxva_ctx->cfg           = &ctx->decoder_config;
@@ -613,7 +609,7 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
     dxva_ctx->surface       = ctx->surfaces;
     dxva_ctx->surface_count = ctx->num_surfaces;
 
-    if (IsEqualGUID(&ctx->decoder_guid, &DXVADDI_Intel_ModeH264_E))
+    if (IsEqualGUID(&device_guid, &DXVADDI_Intel_ModeH264_E))
         dxva_ctx->workaround |= FF_DXVA2_WORKAROUND_INTEL_CLEARVIDEO;
 
     return 0;

--- a/video/dxva2.c
+++ b/video/dxva2.c
@@ -1,0 +1,122 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+
+#include "common/av_common.h"
+#include "dxva2.h"
+#include "mp_image.h"
+#include "img_format.h"
+#include "mp_image_pool.h"
+
+struct dxva2_surface {
+    HMODULE d3dlib;
+    HMODULE dxva2lib;
+
+    IDirectXVideoDecoder *decoder;
+    LPDIRECT3DSURFACE9   surface;
+};
+
+LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi)
+{
+    return mpi && mpi->imgfmt == IMGFMT_DXVA2 ?
+        (LPDIRECT3DSURFACE9)mpi->planes[3] : NULL;
+}
+
+void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder)
+{
+    assert(mpi->imgfmt == IMGFMT_DXVA2);
+    struct dxva2_surface *surface = (struct dxva2_surface *)mpi->planes[0];
+    if (surface->decoder)
+        IDirectXVideoDecoder_Release(surface->decoder);
+    surface->decoder = decoder;
+    IDirectXVideoDecoder_AddRef(surface->decoder);
+}
+
+static void dxva2_pool_release_img(void *arg)
+{
+    struct dxva2_surface *surface = arg;
+    if (surface->surface)
+        IDirect3DSurface9_Release(surface->surface);
+
+    if (surface->decoder)
+        IDirectXVideoDecoder_Release(surface->decoder);
+
+    if (surface->dxva2lib)
+        FreeLibrary(surface->dxva2lib);
+
+    if (surface->d3dlib)
+        FreeLibrary(surface->d3dlib);
+
+    talloc_free(surface);
+}
+
+struct pool_alloc_ctx {
+    IDirectXVideoDecoderService *decoder_service;
+    D3DFORMAT target_format;
+    int surface_alignment;
+};
+
+static struct mp_image *dxva2_pool_alloc_img(void *arg, int fmt, int w, int h)
+{
+    if (fmt != IMGFMT_DXVA2)
+        return NULL;
+    struct dxva2_surface *surface = talloc_zero(NULL, struct dxva2_surface);
+
+    // Add additional references to the libraries which might otherwise be freed
+    // before the surface, which is observed to lead to bad behaviour
+    surface->d3dlib   = LoadLibrary(L"d3d9.dll");
+    surface->dxva2lib = LoadLibrary(L"dxva2.dll");
+    if (!surface->d3dlib || !surface->dxva2lib)
+        goto fail;
+
+    struct pool_alloc_ctx *alloc_ctx = arg;
+    HRESULT hr = IDirectXVideoDecoderService_CreateSurface(
+        alloc_ctx->decoder_service,
+        FFALIGN(w, alloc_ctx->surface_alignment),
+        FFALIGN(h, alloc_ctx->surface_alignment),
+        0, alloc_ctx->target_format, D3DPOOL_DEFAULT, 0,
+        DXVA2_VideoDecoderRenderTarget,
+        &surface->surface, NULL);
+    if (FAILED(hr))
+        goto fail;
+
+    struct mp_image mpi = {0};
+    mp_image_setfmt(&mpi, IMGFMT_DXVA2);
+    mp_image_set_size(&mpi, w, h);
+    mpi.planes[0] = (void *)surface;
+    mpi.planes[3] = (void *)surface->surface;
+
+    return mp_image_new_custom_ref(&mpi, surface, dxva2_pool_release_img);
+fail:
+    dxva2_pool_release_img(surface);
+    return NULL;
+}
+
+void dxva2_pool_set_allocator(struct mp_image_pool *pool,
+                              IDirectXVideoDecoderService *decoder_service,
+                              D3DFORMAT target_format, int surface_alignment)
+{
+    struct pool_alloc_ctx *alloc_ctx = talloc_ptrtype(pool, alloc_ctx);
+    *alloc_ctx =  (struct pool_alloc_ctx){
+        decoder_service   = decoder_service,
+        target_format     = target_format,
+        surface_alignment = surface_alignment
+    };
+    mp_image_pool_set_allocator(pool, dxva2_pool_alloc_img, alloc_ctx);
+    mp_image_pool_set_lru(pool);
+}

--- a/video/dxva2.h
+++ b/video/dxva2.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MPV_DXVA2_H
+#define MPV_DXVA2_H
+
+#include <d3d9.h>
+#include <dxva2api.h>
+
+struct mp_image;
+struct mp_image_pool;
+
+LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi);
+void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder);
+
+void dxva2_pool_set_allocator(struct mp_image_pool *pool,
+                              IDirectXVideoDecoderService *decoder_service,
+                              D3DFORMAT target_format, int surface_alignment);
+
+#endif

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -280,6 +280,7 @@ def build(ctx):
         ( "video/mp_image.c" ),
         ( "video/mp_image_pool.c" ),
         ( "video/sws_utils.c" ),
+        ( "video/dxva2.c",                       "dxva2-hwaccel" ),
         ( "video/vaapi.c",                       "vaapi" ),
         ( "video/vdpau.c",                       "vdpau" ),
         ( "video/vdpau_mixer.c",                 "vdpau" ),


### PR DESCRIPTION
This is the first step towards getting opengl interop. It allows the individual surfaces can pass beyond the dxva2 decoder and be passed to the vo.

This also adds additional data to mp_image->planes[0] for IMGFMT_DXVA2, which is
required for maintaining and releasing the surface even if the decoder code is
uninited.

The IDirectXVideoDecoder itself is encapsulated together with its surface pool
and configuration in a dxva2_decoder structure whose creation and destruction is
managed by talloc.

