### PR TITLE
DVB core updated:

### DIFF
--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -1,6 +1,7 @@
 /* dvbtune - tune.c
 
    Copyright (C) Dave Chapman 2001,2002
+   Copyright (C) Rozhuk Ivan <rozhuk.im@gmail.com> 2016
 
    Modified for use with MPlayer, for details see the changelog at
    http://svn.mplayerhq.hu/mplayer/trunk/
@@ -40,6 +41,37 @@
 #include "dvb_tune.h"
 #include "common/msg.h"
 
+/* Keep in sync with enum fe_delivery_system. */
+static const char *dvb_delsys_str[] = {
+    "UNDEFINED",
+    "DVB-C ANNEX_A",
+    "DVB-C ANNEX_B",
+    "DVB-T",
+    "DSS",
+    "DVB-S",
+    "DVB-S2",
+    "DVB-H",
+    "ISDBT",
+    "ISDBS",
+    "ISDBC",
+    "ATSC",
+    "ATSCMH",
+    "DTMB",
+    "CMMB",
+    "DAB",
+    "DVB-T2",
+    "TURBO",
+    "DVB-C ANNEX_C",
+    NULL
+};
+
+const char *get_dvb_delsys(unsigned int delsys)
+{
+    if (SYS_DVBC_ANNEX_C < delsys)
+        return dvb_delsys_str[0];
+    return dvb_delsys_str[delsys];
+}
+
 int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
 {
 #ifdef DVB_USE_S2API
@@ -63,39 +95,26 @@ int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
     int supported_tuners = 0;
     for(;p[0].u.buffer.len > 0; p[0].u.buffer.len--) {
       fe_delivery_system_t delsys = p[0].u.buffer.data[p[0].u.buffer.len - 1];
-      /* Second level standards like like DVB-T2, DVB-S2 not treated here -
-         Cards can usually either only do S/T/C or both levels.
-         DVB-T2 probably needs more implementation details,
-         DVB-S2 is treated in the DVB-S branch already. */
       switch (delsys) {
       case SYS_DVBT:
-        mp_verbose(log, "Tuner type seems to be DVB-T\n");
-        (*tuner_types)[supported_tuners++] = TUNER_TER;
-        break;
       case SYS_DVBC_ANNEX_AC:
-        mp_verbose(log, "Tuner type seems to be DVB-C\n");
-        (*tuner_types)[supported_tuners++] = TUNER_CBL;
-        break;
       case SYS_DVBS:
-        mp_verbose(log, "Tuner type seems to be DVB-S\n");
-        (*tuner_types)[supported_tuners++] = TUNER_SAT;
-        break;
 #ifdef DVB_ATSC
       case SYS_ATSC:
-        mp_verbose(log, "Tuner type seems to be DVB-ATSC\n");
-        (*tuner_types)[supported_tuners++] = TUNER_ATSC;
-        break;
 #endif
       case SYS_DVBS2:
-        // We actually handle that in the DVB-S branch, ok to ignore here.
-        mp_verbose(log, "Tuner supports DVB-S2\n");
+      case SYS_DVBT2:
         break;
       default:
-        mp_err(log, "Unhandled tuner type: %d\n", delsys);
+        mp_err(log, "Unhandled tuner type: %s - %d\n", get_dvb_delsys(delsys), delsys);
+        continue;
       }
+      mp_verbose(log, "Tuner type seems to be %s\n", get_dvb_delsys(delsys));
+      (*tuner_types)[supported_tuners++] = delsys;
     }
     return supported_tuners;
 #else
+    int delsys;
     struct dvb_frontend_info fe_info;
     int res = ioctl(fe_fd, FE_GET_INFO, &fe_info);
     if (res < 0) {
@@ -107,31 +126,29 @@ int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types)
                fe_info.name, fe_fd);
     switch (fe_info.type) {
     case FE_OFDM:
-        mp_verbose(log, "Tuner type seems to be DVB-T\n");
-        *tuner_types = talloc_array(NULL, int, 1);
-        (*tuner_types)[0] = TUNER_TER;
-        return 1;
+        delsys = SYS_DVBT;
+        break;
     case FE_QPSK:
-        mp_verbose(log, "Tuner type seems to be DVB-S\n");
-        *tuner_types = talloc_array(NULL, int, 1);
-        (*tuner_types)[0] = TUNER_SAT;
-        return 1;
+        delsys = SYS_DVBS;
+        break;
     case FE_QAM:
-        mp_verbose(log, "Tuner type seems to be DVB-C\n");
-        *tuner_types = talloc_array(NULL, int, 1);
-        (*tuner_types)[0] = TUNER_CBL;
-        return 1;
+        delsys = SYS_DVBC_ANNEX_AC;
+        break;
 #ifdef DVB_ATSC
     case FE_ATSC:
-        mp_verbose(log, "Tuner type seems to be DVB-ATSC\n");
-        *tuner_types = talloc_array(NULL, int, 1);
-        (*tuner_types)[0] = TUNER_ATSC;
-        return 1;
+        delsys = SYS_ATSC;
+        break;
 #endif
     default:
         mp_err(log, "Unknown tuner type: %d\n", fe_info.type);
         return 0;
     }
