### PR TITLE
vo_opengl: increase shader limits

### DIFF
--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -431,8 +431,8 @@ void gl_set_debug_logger(GL *gl, struct mp_log *log)
         gl->DebugMessageCallback(log ? gl_debug_cb : NULL, log);
 }
 
-#define SC_ENTRIES 32
-#define SC_UNIFORM_ENTRIES 20
+#define SC_ENTRIES 48
+#define SC_UNIFORM_ENTRIES 64
 
 enum uniform_type {
     UT_invalid,


### PR DESCRIPTION
The new uniforms introduced by 362015c have exceeded the uniform limit
when using high-radius tscale. In addition, the SC limit of 32 entries
might be pushing it with user shaders.

Just make these value a bigger to delay the onset of this same failure
mode. Maybe in the future it should be reworked to grow dynamically?
Either way, we *can* always predict a static upper bound on the number
of uniforms and shader cache entries, it's just that we forgot to do so.

Fixes #3151