### PR TITLE
[RFC] Changing OSC defaults

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -180,6 +180,10 @@ Configurable Options
     | Default: 0.0
     | Horizontal alignment, -1 (left) to 1 (right)
 
+``barmargin``
+    | Default: 0
+    | Margin from bottom (bottombar) or top (topbar), in pixels
+
 ``boxalpha``
     | Default: 80
     | Alpha of the background box, 0 (opaque) to 255 (fully transparent)

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -31,12 +31,14 @@ The Interface
 pl prev
     =============   ================================================
     left-click      play previous file in playlist
+    right-click     show playlist
     shift+L-click   show playlist
     =============   ================================================
 
 pl next
     =============   ================================================
     left-click      play next file in playlist
+    right-click     show playlist
     shift+L-click   show playlist
     =============   ================================================
 
@@ -59,12 +61,14 @@ play
 skip back
     =============   ================================================
     left-click      go to beginning of chapter / previous chapter
+    right-click     show chapters
     shift+L-click   show chapters
     =============   ================================================
 
 skip frwd
     =============   ================================================
     left-click      go to next chapter
+    right-click     show chapters
     shift+L-click   show chapters
     =============   ================================================
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -20,22 +20,23 @@ The Interface
 
 ::
 
-    +------------------+-----------+--------------------+
-    | playlist prev    |   title   |      playlist next |
-    +-------+------+---+--+------+-+----+------+--------+
-    | audio | skip | seek |      | seek | skip |  full  |
-    +-------+ back | back | play | frwd | frwd | screen |
-    | sub   |      |      |      |      |      |        |
-    +-------+------+------+------+------+------+--------+
-    |                     seekbar                       |
-    +----------------+--------------+-------------------+
-    | time passed    | cache status |    time remaining |
-    +----------------+--------------+-------------------+
+    +---------+----------+----------------------------+-------------+
+    | pl prev | pl next  |  title                     |       cache |
+    +------+--+---+------+---------+-----------+------+-------+-----+
+    | play | skip | skip | time    |  seekbar  | time | audio | sub |
+    |      | back | frwd | elapsed |           | left |       |     |
+    +------+------+------+---------+-----------+------+-------+-----+
 
 
-playlist prev
+pl prev
     =============   ================================================
     left-click      play previous file in playlist
+    shift+L-click   show playlist
+    =============   ================================================
+
+pl next
+    =============   ================================================
+    left-click      play next file in playlist
     shift+L-click   show playlist
     =============   ================================================
 
@@ -47,19 +48,12 @@ title
     right-click     show filename
     =============   ================================================
 
-playlist next
-    =============   ================================================
-    left-click      play next file in playlist
-    shift+L-click   show playlist
-    =============   ================================================
+cache
+    | Shows current cache fill status
 
-audio and sub
-    | Displays selected track and amount of available tracks
-
+play
     =============   ================================================
-    left-click      cycle audio/sub tracks forward
-    right-click     cycle audio/sub tracks backwards
-    shift+L-click   show available audio/sub tracks
+    left-click      toggle play/pause
     =============   ================================================
 
 skip back
@@ -68,34 +62,17 @@ skip back
     shift+L-click   show chapters
     =============   ================================================
 
-seek back
-    =============   ================================================
-    left-click      skip back  5 seconds
-    right-click     skip back 30 seconds
-    shift-L-click   skip back  1 frame
-    =============   ================================================
-
-play
-    =============   ================================================
-    left-click      toggle play/pause
-    =============   ================================================
-
-seek frwd
-    =============   ================================================
-    left-click      skip forward 10 seconds
-    right-click     skip forward 60 seconds
-    shift-L-click   skip forward  1 frame
-    =============   ================================================
-
 skip frwd
     =============   ================================================
     left-click      go to next chapter
     shift+L-click   show chapters
     =============   ================================================
 
-fullscreen
+time elapsed
+    | Shows current playback position timestamp
+
     =============   ================================================
-    left-click      toggle fullscreen
+    left-click      toggle displaying timecodes with milliseconds
     =============   ================================================
 
 seekbar
@@ -105,21 +82,20 @@ seekbar
     left-click      seek to position
     =============   ================================================
 
