### PR TITLE
wscript: remove dxva2-dxinterop configure test

### DIFF
--- a/video/out/opengl/hwdec.c
+++ b/video/out/opengl/hwdec.c
@@ -44,10 +44,10 @@ static const struct gl_hwdec_driver *const mpgl_hwdec_drivers[] = {
 #if HAVE_VIDEOTOOLBOX_GL
     &gl_hwdec_videotoolbox,
 #endif
-#if HAVE_DXVA2_DXINTEROP
+#if HAVE_DXVA2_HWACCEL
+#if HAVE_GL_DXINTEROP
     &gl_hwdec_dxva2gldx,
 #endif
-#if HAVE_DXVA2_HWACCEL
     &gl_hwdec_dxva2,
 #endif
     NULL

--- a/wscript
+++ b/wscript
@@ -681,11 +681,6 @@ video_output_features = [
                                 'eglCreateWindowSurface(0, 0, 0, 0)',
                                 lib='EGL')
     } , {
-        'name': '--dxva2-dxinterop',
-        'desc': 'DXVA2/OpenGL/DirectX Interop',
-        'deps': [ 'gl-dxinterop' ],
-        'func': check_true,
-    } , {
         'name': '--vdpau',
         'desc': 'VDPAU acceleration',
         'deps': [ 'x11' ],

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -337,7 +337,7 @@ def build(ctx):
         ( "video/out/opengl/egl_helpers.c",      "egl-helpers" ),
         ( "video/out/opengl/hwdec.c",            "gl" ),
         ( "video/out/opengl/hwdec_dxva2.c",      "gl-win32" ),
-        ( "video/out/opengl/hwdec_dxva2gldx.c",  "dxva2-dxinterop" ),
+        ( "video/out/opengl/hwdec_dxva2gldx.c",  "gl-dxinterop" ),
         ( "video/out/opengl/hwdec_vaegl.c",      "vaapi-egl" ),
         ( "video/out/opengl/hwdec_vaglx.c",      "vaapi-glx" ),
         ( "video/out/opengl/hwdec_osx.c",        "videotoolbox-gl" ),


### PR DESCRIPTION
Wasn't really necessary as it was equivalent to gl-dxinterop.