### PR TITLE
Dxva2 pool3

### DIFF
--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -207,7 +207,8 @@ static struct mp_image *dxva2_retrieve_image(struct lavc_ctx *s,
 
     hr = IDirect3DSurface9_LockRect(surface, &LockedRect, NULL, D3DLOCK_READONLY);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Unable to lock DXVA2 surface\n");
+        MP_ERR(ctx, "Unable to lock DXVA2 surface: %s\n",
+               mp_HRESULT_to_str(hr));
         talloc_free(sw_img);
         return img;
     }
@@ -271,7 +272,8 @@ static int create_device(struct lavc_ctx *s)
                                  D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_MULTITHREADED | D3DCREATE_FPU_PRESERVE,
                                  &d3dpp, &ctx->d3d9device);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to create Direct3D device\n");
+        MP_ERR(ctx, "Failed to create Direct3D device: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
@@ -317,25 +319,29 @@ static int dxva2_init(struct lavc_ctx *s)
 
     hr = createDeviceManager(&resetToken, &ctx->d3d9devmgr);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to create Direct3D device manager\n");
+        MP_ERR(ctx, "Failed to create Direct3D device manager: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
     hr = IDirect3DDeviceManager9_ResetDevice(ctx->d3d9devmgr, ctx->d3d9device, resetToken);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to bind Direct3D device to device manager\n");
+        MP_ERR(ctx, "Failed to bind Direct3D device to device manager: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
     hr = IDirect3DDeviceManager9_OpenDeviceHandle(ctx->d3d9devmgr, &ctx->deviceHandle);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to open device handle\n");
+        MP_ERR(ctx, "Failed to open device handle: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
     hr = IDirect3DDeviceManager9_GetVideoService(ctx->d3d9devmgr, ctx->deviceHandle, &IID_IDirectXVideoDecoderService, (void **)&ctx->decoder_service);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to create IDirectXVideoDecoderService\n");
+        MP_ERR(ctx, "Failed to create IDirectXVideoDecoderService: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
@@ -364,7 +370,8 @@ static int dxva2_get_decoder_configuration(struct lavc_ctx *s,
 
     hr = IDirectXVideoDecoderService_GetDecoderConfigurations(ctx->decoder_service, device_guid, desc, NULL, &cfg_count, &cfg_list);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Unable to retrieve decoder configurations\n");
+        MP_ERR(ctx, "Unable to retrieve decoder configurations: %s\n",
+               mp_HRESULT_to_str(hr));
         return -1;
     }
 
@@ -426,7 +433,8 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
 
     hr = IDirectXVideoDecoderService_GetDecoderDeviceGuids(ctx->decoder_service, &guid_count, &guid_list);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to retrieve decoder device GUIDs\n");
+        MP_ERR(ctx, "Failed to retrieve decoder device GUIDs: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
 
@@ -543,8 +551,8 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
         decoder->num_surfaces - 1, target_format, D3DPOOL_DEFAULT, 0,
         DXVA2_VideoDecoderRenderTarget, decoder->surfaces, NULL);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to create %d video surfaces\n",
-               decoder->num_surfaces);
+        MP_ERR(ctx, "Failed to create %d video surfaces: %s\n",
+               decoder->num_surfaces, mp_HRESULT_to_str(hr));
         goto fail;
     }
 
@@ -552,7 +560,8 @@ static int dxva2_create_decoder(struct lavc_ctx *s, int w, int h,
         ctx->decoder_service, &device_guid, &desc, &decoder->config,
         decoder->surfaces, decoder->num_surfaces, &decoder->decoder);
     if (FAILED(hr)) {
-        MP_ERR(ctx, "Failed to create DXVA2 video decoder\n");
+        MP_ERR(ctx, "Failed to create DXVA2 video decoder: %s\n",
+               mp_HRESULT_to_str(hr));
         goto fail;
     }
     decoder->pool = talloc_steal(decoder, mp_image_pool_new(decoder->num_surfaces));

--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -163,7 +163,8 @@ static struct mp_image *dxva2_allocate_image(struct lavc_ctx *s, int w, int h)
 {
     DXVA2Context *ctx = s->hwdec_priv;
 
-    struct mp_image *img = mp_image_pool_get(ctx->decoder->pool, IMGFMT_DXVA2, w, h);
+    struct mp_image *img = mp_image_pool_get_no_alloc(ctx->decoder->pool,
+                                                      IMGFMT_DXVA2, w, h);
     if (!img)
         MP_ERR(ctx, "Failed to allocate additional DXVA2 surface.\n");
     return img;

--- a/video/dxva2.c
+++ b/video/dxva2.c
@@ -1,18 +1,18 @@
 /*
  * This file is part of mpv.
  *
- * mpv is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * mpv is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along
- * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <assert.h>

--- a/video/dxva2.c
+++ b/video/dxva2.c
@@ -37,17 +37,7 @@ LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi)
         (LPDIRECT3DSURFACE9)mpi->planes[3] : NULL;
 }
 
-void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder)
-{
-    assert(mpi->imgfmt == IMGFMT_DXVA2);
-    struct dxva2_surface *surface = (struct dxva2_surface *)mpi->planes[0];
-    if (surface->decoder)
-        IDirectXVideoDecoder_Release(surface->decoder);
-    surface->decoder = decoder;
-    IDirectXVideoDecoder_AddRef(surface->decoder);
-}
-
-static void dxva2_pool_release_img(void *arg)
+static void dxva2_release_img(void *arg)
 {
     struct dxva2_surface *surface = arg;
     if (surface->surface)
@@ -65,15 +55,10 @@ static void dxva2_pool_release_img(void *arg)
     talloc_free(surface);
 }
 
-struct pool_alloc_ctx {
-    IDirectXVideoDecoderService *decoder_service;
-    D3DFORMAT target_format;
-    int surface_alignment;
-};
-
-static struct mp_image *dxva2_pool_alloc_img(void *arg, int fmt, int w, int h)
+struct mp_image *dxva2_new_ref(IDirectXVideoDecoder *decoder,
+                               LPDIRECT3DSURFACE9 d3d9_surface, int w, int h)
 {
-    if (fmt != IMGFMT_DXVA2)
+    if (!decoder || !d3d9_surface)
         return NULL;
     struct dxva2_surface *surface = talloc_zero(NULL, struct dxva2_surface);
 
@@ -84,39 +69,18 @@ static struct mp_image *dxva2_pool_alloc_img(void *arg, int fmt, int w, int h)
     if (!surface->d3dlib || !surface->dxva2lib)
         goto fail;
 
-    struct pool_alloc_ctx *alloc_ctx = arg;
-    HRESULT hr = IDirectXVideoDecoderService_CreateSurface(
-        alloc_ctx->decoder_service,
-        FFALIGN(w, alloc_ctx->surface_alignment),
-        FFALIGN(h, alloc_ctx->surface_alignment),
-        0, alloc_ctx->target_format, D3DPOOL_DEFAULT, 0,
-        DXVA2_VideoDecoderRenderTarget,
-        &surface->surface, NULL);
-    if (FAILED(hr))
-        goto fail;
+    surface->surface = d3d9_surface;
+    IDirect3DSurface9_AddRef(surface->surface);
+    surface->decoder = decoder;
+    IDirectXVideoDecoder_AddRef(surface->decoder);
 
     struct mp_image mpi = {0};
     mp_image_setfmt(&mpi, IMGFMT_DXVA2);
     mp_image_set_size(&mpi, w, h);
-    mpi.planes[0] = (void *)surface;
     mpi.planes[3] = (void *)surface->surface;
 
-    return mp_image_new_custom_ref(&mpi, surface, dxva2_pool_release_img);
+    return mp_image_new_custom_ref(&mpi, surface, dxva2_release_img);
 fail:
-    dxva2_pool_release_img(surface);
+    dxva2_release_img(surface);
     return NULL;
-}
-
-void dxva2_pool_set_allocator(struct mp_image_pool *pool,
-                              IDirectXVideoDecoderService *decoder_service,
-                              D3DFORMAT target_format, int surface_alignment)
-{
-    struct pool_alloc_ctx *alloc_ctx = talloc_ptrtype(pool, alloc_ctx);
-    *alloc_ctx =  (struct pool_alloc_ctx){
-        decoder_service   = decoder_service,
-        target_format     = target_format,
-        surface_alignment = surface_alignment
-    };
-    mp_image_pool_set_allocator(pool, dxva2_pool_alloc_img, alloc_ctx);
-    mp_image_pool_set_lru(pool);
 }

--- a/video/dxva2.c
+++ b/video/dxva2.c
@@ -74,12 +74,15 @@ struct mp_image *dxva2_new_ref(IDirectXVideoDecoder *decoder,
     surface->decoder = decoder;
     IDirectXVideoDecoder_AddRef(surface->decoder);
 
-    struct mp_image mpi = {0};
-    mp_image_setfmt(&mpi, IMGFMT_DXVA2);
-    mp_image_set_size(&mpi, w, h);
-    mpi.planes[3] = (void *)surface->surface;
+    struct mp_image *mpi = mp_image_new_custom_ref(&(struct mp_image){0},
+                                                   surface, dxva2_release_img);
+    if (!mpi)
+        goto fail;
 
-    return mp_image_new_custom_ref(&mpi, surface, dxva2_release_img);
+    mp_image_setfmt(mpi, IMGFMT_DXVA2);
+    mp_image_set_size(mpi, w, h);
+    mpi->planes[3] = (void *)surface->surface;
+    return mpi;
 fail:
     dxva2_release_img(surface);
     return NULL;

--- a/video/dxva2.h
+++ b/video/dxva2.h
@@ -25,10 +25,8 @@ struct mp_image;
 struct mp_image_pool;
 
 LPDIRECT3DSURFACE9 d3d9_surface_in_mp_image(struct mp_image *mpi);
-void dxva2_img_ref_decoder(struct mp_image *mpi, IDirectXVideoDecoder *decoder);
 
-void dxva2_pool_set_allocator(struct mp_image_pool *pool,
-                              IDirectXVideoDecoderService *decoder_service,
-                              D3DFORMAT target_format, int surface_alignment);
+struct mp_image *dxva2_new_ref(IDirectXVideoDecoder *decoder,
+                               LPDIRECT3DSURFACE9 d3d9_surface, int w, int h);
 
 #endif

--- a/video/dxva2.h
+++ b/video/dxva2.h
@@ -1,18 +1,18 @@
 /*
  * This file is part of mpv.
  *
- * mpv is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
  * mpv is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along
- * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef MPV_DXVA2_H

--- a/video/mp_image_pool.c
+++ b/video/mp_image_pool.c
@@ -164,6 +164,14 @@ struct mp_image *mp_image_pool_get_no_alloc(struct mp_image_pool *pool, int fmt,
     return ref;
 }
 
+void mp_image_pool_add(struct mp_image_pool *pool, struct mp_image *new)
+{
+    struct image_flags *it = talloc_ptrtype(new, it);
+    *it = (struct image_flags) { .pool_alive = true };
+    new->priv = it;
+    MP_TARRAY_APPEND(pool, pool->images, pool->num_images, new);
+}
+
 // Return a new image of given format/size. The only difference to
 // mp_image_alloc() is that there is a transparent mechanism to recycle image
 // data allocations through this pool.
@@ -186,10 +194,7 @@ struct mp_image *mp_image_pool_get(struct mp_image_pool *pool, int fmt,
         }
         if (!new)
             return NULL;
-        struct image_flags *it = talloc_ptrtype(new, it);
-        *it = (struct image_flags) { .pool_alive = true };
-        new->priv = it;
-        MP_TARRAY_APPEND(pool, pool->images, pool->num_images, new);
+        mp_image_pool_add(pool, new);
         new = mp_image_pool_get_no_alloc(pool, fmt, w, h);
     }
     return new;

--- a/video/mp_image_pool.h
+++ b/video/mp_image_pool.h
@@ -8,6 +8,7 @@ struct mp_image_pool;
 struct mp_image_pool *mp_image_pool_new(int max_count);
 struct mp_image *mp_image_pool_get(struct mp_image_pool *pool, int fmt,
                                    int w, int h);
+void mp_image_pool_add(struct mp_image_pool *pool, struct mp_image *new);
 void mp_image_pool_clear(struct mp_image_pool *pool);
 
 void mp_image_pool_set_lru(struct mp_image_pool *pool);


### PR DESCRIPTION
This replaces  #2826.

The abuse of mp_image_pool_set_allocator was getting ridiculous. Just augment the api with mp_image_pool_add, which is what we are really trying to do. 

Also a throw in a few minor fix ups.