### PR TITLE
vo_opengl: cache locations of the uniform variables

### DIFF
--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -544,6 +544,7 @@ struct sc_uniform {
 
 struct sc_entry {
     GLuint gl_shader;
+    GLint uniform_locs[SC_UNIFORM_ENTRIES];
     // the following fields define the shader's contents
     char *key; // vertex+frag shader (mangled)
     struct gl_vao *vao;
@@ -797,14 +798,13 @@ static const char *vao_glsl_type(const struct gl_vao_entry *e)
 }
 
 // Assumes program is current (gl->UseProgram(program)).
-static void update_uniform(GL *gl, GLuint program, struct sc_uniform *u)
+static void update_uniform(GL *gl, GLuint program, struct sc_uniform *u, GLint loc)
 {
     if (u->type == UT_buffer) {
         GLuint idx = gl->GetUniformBlockIndex(program, u->name);
         gl->UniformBlockBinding(program, idx, u->v.buffer.binding);
         return;
     }
-    GLint loc = gl->GetUniformLocation(program, u->name);
     if (loc < 0)
         return;
     switch (u->type) {
@@ -1008,16 +1008,23 @@ void gl_sc_gen_shader_and_reset(struct gl_shader_cache *sc)
         entry = &sc->entries[sc->num_entries++];
         *entry = (struct sc_entry){.key = talloc_strdup(NULL, key)};
     }
-    // build vertex shader from vao
-    if (!entry->gl_shader)
+    // build vertex shader from vao and cache the locations of the uniform variables
+    if (!entry->gl_shader) {
         entry->gl_shader = create_program(sc, vert, frag);
+        for (int n = 0; n < sc->num_uniforms; n++) {
+            entry->uniform_locs[n] = gl->GetUniformLocation(entry->gl_shader,
+                                                         sc->uniforms[n].name);
+        }
+    }
 
     gl->UseProgram(entry->gl_shader);
 
     // For now we set the uniforms every time. This is probably bad, and we
     // should switch to caching them.
-    for (int n = 0; n < sc->num_uniforms; n++)
-        update_uniform(gl, entry->gl_shader, &sc->uniforms[n]);
+    for (int n = 0; n < sc->num_uniforms; n++) {
+        update_uniform(gl, entry->gl_shader, &sc->uniforms[n],
+                       entry->uniform_locs[n]);
+    }
 
     talloc_free(tmp);
 


### PR DESCRIPTION
Calling glGetUniformLocation every frame (and also for every shader) is a bad practice and also is pretty slow.
[Before and after this patch](http://screenshotcomparison.com/comparison/164109) 