### PR TITLE
lua: add timer:is_enabled() 

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -350,6 +350,10 @@ The ``mp`` module is preloaded, although it can be loaded manually with
             with ``add_timeout()``), this starts the timer from the beginning,
             using the initially configured timeout.
 
+        ``is_enabled()``
+            Whether the timer is currently enabled or was previously disabled
+            (e.g. by ``stop()`` or ``kill()``).
+
         ``timeout`` (RW)
             This field contains the current timeout period. This value is not
             updated as time progresses. It's only used to calculate when the

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -275,6 +275,10 @@ function timer_mt.resume(t)
     end
 end
 
+function timer_mt.is_enabled(t)
+    return timers[t] ~= nil
+end
+
 -- Return the timer that expires next.
 local function get_next_timer()
     local best = nil


### PR DESCRIPTION
Hope I didn't miss something, in tests it worked. Named it ``enabled`` to stick with this terminology used in the ``stop()`` and ``kill()`` documentation. 
Also, I'm deliberately not just returning ``timers[t]`` but I don't think anyone would expect this method to do that anyway.