### PR TITLE
win32: make taskbar progress indication optional

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1349,6 +1349,9 @@ Property list
 ``colormatrix-primaries`` (R)
     See ``colormatrix``.
 
+``taskbar-progress`` (RW)
+    See ``--taskbar-progress``.
+
 ``ontop`` (RW)
     See ``--ontop``.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1794,6 +1794,12 @@ Window
         mode can be used to create the window always on program start, but this
         may cause other issues.
 
+``--taskbar-progress``, ``--no-taskbar-progress``
+    (Windows only)
+    Enable/disable playback progress rendering in taskbar (Windows 7 and above).
+    
+    Enabled by default.
+
 ``--ontop``
     Makes the player window stay on top of other windows.
 

--- a/options/options.c
+++ b/options/options.c
@@ -397,6 +397,9 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("audio-fallback-to-null", ao_null_fallback, 0),
     OPT_CHOICE("force-window", force_vo, 0,
                ({"no", 0}, {"yes", 1}, {"immediate", 2})),
+#ifdef _WIN32
+    OPT_FLAG("taskbar-progress", vo.taskbar_progress, 0),
+#endif
     OPT_FLAG("ontop", vo.ontop, M_OPT_FIXED),
     OPT_FLAG("border", vo.border, M_OPT_FIXED),
     OPT_FLAG("fit-border", vo.fit_border, M_OPT_FIXED),
