### PR TITLE
charset_conv: Use CP949 instead of EUC-KR

### DIFF
--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -291,6 +291,9 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
     if (strcasecmp(cp, "UTF-8-BROKEN") == 0)
         return bstr_sanitize_utf8_latin1(NULL, buf);
 
+    if (strcasecmp(cp, "EUC-KR") == 0)
+      cp = "CP949";
+
     iconv_t icdsc;
     if ((icdsc = iconv_open("UTF-8", cp)) == (iconv_t) (-1)) {
         if (flags & MP_ICONV_VERBOSE)

--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -291,6 +291,8 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
     if (strcasecmp(cp, "UTF-8-BROKEN") == 0)
         return bstr_sanitize_utf8_latin1(NULL, buf);
 
+    // Force CP949 over EUC-KR since iconv distinguishes them and
+    // EUC-KR causes error on CP949 encoded data
     if (strcasecmp(cp, "EUC-KR") == 0)
       cp = "CP949";
 


### PR DESCRIPTION
iconv distinguishes between euc-kr and cp949, while libguess
and libuchardet don't (only returns euc-kr). EILSEQ occurs
when the input encoding of iconv is set to euc-kr and if the subs
contain letters not included in euc-kr. Since cp949 is a extension
of euc-kr, choose cp949 instead.

Some more explanation:
If there are Korean characters such as 쨰, 슈, 뷁 (and many more) in the subtitles, mpv isn't able to show subtitles due to iconv error.

 EUC-KR charset can only express 2350 hangul letters, which is much less than 11,172 hangul letters used currently. So MS made an extension to EUC-KR called CP949  (a.k.a MS949, Unified Hangul Codeset), which can express about 8000 characters. Unfortunately CP949 is a charset that is still widely used and default in the Korean version of Microsoft Windows.

For Firefox, Chrome, MX player(android app), if you choose the encoding as Korean, it usually means cp949 rather than euc-kr. 

I also looked at some of the pull requests and PR #3207 is the same issue. But in my opinion it is not "Korean subtitles often include illegal sequences", but rather most Korean subtitles are just encoded in cp949.

