### PR TITLE
vaapi: don’t declare disp_x11 when x11 support is disabled

### DIFF
--- a/video/decode/vaapi.c
+++ b/video/decode/vaapi.c
@@ -72,7 +72,9 @@ struct va_native_display {
     void (*destroy)(struct priv *p);
 };
 
+#if HAVE_VAAPI_X11
 static const struct va_native_display disp_x11;
+#endif
 
 static const struct va_native_display *const native_displays[] = {
 #if HAVE_VAAPI_X11


### PR DESCRIPTION
Removes a warning in vaapi.c when compiled without X11.