### PR TITLE
User hooks (larger vo_opengl refactor)

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -310,6 +310,7 @@ Available filters are:
        :gamma2.2:     Pure power curve (gamma 2.2)
        :gamma2.8:     Pure power curve (gamma 2.8)
        :prophoto:     ProPhoto RGB (ROMM) curve
+       :st2084:       SMPTE ST2084 (HDR) curve
 
     ``<stereo-in>``
         Set the stereo mode the video is assumed to be encoded in. Takes the

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1052,6 +1052,14 @@ Available video output drivers are:
             Pure power curve (gamma 2.8), also used for BT.470-BG
         prophoto
             ProPhoto RGB (ROMM)
+        st2084
+            SMPTE ST2084 (HDR) curve, PQ OETF
+
+    ``target-brightness=<1..100000>``
+        Specifies the display's approximate brightness in cd/m^2. When playing
+        HDR content, video colors will be scaled and clipped to this
+        brightness. The default of 250 cd/m^2 corresponds to a typical consumer
+        display.
 
     ``icc-profile=<file>``
         Load an ICC profile and use it to transform video RGB to screen output.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -739,11 +739,20 @@ Available video output drivers are:
             into. By default, this is set to the special name HOOKED which has
             the effect of overwriting the hooked texture.
 
-        TRANSFORM sx sy ox oy
-            Specifies how this pass intends to transform the hooked texture.
-            ``sx``/``sy`` refer to a linear scale factor, and ``ox``/``oy``
-            refer to a constant pixel shift that the shader will introduce. The
-            default values are 1 1 0 0 which leave the texture size unchanged.
+        WIDTH <szexpr>, HEIGHT <szexpr>
+            Specifies the size of the resulting texture for this pass.
+            ``szexpr`` refers to an expression in RPN (reverse polish
+            notation), using the operators + - * /, floating point literals,
+            and references to existing texture sizes such as MAIN.width or
+            CHROMA.height. By default, these are set to HOOKED.w and HOOKED.h,
+            respectively.
+
+        OFFSET ox oy
+            Indicates a pixel shift (offset) introduced by this pass. These
+            pixel offsets will be accumulated and corrected during the
+            next scaling pass (``cscale`` or ``scale``). The default values
+            are 0 0 which correspond to no shift. Note that offsets are ignored
+            when not overwriting the hooked texture.
 
         COMPONENTS n
             Specifies how many components of this pass's output are relevant
@@ -810,8 +819,9 @@ Available video output drivers are:
             The final output image, after color management but before
             dithering and drawing to screen.
 
-        Only the textures labelled with (resizable) may be transformed by
-        the pass. For all others, the TRANSFORM must be 1 1 0 0 (default).
+        Only the textures labelled with ``resizable`` may be transformed by the
+        pass. When overwriting a texture marked ``fixed``, the WIDTH, HEIGHT
+        and OFFSET must be left at their default values.
 
     ``deband``
         Enable the debanding algorithm. This greatly reduces the amount of

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -763,14 +763,26 @@ Available video output drivers are:
         definitions to that shader pass, where NAME is the name of the bound
         texture:
 
-        sampler NAME
-            The bound texture itself.
+        vec4 NAME_tex(vec2 pos)
+            The sampling function to use to access the texture at a certain
+            spot (in texture coordinate space, range [0,1]). This takes care
+            of any necessary normalization conversions.
+        vec4 NAME_texOff(vec2 offset)
+            Sample the texture at a certain offset in pixels. This works like
+            NAME_tex but additionally takes care of necessary rotations, so
+            that sampling at e.g. vec2(-1,0) is always one pixel to the left.
         vec2 NAME_pos
             The local texture coordinate of that texture, range [0,1].
         vec2 NAME_size
             The (rotated) size in pixels of the texture.
+        mat2 NAME_rot
+            The rotation matrix associated with this texture. (Rotates
+            pixel space to texture coordinates)
         vec2 NAME_pt
             The (unrotated) size of a single pixel, range [0,1].
+        sampler NAME_raw
+            The raw bound texture itself. The use of this should be
+            avoided unless absolutely necessary.
 
         In addition, the global uniforms described in ``post-shaders`` are
         also available.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1057,9 +1057,38 @@ Available video output drivers are:
 
     ``target-brightness=<1..100000>``
         Specifies the display's approximate brightness in cd/m^2. When playing
-        HDR content, video colors will be scaled and clipped to this
-        brightness. The default of 250 cd/m^2 corresponds to a typical consumer
-        display.
+        HDR content, video colors will be tone mapped to this target brightness
+        using the algorithm specified by ``hdr-tone-mapping``. The default of
+        250 cd/m^2 corresponds to a typical consumer display.
+
+    ``hdr-tone-mapping=<value>``
+        Specifies the algorithm used for tone-mapping HDR images onto the
+        target display. Valid values are:
+
+        clip
+            Hard-clip any out-of-range values (default)
+        simple
+            Very simple continuous curve. Preserves dynamic range and peak but
+            uses nonlinear contrast.
+        gamma
+            Fits a logarithmic transfer between the tone curves.
+        linear
+            Linearly stretches the entire reference gamut to (a linear multiple
+            of) the display.
+
+    ``tone-mapping-param=<value>``
+        Set tone mapping parameters. Ignored if the tone mapping algorithm is
+        not tunable. This affects the following tone mapping algorithms:
+
+        simple
+            Specifies the local contrast coefficient at the display peak.
+            Defaults to 0.5, which means that in-gamut values will be about
+            half as bright as when clipping.
+        gamma
+            Specifies the exponent of the function. Defaults to 1.8.
+        linear
+            Specifies the scale factor to use while stretching. Defaults to
+            1.0.
 
     ``icc-profile=<file>``
         Load an ICC profile and use it to transform video RGB to screen output.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -705,6 +705,10 @@ Available video output drivers are:
         flexible: They can be injected at almost arbitrary points in the
         rendering pipeline, and access all previous intermediate textures.
 
