### PR TITLE
Fix wasapi thread loop latency problems in exclusive mode

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -287,7 +287,7 @@ static int init(struct ao *ao)
     state->hInitDone = CreateEventW(NULL, FALSE, FALSE, NULL);
     state->hWake     = CreateEventW(NULL, FALSE, FALSE, NULL);
     if (!state->hInitDone || !state->hWake) {
-        MP_ERR(ao, "Error creating events\n");
+        MP_FATAL(ao, "Error creating events\n");
         uninit(ao);
         return -1;
     }
@@ -298,7 +298,7 @@ static int init(struct ao *ao)
     state->init_ret = E_FAIL;
     state->hAudioThread = CreateThread(NULL, 0, &AudioThread, ao, 0, NULL);
     if (!state->hAudioThread) {
-        MP_ERR(ao, "Failed to create audio thread\n");
+        MP_FATAL(ao, "Failed to create audio thread\n");
         uninit(ao);
         return -1;
     }
@@ -307,7 +307,7 @@ static int init(struct ao *ao)
     SAFE_RELEASE(state->hInitDone,CloseHandle(state->hInitDone));
     if (FAILED(state->init_ret)) {
         if (!ao->probing)
-            MP_ERR(ao, "Received failure from audio thread\n");
+            MP_FATAL(ao, "Received failure from audio thread\n");
         uninit(ao);
         return -1;
     }
@@ -481,7 +481,7 @@ static int hotplug_init(struct ao *ao)
 
     return 0;
     exit_label:
-    MP_ERR(state, "Error setting up audio hotplug: %s\n", mp_HRESULT_to_str(hr));
+    MP_FATAL(state, "Error setting up audio hotplug: %s\n", mp_HRESULT_to_str(hr));
     hotplug_uninit(ao);
     return -1;
 }

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -248,12 +248,11 @@ static void uninit(struct ao *ao)
     if (state->hWake)
         set_thread_state(ao, WASAPI_THREAD_SHUTDOWN);
 
