### PR TITLE
add m4a to zsh completion filetype list

### DIFF
--- a/TOOLS/zsh.pl
+++ b/TOOLS/zsh.pl
@@ -142,7 +142,7 @@ $runtime_completions
     _tags files urls
     while _tags; do
       _requested files expl 'media file' _files -g \\
-        "*.(#i)(asf|asx|avi|f4v|flac|flv|m1v|m2p|m2v|m4v|mjpg|mka|mkv|mov|mp3|mp4|mpe|mpeg|mpg|ogg|ogm|ogv|opus|qt|rm|ts|vob|wav|webm|wma|wmv|wv)(-.)" && rc=0
+        "*.(#i)(asf|asx|avi|f4v|flac|flv|m1v|m2p|m2v|m4a|m4v|mjpg|mka|mkv|mov|mp3|mp4|mpe|mpeg|mpg|ogg|ogm|ogv|opus|qt|rm|ts|vob|wav|webm|wma|wmv|wv)(-.)" && rc=0
       if _requested urls; then
         while _next_label urls expl URL; do
           _urls "\$expl[@]" && rc=0


### PR DESCRIPTION
This relatively common filetype was missed, while other much more obscure ones are completed. This corrects the oversight.

I agree that my changes can be relicensed to whatever you like, incl. LGPL 2.1 or later.
