### PR TITLE
vo_opengl: refactor HDR mechanism

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -312,6 +312,14 @@ Available filters are:
        :prophoto:     ProPhoto RGB (ROMM) curve
        :st2084:       SMPTE ST2084 (HDR) curve
 
+    ``<peak>``
+        Reference peak illumination for the video file. This is mostly
+        interesting for HDR, but it can also be used tone map SDR content
+        to a darker or brighter exposure.
+
+        The default of 0.0 will default to the display's reference brightness
+        for SDR and the source's reference brightness for HDR.
+
     ``<stereo-in>``
         Set the stereo mode the video is assumed to be encoded in. Takes the
         same values as the ``--video-stereo-mode`` option.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1061,9 +1061,10 @@ Available video output drivers are:
 
     ``target-brightness=<1..100000>``
         Specifies the display's approximate brightness in cd/m^2. When playing
-        HDR content, video colors will be tone mapped to this target brightness
-        using the algorithm specified by ``hdr-tone-mapping``. The default of
-        250 cd/m^2 corresponds to a typical consumer display.
+        HDR content on a SDR display (or SDR content on an HDR display), video
+        colors will be tone mapped to this target brightness using the
+        algorithm specified by ``hdr-tone-mapping``. The default of 250 cd/m^2
+        corresponds to a typical consumer display.
 
     ``hdr-tone-mapping=<value>``
         Specifies the algorithm used for tone-mapping HDR images onto the

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1071,13 +1071,14 @@ Available video output drivers are:
         target display. Valid values are:
 
         clip
-            Hard-clip any out-of-range values (default)
+            Hard-clip any out-of-range values.
         reinhard
             Reinhard tone mapping algorithm. Very simple continuous curve.
             Preserves dynamic range and peak but uses nonlinear contrast.
         hable
-            Similar to ``reinhard`` but preserves dark contrast better (slightly
-            sigmoidal). Developed by John Hable for use in video games.
+            Similar to ``reinhard`` but preserves dark contrast better
+            (slightly sigmoidal). Developed by John Hable for use in video
+            games. (default)
         gamma
             Fits a logarithmic transfer between the tone curves.
         linear

--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -38,6 +38,7 @@ struct vf_priv_s {
     int colorlevels;
     int primaries;
     int gamma;
+    float peak;
     int chroma_location;
     int stereo_in;
     int stereo_out;
@@ -94,6 +95,8 @@ static int reconfig(struct vf_instance *vf, struct mp_image_params *in,
         out->primaries = p->primaries;
     if (p->gamma)
         out->gamma = p->gamma;
+    if (p->peak)
+        out->peak = p->peak;
     if (p->chroma_location)
         out->chroma_location = p->chroma_location;
     if (p->stereo_in)
@@ -142,6 +145,7 @@ static const m_option_t vf_opts_fields[] = {
     OPT_CHOICE_C("colorlevels", colorlevels, 0, mp_csp_levels_names),
     OPT_CHOICE_C("primaries", primaries, 0, mp_csp_prim_names),
     OPT_CHOICE_C("gamma", gamma, 0, mp_csp_trc_names),
+    OPT_FLOAT("peak", peak, 0),
     OPT_CHOICE_C("chroma-location", chroma_location, 0, mp_chroma_names),
     OPT_CHOICE_C("stereo-in", stereo_in, 0, mp_stereo3d_names),
     OPT_CHOICE_C("stereo-out", stereo_out, 0, mp_stereo3d_names),

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -570,6 +570,7 @@ bool mp_image_params_equal(const struct mp_image_params *p1,
            p1->colorlevels == p2->colorlevels &&
            p1->primaries == p2->primaries &&
            p1->gamma == p2->gamma &&
+           p1->peak == p2->peak &&
            p1->chroma_location == p2->chroma_location &&
            p1->rotate == p2->rotate &&
            p1->stereo_in == p2->stereo_in &&
@@ -663,6 +664,12 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
         params->colorlevels = MP_CSP_LEVELS_AUTO;
         params->primaries = MP_CSP_PRIM_AUTO;
         params->gamma = MP_CSP_TRC_AUTO;
+    }
+
+    // Guess the reference peak (independent of the colorspace)
+    if (params->gamma == MP_CSP_TRC_SMPTE_ST2084) {
+        if (!params->peak)
+            params->peak = 10000; // As per the spec
     }
 }
 

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -47,6 +47,7 @@ struct mp_image_params {
     enum mp_csp_levels colorlevels;
     enum mp_csp_prim primaries;
     enum mp_csp_trc gamma;
+    float peak; // 0 = auto/unknown
     enum mp_chroma_location chroma_location;
     // The image should be rotated clockwise (0-359 degrees).
     int rotate;

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -322,6 +322,7 @@ const struct gl_video_opts gl_video_opts_def = {
     .prescale_passes = 1,
     .prescale_downscaling_threshold = 2.0f,
     .target_brightness = 250,
+    .hdr_tone_mapping = TONE_MAPPING_HABLE,
     .tone_mapping_param = NAN,
 };
 
@@ -352,6 +353,7 @@ const struct gl_video_opts gl_video_opts_hq_def = {
     .prescale_passes = 1,
     .prescale_downscaling_threshold = 2.0f,
     .target_brightness = 250,
+    .hdr_tone_mapping = TONE_MAPPING_HABLE,
     .tone_mapping_param = NAN,
 };
 

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -38,7 +38,7 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
 void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 
-void pass_tone_map(struct gl_shader_cache *sc, float peak_src, float peak_dst,
+void pass_tone_map(struct gl_shader_cache *sc, float peak,
                    enum tone_mapping algo, float param);
 
 void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,


### PR DESCRIPTION
Instead of doing HDR tone mapping on an ad-hoc basis inside
pass_colormanage, the reference peak of an image is now part of the
image params (alongside colorspace, gamma, etc.) and tone mapping is
done whenever peak_src != peak_dst.

To get sensible behavior when mixing HDR and SDR content and displays,
target-brightness is a generic filler for "the assumed brightness of SDR
content".

This gets rid of the weird display_scaled hack, sets the framework
for multiple HDR functions with difference reference peaks, and allows
us to (in a future commit) autodetect the right source peak from
the HDR metadata.

(Apart from metadata, the source peak can also be controlled via
vf_format. For HDR content this adjusts the overall image brightness,
for SDR content it's like simulating a different exposure)