### PR TITLE
Expose VO performance data (render/present times) to users

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -894,6 +894,30 @@ Property list
     .. note:: This is only an estimate. (It's computed from two unreliable
               quantities: fps and possibly rounded timestamps.)
 
+``render-time-last``
+    Time needed to render the last frame in microseconds. Not implemented by
+    all VOs.
+
+``render-time-avg``
+    Average of ``render-time-last`` over the last few frames. (The exact
+    averaging time is variable, but it should generally be a few seconds)
+
+``render-time-peak``
+    Peak (maximum) of ``render-time-last`` over the last few frames.
+
+``present-time-last``, ``present-time-avg``, ``present-time-peak``
+    Analogous to ``render-time-last`` etc. but measures the time needed to
+    draw a rendered frame to the screen. Not implemented by all VOs.
+
+    (This is separate from ``render-time-last`` because VOs may interpolate,
+    deinterlace or otherwise mix multiple source frames into a single output
+    frame)
+
+``upload-time-last``, ``upload-time-avg``, ``upload-time-peak``
+    Analogous to ``render-time-last`` etc. but measures the time needed to
+    upload a frame from system memory to a GPU texture. Not implemented by all
+    VOs.
+
 ``path``
     Full path of the currently played file. Usually this is exactly the same
     string you pass on the mpv command line or the ``loadfile`` command, even

--- a/player/command.c
+++ b/player/command.c
@@ -2381,6 +2381,39 @@ static int panscan_property_helper(void *ctx, struct m_property *prop,
     return r;
 }
 
+// Properties retrieved through VOCTRL_PERFORMANCE_DATA
+static int perfdata_property_helper(void *ctx, struct m_property *prop,
+                                    int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    if (!mpctx->video_out)
+        return M_PROPERTY_UNAVAILABLE;
+
+    struct voctrl_performance_data data = {0};
+    if (vo_control(mpctx->video_out, VOCTRL_PERFORMANCE_DATA, &data) <= 0)
+        return M_PROPERTY_UNAVAILABLE;
+
+    // Figure out the right field based on the name. This string
+    // match should never fail (based on the hard-coded property names)
+    struct bstr name = bstr0(prop->name), prefix, field;
+    assert(bstr_split_tok(name, "-", &prefix, &name));
+    assert(bstr_split_tok(name, "-", &name, &field));
+
+    // No need to have a failure case or fallthrough since these checks are all
+    // mutually exclusive and will never fail (based on the hard-coded names)
+    struct voctrl_performance_entry e = {0};
+    if (bstrcmp0(prefix, "upload")  == 0) e = data.upload;
+    if (bstrcmp0(prefix, "render")  == 0) e = data.render;
+    if (bstrcmp0(prefix, "present") == 0) e = data.present;
+
+    uint64_t val = 0;
+    if (bstrcmp0(field, "last") == 0) val = e.last;
+    if (bstrcmp0(field, "avg")  == 0) val = e.avg;
+    if (bstrcmp0(field, "peak") == 0) val = e.peak;
+
+    return m_property_int64_ro(action, arg, val);
+}
+
 /// Helper to set vo flags.
 /** \ingroup PropertyImplHelper
  */
