### PR TITLE
command: add properties for HDR metadata

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1479,6 +1479,12 @@ Property list
     ``video-params/gamma``
         The gamma function in use as string. (Exact values subject to change.)
 
+    ``video-params/nom-peak``
+        The video encoding's nominal peak brightness as float.
+
+    ``video-params/sig-peak``
+        The video file's tagged signal peak as float.
+
     ``video-params/chroma-location``
         Chroma location as string. (Exact values subject to change.)
 

--- a/player/command.c
+++ b/player/command.c
@@ -2533,6 +2533,8 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
             SUB_PROP_STR(m_opt_choice_str(mp_csp_prim_names, p.color.primaries))},
         {"gamma",
             SUB_PROP_STR(m_opt_choice_str(mp_csp_trc_names, p.color.gamma))},
+        {"nom-peak", SUB_PROP_FLOAT(p.color.nom_peak)},
+        {"sig-peak", SUB_PROP_FLOAT(p.color.sig_peak)},
         {"chroma-location",
             SUB_PROP_STR(m_opt_choice_str(mp_chroma_names, p.chroma_location))},
         {"stereo-in",


### PR DESCRIPTION
Since it turns out that knowing what exactly a file was tagged with can
be useful for debugging purposes, expose this as a property so I can
check it more easily.

This is mostly useful for sig-peak (since nom-peak is currently entirely
calculated by us), but I added both for consistency.