### PR TITLE
TOOLS/zsh.pl: add .f4v extension in zsh completions

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -142,7 +142,7 @@ $runtime_completions
     _tags files urls
     while _tags; do
       _requested files expl 'media file' _files -g \\
-        "*.(#i)(asf|asx|avi|flac|flv|m1v|m2p|m2v|m4v|mjpg|mka|mkv|mov|mp3|mp4|mpe|mpeg|mpg|ogg|ogm|ogv|opus|qt|rm|ts|vob|wav|webm|wma|wmv|wv)(-.)" && rc=0
+        "*.(#i)(asf|asx|avi|f4v|flac|flv|m1v|m2p|m2v|m4v|mjpg|mka|mkv|mov|mp3|mp4|mpe|mpeg|mpg|ogg|ogm|ogv|opus|qt|rm|ts|vob|wav|webm|wma|wmv|wv)(-.)" && rc=0
       if _requested urls; then
         while _next_label urls expl URL; do
           _urls "\$expl[@]" && rc=0


### PR DESCRIPTION
Most videos downloaded from iqiyi.com ends in ```.f4v```.

I've seen a debate at #2273. There are commits adding individual file extensions, too: #2649, d5c5a2b05ec5aed62bbabd7ce207205bfd0dd8eb. I guess it's OK to add file extensions that are used dedicated for multimedia files.