### PR TITLE
lcms.c improvements

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -951,6 +951,13 @@ Available video output drivers are:
         Default is 128x256x64.
         Sizes must be a power of two, and 512 at most.
 
+    ``icc-contrast=<0-100000>``
+        Specifies an upper limit on the target device's contrast ratio.
+        This is detected automatically from the profile if possible, but for
+        some profiles it might be missing, causing the contrast to be assumed
+        as infinite. As a result, video may appear darker than intended. This
+        only affects BT.1886 content. The default of 0 means no limit.
+
     ``blend-subtitles=<yes|video|no>``
         Blend subtitles directly onto upscaled video frames, before
         interpolation and/or color management (default: no). Enabling this

--- a/video/out/opengl/lcms.c
+++ b/video/out/opengl/lcms.c
@@ -335,7 +335,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
     }
 
     // check cache
-    if (cache_file) {
+    if (cache_file && stat(cache_file, &(struct stat){0}) == 0) {
         MP_VERBOSE(p, "Opening 3D LUT cache in file '%s'.\n", cache_file);
         struct bstr cachedata = stream_read_file(cache_file, tmp, p->global,
                                                  1000000000); // 1 GB

--- a/video/out/opengl/lcms.h
+++ b/video/out/opengl/lcms.h
@@ -13,6 +13,7 @@ struct mp_icc_opts {
     char *cache_dir;
     char *size_str;
     int intent;
+    int contrast;
 };
 
 struct lut3d;


### PR DESCRIPTION
See the commit messages. As discussed in #3002. This improves BT.1886 handling for more profiles, while remaining fully backwards compatible with the current behavior for profiles where BT.1886 was already working.