### PR TITLE
Use - as command-name separator everywhere

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -640,7 +640,7 @@ Input Commands that are Possibly Subject to Change
     The argument is the name of the binding.
 
     It can optionally be prefixed with the name of the script, using ``/`` as
-    separator, e.g. ``script_binding scriptname/bindingname``.
+    separator, e.g. ``script-binding scriptname/bindingname``.
 
     For completeness, here is how this command works internally. The details
     could change any time. On any matching key event, ``script-message-to``
@@ -809,7 +809,7 @@ Input sections group a set of bindings, and enable or disable them at once.
 In ``input.conf``, each key binding is assigned to an input section, rather
 than actually having explicit text sections.
 
-See also: ``enable_section`` and ``disable_section`` commands.
+See also: ``enable-section`` and ``disable-section`` commands.
 
 Predefined bindings:
 
@@ -1594,7 +1594,7 @@ Property list
 
 ``osd-width``, ``osd-height``
     Last known OSD width (can be 0). This is needed if you want to use the
-    ``overlay_add`` command. It gives you the actual OSD size, which can be
+    ``overlay-add`` command. It gives you the actual OSD size, which can be
     different from the window size in some cases.
 
 ``osd-par``

--- a/DOCS/man/ipc.rst
+++ b/DOCS/man/ipc.rst
@@ -41,7 +41,7 @@ It's also possible to send input.conf style text-only commands:
 
 ::
 
-    > echo 'show_text ${playback-time}' | socat - /tmp/mpvsocket
+    > echo 'show-text ${playback-time}' | socat - /tmp/mpvsocket
 
 But you won't get a reply over the socket. (This particular command shows the
 playback time on the player's OSD.)
@@ -65,7 +65,7 @@ You can send commands from a command prompt:
 
 ::
 
-    echo show_text ${playback-time} >\\.\pipe\mpvsocket
+    echo show-text ${playback-time} >\\.\pipe\mpvsocket
 
 To be able to simultaneously read and write from the IPC pipe, like on Linux,
 it's necessary to write an external program that uses overlapped file I/O (or

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -946,7 +946,7 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
 ``~/.config/mpv/watch_later/``
     Contains temporary config files needed for resuming playback of files with
     the watch later feature. See for example the ``Q`` key binding, or the
