### PR TITLE
build: silence -Wunused-result

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -462,7 +462,7 @@ static int init(struct ao *ao)
         p->buffersize = 0;
         memset(data, 0, p->outburst);
         while (p->buffersize < 0x40000 && device_writable(ao) > 0) {
-            write(p->audio_fd, data, p->outburst);
+            (void)write(p->audio_fd, data, p->outburst);
             p->buffersize += p->outburst;
         }
         free(data);

--- a/audio/out/push.c
+++ b/audio/out/push.c
@@ -489,7 +489,7 @@ int ao_wait_poll(struct ao *ao, struct pollfd *fds, int num_fds,
         // flush the wakeup pipe contents - might "drown" some wakeups, but
         // that's ok for our use-case
         char buf[100];
-        read(p->wakeup_pipe[0], buf, sizeof(buf));
+        (void)read(p->wakeup_pipe[0], buf, sizeof(buf));
     }
     return (r >= 0 || r == -EINTR) ? wakeup : -1;
 }
@@ -499,7 +499,7 @@ void ao_wakeup_poll(struct ao *ao)
     assert(ao->api == &ao_api_push);
     struct ao_push_state *p = ao->api_priv;
 
-    write(p->wakeup_pipe[1], &(char){0}, 1);
+    (void)write(p->wakeup_pipe[1], &(char){0}, 1);
 }
 
 #endif

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -134,7 +134,7 @@ static void *client_thread(void *p)
 
         if (fds[0].revents & POLLIN) {
             char discard[100];
-            read(pipe_fd, discard, sizeof(discard));
+            (void)read(pipe_fd, discard, sizeof(discard));
 
             while (1) {
                 mpv_event *event = mpv_wait_event(arg->client, 0);
@@ -413,7 +413,7 @@ void mp_uninit_ipc(struct mp_ipc_ctx *arg)
     if (!arg)
         return;
 
-    write(arg->death_pipe[1], &(char){0}, 1);
+    (void)write(arg->death_pipe[1], &(char){0}, 1);
     pthread_join(arg->thread, NULL);
 
     close(arg->death_pipe[0]);

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -275,7 +275,7 @@ static void enable_kx(bool enable)
     // shouldn't be relied on here either.
     if (isatty(STDOUT_FILENO)) {
         char *cmd = enable ? "\033=" : "\033>";
-        write(STDOUT_FILENO, cmd, strlen(cmd));
+        (void)write(STDOUT_FILENO, cmd, strlen(cmd));
     }
 }
 
@@ -378,7 +378,7 @@ static void quit_request_sighandler(int signum)
 {
     do_deactivate_getch2();
 
-    write(death_pipe[1], &(char){0}, 1);
+    (void)write(death_pipe[1], &(char){0}, 1);
 }
 
 static void *terminal_thread(void *ptr)
@@ -450,7 +450,7 @@ void terminal_uninit(void)
     do_deactivate_getch2();
 
     if (input_ctx) {
-        write(death_pipe[1], &(char){0}, 1);
+        (void)write(death_pipe[1], &(char){0}, 1);
         pthread_join(input_thread, NULL);
         close(death_pipe[0]);
         close(death_pipe[1]);

--- a/player/client.c
+++ b/player/client.c
@@ -280,7 +280,7 @@ static void wakeup_client(struct mpv_handle *ctx)
         if (ctx->wakeup_cb)
             ctx->wakeup_cb(ctx->wakeup_cb_ctx);
         if (ctx->wakeup_pipe[0] != -1)
-            write(ctx->wakeup_pipe[1], &(char){0}, 1);
+            (void)write(ctx->wakeup_pipe[1], &(char){0}, 1);
     }
     pthread_mutex_unlock(&ctx->wakeup_lock);
 }