+        .. admonition:: Warning
+
+            The syntax is not stable yet and may change any time.
+
         The general syntax of a user shader looks like this::
 
             //!METADATA ARGS...

--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -215,9 +215,9 @@ struct bstr *bstr_splitlines(void *talloc_ctx, struct bstr str)
     return r;
 }
 
-struct bstr bstr_getline(struct bstr str, struct bstr *rest)
+struct bstr bstr_splitchar(struct bstr str, struct bstr *rest, const char c)
 {
-    int pos = bstrchr(str, '\n');
+    int pos = bstrchr(str, c);
     if (pos < 0)
         pos = str.len;
     if (rest)
@@ -240,6 +240,14 @@ bool bstr_eatstart(struct bstr *s, struct bstr prefix)
     if (!bstr_startswith(*s, prefix))
         return false;
     *s = bstr_cut(*s, prefix.len);
+    return true;
+}
+
+bool bstr_eatend(struct bstr *s, struct bstr prefix)
+{
+    if (!bstr_endswith(*s, prefix))
+        return false;
+    s->len -= prefix.len;
     return true;
 }
 

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -116,10 +116,15 @@ int bstr_validate_utf8(struct bstr s);
 // talloc, with talloc_ctx as parent.
 struct bstr bstr_sanitize_utf8_latin1(void *talloc_ctx, struct bstr s);
 
-// Return the text before the next line break, and return it. Change *rest to
-// point to the text following this line break. (rest can be NULL.)
-// Line break characters are not stripped.
-struct bstr bstr_getline(struct bstr str, struct bstr *rest);
+// Return the text before the occurance of a character, and return it. Change
+// *rest to point to the text following this character. (rest can be NULL.)
+struct bstr bstr_splitchar(struct bstr str, struct bstr *rest, const char c);
+
+// Like bstr_splitchar. Trailing newlines are not stripped.
+static inline struct bstr bstr_getline(struct bstr str, struct bstr *rest)
+{
+    return bstr_splitchar(str, rest, '\n');
+}
 
 // Strip one trailing line break. This is intended for use with bstr_getline,
 // and will remove the trailing \n or \r\n sequence.
@@ -131,8 +136,10 @@ void bstr_xappend_asprintf(void *talloc_ctx, bstr *s, const char *fmt, ...)
 void bstr_xappend_vasprintf(void *talloc_ctx, bstr *s, const char *fmt, va_list va)
     PRINTF_ATTRIBUTE(3, 0);
 
-// If s starts with prefix, return true and return the rest of the string in s.
+// If s starts/ends with prefix, return true and return the rest of the string
+// in s.
 bool bstr_eatstart(struct bstr *s, struct bstr prefix);
+bool bstr_eatend(struct bstr *s, struct bstr prefix);
 
 bool bstr_case_startswith(struct bstr s, struct bstr prefix);
 bool bstr_case_endswith(struct bstr s, struct bstr suffix);
@@ -200,9 +207,14 @@ static inline int bstr_find0(struct bstr haystack, const char *needle)
     return bstr_find(haystack, bstr0(needle));
 }
 
-static inline int bstr_eatstart0(struct bstr *s, const char *prefix)
+static inline bool bstr_eatstart0(struct bstr *s, const char *prefix)
 {
     return bstr_eatstart(s, bstr0(prefix));
+}
+
+static inline bool bstr_eatend0(struct bstr *s, const char *prefix)
+{
+    return bstr_eatend(s, bstr0(prefix));
 }
 
 // create a pair (not single value!) for "%.*s" printf syntax

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -171,6 +171,9 @@ enum mp_csp_trc avcol_trc_to_mp_csp_trc(int avtrc)
     case AVCOL_TRC_LINEAR:       return MP_CSP_TRC_LINEAR;
     case AVCOL_TRC_GAMMA22:      return MP_CSP_TRC_GAMMA22;
     case AVCOL_TRC_GAMMA28:      return MP_CSP_TRC_GAMMA28;
+#if HAVE_AVUTIL_ST2084
+    case AVCOL_TRC_SMPTEST2084:  return MP_CSP_TRC_SMPTE_ST2084;
+#endif
     default:                     return MP_CSP_TRC_AUTO;
     }
 }
