### PR TITLE
Header fixes for GLES

### DIFF
--- a/video/out/opengl/header_fixes.h
+++ b/video/out/opengl/header_fixes.h
@@ -62,6 +62,10 @@
 #define GL_DEBUG_SEVERITY_NOTIFICATION    0x826B
 #endif
 
+#ifndef GL_BACK_LEFT
+#define GL_BACK_LEFT                      0x0402
+#endif
+
 #if HAVE_ANDROID_GL
 #define GL_UNSIGNED_BYTE_3_3_2            0x8032
 #define GL_UNSIGNED_BYTE_2_3_3_REV        0x8362

--- a/video/out/opengl/header_fixes.h
+++ b/video/out/opengl/header_fixes.h
@@ -94,11 +94,8 @@
 
 // GL_ARB_timer_query and EXT_disjoint_timer_query
 #ifndef GL_TIME_ELAPSED
-#ifdef GL_TIME_ELAPSED_EXT
-#define GL_TIME_ELAPSED GL_TIME_ELAPSED_EXT
-#else
+// Same as GL_TIME_ELAPSED_EXT
 #define GL_TIME_ELAPSED 0x88BF
-#endif
 #endif
 
 // GL_OES_EGL_image_external, GL_NV_EGL_stream_consumer_external

--- a/video/out/opengl/header_fixes.h
+++ b/video/out/opengl/header_fixes.h
@@ -88,6 +88,15 @@
 #define GL_UNSIGNED_SHORT_8_8_REV_APPLE 0x85BB
 #endif
 
+// GL_ARB_timer_query and EXT_disjoint_timer_query
+#ifndef GL_TIME_ELAPSED
+#ifdef GL_TIME_ELAPSED_EXT
+#define GL_TIME_ELAPSED GL_TIME_ELAPSED_EXT
+#else
+#define GL_TIME_ELAPSED 0x88BF
+#endif
+#endif
+
 // GL_OES_EGL_image_external, GL_NV_EGL_stream_consumer_external
 #ifndef GL_TEXTURE_EXTERNAL_OES
 #define GL_TEXTURE_EXTERNAL_OES 0x8D65


### PR DESCRIPTION
See the commit messages. Those constants aren't defined when compiling for GLES (at least for Android) and cause the build to break, even if the constant isn't used.

I agree that my changes can be relicensed to LGPL 2.1 or later.
