### PR TITLE
vo_opengl: make size of cropped INPUT available to user shaders

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4208,6 +4208,8 @@ The following video options are currently all specific to ``--vo=opengl`` and
     vec2 target_size
         The size in pixels of the visible part of the scaled (and possibly
         cropped) image.
+    vec2 tex_offset
+        Texture offset introduced by user shaders or options like panscan, video-align-x/y, video-pan-x/y.
 
     Internally, vo_opengl may generate any number of the following textures.
     Whenever a texture is rendered and saved by vo_opengl, all of the passes

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4203,8 +4203,8 @@ The following video options are currently all specific to ``--vo=opengl`` and
     int frame
         A simple count of frames rendered, increases by one per frame and never
         resets (regardless of seeks).
-    vec2 image_size
-        The size in pixels of the input image.
+    vec2 input_size
+        The size in pixels of the input image (possibly cropped and prescaled).
     vec2 target_size
         The size in pixels of the visible part of the scaled (and possibly
         cropped) image.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4145,9 +4145,11 @@ The following video options are currently all specific to ``--vo=opengl`` and
         Specifies the size of the resulting texture for this pass. ``szexpr``
         refers to an expression in RPN (reverse polish notation), using the
         operators + - * / > < !, floating point literals, and references to
-        sizes of existing texture and OUTPUT (such as MAIN.width or
-        CHROMA.height). By default, these are set to HOOKED.w and HOOKED.h,
-        respectively.
+        sizes of existing texture (such as MAIN.width or CHROMA.height),
+        OUTPUT, or NATIVE_CROPPED (size of an input texture cropped after
+        pan-and-scan, video-align-x/y, video-pan-x/y, etc. and possibly
+        prescaled). By default, these are set to HOOKED.w and HOOKED.h,
+        espectively.
 
     WHEN <szexpr>
         Specifies a condition that needs to be true (non-zero) for the shader

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1509,6 +1509,12 @@ static bool szexp_lookup(void *priv, struct bstr var, float size[2])
     struct szexp_ctx *ctx = priv;
     struct gl_video *p = ctx->p;
 
+    if (bstr_equals0(var, "NATIVE_CROPPED")) {
+        size[0] = (p->src_rect.x1 - p->src_rect.x0) * p->texture_offset.m[0][0];
+        size[1] = (p->src_rect.y1 - p->src_rect.y0) * p->texture_offset.m[1][1];
+        return true;
+    }
+
     // The size of OUTPUT is determined. It could be useful for certain
     // user shaders to skip passes.
     if (bstr_equals0(var, "OUTPUT")) {

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1229,6 +1229,11 @@ static void load_shader(struct gl_video *p, struct bstr body)
     gl_sc_uniform_vec2(p->sc, "target_size",
                        (GLfloat[]){p->dst_rect.x1 - p->dst_rect.x0,
                                    p->dst_rect.y1 - p->dst_rect.y0});
+    gl_sc_uniform_vec2(p->sc, "tex_offset",
+                       (GLfloat[]){p->src_rect.x0 * p->texture_offset.m[0][0] +
+                                   p->texture_offset.t[0],
+                                   p->src_rect.y0 * p->texture_offset.m[1][1] +
+                                   p->texture_offset.t[1]});
 }
 
 // Semantic equality

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1224,8 +1224,11 @@ static void load_shader(struct gl_video *p, struct bstr body)
     gl_sc_hadd_bstr(p->sc, body);
     gl_sc_uniform_f(p->sc, "random", (double)av_lfg_get(&p->lfg) / UINT32_MAX);
     gl_sc_uniform_f(p->sc, "frame", p->frames_uploaded);
-    gl_sc_uniform_vec2(p->sc, "image_size", (GLfloat[]){p->image_params.w,
-                                                        p->image_params.h});
+    gl_sc_uniform_vec2(p->sc, "input_size",
+                       (GLfloat[]){(p->src_rect.x1 - p->src_rect.x0) *
+                                   p->texture_offset.m[0][0],
+                                   (p->src_rect.y1 - p->src_rect.y0) *
+                                   p->texture_offset.m[1][1]});
     gl_sc_uniform_vec2(p->sc, "target_size",
                        (GLfloat[]){p->dst_rect.x1 - p->dst_rect.x0,
                                    p->dst_rect.y1 - p->dst_rect.y0});


### PR DESCRIPTION
Can be useful for some user shaders to be compatible with pan-and-scan.

I agree that my changes can be relicensed to LGPL 2.1 or later.
