### PR TITLE
aspect: use nominal width instead of actual width for video-unscaled

### DIFF
--- a/video/out/aspect.c
+++ b/video/out/aspect.c
@@ -54,9 +54,9 @@ static void aspect_calc_panscan(struct mp_vo_opts *opts,
 
     if (unscaled) {
         vo_panscan_area = 0;
-        if (unscaled != 2 || (w <= window_w && h <= window_h)) {
-            fwidth = w;
-            fheight = h;
+        if (unscaled != 2 || (d_w <= window_w && d_h <= window_h)) {
+            fwidth = d_w * monitor_par;
+            fheight = d_h;
         }
     }
 


### PR DESCRIPTION
The documentation claims that --video-unscaled will still perform
anamorphic adjustments, and it rightfully should. The current reality is
that it does not, because the video-unscaled size was based on the wrong
set of variables. (encoded width/height instead of nominal display
width/height)