### PR TITLE
vd_lavc: Add hwdec wrapper for crystalhd

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -625,6 +625,7 @@ Video
     :rpi-copy:  copies video back to system RAM (Raspberry Pi only)
     :cuda:      requires ``--vo=opengl`` (Any platform CUDA is available)
     :cuda-copy: copies video back to system RAM (Any platform CUDA is available)
+    :crystalhd: copies video back to system RAM (Any platform supported by hardware)
 
     ``auto`` tries to automatically enable hardware decoding using the first
     available method. This still depends what VO you are using. For example,
@@ -710,6 +711,11 @@ Video
 
         ``rpi`` always uses the hardware overlay renderer, even with
         ``--vo=opengl``.
+
+        ``crystalhd`` is not safe. It always converts to 4:2:2 YUV, which
+        may be lossy, depending on how chroma sub-sampling is done during
+        conversion. It also discards the top left pixel of each frame for
+        some reason.
 
         All other methods, in particular the copy-back methods (like
         ``dxva2-copy`` etc.) are either fully safe, or not worse than software

--- a/options/options.c
+++ b/options/options.c
@@ -106,6 +106,7 @@ const struct m_opt_choice_alternatives mp_hwdec_names[] = {
     {"mediacodec",  HWDEC_MEDIACODEC},
     {"cuda",        HWDEC_CUDA},
     {"cuda-copy",   HWDEC_CUDA_COPY},
+    {"crystalhd",   HWDEC_CRYSTALHD},
     {0}
 };
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -164,6 +164,12 @@ static const struct vd_lavc_hwdec mp_vd_lavc_cuda_copy = {
 };
 #endif
 
+static const struct vd_lavc_hwdec mp_vd_lavc_crystalhd = {
+    .type = HWDEC_CRYSTALHD,
+    .lavc_suffix = "_crystalhd",
+    .copying = true,
+};
+
 static const struct vd_lavc_hwdec *const hwdec_list[] = {
 #if HAVE_RPI
     &mp_vd_lavc_rpi,
@@ -193,6 +199,7 @@ static const struct vd_lavc_hwdec *const hwdec_list[] = {
     &mp_vd_lavc_cuda,
     &mp_vd_lavc_cuda_copy,
 #endif
+    &mp_vd_lavc_crystalhd,
     NULL
 };
 

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -24,6 +24,7 @@ enum hwdec_type {
     HWDEC_MEDIACODEC,
     HWDEC_CUDA,
     HWDEC_CUDA_COPY,
+    HWDEC_CRYSTALHD,
 };
 
 #define HWDEC_IS_AUTO(x) ((x) == HWDEC_AUTO || (x) == HWDEC_AUTO_COPY)


### PR DESCRIPTION
This hardware decodes to system memory so it only requires a wrapper.