### PR TITLE
enable TCP server socket for JSON commands

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -187,6 +187,23 @@ char *mp_get_user_path(void *talloc_ctx, struct mpv_global *global,
     return res;
 }
 
+char* mp_unix_path_to_win(void *talloc_ctx,struct mpv_global *global,const char *path)
+{
+    if (!path)
+        return NULL;
+    char *res = talloc_strdup(talloc_ctx, path);
+
+    if(res[0]=='/')
+    {
+        res[0] = res[1];
+        res[1] = ':';
+        for(int i=2;i<strlen(res);i++)
+            if(res[i]=='/') res[i]='\\';
+    }
+    MP_VERBOSE(global, "windows path: '%s' -> '%s'\n", path, res);
+    return res;
+}
+
 char *mp_basename(const char *path)
 {
     char *s;

--- a/options/path.h
+++ b/options/path.h
@@ -86,4 +86,6 @@ bstr mp_split_proto(bstr path, bstr *out_url);
 void mp_mkdirp(const char *dir);
 void mp_mk_config_dir(struct mpv_global *global, char *subdir);
 
+char* mp_unix_path_to_win(void *talloc_ctx,struct mpv_global *global,const char *path);
+
 #endif /* MPLAYER_PATH_H */

--- a/player/main.c
+++ b/player/main.c
@@ -183,10 +183,8 @@ static void shutdown_clients(struct MPContext *mpctx)
 
 void mp_destroy(struct MPContext *mpctx)
 {
-#if !defined(__MINGW32__)
     mp_uninit_ipc(mpctx->ipc_ctx);
     mpctx->ipc_ctx = NULL;
-#endif
 
     shutdown_clients(mpctx);
 
@@ -472,9 +470,7 @@ int mp_initialize(struct MPContext *mpctx, char **options)
     if (opts->force_vo == 2 && handle_force_window(mpctx, false) < 0)
         return -1;
 
-#if !defined(__MINGW32__)
     mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
-#endif
 
 #ifdef _WIN32
     if (opts->w32_priority > 0)

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -703,6 +703,7 @@ static void uninit(struct vf_instance *vf)
     pthread_cond_destroy(&p->wakeup);
     pthread_mutex_destroy(&p->lock);
 }
+
 static int vf_open(vf_instance_t *vf)
 {
     struct vf_priv_s *p = vf->priv;
@@ -713,7 +714,11 @@ static int vf_open(vf_instance_t *vf)
         return 0;
     }
     talloc_steal(vf, p->cfg_file);
+#ifndef _WIN32
     p->cfg_file = mp_get_user_path(vf, vf->chain->global, p->cfg_file);
+#else
+    p->cfg_file = mp_unix_path_to_win(vf, vf->chain->global, p->cfg_file);
+#endif
 
     pthread_mutex_init(&p->lock, NULL);
     pthread_cond_init(&p->wakeup, NULL);

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -190,7 +190,7 @@ def build(ctx):
         ( "input/cmd_parse.c" ),
         ( "input/event.c" ),
         ( "input/input.c" ),
-        ( "input/ipc.c",                         "!mingw" ),
+        ( "input/ipc.c" ),
         ( "input/keycodes.c" ),
         ( "input/pipe-win32.c",                  "mingw" ),
 


### PR DESCRIPTION
1. MINGW: instead of unix domain socket, TCP server socket on 127.0.0.1:<port> is opened with "--input-unix-socket=<port>" parameter.
2. Vapoursynth: absolute paths on Windows doesn't working because of ':' delmiter. This patch adds another path conversion function, it converts "/c/anything/..." into "c:\anything\..."