### PR TITLE
ao_opensles: remove 32bit audio

### DIFF
--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -46,7 +46,6 @@ struct priv {
 static const int fmtmap[][2] = {
     { AF_FORMAT_U8, SL_PCMSAMPLEFORMAT_FIXED_8 },
     { AF_FORMAT_S16, SL_PCMSAMPLEFORMAT_FIXED_16 },
-    { AF_FORMAT_S32, SL_PCMSAMPLEFORMAT_FIXED_32 },
     { 0 }
 };
 


### PR DESCRIPTION
It's unsupported by android, and can cause problems when trying to play 32bit audio. Removing 32bit fixes it by forcing 16 bit or 8 bit audio.