-time passed
-    | Shows current playback position timestamp
-
-    =============   ================================================
-    left-click      toggle displaying timecodes with milliseconds
-    =============   ================================================
-
-cache status
-    | Shows current cache fill status (only visible when below 45%)
-
-time remaining
+time left
     | Shows remaining playback time timestamp
 
     =============   ================================================
     left-click      toggle between total and remaining time
+    =============   ================================================
+
+audio and sub
+    | Displays selected track and amount of available tracks
+
+    =============   ================================================
+    left-click      cycle audio/sub tracks forward
+    right-click     cycle audio/sub tracks backwards
+    shift+L-click   show available audio/sub tracks
     =============   ================================================
 
 Key Bindings
@@ -176,11 +152,11 @@ Configurable Options
     | Enable the OSC when fullscreen
 
 ``scalewindowed``
-    | Default: 1.0
+    | Default: 1.5
     | Scale factor of the OSC when windowed
 
 ``scalefullscreen``
-    | Default: 1.0
+    | Default: 1.5
     | Scale factor of the OSC when fullscreen
 
 ``scaleforcedwindow``
@@ -214,7 +190,7 @@ Configurable Options
     | Duration of fade out in ms, 0 = no fade
 
 ``deadzonesize``
-    | Default: 0
+    | Default: 1
     | Size of the deadzone. The deadzone is an area that makes the mouse act
       like leaving the window. Movement there won't make the OSC show up and
       it will hide immediately if the mouse enters it. The deadzone starts
@@ -222,17 +198,17 @@ Configurable Options
       of the window it will span. Values between 0 and 1.
 
 ``minmousemove``
-    | Default: 3
+    | Default: 0
     | Minimum amount of pixels the mouse has to move between ticks to make
       the OSC show up
 
 ``layout``
-    | Default: box
+    | Default: bottombar
     | The layout for the OSC. Currently available are: box, slimbox,
       bottombar and topbar.
 
 ``seekbarstyle``