-    // wait up to 10 seconds
     if (state->hAudioThread &&
-        WaitForSingleObject(state->hAudioThread, 10000) == WAIT_TIMEOUT)
+        WaitForSingleObject(state->hAudioThread, INFINITE) != WAIT_OBJECT_0)
     {
-        MP_ERR(ao, "Audio loop thread refuses to abort\n");
-        return;
+        MP_ERR(ao, "Unexpected return value from WaitForSingleObject "
+               "while waiting for audio thread to terminate\n");
     }
 
     SAFE_RELEASE(state->hInitDone,   CloseHandle(state->hInitDone));

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -60,7 +60,7 @@ static HRESULT get_device_delay(struct wasapi_state *state, double *delay_us) {
     QueryPerformanceCounter(&qpc);
     INT64 qpc_diff = av_rescale(qpc.QuadPart, 10000000, state->qpc_frequency.QuadPart)
                      - qpc_position;
-    // ignore the above calculation if it yeilds more than 10 seconds (due to
+    // ignore the above calculation if it yields more than 10 seconds (due to
     // possible overflow inside IAudioClock_GetPosition)
     if (qpc_diff < 10 * 10000000) {
         *delay_us -= qpc_diff / 10.0; // convert to us

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -66,6 +66,7 @@ typedef struct wasapi_state {
     HANDLE hAudioThread;     // the audio thread itself
     HANDLE hWake;            // thread wakeup event
     atomic_int thread_state; // enum wasapi_thread_state (what to do on wakeup)
+    struct mp_dispatch_queue *dispatch; // for volume/mute/session display
 
     // for setting the audio thread priority
     HANDLE hTask;
@@ -83,24 +84,11 @@ typedef struct wasapi_state {
     UINT64 clock_frequency;      // scale for position returned by GetPosition
     LARGE_INTEGER qpc_frequency; // frequency of Windows' high resolution timer
 
-    // WASAPI control (handles owned by audio thread but used by main thread)
+    // WASAPI control
     IAudioSessionControl *pSessionControl; // setting the stream title
     IAudioEndpointVolume *pEndpointVolume; // exclusive mode volume/mute
     ISimpleAudioVolume *pAudioVolume;      // shared mode volume/mute
     DWORD vol_hw_support; // is hardware volume supported for exclusive-mode?
-
-    // Streams used to marshal the proxy objects. The thread owning the actual
-    // objects needs to marshal proxy objects into these streams, and the thread
-    // that wants the proxies unmarshals them from here.
-    IStream *sSessionControl;
-    IStream *sEndpointVolume;
-    IStream *sAudioVolume;
-
-    // WASAPI proxy handles, for Single-Threaded Apartment communication. One is
-    // needed for each audio thread object that's accessed from the main thread.
-    IAudioSessionControl *pSessionControlProxy;
-    IAudioEndpointVolume *pEndpointVolumeProxy;
-    ISimpleAudioVolume *pAudioVolumeProxy;
 
     // ao options
     int opt_exclusive;

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -978,7 +978,7 @@ retry: ;
     MP_DBG(ao, "Init wasapi thread done\n");
     return S_OK;
 exit_label:
-    MP_ERR(state, "Error setting up audio thread: %s\n", mp_HRESULT_to_str(hr));
+    MP_FATAL(state, "Error setting up audio thread: %s\n", mp_HRESULT_to_str(hr));
     return hr;
 }
 

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -298,7 +298,7 @@ static bool try_format_exclusive(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat)
     if (hr != AUDCLNT_E_UNSUPPORTED_FORMAT)
         EXIT_ON_ERROR(hr);
 
-    return hr == S_OK;
+    return SUCCEEDED(hr);
 exit_label:
     MP_ERR(state, "Error testing exclusive format: %s\n", mp_HRESULT_to_str(hr));
     return false;


### PR DESCRIPTION
These commits were motivated by short "pops" heard around once a minute when using exclusive mode to play to an HRT microStreamer DAC. It was discovered that reducing the exclusive mode buffer size to the device period made this problem go away. It would seem that provided you can feed the device fast enough, exclusive mode works best when the buffer size is equal to the device period as suggested by the [MSDN example code](https://msdn.microsoft.com/en-us/library/windows/desktop/dd370844%28v=vs.85%29.aspx).

The problem is that we had previously increased the buffer from this value because there were under-run problems (particularly when toggling fullscreen) and glitches on unpausing/seeking. The former seems to have already been fixed by the previous refactor that switched to using an atomic state variable from separate events for thread feed/resume/reset/shutdown. The under-run problems related to full-screen toggling however persisted when using ```vo=opengl:backend=win```. 

The under-run problem was actually two fold. First, once an under-run occurred for a given feed event, it cascaded to all subsequent events until the stream was reset because WASAPI somehow didn't know that it was behind and needed to catch up. This is solved here by simply feeding twice for a single feed event when it is detected that the device does not have a full buffer to play while we fill the other. 

The second problem is of course that the under-runs occur at all. Some studying of MP_STATS output showed that these under-runs were not the result of ao_wasapi taking too long to fill the buffer, which happens pretty much instantaneously relative the normal time between feed wakeup events. Instead the under-runs were the result of MsgWaitForMultipleObjects not returning at consistent intervals. It was indeed discovered that using a simple WaitForSingleObject on the thread wakeup event eliminated these under-runs.

However, in the [Single Threaded Apartment](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680112%28v=vs.85%29.aspx) model mandatory for using the WASAPI, MsgWaitForMultipleObjects is required to synchronize the proxied interfaces in the main thread used to control volume, mute, and the session display.

The solution then is to simply not proxy those interfaces and access them only from the audio thread. Synchronization of AOCONTROL messages is carried out much more efficiently using mp_dispatch_queue.








