### PR TITLE
af_rubberband: default to channels=together

### DIFF
--- a/audio/filter/af_rubberband.c
+++ b/audio/filter/af_rubberband.c
@@ -190,6 +190,7 @@ const struct af_info af_info_rubberband = {
         .opt_pitch = RubberBandOptionPitchHighConsistency,
         .opt_transients = RubberBandOptionTransientsMixed,
         .opt_formant = RubberBandOptionFormantPreserved,
+        .opt_channels = RubberBandOptionChannelsTogether,
     },
     .options = (const struct m_option[]) {
         OPT_CHOICE("transients", opt_transients, 0,


### PR DESCRIPTION
For stereo and typical L/R-first channel arrangements, this avoids
undesirable phasing artifacts, especially obvious when speed is changed
and then reset. Without this, there is a very audible change in the
stereo field even when librubberband is no longer actually making any
speed changes.

I actually think there is still a minor change in audio quality after changing and resetting speed, but it's a lot less noticeable than previously.