### PR TITLE
vo_opengl: make size of OUTPUT available to user shaders

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -747,9 +747,9 @@ Available video output drivers are:
             Specifies the size of the resulting texture for this pass.
             ``szexpr`` refers to an expression in RPN (reverse polish
             notation), using the operators + - * / > < !, floating point
-            literals, and references to existing texture sizes such as
-            MAIN.width or CHROMA.height. By default, these are set to HOOKED.w
-            and HOOKED.h, respectively.
+            literals, and references to sizes of existing texture and OUTPUT
+            (such as MAIN.width or CHROMA.height). By default, these are set to
+            HOOKED.w and HOOKED.h, respectively.
 
         WHEN <szexpr>
             Specifies a condition that needs to be true (non-zero) for the

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1688,6 +1688,15 @@ static bool eval_szexpr(struct gl_video *p, struct img_tex tex,
             struct bstr name = expr[i].val.varname;
             struct img_tex var_tex;
 
+            // The size of OUTPUT is determined. It could be useful for certain
+            // user shaders to skip passes.
+            if (bstr_equals0(name, "OUTPUT")) {
+                int vp_w = p->dst_rect.x1 - p->dst_rect.x0;
+                int vp_h = p->dst_rect.y1 - p->dst_rect.y0;
+                stack[idx++] = (expr[i].tag == SZEXP_VAR_W) ? vp_w : vp_h;
+                continue;
+            }
+
             // HOOKED is a special case
             if (bstr_equals0(name, "HOOKED")) {
                 var_tex = tex;


### PR DESCRIPTION
Currently only size of textures in the front of rendering chains are available. The size of `OUTPUT` is determined and could be very useful for user shaders to skip unnecessary passes.