### PR TITLE
wscript_build: skip desktop/icon files for win32

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -568,17 +568,19 @@ def build(ctx):
                 ctx.env.ZSHDIR,
                 ['etc/_mpv'])
 
-        ctx.install_files(
-            ctx.env.DATADIR + '/applications',
-            ['etc/mpv.desktop'] )
-
         ctx.install_files(ctx.env.CONFDIR, ['etc/encoding-profiles.conf'] )
 
-        for size in '16x16 32x32 64x64'.split():
-            ctx.install_as(
-                ctx.env.DATADIR + '/icons/hicolor/' + size + '/apps/mpv.png',
-                'etc/mpv-icon-8bit-' + size + '.png')
+        if ctx.env.DEST_OS != 'win32':
 
-        ctx.install_as(
-                ctx.env.DATADIR + '/icons/hicolor/scalable/apps/mpv.svg',
-                'etc/mpv-gradient.svg')
+            ctx.install_files(
+                ctx.env.DATADIR + '/applications',
+                ['etc/mpv.desktop'] )
+
+            for size in '16x16 32x32 64x64'.split():
+                ctx.install_as(
+                    ctx.env.DATADIR + '/icons/hicolor/' + size + '/apps/mpv.png',
+                    'etc/mpv-icon-8bit-' + size + '.png')
+
+            ctx.install_as(
+                    ctx.env.DATADIR + '/icons/hicolor/scalable/apps/mpv.svg',
+                    'etc/mpv-gradient.svg')


### PR DESCRIPTION
These files are useless on Windows