@@ -709,6 +712,7 @@ const struct MPOpts mp_default_opts = {
         .panscan = 0.0f,
         .keepaspect = 1,
         .keepaspect_window = 1,
+        .taskbar_progress = 1,
         .border = 1,
         .fit_border = 1,
         .WinID = -1,

--- a/options/options.c
+++ b/options/options.c
@@ -397,9 +397,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("audio-fallback-to-null", ao_null_fallback, 0),
     OPT_CHOICE("force-window", force_vo, 0,
                ({"no", 0}, {"yes", 1}, {"immediate", 2})),
-#ifdef _WIN32
     OPT_FLAG("taskbar-progress", vo.taskbar_progress, 0),
-#endif
     OPT_FLAG("ontop", vo.ontop, M_OPT_FIXED),
     OPT_FLAG("border", vo.border, M_OPT_FIXED),
     OPT_FLAG("fit-border", vo.fit_border, M_OPT_FIXED),

--- a/options/options.h
+++ b/options/options.h
@@ -9,6 +9,7 @@
 typedef struct mp_vo_opts {
     struct m_obj_settings *video_driver_list, *vo_defs;
 
+    int taskbar_progress;
     int ontop;
     int fullscreen;
     int border;

--- a/player/command.c
+++ b/player/command.c
@@ -2364,7 +2364,6 @@ static int mp_property_fullscreen(void *ctx, struct m_property *prop,
     return r;
 }
 
-#ifdef _WIN32
 /// Show playback progress in Windows 7+ taskbar (RW)
 static int mp_property_taskbar_progress(void *ctx, struct m_property *prop,
                              int action, void *arg)
@@ -2381,7 +2380,6 @@ static int mp_property_taskbar_progress(void *ctx, struct m_property *prop,
     }
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
-#endif
 
 /// Window always on top (RW)
 static int mp_property_ontop(void *ctx, struct m_property *prop,
@@ -3677,9 +3675,7 @@ static const struct m_property mp_properties[] = {
     {"fullscreen", mp_property_fullscreen},
     {"deinterlace", mp_property_deinterlace},
     {"field-dominance", mp_property_generic_option},
-#ifdef _WIN32
     {"taskbar-progress", mp_property_taskbar_progress},
-#endif
     {"ontop", mp_property_ontop},
     {"border", mp_property_border},
     {"on-all-workspaces", mp_property_all_workspaces},

--- a/player/command.c
+++ b/player/command.c
@@ -2364,6 +2364,25 @@ static int mp_property_fullscreen(void *ctx, struct m_property *prop,
     return r;
 }
 
+#ifdef _WIN32
+/// Show playback progress in Windows 7+ taskbar (RW)
+static int mp_property_taskbar_progress(void *ctx, struct m_property *prop,
+                             int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    if (action == M_PROPERTY_SET) {
+        int desired = !!*(int *) arg;
+        if (mpctx->opts->vo.taskbar_progress == desired)
+            return M_PROPERTY_OK;
+        mpctx->opts->vo.taskbar_progress = desired;
+        if (mpctx->video_out)
+            update_vo_playback_state( mpctx );
+        return M_PROPERTY_OK;
+    }
+    return mp_property_generic_option(mpctx, prop, action, arg);
+}
+#endif
+
 /// Window always on top (RW)
 static int mp_property_ontop(void *ctx, struct m_property *prop,
                              int action, void *arg)
@@ -3658,6 +3677,9 @@ static const struct m_property mp_properties[] = {
     {"fullscreen", mp_property_fullscreen},
     {"deinterlace", mp_property_deinterlace},
     {"field-dominance", mp_property_generic_option},
+#ifdef _WIN32
+    {"taskbar-progress", mp_property_taskbar_progress},
+#endif
     {"ontop", mp_property_ontop},
     {"border", mp_property_border},
     {"on-all-workspaces", mp_property_all_workspaces},
@@ -3989,6 +4011,7 @@ static const struct property_osd_display {
     { "balance", "Balance", .osd_progbar = OSD_BALANCE },
     // video
     { "panscan", "Panscan", .osd_progbar = OSD_PANSCAN },
+    { "taskbar-progress", "Progress in taskbar" },
     { "ontop", "Stay on top" },
     { "border", "Border" },
     { "framedrop", "Framedrop" },

--- a/player/misc.c
+++ b/player/misc.c
@@ -116,16 +116,24 @@ void update_vo_playback_state(struct MPContext *mpctx)
     if (mpctx->video_out) {
         struct voctrl_playback_state oldstate = mpctx->vo_playback_state;
         struct voctrl_playback_state newstate = {
+            .taskbar_progress = mpctx->opts->vo.taskbar_progress,
             .playing = mpctx->playing,
             .paused = mpctx->paused,
             .percent_pos = get_percent_pos(mpctx),
         };
 
-        if (oldstate.playing != newstate.playing ||
+        if (oldstate.taskbar_progress != newstate.taskbar_progress ||
+            oldstate.playing != newstate.playing ||
             oldstate.paused != newstate.paused ||
-            oldstate.percent_pos != newstate.percent_pos) {
-            vo_control(mpctx->video_out,
-                       VOCTRL_UPDATE_PLAYBACK_STATE, &newstate);
+            oldstate.percent_pos != newstate.percent_pos)
+        {
+            // Don't update progress bar if it was and still is hidden
+            if ((oldstate.playing && oldstate.taskbar_progress) ||
+                (newstate.playing && newstate.taskbar_progress))
+            {
+                vo_control(mpctx->video_out,
+                           VOCTRL_UPDATE_PLAYBACK_STATE, &newstate);
+            }
             mpctx->vo_playback_state = newstate;
         }
     } else {

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -132,6 +132,7 @@ struct voctrl_get_equalizer_args {
 
 // VOCTRL_UPDATE_PLAYBACK_STATE
 struct voctrl_playback_state {
+    bool taskbar_progress;
     bool playing;
     bool paused;
     int percent_pos;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1435,7 +1435,7 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         if (!w32->taskbar_list3 || !w32->tbtnCreated)
             return VO_TRUE;
 
-        if (!pstate->playing) {
+        if (!pstate->playing || !pstate->taskbar_progress) {
             ITaskbarList3_SetProgressState(w32->taskbar_list3, w32->window,
                                            TBPF_NOPROGRESS);
             return VO_TRUE;


### PR DESCRIPTION
Add `--taskbar-progress` command line option and property which controls taskbar
progress indication rendering in Windows 7+. This option is on by default and
can be toggled during playback.

This also stops `update_vo_playback_state` from calling `vo_control` when the
progress bar was and still is hidden and therefore there is nothing to update.