### PR TITLE
charset_conv: Discard illegal sequence and continue

### DIFF
--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -323,6 +323,9 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
                 op = outbuf + offset;
                 osize += size;
                 oleft += size;
+            } else if(errno == EILSEQ) {
+                int one = 1;
+                iconvctl(icdsc, ICONV_SET_DISCARD_ILSEQ, &one);
             } else {
                 if (errno == EINVAL && (flags & MP_ICONV_ALLOW_CUTOFF)) {
                     // This is intended for cases where the input buffer is cut


### PR DESCRIPTION
Korean subtitles often include illegal sequences.