### PR TITLE
Add Appveyor CI integration for Windows builds

### DIFF
--- a/TOOLS/appveyor-build.sh
+++ b/TOOLS/appveyor-build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+set -e
+
+export DEST_OS=win32
+export CC=gcc
+export PKG_CONFIG=/usr/bin/pkg-config
+export PERL=/usr/bin/perl
+export PYTHON=/usr/bin/python3
+
+"$PYTHON" bootstrap.py
+"$PYTHON" waf configure \
+    --check-c-compiler=gcc \
+    --disable-cdda \
+    --enable-egl-angle \
+    --enable-gpl3 \
+    --enable-jpeg \
+    --enable-lcms2 \
+    --enable-libarchive \
+    --enable-libass \
+    --enable-lua \
+    --enable-rubberband \
+    --enable-uchardet
+"$PYTHON" waf build

--- a/TOOLS/appveyor-install.sh
+++ b/TOOLS/appveyor-install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+set -e
+
+case $MSYSTEM in
+MINGW32)
+    export MINGW_PACKAGE_PREFIX=mingw-w64-i686
+    ;;
+MINGW64)
+    export MINGW_PACKAGE_PREFIX=mingw-w64-x86_64
+    ;;
+esac
+
+# Write an empty fonts.conf to speed up fc-cache
+export FONTCONFIG_FILE=/dummy-fonts.conf
+cat >"$FONTCONFIG_FILE" <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig></fontconfig>
+EOF
+
+# Install build dependencies for mpv
+pacman -S --noconfirm --needed \
+    $MINGW_PACKAGE_PREFIX-gcc \
+    $MINGW_PACKAGE_PREFIX-angleproject-git \
+    $MINGW_PACKAGE_PREFIX-ffmpeg \
+    $MINGW_PACKAGE_PREFIX-lcms2 \
+    $MINGW_PACKAGE_PREFIX-libarchive \
+    $MINGW_PACKAGE_PREFIX-libass \
+    $MINGW_PACKAGE_PREFIX-libjpeg-turbo \
+    $MINGW_PACKAGE_PREFIX-lua51 \
+    $MINGW_PACKAGE_PREFIX-rubberband \
+    $MINGW_PACKAGE_PREFIX-uchardet-git
+
+# Delete unused packages to reduce space used in the Appveyor cache
+pacman -Sc --noconfirm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+branches:
+  only:
+    - master
+    - appveyor
+
+environment:
+  matrix:
+    - MSYSTEM: MINGW64
+    - MSYSTEM: MINGW32
+
+shallow_clone: true
+test: off
+
+install:
+  # Update core packages
+  - C:\msys64\usr\bin\pacman -Syyuu --noconfirm
+  # Update non-core packages
+  - C:\msys64\usr\bin\pacman -Suu --noconfirm
+  # Install required MSYS2 packages
+  - C:\msys64\usr\bin\pacman -S --noconfirm --needed perl python pkg-config
+  # Now MSYS2 is up to date, do the rest of the install from a bash script
+  - C:\msys64\usr\bin\bash -lc "cd \"$APPVEYOR_BUILD_FOLDER\" && exec ./TOOLS/appveyor-install.sh"
+build_script:
+  - C:\msys64\usr\bin\bash -lc "cd \"$APPVEYOR_BUILD_FOLDER\" && exec ./TOOLS/appveyor-build.sh"
+on_failure:
+  - type "%APPVEYOR_BUILD_FOLDER%\build\config.log"
+
+cache:
+  - C:\msys64\var\cache\pacman\pkg


### PR DESCRIPTION
Because seemingly innocuous changes tend to break on Windows :)

Test builds are logged here: https://ci.appveyor.com/project/rossy/mpv (It will probably be necessary to create an account for mpv if this is merged.)

This uses MSYS2 for the build, which comes pre-installed in the Appveyor image. It pulls in a few more dependencies than the Travis build, but I think it would be good to make sure bits like the ANGLE code build as well.

This doesn't run the cmocka tests, but I couldn't get them to link and I noticed Travis doesn't run them either.