### PR TITLE
Improve options.rst

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1989,7 +1989,7 @@ Window
 
     .. admonition:: Example for GNOME screensaver
 
-        ``mpv --heartbeat-cmd="gnome-screensaver-command -p" file``
+        ``mpv --heartbeat-cmd="gnome-screensaver-command --deactivate" file``
 
 
 ``--heartbeat-interval=<sec>``


### PR DESCRIPTION
Update typo in gnome-screensaver deactivation example.
Correct options to deactivate is -d or --deactivate.