### PR TITLE
Support for FFmpeg MediaCodec as hwdec

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -89,6 +89,7 @@ const struct m_opt_choice_alternatives mp_hwdec_names[] = {
     {"dxva2",       HWDEC_DXVA2},
     {"dxva2-copy",  HWDEC_DXVA2_COPY},
     {"rpi",         HWDEC_RPI},
+    {"mediacodec",  HWDEC_MEDIACODEC},
     {0}
 };
 

--- a/video/decode/mediacodec.c
+++ b/video/decode/mediacodec.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "lavc.h"
+#include "common/common.h"
+
+static const char *const codecs[][2] = {
+    {"h264",        "h264_mediacodec"},
+    {0}
+};
+
+static const char *map_codec(const char *c)
+{
+    for (int n = 0; codecs[n][0]; n++) {
+        if (c && strcmp(codecs[n][0], c) == 0)
+            return codecs[n][1];
+    }
+    return NULL;
+}
+
+static int init_decoder(struct lavc_ctx *ctx, int w, int h)
+{
+    return 0;
+}
+
+static void uninit(struct lavc_ctx *ctx)
+{
+}
+
+static int init(struct lavc_ctx *ctx)
+{
+    return 0;
+}
+
+static int probe(struct vd_lavc_hwdec *hwdec, struct mp_hwdec_info *info,
+                 const char *decoder)
+{
+    return map_codec(decoder) ? 0 : HWDEC_ERR_NO_CODEC;
+}
+
+static const char *get_codec(struct lavc_ctx *ctx, const char *codec)
+{
+    return map_codec(codec);
+}
+
+const struct vd_lavc_hwdec mp_vd_lavc_mediacodec = {
+    .type = HWDEC_MEDIACODEC,
+    .image_format = IMGFMT_NV12,
+    .probe = probe,
+    .init = init,
+    .uninit = uninit,
+    .init_decoder = init_decoder,
+    .get_codec = get_codec,
+};

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -127,6 +127,7 @@ extern const struct vd_lavc_hwdec mp_vd_lavc_vaapi_copy;
 extern const struct vd_lavc_hwdec mp_vd_lavc_dxva2;
 extern const struct vd_lavc_hwdec mp_vd_lavc_dxva2_copy;
 extern const struct vd_lavc_hwdec mp_vd_lavc_rpi;
+extern const struct vd_lavc_hwdec mp_vd_lavc_mediacodec;
 
 static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #if HAVE_RPI
@@ -145,6 +146,9 @@ static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #if HAVE_DXVA2_HWACCEL
     &mp_vd_lavc_dxva2,
     &mp_vd_lavc_dxva2_copy,
+#endif
+#if HAVE_ANDROID
+    &mp_vd_lavc_mediacodec,
 #endif
     NULL
 };

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -366,7 +366,7 @@ static void init_avctx(struct dec_video *vd, const char *decoder,
     ctx->hwdec_info = vd->hwdec_info;
 
     ctx->codec_timebase = (AVRational){0};
-    if (strstr(decoder, "_mmal"))
+    if (strstr(decoder, "_mmal") || strstr(decoder, "_mediacodec"))
         ctx->codec_timebase = (AVRational){1, 1000000};
 
     ctx->pix_fmt = AV_PIX_FMT_NONE;

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -16,6 +16,7 @@ enum hwdec_type {
     HWDEC_DXVA2 = 6,
     HWDEC_DXVA2_COPY = 7,
     HWDEC_RPI = 8,
+    HWDEC_MEDIACODEC = 9,
 };
 
 // hwdec_type names (options.c)

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -296,6 +296,7 @@ def build(ctx):
         ( "video/decode/vd_lavc.c" ),
         ( "video/decode/videotoolbox.c",         "videotoolbox-hwaccel" ),
         ( "video/decode/vdpau.c",                "vdpau-hwaccel" ),
+        ( "video/decode/mediacodec.c",           "android" ),
         ( "video/filter/vf.c" ),
         ( "video/filter/vf_buffer.c" ),
         ( "video/filter/vf_crop.c" ),


### PR DESCRIPTION
Posting these now that h264_mediacodec has been merged into FFmpeg master.

* The `_mediacodec` decoders seem to require the same timebase simplification as the `_mmal` ones.
* Adds a similar wrapper for `_mediacodec` decoders as the `_mmal` ones have for rpi. This way one can enable a "mediacodec" hwdec and enjoy hardware decoding and a fallback to software decoding if the back-end of a specific device handles it well enough.