### PR TITLE
Mark hearing/visual impaired audio tracks

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -699,6 +699,10 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
         AVDictionaryEntry *title = av_dict_get(st->metadata, "title", NULL, 0);
         if (title && title->value)
             sh->title = talloc_strdup(sh, title->value);
+        if (!sh->title && st->disposition & AV_DISPOSITION_VISUAL_IMPAIRED)
+            sh->title = talloc_asprintf(sh, "visual impaired");
+        if (!sh->title && st->disposition & AV_DISPOSITION_HEARING_IMPAIRED)
+            sh->title = talloc_asprintf(sh, "hearing impaired");
         AVDictionaryEntry *lang = av_dict_get(st->metadata, "language", NULL, 0);
         if (lang && lang->value)
             sh->lang = talloc_strdup(sh, lang->value);


### PR DESCRIPTION
Sets the title on hearing/visual impaired tracks if one isn't available already. This makes it much easier to find and use these audio tracks when they're available.