### PR TITLE
Don't rely on "__thread" being always available with GCC

### DIFF
--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -125,7 +125,7 @@ int mpgl_validate_backend_opt(struct mp_log *log, const struct m_option *opt,
 
 #if HAVE_C11_TLS
 #define MP_TLS _Thread_local
-#elif defined(__GNUC__)
+#elif HAVE_GCC_TLS
 #define MP_TLS __thread
 #endif
 

--- a/wscript
+++ b/wscript
@@ -186,6 +186,10 @@ main_dependencies = [
         'desc': 'C11 TLS support',
         'func': check_statement('stddef.h', 'static _Thread_local int x = 0'),
     }, {
+        'name': 'gcc-tls',
+        'desc': 'GCC/LLVM TLS support',
+        'func': check_statement('stddef.h', 'static __thread int x = 0'),
+    }, {
         'name': 'librt',
         'desc': 'linking with -lrt',
         'deps': [ 'pthreads' ],


### PR DESCRIPTION
After commit 8c39c6903b94636742c81922a2f26cfa07510fc6 mpv fails to build on OpenBSD with the following error:
```
../video/out/opengl/context.c:133: error: thread-local storage not supported for this target
```
Indeed, on OpenBSD GCC does not support `__thread` keyword.  This change adds a waf test, so that consequently the code may rely on `HAVE_GCC_TLS` macro instead of `__GNUC__`.  This should also work with Clang.