### PR TITLE
aspect: calculate the correct dimension of the image scaled with pan-…

### DIFF
--- a/video/out/aspect.c
+++ b/video/out/aspect.c
@@ -146,6 +146,22 @@ void mp_get_src_dst_rects(struct mp_log *log, struct mp_vo_opts *opts,
                               opts->zoom, opts->align_y, opts->pan_y,
                               &src.y0, &src.y1, &dst.y0, &dst.y1,
                               &osd.mt, &osd.mb);
+
+        //Calculate the size of the smaller side of the scaled image based
+        // on the aspect ratio
+        if (opts->panscan) {
+            float dst_ar = window_w / (float)window_h;
+            float src_ar = src_w / (float)src_h;
+            if (dst_ar > src_ar) {
+                dst.x1 = (dst.y1 - dst.y0) 
+                       * ((src.x1 - src.x0) / (double)(src.y1 - src.y0))
+                       + dst.x0 + 0.5;
+            } else if (dst_ar < src_ar) {
+                dst.y1 = (dst.x1 - dst.x0) 
+                       / ((src.x1 - src.x0) / (double)(src.y1 - src.y0))
+                       + dst.y0 + 0.5;
+            }
+        }
     }
 
     *out_src = src;


### PR DESCRIPTION
…and-scan

Currently pan-and-scan doesn't take into account the aspect ratio, thus sometimes size of the smaller side of the output image is off by 1 or 2 pixels.

I agree that my changes can be relicensed to LGPL 2.1 or later.