### PR TITLE
Add ARIB STD-B67 support

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -311,6 +311,7 @@ Available filters are:
        :gamma2.8:     Pure power curve (gamma 2.8)
        :prophoto:     ProPhoto RGB (ROMM) curve
        :st2084:       SMPTE ST2084 (HDR) curve
+       :std-b67:      ARIB STD-B67 (Hybrid Log-gamma) curve
 
     ``<peak>``
         Reference peak illumination for the video file. This is mostly

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1003,6 +1003,8 @@ Available video output drivers are:
             ProPhoto RGB (ROMM)
         st2084
             SMPTE ST2084 (HDR) curve, PQ OETF
+        std-b67
+            ARIB STD-B67 (Hybrid Log-gamma) curve, also known as BBC/NHK HDR
 
     ``target-brightness=<1..100000>``
         Specifies the display's approximate brightness in cd/m^2. When playing

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1006,6 +1006,12 @@ Available video output drivers are:
         std-b67
             ARIB STD-B67 (Hybrid Log-gamma) curve, also known as BBC/NHK HDR
 
+        NOTE: When using HDR output formats, mpv will encode to the specified
+              curve but it will not set any HDMI flags or other signalling that
+              might be required for the target device to correctly display the
+              HDR signal. The user should independently guarantee this before
+              using these signal formats for display.
+
     ``target-brightness=<1..100000>``
         Specifies the display's approximate brightness in cd/m^2. When playing
         HDR content on a SDR display (or SDR content on an HDR display), video

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -78,6 +78,7 @@ const struct m_opt_choice_alternatives mp_csp_trc_names[] = {
     {"gamma2.8",    MP_CSP_TRC_GAMMA28},
     {"prophoto",    MP_CSP_TRC_PRO_PHOTO},
     {"st2084",      MP_CSP_TRC_SMPTE_ST2084},
+    {"std-b67",     MP_CSP_TRC_ARIB_STD_B67},
     {0}
 };
 
@@ -171,8 +172,9 @@ enum mp_csp_trc avcol_trc_to_mp_csp_trc(int avtrc)
     case AVCOL_TRC_LINEAR:       return MP_CSP_TRC_LINEAR;
     case AVCOL_TRC_GAMMA22:      return MP_CSP_TRC_GAMMA22;
     case AVCOL_TRC_GAMMA28:      return MP_CSP_TRC_GAMMA28;
-#if HAVE_AVUTIL_ST2084
+#if HAVE_AVUTIL_HDR
     case AVCOL_TRC_SMPTEST2084:  return MP_CSP_TRC_SMPTE_ST2084;
+    case AVCOL_TRC_ARIB_STD_B67: return MP_CSP_TRC_ARIB_STD_B67;
 #endif
     default:                     return MP_CSP_TRC_AUTO;
     }
@@ -222,8 +224,9 @@ int mp_csp_trc_to_avcol_trc(enum mp_csp_trc trc)
     case MP_CSP_TRC_LINEAR:       return AVCOL_TRC_LINEAR;
     case MP_CSP_TRC_GAMMA22:      return AVCOL_TRC_GAMMA22;
     case MP_CSP_TRC_GAMMA28:      return AVCOL_TRC_GAMMA28;
-#if HAVE_AVUTIL_ST2084
+#if HAVE_AVUTIL_HDR
     case MP_CSP_TRC_SMPTE_ST2084: return AVCOL_TRC_SMPTEST2084;
+    case MP_CSP_TRC_ARIB_STD_B67: return AVCOL_TRC_ARIB_STD_B67;
 #endif
     default:                      return AVCOL_TRC_UNSPECIFIED;
     }

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -79,6 +79,7 @@ enum mp_csp_trc {
     MP_CSP_TRC_GAMMA28,
     MP_CSP_TRC_PRO_PHOTO,
     MP_CSP_TRC_SMPTE_ST2084,
+    MP_CSP_TRC_ARIB_STD_B67,
     MP_CSP_TRC_COUNT
 };
 

--- a/wscript
+++ b/wscript
@@ -498,10 +498,11 @@ FFmpeg/Libav libraries. You need at least {0}. Aborting.".format(libav_versions_
                                 '(void)offsetof(AVFrame, hw_frames_ctx)',
                                 use='libav'),
     }, {
-        'name': 'avutil-st2084',
-        'desc': 'libavutil AVCOL_TRC_SMPTEST2084',
+        'name': 'avutil-hdr',
+        'desc': 'libavutil HDR TRCs',
         'func': check_statement('libavutil/pixfmt.h',
-                                'AVCOL_TRC_SMPTEST2084',
+                                'AVCOL_TRC_SMPTEST2084,'
+                                'AVCOL_TRC_ARIB_STD_B67',
                                 use='libav'),
     }
 ]


### PR DESCRIPTION
HDR video standard, competes with SMPTE ST.2084. I greatly prefer this one to ST.2084. I hope it takes off. (I mean, assuming HDR takes off at all, which I still hope it doesn't)