### PR TITLE
command: allow absolute seeks relative to end of stream

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -95,7 +95,7 @@ List of Input Commands
     relative (default)
         Seek relative to current position (a negative value seeks backwards).
     absolute
-        Seek to a given time.
+        Seek to a given time (a negative value starts from the end of the file).
     absolute-percent
         Seek to a given percent position.
     relative-percent

--- a/player/command.c
+++ b/player/command.c
@@ -930,7 +930,9 @@ static int mp_property_chapter(void *ctx, struct m_property *prop,
                 if (current_chapter_start != MP_NOPTS_VALUE &&
                     get_current_time(mpctx) - current_chapter_start >
                     mpctx->opts->chapter_seek_threshold)
+                {
                     step_all++;
+                }
             }
         } else // Absolute set
             step_all = *(int *)arg - chapter;
@@ -4815,6 +4817,13 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             break;
         }
         case 2: { // Absolute seek to a timestamp in seconds
+            if (v < 0) {
+                // Seek from end
+                double len = get_time_length(mpctx);
+                if (len < 0)
+                    return -1;
+                v = MPMAX(0, len + v);
+            }
             queue_seek(mpctx, MPSEEK_ABSOLUTE, v, precision, MPSEEK_FLAG_DELAY);
             set_osd_function(mpctx,
                              v > get_current_time(mpctx) ? OSD_FFW : OSD_REW);


### PR DESCRIPTION
"seek -10 absolute" will seek to 10 seconds before the end. This more or less matches the --start option and negative seeks were otherwise useless (they just clipped to 0).

My use case for this is to seek to near the end of the file if I'm looking for something around there. `absolute-percent` doesn't work very well for this because using 100 just quits without `keep-open` and for any other value the actual distance to the end depends on the length of the file.

I wasn't sure what should happen if you try this on a stream with unknown length, so I just return failure. If something else is better, I'm happy to change it, doesn't matter to me.