### PR TITLE
hwdec_cuda: Add trivial cuda-copy wrapper

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -607,6 +607,7 @@ Video
     :mediacodec: copies video back to system RAM (Android only)
     :rpi:       requires ``--vo=rpi`` (Raspberry Pi only - default if available)
     :cuda:      requires ``--vo=opengl`` (Any platform CUDA is available)
+    :cuda-copy: copies video back to system RAM (Any platform CUDA is available)
 
     ``auto`` tries to automatically enable hardware decoding using the first
     available method. This still depends what VO you are using. For example,
@@ -678,10 +679,14 @@ Video
         affect this additionally. This can give incorrect results even with
         completely ordinary video sources.
 
-        ``cuda`` is usually safe. However, it will usually not fallback cleanly
-        for unsupported profiles of otherwise supported codecs - most obviously,
-        this is the case for 10bit H.264 content. 10bit HEVC is currently not
-        supported but we can add support after CUDA 8 is released.
+        ``cuda`` is usually safe. Interlaced content will be weaved by the
+        decoder, and it may not be possible for a deinterlacing filter to
+        do anything useful with this. 10bit HEVC is currently not
+        supported but maybe we can add support after CUDA 8 is released (and
+        it will be rounded down to 8 bits).
+
+	``cuda-copy`` has the same limitations as ``cuda`` - particularly
+	its handling of deinterlacing.
 
         All other methods, in particular the copy-back methods (like
         ``dxva2-copy`` etc.) are either fully safe, or not worse than software

--- a/options/options.c
+++ b/options/options.c
@@ -99,6 +99,7 @@ const struct m_opt_choice_alternatives mp_hwdec_names[] = {
     {"rpi",         HWDEC_RPI},
     {"mediacodec",  HWDEC_MEDIACODEC},
     {"cuda",        HWDEC_CUDA},
+    {"cuda-copy",   HWDEC_CUDA_COPY},
     {0}
 };
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -151,6 +151,14 @@ static const struct vd_lavc_hwdec mp_vd_lavc_mediacodec = {
 };
 #endif
 
+#if HAVE_CUDA_GL
+static const struct vd_lavc_hwdec mp_vd_lavc_cuda_copy = {
+    .type = HWDEC_CUDA_COPY,
+    .lavc_suffix = "_cuvid",
+    .copying = true,
+};
+#endif
+
 static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #if HAVE_RPI
     &mp_vd_lavc_rpi,
@@ -177,6 +185,7 @@ static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #endif
 #if HAVE_CUDA_GL
     &mp_vd_lavc_cuda,
+    &mp_vd_lavc_cuda_copy,
 #endif
     NULL
 };

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -22,6 +22,7 @@ enum hwdec_type {
     HWDEC_RPI,
     HWDEC_MEDIACODEC,
     HWDEC_CUDA,
+    HWDEC_CUDA_COPY,
 };
 
 #define HWDEC_IS_AUTO(x) ((x) == HWDEC_AUTO || (x) == HWDEC_AUTO_COPY)


### PR DESCRIPTION
The cuvid decoder already knows how to copy back to system memory
if NV12 frames are requested, and this will happen if the decoder
is used without the hwdec.

For convenience, let's add a wrapper hwdec so people don't have
to explicitly pick the cuvid decoder if they want this behaviour.