### PR TITLE
audio: force pts_reset only when pts jumps forward more than 5s

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -840,8 +840,8 @@ static int filter_audio(struct MPContext *mpctx, struct mp_audio_buffer *outbuf,
             // Attempt to detect jumps in PTS. Even for the lowest sample rates
             // and with worst container rounded timestamp, this should be a
             // margin more than enough.
-            double desync = fabs(mpa->pts - ao_c->pts);
-            if (ao_c->pts != MP_NOPTS_VALUE && desync > 0.1) {
+            double desync = mpa->pts - ao_c->pts;
+            if (ao_c->pts != MP_NOPTS_VALUE && fabs(desync) > 0.1) {
                 MP_WARN(ao_c, "Invalid audio PTS: %f -> %f\n",
                         ao_c->pts, mpa->pts);
                 if (desync >= 5)


### PR DESCRIPTION
here's a sample that is currently broken with `master`: https://s3.amazonaws.com/tmm1/audiopts.ts

11seconds into the sample, a commercial for "wocket" starts. but the audio associated with that commercial never plays.. instead the audio for the next clip *after* the commercial starts playing. by the time the commercial ends, the audio is completely out of sync.

after this patch, the audio plays as expected.