### PR TITLE
vo_opengl: angle: new opengl flag to control DirectComposition

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -881,6 +881,16 @@ Available video output drivers are:
 
         Windows only.
 
+    ``dcomposition=<yes|no>``
+        Allows DirectComposition when using the ANGLE backend (default: yes).
+        DirectComposition implies flip-model presentation, which can improve
+        rendering efficiency on Windows 8+ by avoiding a copy of the video frame.
+        mpv uses it by default where possible, but it can cause poor behaviour
+        with some drivers, such as a black screen or graphical corruption when
+        leaving full-screen mode. Use "no" to disable it.
+
+        Windows with ANGLE only.
+
     ``sw``
         Continue even if a software renderer is detected.
 

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -32,6 +32,7 @@ enum {
     VOFLAG_GL_DEBUG     = 1 << 2,       // Hint to request debug OpenGL context
     VOFLAG_ALPHA        = 1 << 3,       // Hint to request alpha framebuffer
     VOFLAG_SW           = 1 << 4,       // Hint to accept a software GL renderer
+    VOFLAG_ANGLE_DCOMP  = 1 << 5,       // Whether DirectComposition is allowed
 };
 
 extern const int mpgl_preferred_gl_versions[];

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -306,8 +306,13 @@ static int angle_init(struct MPGLContext *ctx, int flags)
 
     // EGL_DIRECT_COMPOSITION_ANGLE enables the use of flip-mode present, which
     // avoids a copy of the video image and lowers vsync jitter, though the
-    // extension is only present on Windows 8 and up.
-    if (strstr(exts, "EGL_ANGLE_direct_composition")) {
+    // extension is only present on Windows 8 and up, and might have subpar
+    // behavior with some drivers (Intel? symptom - whole desktop is black for
+    // some seconds after spending some minutes in fullscreen and then leaving
+    // fullscreen).
+    if ((flags & VOFLAG_ANGLE_DCOMP) &&
+        strstr(exts, "EGL_ANGLE_direct_composition"))
+    {
         MP_TARRAY_APPEND(NULL, window_attribs, window_attribs_len,
             EGL_DIRECT_COMPOSITION_ANGLE);
         MP_TARRAY_APPEND(NULL, window_attribs, window_attribs_len, EGL_TRUE);

--- a/video/out/vo_opengl.c
+++ b/video/out/vo_opengl.c
@@ -70,6 +70,7 @@ struct gl_priv {
     int allow_sw;
     int swap_interval;
     int dwm_flush;
+    int allow_direct_composition;
     int opt_vsync_fences;
 
     char *backend;
@@ -409,6 +410,9 @@ static int preinit(struct vo *vo)
     if (p->allow_sw)
         vo_flags |= VOFLAG_SW;
 
+    if (p->allow_direct_composition)
+        vo_flags |= VOFLAG_ANGLE_DCOMP;
+
     p->glctx = mpgl_init(vo, p->backend, vo_flags);
     if (!p->glctx)
         goto err_out;
@@ -460,6 +464,7 @@ static const struct m_option options[] = {
     OPT_INT("swapinterval", swap_interval, 0, OPTDEF_INT(1)),
     OPT_CHOICE("dwmflush", dwm_flush, 0,
                ({"no", -1}, {"auto", 0}, {"windowed", 1}, {"yes", 2})),
+    OPT_FLAG("dcomposition", allow_direct_composition, 0, OPTDEF_INT(1)),
     OPT_FLAG("debug", use_gl_debug, 0),
     OPT_STRING_VALIDATE("backend", backend, 0, mpgl_validate_backend_opt),
     OPT_FLAG("sw", allow_sw, 0),


### PR DESCRIPTION
On some systems DirectComposition might be buggy. Add an opengl suboption
flag 'dcomposition' (default=yes) which allows disabling it.