### PR TITLE
aspect: rework --video-unscaled

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,8 @@ Interface changes
     - rename --input-unix-socket to --input-ipc-server, and make it work on
       Windows too
     - change the exact behavior of the "video-zoom" property
+    - --video-unscaled no longer disables --video-zoom and --video-aspect
+      To force the old behavior, set --video-zoom=0 and --video-aspect=0
  --- mpv 0.16.0 ---
     - change --audio-channels default to stereo (use --audio-channels=auto to
       get the old default)

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -684,15 +684,12 @@ Video
 ``--video-unscaled``
     Disable scaling of the video. If the window is larger than the video,
     black bars are added. Otherwise, the video is cropped. The video still
-    can be influenced by the other ``--video-...`` options. (But not all; for
-    example ``--video-zoom`` does nothing if this option is enabled.)
-
-    The video and monitor aspects aspect will be ignored. Aspect correction
-    would require scaling the video in the X or Y direction, but this option
-    disables scaling, disabling all aspect correction.
+    can be influenced by the other ``--video-...`` options.
 
     Note that the scaler algorithm may still be used, even if the video isn't
-    scaled. For example, this can influence chroma conversion.
+    scaled. For example, this can influence chroma conversion. The video will
+    also still be scaled in one dimension if the source uses non-square pixels
+    (e.g. anamorphic widescreen DVDs).
 
     This option is disabled if the ``--no-keepaspect`` option is used.
 


### PR DESCRIPTION
In the past, --video-unscaled also disabled zooming and aspect ratio
corrections. But this didn't make much sense in terms of being a useful
option. The new behavior just sets the initial video size to be
unscaled, but it's still affected by zoom commands and aspect ratio
corrections.

To get the old behavior back, --video-aspect=0 --video-zoom=0 need to be
added as well (in the general case). Most of the time it should not make
a difference though.

Also, there seems to have been some additional dst_rect clamping code
inside src_dst_split_scaling that didn't seem to either be necessary nor
ever get triggered. (The code immediately above it already makes sure to
crop the video if it's larger than the dst_rect)

No idea why it was there, but I just removed it.