### PR TITLE
vo_xv, vo_x11: fix typos in warnings

### DIFF
--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -407,8 +407,8 @@ static int preinit(struct vo *vo)
         goto error;
 
     p->gc = XCreateGC(x11->display, x11->window, 0, NULL);
-    MP_WARN(vo, "Warning: this legacy VO has bad performance. Consider fixing"
-                "your graphic drivers, or not forcing the x11 VO.\n");
+    MP_WARN(vo, "Warning: this legacy VO has bad performance. Consider fixing "
+                "your graphics drivers, or not forcing the x11 VO.\n");
     return 0;
 
 error:

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -856,7 +856,7 @@ static int preinit(struct vo *vo)
 
     MP_WARN(vo, "Warning: this legacy VO has bad quality and performance, "
                 "and will in particular result in blurry OSD and subtitles. "
-                "You should fix your graphic drivers, or not force the xv VO.\n");
+                "You should fix your graphics drivers, or not force the xv VO.\n");
     return 0;
 
   error:


### PR DESCRIPTION
As a side note, the suggestion that I should fix my graphics driver is counter-productive.
It's not like I enjoy brokenness of my driver. If I had time and skills to fix it, I'd have done it already without your hint.