### PR TITLE
wscript: rebuild on library header changes

### DIFF
--- a/wscript
+++ b/wscript
@@ -4,9 +4,13 @@ import sys, os, re
 sys.path.insert(0, os.path.join(os.getcwd(), 'waftools'))
 sys.path.insert(0, os.getcwd())
 from waflib.Configure import conf
+from waflib.Tools import c_preproc
 from waflib import Utils
 from waftools.checks.generic import *
 from waftools.checks.custom import *
+
+c_preproc.go_absolute=True # enable system folders
+c_preproc.standard_includes.append('/usr/local/include')
 
 build_options = [
     {


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.

In particular, libav<x>/version.h changing should trigger a rebuild