### PR TITLE
Move wayland to the new wakep/wait_events framework + style fixes

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -207,8 +207,7 @@ static void waylandgl_swap_buffers(MPGLContext *ctx)
     if (!wl->frame.callback)
         vo_wayland_request_frame(ctx->vo, NULL, NULL);
 
-    if (!vo_wayland_wait_frame(ctx->vo))
-        MP_DBG(wl, "discarding frame callback\n");
+    vo_wayland_wait_events(ctx->vo, 0);
 
     eglSwapBuffers(wl->egl_context.egl.dpy, wl->egl_context.egl_surface);
 }
@@ -225,6 +224,16 @@ static int waylandgl_control(MPGLContext *ctx, int *events, int request,
     return r;
 }
 
+static void wayland_wakeup(struct MPGLContext *ctx)
+{
+    vo_wayland_wakeup(ctx->vo);
+}
+
+static void wayland_wait_events(struct MPGLContext *ctx, int64_t until_time_us)
+{
+    vo_wayland_wait_events(ctx->vo, until_time_us);
+}
+
 static int waylandgl_init(struct MPGLContext *ctx, int flags)
 {
     if (!vo_wayland_init(ctx->vo))
@@ -239,5 +248,7 @@ const struct mpgl_driver mpgl_driver_wayland = {
     .reconfig       = waylandgl_reconfig,
     .swap_buffers   = waylandgl_swap_buffers,
     .control        = waylandgl_control,
+    .wakeup         = wayland_wakeup,
+    .wait_events    = wayland_wait_events,
     .uninit         = waylandgl_uninit,
 };

--- a/video/out/vo_wayland.c
+++ b/video/out/vo_wayland.c
@@ -373,8 +373,7 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
         p->original_image = mpi;
     }
 
-    if (!vo_wayland_wait_frame(vo))
-        MP_DBG(p->wl, "discarding frame callback\n");
+    vo_wayland_wait_events(vo, 0);
 
     shm_buffer_t *buf = buffer_pool_get_back(&p->video_bufpool);
 
@@ -513,8 +512,7 @@ static void flip_page(struct vo *vo)
     if (!p->wl->frame.callback)
         vo_wayland_request_frame(vo, p, redraw);
 
-    if (!vo_wayland_wait_frame(vo))
-        MP_DBG(p->wl, "discarding frame callback\n");
+    vo_wayland_wait_events(vo, 0);
 }
 
 static int query_format(struct vo *vo, int format)
