### PR TITLE
vo_drm: refactor getting display fps

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -215,6 +215,11 @@ void kms_destroy(struct kms *kms)
     talloc_free(kms);
 }
 
+double kms_get_display_fps(const struct kms *kms)
+{
+    return kms->mode.clock * 1000.0 / kms->mode.htotal / kms->mode.vtotal;
+}
+
 
 
 // VT switcher ----------------------------------------------------------------

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -49,5 +49,6 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*), void *us
 struct kms *kms_create(struct mp_log *log);
 bool kms_setup(struct kms *kms, const char *device_path, int conn_id, int mode_id);
 void kms_destroy(struct kms *kms);
+double kms_get_display_fps(const struct kms *kms);
 
 #endif

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -370,11 +370,7 @@ static int drm_egl_control(struct MPGLContext *ctx, int *events, int request,
     struct priv *p = ctx->priv;
     switch (request) {
     case VOCTRL_GET_DISPLAY_FPS: {
-        double fps =
-            p->kms->mode.clock
-            * 1000.0
-            / p->kms->mode.htotal
-            / p->kms->mode.vtotal;
+        double fps = kms_get_display_fps(p->kms);
         if (fps <= 0)
             break;
         *(double*)arg = fps;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -482,11 +482,7 @@ static int control(struct vo *vo, uint32_t request, void *arg)
             reconfig(vo, vo->params);
         return VO_TRUE;
     case VOCTRL_GET_DISPLAY_FPS: {
-        double fps =
-            p->kms->mode.clock
-            * 1000.0
-            / p->kms->mode.htotal
-            / p->kms->mode.vtotal;
+        double fps = kms_get_display_fps(p->kms);
         if (fps <= 0)
             break;
         *(double*)arg = fps;


### PR DESCRIPTION
Reduces code duplication between OpenGL backend and DRM VO.

(The control() for OpenGL backend isn't sufficiently similar to the
VO's control() to consider merging it as a whole - I extracted only the
FPS code.)