### PR TITLE
vo_opengl: increase the size limit for cached file

### DIFF
--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -520,7 +520,7 @@ static struct bstr load_cached_file(struct gl_video *p, const char *path)
             return p->files[n].body;
     }
     // not found -> load it
-    struct bstr s = stream_read_file(path, p, p->global, 100000); // 100 kB
+    struct bstr s = stream_read_file(path, p, p->global, 1024000); // 1024 kB
     if (s.len) {
         struct cached_file new = {
             .path = talloc_strdup(p, path),


### PR DESCRIPTION
This is mainly for the nnedi3 user shader. With all whose NN weights
hardcoded into the shader source code, the shader file could be as
large as 300 kB.

As there are `stream_read_file` calls in `lcms.c` with `1GB` limitation, I'm assuming setting it to `1MB` here would be fine.