### PR TITLE
Improve interactive sub-speed option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,7 @@ Interface changes
 ::
 
  --- mpv 0.21.0 ---
+    - implement changing sub-speed during playback
     - deprecate _all_ --vo and --ao suboptions. Generally, all suboptions are
       replaced by global options, which do exactly the same. For example,
       "--vo=opengl:scale=nearest" turns into "--scale=nearest". In some cases,

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -85,6 +85,8 @@
 #I show-text "${filename}"              # display filename in osd
 #z add sub-delay -0.1                   # subtract 100 ms delay from subs
 #x add sub-delay +0.1                   # add
+#Z add sub-speed -0.001                 # subtract 0.1% from sub speed
+#X add sub-speed +0.001                 # add
 #ctrl++ add audio-delay 0.100           # this changes audio/video sync
 #ctrl+- add audio-delay -0.100
 #9 add volume -2

--- a/player/command.c
+++ b/player/command.c
@@ -2958,6 +2958,9 @@ static int mp_property_sub_speed(void *ctx, struct m_property *prop,
         }
         return M_PROPERTY_OK;
     }
+    case M_PROPERTY_PRINT:
+        *(char **)arg = talloc_asprintf(NULL, "%4.1f%%", 100 * opts->sub_speed);
+        return M_PROPERTY_OK;
     }
     return property_osd_helper(mpctx, prop, action, arg);
 }
@@ -4174,6 +4177,7 @@ static const struct property_osd_display {
     { "secondary-sid", "Secondary subtitles" },
     { "sub-pos", "Sub position" },
     { "sub-delay", "Sub delay" },
+    { "sub-speed", "Sub speed" },
     { "sub-visibility", .msg = "Subtitles ${!sub-visibility==yes:hidden}"
         "${?sub-visibility==yes:visible${?sub==no: (but no subtitles selected)}}" },
     { "sub-forced-only", "Forced sub only" },

--- a/player/command.c
+++ b/player/command.c
@@ -2942,6 +2942,26 @@ static int mp_property_sub_delay(void *ctx, struct m_property *prop,
     return property_osd_helper(mpctx, prop, action, arg);
 }
 
+/// Subtitle speed (RW)
+static int mp_property_sub_speed(void *ctx, struct m_property *prop,
+                                 int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    struct MPOpts *opts = mpctx->opts;
+    switch (action) {
+    case M_PROPERTY_SET: {
+        opts->sub_speed = *(float *)arg;
+        struct track *track = mpctx->current_track[0][STREAM_SUB];
+        struct dec_sub *sub = track ? track->d_sub : NULL;
+        if (sub) {
+            sub_control(track->d_sub, SD_CTRL_UPDATE_SPEED, NULL);
+        }
+        return M_PROPERTY_OK;
+    }
+    }
+    return property_osd_helper(mpctx, prop, action, arg);
+}
+
 static int mp_property_sub_pos(void *ctx, struct m_property *prop,
                                int action, void *arg)
 {
@@ -3836,6 +3856,7 @@ static const struct m_property mp_properties_base[] = {
     {"sid", mp_property_sub},
     {"secondary-sid", mp_property_sub2},
     {"sub-delay", mp_property_sub_delay},
+    {"sub-speed", mp_property_sub_speed},
     {"sub-pos", mp_property_sub_pos},
     {"sub-text", mp_property_sub_text},
     {"sub-visibility", property_osd_helper},

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -233,6 +233,7 @@ static const char *const backup_properties[] = {
     "options/vid",
     "options/sid",
     "options/sub-delay",
+    "options/sub-speed",
     "options/sub-pos",
     "options/sub-visibility",
     "options/sub-scale",

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -19,6 +19,7 @@ enum sd_ctrl {
     SD_CTRL_GET_RESOLUTION,
     SD_CTRL_SET_TOP,
     SD_CTRL_SET_VIDEO_DEF_FPS,
+    SD_CTRL_UPDATE_SPEED,
 };
 
 struct attachment_list {

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -671,6 +671,9 @@ static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
         ctx->video_fps = *(double *)arg;
         update_subtitle_speed(sd);
         return CONTROL_OK;
+    case SD_CTRL_UPDATE_SPEED:
+        update_subtitle_speed(sd);
+        return CONTROL_OK;
     default:
         return CONTROL_UNKNOWN;
     }


### PR DESCRIPTION
- Apply new sub-speed values during playback
- Improve OSD formatting
- Add default keybindings (Z/X, to complement z/x for sub-delay)
- Save sub-speed value when resuming playback

I agree that my changes can be relicensed to LGPL 2.1 or later.

#3516