-    | Default: slider
+    | Default: bar
     | Sets the style of the seekbar, slider (diamond marker) or bar (fill)
 
 ``tooltipborder``

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -17,6 +17,7 @@ local user_opts = {
     vidscale = true,            -- scale the controller with the video?
     valign = 0.8,               -- vertical alignment, -1 (top) to 1 (bottom)
     halign = 0,                 -- horizontal alignment, -1 (left) to 1 (right)
+    barmargin = 0,              -- vertical margin of top/bottombar
     boxalpha = 80,              -- alpha of the background box,
                                 -- 0 (opaque) to 255 (fully transparent)
     hidetimeout = 500,          -- duration in ms until the OSC hides if no
@@ -1042,7 +1043,7 @@ end
 layouts["bottombar"] = function()
     local osc_geo = {
         x = -2,
-        y = osc_param.playresy - 36,
+        y = osc_param.playresy - 36 - user_opts.barmargin,
         an = 7,
         w = osc_param.playresx + 4,
         h = 38,
@@ -1061,7 +1062,7 @@ layouts["bottombar"] = function()
     local sh_area_y0, sh_area_y1
     sh_area_y0 = get_align(-1 + (2*user_opts.deadzonesize),
                            osc_geo.y - (osc_geo.h / 2), 0, 0)
-    sh_area_y1 = osc_param.playresy
+    sh_area_y1 = osc_param.playresy - user_opts.barmargin
     add_area("showhide", 0, sh_area_y0, osc_param.playresx, sh_area_y1)
 
     local lo, geo
@@ -1177,7 +1178,7 @@ end
 layouts["topbar"] = function()
     local osc_geo = {
         x = -2,
-        y = 36,
+        y = 36 + user_opts.barmargin,
         an = 1,
         w = osc_param.playresx + 4,
         h = 38,
@@ -1194,7 +1195,7 @@ layouts["topbar"] = function()
                                         osc_geo.w, osc_geo.h))
 
     local sh_area_y0, sh_area_y1
-    sh_area_y0 = 0
+    sh_area_y0 = user_opts.barmargin
     sh_area_y1 = (osc_geo.y + (osc_geo.h / 2)) +
                  get_align(1 - (2*user_opts.deadzonesize),
                  osc_param.playresy - (osc_geo.y + (osc_geo.h / 2)), 0, 0)
@@ -1264,7 +1265,7 @@ layouts["topbar"] = function()
 
 
     -- Seekbar
-    geo = { x = sb_l, y = 0, an = 7, w = math.max(0, sb_r - sb_l), h = geo.h }
+    geo = { x = sb_l, y = user_opts.barmargin, an = 7, w = math.max(0, sb_r - sb_l), h = geo.h }
     new_element("bgbar1", "box")
     lo = add_layout("bgbar1")
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1398,6 +1398,8 @@ function osc_init()
         function () mp.commandv("playlist-prev", "weak") end
     ne.eventresponder["shift+mouse_btn0_up"] =
         function () show_message(mp.get_property_osd("playlist"), 3) end
+    ne.eventresponder["mouse_btn2_up"] =
+        function () show_message(mp.get_property_osd("playlist"), 3) end
 
     --next
     ne = new_element("pl_next", "button")
@@ -1407,6 +1409,8 @@ function osc_init()
     ne.eventresponder["mouse_btn0_up"] =
         function () mp.commandv("playlist-next", "weak") end
     ne.eventresponder["shift+mouse_btn0_up"] =
+        function () show_message(mp.get_property_osd("playlist"), 3) end
+    ne.eventresponder["mouse_btn2_up"] =
         function () show_message(mp.get_property_osd("playlist"), 3) end
 
 
@@ -1458,6 +1462,8 @@ function osc_init()
         function () mp.commandv("osd-msg", "add", "chapter", -1) end
     ne.eventresponder["shift+mouse_btn0_up"] =
         function () show_message(mp.get_property_osd("chapter-list"), 3) end
+    ne.eventresponder["mouse_btn2_up"] =
+        function () show_message(mp.get_property_osd("chapter-list"), 3) end
 
     --ch_next
     ne = new_element("ch_next", "button")
@@ -1467,6 +1473,8 @@ function osc_init()
     ne.eventresponder["mouse_btn0_up"] =
         function () mp.commandv("osd-msg", "add", "chapter", 1) end
     ne.eventresponder["shift+mouse_btn0_up"] =
+        function () show_message(mp.get_property_osd("chapter-list"), 3) end
+    ne.eventresponder["mouse_btn2_up"] =
         function () show_message(mp.get_property_osd("chapter-list"), 3) end
 
     --

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -11,8 +11,8 @@ local opt = require 'mp.options'
 local user_opts = {
     showwindowed = true,        -- show OSC when windowed?
     showfullscreen = true,      -- show OSC when fullscreen?
-    scalewindowed = 1,          -- scaling of the controller when windowed
-    scalefullscreen = 1,        -- scaling of the controller when fullscreen
+    scalewindowed = 1.5,        -- scaling of the controller when windowed
+    scalefullscreen = 1.5,      -- scaling of the controller when fullscreen
     scaleforcedwindow = 2,      -- scaling when rendered on a forced window
     vidscale = true,            -- scale the controller with the video?
     valign = 0.8,               -- vertical alignment, -1 (top) to 1 (bottom)
@@ -23,14 +23,14 @@ local user_opts = {
                                 -- mouse movement. enforced non-negative for the
                                 -- user, but internally negative is "always-on".
     fadeduration = 200,         -- duration of fade out in ms, 0 = no fade
-    deadzonesize = 0,           -- size of deadzone
-    minmousemove = 3,           -- minimum amount of pixels the mouse has to
+    deadzonesize = 1,           -- size of deadzone
+    minmousemove = 0,           -- minimum amount of pixels the mouse has to
                                 -- move between ticks to make the OSC show up
     iamaprogrammer = false,     -- use native mpv values and disable OSC
                                 -- internal track list management (and some
                                 -- functions that depend on it)
-    layout = "box",
-    seekbarstyle = "slider",    -- slider (diamond marker) or bar (fill)
+    layout = "bottombar",
+    seekbarstyle = "bar",    -- slider (diamond marker) or bar (fill)
     tooltipborder = 1,          -- border of tooltip in bottom/topbar
     timetotal = false,          -- display total time instead of remaining time?
     timems = false,             -- display timecodes with milliseconds?


### PR DESCRIPTION
Continuation of #1931.

Suggestions:
- [x] layout=bottombar
- [x] scalewindowed=1.5
 - default of 1 looks tiny
- [x] seekbarstyle=bar
 - looks better than slider with bottombar
- [x] deadzonesize=1 & minmousemove=0
 - same behavior as MPC-HC (only shows osc if the mouse is over it)
- [ ] pop osc on seeks instead of osd
 - basically, disable osd-bar if osc is enabled (maybe user choice?)