### PR TITLE
vo_drm: fix tiny memory leak

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -190,13 +190,18 @@ bool kms_setup(struct kms *kms, const char *device_path, int connector_id, int m
     }
 
     if (!setup_connector(kms, res, connector_id))
-        return false;
+        goto err;
     if (!setup_crtc(kms, res))
-        return false;
+        goto err;
     if (!setup_mode(kms, mode_id))
-        return false;
+        goto err;
 
+    drmModeFreeResources(res);
     return true;
+
+err:
+    drmModeFreeResources(res);
+    return false;
 }
 
 void kms_destroy(struct kms *kms)


### PR DESCRIPTION
The result of

```
extern drmModeResPtr drmModeGetResources(int fd);
```

must be freed with

```
extern void drmModeFreeResources( drmModeResPtr ptr );
```

Source:

https://www.mankier.com/3/drmModeGetResources