### PR TITLE
aspect: make video-zoom logarithmic

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,6 +27,7 @@ Interface changes
     - add "cache-speed" property
     - rename --input-unix-socket to --input-ipc-server, and make it work on
       Windows too
+    - change the exact behavior of the "video-zoom" property
  --- mpv 0.16.0 ---
     - change --audio-channels default to stereo (use --audio-channels=auto to
       get the old default)

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -732,12 +732,10 @@ Video
     appear in files, but can't be handled properly by mpv.
 
 ``--video-zoom=<value>``
-    Adjust the video display scale factor by the given value. The unit is in
-    fractions of the (scaled) window video size.
-
-    For example, given a 1280x720 video shown in a 1280x720 window,
-    ``--video-zoom=-0.1`` would make the video by 128 pixels smaller in
-    X direction, and 72 pixels in Y direction.
+    Adjust the video display scale factor by the given value. The parameter is
+    given log 2. For example, ``--video-zoom=0`` is unscaled,
+    ``--video-zoom=1`` is twice the size, ``--video-zoom=-2`` is one fourth of
+    the size, and so on.
 
     This option is disabled if the ``--no-keepaspect`` option is used.
 

--- a/video/out/aspect.c
+++ b/video/out/aspect.c
@@ -17,6 +17,7 @@
 
 /* Stuff for correct aspect scaling. */
 #include "aspect.h"
+#include "math.h"
 #include "vo.h"
 #include "common/msg.h"
 #include "options/options.h"
@@ -84,7 +85,7 @@ static void src_dst_split_scaling(int src_size, int dst_size,
         zoom = 0.0;
     }
 
-    scaled_src_size += zoom * scaled_src_size;
+    scaled_src_size *= powf(2, zoom);
     align = (align + 1) / 2;
 
     *src_start = 0;


### PR DESCRIPTION
The past behavior was a bit weird, especially when zooming out. There
was no simple way to zoom in or out in consistent increments using
keybindings alone.

The new behavior preserves most of the old behavior's semantics but
scales out to infinity better. It coincidentally also makes it
really easy to get clean power of 2 ratios (e.g. 2x, 4x, 8x and their
inverses).