### PR TITLE
lua: expose subprocess_detached

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -635,6 +635,19 @@ strictly part of the guaranteed API.
 
     In all cases, ``mp.resume_all()`` is implicitly called.
 
+``utils.subprocess_detached(t)``
+    Runs an external process and detaches it from mpv's control.
+
+    The parameter ``t`` is a table. The function reads the following entries:
+
+        ``args``
+            Array of strings of the same semantics as the ``args`` used in the
+            ``subprocess`` function.
+
+    The function returns ``nil``.
+
+    In all cases, ``mp.resume_all()`` is implicitly called.
+
 ``utils.parse_json(str [, trail])``
     Parses the given string argument as JSON, and returns it as a Lua table. On
     error, returns ``nil, error``. (Currently, ``error`` is just a string


### PR DESCRIPTION
I didn't flatten `args` in case there comes some `env` etc. in the future.

I considered putting the code behind argument expansion into a shared function, but had problems with `char *args[256]` being a static sized array of pointers:

- couldn't pass it via argument because `MP_ARRAY_SIZE` would treat it as array of `char**` and report invalid size
- couldn't pass it via return value either because it would require `args` to be `static` and this destroys thread safety

so I decided not to touch things too much and just left it as is.

---

Personally I have two use cases for this command:

1. Run a lengthy process that involves HTTP for which I don't care about stdout, but it mustn't be terminated on playback cycle or player quit
2. On a specific hotkey, send the file to another program and quit mpv