### PR TITLE
Try the D3D9 ANGLE backend when eglInitialize fails for D3D11

### DIFF
--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -216,16 +216,17 @@ static int angle_init(struct MPGLContext *ctx, int flags)
 
         p->egl_display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, dc,
             display_attributes);
-        if (p->egl_display != EGL_NO_DISPLAY)
-            break;
+        if (p->egl_display == EGL_NO_DISPLAY)
+            continue;
+
+        if (!eglInitialize(p->egl_display, NULL, NULL)) {
+            p->egl_display = EGL_NO_DISPLAY;
+            continue;
+        }
+        break;
     }
     if (p->egl_display == EGL_NO_DISPLAY) {
         MP_FATAL(vo, "Couldn't get display\n");
-        goto fail;
-    }
-
-    if (!eglInitialize(p->egl_display, NULL, NULL)) {
-        MP_FATAL(vo, "Couldn't initialize EGL\n");
         goto fail;
     }
 


### PR DESCRIPTION
This will happen when D3D11 is present on the machine but the supported feature level is too low, eg. on feature level 9_3 hardware.

I'm not 100% sure if the eglTerminate is required.