### PR TITLE
vo_wayland: fix high CPU usage due to busy polling

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1106,7 +1106,7 @@ static int vo_wayland_poll (struct vo *vo, int timeout_msecs)
 
     struct pollfd fd = {
         wl->display.display_fd,
-        POLLIN | POLLOUT | POLLERR | POLLHUP,
+        POLLIN | POLLERR | POLLHUP,
         0
     };
 
@@ -1125,8 +1125,8 @@ static int vo_wayland_poll (struct vo *vo, int timeout_msecs)
         }
         if (fd.revents & POLLIN)
             wl_display_dispatch(dp);
-        if (fd.revents & POLLOUT)
-            wl_display_flush(dp);
+        else
+            wl_display_dispatch_pending(dp);
     }
 
     return polled;


### PR DESCRIPTION
There's no need to call wl_display_flush() since all the client-side
buffered data has already been flushed prior to polling the fd.
Instead only check for POLLIN and the usual ERR+HUP.

This fixes high CPU usage when playing videos with the same framerate as the monitor under both mutter and weston.

For reference check wl_display_dispatch_pending() and wl_display_flush() in the [docs](https://people.freedesktop.org/~whot/wayland-doxygen/wayland/Client/classwl__display.html)