### PR TITLE
Change OSD mode cycle in standard input.conf

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -79,7 +79,7 @@
 #> playlist-next                        # skip to next file
 #ENTER playlist-next                    # skip to next file
 #< playlist-prev                        # skip to previous file
-#O no-osd cycle_values osd-level 3 1    # cycle through OSD mode
+#O no-osd cycle_values osd-level 3 2 1  # cycle through OSD mode
 #o show-progress
 #P show-progress
 #I show-text "${filename}"              # display filename in osd


### PR DESCRIPTION
Cycle through all OSD levels (1-3) instead of only (3, 1)

No idea why this was the default..
I just stumbled upon this, and couldn't figure what went wrong first.

BTW:

Unless `cycle`, `cycle_values` is not documented in the reference manual.