### PR TITLE
player: allow opts in pseudo-gui set by the user to override user's default

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -737,20 +737,22 @@ Currently this happens only in the following cases:
 - if started from explorer.exe on Windows (technically, if it was started on
   Windows, and all of the stdout/stderr/stdin handles are unset)
 - started out of the bundle on OSX
-- you can add ``--profile=pseudo-gui`` to the command line, but it will behave
-  subtly differently (since mpv 0.22.0)
+- you can manually add ``--player-operation-mode=pseudo-gui` or
+  ``--profile=pseudo-gui`` to the command line
 
 This mode implicitly performs the same action as ``--profile=pseudo-gui``, but
-roughly before config files are loaded and the command line is applied. The
-``pseudo-gui`` profile is predefined with the following contents:
+predefines some options from a different profile called ``builtin-pseudo-gui``,
+which allows mpv to not overwrite any user-defined options:
 
 ::
 
-    [pseudo-gui]
+    [builtin-pseudo-gui]
     terminal=no
     force-window=yes
     idle=once
     screenshot-directory=~~desktop/
+    [pseudo-gui]
+    player-operation-mode=pseudo-gui
 
 .. warning::
 

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -3,6 +3,9 @@
 # applied at later stages during loading.
 
 [pseudo-gui]
+player-operation-mode=pseudo-gui
+
+[builtin-pseudo-gui]
 terminal=no
 force-window=yes
 idle=once

--- a/player/main.c
+++ b/player/main.c
@@ -408,8 +408,10 @@ int mp_initialize(struct MPContext *mpctx, char **options)
             return r == M_OPT_EXIT ? -2 : -1;
     }
 
-    if (opts->operation_mode == 1)
-        m_config_set_profile(mpctx->mconfig, "pseudo-gui", M_SETOPT_NO_OVERWRITE);
+    if (opts->operation_mode == 1) {
+        m_config_set_profile(mpctx->mconfig, "builtin-pseudo-gui", M_SETOPT_NO_OVERWRITE);
+        m_config_set_profile(mpctx->mconfig, "pseudo-gui", 0);
+    }
 
     mp_get_resume_defaults(mpctx);
 


### PR DESCRIPTION
This should still allow user-set default options to override built-in
pseudo-gui while respecting user-set pseudo-gui options.

Pros:
- user option in default profile overrides built-in pseudo-gui's options
  - ex: `screenshot-directory` overrides built-in pseudo-gui's
- user can "fix" pseudo-gui if some option like `force-window=no` is set
  in default by setting `force-window=yes` in [pseudo-gui]

Cons:
- `--show-profile=pseudo-gui` won't display the built-in's options
- `mpv --profile=pseudo-gui` won't use the built-in's options, only `mpv --player-operation-mode=pseudo-gui` does

Original idea from wm4.