### PR TITLE
ass_process_chunk: use llrint, not lrint

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -270,8 +270,8 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         // Note that for this packet format, libass has an internal mechanism
         // for discarding duplicate (already seen) packets.
         ass_process_chunk(track, packet->buffer, packet->len,
-                          lrint(packet->pts * 1000),
-                          lrint(packet->duration * 1000));
+                          llrint(packet->pts * 1000),
+                          llrint(packet->duration * 1000));
     }
 }
 


### PR DESCRIPTION
libass's ass_process_chunk expects long long int for the timecode and durations arguments, thus should use llrint instead of lrint.

This does not cause any problems on most platforms, but on cygwin, it causes strange subtitle behavior, like subtitles not showing, getting stuck or old subtitles showing at the same time as new subtitles.

It's a bit of a strange bug. Even if you use llrint, but include the line "long long temp = lrint(0);" right before the ass_process_chunk call, the issue will still show. Cygwin's gcc does not seem to like casting the return value of lrint to a long long int.