### PR TITLE
DOCS/compile-windows.md: use mingw pkg-config in msys2 instructions

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -156,14 +156,14 @@ Finally, compile and install mpv. Binaries will be installed to
 
 ```bash
 # For a 32-bit build, use --prefix=/mingw32 instead
-./waf configure CC=gcc --check-c-compiler=gcc --prefix=/mingw64
+./waf configure CC=gcc.exe --check-c-compiler=gcc --prefix=/mingw64
 ./waf install
 ```
 
 Or, compile and install both libmpv and mpv:
 
 ```bash
-./waf configure CC=gcc --check-c-compiler=gcc --enable-libmpv-shared --prefix=/mingw64
+./waf configure CC=gcc.exe --check-c-compiler=gcc --enable-libmpv-shared --prefix=/mingw64
 ./waf install
 
 # waf installs libmpv to the wrong directory, so fix it up

--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -129,7 +129,7 @@ Installing mpv dependencies
 
 ```bash
 # Install MSYS2 build dependencies and a MinGW-w64 compiler
-pacman -S git pkg-config python3 mingw-w64-x86_64-gcc
+pacman -S git mingw-w64-x86_64-pkg-config python mingw-w64-x86_64-gcc
 
 # Install the most important MinGW-w64 dependencies. libass, libbluray and
 # lcms2 are also pulled in as dependencies of ffmpeg.


### PR DESCRIPTION
Apparently, you aren't supposed to use msys2 pkg-config for mingw stuff.

