### PR TITLE
Install symbolic SVG icon

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -586,3 +586,7 @@ def build(ctx):
         ctx.install_as(
                 ctx.env.DATADIR + '/icons/hicolor/scalable/apps/mpv.svg',
                 'etc/mpv-gradient.svg')
+
+        ctx.install_files(
+            ctx.env.DATADIR + '/icons/hicolor/symbolic/apps',
+            ['etc/mpv-symbolic.svg'])


### PR DESCRIPTION
Small PR. Install the symbolic icon so that desktop-environments (e.g. Gnome) can use it, if needed.