### PR TITLE
audio: fix segfault when yanking USB DAC

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -884,6 +884,7 @@ void fill_audio_out_buffers(struct MPContext *mpctx)
                 }
             }
             reinit_audio_filters_and_output(mpctx);
+            ao_c = mpctx->ao_chain;
         }
     }
 


### PR DESCRIPTION
The ao_c pointer was stale after the mpctx entry was freed / NULLed.
This prevented the correct early exit from fill_audio_out_buffers.

```
Thread 1 "mpv" received signal SIGSEGV, Segmentation fault.
fill_audio_out_buffers (mpctx=mpctx@entry=0x1fe8c70) at ../player/audio.c:896
896	        int r = decode_new_frame(mpctx->ao_chain);
(gdb) bt
#0  fill_audio_out_buffers (mpctx=mpctx@entry=0x1fe8c70) at ../player/audio.c:896
#1  0x000000000050a58d in run_playloop (mpctx=mpctx@entry=0x1fe8c70) at ../player/playloop.c:1068
#2  0x00000000005014b9 in play_current_file (mpctx=0x1fe8c70) at ../player/loadfile.c:1151
#3  mp_play_files (mpctx=mpctx@entry=0x1fe8c70) at ../player/loadfile.c:1306
#4  0x000000000050226d in mpv_main (argc=<optimized out>, argv=<optimized out>) at ../player/main.c:499
#5  0x00007fffe95202b1 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#6  0x00000000004a1cba in _start ()
```