### PR TITLE
Deprioritize clearvideo

### DIFF
--- a/video/decode/d3d.c
+++ b/video/decode/d3d.c
@@ -76,8 +76,8 @@ static const struct d3dva_mode d3dva_modes[] = {
 
     // H.264
     {MODE2(H264_F),                        AV_CODEC_ID_H264, PROF_H264_HIGH},
-    {MODE (Intel_H264_NoFGT_ClearVideo),   AV_CODEC_ID_H264, PROF_H264_HIGH},
     {MODE2(H264_E),                        AV_CODEC_ID_H264, PROF_H264_HIGH},
+    {MODE (Intel_H264_NoFGT_ClearVideo),   AV_CODEC_ID_H264, PROF_H264_HIGH},
     {MODE (ModeH264_VLD_WithFMOASO_NoFGT), AV_CODEC_ID_H264, PROF_H264_HIGH},
     {MODE (ModeH264_VLD_NoFGT_Flash),      AV_CODEC_ID_H264, PROF_H264_HIGH},
 

--- a/video/decode/d3d11va.c
+++ b/video/decode/d3d11va.c
@@ -160,10 +160,14 @@ static void dump_decoder_info(struct lavc_ctx *s, const GUID *guid)
 
 static DWORD get_dxfmt_cb(struct lavc_ctx *s, const GUID *guid, int depth)
 {
+    struct priv *p = s->hwdec_priv;
     for (int i = 0; i < MP_ARRAY_SIZE(d3d11_formats); i++) {
         const struct d3d11_format *format = &d3d11_formats[i];
         if (depth <= format->depth &&
             d3d11_format_supported(s, guid, format)) {
+            MP_VERBOSE(p, "Selecting %s %s\n",
+                       d3d_decoder_guid_to_desc(guid),
+                       format->name);
             return format->format;
         }
     }

--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -133,7 +133,7 @@ static void dump_decoder_info(struct lavc_ctx *s,
         HRESULT hr = IDirectXVideoDecoderService_GetDecoderRenderTargets(
             p->decoder_service, guid, &n_formats, &formats);
         if (FAILED(hr)) {
-            MP_ERR(p, "Failed to get render targets for decoder %s:%s",
+            MP_ERR(p, "Failed to get render targets for decoder %s:%s\n",
                    description, mp_HRESULT_to_str(hr));
         }
 

--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -170,6 +170,9 @@ static DWORD get_dxfmt_cb(struct lavc_ctx *s, const GUID *guid, int depth)
         for (UINT j = 0; j < n_formats; j++) {
             if (formats[i] == d3d9_fmt->format) {
                 ret = formats[i];
+                MP_VERBOSE(p, "Selecting %s %s\n",
+                           d3d_decoder_guid_to_desc(guid),
+                           mp_tag_str(ret));
                 goto done;
             }
         }


### PR DESCRIPTION
move Intel_H264_NoFGT_ClearVideo to lower priority so that H264_E is preferred. Also add some debugging about which decoder is selected and fix a missing newline.

Fixes #3059.