### PR TITLE
Select best samplerate

### DIFF
--- a/audio/format.c
+++ b/audio/format.c
@@ -245,6 +245,37 @@ void af_get_best_sample_formats(int src_format, int out_formats[AF_FORMAT_COUNT]
     out_formats[num] = 0;
 }
 
+// Return the best match to src_samplerate from the list provided in the array
+// *available, which must be terminated by 0, or itself NULL. If *available is
+// empty or NULL, return a negative value. Exact match to src_samplerate is
+// most preferred, followed by the lowest integer multiple, followed by the
+// maximum of *available.
+int af_select_best_samplerate(int src_samplerate, const int *available)
+{
+    if (!available)
+        return -1;
+
+    int min_mult_rate = INT_MAX;
+    int max_rate      = INT_MIN;
+    for (int i = 0; available[i]; i++) {
+        if (available[i] == src_samplerate)
+            return available[i];
+
+        if (!(available[i] % src_samplerate))
+            min_mult_rate = MPMIN(min_mult_rate, available[i]);
+
+        max_rate = MPMAX(max_rate, available[i]);
+    }
+
+    if (min_mult_rate < INT_MAX)
+        return min_mult_rate;
+
+    if (max_rate > INT_MIN)
+        return max_rate;
+
+    return -1;
+}
+
 // Return the number of samples that make up one frame in this format.
 // You get the byte size by multiplying them with sample size and channel count.
 int af_format_sample_alignment(int format)

--- a/audio/format.h
+++ b/audio/format.h
@@ -76,6 +76,7 @@ int af_fmt_seconds_to_bytes(int format, float seconds, int channels, int sampler
 void af_fill_silence(void *dst, size_t bytes, int format);
 
 void af_get_best_sample_formats(int src_format, int out_formats[AF_FORMAT_COUNT]);
+int af_select_best_samplerate(int src_sampelrate, const int *available);
 
 int af_format_sample_alignment(int format);
 

--- a/audio/out/ao_lavc.c
+++ b/audio/out/ao_lavc.c
@@ -108,6 +108,11 @@ static int init(struct ao *ao)
 
     codec = encode_lavc_get_codec(ao->encode_lavc_ctx, ac->stream);
 
+    int samplerate = af_select_best_samplerate(ao->samplerate,
+                                               codec->supported_samplerates);
+    if (samplerate > 0)
+        ao->samplerate = samplerate;
+
     // TODO: Remove this redundancy with encode_lavc_alloc_stream also
     // setting the time base.
     // Using codec->time_bvase is deprecated, but needed for older lavf.

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -364,17 +364,9 @@ static bool search_samplerates(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat,
         }
     }
 
-    for (int i = 0; supported[i]; i++) {
-        // first choose the lowest integer multiple of the sample rate
-        if (!(supported[i] % ao->samplerate)) {
-            change_waveformat_samplerate(wformat, supported[i]);
-            return true;
-        }
-    }
-
-    // then choose the highest supported (if any)
-    if (n) {
-        change_waveformat_samplerate(wformat, supported[n-1]);
+    int samplerate = af_select_best_samplerate(ao->samplerate, supported);
+    if (samplerate > 0) {
+        change_waveformat_samplerate(wformat, samplerate);
         return true;
     }
 


### PR DESCRIPTION
 audio: add af_select_best_samplerate function

This function chooses the best match to a given sample rate from a provided
list. This can be used by the ao to decide what samplerate to use for output.

This is then used in `ao_wasapi` exclusive mode and and `ao_lavc`. The behaviour is of `ao_wasapi` is unchanged as this essentially moves it's sample rate selection logic to `audio/format.c`. This is an improvement for `ao_lavc`, which previously failed when attempting to output a sample rate incompatible with the codec (i.e., opus).