### PR TITLE
csputils: add DCI-P3 colorspace

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -887,6 +887,8 @@ Available video output drivers are:
             ProPhoto RGB (ROMM)
         cie1931
             CIE 1931 RGB (not to be confused with CIE XYZ)
+        dci-p3
+            DCI-P3 (Digital Cinema Colorspace), SMPTE RP431-2
 
     ``target-trc=<value>``
         Specifies the transfer characteristics (gamma) of the display. Video

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -64,6 +64,7 @@ const struct m_opt_choice_alternatives mp_csp_prim_names[] = {
     {"adobe",       MP_CSP_PRIM_ADOBE},
     {"prophoto",    MP_CSP_PRIM_PRO_PHOTO},
     {"cie1931",     MP_CSP_PRIM_CIE_1931},
+    {"dci-p3",      MP_CSP_PRIM_DCI_P3},
     {0}
 };
 
@@ -402,6 +403,14 @@ struct mp_csp_primaries mp_get_csp_primaries(enum mp_csp_prim spc)
             .green = {0.2738, 0.7174},
             .blue  = {0.1666, 0.0089},
             .white = e
+        };
+    // From SMPTE RP 431-2
+    case MP_CSP_PRIM_DCI_P3:
+        return (struct mp_csp_primaries) {
+            .red   = {0.680, 0.320},
+            .green = {0.265, 0.690},
+            .blue  = {0.150, 0.060},
+            .white = d65
         };
     default:
         return (struct mp_csp_primaries) {{0}};

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -63,6 +63,7 @@ enum mp_csp_prim {
     MP_CSP_PRIM_ADOBE,
     MP_CSP_PRIM_PRO_PHOTO,
     MP_CSP_PRIM_CIE_1931,
+    MP_CSP_PRIM_DCI_P3,
     MP_CSP_PRIM_COUNT
 };
 


### PR DESCRIPTION
This colorspace has been historically used as a calibration target for
most digital projectors and sees some involvement in the UltraHD
standards, so it's a useful addition to mpv.

(In particular, I actually *needed* this option when testing some stuff earlier!)