### PR TITLE
player: integrate svtplay-dl hook script

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -457,6 +457,34 @@ Program Behavior
 
         May be dangerous if playing from untrusted media.
 
+``--svtplay-dl``, ``--no-svtplay-dl``
+    Enable the svtplay-dl hook-script. It will look at the input URL, and will
+    play the media located on the website. This works with many streaming sites,
+    not just the one that the script is named after. This requires a recent
+    version of svtplay-dl to be installed on the system. (Enabled by default,
+    except when the client API / libmpv is used.)
+
+    If the script can't do anything with an URL, it will do nothing.
+
+``--svtplay-dl-quality=...``
+    Video quality. The possible values are specific to the website of the video,
+    for a given URL the available formats can be found with the command
+    ``svtplay-dl --list-quality URL``. See svtplay-dl's documentation for
+    further information.
+    (Default: svtplay-dl defaults to downloading the best quality.)
+
+``--svtplay-dl-raw-options=<key>=<value>[,<key>=<value>[,...]]``
+    Pass arbitrary options to svtplay-dl. Parameter and argument should be
+    passed as a key-value pair. Options without argument must include ``=``.
+
+    There is no sanity checking so it's possible to break things (i.e. passing
+    invalid parameters to svtplay-dl).
+
+    .. admonition:: Example
+
+        ``--svtplay-raw-options=username=user,password=pass``
+        ``--svtplay-raw-options=live``
+
 ``--ytdl``, ``--no-ytdl``
     Enable the youtube-dl hook-script. It will look at the input URL, and will
     play the video located on the website. This works with many streaming sites,

--- a/options/options.c
+++ b/options/options.c
@@ -143,6 +143,9 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("ytdl", lua_load_ytdl, CONF_GLOBAL),
     OPT_STRING("ytdl-format", lua_ytdl_format, CONF_GLOBAL),
     OPT_KEYVALUELIST("ytdl-raw-options", lua_ytdl_raw_options, CONF_GLOBAL),
+    OPT_FLAG("svtplay-dl", lua_load_svtplay_dl, CONF_GLOBAL),
+    OPT_STRING("svtplay-dl-quality", lua_svtplay_dl_quality, CONF_GLOBAL),
+    OPT_KEYVALUELIST("svtplay-dl-raw-options", lua_svtplay_dl_raw_options, CONF_GLOBAL),
     OPT_FLAG("load-scripts", auto_load_scripts, CONF_GLOBAL),
 #endif
 
