### PR TITLE
ytdl_hook: handle optional format_note

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -207,7 +207,7 @@ mp.add_hook("on_load", 10, function ()
 
                 -- audio url
                 mp.commandv("audio-add", json["requested_formats"][2].url,
-                    "select", json["requested_formats"][2]["format_note"])
+                    "select", json["requested_formats"][2]["format_note"] or "")
 
             elseif not (json.url == nil) then
                 -- normal video


### PR DESCRIPTION
some youtube-dl extractors (like for ted.com) don't return a format_note for their audio stream which resulted in commandv complaining "argument 4 is not a string" (because it got nil).