### PR TITLE
win32: fit to screen and window-scale fixes; --geometry positioning fix

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2089,6 +2089,10 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
         } else if (!(gm->w > 0) && gm->h > 0) {
             *widw = *widh * asp;
         }
+        // Center window after resize. If valid x:y values are passed to
+        // geometry, then those values will be overriden.
+        *xpos += prew / 2 - *widw / 2;
+        *ypos += preh / 2 - *widh / 2;
     }
 
     if (gm->xy_valid) {

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1103,17 +1103,20 @@ static void reinit_window_state(struct vo_w32_state *w32)
         // Save new size
         w32->dw = n_w;
         w32->dh = n_h;
+        // Get old window center
+        long o_cx = r.left + (r.right - r.left) / 2;
+        long o_cy = r.top + (r.bottom - r.top) / 2;
         // Add window borders to the new window size
         r = (RECT){.right = n_w, .bottom = n_h};
         add_window_borders(w32->window, &r);
         // Get top and left border size for client area position calculation
         long b_top = -r.top;
         long b_left = -r.left;
-        // Center the final window
+        // Center the final window around the old window center
         n_w = r.right - r.left;
         n_h = r.bottom - r.top;
-        r.left = w32->screenrc.x0 + screen_w / 2 - n_w / 2;
-        r.top = w32->screenrc.y0 + screen_h / 2 - n_h / 2;
+        r.left = o_cx - n_w / 2;
+        r.top = o_cy - n_h / 2;
         r.right = r.left + n_w;
         r.bottom = r.top + n_h;
         // Save new client area position

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1403,9 +1403,13 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         if (!w32->window_bounds_initialized)
             return VO_FALSE;
         if (w32->current_fs) {
+            w32->prev_x += w32->prev_width / 2 - s[0] / 2;
+            w32->prev_y += w32->prev_height / 2 - s[1] / 2;
             w32->prev_width = s[0];
             w32->prev_height = s[1];
         } else {
+            w32->window_x += w32->dw / 2 - s[0] / 2;
+            w32->window_y += w32->dh / 2 - s[1] / 2;
             w32->dw = s[0];
             w32->dh = s[1];
         }

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1100,8 +1100,15 @@ static void reinit_window_state(struct vo_w32_state *w32)
         } else {
             n_w = n_h * asp;
         }
+        // Save new size
+        w32->dw = n_w;
+        w32->dh = n_h;
+        // Add window borders to the new window size
         r = (RECT){.right = n_w, .bottom = n_h};
         add_window_borders(w32->window, &r);
+        // Get top and left border size for client area position calculation
+        long b_top = -r.top;
+        long b_left = -r.left;
         // Center the final window
         n_w = r.right - r.left;
         n_h = r.bottom - r.top;
@@ -1109,6 +1116,9 @@ static void reinit_window_state(struct vo_w32_state *w32)
         r.top = w32->screenrc.y0 + screen_h / 2 - n_h / 2;
         r.right = r.left + n_w;
         r.bottom = r.top + n_h;
+        // Save new client area position
+        w32->window_x = r.left + b_left;
+        w32->window_y = r.top + b_top;
     }
 
     MP_VERBOSE(w32, "reset window bounds: %d:%d:%d:%d\n",


### PR DESCRIPTION
1. Properly update stored client area size and position when the window is resized to fit screen. This was causing wrong behavior with window-scale - when window size was becoming too big the window was resized but the video was not.

2. Center the window on the original window center when the window is resized to fit screen. If user moved the window, he probably did it for a reason and he probably don't want it to get back to the center of the screen when he is resizing it (with window-scale for example).

3. Make VOCTRL_SET_UNFS_WINDOW_SIZE resize the window around its center. This will not affect resizes made by the user (dragging window edge).
Fixes #3164.

4. Center window position after applying W and H parameters of the --geometry option. Passing valid X and Y values will still override the position.
Fixes #2397.

Last change should affect all platforms. I was able to check only windows and x11.

Interestingly enough, it had no effect on x11 for me. Also geometry resize is not always working correctly for me. In some cases (low % values) it centers the window just fine, in other cases (high % values) window shows up in the left-top or bottom-right corner. Maybe it's just my broken test config on VM I don't know.