### PR TITLE
Don't miss property changes after the property is updated

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -1373,11 +1373,9 @@ int mpv_unobserve_property(mpv_handle *ctx, uint64_t userdata)
 static void mark_property_changed(struct mpv_handle *client, int index)
 {
     struct observe_property *prop = client->properties[index];
-    if (!prop->changed && !prop->need_new_value) {
-        prop->changed = true;
-        prop->need_new_value = prop->format != 0;
-        client->lowest_changed = MPMIN(client->lowest_changed, index);
-    }
+    prop->changed = true;
+    prop->need_new_value = prop->format != 0;
+    client->lowest_changed = MPMIN(client->lowest_changed, index);
 }
 
 // Broadcast that a property has changed.


### PR DESCRIPTION
I had another look at this and I think the changes are correct, whereas with the old code, there was always the possibility of missing property change events that should have been generated.