@@ -675,6 +673,8 @@ const struct vo_driver video_out_wayland = {
     .control = control,
     .draw_image = draw_image,
     .flip_page = flip_page,
+    .wakeup = vo_wayland_wakeup,
+    .wait_events = vo_wayland_wait_events,
     .uninit = uninit,
     .options = (const struct m_option[]) {
         OPT_FLAG("alpha", enable_alpha, 0),

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -58,7 +58,7 @@ static void schedule_resize(struct vo_wayland_state *wl,
                             int32_t width,
                             int32_t height);
 
-static void vo_wayland_fullscreen (struct vo *vo);
+static void vo_wayland_fullscreen(struct vo *vo);
 
 static const struct wl_callback_listener frame_listener;
 
@@ -615,11 +615,9 @@ static const struct wl_data_device_listener data_device_listener = {
     data_device_handle_selection
 };
 
-static void registry_handle_global (void *data,
-                                    struct wl_registry *reg,
-                                    uint32_t id,
-                                    const char *interface,
-                                    uint32_t version)
+static void registry_handle_global(void *data, struct wl_registry *reg,
+                                   uint32_t id, const char *interface,
+                                   uint32_t version)
 {
     struct vo_wayland_state *wl = data;
 
@@ -679,9 +677,9 @@ static void registry_handle_global (void *data,
     }
 }
 
-static void registry_handle_global_remove (void *data,
-                                           struct wl_registry *registry,
-                                           uint32_t id)
+static void registry_handle_global_remove(void *data,
+                                          struct wl_registry *registry,
+                                          uint32_t id)
 {
 }
 
@@ -840,7 +838,7 @@ static const struct wl_callback_listener frame_listener = {
     frame_callback
 };
 
-static bool create_display (struct vo_wayland_state *wl)
+static bool create_display(struct vo_wayland_state *wl)
 {
     if (wl->vo->probing && !getenv("XDG_RUNTIME_DIR"))
         return false;
@@ -865,7 +863,7 @@ static bool create_display (struct vo_wayland_state *wl)
     return true;
 }
 
-static void destroy_display (struct vo_wayland_state *wl)
+static void destroy_display(struct vo_wayland_state *wl)
 {
     struct vo_wayland_output *output = NULL;
     struct vo_wayland_output *tmp = NULL;
@@ -899,7 +897,7 @@ static void destroy_display (struct vo_wayland_state *wl)
     }
 }
 
-static bool create_window (struct vo_wayland_state *wl)
+static bool create_window(struct vo_wayland_state *wl)
 {
     wl->window.video_surface =
         wl_compositor_create_surface(wl->display.compositor);
@@ -926,7 +924,7 @@ static bool create_window (struct vo_wayland_state *wl)
     return true;
 }
 
-static void destroy_window (struct vo_wayland_state *wl)
+static void destroy_window(struct vo_wayland_state *wl)
 {
     if (wl->window.shell_surface)
         wl_shell_surface_destroy(wl->window.shell_surface);
@@ -938,7 +936,7 @@ static void destroy_window (struct vo_wayland_state *wl)
         wl_callback_destroy(wl->frame.callback);
 }
 
-static bool create_cursor (struct vo_wayland_state *wl)
+static bool create_cursor(struct vo_wayland_state *wl)
 {
     if (!wl->display.shm) {
         MP_ERR(wl->vo, "no shm interface available\n");
@@ -958,7 +956,7 @@ static bool create_cursor (struct vo_wayland_state *wl)
     return true;
 }
 
-static void destroy_cursor (struct vo_wayland_state *wl)
+static void destroy_cursor(struct vo_wayland_state *wl)
 {
     if (wl->cursor.theme)
         wl_cursor_theme_destroy(wl->cursor.theme);
@@ -967,7 +965,7 @@ static void destroy_cursor (struct vo_wayland_state *wl)
         wl_surface_destroy(wl->cursor.surface);
 }
 
-static bool create_input (struct vo_wayland_state *wl)
+static bool create_input(struct vo_wayland_state *wl)
 {
     wl->input.xkb.context = xkb_context_new(0);
 
@@ -981,7 +979,7 @@ static bool create_input (struct vo_wayland_state *wl)
     return true;
 }
 
-static void destroy_input (struct vo_wayland_state *wl)
+static void destroy_input(struct vo_wayland_state *wl)
 {
     if (wl->input.keyboard) {
         wl_keyboard_destroy(wl->input.keyboard);
@@ -1007,7 +1005,7 @@ static void destroy_input (struct vo_wayland_state *wl)
 
 /*** mplayer2 interface ***/
 
-int vo_wayland_init (struct vo *vo)
+int vo_wayland_init(struct vo *vo)
 {
     vo->wayland = talloc_zero(NULL, struct vo_wayland_state);
     struct vo_wayland_state *wl = vo->wayland;
@@ -1047,7 +1045,7 @@ int vo_wayland_init (struct vo *vo)
     return true;
 }
 
-void vo_wayland_uninit (struct vo *vo)
+void vo_wayland_uninit(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wayland;
     destroy_cursor(wl);
@@ -1060,7 +1058,7 @@ void vo_wayland_uninit (struct vo *vo)
     vo->wayland = NULL;
 }
 
-static void vo_wayland_ontop (struct vo *vo)
+static void vo_wayland_ontop(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wayland;
     MP_DBG(wl, "going ontop\n");
@@ -1069,7 +1067,7 @@ static void vo_wayland_ontop (struct vo *vo)
     schedule_resize(wl, 0, wl->window.width, wl->window.height);
 }
 
-static void vo_wayland_fullscreen (struct vo *vo)
+static void vo_wayland_fullscreen(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wayland;
     if (!wl->display.shell)
@@ -1208,7 +1206,7 @@ static void vo_wayland_update_screeninfo(struct vo *vo, struct mp_rect *screenrc
     wl->window.fs_height = screenrc->y1;
 }
 
-int vo_wayland_control (struct vo *vo, int *events, int request, void *arg)
+int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
 {
     struct vo_wayland_state *wl = vo->wayland;
     wl_display_dispatch_pending(wl->display.display);
@@ -1263,7 +1261,7 @@ int vo_wayland_control (struct vo *vo, int *events, int request, void *arg)
     return VO_NOTIMPL;
 }
 
-bool vo_wayland_config (struct vo *vo)
+bool vo_wayland_config(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wayland;
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -53,14 +53,12 @@ typedef void (*vo_wayland_frame_cb)(void *data, uint32_t time);
 struct vo_wayland_state {
     struct vo *vo;
     struct mp_log* log;
+    int wakeup_pipe[2];
 
     struct {
         void *data;
         vo_wayland_frame_cb function;
         struct wl_callback *callback;
-        uint64_t last_us;
-        bool pending;
-        bool dropping;
     } frame;
 
 #if HAVE_GL_WAYLAND
@@ -150,8 +148,9 @@ int vo_wayland_init(struct vo *vo);
 void vo_wayland_uninit(struct vo *vo);
 bool vo_wayland_config(struct vo *vo);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
+void vo_wayland_wakeup(struct vo *vo);
+void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
 void vo_wayland_request_frame(struct vo *vo, void *data, vo_wayland_frame_cb cb);
-bool vo_wayland_wait_frame(struct vo *vo);
 
 #endif /* MPLAYER_WAYLAND_COMMON_H */
 


### PR DESCRIPTION
This also fixes the recent regression introduced which made the player believe it was meant to render when its callbacks weren't getting poked so it ended up dropping huge amount of frames to compensate once it was visible again.
