### PR TITLE
dxva2: another attempt at using mp_image pool

### DIFF
--- a/video/dxva2.c
+++ b/video/dxva2.c
@@ -37,17 +37,7 @@ LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi)
         (LPDIRECT3DSURFACE9)mpi->planes[3] : NULL;
 }
 
-void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder)
-{
-    assert(mpi->imgfmt == IMGFMT_DXVA2);
-    struct dxva2_surface *surface = (struct dxva2_surface *)mpi->planes[0];
-    if (surface->decoder)
-        IDirectXVideoDecoder_Release(surface->decoder);
-    surface->decoder = decoder;
-    IDirectXVideoDecoder_AddRef(surface->decoder);
-}
-
-static void dxva2_pool_release_img(void *arg)
+static void dxva2_release_img(void *arg)
 {
     struct dxva2_surface *surface = arg;
     if (surface->surface)
@@ -65,58 +55,35 @@ static void dxva2_pool_release_img(void *arg)
     talloc_free(surface);
 }
 
-struct pool_alloc_ctx {
-    IDirectXVideoDecoderService *decoder_service;
-    D3DFORMAT target_format;
-    int surface_alignment;
-};
-
-static struct mp_image *dxva2_pool_alloc_img(void *arg, int fmt, int w, int h)
+struct mp_image *dxva2_alloc_img(void *arg, int fmt, int w, int h)
 {
-    if (fmt != IMGFMT_DXVA2)
+    struct dxva2_decoder *decoder = arg;
+    if (fmt != IMGFMT_DXVA2 ||
+        FFALIGN(w, decoder->align) != decoder->w_align ||
+        FFALIGN(h, decoder->align) != decoder->h_align ||
+        decoder->next_surface >= decoder->num_surfaces) {
         return NULL;
-    struct dxva2_surface *surface = talloc_zero(NULL, struct dxva2_surface);
+    }
 
+    struct dxva2_surface *surface = talloc_zero(NULL, struct dxva2_surface);
     // Add additional references to the libraries which might otherwise be freed
     // before the surface, which is observed to lead to bad behaviour
     surface->d3dlib   = LoadLibrary(L"d3d9.dll");
     surface->dxva2lib = LoadLibrary(L"dxva2.dll");
-    if (!surface->d3dlib || !surface->dxva2lib)
-        goto fail;
+    if (!surface->d3dlib || !surface->dxva2lib) {
+        dxva2_release_img(surface);
+        return NULL;
+    }
 
-    struct pool_alloc_ctx *alloc_ctx = arg;
-    HRESULT hr = IDirectXVideoDecoderService_CreateSurface(
-        alloc_ctx->decoder_service,
-        FFALIGN(w, alloc_ctx->surface_alignment),
-        FFALIGN(h, alloc_ctx->surface_alignment),
-        0, alloc_ctx->target_format, D3DPOOL_DEFAULT, 0,
-        DXVA2_VideoDecoderRenderTarget,
-        &surface->surface, NULL);
-    if (FAILED(hr))
-        goto fail;
+    surface->surface = decoder->surfaces[decoder->next_surface++];
+    IDirect3DSurface9_AddRef(surface->surface);
+    surface->decoder = decoder->decoder;
+    IDirectXVideoDecoder_AddRef(surface->decoder);
 
     struct mp_image mpi = {0};
     mp_image_setfmt(&mpi, IMGFMT_DXVA2);
     mp_image_set_size(&mpi, w, h);
-    mpi.planes[0] = (void *)surface;
     mpi.planes[3] = (void *)surface->surface;
 
-    return mp_image_new_custom_ref(&mpi, surface, dxva2_pool_release_img);
-fail:
-    dxva2_pool_release_img(surface);
-    return NULL;
-}
-
-void dxva2_pool_set_allocator(struct mp_image_pool *pool,
-                              IDirectXVideoDecoderService *decoder_service,
-                              D3DFORMAT target_format, int surface_alignment)
-{
-    struct pool_alloc_ctx *alloc_ctx = talloc_ptrtype(pool, alloc_ctx);
-    *alloc_ctx =  (struct pool_alloc_ctx){
-        decoder_service   = decoder_service,
-        target_format     = target_format,
-        surface_alignment = surface_alignment
-    };
-    mp_image_pool_set_allocator(pool, dxva2_pool_alloc_img, alloc_ctx);
-    mp_image_pool_set_lru(pool);
+    return mp_image_new_custom_ref(&mpi, surface, dxva2_release_img);
 }

--- a/video/dxva2.h
+++ b/video/dxva2.h
@@ -25,10 +25,15 @@ struct mp_image;
 struct mp_image_pool;
 
 LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi);
-void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder);
 
-void dxva2_pool_set_allocator(struct mp_image_pool *pool,
-                              IDirectXVideoDecoderService *decoder_service,
-                              D3DFORMAT target_format, int surface_alignment);
+struct dxva2_decoder {
+    DXVA2_ConfigPictureDecode config;
+    IDirectXVideoDecoder      *decoder;
+    LPDIRECT3DSURFACE9        *surfaces;
+    int num_surfaces;
+    int next_surface;
+    int w_align, h_align, align;
+};
+struct mp_image *dxva2_alloc_img(void *dxva2_decoder, int fmt, int w, int h);
 
 #endif


### PR DESCRIPTION
Apparently, some drivers require you to allocate all of the decoder d3d surfaces
at once. This commit changes the strategy from allocating surfaces as needed to
fill the pool with mp_images, to preallocating all the surfaces and providing
them as a list in the mp_image_pool alloc context.

The pool allocator will then pick each of the surfaces from the list in order as
new mp_images are created. This still requires preallocating the pool to ensure
that the it actually uses all of the provided surfaces in lru order.

fixes #2822