### PR TITLE
ytdl_hook: Support playlist entries without subtitles

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -180,11 +180,25 @@ mp.add_hook("on_load", 10, function ()
                         json.title)
                 end
 
-                if not (json.entries[1].requested_subtitles == nil) then
-                    for j, req in pairs(json.entries[1].requested_subtitles) do
+                -- there might not be subs for the first segment
+                local entry_wsubs = nil
+                for i, entry in pairs(json.entries) do
+                    if not (entry.requested_subtitles == nil) then
+                        entry_wsubs = i
+                        break
+                    end
+                end
+
+                if not (entry_wsubs == nil) then
+                    for j, req in pairs(json.entries[entry_wsubs].requested_subtitles) do
                         local subfile = "edl://"
                         for i, entry in pairs(json.entries) do
-                            subfile = subfile..edl_escape(entry.requested_subtitles[j].url)
+                            if not (entry.requested_subtitles == nil) and
+                                not (entry.requested_subtitles[j] == nil) then
+                                subfile = subfile..edl_escape(entry.requested_subtitles[j].url)
+                            else
+                                subfile = subfile..edl_escape("memory://WEBVTT")
+                            end
                             if not (entry.duration == nil) then
                                 subfile = subfile..",start=0,length="..entry.duration
                             end

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -189,7 +189,8 @@ mp.add_hook("on_load", 10, function ()
                     end
                 end
 
-                if not (entry_wsubs == nil) then
+                if not (entry_wsubs == nil) and
+                    not (json.entries[entry_wsubs].duration == nil) then
                     for j, req in pairs(json.entries[entry_wsubs].requested_subtitles) do
                         local subfile = "edl://"
                         for i, entry in pairs(json.entries) do
@@ -199,10 +200,7 @@ mp.add_hook("on_load", 10, function ()
                             else
                                 subfile = subfile..edl_escape("memory://WEBVTT")
                             end
-                            if not (entry.duration == nil) then
-                                subfile = subfile..",start=0,length="..entry.duration
-                            end
-                            subfile = subfile .. ";"
+                            subfile = subfile..",start=0,length="..entry.duration..";"
                         end
                         msg.debug(j.." sub EDL: "..subfile)
                         mp.commandv("sub-add", subfile, "auto", req.ext, j)


### PR DESCRIPTION
Fixes missing subtitle tracks if the first entry didn't have any.

Previously it just checked for the first entry in the playlist for
requested languages and if that entry happened to not have subtitles
they also wouldn't show up for the other entries.

It will skip languages if the first entry with subs has less or
different languages than the others.

Unrelated to http_dash_segments.

@ChrisK2 