### PR TITLE
vo_opengl: fix typo in bt.601 auto-guessing logic

### DIFF
--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2138,7 +2138,7 @@ static void pass_colormanage(struct gl_video *p, struct mp_colorspace src, bool 
             // combined with the fact that they're very similar to begin with,
             // and to avoid confusing the average user, just don't adapt BT.601
             // content automatically at all.
-            dst.primaries = ref.gamma;
+            dst.primaries = ref.primaries;
         }
     }
 


### PR DESCRIPTION
The wrong enum got copied here, so it was essentially using the transfer
characteristics as the primaries (instead of the primaries), which
accidentally worked fine most of the time (since the two usually
coincided), but broke on weird/mistagged files.