### PR TITLE
osc: remove enable/disable controls and add unified visibility never/auto/always

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -130,7 +130,7 @@ these keys. In case of collision, the function needs to be bound to a
 different key. See the `Script Commands`_ section.
 
 =============   ================================================
-del             Hide the OSC permanently until mpv is restarted.
+del             Cycles visibility between never / auto (mouse-move) / always
 =============   ================================================
 
 Configuration
@@ -206,8 +206,8 @@ Configurable Options
 
 ``hidetimeout``
     | Default: 500
-    | Duration in ms until the OSC hides if no mouse movement, negative value
-      disables auto-hide
+    | Duration in ms until the OSC hides if no mouse movement, must not be
+      negative
 
 ``fadeduration``
     | Default: 200
@@ -243,28 +243,29 @@ Configurable Options
     | Default: no
     | Display timecodes with milliseconds
 
+``visibility``
+    | Default: auto (auto hide/show on mouse move)
+    | Also supports ``never`` and ``always``
+
 Script Commands
 ~~~~~~~~~~~~~~~
 
 The OSC script listens to certain script commands. These commands can bound
 in ``input.conf``, or sent by other scripts.
 
-``enable-osc``
-    Undoes ``disable-osc`` or the effect of the ``del`` key.
-
-``disable-osc``
-    Hide the OSC permanently. This is also what the ``del`` key does.
-
 ``osc-message``
     Show a message on screen using the OSC. First argument is the message,
     second the duration in seconds.
 
+``osc-visibility``
+    Controls visibility mode ``never`` / ``auto`` (on mouse move) / ``always``
+    and also ``cycle`` to cycle between the modes
 
 Example
 
 You could put this into ``input.conf`` to hide the OSC with the ``a`` key and
-to unhide it with ``b``::
+to set auto mode (the default) with ``b``::
 
-    a script_message disable-osc
-    b script_message enable-osc
+    a script_message osc-visibility never
+    b script_message osc-visibility auto
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -20,7 +20,8 @@ local user_opts = {
     boxalpha = 80,              -- alpha of the background box,
                                 -- 0 (opaque) to 255 (fully transparent)
     hidetimeout = 500,          -- duration in ms until the OSC hides if no
-                                -- mouse movement, negative value = disabled
+                                -- mouse movement. enforced non-negative for the
+                                -- user, but internally negative is "always-on".
     fadeduration = 200,         -- duration of fade out in ms, 0 = no fade
     deadzonesize = 0,           -- size of deadzone
     minmousemove = 3,           -- minimum amount of pixels the mouse has to
@@ -32,10 +33,18 @@ local user_opts = {
     seekbarstyle = "slider",    -- slider (diamond marker) or bar (fill)
     timetotal = false,          -- display total time instead of remaining time?
     timems = false,             -- display timecodes with milliseconds?
+    visibility = "auto",        -- only used at init to set visibility_mode(...)
 }
 
+-- read_options may modify hidetimeout, so save the original default value in
+-- case the user set hidetimeout < 0 and we need the default instead.
+local hidetimeout_def = user_opts.hidetimeout
 -- read options from config and command-line
 opt.read_options(user_opts, "osc")
+if user_opts.hidetimeout < 0 then
+    user_opts.hidetimeout = hidetimeout_def
+    msg.warn("hidetimeout cannot be negative. Using " .. user_opts.hidetimeout)
+end
 
 local osc_param = { -- calculated by osc_init()
     playresy = 0,                           -- canvas size Y
@@ -1696,7 +1705,9 @@ end
 
 
 function mouse_leave()
-    hide_osc()
+    if user_opts.hidetimeout >= 0 then
+        hide_osc()
+    end
     -- reset mouse position
     state.last_mouseX, state.last_mouseY = nil, nil
 end
@@ -1981,9 +1992,6 @@ mp.register_event("start-file", request_init)
 mp.register_event("tracks-changed", request_init)
 mp.observe_property("playlist", nil, request_init)
 
-mp.register_script_message("enable-osc", function() enable_osc(true) end)
-mp.register_script_message("disable-osc", function() enable_osc(false) end)
-
 mp.register_script_message("osc-message", show_message)
 
 mp.observe_property("fullscreen", "bool",
@@ -2025,6 +2033,53 @@ mp.set_key_bindings({
     {"mouse_btn0_dbl",          "ignore"},
     {"shift+mouse_btn0_dbl",    "ignore"},
     {"mouse_btn2_dbl",          "ignore"},
-    {"del",                     function() enable_osc(false) end}
 }, "input", "force")
 mp.enable_key_bindings("input")
+
+
+user_opts.hidetimeout_orig = user_opts.hidetimeout
+
+function always_on(val)
+    if val then
+        user_opts.hidetimeout = -1 -- disable autohide
+        if state.enabled then show_osc() end
+    else
+        user_opts.hidetimeout = user_opts.hidetimeout_orig
+        if state.enabled then hide_osc() end
+    end
+end
+
+-- mode can be auto/always/never/cycle
+-- the modes only affect internal variables and not stored on its own.
+function visibility_mode(mode, no_osd)
+    if mode == "cycle" then
+        if not state.enabled then
+            mode = "auto"
+        elseif user_opts.hidetimeout >= 0 then
+            mode = "always"
+        else
+            mode = "never"
+        end
+    end
+
+    if mode == "auto" then
+        always_on(false)
+        enable_osc(true)
+    elseif mode == "always" then
+        enable_osc(true)
+        always_on(true)
+    elseif mode == "never" then
+        enable_osc(false)
+    else
+        msg.warn("Ignoring unknown visibility mode '" .. mode .. "'")
+        return
+    end
+
+    if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
+        mp.osd_message("OSC visibility: " .. mode)
+    end
+end
+
+visibility_mode(user_opts.visibility, true)
+mp.register_script_message("osc-visibility", visibility_mode)
+mp.add_key_binding("del", function() visibility_mode("cycle") end)


### PR DESCRIPTION
- Fix the enable/disable controls
- add always-on mode
- add global mode cycle
- remove user control for enable/disable/alwayson and combine them into a single visibility mode which is supported as user-opts and as script message, as well as cycling between them.