### PR TITLE
w32_common: implement --fit-border option and fix size calculations

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1799,6 +1799,12 @@ Window
     Play video with window border and decorations. Since this is on by
     default, use ``--no-border`` to disable the standard window decorations.
 
+``--fit-border``, ``--no-fit-border``
+    (Windows only) Fit the whole window with border and decorations on the
+    screen. Since this is on by default, use ``--no-fit-border`` to make mpv
+    try to only fit client area with video on the screen. This behavior only
+    applied to window/video with size exceeding size of the screen.
+
 ``--on-all-workspaces``
     (X11 only)
     Show the video window on all virtual desktops.

--- a/options/options.c
+++ b/options/options.c
@@ -398,6 +398,7 @@ const m_option_t mp_opts[] = {
                ({"no", 0}, {"yes", 1}, {"immediate", 2})),
     OPT_FLAG("ontop", vo.ontop, M_OPT_FIXED),
     OPT_FLAG("border", vo.border, M_OPT_FIXED),
+    OPT_FLAG("fit-border", vo.fit_border, M_OPT_FIXED),
     OPT_FLAG("on-all-workspaces", vo.all_workspaces, M_OPT_FIXED),
 
     OPT_FLAG("window-dragging", allow_win_drag, CONF_GLOBAL),
@@ -707,6 +708,7 @@ const struct MPOpts mp_default_opts = {
         .keepaspect = 1,
         .keepaspect_window = 1,
         .border = 1,
+        .fit_border = 1,
         .WinID = -1,
         .window_scale = 1.0,
         .x11_bypass_compositor = 0,

--- a/options/options.h
+++ b/options/options.h
@@ -12,6 +12,7 @@ typedef struct mp_vo_opts {
     int ontop;
     int fullscreen;
     int border;
+    int fit_border;
     int all_workspaces;
 
     int screen_id;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1067,15 +1067,31 @@ static void reinit_window_state(struct vo_w32_state *w32)
 
     RECT cr = r;
     add_window_borders(w32->window, &r);
+    // Check on client area size instead of window size on --fit-border=no
+    long o_w;
+    long o_h;
+    if( w32->opts->fit_border ) {
+        o_w = r.right - r.left;
+        o_h = r.bottom - r.top;
+    } else {
+        o_w = cr.right - cr.left;
+        o_h = cr.bottom - cr.top;
+    }
 
-    if (!w32->current_fs &&
-        ((r.right - r.left) > screen_w || (r.bottom - r.top) > screen_h))
+    if ( !w32->current_fs && ( o_w > screen_w || o_h > screen_h ) )
     {
         MP_VERBOSE(w32, "requested window size larger than the screen\n");
         // Use the aspect of the client area, not the full window size.
         // Basically, try to compute the maximum window size.
-        long n_w = screen_w - (r.right - cr.right) - (cr.left - r.left);
-        long n_h = screen_h - (r.bottom - cr.bottom) - (cr.top - r.top);
+        long n_w;
+        long n_h;
+        if( w32->opts->fit_border ) {
+            n_w = screen_w - (r.right - cr.right) - (cr.left - r.left);
+            n_h = screen_h - (r.bottom - cr.bottom) - (cr.top - r.top);
+        } else {
+            n_w = screen_w;
+            n_h = screen_h;
+        }
         // Letterbox
         double asp = (cr.right - cr.left) / (double)(cr.bottom - cr.top);
         double s_asp = n_w / (double)n_h;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1069,13 +1069,13 @@ static void reinit_window_state(struct vo_w32_state *w32)
     add_window_borders(w32->window, &r);
 
     if (!w32->current_fs &&
-        ((r.right - r.left) >= screen_w || (r.bottom - r.top) >= screen_h))
+        ((r.right - r.left) > screen_w || (r.bottom - r.top) > screen_h))
     {
         MP_VERBOSE(w32, "requested window size larger than the screen\n");
         // Use the aspect of the client area, not the full window size.
         // Basically, try to compute the maximum window size.
-        long n_w = screen_w - (r.right - cr.right) - (cr.left - r.left) - 1;
-        long n_h = screen_h - (r.bottom - cr.bottom) - (cr.top - r.top) - 1;
+        long n_w = screen_w - (r.right - cr.right) - (cr.left - r.left);
+        long n_h = screen_h - (r.bottom - cr.bottom) - (cr.top - r.top);
         // Letterbox
         double asp = (cr.right - cr.left) / (double)(cr.bottom - cr.top);
         double s_asp = n_w / (double)n_h;


### PR DESCRIPTION
Fixes for main issue and 2.b in #2935.

--fit-border is on by default and results in the same behavior as before - fitting of the whole window. --no-fit-border will make mpv try to fit the client area into the screen.

I'm yet to find out how fitting is implemented on other platforms and can this option be used on them at all, so it's Windows-only option for now.