### PR TITLE
vo_xv: Handle incorrect size returned by Xv(Shm)CreateImage

### DIFF
--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -577,6 +577,15 @@ static bool allocate_xvimage(struct vo *vo, int foo)
             return false;
         XSync(x11->display, False);
     }
+
+    if ((ctx->xvimage[foo]->width != aligned_w) ||
+        (ctx->xvimage[foo]->height != ctx->image_height)) {
+        MP_ERR(vo, "Got XvImage with incorrect size: %ux%u (expected %ux%u)\n",
+               ctx->xvimage[foo]->width, ctx->xvimage[foo]->height,
+               aligned_w, ctx->image_height);
+        return false;
+    }
+
     struct mp_image img = get_xv_buffer(vo, foo);
     img.w = aligned_w;
     mp_image_clear(&img, 0, 0, img.w, img.h);


### PR DESCRIPTION
Fixes #320 (which is closed as 'not our problem' but eh)

Relevant xorg bug: https://bugs.freedesktop.org/show_bug.cgi?id=70931

For me this happened when (accidentally) trying to play a 8460x2812 jpg
file with mpv. Like the referenced bug, xvinfo reports "maximum XvImage
size: 8192 x 8192". So the returned XvImage is 8192x2812 and memory
corruption happens.

Only after handling this BadShmSeg X11 errors are shown.