### PR TITLE
Wayland usability fixes

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -59,9 +59,7 @@ static void egl_resize(struct vo_wayland_state *wl)
     /* set size for mplayer */
     wl->vo->dwidth  = scale*wl->window.width;
     wl->vo->dheight = scale*wl->window.height;
-
     wl->vo->want_redraw = true;
-    wl->window.events = 0;
 }
 
 static int egl_create_context(struct vo_wayland_state *wl,

--- a/video/out/vo_wayland.c
+++ b/video/out/vo_wayland.c
@@ -314,7 +314,6 @@ static bool resize(struct priv *p)
 
     p->x = x;
     p->y = y;
-    p->wl->window.events = 0;
     p->vo->want_redraw = true;
     return true;
 }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -141,6 +141,9 @@ static void ssurface_handle_configure(void *data,
                                       int32_t height)
 {
     struct vo_wayland_state *wl = data;
+    float win_aspect = wl->window.aspect;
+    if (!wl->window.is_fullscreen)
+        width = win_aspect * height;
     schedule_resize(wl, edges, width, height);
 }
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -707,9 +707,7 @@ static void schedule_resize(struct vo_wayland_state *wl,
     wl->window.sh_height = height;
     wl->window.sh_x = x;
     wl->window.sh_y = y;
-    wl->window.events |= VO_EVENT_WIN_STATE | VO_EVENT_RESIZE;
-    wl->vo->dwidth = width;
-    wl->vo->dheight = height;
+    wl->window.events |= VO_EVENT_RESIZE;
 }
 
 static void frame_callback(void *data,
@@ -976,6 +974,8 @@ static void vo_wayland_fullscreen(struct vo *vo)
         wl->window.is_fullscreen = true;
         wl->window.p_width = wl->window.width;
         wl->window.p_height = wl->window.height;
+        schedule_resize(wl, 0, wl->display.current_output->width,
+                        wl->display.current_output->height);
         wl_shell_surface_set_fullscreen(wl->window.shell_surface,
                 WL_SHELL_SURFACE_FULLSCREEN_METHOD_DEFAULT,
                 0, fs_output);
@@ -1040,6 +1040,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
     switch (request) {
     case VOCTRL_CHECK_EVENTS:
         *events |= wl->window.events;
+        wl->window.events = 0;
         return VO_TRUE;
     case VOCTRL_FULLSCREEN:
         vo->opts->fullscreen = !vo->opts->fullscreen;


### PR DESCRIPTION
Fixes the 2 very annoying bugs when using the Wayland backend.
This basically brings feature/usability parity when using the wayland backend compared to the X11 backend.