@@ -3784,6 +3817,16 @@ static const struct m_property mp_properties[] = {
 
     {"estimated-frame-count", mp_property_frame_count},
     {"estimated-frame-number", mp_property_frame_number},
+
+    {"upload-time-last", perfdata_property_helper},
+    {"upload-time-avg", perfdata_property_helper},
+    {"upload-time-peak", perfdata_property_helper},
+    {"render-time-last", perfdata_property_helper},
+    {"render-time-avg", perfdata_property_helper},
+    {"render-time-peak", perfdata_property_helper},
+    {"present-time-last", perfdata_property_helper},
+    {"present-time-avg", perfdata_property_helper},
+    {"present-time-peak", perfdata_property_helper},
 
     {"osd-width", mp_property_osd_w},
     {"osd-height", mp_property_osd_h},

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -274,6 +274,23 @@ static const struct gl_functions gl_functions[] = {
         },
     },
     {
+        .ver_core = 330,
+        .extension = "GL_ARB_timer_query",
+        .functions = (const struct gl_function[]) {
+            DEF_FN(GenQueries),
+            DEF_FN(DeleteQueries),
+            DEF_FN(BeginQuery),
+            DEF_FN(EndQuery),
+            DEF_FN(QueryCounter),
+            DEF_FN(IsQuery),
+            DEF_FN(GetQueryObjectiv),
+            DEF_FN(GetQueryObjecti64v),
+            DEF_FN(GetQueryObjectuiv),
+            DEF_FN(GetQueryObjectui64v),
+            {0}
+        },
+    },
+    {
         .ver_core = 430,
         .ver_es_core = 300,
         .functions = (const struct gl_function[]) {

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -186,6 +186,17 @@ struct GL {
     GLenum (GLAPIENTRY *ClientWaitSync)(GLsync, GLbitfield, GLuint64);
     void (GLAPIENTRY *DeleteSync)(GLsync sync);
 
+    void (GLAPIENTRY *GenQueries)(GLsizei, GLuint *);
+    void (GLAPIENTRY *DeleteQueries)(GLsizei, const GLuint *);
+    void (GLAPIENTRY *BeginQuery)(GLenum,  GLuint);
+    void (GLAPIENTRY *EndQuery)(GLenum);
+    void (GLAPIENTRY *QueryCounter)(GLuint, GLenum);
+    GLboolean (GLAPIENTRY *IsQuery)(GLuint);
+    void (GLAPIENTRY *GetQueryObjectiv)(GLuint, GLenum, GLint *);
+    void (GLAPIENTRY *GetQueryObjecti64v)(GLuint, GLenum, GLint64 *);
+    void (GLAPIENTRY *GetQueryObjectuiv)(GLuint, GLenum, GLuint *);
+    void (GLAPIENTRY *GetQueryObjectui64v)(GLuint, GLenum, GLuint64 *);
+
     void (GLAPIENTRY *VDPAUInitNV)(const GLvoid *, const GLvoid *);
     void (GLAPIENTRY *VDPAUFiniNV)(void);
     GLvdpauSurfaceNV (GLAPIENTRY *VDPAURegisterOutputSurfaceNV)

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -172,4 +172,16 @@ void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name);
 void gl_sc_gen_shader_and_reset(struct gl_shader_cache *sc);
 void gl_sc_reset(struct gl_shader_cache *sc);
 
+struct gl_timer;
+
+struct gl_timer *gl_timer_create(GL *gl);
+void gl_timer_free(struct gl_timer *timer);
+void gl_timer_start(struct gl_timer *timer);
+void gl_timer_stop(struct gl_timer *timer);
+
+int gl_timer_sample_count(struct gl_timer *timer);
+uint64_t gl_timer_last_us(struct gl_timer *timer);
+uint64_t gl_timer_avg_us(struct gl_timer *timer);
+uint64_t gl_timer_peak_us(struct gl_timer *timer);
+
 #endif

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2908,6 +2908,24 @@ void gl_video_resize(struct gl_video *p, int vp_w, int vp_h,
         mpgl_osd_resize(p->osd, p->osd_rect, p->image_params.stereo_out);
 }
 
+static struct voctrl_performance_entry gl_video_perfentry(struct gl_timer *t)
+{
+    return (struct voctrl_performance_entry) {
+        .last = gl_timer_last_us(t),
+        .avg  = gl_timer_avg_us(t),
+        .peak = gl_timer_peak_us(t),
+    };
+}
+
+struct voctrl_performance_data gl_video_perfdata(struct gl_video *p)
+{
+    return (struct voctrl_performance_data) {
+        .upload = gl_video_perfentry(p->upload_timer),
+        .render = gl_video_perfentry(p->render_timer),
+        .present = gl_video_perfentry(p->present_timer),
+    };
+}
+
 static bool unmap_image(struct gl_video *p, struct mp_image *mpi)
 {
     GL *gl = p->gl;

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2991,8 +2991,11 @@ static bool gl_video_upload_image(struct gl_video *p, struct mp_image *mpi)
     p->frames_uploaded++;
 
     if (p->hwdec_active) {
+        // Hardware decoding
         struct gl_hwdec_frame gl_frame = {0};
+        gl_timer_start(p->upload_timer);
         bool ok = p->hwdec->driver->map_frame(p->hwdec, vimg->mpi, &gl_frame) >= 0;
+        gl_timer_stop(p->upload_timer);
         vimg->hwdec_mapped = true;
         if (ok) {
             struct mp_image layout = {0};
@@ -3017,6 +3020,7 @@ static bool gl_video_upload_image(struct gl_video *p, struct mp_image *mpi)
         return true;
     }
 
+    // Software decoding
     assert(mpi->num_planes == p->plane_count);
 
     gl_timer_start(p->upload_timer);

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -196,6 +196,10 @@ struct gl_video {
 
     GLuint nnedi3_weights_buffer;
 
+    struct gl_timer *upload_timer;
+    struct gl_timer *render_timer;
+    struct gl_timer *present_timer;
+
     struct mp_image_params real_image_params;   // configured format
     struct mp_image_params image_params;        // texture format (mind hwdec case)
     struct mp_imgfmt_desc image_desc;
@@ -2497,6 +2501,11 @@ static void pass_render_frame(struct gl_video *p)
     if (p->dumb_mode)
         return;
 
+    // start the render timer here. it will continue to the end of this
+    // function, to render the time needed to draw (excluding screen
+    // presentation)
+    gl_timer_start(p->render_timer);
+
     p->use_linear = p->opts.linear_scaling || p->opts.sigmoid_upscaling;
     pass_read_video(p);
     pass_opt_hook_point(p, "NATIVE", &p->texture_offset);
@@ -2553,10 +2562,14 @@ static void pass_render_frame(struct gl_video *p)
     }
 
     pass_opt_hook_point(p, "SCALED", NULL);
+
+    gl_timer_stop(p->render_timer);
 }
 
 static void pass_draw_to_screen(struct gl_video *p, int fbo)
 {
+    gl_timer_start(p->present_timer);
+
     if (p->dumb_mode)
         pass_render_frame_dumb(p, fbo);
 
@@ -2582,6 +2595,8 @@ static void pass_draw_to_screen(struct gl_video *p, int fbo)
 
     pass_dither(p);
     finish_pass_direct(p, fbo, p->vp_w, p->vp_h, &p->dst_rect);
+
+    gl_timer_stop(p->present_timer);
 }
 
 // Draws an interpolate frame to fbo, based on the frame timing in t
@@ -2754,6 +2769,16 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
     p->frames_drawn += 1;
 }
 
+static void timer_dbg(struct gl_video *p, const char *name, struct gl_timer *t)
+{
+    if (gl_timer_sample_count(t) > 0) {
+        MP_DBG(p, "%s time: last %dus avg %dus peak %dus\n", name,
+               (int)gl_timer_last_us(t),
+               (int)gl_timer_avg_us(t),
+               (int)gl_timer_peak_us(t));
+    }
+}
+
 // (fbo==0 makes BindFramebuffer select the screen backbuffer)
 void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame, int fbo)
 {
@@ -2857,6 +2882,11 @@ done:
     gl->Flush();
 
     p->frames_rendered++;
+
+    // Report performance metrics
+    timer_dbg(p, "upload", p->upload_timer);
+    timer_dbg(p, "render", p->render_timer);
+    timer_dbg(p, "present", p->present_timer);
 }
 
 // vp_w/vp_h is the implicit size of the target framebuffer.
@@ -2971,6 +3001,8 @@ static bool gl_video_upload_image(struct gl_video *p, struct mp_image *mpi)
 
     assert(mpi->num_planes == p->plane_count);
 
+    gl_timer_start(p->upload_timer);
+
     mp_image_t pbo_mpi = *mpi;
     bool pbo = map_image(p, &pbo_mpi);
     if (pbo) {
@@ -2997,6 +3029,8 @@ static bool gl_video_upload_image(struct gl_video *p, struct mp_image *mpi)
     gl->ActiveTexture(GL_TEXTURE0);
     if (pbo)
         gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+    gl_timer_stop(p->upload_timer);
 
     return true;
 
@@ -3227,6 +3261,10 @@ static void init_gl(struct gl_video *p)
         gl->DeleteTextures(1, &tex);
     }
 
+    p->upload_timer = gl_timer_create(p->gl);
+    p->render_timer = gl_timer_create(p->gl);
+    p->present_timer = gl_timer_create(p->gl);
+
     debug_check_gl(p, "after init_gl");
 }
 