@@ -1559,7 +1559,7 @@ int mpv_get_wakeup_pipe(mpv_handle *ctx)
     pthread_mutex_lock(&ctx->wakeup_lock);
     if (ctx->wakeup_pipe[0] == -1) {
         if (mp_make_wakeup_pipe(ctx->wakeup_pipe) >= 0)
-            write(ctx->wakeup_pipe[1], &(char){0}, 1);
+            (void)write(ctx->wakeup_pipe[1], &(char){0}, 1);
     }
     int fd = ctx->wakeup_pipe[0];
     pthread_mutex_unlock(&ctx->wakeup_lock);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -612,7 +612,7 @@ static void handle_heartbeat_cmd(struct MPContext *mpctx)
         double now = mp_time_sec();
         if (mpctx->next_heartbeat <= now) {
             mpctx->next_heartbeat = now + opts->heartbeat_interval;
-            system(opts->heartbeat_cmd);
+            (void)system(opts->heartbeat_cmd);
         }
         mpctx->sleeptime = MPMIN(mpctx->sleeptime, mpctx->next_heartbeat - now);
     }

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -978,7 +978,7 @@ struct mp_cancel *mp_cancel_new(void *talloc_ctx)
 void mp_cancel_trigger(struct mp_cancel *c)
 {
     atomic_store(&c->triggered, true);
-    write(c->wakeup_pipe[1], &(char){0}, 1);
+    (void)write(c->wakeup_pipe[1], &(char){0}, 1);
 }
 
 // Restore original state. (Allows reusing a mp_cancel.)

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -222,7 +222,7 @@ void kms_destroy(struct kms *kms)
 static void vt_switcher_sighandler(int sig)
 {
     unsigned char event = sig == RELEASE_SIGNAL ? EVT_RELEASE : EVT_ACQUIRE;
-    write(vt_switcher_pipe[1], &event, sizeof(event));
+    (void)write(vt_switcher_pipe[1], &event, sizeof(event));
 }
 
 static bool has_signal_installed(int signo)
@@ -312,7 +312,7 @@ void vt_switcher_release(struct vt_switcher *s,
 void vt_switcher_interrupt_poll(struct vt_switcher *s)
 {
     unsigned char event = EVT_INTERRUPT;
-    write(vt_switcher_pipe[1], &event, sizeof(event));
+    (void)write(vt_switcher_pipe[1], &event, sizeof(event));
 }
 
 void vt_switcher_destroy(struct vt_switcher *s)

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -596,14 +596,14 @@ static void wait_event_fd(struct vo *vo, int64_t until_time)
 
     if (fds[1].revents & POLLIN) {
         char buf[100];
-        read(in->wakeup_pipe[0], buf, sizeof(buf)); // flush
+        (void)read(in->wakeup_pipe[0], buf, sizeof(buf)); // flush
     }
 }
 static void wakeup_event_fd(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
 
-    write(in->wakeup_pipe[1], &(char){0}, 1);
+    (void)write(in->wakeup_pipe[1], &(char){0}, 1);
 }
 #else
 static void wait_event_fd(struct vo *vo, int64_t until_time){}

--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -41,7 +41,9 @@ def __add_generic_flags__(ctx):
 def __add_gcc_flags__(ctx):
     ctx.env.CFLAGS += ["-Wall", "-Wundef", "-Wmissing-prototypes", "-Wshadow",
                        "-Wno-switch", "-Wparentheses", "-Wpointer-arith",
-                       "-Wno-pointer-sign"]
+                       "-Wno-pointer-sign",
+                       # GCC bug 66425
+                       "-Wno-unused-result"]
 
 def __add_clang_flags__(ctx):
     ctx.env.CFLAGS += ["-Wno-logical-op-parentheses", "-fcolor-diagnostics",


### PR DESCRIPTION
For clang, it's enough to just put (void) around usages we are
intentionally ignoring the result of.

Since GCC does not seem to want to respect this decision, we are forced
to disable the warning globally.

(Also rewrite one of the ignored return values into an actual warning)