### PR TITLE
build: also use the iconv check on freebsd

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -47,7 +47,7 @@ def check_iconv(ctx, dependency_identifier):
     libdliconv = " ".join(ctx.env.LIB_LIBDL + ['iconv'])
     libs       = ['iconv', libdliconv]
     args       = {'fragment': iconv_program}
-    if ctx.env.DEST_OS == 'openbsd':
+    if ctx.env.DEST_OS == 'openbsd' or ctx.env.DEST_OS == 'freebsd':
         args['cflags'] = '-I/usr/local/include'
         args['linkflags'] = '-L/usr/local/lib'
     checkfn = check_cc(**args)


### PR DESCRIPTION
This is necessary to make mpv build out of box on FreeBSD.