### PR TITLE
stream/stream_lavf: user-agent option is deprecated

### DIFF
--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -182,7 +182,7 @@ void mp_setup_av_network_options(AVDictionary **dict, struct mpv_global *global,
 
     // HTTP specific options (other protocols ignore them)
     if (opts->useragent)
-        av_dict_set(dict, "user-agent", opts->useragent, 0);
+        av_dict_set(dict, "user_agent", opts->useragent, 0);
     if (opts->cookies_enabled) {
         char *file = opts->cookies_file;
         if (file && file[0])


### PR DESCRIPTION
There was both user-agent and user_agent options, the former is deprecated in FFmpeg/FFmpeg@27714b462 master.
Libav uses both forms.

This avoids constant `[ffmpeg] http: the user-agent option is deprecated, please use user_agent option` warnings using ytdl_hook.