### PR TITLE
Add --watch-later-directory option.

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -381,6 +381,13 @@ Program Behavior
     This behavior is disabled by default, but is always available when quitting
     the player with Shift+Q.
 
+``--watch-later-directory=<path>``
+
+    The directory in which to store the "watch later" temporary files.
+
+    The default is a subdirectory named "watch_later" underneath the
+    config directory (usually ``~/.config/mpv/``).
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/options/options.c
+++ b/options/options.c
@@ -585,6 +585,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("save-position-on-quit", position_save_on_quit, 0),
     OPT_FLAG("write-filename-in-watch-later-config", write_filename_in_watch_later_config, 0),
     OPT_FLAG("ignore-path-in-watch-later-config", ignore_path_in_watch_later_config, 0),
+    OPT_STRING("watch-later-directory", watch_later_directory, 0),
 
     OPT_FLAG("ordered-chapters", ordered_chapters, 0),
     OPT_STRING("ordered-chapters-files", ordered_chapters_files, M_OPT_FILE),

--- a/options/options.h
+++ b/options/options.h
@@ -191,6 +191,7 @@ typedef struct MPOpts {
     int position_save_on_quit;
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
+    char *watch_later_directory;
     int pause;
     int keep_open;
     double image_display_duration;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -195,7 +195,6 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
         char *wl_dir = mpctx->opts->watch_later_directory;
         if (wl_dir && wl_dir[0]) {
             mpctx->cached_watch_later_configdir = mp_get_user_path(NULL, mpctx->global, wl_dir);
-            mp_mkdirp(mpctx->cached_watch_later_configdir);
         }
     }
 
@@ -321,7 +320,7 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
         goto exit;
     }
 
-    mp_mk_config_dir(mpctx->global, MP_WATCH_LATER_CONF);
+    mp_mk_config_dir(mpctx->global, mpctx->cached_watch_later_configdir);
 
     conffile = mp_get_playback_resume_config_filename(mpctx, cur->filename);
     if (!conffile)

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -192,6 +192,14 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
         conf = talloc_asprintf_append(conf, "%02X", md5[i]);
 
     if (!mpctx->cached_watch_later_configdir) {
+        char *wl_dir = mpctx->opts->watch_later_directory;
+        if (wl_dir && wl_dir[0]) {
+            mpctx->cached_watch_later_configdir = mp_get_user_path(NULL, mpctx->global, wl_dir);
+            mp_mkdirp(mpctx->cached_watch_later_configdir);
+        }
+    }
+
+    if (!mpctx->cached_watch_later_configdir) {
         mpctx->cached_watch_later_configdir =
             mp_find_user_config_file(mpctx, mpctx->global, MP_WATCH_LATER_CONF);
     }

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -320,11 +320,11 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
         goto exit;
     }
 
-    mp_mk_config_dir(mpctx->global, mpctx->cached_watch_later_configdir);
-
     conffile = mp_get_playback_resume_config_filename(mpctx, cur->filename);
     if (!conffile)
         goto exit;
+
+    mp_mk_config_dir(mpctx->global, mpctx->cached_watch_later_configdir);
 
     MP_INFO(mpctx, "Saving state.\n");
 


### PR DESCRIPTION
Like a lot of people, I keep my mpv config in my dotfiles repo. To avoid accidentally committing superfluous files, I've added an option which allows users to specify where to keep "watch later" files.

I agree that my changes can be relicensed to LGPL 2.1 or later.