+
+    mp_verbose(log, "Tuner type seems to be %s\n", get_dvb_delsys(delsys));
+    *tuner_types = talloc_array(NULL, int, 1);
+    (*tuner_types)[0] = delsys;
+
+    return 1;
 #endif
 }
 
@@ -164,7 +181,6 @@ int dvb_open_devices(dvb_priv_t *priv, int n, int demux_cnt)
             state->demux_fds_cnt++;
         }
     }
-
 
     state->dvr_fd = open(dvr_dev, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
     if (state->dvr_fd < 0) {
@@ -220,7 +236,7 @@ int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid,
     pesFilterParams.flags   = DMX_IMMEDIATE_START;
 
     {
-        int buffersize = 64 * 1024;
+        int buffersize = 256 * 1024;
         if (ioctl(fd, DMX_SET_BUFFER_SIZE, buffersize) < 0)
             MP_ERR(priv, "ERROR IN DMX_SET_BUFFER_SIZE %i for fd %d: ERRNO: %d\n",
                    pid, fd, errno);
@@ -436,8 +452,8 @@ static int do_diseqc(int secfd, int sat_no, int polv, int hi_lo)
 }
 
 static int tune_it(dvb_priv_t *priv, int fd_frontend,
-                   unsigned int freq, unsigned int srate, char pol, int tone,
-                   bool is_dvb_s2, int stream_id,
+                   unsigned int freq, unsigned int srate, char pol,
+                   int tone, int stream_id,
                    fe_spectral_inversion_t specInv, unsigned int diseqc,
                    fe_modulation_t modulation,
                    fe_code_rate_t HP_CodeRate,
@@ -447,18 +463,14 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend,
                    fe_code_rate_t LP_CodeRate, fe_hierarchy_t hier,
                    int timeout)
 {
-    int hi_lo = 0, dfd;
-
+    int hi_lo = 0, bandwidth_hz = 0;
     dvb_state_t* state = priv->state;
 
-    struct dvb_frontend_parameters feparams;
 
     MP_VERBOSE(priv, "TUNE_IT, fd_frontend %d, freq %lu, srate %lu, "
                "pol %c, tone %i, diseqc %u\n", fd_frontend,
                (long unsigned int)freq, (long unsigned int)srate, pol,
                tone, diseqc);
-
-    memset(&feparams, 0, sizeof(feparams));
 
     MP_VERBOSE(priv, "Using DVB card \"%s\"\n", state->cards[state->card].name);
 
@@ -471,53 +483,70 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend,
         }
     }
 
-    switch (state->tuner_type) {
-    case TUNER_TER: {
+   /* Prepare params, be verbose. */
+   switch (state->tuner_type) {
+    case SYS_DVBT2:
+#ifndef DVB_USE_S2API
+        MP_ERR(priv, "ERROR: Can not tune to T2 channel, S2-API not "
+                     "available, will tune to DVB-T!\n");
+#endif
+	/* PASSTROUTH. */
+    case SYS_DVBT:
         if (freq < 1000000)
             freq *= 1000UL;
-        feparams.frequency = freq;
-        feparams.inversion = specInv;
-        feparams.u.ofdm.bandwidth = bandwidth;
-        feparams.u.ofdm.code_rate_HP = HP_CodeRate;
-        feparams.u.ofdm.code_rate_LP = LP_CodeRate;
-        feparams.u.ofdm.constellation = modulation;
-        feparams.u.ofdm.transmission_mode = TransmissionMode;
-        feparams.u.ofdm.guard_interval = guardInterval;
-        feparams.u.ofdm.hierarchy_information = hier;
-        MP_VERBOSE(priv, "tuning DVB-T to %d Hz, bandwidth: %d\n",
-                   freq, bandwidth);
-        if (ioctl(fd_frontend, FE_SET_FRONTEND, &feparams) < 0) {
-            MP_ERR(priv, "ERROR tuning channel\n");
-            return -1;
+        switch (bandwidth) {
+        case BANDWIDTH_5_MHZ:
+            bandwidth_hz = 5000000;
+            break;
+        case BANDWIDTH_6_MHZ:
+            bandwidth_hz = 6000000;
+            break;
+        case BANDWIDTH_7_MHZ:
+            bandwidth_hz = 7000000;
+            break;
+        case BANDWIDTH_8_MHZ:
+            bandwidth_hz = 8000000;
+            break;
+        case BANDWIDTH_10_MHZ:
+            bandwidth_hz = 10000000;
+            break;
+        case BANDWIDTH_AUTO:
+            if (freq < 474000000) {
+                bandwidth_hz = 7000000;
+            } else {
+                bandwidth_hz = 8000000;
+            }
+            break;
+        default:
+            bandwidth_hz = 0;
+            break;
         }
-    }
-    break;
-    case TUNER_SAT: {
-        // DVB-S
+
+        MP_VERBOSE(priv, "tuning %s to %d Hz, bandwidth: %d\n",
+                   get_dvb_delsys(state->tuner_type), freq, bandwidth_hz);
+        break;
+    case SYS_DVBS2:
+#ifndef DVB_USE_S2API
+        MP_ERR(priv, "ERROR: Can not tune to S2 channel, S2-API not "
+                     "available, will tune to DVB-S!\n");
+#endif
+	/* PASSTROUTH. */
+    case SYS_DVBS:
         if (freq > 2200000) {
             // this must be an absolute frequency
             if (freq < SLOF) {
-                freq = feparams.frequency = (freq - LOF1);
+                freq -= LOF1;
                 hi_lo = 0;
             } else {
-                freq = feparams.frequency = (freq - LOF2);
+                freq -= LOF2;
                 hi_lo = 1;
             }
-        } else {
-            // this is an L-Band frequency
-            feparams.frequency = freq;
         }
-
-        feparams.inversion = specInv;
-        feparams.u.qpsk.symbol_rate = srate;
-        feparams.u.qpsk.fec_inner = HP_CodeRate;
-        dfd = fd_frontend;
-
-        MP_VERBOSE(priv, "tuning DVB-S%sto Freq: %u, Pol: %c Srate: %d, "
-                   "22kHz: %s, LNB:  %d\n", is_dvb_s2 ? "2 " : " ", freq,
+        MP_VERBOSE(priv, "tuning %s to Freq: %u, Pol: %c Srate: %d, "
+                   "22kHz: %s, LNB:  %d\n", get_dvb_delsys(state->tuner_type), freq,
                    pol, srate, hi_lo ? "on" : "off", diseqc);
 
-        if (do_diseqc(dfd, diseqc, (pol == 'V' ? 1 : 0), hi_lo) == 0) {
+        if (do_diseqc(fd_frontend, diseqc, (pol == 'V' ? 1 : 0), hi_lo) == 0) {
             MP_VERBOSE(priv, "DISEQC setting succeeded\n");
         } else {
             MP_ERR(priv, "DISEQC setting failed\n");
@@ -525,25 +554,53 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend,
         }
         usleep(100000);
 
+        break;
+    case SYS_DVBC_ANNEX_AC:
+        MP_VERBOSE(priv, "tuning %s to %d, srate=%d\n",
+                   get_dvb_delsys(state->tuner_type), freq, srate);
+        break;
+#ifdef DVB_ATSC
+    case SYS_ATSC:
+        MP_VERBOSE(priv, "tuning %s to %d, modulation=%d\n",
+                   get_dvb_delsys(state->tuner_type), freq, modulation);
+        break;
+#endif
+    default:
+        MP_VERBOSE(priv, "Unknown FE type. Aborting\n");
+        return 0;
+    }
+
 #ifdef DVB_USE_S2API
         /* S2API is the DVB API new since 2.6.28.
          * It is needed to tune to new delivery systems, e.g. DVB-S2.
          * It takes a struct with a list of pairs of command + parameter.
          */
 
-        fe_delivery_system_t delsys = SYS_DVBS;
-        if (is_dvb_s2)
-            delsys = SYS_DVBS2;
-        fe_rolloff_t rolloff = ROLLOFF_AUTO;
+        /* Reset before tune. */
+        struct dtv_property p_clear[] = {
+            { .cmd = DTV_CLEAR },
+        };
 
+        struct dtv_properties cmdseq_clear = {
+            .num = 1,
+            .props = p_clear
+        };
+
+        if ((ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq_clear)) == -1) {
+            MP_ERR(priv, "FE_SET_PROPERTY DTV_CLEAR failed\n");
+            return -1;
+        }
+
+        /* Tune. */
         struct dtv_property p[] = {
-            { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
+            { .cmd = DTV_DELIVERY_SYSTEM, .u.data = state->tuner_type },
             { .cmd = DTV_FREQUENCY, .u.data = freq },
             { .cmd = DTV_MODULATION, .u.data = modulation },
             { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
             { .cmd = DTV_INNER_FEC, .u.data = HP_CodeRate },
             { .cmd = DTV_INVERSION, .u.data = specInv },
-            { .cmd = DTV_ROLLOFF, .u.data = rolloff },
+            { .cmd = DTV_ROLLOFF, .u.data = ROLLOFF_AUTO },
+            { .cmd = DTV_BANDWIDTH_HZ, .u.data = bandwidth_hz },
             { .cmd = DTV_PILOT, .u.data = PILOT_AUTO },
             { .cmd = DTV_STREAM_ID, .u.data = stream_id },
             { .cmd = DTV_TUNE },
@@ -552,88 +609,64 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend,
             .num = sizeof(p) / sizeof(p[0]),
             .props = p
         };
-        MP_VERBOSE(priv, "Tuning via S2API, channel is DVB-S%s.\n",
-                   is_dvb_s2 ? "2" : "");
+        MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
+                   get_dvb_delsys(state->tuner_type));
         if ((ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq)) == -1) {
             MP_ERR(priv, "ERROR tuning channel\n");
             return -1;
         }
 #else
-        MP_VERBOSE(priv, "Tuning via DVB-API version 3.\n");
-        if (is_dvb_s2) {
-            MP_ERR(priv, "ERROR: Can not tune to S2 channel, S2-API not "
-                         "available, will tune to DVB-S!\n");
-        }
-        if (ioctl(fd_frontend, FE_SET_FRONTEND, &feparams) < 0) {
-            MP_ERR(priv, "ERROR tuning channel\n");
-            return -1;
-        }
-#endif
-    }
-    break;
-    case TUNER_CBL: {
-#ifdef DVB_USE_S2API
-        /* S2API is the DVB API new since 2.6.28.
-         * It is also needed for devices supporting multiple delivery systems,
-         * commonly DVB-C + DVB-T are supported here.
-         */
-        fe_delivery_system_t delsys = SYS_DVBC_ANNEX_AC;
-        struct dtv_property p[] = {
-            { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
-            { .cmd = DTV_FREQUENCY, .u.data = freq },
-            { .cmd = DTV_INVERSION, .u.data = specInv },
-            { .cmd = DTV_MODULATION, .u.data = modulation },
-            { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
-            { .cmd = DTV_INNER_FEC, .u.data = HP_CodeRate },
-            { .cmd = DTV_TUNE },
-        };
-        struct dtv_properties cmdseq = {
-            .num = sizeof(p) / sizeof(p[0]),
-            .props = p
-        };
-        MP_VERBOSE(priv, "tuning DVB-C to %d, srate=%d using DVBv5 API...\n",
-                   freq, srate);
-        if ((ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq)) == -1) {
-            MP_ERR(priv, "ERROR tuning channel\n");
-            return -1;
-        }
-#else
-        feparams.frequency = freq;
+    struct dvb_frontend_parameters feparams;
+
+    memset(&feparams, 0, sizeof(feparams));
+    feparams.frequency = freq;
+
+    MP_VERBOSE(priv, "Tuning via DVB-API version 3.\n");
+
+    switch (state->tuner_type) {
+    case SYS_DVBT:
+    case SYS_DVBT2:
+        feparams.inversion = specInv;
+        feparams.u.ofdm.bandwidth = bandwidth;
+        feparams.u.ofdm.code_rate_HP = HP_CodeRate;
+        feparams.u.ofdm.code_rate_LP = LP_CodeRate;
+        feparams.u.ofdm.constellation = modulation;
+        feparams.u.ofdm.transmission_mode = TransmissionMode;
+        feparams.u.ofdm.guard_interval = guardInterval;
+        feparams.u.ofdm.hierarchy_information = hier;
+        break;
+    case SYS_DVBS:
+    case SYS_DVBS2:
+        feparams.inversion = specInv;
+        feparams.u.qpsk.symbol_rate = srate;
+        feparams.u.qpsk.fec_inner = HP_CodeRate;
+        break;
+    case SYS_DVBC_ANNEX_AC: {
         feparams.inversion = specInv;
         feparams.u.qam.symbol_rate = srate;
         feparams.u.qam.fec_inner = HP_CodeRate;
         feparams.u.qam.modulation = modulation;
-        MP_VERBOSE(priv, "tuning DVB-C to %d, srate=%d\n", freq, srate);
-        if (ioctl(fd_frontend, FE_SET_FRONTEND, &feparams) < 0) {
-            MP_ERR(priv, "ERROR tuning channel\n");
-            return -1;
-        }
-#endif
     }
     break;
 #ifdef DVB_ATSC
-    case TUNER_ATSC: {
-        feparams.frequency = freq;
+    case SYS_ATSC:
         feparams.u.vsb.modulation = modulation;
-        MP_VERBOSE(priv, "tuning ATSC to %d, modulation=%d\n", freq, modulation);
-        if (ioctl(fd_frontend, FE_SET_FRONTEND, &feparams) < 0) {
-            MP_ERR(priv, "ERROR tuning channel\n");
-            return -1;
-        }
-    }
-    break;
+        break;
 #endif
-    default:
-        MP_VERBOSE(priv, "Unknown FE type. Aborting\n");
-        return 0;
     }
+
+    if (ioctl(fd_frontend, FE_SET_FRONTEND, &feparams) < 0) {
+        MP_ERR(priv, "ERROR tuning channel\n");
+        return -1;
+    }
+#endif
 
     return check_status(priv, fd_frontend, timeout);
 }
 
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
              int tone,
-             bool is_dvb_s2, int stream_id, fe_spectral_inversion_t specInv,
+             int stream_id, fe_spectral_inversion_t specInv,
              fe_modulation_t modulation, fe_guard_interval_t guardInterval,
              fe_transmit_mode_t TransmissionMode, fe_bandwidth_t bandWidth,
              fe_code_rate_t HP_CodeRate,
@@ -645,7 +678,7 @@ int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
     dvb_state_t* state = priv->state;
 
     int ris = tune_it(priv, state->fe_fd, freq, srate, pol, tone,
-                      is_dvb_s2, stream_id, specInv, diseqc, modulation,
+                      stream_id, specInv, diseqc, modulation,
                       HP_CodeRate, TransmissionMode, guardInterval,
                       bandWidth, LP_CodeRate, hier, timeout);
 

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -23,6 +23,7 @@
 
 struct mp_log;
 
+const char *get_dvb_delsys(fe_delivery_system_t delsys);
 int dvb_get_tuner_types(int fe_fd, struct mp_log *log, int** tuner_types);
 int dvb_open_devices(dvb_priv_t *priv, int n, int demux_cnt);
 int dvb_fix_demuxes(dvb_priv_t *priv, int cnt);
@@ -31,7 +32,7 @@ int dvb_get_pmt_pid(dvb_priv_t *priv, int card, int service_id);
 int dvb_demux_stop(int fd);
 int dvb_demux_start(int fd);
 int dvb_tune(dvb_priv_t *priv, int freq, char pol, int srate, int diseqc,
-             int tone, bool is_dvb_s2, int stream_id, fe_spectral_inversion_t specInv,
+             int tone, int stream_id, fe_spectral_inversion_t specInv,
              fe_modulation_t modulation, fe_guard_interval_t guardInterval,
              fe_transmit_mode_t TransmissionMode, fe_bandwidth_t bandWidth,
              fe_code_rate_t HP_CodeRate, fe_code_rate_t LP_CodeRate,

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -122,13 +122,15 @@ typedef struct {
 } dvb_priv_t;
 
 
+/* Keep in sync with enum fe_delivery_system. */
 #ifndef DVB_USE_S2API
-#    define SYS_DVBT                0
-#    define SYS_DVBT2               1
-#    define SYS_DVBC_ANNEX_AC       2
-#    define SYS_DVBS                3
-#    define SYS_DVBS2               4
-#    define SYS_ATSC                5
+#    define SYS_DVBC_ANNEX_AC       1
+#    define SYS_DVBT                3
+#    define SYS_DVBS                5
+#    define SYS_DVBS2               6
+#    define SYS_ATSC                11
+#    define SYS_DVBT2               16
+#    define SYS_DVBC_ANNEX_C        18
 #endif
 
 int dvb_step_channel(stream_t *, int);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -65,7 +65,6 @@ typedef struct {
     int freq, srate, diseqc, tone;
     char pol;
     int tpid, dpid1, dpid2, progid, ca, pids[DMX_FILTER_SIZE], pids_cnt;
-    bool is_dvb_s2;
     int stream_id;
     int service_id;
     fe_spectral_inversion_t inv;
@@ -109,7 +108,7 @@ typedef struct {
     bool stream_used;
 } dvb_state_t;
 
-typedef struct dvb_params {
+typedef struct {
     struct mp_log *log;
 
     dvb_state_t *state;
@@ -122,10 +121,15 @@ typedef struct dvb_params {
     int cfg_full_transponder;
 } dvb_priv_t;
 
-#define TUNER_SAT       1
-#define TUNER_TER       2
-#define TUNER_CBL       3
-#define TUNER_ATSC      4
+
+#ifndef DVB_USE_S2API
+#    define SYS_DVBT                0
+#    define SYS_DVBT2               1
+#    define SYS_DVBC_ANNEX_AC       2
+#    define SYS_DVBS                3
+#    define SYS_DVBS2               4
+#    define SYS_ATSC                5
+#endif
 
 int dvb_step_channel(stream_t *, int);
 int dvb_set_channel(stream_t *, int, int);


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.

+ add support DVB-T2
+ channels.conf.ter2 used for DVB-T2 channels
* channels.conf.sat2 used for DVB-S2 channels
* DVB params set to AUTO by default
* MAX_CARDS: 4 -> 16
* DMX_SET_BUFFER_SIZE: 64kb -> 256kb
+ add DTV_CLEAR call before tune
* many small changes

Tested S2API with DVB-T2 on FreeBSD 11.