### PR TITLE
player: add on_prerender hook

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -780,6 +780,11 @@ The following hooks are currently defined:
     Run before closing a file, and before actually uninitializing
     everything. It's not possible to resume playback in this state.
 
+``on_prerender``
+    Called after a file has been loaded, and before rendering the first frame
+    in the file. This is useful when the user wants to change things that alter
+    the video output and avoid unneccessary flickering.
+
 Input Command Prefixes
 ----------------------
 

--- a/player/video.c
+++ b/player/video.c
@@ -1244,6 +1244,14 @@ static void calculate_frame_duration(struct MPContext *mpctx)
     mpctx->past_frames[0].approx_duration = approx_duration;
 }
 
+static void process_prerender_hooks(struct MPContext *mpctx)
+{
+    mp_hook_run(mpctx, NULL, "on_prerender");
+
+    while (!mp_hook_test_completion(mpctx, "on_prerender"))
+        mp_idle(mpctx);
+}
+
 void write_video(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
@@ -1382,6 +1390,8 @@ void write_video(struct MPContext *mpctx)
 
     mpctx->osd_force_update = true;
     update_osd_msg(mpctx);
+
+    process_prerender_hooks(mpctx);
 
     vo_queue_frame(vo, frame);
 


### PR DESCRIPTION
This proposition introduces a new hook that is called just before the first frame in the file is rendered.

Rationale / use case:

1. The user fiddles with `video-zoom` in `file-loaded` event within a LUA script.
2. The user navigates the playlist.
3. Rather than seeing the scale change only in the new file, it can be also briefly seen with the previous file.

Changing the `video-zoom` value for each file is useful for custom zoom implementations (fitting inside, fitting outside, keeping original frame size, changing aspect ratio etc.), which can be invaluable when configuring mpv as a picture viewer.

Currently there are no mechanisms to overcome this outside this proposed hook - listening to `video-reconfig` and `tick` events doesn't help too much.