### PR TITLE
Build with -DINITGUID on Windows

### DIFF
--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -17,7 +17,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <wchar.h>
 
 #include "ao_wasapi.h"

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -20,7 +20,6 @@
 #include <math.h>
 #include <wchar.h>
 #include <windows.h>
-#include <initguid.h>
 #include <errors.h>
 #include <ksguid.h>
 #include <ksmedia.h>

--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -17,7 +17,6 @@
 
 #include <windows.h>
 #include <shlobj.h>
-#include <initguid.h>
 #include <knownfolders.h>
 #include <pthread.h>
 

--- a/video/decode/d3d.c
+++ b/video/decode/d3d.c
@@ -31,7 +31,8 @@
 
 // define all the GUIDs used directly here, to avoid problems with inconsistent
 // dxva2api.h versions in mingw-w64 and different MSVC version
-#include <initguid.h>
+#include <guiddef.h>
+#include <cguid.h>
 DEFINE_GUID(DXVA2_ModeMPEG2_VLD,                0xee27417f, 0x5e28, 0x4e65, 0xbe, 0xea, 0x1d, 0x26, 0xb5, 0x08, 0xad, 0xc9);
 DEFINE_GUID(DXVA2_ModeMPEG2and1_VLD,            0x86695f12, 0x340e, 0x4f04, 0x9f, 0xd3, 0x92, 0x53, 0xdd, 0x32, 0x74, 0x60);
 

--- a/video/decode/d3d11va.c
+++ b/video/decode/d3d11va.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <libavcodec/d3d11va.h>
 
 #include "lavc.h"

--- a/video/decode/dxva2.c
+++ b/video/decode/dxva2.c
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <initguid.h>
-
 #define DXVA2API_USE_BITFIELDS
 #include <libavcodec/dxva2.h>
 

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <assert.h>
 #include <windows.h>
 #include <d3d11.h>

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <windows.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -17,7 +17,6 @@
 
 #include <windows.h>
 #include <versionhelpers.h>
-#include <initguid.h>
 #include <d3d9.h>
 #include <dwmapi.h>
 #include "osdep/windows_utils.h"

--- a/video/out/opengl/hwdec_d3d11egl.c
+++ b/video/out/opengl/hwdec_d3d11egl.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <assert.h>
 #include <windows.h>
 #include <d3d11.h>

--- a/video/out/opengl/hwdec_d3d11eglrgb.c
+++ b/video/out/opengl/hwdec_d3d11eglrgb.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <assert.h>
 #include <windows.h>
 #include <d3d11.h>

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -15,7 +15,6 @@
  * with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
 #include <stdio.h>
 #include <limits.h>
 #include <pthread.h>

--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -52,7 +52,7 @@ def __add_clang_flags__(ctx):
 
 def __add_mswin_flags__(ctx):
     ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x0601', '-DUNICODE', '-DCOBJMACROS',
-                       '-U__STRICT_ANSI__']
+                       '-DINITGUID', '-U__STRICT_ANSI__']
     ctx.env.LAST_LINKFLAGS += ['-Wl,--major-os-version=6,--minor-os-version=0',
                  '-Wl,--major-subsystem-version=6,--minor-subsystem-version=0']
 

--- a/waftools/fragments/wasapi.c
+++ b/waftools/fragments/wasapi.c
@@ -1,7 +1,6 @@
 #include <malloc.h>
 #include <stdlib.h>
 #include <process.h>
-#include <initguid.h>
 #include <audioclient.h>
 #include <endpointvolume.h>
 #include <mmdeviceapi.h>

--- a/wscript
+++ b/wscript
@@ -135,7 +135,7 @@ main_dependencies = [
         'name': 'win32',
         'desc': 'win32',
         'deps_any': [ 'os-win32', 'os-cygwin' ],
-        'func': check_cc(lib=['winmm', 'gdi32', 'ole32', 'avrt', 'dwmapi']),
+        'func': check_cc(lib=['winmm', 'gdi32', 'ole32', 'uuid', 'avrt', 'dwmapi']),
     }, {
         'name': '--win32-internal-pthreads',
         'desc': 'internal pthread wrapper for win32 (Vista+)',


### PR DESCRIPTION
This should solve some sporadic linking errors. As in 622bcb0, it takes advantage of the fact that __declspec(selectany) prevents multiple definitions of each GUID, so it's safe to define INITGUID in multiple files.

See also the second note here: https://support.microsoft.com/en-us/kb/130869