### PR TITLE
x11: tell GNOME 3 to use dark window decorations

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1459,6 +1459,7 @@ static void vo_x11_create_window(struct vo *vo, XVisualInfo *vis,
         vo_x11_set_wm_icon(x11);
         vo_x11_update_window_title(vo);
         vo_x11_dnd_init_window(vo);
+        vo_x11_set_property_utf8(vo, XA(x11, _GTK_THEME_VARIANT), "dark");
     }
     vo_x11_xembed_update(x11, 0);
 }


### PR DESCRIPTION
The default white titlebar is rather distracting, so this tells the WM to prefer the dark variant (if the theme provides one). Tested with gnome-shell 3.20, should work on 3.2 and above.

I don't have many expectations on having a very DE-specific option being merged, but doesn't hurt to try.