### PR TITLE
vo_drm: simplify CLI options

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -495,13 +495,13 @@ Available video output drivers are:
 
     The following global options are supported by this video output:
 
-    ``--drm-connector=<number>``
-        Select the connector to use (usually this is a monitor.) If set to -1,
-        mpv renders the output on the first available connector. (default: -1)
-
-    ``--drm-devpath=<filename>``
-        Path to graphic card device.
-        (default: /dev/dri/card0)
+    ``--drm-connector=[<gpu_number>.]<name>``
+        Select the connector to use (usually this is a monitor.) If ``<name>``
+        is empty or ``auto``, mpv renders the output on the first available
+        connector. Use ``--drm-connector=help`` to get list of available
+        connectors. When using multiple graphic cards, use the ``<gpu_number>``
+        argument to disambiguate.
+        (default: empty)
 
     ``--drm-mode=<number>``
         Mode ID to use (resolution, bit depth and frame rate).

--- a/options/options.c
+++ b/options/options.c
@@ -48,6 +48,10 @@
 #include "player/command.h"
 #include "stream/stream.h"
 
+#if HAVE_DRM
+#include "video/out/drm_common.h"
+#endif
+
 extern const char mp_help_text[];
 
 static void print_version(struct mp_log *log)
@@ -189,6 +193,11 @@ static const m_option_t mp_vo_opt_list[] = {
 #endif
 #if HAVE_WIN32
     OPT_STRING("vo-mmcss-profile", mmcss_profile, 0),
+#endif
+#if HAVE_DRM
+    OPT_STRING_VALIDATE("drm-connector", drm_connector_spec,
+                        0, drm_validate_connector_opt),
+    OPT_INT("drm-mode", drm_mode_id, 0),
 #endif
 
     {0}

--- a/options/options.h
+++ b/options/options.h
@@ -51,6 +51,9 @@ typedef struct mp_vo_opts {
     struct sws_opts *sws_opts;
     // vo_opengl, vo_opengl_cb
     int hwdec_preload_api;
+    // vo_drm
+    char *drm_connector_spec;
+    int drm_mode_id;
 } mp_vo_opts;
 
 struct mp_cache_opts {

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include "options/m_option.h"
 
 struct kms {
     struct mp_log *log;
@@ -29,6 +30,7 @@ struct kms {
     drmModeEncoder *encoder;
     drmModeModeInfo mode;
     uint32_t crtc_id;
+    int card_no;
 };
 
 struct vt_switcher {
@@ -43,12 +45,22 @@ void vt_switcher_destroy(struct vt_switcher *s);
 void vt_switcher_poll(struct vt_switcher *s, int timeout_ms);
 void vt_switcher_interrupt_poll(struct vt_switcher *s);
 
-void vt_switcher_acquire(struct vt_switcher *s, void (*handler)(void*), void *user_data);
-void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*), void *user_data);
+void vt_switcher_acquire(struct vt_switcher *s, void (*handler)(void*),
+                         void *user_data);
+void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
+                         void *user_data);
 
-struct kms *kms_create(struct mp_log *log);
-bool kms_setup(struct kms *kms, const char *device_path, int conn_id, int mode_id);
+struct kms *kms_create(struct mp_log *log, const char *connector_spec,
+                       int mode_id);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
+
+void kms_show_available_connectors(struct mp_log *log, int card_no);
+void kms_show_available_modes(struct mp_log *log,
+                              const drmModeConnector *connector);
+void kms_show_available_cards_and_connectors(struct mp_log *log);
+
+int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
+                               struct bstr name, struct bstr param);
 
 #endif


### PR DESCRIPTION
A few notes

- The device names are taken directly from linux kernel
- There's no sanity check if `connector_type` returned by `libdrm` fits in `connector_names` array; I assume the kernel sends reasonable values (although in other places we do check for unlikely `NULL`s...)
- The documentation claims `--drm-connector=help` shows the list of available connectors. While this is technically true, it also shows a lot of errors such as `error initializing vo`, `connector with name help not found` etc. along the way. I wonder if we can improve that? (In a separate commit)