### PR TITLE
cocoa: fix fullscreen regression on 10.11 and newer

### DIFF
--- a/video/out/opengl/context_cocoa.c
+++ b/video/out/opengl/context_cocoa.c
@@ -54,7 +54,6 @@ static CGLError test_gl_version(struct vo *vo,
     CGLPixelFormatAttribute attrs[] = {
         kCGLPFAOpenGLProfile,
         (CGLPixelFormatAttribute) version,
-        kCGLPFADoubleBuffer,
         kCGLPFAAccelerated,
         #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_8
         // leave this as the last entry of the array to not break the fallback


### PR DESCRIPTION
after some tests this fixes #3364 and potentially fixes #2392 (on 10.12) or majorly improves the situation (10.11+).

a [bundle](https://dl.dropboxusercontent.com/u/68772824/mpv-new2.zip) can be found here for testing.