### PR TITLE
ytdl: Error out with http_dash_segments

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -222,6 +222,10 @@ mp.add_hook("on_load", 10, function ()
 
             -- DASH?
             if not (json["requested_formats"] == nil) then
+                if (json["requested_formats"][1].protocol == "http_dash_segments") then
+                    msg.error("MPEG-Dash Segments unsupported, add [protocol!=http_dash_segments] to your ytdl-format.")
+                    return
+                end
 
                 -- video url
                 streamurl = json["requested_formats"][1].url


### PR DESCRIPTION
Unsupported for now.

Could probably be supported using huge EDL strings, but should be supported in ffmpeg instead(?)