### PR TITLE
input: fix parsing multiple input command prefixes

### DIFF
--- a/input/cmd_parse.c
+++ b/input/cmd_parse.c
@@ -273,7 +273,6 @@ static struct mp_cmd *parse_cmd_str(struct mp_log *log, void *tmp,
             break;
         if (pctx_read_token(ctx, &cur_token) < 0)
             goto error;
-        break;
     }
 
     if (!find_cmd(ctx->log, cmd, cur_token))


### PR DESCRIPTION
Looks like this has been broken for a while. I guess using multiple prefixes isn't very common? My use case is `no-osd raw cycle_values options/osd-msg1 "${vsync-jitter}" ""`