### PR TITLE
cocoa: fix actual display refresh rate retrieval

### DIFF
--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -56,6 +56,11 @@
     [self.adapter setNeedsResize];
 }
 
+- (void)windowDidChangeScreen:(NSNotification *)notification
+{
+    [self.adapter windowDidChangeScreen:notification];
+}
+
 - (void)windowDidChangeScreenProfile:(NSNotification *)notification
 {
     [self.adapter didChangeWindowedScreenProfile:[self screen]];

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -49,6 +49,9 @@
 
 #include "common/msg.h"
 
+static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp* now, 
+                                    const CVTimeStamp* outputTime, CVOptionFlags flagsIn, 
+                                    CVOptionFlags* flagsOut, void* displayLinkContext);
 static int vo_cocoa_fullscreen(struct vo *vo);
 static void cocoa_rm_fs_screen_profile_observer(struct vo_cocoa_state *s);
 static void cocoa_add_screen_reconfiguration_observer(struct vo *vo);
@@ -373,26 +376,38 @@ static void vo_cocoa_update_screen_fps(struct vo *vo)
 
     CVDisplayLinkRef link;
     CVDisplayLinkCreateWithActiveCGDisplays(&link);
+    CVDisplayLinkSetOutputCallback(link, &displayLinkCallback, NULL);
     CVDisplayLinkStart(link);
 
     CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(
         link, s->cgl_ctx, CGLGetPixelFormat(s->cgl_ctx));
 
-    s->screen_fps = CVDisplayLinkGetActualOutputVideoRefreshPeriod(link);
+    double display_period = CVDisplayLinkGetActualOutputVideoRefreshPeriod(link);
 
-    if (s->screen_fps == 0) {
+    if (display_period > 0) {
+        s->screen_fps = 1/display_period;
+    } else {
         // Fallback to using Nominal refresh rate from DisplayLink,
         // CVDisplayLinkGet *Actual* OutputVideoRefreshPeriod seems to
         // return 0 on some Apple devices. Use the nominal refresh period
         // instead.
         const CVTime t = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(link);
-        if (!(t.flags & kCVTimeIsIndefinite))
+        if (!(t.flags & kCVTimeIsIndefinite)) {
             s->screen_fps = (t.timeScale / (double) t.timeValue);
+            MP_VERBOSE(vo, "Falling back to %f for display sync.\n", s->screen_fps);
+        }
     }
 
     CVDisplayLinkRelease(link);
 
     flag_events(vo, VO_EVENT_WIN_STATE);
+}
+
+static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp* now,
+                                    const CVTimeStamp* outputTime, CVOptionFlags flagsIn,
+                                    CVOptionFlags* flagsOut, void* displayLinkContext)
+{
+    return kCVReturnSuccess;
 }
 
 static void vo_cocoa_update_screen_info(struct vo *vo, struct mp_rect *out_rc)


### PR DESCRIPTION
i was investigating the display sync problem under OS X a bit more and found this bug, which is sadly unrelated to the display sync problem. since i only tested it on two different machines i didn't remove the fallback and the comment yet since it might still be true in some cases.

though i assume it always fell back to CVDisplayLinkGetNominalOutputVideoRefreshPeriod on any Mac, otherwise it would have caused massive problems and most likely to at least 1 bug report.