### PR TITLE
wayland: display refresh rate and error print

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -224,6 +224,8 @@ static void surface_handle_enter(void *data,
             break;
         }
     }
+
+    wl->window.events |= VO_EVENT_WIN_STATE;
 }
 
 static void surface_handle_leave(void *data,
@@ -805,7 +807,7 @@ static void schedule_resize(struct vo_wayland_state *wl,
     wl->window.sh_height = height;
     wl->window.sh_x = x;
     wl->window.sh_y = y;
-    wl->window.events |= VO_EVENT_RESIZE;
+    wl->window.events |= VO_EVENT_WIN_STATE | VO_EVENT_RESIZE;
     wl->vo->dwidth = width;
     wl->vo->dheight = height;
 }
@@ -1037,10 +1039,10 @@ int vo_wayland_init (struct vo *vo)
                        "\tmodel: %s\n"
                        "\tw: %d, h: %d\n"
                        "\tscale: %d\n"
-                       "\tHz: %d\n",
+                       "\tHz: %f\n",
                        o->make, o->model,
                        o->width, o->height, o->scale,
-                       o->refresh_rate / 1000);
+                       o->refresh_rate / 1000.0f);
     }
 
     vo->event_fd = wl->display.display_fd;
@@ -1290,7 +1292,7 @@ int vo_wayland_control (struct vo *vo, int *events, int request, void *arg)
             break;
 
         // refresh rate is stored in milli-Hertz (mHz)
-        double fps = wl->display.current_output->refresh_rate / 1000;
+        double fps = wl->display.current_output->refresh_rate / 1000.0f;
         *(double*) arg = fps;
         return VO_TRUE;
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -540,7 +540,7 @@ static void data_device_handle_data_offer(void *data,
 {
     struct vo_wayland_state *wl = data;
     if (wl->input.offer) {
-        MP_ERR(wl, "There is already a dnd entry point.\n");
+        MP_DBG(wl, "There is already a dnd entry point.\n");
         wl_data_offer_destroy(wl->input.offer);
     }
 


### PR DESCRIPTION
One commit will cause the wayland backend and vo to correctly report
the display frame rate. This didn't work as VOCTRL_GET_DISPLAY_FPS was
received way too early, before the window was created (and thus
current_output set).

The VO will now signal VO_EVENT_WIN_STATE after window initialization
and upon a resize.

The other commit will reduce the severity of the existing dnd entry print, which tends to gets spammed and provide no information.

Signed-off-by: Rostislav Pehlivanov <atomnuker@gmail.com>