### PR TITLE
vo: update w32_common left out by 4d75514

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1464,16 +1464,13 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 {
     switch (request) {
     case VOCTRL_FULLSCREEN:
-        w32->opts->fullscreen = !w32->opts->fullscreen;
         if (w32->opts->fullscreen != w32->current_fs)
             reinit_window_state(w32);
         return VO_TRUE;
     case VOCTRL_ONTOP:
-        w32->opts->ontop = !w32->opts->ontop;
         reinit_window_state(w32);
         return VO_TRUE;
     case VOCTRL_BORDER:
-        w32->opts->border = !w32->opts->border;
         reinit_window_state(w32);
         return VO_TRUE;
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {


### PR DESCRIPTION
4d75514 left me unable to toggle the fullscreen, border and ontop properties. This should fix it.

I agree that my changes can be relicensed to LGPL 2.1 or later.

