### PR TITLE
player: guard against MPSEEK_RELATIVE when current pts is unknown

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -249,6 +249,8 @@ static void mp_seek(MPContext *mpctx, struct seek_params seek)
 
     bool hr_seek_very_exact = seek.exact == MPSEEK_VERY_EXACT;
     double current_time = get_current_time(mpctx);
+    if (current_time == MP_NOPTS_VALUE && seek.type == MPSEEK_RELATIVE)
+        return;
     if (current_time == MP_NOPTS_VALUE)
         current_time = 0;
     double seek_pts = MP_NOPTS_VALUE;


### PR DESCRIPTION
in very rare circumstances, doing a relative seek like +1s will end up doing an absolute seek to 00:01. this guards against that possibility.

so far i've only ever seen this issue when using `--ad=lavc:ac3_at` and doing several relative seeks in quick succession. this is likely either a bug in the audiotoolbox decoder in ffmpeg, or simply due to inherent latency in that hardware decoder which causes brief periods of time where the current audio pts is unknown.