@@ -214,12 +217,15 @@ int mp_csp_trc_to_avcol_trc(enum mp_csp_trc trc)
 {
     switch (trc) {
     // We just call it BT.1886 since we're decoding, but it's still BT.709
-    case MP_CSP_TRC_BT_1886:     return AVCOL_TRC_BT709;
-    case MP_CSP_TRC_SRGB:        return AVCOL_TRC_IEC61966_2_1;
-    case MP_CSP_TRC_LINEAR:      return AVCOL_TRC_LINEAR;
-    case MP_CSP_TRC_GAMMA22:     return AVCOL_TRC_GAMMA22;
-    case MP_CSP_TRC_GAMMA28:     return AVCOL_TRC_GAMMA28;
-    default:                     return AVCOL_TRC_UNSPECIFIED;
+    case MP_CSP_TRC_BT_1886:      return AVCOL_TRC_BT709;
+    case MP_CSP_TRC_SRGB:         return AVCOL_TRC_IEC61966_2_1;
+    case MP_CSP_TRC_LINEAR:       return AVCOL_TRC_LINEAR;
+    case MP_CSP_TRC_GAMMA22:      return AVCOL_TRC_GAMMA22;
+    case MP_CSP_TRC_GAMMA28:      return AVCOL_TRC_GAMMA28;
+#if HAVE_AVUTIL_ST2084
+    case MP_CSP_TRC_SMPTE_ST2084: return AVCOL_TRC_SMPTEST2084;
+#endif
+    default:                      return AVCOL_TRC_UNSPECIFIED;
     }
 }
 

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -77,6 +77,7 @@ const struct m_opt_choice_alternatives mp_csp_trc_names[] = {
     {"gamma2.2",    MP_CSP_TRC_GAMMA22},
     {"gamma2.8",    MP_CSP_TRC_GAMMA28},
     {"prophoto",    MP_CSP_TRC_PRO_PHOTO},
+    {"st2084",      MP_CSP_TRC_SMPTE_ST2084},
     {0}
 };
 

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -78,6 +78,7 @@ enum mp_csp_trc {
     MP_CSP_TRC_GAMMA22,
     MP_CSP_TRC_GAMMA28,
     MP_CSP_TRC_PRO_PHOTO,
+    MP_CSP_TRC_SMPTE_ST2084,
     MP_CSP_TRC_COUNT
 };
 

--- a/video/out/opengl/nnedi3.h
+++ b/video/out/opengl/nnedi3.h
@@ -38,8 +38,8 @@ extern const struct m_sub_options nnedi3_conf;
 
 const float* get_nnedi3_weights(const struct nnedi3_opts *conf, int *size);
 
-void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int planes, int tex_num,
-                 int step, float tex_mul, const struct nnedi3_opts *conf,
-                 struct gl_transform *transform, GLenum tex_target);
+void pass_nnedi3(GL *gl, struct gl_shader_cache *sc, int step,
+                 const struct nnedi3_opts *conf,
+                 struct gl_transform *transform);
 
 #endif

--- a/video/out/opengl/superxbr.h
+++ b/video/out/opengl/superxbr.h
@@ -24,7 +24,7 @@
 extern const struct superxbr_opts superxbr_opts_def;
 extern const struct m_sub_options superxbr_conf;
 
-void pass_superxbr(struct gl_shader_cache *sc, int id, int step, float tex_mul,
+void pass_superxbr(struct gl_shader_cache *sc, int step,
                    const struct superxbr_opts *conf,
                    struct gl_transform *transform);
 

--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -154,9 +154,7 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
         }
 
         // Unknown command type
-        char *str = bstrto0(NULL, line);
-        mp_err(log, "Unrecognized command '%s'!\n", str);
-        talloc_free(str);
+        mp_err(log, "Unrecognized command '%.*s'!\n", BSTR_P(line));
         return false;
     }
 

--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -1,0 +1,106 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "user_shaders.h"
+
+// Returns false if no more shaders could be parsed
+bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
+                            struct gl_user_shader *out)
+{
+    if (!body || !out || !body->start || body->len == 0)
+        return false;
+
+    *out = (struct gl_user_shader){ .transform = identity_trans };
+    int hook_idx = 0;
+    int bind_idx = 0;
+
+    // First parse all the headers
+    while (true) {
+        struct bstr rest;
+        struct bstr line = bstr_getline(*body, &rest);
+
+        // Check for the presence of the magic line beginning
+        if (!bstr_eatstart0(&line, "//!"))
+            break;
+
+        *body = rest;
+
+        // Parse the supported commands
+        if (bstr_eatstart0(&line, "HOOK")) {
+            if (hook_idx == SHADER_MAX_HOOKS) {
+                mp_err(log, "Passes may only hook up to %d textures!\n",
+                       SHADER_MAX_HOOKS);
+                return false;
+            }
+            out->hook_tex[hook_idx++] = bstr_strip(line);
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "BIND")) {
+            if (bind_idx == SHADER_MAX_BINDS) {
+                mp_err(log, "Passes may only bind up to %d textures!\n",
+                       SHADER_MAX_BINDS);
+                return false;
+            }
+            out->bind_tex[bind_idx++] = bstr_strip(line);
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "SAVE")) {
+            out->save_tex = bstr_strip(line);
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "TRANSFORM")) {
+            float sx, sy, ox, oy;
+            if (bstr_sscanf(line, "%f %f %f %f", &sx, &sy, &ox, &oy) != 4) {
+                mp_err(log, "Error while parsing TRANSFORM!\n");
+                return false;
+            }
+            out->transform = (struct gl_transform){{{sx, 0}, {0, sy}}, {ox, oy}};
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "COMPONENTS")) {
+            if (bstr_sscanf(line, "%d", &out->components) != 1) {
+                mp_err(log, "Error while parsing COMPONENTS!\n");
+                return false;
+            }
+            continue;
+        }
+
+        // Unknown command type
+        char *str = bstrto0(NULL, line);
+        mp_err(log, "Unrecognized command '%s'!\n", str);
+        talloc_free(str);
+        return false;
+    }
+
+    // The rest of the file up until the next magic line beginning (if any)
+    // shall be the shader body
+    if (bstr_split_tok(*body, "//!", &out->pass_body, body)) {
+        // Make sure the magic line is part of the rest
+        body->start -= 3;
+        body->len += 3;
+    }
+
+    // Sanity checking
+    if (hook_idx == 0)
+        mp_warn(log, "Pass has no hooked textures (will be ignored)!\n");
+
+    return true;
+}

