### PR TITLE
vo_opengl: make user hook passes optional

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -746,10 +746,17 @@ Available video output drivers are:
         WIDTH <szexpr>, HEIGHT <szexpr>
             Specifies the size of the resulting texture for this pass.
             ``szexpr`` refers to an expression in RPN (reverse polish
-            notation), using the operators + - * /, floating point literals,
-            and references to existing texture sizes such as MAIN.width or
-            CHROMA.height. By default, these are set to HOOKED.w and HOOKED.h,
-            respectively.
+            notation), using the operators + - * / > < !, floating point
+            literals, and references to existing texture sizes such as
+            MAIN.width or CHROMA.height. By default, these are set to HOOKED.w
+            and HOOKED.h, respectively.
+
+        WHEN <szexpr>
+            Specifies a condition that needs to be true (non-zero) for the
+            shader stage to be evaluated. If it fails, it will silently be
+            omitted. (Note that a shader stage like this which has a dependency
+            on an optional hook point can still cause that hook point to be
+            saved, which has some minor overhead)
 
         OFFSET ox oy
             Indicates a pixel shift (offset) introduced by this pass. These

--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -50,6 +50,9 @@ static bool parse_rpn_szexpr(struct bstr line, struct szexp out[MAX_SZEXP_SIZE])
         case '-': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_SUB; continue;
         case '*': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_MUL; continue;
         case '/': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_DIV; continue;
+        case '!': exp->tag = SZEXP_OP1; exp->val.op = SZEXP_OP_NOT; continue;
+        case '>': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_GT;  continue;
+        case '<': exp->tag = SZEXP_OP2; exp->val.op = SZEXP_OP_LT;  continue;
         }
 
         if (isdigit(word.start[0])) {
@@ -77,6 +80,7 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
         .offset = identity_trans,
         .width = {{ SZEXP_VAR_W, { .varname = bstr0("HOOKED") }}},
         .height = {{ SZEXP_VAR_H, { .varname = bstr0("HOOKED") }}},
+        .cond = {{ SZEXP_CONST, { .cval = 1.0 }}},
     };
 
     int hook_idx = 0;
@@ -149,6 +153,14 @@ bool parse_user_shader_pass(struct mp_log *log, struct bstr *body,
         if (bstr_eatstart0(&line, "HEIGHT")) {
             if (!parse_rpn_szexpr(line, out->height)) {
                 mp_err(log, "Error while parsing HEIGHT!\n");
+                return false;
+            }
+            continue;
+        }
+
+        if (bstr_eatstart0(&line, "WHEN")) {
+            if (!parse_rpn_szexpr(line, out->cond)) {
+                mp_err(log, "Error while parsing WHEN!\n");
                 return false;
             }
             continue;

--- a/video/out/opengl/user_shaders.h
+++ b/video/out/opengl/user_shaders.h
@@ -31,6 +31,9 @@ enum szexp_op {
     SZEXP_OP_SUB,
     SZEXP_OP_MUL,
     SZEXP_OP_DIV,
+    SZEXP_OP_NOT,
+    SZEXP_OP_GT,
+    SZEXP_OP_LT,
 };
 
 enum szexp_tag {
@@ -39,6 +42,7 @@ enum szexp_tag {
     SZEXP_VAR_W, // Get the width/height of a named texture (variable)
     SZEXP_VAR_H,
     SZEXP_OP2, // Pop two elements and push the result of a dyadic operation
+    SZEXP_OP1, // Pop one element and push the result of a monadic operation
 };
 
 struct szexp {
@@ -58,6 +62,7 @@ struct gl_user_shader {
     struct gl_transform offset;
     struct szexp width[MAX_SZEXP_SIZE];
     struct szexp height[MAX_SZEXP_SIZE];
+    struct szexp cond[MAX_SZEXP_SIZE];
     int components;
 };
 


### PR DESCRIPTION
User hooks can now use an extra WHEN expression to specify when the
shader should be run. For example, this can be used to only run a chroma
scaling shader `WHEN CHROMA.w LUMA.w <`.

There's a slight semantics change to user shaders: When trying to bind a
texture that does not exist, a shader will now be silently skipped
(similar to when the condition is false) instead of generating an error.

This allows shader stages to depend on an optional earlier stage without
having to copy/paste the same condition everywhere.

(In other words: there's an implicit condition on all of the bound
textures existing)

This would help for issues like #3226.