-    ``quit_watch_later`` input command.
+    ``quit-watch-later`` input command.
 
     Each file is a small config file which is loaded if the corresponding media
     file is loaded. It contains the playback position and some (not necessarily

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -404,7 +404,7 @@ Program Behavior
 ``--no-resume-playback``
     Do not restore playback position from the ``watch_later`` configuration
     subdirectory (usually ``~/.config/mpv/watch_later/``).
-    See ``quit_watch_later`` input command.
+    See ``quit-watch-later`` input command.
 
 ``--profile=<profile1,profile2,...>``
     Use the given profile(s), ``--profile=help`` displays a list of the
@@ -1283,7 +1283,7 @@ Audio
     or to set your own application name when using libmpv.
 
 ``--volume-restore-data=<string>``
-    Used internally for use by playback resume (e.g. with ``quit_watch_later``).
+    Used internally for use by playback resume (e.g. with ``quit-watch-later``).
     Restoring value has to be done carefully, because different AOs as well as
     softvol can have different value ranges, and we don't want to restore
     volume if setting the volume changes it system wide. The normal options
@@ -2658,7 +2658,7 @@ OSD
     (default), then the playback time, duration, and some more information is
     shown.
 
-    This is also used for the ``show_progress`` command (by default mapped to
+    This is also used for the ``show-progress`` command (by default mapped to
     ``P``), or in some non-default cases when seeking.
 
     ``--osd-status-msg`` is a legacy equivalent (but with a minor difference).
@@ -2666,7 +2666,7 @@ OSD
 ``--osd-status-msg=<string>``
     Show a custom string during playback instead of the standard status text.
     This overrides the status text used for ``--osd-level=3``, when using the
-    ``show_progress`` command (by default mapped to ``P``), or in some
+    ``show-progress`` command (by default mapped to ``P``), or in some
     non-default cases when seeking. Expands properties. See
     `Property Expansion`_.
 

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -1300,7 +1300,7 @@ Available video output drivers are:
     This also supports many of the suboptions the ``opengl`` VO has. Run
     ``mpv --vo=opengl-cb:help`` for a list.
 
-    This also supports the ``vo_cmdline`` command.
+    This also supports the ``vo-cmdline`` command.
 
 ``rpi`` (Raspberry Pi)
     Native video output on the Raspberry Pi using the MMAL API.

--- a/DOCS/mplayer-changes.rst
+++ b/DOCS/mplayer-changes.rst
@@ -30,7 +30,7 @@ Player
 * Slave mode compatibility broken (see below).
 * Re-enable screensaver while the player is paused.
 * Allow resuming playback at a later point with ``Shift+q``, also see the
-  ``quit_watch_later`` input command.
+  ``quit-watch-later`` input command.
 * ``--keep-open`` option to stop the player from closing the window and
   exiting after playback ends.
 * A client API, that allows embedding **mpv** into applications
@@ -312,11 +312,11 @@ input.conf and Slave Commands
     +--------------------------------+----------------------------------------+
     | Old                            | New                                    |
     +================================+========================================+
-    | ``pt_step 1 [0|1]``            | ``playlist_next [weak|force]``         |
+    | ``pt_step 1 [0|1]``            | ``playlist-next [weak|force]``         |
     |                                | (translation layer cannot deal with    |
     |                                | whitespace)                            |
     +--------------------------------+----------------------------------------+
-    | ``pt_step -1 [0|1]``           | ``playlist_prev [weak|force] (same)``  |
+    | ``pt_step -1 [0|1]``           | ``playlist-prev [weak|force] (same)``  |
     +--------------------------------+----------------------------------------+
     | ``switch_ratio [<ratio>]``     | ``set video-aspect <ratio>``           |
     |                                |                                        |
@@ -331,7 +331,7 @@ input.conf and Slave Commands
     | ``<step> <dir>``               | ``no-osd``: ``no-osd cycle <prop>``    |
     |                                | ``<step>``                             |
     +--------------------------------+----------------------------------------+
-    | ``osd_show_property_text``     | ``show_text <text>``                   |
+    | ``osd_show_property_text``     | ``show-text <text>``                   |
     | ``<text>``                     | The property expansion format string   |
     |                                | syntax slightly changed.               |
     +--------------------------------+----------------------------------------+
@@ -340,9 +340,9 @@ input.conf and Slave Commands
     |                                | ``raw`` prefix to disable property     |
     |                                | expansion.                             |
     +--------------------------------+----------------------------------------+
-    | ``show_tracks``                | ``show_text ${track-list}``            |
+    | ``show_tracks``                | ``show-text ${track-list}``            |
     +--------------------------------+----------------------------------------+
-    | ``show_chapters``              | ``show_text ${chapter-list}``          |
+    | ``show_chapters``              | ``show-text ${chapter-list}``          |
     +--------------------------------+----------------------------------------+
     | ``af_switch``, ``af_add``, ... | ``af set|add|...``                     |
     +--------------------------------+----------------------------------------+

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -25,7 +25,7 @@ function add_files_at(index, files)
     local oldcount = mp.get_property_number("playlist-count", 1)
     for i = 1, #files do
         mp.commandv("loadfile", files[i], "append")
-        mp.commandv("playlist_move", oldcount + i - 1, index + i - 1)
+        mp.commandv("playlist-move", oldcount + i - 1, index + i - 1)
     end
 end
 

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -79,7 +79,7 @@
 #> playlist-next                        # skip to next file
 #ENTER playlist-next                    # skip to next file
 #< playlist-prev                        # skip to previous file
-#O no-osd cycle_values osd-level 3 1    # cycle through OSD mode
+#O no-osd cycle-values osd-level 3 1    # cycle through OSD mode
 #o show-progress
 #P show-progress
 #I show-text "${filename}"              # display filename in osd

--- a/etc/mplayer-input.conf
+++ b/etc/mplayer-input.conf
@@ -24,19 +24,19 @@ SHARP cycle audio           # switch audio streams
 BS set speed 1.0	# reset speed to normal
 q quit
 ESC quit
-ENTER playlist_next force       # skip to next file
+ENTER playlist-next force       # skip to next file
 p cycle pause
-. frame_step            # advance one frame and pause
+. frame-step            # advance one frame and pause
 SPACE cycle pause
 HOME set playlist-pos 0 # not the same as MPlayer
 #END pt_up_step -1
-> playlist_next             # skip to next file
-< playlist_prev             #         previous
+> playlist-next             # skip to next file
+< playlist-prev             #         previous
 #INS alt_src_step 1
 #DEL alt_src_step -1
 o osd
-I show_text "${filename}"     # display filename in osd
-P show_progress
+I show-text "${filename}"     # display filename in osd
+P show-progress
 z add sub-delay -0.1        # subtract 100 ms delay from subs
 x add sub-delay +0.1        # add
 9 add volume -1
@@ -57,8 +57,8 @@ d cycle framedrop
 D cycle deinterlace # toggle deinterlacer (auto-inserted filter)
 r add sub-pos -1            # move subtitles up
 t add sub-pos +1            #                down
-#? sub_step +1		# immediately display next subtitle
-#? sub_step -1		#                     previous
+#? sub-step +1		# immediately display next subtitle
+#? sub-step -1		#                     previous
 #? add sub-scale +0.1	# increase subtitle font size
 #? add sub-scale -0.1	# decrease subtitle font size
 f cycle fullscreen

--- a/etc/restore-old-bindings.conf
+++ b/etc/restore-old-bindings.conf
@@ -17,7 +17,7 @@ d cycle framedrop
 
 # changed in mpv 0.7.0
 
-ENTER playlist_next force
+ENTER playlist-next force
 
 # changed in mpv 0.6.0
 
@@ -38,4 +38,4 @@ TAB cycle program
 A cycle angle
 U stop
 o osd
-I show_text "${filename}"
+I show-text "${filename}"

--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -257,7 +257,7 @@ static const struct legacy_cmd legacy_cmds[] = {
     {"saturation",              "add saturation"},
     {"hue",                     "add hue"},
     {"switch_vsync",            "cycle vsync"},
-    {"sub_load",                "sub_add"},
+    {"sub_load",                "sub-add"},
     {"sub_select",              "cycle sub"},
     {"sub_pos",                 "add sub-pos"},
     {"sub_delay",               "add sub-delay"},

--- a/input/event.c
+++ b/input/event.c
@@ -31,7 +31,7 @@ void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files,
         for (int i = 0; i < num_files; i++) {
             const char *cmd[] = {
                 "osd-auto",
-                "sub_add",
+                "sub-add",
                 files[i],
                 NULL
             };

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -660,7 +660,7 @@ typedef enum mpv_format {
     MPV_FORMAT_NODE_MAP         = 8,
     /**
      * A raw, untyped byte array. Only used only with mpv_node, and only in
-     * some very special situations. (Currently, only for the screenshot_raw
+     * some very special situations. (Currently, only for the screenshot-raw
      * command.)
      */
     MPV_FORMAT_BYTE_ARRAY       = 9
@@ -1148,13 +1148,13 @@ typedef enum mpv_event_id {
      * @deprecated This was used internally with the internal "script_dispatch"
      *             command to dispatch keyboard and mouse input for the OSC.
      *             It was never useful in general and has been completely
-     *             replaced with "script_binding".
+     *             replaced with "script-binding".
      *             This event never happens anymore, and is included in this
      *             header only for compatibility.
      */
     MPV_EVENT_SCRIPT_INPUT_DISPATCH = 15,
     /**
-     * Triggered by the script_message input command. The command uses the
+     * Triggered by the script-message input command. The command uses the
      * first argument of the command as client name (see mpv_client_name()) to
      * dispatch the message, and passes along all arguments starting from the
      * second argument as strings.

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -161,7 +161,7 @@ static void terminate_cocoa_application(void)
 
 - (void)stopPlaybackAndRememberPosition
 {
-    [self stopMPV:"quit_watch_later"];
+    [self stopMPV:"quit-watch-later"];
 }
 
 - (void)stopMPV:(char *)cmd

--- a/player/command.c
+++ b/player/command.c
@@ -220,7 +220,7 @@ static void mp_hook_add(struct MPContext *mpctx, char *client, char *name,
     qsort(cmd->hooks, cmd->num_hooks, sizeof(cmd->hooks[0]), compare_hook);
 }
 
-// Call before a seek, in order to allow revert_seek to undo the seek.
+// Call before a seek, in order to allow revert-seek to undo the seek.
 static void mark_seek(struct MPContext *mpctx)
 {
     struct command_ctx *cmd = mpctx->command_ctx;
@@ -4385,15 +4385,15 @@ static int overlay_add(struct MPContext *mpctx, int id, int x, int y,
 {
     int r = -1;
     if (strcmp(fmt, "bgra") != 0) {
-        MP_ERR(mpctx, "overlay_add: unsupported OSD format '%s'\n", fmt);
+        MP_ERR(mpctx, "overlay-add: unsupported OSD format '%s'\n", fmt);
         goto error;
     }
     if (id < 0 || id >= 64) { // arbitrary upper limit
-        MP_ERR(mpctx, "overlay_add: invalid id %d\n", id);
+        MP_ERR(mpctx, "overlay-add: invalid id %d\n", id);
         goto error;
     }
     if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4)) {
-        MP_ERR(mpctx, "overlay_add: inconsistent parameters\n");
+        MP_ERR(mpctx, "overlay-add: inconsistent parameters\n");
         goto error;
     }
     struct overlay overlay = {
@@ -4431,7 +4431,7 @@ static int overlay_add(struct MPContext *mpctx, int id, int x, int y,
             p = m;
     }
     if (!p) {
-        MP_ERR(mpctx, "overlay_add: could not open or map '%s'\n", file);
+        MP_ERR(mpctx, "overlay-add: could not open or map '%s'\n", file);
         talloc_free(overlay.source);
         goto error;
     }

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -42,8 +42,8 @@ function mp.input_disable_section(section)
     mp.commandv("disable-section", section)
 end
 
--- For dispatching script_binding. This is sent as:
---      script_message_to $script_name $binding_name $keystate
+-- For dispatching script-binding. This is sent as:
+--      script-message-to $script_name $binding_name $keystate
 -- The array is indexed by $binding_name, and has functions like this as value:
 --      fn($binding_name, $keystate)
 local dispatch_key_bindings = {}
@@ -412,7 +412,7 @@ mp.register_event("shutdown", function() mp.keep_running = false end)
 mp.register_event("client-message", message_dispatch)
 mp.register_event("property-change", property_change)
 
--- sent by "script_binding"
+-- sent by "script-binding"
 mp.register_script_message("key-binding", dispatch_key_binding)
 
 mp.msg = {

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1383,7 +1383,7 @@ function osc_init()
     ne.content = "\238\132\144"
     ne.visible = have_pl
     ne.eventresponder["mouse_btn0_up"] =
-        function () mp.commandv("playlist_prev", "weak") end
+        function () mp.commandv("playlist-prev", "weak") end
     ne.eventresponder["shift+mouse_btn0_up"] =
         function () show_message(mp.get_property_osd("playlist"), 3) end
 
@@ -1393,7 +1393,7 @@ function osc_init()
     ne.content = "\238\132\129"
     ne.visible = have_pl
     ne.eventresponder["mouse_btn0_up"] =
-        function () mp.commandv("playlist_next", "weak") end
+        function () mp.commandv("playlist-next", "weak") end
     ne.eventresponder["shift+mouse_btn0_up"] =
         function () show_message(mp.get_property_osd("playlist"), 3) end
 
@@ -1421,7 +1421,7 @@ function osc_init()
     ne.eventresponder["mouse_btn0_down"] =
         function () mp.commandv("seek", -5, "relative", "keyframes") end
     ne.eventresponder["shift+mouse_btn0_down"] =
-        function () mp.commandv("frame_back_step") end
+        function () mp.commandv("frame-back-step") end
     ne.eventresponder["mouse_btn2_down"] =
         function () mp.commandv("seek", -30, "relative", "keyframes") end
 
@@ -1433,7 +1433,7 @@ function osc_init()
     ne.eventresponder["mouse_btn0_down"] =
         function () mp.commandv("seek", 10, "relative", "keyframes") end
     ne.eventresponder["shift+mouse_btn0_down"] =
-        function () mp.commandv("frame_step") end
+        function () mp.commandv("frame-step") end
     ne.eventresponder["mouse_btn2_down"] =
         function () mp.commandv("seek", 60, "relative", "keyframes") end
 


### PR DESCRIPTION
As far as I can tell these were the only remaining occurrences using old-style commands, except for two other places where I was not sure it would be OK to change them. One is in `DOCS/interface-changes.rst`, and the other are error messages in the function `overlay_add` in `player/command.c` (since this function is only called by the `overlay-add` command, I think it could be changed). I have not tested the change to `osdep/macosx_application.m`.

I agree that my changes can be relicensed to LGPL 2.1 or later.