### PR TITLE
Make Windows process priority runtime-settable

### DIFF
--- a/options/m_option.h
+++ b/options/m_option.h
@@ -389,7 +389,8 @@ struct m_option {
 #define UPDATE_IMGPAR           (1 << 12) // video image params overrides
 #define UPDATE_INPUT            (1 << 13) // mostly --input-* options
 #define UPDATE_AUDIO            (1 << 14) // --audio-channels etc.
-#define UPDATE_OPT_LAST         (1 << 14)
+#define UPDATE_PRIORITY         (1 << 15) // --priority (Windows-only)
+#define UPDATE_OPT_LAST         (1 << 15)
 
 // All bits between _FIRST and _LAST (inclusive)
 #define UPDATE_OPTS_MASK \

--- a/options/options.c
+++ b/options/options.c
@@ -269,7 +269,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("msg-module", msg_module, UPDATE_TERM),
     OPT_FLAG("msg-time", msg_time, UPDATE_TERM),
 #ifdef _WIN32
-    OPT_CHOICE("priority", w32_priority, M_OPT_FIXED,
+    OPT_CHOICE("priority", w32_priority, UPDATE_PRIORITY,
                ({"no",          0},
                 {"realtime",    REALTIME_PRIORITY_CLASS},
                 {"high",        HIGH_PRIORITY_CLASS},

--- a/player/main.c
+++ b/player/main.c
@@ -66,10 +66,6 @@ static const char def_config[] =
 #include "player/builtin_conf.inc"
 ;
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #if HAVE_COCOA
 #include "osdep/macosx_events.h"
 #endif
@@ -471,11 +467,6 @@ int mp_initialize(struct MPContext *mpctx, char **options)
 
     if (opts->force_vo == 2 && handle_force_window(mpctx, false) < 0)
         return -1;
-
-#ifdef _WIN32
-    if (opts->w32_priority > 0)
-        SetPriorityClass(GetCurrentProcess(), opts->w32_priority);
-#endif
 
     MP_STATS(mpctx, "end init");
 


### PR DESCRIPTION
I hope it's okay to waste an option flag on a single option. It seems like all the other UPDATE_* flags cover more than one option.