### PR TITLE
wscript: don't check for fork() on POSIX checks

### DIFF
--- a/wscript
+++ b/wscript
@@ -127,7 +127,7 @@ main_dependencies = [
         'desc': 'POSIX environment',
         # This should be good enough.
         'func': check_statement(['poll.h', 'unistd.h', 'sys/mman.h'],
-            'struct pollfd pfd; poll(&pfd, 1, 0); fork(); int f[2]; pipe(f); munmap(f,0)'),
+            'struct pollfd pfd; poll(&pfd, 1, 0); int f[2]; pipe(f); munmap(f,0)'),
     }, {
         'name': 'posix-or-mingw',
         'desc': 'development environment',


### PR DESCRIPTION
It's not being used, and in fact prevents mpv from being built in nommu
architectures (cortex M, blackfin, ...)

Signed-off-by: Gustavo Zacarias gustavo@zacarias.com.ar
