### PR TITLE
vo_opengl: skip junk before first user shader pass

### DIFF
--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -82,6 +82,14 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
     int hook_idx = 0;
     int bind_idx = 0;
 
+    // Skip all garbage (e.g. comments) before the first header
+    int pos = bstr_find(*body, bstr0("//!"));
+    if (pos < 0) {
+        mp_warn(log, "Shader appears to contain no passes!\n");
+        return false;
+    }
+    *body = bstr_cut(*body, pos);
+
     // First parse all the headers
     while (true) {
         struct bstr rest;


### PR DESCRIPTION
A lot of real-world shaders start off with comments explaining the usage
or license, generating lots of "empty" passes. This simply change allows
us to skip them, which silences the warning spam and prevents us from
having to store and copy around these empty passes.

It also adds a more useful failure check: Attempting to use a user
shader that doesn't define any passes at all.