@@ -3244,6 +3282,10 @@ void gl_video_uninit(struct gl_video *p)
     gl_vao_uninit(&p->vao);
 
     gl->DeleteTextures(1, &p->lut_3d_texture);
+
+    gl_timer_free(p->upload_timer);
+    gl_timer_free(p->render_timer);
+    gl_timer_free(p->present_timer);
 
     mpgl_osd_destroy(p->osd);
 

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -169,6 +169,7 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame, int fbo);
 void gl_video_resize(struct gl_video *p, int vp_w, int vp_h,
                      struct mp_rect *src, struct mp_rect *dst,
                      struct mp_osd_res *osd);
+struct voctrl_performance_data gl_video_perfdata(struct gl_video *p);
 struct mp_csp_equalizer;
 struct mp_csp_equalizer *gl_video_eq_ptr(struct gl_video *p);
 void gl_video_eq_update(struct gl_video *p);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -77,6 +77,8 @@ enum mp_voctrl {
     VOCTRL_UPDATE_WINDOW_TITLE,         // char*
     VOCTRL_UPDATE_PLAYBACK_STATE,       // struct voctrl_playback_state*
 
+    VOCTRL_PERFORMANCE_DATA,            // struct voctrl_performance_data*
+
     VOCTRL_SET_CURSOR_VISIBILITY,       // bool*
 
     VOCTRL_KILL_SCREENSAVER,
@@ -135,6 +137,16 @@ struct voctrl_playback_state {
     bool playing;
     bool paused;
     int percent_pos;
+};
+
+// VOCTRL_PERFORMANCE_DATA
+struct voctrl_performance_entry {
+    // Times are in microseconds
+    uint64_t last, avg, peak;
+};
+
+struct voctrl_performance_data {
+    struct voctrl_performance_entry upload, render, present;
 };
 
 enum {

--- a/video/out/vo_opengl.c
+++ b/video/out/vo_opengl.c
@@ -329,6 +329,9 @@ static int control(struct vo *vo, uint32_t request, void *data)
             vo_wakeup(vo);
         }
         return true;
+    case VOCTRL_PERFORMANCE_DATA:
+        *(struct voctrl_performance_data *)data = gl_video_perfdata(p->renderer);
+        return true;
     }
 
     int events = 0;


### PR DESCRIPTION
Currently exposed as a property, backed by a VOCTRL. Not sure if this is the best design, but it's the best I could come up with.

This should allow projects like https://github.com/Argon-/mpv-stats to present the user with meaningful performance metrics, similar to madVR / MPDN etc, hopefully helping users understand performance impacts of different settings and pick the right options for their setups.