### PR TITLE
osc: add script message handlers for chapter/track/playlists

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -260,3 +260,7 @@ to set auto mode (the default) with ``b``::
     a script-message osc-visibility never
     b script-message osc-visibility auto
 
+``osc-playlist``, ``osc-chapterlist``, ``osc-tracklist``
+    Shows a limited view of the respective type of list using the OSC. First
+    argument is duration in seconds.
+

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2127,6 +2127,19 @@ mp.register_event("tracks-changed", request_init)
 mp.observe_property("playlist", nil, request_init)
 
 mp.register_script_message("osc-message", show_message)
+mp.register_script_message("osc-chapterlist", function(dur)
+    show_message(get_chapterlist(), dur)
+end)
+mp.register_script_message("osc-playlist", function(dur)
+    show_message(get_playlist(), dur)
+end)
+mp.register_script_message("osc-tracklist", function(dur)
+    local msg = {}
+    for k,v in pairs(nicetypes) do
+        table.insert(msg, get_tracklist(k))
+    end
+    show_message(table.concat(msg, '\n\n'), dur)
+end)
 
 mp.observe_property("fullscreen", "bool",
     function(name, val)


### PR DESCRIPTION
Someone suggested this in IRC.

Didn't add for filters because there's no selected/disabled properties for those and they're generic lists done with just `script-message osc-message "Video filters:\n${vf}\n\nAudio filters:\n${af}"`

And they're not keybinds because you can't change the duration with those‽