--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -16,6 +16,54 @@
  */
 
 #include "user_shaders.h"
+#include "ctype.h"
+
+static bool parse_rpn_szexpr(struct bstr line, struct szexp out[MAX_SZEXP_SIZE])
+{
+    int pos = 0;
+
+    while (line.len > 0) {
+        struct bstr word = bstr_strip(bstr_splitchar(line, &line, ' '));
+        if (word.len == 0)
+            continue;
+
+        if (pos >= MAX_SZEXP_SIZE)
+            return false;
+
+        struct szexp *exp = &out[pos++];
+
+        if (bstr_eatend0(&word, ".w") || bstr_eatend0(&word, ".width")) {
+            exp->tag = SZEXP_VAR_W;
+            exp->val.varname = word;
+            continue;
+        }
+
+        if (bstr_eatend0(&word, ".h") || bstr_eatend0(&word, ".height")) {
+            exp->tag = SZEXP_VAR_H;
+            exp->val.varname = word;
+            continue;
+        }
+
+        switch (word.start[0]) {
+        case '+': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_ADD; continue;
+        case '-': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_SUB; continue;
+        case '*': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_MUL; continue;
+        case '/': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_DIV; continue;
+        }
+
+        if (isdigit(word.start[0])) {
+            exp->tag = SZEXP_CONST;
+            if (bstr_sscanf(word, "%f", &exp->val.cval) != 1)
+                return false;
+            continue;
+        }
+
+        // Some sort of illegal expression
+        return false;
+    }
+
+    return true;
+}
 
 // Returns false if no more shaders could be parsed
 bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
@@ -24,14 +72,19 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
     if (!body || !out || !body->start || body->len == 0)
         return false;
 
-    *out = (struct gl_user_shader){ .transform = identity_trans };
+    *out = (struct gl_user_shader){
+        .offset = identity_trans,
+        .width = {{ SZEXP_VAR_W, { .varname = bstr0("HOOKED") }}},
+        .height = {{ SZEXP_VAR_H, { .varname = bstr0("HOOKED") }}},
+    };
+
     int hook_idx = 0;
     int bind_idx = 0;
 
     // First parse all the headers
     while (true) {
         struct bstr rest;
-        struct bstr line = bstr_getline(*body, &rest);
+        struct bstr line = bstr_strip(bstr_getline(*body, &rest));
 
         // Check for the presence of the magic line beginning
         if (!bstr_eatstart0(&line, "//!"))
@@ -65,13 +118,30 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
             continue;
         }
 
-        if (bstr_eatstart0(&line, "TRANSFORM")) {
-            float sx, sy, ox, oy;
-            if (bstr_sscanf(line, "%f %f %f %f", &sx, &sy, &ox, &oy) != 4) {
-                mp_err(log, "Error while parsing TRANSFORM!\n");
+        if (bstr_eatstart0(&line, "OFFSET")) {
+            float ox, oy;
+            if (bstr_sscanf(line, "%f %f", &ox, &oy) != 2) {
+                mp_err(log, "Error while parsing OFFSET!\n");
                 return false;
             }
-            out->transform = (struct gl_transform){{{sx, 0}, {0, sy}}, {ox, oy}};
+            out->offset.t[0] = ox;
+            out->offset.t[1] = oy;
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "WIDTH")) {
+            if (!parse_rpn_szexpr(line, out->width)) {
+                mp_err(log, "Error while parsing WIDTH!\n");
+                return false;
+            }
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "HEIGHT")) {
+            if (!parse_rpn_szexpr(line, out->height)) {
+                mp_err(log, "Error while parsing HEIGHT!\n");
+                return false;
+            }
             continue;
         }
 

--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -15,8 +15,9 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <ctype.h>
+
 #include "user_shaders.h"
-#include "ctype.h"
 
 static bool parse_rpn_szexpr(struct bstr line, struct szexp out[MAX_SZEXP_SIZE])
 {

--- a/video/out/opengl/user_shaders.h
+++ b/video/out/opengl/user_shaders.h
@@ -24,13 +24,40 @@
 #define SHADER_API 1
 #define SHADER_MAX_HOOKS 16
 #define SHADER_MAX_BINDS 6
+#define MAX_SZEXP_SIZE 32
+
+enum szexp_op {
+    SZEXP_OP_ADD,
+    SZEXP_OP_SUB,
+    SZEXP_OP_MUL,
+    SZEXP_OP_DIV,
+};
+
+enum szexp_tag {
+    SZEXP_END = 0, // End of an RPN expression
+    SZEXP_CONST, // Push a constant value onto the stack
+    SZEXP_VAR_W, // Get the width/height of a named texture (variable)
+    SZEXP_VAR_H,
+    SZEXP_OP2, // Pop two elements and push the result of a dyadic operation
+} tag;
+
+struct szexp {
+    enum szexp_tag tag;
+    union {
+        float cval;
+        struct bstr varname;
+        enum szexp_op op;
+    } val;
+};
 
 struct gl_user_shader {
     struct bstr hook_tex[SHADER_MAX_HOOKS];
     struct bstr bind_tex[SHADER_MAX_BINDS];
     struct bstr save_tex;
     struct bstr pass_body;
-    struct gl_transform transform;
+    struct gl_transform offset;
+    struct szexp width[MAX_SZEXP_SIZE];
+    struct szexp height[MAX_SZEXP_SIZE];
     int components;
 };
 

--- a/video/out/opengl/user_shaders.h
+++ b/video/out/opengl/user_shaders.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MP_GL_USER_SHADERS_H
+#define MP_GL_USER_SHADERS_H
+
+#include "common.h"
+#include "utils.h"
+
+#define SHADER_API 1
+#define SHADER_MAX_HOOKS 16
+#define SHADER_MAX_BINDS 6
+
+struct gl_user_shader {
+    struct bstr hook_tex[SHADER_MAX_HOOKS];
+    struct bstr bind_tex[SHADER_MAX_BINDS];
+    struct bstr save_tex;
+    struct bstr pass_body;
+    struct gl_transform transform;
+    int components;
+};
+
+// Parse the next shader pass from 'body'. Returns false if the end of the
+// string was reached
+bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
+                            struct gl_user_shader *out);
+
+#endif

