### PR TITLE
osc: Use Unicode minus for remaining playtime.

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1581,9 +1581,9 @@ function osc_init()
     ne.content = function ()
         if (state.rightTC_trem) then
             if state.tc_ms then
-                return ("-"..mp.get_property_osd("playtime-remaining/full"))
+                return ("\226\136\146"..mp.get_property_osd("playtime-remaining/full"))
             else
-                return ("-"..mp.get_property_osd("playtime-remaining"))
+                return ("\226\136\146"..mp.get_property_osd("playtime-remaining"))
             end
         else
             if state.tc_ms then


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.

Before:
![before](https://cloud.githubusercontent.com/assets/126009/18025433/4ef0edfc-6be6-11e6-80da-25339c342275.png)

After:
![after](https://cloud.githubusercontent.com/assets/126009/18025434/5976442a-6be6-11e6-94a5-d733c471ef75.png)
