### PR TITLE
audio: add audio-exclusive property

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -500,7 +500,7 @@ const m_option_t mp_opts[] = {
     OPT_SETTINGSLIST("ao-defaults", ao_defs, 0, &ao_obj_list,
                      .deprecation_message = "deprecated, use global options"),
     OPT_STRING("audio-device", audio_device, 0),
-    OPT_FLAG("audio-exclusive", audio_exclusive, 0),
+    OPT_FLAG("audio-exclusive", audio_exclusive, UPDATE_AUDIO),
     OPT_STRING("audio-client-name", audio_client_name, 0),
     OPT_FLAG("audio-fallback-to-null", ao_null_fallback, 0),
     OPT_FLAG("audio-stream-silence", audio_stream_silence, 0),


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later. (do I still need to keep this text here since I've already indicated my consent in #2033). I notice that there, I only agreed for contributions prior to "signing". I guess I can't agree for code that isn't written yet? 

Facilitates changing exclusive mode at runtime. This is usefull for conditionally
bypassing audio filters and mixers added by the operating system when outputting
PCM mode.