### PR TITLE
opengl: add output_size uniform to custom shader

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -629,6 +629,8 @@ Available video output drivers are:
             never resets (regardless of seeks).
         vec2 image_size
             The size in pixels of the input image.
+        vec2 output_size
+            The size in pixels of the output screen.
 
         For example, a shader that inverts the colors could look like this::
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1239,6 +1239,9 @@ static void load_shader(struct gl_video *p, struct bstr body)
     gl_sc_uniform_f(p->sc, "frame", p->frames_uploaded);
     gl_sc_uniform_vec2(p->sc, "image_size", (GLfloat[]){p->image_params.w,
                                                         p->image_params.h});
+    gl_sc_uniform_vec2(p->sc, "output_size",
+                       (GLfloat[]){p->dst_rect.x1 - p->dst_rect.x0,
+                                   p->dst_rect.y1 - p->dst_rect.y0});
 }
 
 static const char *get_custom_shader_fn(struct gl_video *p, const char *body)


### PR DESCRIPTION
logically, scaler should know its input and output size

I agree that my changes can be relicensed to LGPL 2.1 or later.