@@ -736,6 +739,9 @@ const struct MPOpts mp_default_opts = {
     .lua_load_ytdl = 1,
     .lua_ytdl_format = NULL,
     .lua_ytdl_raw_options = NULL,
+    .lua_load_svtplay_dl = 1,
+    .lua_svtplay_dl_quality = NULL,
+    .lua_svtplay_dl_raw_options = NULL,
 #endif
     .auto_load_scripts = 1,
     .loop_times = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -78,6 +78,9 @@ typedef struct MPOpts {
     int lua_load_ytdl;
     char *lua_ytdl_format;
     char **lua_ytdl_raw_options;
+    int lua_load_svtplay_dl;
+    char *lua_svtplay_dl_quality;
+    char **lua_svtplay_dl_raw_options;
 
     int auto_load_scripts;
 

--- a/player/lua.c
+++ b/player/lua.c
@@ -69,6 +69,9 @@ static const char * const builtin_lua_scripts[][2] = {
     {"@ytdl_hook.lua",
 #   include "player/lua/ytdl_hook.inc"
     },
+    {"@svtplay_dl_hook.lua",
+#   include "player/lua/svtplay_dl_hook.inc"
+    },
     {0}
 };
 

--- a/player/lua/svtplay_dl_hook.lua
+++ b/player/lua/svtplay_dl_hook.lua
@@ -1,0 +1,67 @@
+local utils = require 'mp.utils'
+local msg = require 'mp.msg'
+
+local svtplay_dl = {
+    path = "svtplay-dl",
+    searched = false
+}
+
+local function exec(args)
+    local ret = utils.subprocess({args = args})
+    return ret.status, ret.stdout, ret
+end
+
+mp.add_hook("on_load", 10, function ()
+    local url = mp.get_property("stream-open-filename")
+
+    if (url:find("http://") == 1) or (url:find("https://") == 1) then
+
+        -- check for svtplay-dl in mpv's config dir
+        if not (svtplay_dl.searched) then
+            local svtplay_dl_mcd = mp.find_config_file("svtplay-dl")
+            if not (svtplay_dl_mcd == nil) then
+                msg.verbose("found svtplay-dl at: " .. svtplay_dl_mcd)
+                svtplay_dl.path = svtplay_dl_mcd
+            end
+            svtplay_dl.searched = true
+        end
+
+        local quality = mp.get_property("options/svtplay-dl-quality")
+        local raw_options =
+            mp.get_property_native("options/svtplay-dl-raw-options")
+
+        local command = {
+            svtplay_dl.path, "--silent", "--get-url"
+        }
+
+        if (quality ~= "") then
+            table.insert(command, "--quality")
+            table.insert(command, quality)
+        end
+
+        for param, arg in pairs(raw_options) do
+            table.insert(command, "--" .. param)
+            if (arg ~= "") then
+                table.insert(command, arg)
+            end
+        end
+
+        table.insert(command, url)
+
+        msg.debug("Running: " .. table.concat(command, ' '))
+        local es, stdout, result = exec(command)
+
+        if (es < 0) or (stdout == nil) or (stdout == "") then
+            if not result.killed_by_us then
+                msg.warn("svtplay-dl failed, trying to play URL directly ...")
+                msg.warn("try disabling youtube-dl hook with --no-ytdl")
+            end
+            return
+        end
+
+        msg.verbose("svtplay-dl succeeded!")
+
+        streamurl = string.gsub(stdout, "\n", "")
+        mp.set_property("stream-open-filename", streamurl)
+    end
+end)

--- a/player/main.c
+++ b/player/main.c
@@ -115,6 +115,7 @@ static const char def_config[] =
     "input-terminal=no\n"
     "osc=no\n"
     "ytdl=no\n"
+    "svtplay-dl=no\n"
     "input-default-bindings=no\n"
     "input-vo-keyboard=no\n"
     "input-lirc=no\n"

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -182,6 +182,8 @@ void mp_load_scripts(struct MPContext *mpctx)
         mp_load_script(mpctx, "@osc.lua");
     if (mpctx->opts->lua_load_ytdl)
         mp_load_script(mpctx, "@ytdl_hook.lua");
+    if (mpctx->opts->lua_load_svtplay_dl)
+        mp_load_script(mpctx, "@svtplay_dl_hook.lua");
     char **files = mpctx->opts->script_files;
     for (int n = 0; files && files[n]; n++) {
         if (files[n][0])

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -72,7 +72,7 @@ def build(ctx):
         target = "video/out/opengl/nnedi3_weights.inc")
 
     lua_files = ["defaults.lua", "assdraw.lua", "options.lua", "osc.lua",
-                 "ytdl_hook.lua"]
+                 "ytdl_hook.lua", "svtplay_dl_hook.lua"]
     for fn in lua_files:
         fn = "player/lua/" + fn
         ctx.file2string(source = fn, target = os.path.splitext(fn)[0] + ".inc")


### PR DESCRIPTION
The integration of the svtplay-dl hook script enables more streaming
sites being played directly with mpv.

There are some consideration though.

* For every URL youtube-dl has presedence. This is fine as long as it
  returns a streamable URL, although that is not always the case.

  Since the ytdl_hook sets stream-open-filename, and svtplay_dl_hook is
  called afterwards, svtplay_dl_hook bails stating that the URL is not
  supported.

  Run e.g.

      build/mpv http://www.ur.se/Produkter/186582-Lassugen-Lydia-och-Markoolio
      ...
      [svtplay_dl_hook] ERROR: That site is not supported. Make a ticket or send a message

  Without ytdl_hook it plays fine

      build/mpv --no-ytdl http://www.ur.se/Produkter/186582-Lassugen-Lydia-och-Markoolio

  Without added verbosity it seems that svtplay-dl doesn't support the URL
  which it actually does. To help remedy this, the user receieves a
  warning to disable ytdl_hook with --no-ytdl.

* svtplay_dl_hook is always run even if ytdl_hook has set
  stream-open-filename with a streamable URL. This means svtplay_dl_hook
  will output critical error messages to the user even if a stream has
  been initiated.