### PR TITLE
vo_rpi: fix destroying overlays

### DIFF
--- a/video/out/vo_rpi.c
+++ b/video/out/vo_rpi.c
@@ -729,6 +729,9 @@ static void uninit(struct vo *vo)
 
     destroy_dispmanx(vo);
 
+    if (p->update)
+        vc_dispmanx_update_submit_sync(p->update);
+
     if (p->renderer)
         mmal_component_release(p->renderer);
 


### PR DESCRIPTION
Commit 74e3d11 resulted in the background overlay not getting destroyed
when mpv quits. Add back a piece of code that was removed in that commit
to restore correct functionality.

Fixes issue #3100