--- a/video/out/opengl/user_shaders.h
+++ b/video/out/opengl/user_shaders.h
@@ -39,7 +39,7 @@ enum szexp_tag {
     SZEXP_VAR_W, // Get the width/height of a named texture (variable)
     SZEXP_VAR_H,
     SZEXP_OP2, // Pop two elements and push the result of a dyadic operation
-} tag;
+};
 
 struct szexp {
     enum szexp_tag tag;

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -565,6 +565,11 @@ void gl_sc_haddf(struct gl_shader_cache *sc, const char *textf, ...)
     va_end(ap);
 }
 
+void gl_sc_hadd_bstr(struct gl_shader_cache *sc, struct bstr text)
+{
+    bstr_xappend(sc, &sc->header_text, text);
+}
+
 static struct sc_uniform *find_uniform(struct gl_shader_cache *sc,
                                        const char *name)
 {

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -152,6 +152,7 @@ void gl_sc_add(struct gl_shader_cache *sc, const char *text);
 void gl_sc_addf(struct gl_shader_cache *sc, const char *textf, ...);
 void gl_sc_hadd(struct gl_shader_cache *sc, const char *text);
 void gl_sc_haddf(struct gl_shader_cache *sc, const char *textf, ...);
+void gl_sc_hadd_bstr(struct gl_shader_cache *sc, struct bstr text);
 void gl_sc_uniform_sampler(struct gl_shader_cache *sc, char *name, GLenum target,
                            int unit);
 void gl_sc_uniform_sampler_ui(struct gl_shader_cache *sc, char *name, int unit);

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -20,6 +20,7 @@
 #define MP_GL_UTILS_
 
 #include "common.h"
+#include "math.h"
 
 struct mp_log;
 
@@ -113,6 +114,13 @@ static inline void gl_transform_vec(struct gl_transform t, float *x, float *y)
 struct mp_rect_f {
     float x0, y0, x1, y1;
 };
+
+// Semantic equality (fuzzy comparison)
+static inline bool mp_rect_f_seq(struct mp_rect_f a, struct mp_rect_f b)
+{
+    return fabs(a.x0 - b.x0) < 1e-6 && fabs(a.x1 - b.x1) < 1e-6 &&
+           fabs(a.y0 - b.y0) < 1e-6 && fabs(a.y1 - b.y1) < 1e-6;
+}
 
 static inline void gl_transform_rect(struct gl_transform t, struct mp_rect_f *r)
 {

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -148,6 +148,8 @@ struct gl_shader_cache;
 
 struct gl_shader_cache *gl_sc_create(GL *gl, struct mp_log *log);
 void gl_sc_destroy(struct gl_shader_cache *sc);
+bool gl_sc_error_state(struct gl_shader_cache *sc);
+void gl_sc_reset_error(struct gl_shader_cache *sc);
 void gl_sc_add(struct gl_shader_cache *sc, const char *text);
 void gl_sc_addf(struct gl_shader_cache *sc, const char *textf, ...);
 void gl_sc_hadd(struct gl_shader_cache *sc, const char *text);

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1546,6 +1546,9 @@ static void pass_add_hook(struct gl_video *p, struct tex_hook hook)
         p->tex_hooks[p->tex_hook_num++] = hook;
     } else {
         MP_ERR(p, "Too many hooks! Limit is %d.\n", MAX_TEXTURE_HOOKS);
+
+        if (hook.free)
+            hook.free(&hook);
     }
 }
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2240,10 +2240,15 @@ static void pass_colormanage(struct gl_video *p, bool display_scaled,
         prim_dst = prim_src;
     if (trc_dst == MP_CSP_TRC_AUTO) {
         trc_dst = trc_src;
-        // Avoid outputting linear light at all costs
+        // Avoid outputting linear light at all costs. First try
+        // falling back to the image gamma (e.g. in the case that the input
+        // was linear light due to linear-scaling)
         if (trc_dst == MP_CSP_TRC_LINEAR)
             trc_dst = p->image_params.gamma;
-        if (trc_dst == MP_CSP_TRC_LINEAR)
+
+        // Failing that, pick gamma 2.2 as a reasonable default. This is also
+        // picked as a default for outputting HDR content
+        if (trc_dst == MP_CSP_TRC_LINEAR || trc_dst == MP_CSP_TRC_SMPTE_ST2084)
             trc_dst = MP_CSP_TRC_GAMMA22;
     }
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2259,7 +2259,9 @@ static void pass_colormanage(struct gl_video *p, bool display_scaled,
     // For HDR, the assumption of reference brightness = display brightness
     // is discontinued. Instead, we have to tone map the brightness to
     // the display using some algorithm.
-    if (p->image_params.gamma == MP_CSP_TRC_SMPTE_ST2084 && !display_scaled) {
+    if (p->image_params.gamma == MP_CSP_TRC_SMPTE_ST2084 &&
+        trc_dst != MP_CSP_TRC_SMPTE_ST2084 && !display_scaled)
+    {
         GLSLF("// HDR tone mapping\n");
         int reference_brightness = 10000; // As per SMPTE ST.2084
         pass_tone_map(p->sc, reference_brightness, p->opts.target_brightness,

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1633,7 +1633,9 @@ static float eval_szexpr(struct gl_video *p, struct img_tex tex,
             }
 
             // Pop the operands in reverse order
-            float op2 = stack[--idx], op1 = stack[--idx], res = 0.0;
+            float op2 = stack[--idx];
+            float op1 = stack[--idx];
+            float res = 0.0;
             switch (expr[i].val.op) {
             case SZEXP_OP_ADD: res = op1 + op2; break;
             case SZEXP_OP_SUB: res = op1 - op2; break;

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1711,9 +1711,12 @@ static void pass_scale_main(struct gl_video *p)
     struct scaler_config scaler_conf = p->opts.scaler[SCALER_SCALE];
     if (p->opts.scaler_resizes_only && !downscaling && !upscaling) {
         scaler_conf.kernel.name = "bilinear";
-        // bilinear is going to be used, just remove all sub-pixel offsets.
-        p->texture_offset.t[0] = (int)p->texture_offset.t[0];
-        p->texture_offset.t[1] = (int)p->texture_offset.t[1];
+        // For scaler-resizes-only, we round the texture offset to
+        // the nearest round value in order to prevent ugly blurriness
+        // (in exchange for slightly shifting the image by up to half a
+        // subpixel)
+        p->texture_offset.t[0] = roundf(p->texture_offset.t[0]);
+        p->texture_offset.t[1] = roundf(p->texture_offset.t[1]);
     }
     if (downscaling && p->opts.scaler[SCALER_DSCALE].kernel.name) {
         scaler_conf = p->opts.scaler[SCALER_DSCALE];

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2506,15 +2506,15 @@ static void pass_render_frame(struct gl_video *p)
         rect.ml *= scale[0]; rect.mr *= scale[0];
         rect.mt *= scale[1]; rect.mb *= scale[1];
         // We should always blend subtitles in non-linear light
-        if (p->use_linear)
+        if (p->use_linear) {
             pass_delinearize(p->sc, p->image_params.gamma);
+            p->use_linear = false;
+        }
         finish_pass_fbo(p, &p->blend_subs_fbo, p->texture_w, p->texture_h,
                         FBOTEX_FUZZY);
         pass_draw_osd(p, OSD_DRAW_SUB_ONLY, vpts, rect,
                       p->texture_w, p->texture_h, p->blend_subs_fbo.fbo, false);
         pass_read_fbo(p, &p->blend_subs_fbo);
-        if (p->use_linear)
-            pass_linearize(p->sc, p->image_params.gamma);
     }
 
     pass_opt_hook_point(p, "SCALED", NULL);

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -613,6 +613,8 @@ static void uninit_rendering(struct gl_video *p)
 
     gl_video_reset_surfaces(p);
     gl_video_reset_hooks(p);
+
+    gl_sc_reset_error(p->sc);
 }
 
 void gl_video_update_profile(struct gl_video *p)
@@ -2500,6 +2502,8 @@ static void pass_render_frame(struct gl_video *p)
 
 static void pass_draw_to_screen(struct gl_video *p, int fbo)
 {
+    GL *gl = p->gl;
+
     if (p->dumb_mode)
         pass_render_frame_dumb(p, fbo);
 
@@ -2525,6 +2529,13 @@ static void pass_draw_to_screen(struct gl_video *p, int fbo)
 
     pass_dither(p);
     finish_pass_direct(p, fbo, p->vp_w, p->vp_h, &p->dst_rect);
+
+    if (gl_sc_error_state(p->sc)) {
+        // Make the screen solid blue to make it visually clear that an
+        // error has occurred
+        gl->ClearColor(0.0, 0.05, 0.5, 1.0);
+        gl->Clear(GL_COLOR_BUFFER_BIT);
+    }
 }
 
 // Draws an interpolate frame to fbo, based on the frame timing in t

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -3063,6 +3063,9 @@ static void check_gl_features(struct gl_video *p)
             .use_rectangle = p->opts.use_rectangle,
             .background = p->opts.background,
             .dither_algo = DITHER_NONE,
+            .target_brightness = p->opts.target_brightness,
+            .hdr_tone_mapping = p->opts.hdr_tone_mapping,
+            .tone_mapping_param = p->opts.tone_mapping_param,
         };
         for (int n = 0; n < SCALER_COUNT; n++)
             new_opts.scaler[n] = gl_video_opts_def.scaler[n];

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -146,9 +146,9 @@ struct saved_tex {
 // A texture hook. This is some operation that transforms a named texture as
 // soon as it's generated
 struct tex_hook {
-    const char *hook_tex;
-    const char *save_tex;
-    const char *bind_tex[TEXUNIT_VIDEO_NUM];
+    char *hook_tex;
+    char *save_tex;
+    char *bind_tex[TEXUNIT_VIDEO_NUM];
     int components; // how many components are relevant (0 = same as input)
     void *priv; // this can be set to whatever the hook wants
     void (*hook)(struct gl_video *p, struct img_tex tex, // generates GLSL
@@ -1554,9 +1554,9 @@ static void pass_add_hook(struct gl_video *p, struct tex_hook hook)
 
 // Adds a hook multiple times, one per name. The last name must be NULL to
 // signal the end of the argument list.
-#define HOOKS(...) ((const char*[]){__VA_ARGS__, NULL})
+#define HOOKS(...) ((char*[]){__VA_ARGS__, NULL})
 static void pass_add_hooks(struct gl_video *p, struct tex_hook hook,
-                           const char **names)
+                           char **names)
 {
     for (int i = 0; names[i] != NULL; i++) {
         hook.hook_tex = names[i];
@@ -1709,14 +1709,14 @@ static void user_hook(struct gl_video *p, struct img_tex tex,
 
 static void user_hook_free(struct tex_hook *hook)
 {
-    talloc_free((void *)hook->hook_tex);
-    talloc_free((void *)hook->save_tex);
+    talloc_free(hook->hook_tex);
+    talloc_free(hook->save_tex);
     for (int i = 0; i < TEXUNIT_VIDEO_NUM; i++)
-        talloc_free((void *)hook->bind_tex[i]);
+        talloc_free(hook->bind_tex[i]);
     talloc_free(hook->priv);
 }
 
-static void pass_hook_user_shaders_old(struct gl_video *p, const char *name,
+static void pass_hook_user_shaders_old(struct gl_video *p, char *name,
                                        char **shaders)
 {
     assert(name);
@@ -1724,13 +1724,13 @@ static void pass_hook_user_shaders_old(struct gl_video *p, const char *name,
         return;
 
     for (int n = 0; shaders[n] != NULL; n++) {
-        const char *body = load_cached_file(p, shaders[n]).start;
+        char *body = load_cached_file(p, shaders[n]).start;
         if (body) {
             pass_add_hook(p, (struct tex_hook) {
                 .hook_tex = name,
                 .bind_tex = {"HOOKED"},
                 .hook = user_hook_old,
-                .priv = (void *)body,
+                .priv = body,
             });
         }
     }

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1670,9 +1670,7 @@ static float eval_szexpr(struct gl_video *p, struct img_tex tex,
                 }
             }
 
-            char *errname = bstrto0(NULL, name);
-            MP_WARN(p, "Texture %s not found in RPN expression!\n", errname);
-            talloc_free(errname);
+            MP_WARN(p, "Texture %.*s not found in RPN expression!\n", BSTR_P(name));
             return 1.0;
 
 found_tex:

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -111,6 +111,7 @@ struct gl_video_opts {
     int gamma_auto;
     int target_prim;
     int target_trc;
+    int target_brightness;
     int linear_scaling;
     int correct_downscaling;
     int sigmoid_upscaling;

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -103,6 +103,13 @@ enum prescalers {
     PRESCALE_NNEDI3,
 };
 
+enum tone_mapping {
+    TONE_MAPPING_CLIP,
+    TONE_MAPPING_SIMPLE,
+    TONE_MAPPING_GAMMA,
+    TONE_MAPPING_LINEAR,
+};
+
 struct gl_video_opts {
     int dumb_mode;
     struct scaler_config scaler[4];
@@ -112,6 +119,8 @@ struct gl_video_opts {
     int target_prim;
     int target_trc;
     int target_brightness;
+    int hdr_tone_mapping;
+    float tone_mapping_param;
     int linear_scaling;
     int correct_downscaling;
     int sigmoid_upscaling;

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -78,6 +78,31 @@ enum scaler_unit {
     SCALER_COUNT
 };
 
+enum dither_algo {
+    DITHER_NONE = 0,
+    DITHER_FRUIT,
+    DITHER_ORDERED,
+};
+
+enum alpha_mode {
+    ALPHA_NO = 0,
+    ALPHA_YES,
+    ALPHA_BLEND,
+    ALPHA_BLEND_TILES,
+};
+
+enum blend_subs_mode {
+    BLEND_SUBS_NO = 0,
+    BLEND_SUBS_YES,
+    BLEND_SUBS_VIDEO,
+};
+
+enum prescalers {
+    PRESCALE_NONE = 0,
+    PRESCALE_SUPERXBR,
+    PRESCALE_NNEDI3,
+};
+
 struct gl_video_opts {
     int dumb_mode;
     struct scaler_config scaler[4];

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -108,6 +108,7 @@ struct gl_video_opts {
     char *scale_shader;
     char **pre_shaders;
     char **post_shaders;
+    char **user_shaders;
     int deband;
     struct deband_opts *deband_opts;
     float unsharp;

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -383,11 +383,8 @@ void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
     GLSLF("}\n");
 }
 
-void pass_sample_unsharp(struct gl_shader_cache *sc, int tex_num, float param)
-{
+void pass_sample_unsharp(struct gl_shader_cache *sc, float param) {
     GLSLF("// unsharp\n");
-    sampler_prelude(sc, tex_num);
-
     GLSLF("{\n");
     GLSL(vec2 st1 = pt * 1.2;)
     GLSL(vec4 p = texture(tex, pos);)

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -177,7 +177,7 @@ static void bicubic_calcweights(struct gl_shader_cache *sc, const char *t, const
     GLSLF("%s = %s * %s + vec4(0, 0, -0.5, 0.5);\n", t, t, s);
     GLSLF("%s = %s * %s + vec4(-0.6666, 0, 0.8333, 0.1666);\n", t, t, s);
     GLSLF("%s.xy *= vec2(1, 1) / vec2(%s.z, %s.w);\n", t, t, t);
-    GLSLF("%s.xy += vec2(1 + %s, 1 - %s);\n", t, s, s);
+    GLSLF("%s.xy += vec2(1.0 + %s, 1.0 - %s);\n", t, s, s);
 }
 
 void pass_sample_bicubic_fast(struct gl_shader_cache *sc)

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -313,6 +313,46 @@ void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc)
     }
 }
 
+// Tone map from one brightness to another
+void pass_tone_map(struct gl_shader_cache *sc, float peak_src, float peak_dst,
+                   enum tone_mapping algo, float param)
+{
+    // First we renormalize to the output range
+    float scale = peak_src / peak_dst;
+    GLSLF("color.rgb *= vec3(%f);\n", scale);
+
+    // Then we use some algorithm to map back to [0,1]
+    switch (algo) {
+    case TONE_MAPPING_CLIP:
+        GLSL(color.rgb = clamp(color.rgb, 0.0, 1.0);)
+        break;
+
+    case TONE_MAPPING_SIMPLE: {
+        float contrast = isnan(param) ? 0.5 : param,
+              offset = (1.0 - contrast) / contrast;
+        GLSLF("color.rgb = color.rgb / (color.rgb + vec3(%f));\n", offset);
+        GLSLF("color.rgb *= vec3(%f);\n", (scale + offset) / scale);
+        break;
+    }
+
+    case TONE_MAPPING_GAMMA: {
+        float gamma = isnan(param) ? 1.8 : param;
+        GLSLF("color.rgb = pow(color.rgb / vec3(%f), vec3(%f));\n",
+              scale, 1.0/gamma);
+        break;
+    }
+
+    case TONE_MAPPING_LINEAR: {
+        float coeff = isnan(param) ? 1.0 : param;
+        GLSLF("color.rgb = vec3(%f) * color.rgb;\n", coeff / scale);
+        break;
+    }
+
+    default:
+        abort();
+    }
+}
+
 // Wide usage friendly PRNG, shamelessly stolen from a GLSL tricks forum post.
 // Obtain random numbers by calling rand(h), followed by h = permute(h) to
 // update the state. Assumes the texture was hooked.

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -38,6 +38,8 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
 void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 
+void pass_tone_map(struct gl_shader_cache *sc, float peak_src, float peak_dst,
+                   enum tone_mapping algo, float param);
 
 void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
                         AVLFG *lfg);

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -41,6 +41,6 @@ void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
                         int tex_num, float tex_mul, GLenum tex_target, AVLFG *lfg);
 
-void pass_sample_unsharp(struct gl_shader_cache *sc, int tex_num, float param);
+void pass_sample_unsharp(struct gl_shader_cache *sc, float param);
 
 #endif

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -38,8 +38,9 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
 void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 
+
 void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
-                        int tex_num, float tex_mul, GLenum tex_target, AVLFG *lfg);
+                        AVLFG *lfg);
 
 void pass_sample_unsharp(struct gl_shader_cache *sc, float param);
 

--- a/wscript
+++ b/wscript
@@ -502,7 +502,13 @@ FFmpeg/Libav libraries. You need at least {0}. Aborting.".format(libav_versions_
         'func': check_statement('libavutil/frame.h',
                                 '(void)offsetof(AVFrame, hw_frames_ctx)',
                                 use='libav'),
-    },
+    }, {
+        'name': 'avutil-st2084',
+        'desc': 'libavutil AVCOL_TRC_SMPTEST2084',
+        'func': check_statement('libavutil/pixfmt.h',
+                                'AVCOL_TRC_SMPTEST2084',
+                                use='libav'),
+    }
 ]
 
 audio_output_features = [

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -356,6 +356,7 @@ def build(ctx):
         ( "video/out/opengl/nnedi3.c",           "gl" ),
         ( "video/out/opengl/osd.c",              "gl" ),
         ( "video/out/opengl/superxbr.c",         "gl" ),
+        ( "video/out/opengl/user_shaders.c",     "gl" ),
         ( "video/out/opengl/utils.c",            "gl" ),
         ( "video/out/opengl/video.c",            "gl" ),
         ( "video/out/opengl/video_shaders.c",    "gl" ),


### PR DESCRIPTION
This makes it possible for users to define and use their own shaders like SuperRes, CrossBilateral, etc. in the vo_opengl pipeline.

Notably, things like superxbr, debanding and unsharpen are now just “regular” hooks internally. In fact, they could be replaced by a drop-in user shader with absolutely no difference, so in the future we could maybe remove them from vo_opengl's codebase entirely (and include them in etc/ or so).

Worth mentioning is that this series of commits includes one FIXME in the code, which is a preservation of the status quo (the same bug is in master currently). Fixing that bug should be a high priority, but I didn't want to delay this pull request even further. (It's also only a minor issue, related to chroma offset off-by-ones on rotated video)

This series of changes brings with it more improvements than just `user-shaders` - notably debanding and superxbr now work correctly on rotated video, among other internal benefits to both robustness (when dealing with planes of different sizes, offsets and rotations) and `pass_read_video`'s clarity (IMO).