### PR TITLE
player: add NUMA-awareness options

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4626,6 +4626,23 @@ Miscellaneous
 
     .. warning:: Using realtime priority can cause system lockup.
 
+``--numa-membind=<node>``
+    (Linux only.)
+    Bind all memory allocations to a specified NUMA node. This can significantly
+    reduce stuttering and dropped frames on NUMA systems.
+
+    Value is the ID of the NUMA node to bind to (range 0 to 4096), or -1 to
+    use the system's default NUMA policy. Default is -1.
+
+``--numa-cpubind=<node>``
+    (Linux only.)
+    Bind all CPU threads to a specified NUMA node. This can reduce stuttering
+    and dropped frames on NUMA systems, but will limit the number of useful
+    cores for decoding.
+
+    Value is the ID of the NUMA node to bind to (range 0 to 4096), or -1 to
+    use the system's default NUMA policy. Default is -1.
+
 ``--force-media-title=<string>``
     Force the contents of the ``media-title`` property to this value. Useful
     for scripts which want to set a title, without overriding the user's

--- a/options/options.c
+++ b/options/options.c
@@ -274,6 +274,10 @@ const m_option_t mp_opts[] = {
                 {"belownormal", BELOW_NORMAL_PRIORITY_CLASS},
                 {"idle",        IDLE_PRIORITY_CLASS})),
 #endif
+#ifdef HAVE_NUMA
+    OPT_INTRANGE("numa-membind", numa_membind, CONF_GLOBAL, -1, 4096),
+    OPT_INTRANGE("numa-cpubind", numa_cpubind, CONF_GLOBAL, -1, 4096),
+#endif
     OPT_FLAG("config", load_config, CONF_GLOBAL | CONF_PRE_PARSE),
     OPT_STRING("config-dir", force_configdir,
                CONF_GLOBAL | CONF_NOCFG | CONF_PRE_PARSE),
@@ -869,6 +873,9 @@ const struct MPOpts mp_default_opts = {
     .use_embedded_fonts = 1,
     .sub_fix_timing = 1,
     .screenshot_template = "mpv-shot%n",
+
+    .numa_membind = -1,
+    .numa_cpubind = -1,
 
     .hwdec_api = HAVE_RPI ? HWDEC_RPI : 0,
     .hwdec_codecs = "h264,vc1,wmv3,hevc,mpeg2video,vp9",

--- a/options/options.h
+++ b/options/options.h
@@ -282,6 +282,8 @@ typedef struct MPOpts {
     int videotoolbox_format;
 
     int w32_priority;
+    int numa_membind;
+    int numa_cpubind;
 
     struct tv_params *tv_params;
     struct pvr_params *stream_pvr_opts;

--- a/wscript
+++ b/wscript
@@ -386,6 +386,10 @@ iconv support use --disable-iconv.",
         'desc': 'libarchive wrapper for reading zip files and more',
         'func': check_pkg_config('libarchive >= 3.0.0'),
         'default': 'disable',
+    }, {
+        'name': '--numa',
+        'desc': 'NUMA support',
+        'func': check_cc(header_name='numa.h', lib='numa'),
     }
 ]
 


### PR DESCRIPTION
This can significantly improve video playback (fewer dropped frames) on
NUMA systems. The default is no change in behavior, as is trying to bind
to nodes that don't exist.

This is mainly a convenience for now, although it could easily be argued
that the default should be to bind to node 0 instead. I'll defer that
judgement.