### PR TITLE
top/bottombar: address issues

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -148,18 +148,21 @@ Configurable Options
 ~~~~~~~~~~~~~~~~~~~~
 
 ``layout``
-    | Default: bottombar
-    | The layout for the OSC. Currently available are: box, slimbox,
+    Default: bottombar
+
+    The layout for the OSC. Currently available are: box, slimbox,
       bottombar and topbar. Default pre-0.21.0 was 'box'.
 
 ``seekbarstyle``
-    | Default: bar
-    | Sets the style of the seekbar, slider (diamond marker) or bar (fill).
+    Default: bar
+
+    Sets the style of the seekbar, slider (diamond marker) or bar (fill).
       Default pre-0.21.0 was 'slider'.
 
 ``deadzonesize``
-    | Default: 0.5
-    | Size of the deadzone. The deadzone is an area that makes the mouse act
+    Default: 0.5
+
+    Size of the deadzone. The deadzone is an area that makes the mouse act
       like leaving the window. Movement there won't make the OSC show up and
       it will hide immediately if the mouse enters it. The deadzone starts
       at the window border opposite to the OSC and the size controls how much
@@ -168,75 +171,92 @@ Configurable Options
       OSC will only show up when the mouse hovers it. Default pre-0.21.0 was 0.
 
 ``minmousemove``
-    | Default: 0
-    | Minimum amount of pixels the mouse has to move between ticks to make
+    Default: 0
+
+    Minimum amount of pixels the mouse has to move between ticks to make
       the OSC show up. Default pre-0.21.0 was 3.
 
 ``showwindowed``
-    | Default: yes
-    | Enable the OSC when windowed
+    Default: yes
+
+    Enable the OSC when windowed
 
 ``showfullscreen``
-    | Default: yes
-    | Enable the OSC when fullscreen
+    Default: yes
+
+    Enable the OSC when fullscreen
 
 ``scalewindowed``
-    | Default: 1.5
-    | Scale factor of the OSC when windowed
+    Default: 1.5
+
+    Scale factor of the OSC when windowed
 
 ``scalefullscreen``
-    | Default: 1.5
-    | Scale factor of the OSC when fullscreen
+    Default: 1.5
+
+    Scale factor of the OSC when fullscreen
 
 ``scaleforcedwindow``
-    | Default: 2.0
-    | Scale factor of the OSC when rendered on a forced (dummy) window
+    Default: 2.0
+
+    Scale factor of the OSC when rendered on a forced (dummy) window
 
 ``vidscale``
-    | Default: yes
-    | Scale the OSC with the video
-    | ``no`` tries to keep the OSC size constant as much as the window size allows
+    Default: yes
+
+    Scale the OSC with the video
+    ``no`` tries to keep the OSC size constant as much as the window size allows
 
 ``valign``
-    | Default: 0.8
-    | Vertical alignment, -1 (top) to 1 (bottom)
+    Default: 0.8
+
+    Vertical alignment, -1 (top) to 1 (bottom)
 
 ``halign``
-    | Default: 0.0
-    | Horizontal alignment, -1 (left) to 1 (right)
+    Default: 0.0
+
+    Horizontal alignment, -1 (left) to 1 (right)
 
 ``barmargin``
-    | Default: 0
-    | Margin from bottom (bottombar) or top (topbar), in pixels
+    Default: 0
+
+    Margin from bottom (bottombar) or top (topbar), in pixels
 
 ``boxalpha``
-    | Default: 80
-    | Alpha of the background box, 0 (opaque) to 255 (fully transparent)
+    Default: 80
+
+    Alpha of the background box, 0 (opaque) to 255 (fully transparent)
 
 ``hidetimeout``
-    | Default: 500
-    | Duration in ms until the OSC hides if no mouse movement, must not be
+    Default: 500
+
+    Duration in ms until the OSC hides if no mouse movement, must not be
       negative
 
 ``fadeduration``
-    | Default: 200
-    | Duration of fade out in ms, 0 = no fade
+    Default: 200
+
+    Duration of fade out in ms, 0 = no fade
 
 ``tooltipborder``
-    | Default: 1
-    | Size of the tooltip outline when using bottombar or topbar layouts
+    Default: 1
+
+    Size of the tooltip outline when using bottombar or topbar layouts
 
 ``timetotal``
-    | Default: no
-    | Show total time instead of time remaining
+    Default: no
+
+    Show total time instead of time remaining
 
 ``timems``
-    | Default: no
-    | Display timecodes with milliseconds
+    Default: no
+
+    Display timecodes with milliseconds
 
 ``visibility``
-    | Default: auto (auto hide/show on mouse move)
-    | Also supports ``never`` and ``always``
+    Default: auto (auto hide/show on mouse move)
+
+    Also supports ``never`` and ``always``
 
 Script Commands
 ~~~~~~~~~~~~~~~

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -158,7 +158,7 @@ Configurable Options
       Default pre-0.21.0 was 'slider'.
 
 ``deadzonesize``
-    | Default: 1.0
+    | Default: 0.5
     | Size of the deadzone. The deadzone is an area that makes the mouse act
       like leaving the window. Movement there won't make the OSC show up and
       it will hide immediately if the mouse enters it. The deadzone starts

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -187,12 +187,12 @@ Configurable Options
     Enable the OSC when fullscreen
 
 ``scalewindowed``
-    Default: 1.5
+    Default: 1.0
 
-    Scale factor of the OSC when windowed
+    Scale factor of the OSC when windowed.
 
 ``scalefullscreen``
-    Default: 1.5
+    Default: 1.0
 
     Scale factor of the OSC when fullscreen
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1131,6 +1131,7 @@ layouts["bottombar"] = function()
     local padY = 2
     local line1 = osc_geo.y + 6 + padY
     local line2 = osc_geo.y + 24 + padY
+    local tc_width = (state.tc_ms) and 100 or 70
 
     osc_param.areas = {}
 
@@ -1201,7 +1202,8 @@ layouts["bottombar"] = function()
 
 
     -- Left timecode
-    geo = { x = geo.x + geo.w + padX + 100, y = geo.y, an = 6, w = 100, h = geo.h }
+    geo = { x = geo.x + geo.w + padX + tc_width, y = geo.y, an = 6,
+            w = tc_width, h = geo.h }
     lo = add_layout("tc_left")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1223,8 +1225,8 @@ layouts["bottombar"] = function()
 
 
     -- Right timecode
-    geo = { x = geo.x - geo.w - padX - 100, y = geo.y, an = 4,
-            w = 100, h = geo.h }
+    geo = { x = geo.x - geo.w - padX - tc_width, y = geo.y, an = 4,
+            w = tc_width, h = geo.h }
     lo = add_layout("tc_right")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1266,6 +1268,7 @@ layouts["topbar"] = function()
     local padY = 2
     local line1 = osc_geo.y - 24 - padY
     local line2 = osc_geo.y - 6 - padY
+    local tc_width = (state.tc_ms) and 100 or 70
 
     osc_param.areas = {}
 
@@ -1310,8 +1313,8 @@ layouts["topbar"] = function()
 
 
     -- Left timecode
-    geo = { x = geo.x + geo.w + padX + 100, y = geo.y, an = 6,
-            w = 100, h = geo.h }
+    geo = { x = geo.x + geo.w + padX + tc_width, y = geo.y, an = 6,
+            w = tc_width, h = geo.h }
     lo = add_layout("tc_left")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1333,8 +1336,8 @@ layouts["topbar"] = function()
 
 
     -- Right timecode
-    geo = { x = geo.x - geo.w - padX - 100, y = geo.y, an = 4,
-            w = 100, h = geo.h }
+    geo = { x = geo.x - geo.w - padX - tc_width, y = geo.y, an = 4,
+            w = tc_width, h = geo.h }
     lo = add_layout("tc_right")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1681,8 +1684,10 @@ function osc_init()
             return (mp.get_property_osd("playback-time"))
         end
     end
-    ne.eventresponder["mouse_btn0_up"] =
-        function () state.tc_ms = not state.tc_ms end
+    ne.eventresponder["mouse_btn0_up"] = function ()
+        state.tc_ms = not state.tc_ms
+        request_init()
+    end
 
     -- tc_right (total/remaining time)
     ne = new_element("tc_right", "button")

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -65,7 +65,7 @@ local osc_styles = {
 
     elementDown = "{\\1c&H999999}",
     timecodes = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs20}",
-    vidtitle = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs12}",
+    vidtitle = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs12\\q2}",
     timePos = "{\\blur0\\bord".. user_opts.tooltipborder .."\\1c&HFFFFFF\\3c&H000000\\1a&H00\\3a&H88\\fs20}",
     box = "{\\rDefault\\blur0\\bord1\\1c&H000000\\3c&HFFFFFF}",
 }

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -25,14 +25,14 @@ local user_opts = {
                                 -- mouse movement. enforced non-negative for the
                                 -- user, but internally negative is "always-on".
     fadeduration = 200,         -- duration of fade out in ms, 0 = no fade
-    deadzonesize = 1,           -- size of deadzone
+    deadzonesize = 0.5,         -- size of deadzone
     minmousemove = 0,           -- minimum amount of pixels the mouse has to
                                 -- move between ticks to make the OSC show up
     iamaprogrammer = false,     -- use native mpv values and disable OSC
                                 -- internal track list management (and some
                                 -- functions that depend on it)
     layout = "bottombar",
-    seekbarstyle = "bar",    -- slider (diamond marker) or bar (fill)
+    seekbarstyle = "bar",       -- slider (diamond marker) or bar (fill)
     tooltipborder = 1,          -- border of tooltip in bottom/topbar
     timetotal = false,          -- display total time instead of remaining time?
     timems = false,             -- display timecodes with milliseconds?

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -560,6 +560,7 @@ function render_elements(master_ass)
                 if (slider_lo.stype == "slider") then
                     foH = elem_geo.h / 2
                 elseif (slider_lo.stype == "bar") then
+                    foV = foV + 1
                     foH = slider_lo.border + slider_lo.gap
                 end
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1179,12 +1179,7 @@ layouts["bottombar"] = function()
     lo.geometry = geo
     lo.style = osc_styles.topButtons
 
-    -- Title
-    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an,
-            w = 1000, h = geo.h }
-    lo = add_layout("title")
-    lo.geometry = geo
-    lo.style = osc_styles.vidtitle
+    local t_l = geo.x + geo.w + padX
 
     -- Cache
     geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y,
@@ -1192,6 +1187,16 @@ layouts["bottombar"] = function()
     lo = add_layout("cache")
     lo.geometry = geo
     lo.style = osc_styles.vidtitle
+
+    local t_r = geo.x - geo.w - padX*2
+
+    -- Title
+    geo = { x = t_l, y = geo.y, an = 4,
+            w = t_r - t_l, h = geo.h }
+    lo = add_layout("title")
+    lo.geometry = geo
+    lo.style = osc_styles.vidtitle
+    lo.button.maxchars = math.floor(geo.w/4)
 
 
     -- Playback control buttons
@@ -1398,19 +1403,24 @@ layouts["topbar"] = function()
     lo.geometry = geo
     lo.style = osc_styles.topButtons
 
-    -- Title
-    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an,
-            w = 1000, h = geo.h }
-    lo = add_layout("title")
-    lo.geometry = geo
-    lo.style = osc_styles.vidtitle
+    local t_l = geo.x + geo.w + padX
 
     -- Cache
-    geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y, an = 6,
-            w = 100, h = geo.h }
+    geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y,
+            an = 6, w = 100, h = geo.h }
     lo = add_layout("cache")
     lo.geometry = geo
     lo.style = osc_styles.vidtitle
+
+    local t_r = geo.x - geo.w - padX*2
+
+    -- Title
+    geo = { x = t_l, y = geo.y, an = 4,
+            w = t_r - t_l, h = geo.h }
+    lo = add_layout("title")
+    lo.geometry = geo
+    lo.style = osc_styles.vidtitle
+    lo.button.maxchars = math.floor(geo.w/4)
 end
 
 -- Validate string type user options

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -12,8 +12,8 @@ local utils = require 'mp.utils'
 local user_opts = {
     showwindowed = true,        -- show OSC when windowed?
     showfullscreen = true,      -- show OSC when fullscreen?
-    scalewindowed = 1.5,        -- scaling of the controller when windowed
-    scalefullscreen = 1.5,      -- scaling of the controller when fullscreen
+    scalewindowed = 1,          -- scaling of the controller when windowed
+    scalefullscreen = 1,        -- scaling of the controller when fullscreen
     scaleforcedwindow = 2,      -- scaling when rendered on a forced window
     vidscale = true,            -- scale the controller with the video?
     valign = 0.8,               -- vertical alignment, -1 (top) to 1 (bottom)
@@ -59,15 +59,20 @@ local osc_param = { -- calculated by osc_init()
 local osc_styles = {
     bigButtons = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs50\\fnmpv-osd-symbols}",
     smallButtonsL = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs19\\fnmpv-osd-symbols}",
-    smallButtonsLlabel = "{\\fs20\\fn" .. mp.get_property("options/osd-font") .. "}",
+    smallButtonsLlabel = "{\\fscx105\\fscy105\\fn" .. mp.get_property("options/osd-font") .. "}",
     smallButtonsR = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs30\\fnmpv-osd-symbols}",
     topButtons = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs12\\fnmpv-osd-symbols}",
 
     elementDown = "{\\1c&H999999}",
     timecodes = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs20}",
     vidtitle = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs12\\q2}",
-    timePos = "{\\blur0\\bord".. user_opts.tooltipborder .."\\1c&HFFFFFF\\3c&H000000\\1a&H00\\3a&H88\\fs20}",
     box = "{\\rDefault\\blur0\\bord1\\1c&H000000\\3c&HFFFFFF}",
+
+    topButtonsBar = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs18\\fnmpv-osd-symbols}",
+    smallButtonsBar = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs28\\fnmpv-osd-symbols}",
+    timecodesBar = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs27}",
+    timePosBar = "{\\blur0\\bord".. user_opts.tooltipborder .."\\1c&HFFFFFF\\3c&H000000\\1a&H00\\3a&H88\\fs30}",
+    vidtitleBar = "{\\blur0\\bord0\\1c&HFFFFFF\\3c&HFFFFFF\\fs18\\q2}",
 }
 
 -- internal states, do not touch
@@ -1121,28 +1126,28 @@ end
 layouts["bottombar"] = function()
     local osc_geo = {
         x = -2,
-        y = osc_param.playresy - 36 - user_opts.barmargin,
+        y = osc_param.playresy - 54 - user_opts.barmargin,
         an = 7,
         w = osc_param.playresx + 4,
-        h = 38,
+        h = 56,
     }
 
-    local padX = 6
-    local padY = 2
-    local buttonW = 18
-    local tcW = (state.tc_ms) and 100 or 70
-    local tsW = 60
+    local padX = 9
+    local padY = 3
+    local buttonW = 27
+    local tcW = (state.tc_ms) and 150 or 105
+    local tsW = 90
     local minW = (buttonW + padX)*3 + (tcW + padX)*4 + (tsW + padX)*2
 
     if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
         osc_param.playresy = minW / osc_param.display_aspect
         osc_param.playresx = osc_param.playresy * osc_param.display_aspect
-        osc_geo.y = osc_param.playresy - 36 - user_opts.barmargin
+        osc_geo.y = osc_param.playresy - 54 - user_opts.barmargin
         osc_geo.w = osc_param.playresx + 4
     end
 
-    local line1 = osc_geo.y + 6 + padY
-    local line2 = osc_geo.y + 24 + padY
+    local line1 = osc_geo.y + 9 + padY
+    local line2 = osc_geo.y + 36 + padY
 
     osc_param.areas = {}
 
@@ -1169,24 +1174,24 @@ layouts["bottombar"] = function()
 
     -- Playlist prev/next
     geo = { x = osc_geo.x + padX, y = line1,
-            an = 4, w = 12, h = 12 - padY }
+            an = 4, w = 18, h = 18 - padY }
     lo = add_layout("pl_prev")
     lo.geometry = geo
-    lo.style = osc_styles.topButtons
+    lo.style = osc_styles.topButtonsBar
 
     geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
     lo = add_layout("pl_next")
     lo.geometry = geo
-    lo.style = osc_styles.topButtons
+    lo.style = osc_styles.topButtonsBar
 
     local t_l = geo.x + geo.w + padX
 
     -- Cache
     geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y,
-            an = 6, w = 100, h = geo.h }
+            an = 6, w = 150, h = geo.h }
     lo = add_layout("cache")
     lo.geometry = geo
-    lo.style = osc_styles.vidtitle
+    lo.style = osc_styles.vidtitleBar
 
     local t_r = geo.x - geo.w - padX*2
 
@@ -1195,13 +1200,134 @@ layouts["bottombar"] = function()
             w = t_r - t_l, h = geo.h }
     lo = add_layout("title")
     lo.geometry = geo
-    lo.style = osc_styles.vidtitle
-    lo.button.maxchars = math.floor(geo.w/4)
+    lo.style = osc_styles.vidtitleBar
+    lo.button.maxchars = math.floor(geo.w/7)
 
 
     -- Playback control buttons
     geo = { x = osc_geo.x + padX, y = line2, an = 4,
-            w = buttonW, h = 24 - padY*2}
+            w = buttonW, h = 36 - padY*2}
+    lo = add_layout("playpause")
+    lo.geometry = geo
+    lo.style = osc_styles.smallButtonsBar
+
+    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
+    lo = add_layout("ch_prev")
+    lo.geometry = geo
+    lo.style = osc_styles.smallButtonsBar
+
+    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
+    lo = add_layout("ch_next")
+    lo.geometry = geo
+    lo.style = osc_styles.smallButtonsBar
+
+    -- Left timecode
+    geo = { x = geo.x + geo.w + padX + tcW, y = geo.y, an = 6,
+            w = tcW, h = geo.h }
+    lo = add_layout("tc_left")
+    lo.geometry = geo
+    lo.style = osc_styles.timecodesBar
+
+    local sb_l = geo.x + padX
+
+
+    -- Track selection buttons
+    geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y, an = geo.an,
+            w = tsW, h = geo.h }
+    lo = add_layout("cy_sub")
+    lo.geometry = geo
+    lo.style = osc_styles.smallButtonsBar
+
+    geo = { x = geo.x - geo.w - padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
+    lo = add_layout("cy_audio")
+    lo.geometry = geo
+    lo.style = osc_styles.smallButtonsBar
+
+
+    -- Right timecode
+    geo = { x = geo.x - geo.w - padX - tcW, y = geo.y, an = 4,
+            w = tcW, h = geo.h }
+    lo = add_layout("tc_right")
+    lo.geometry = geo
+    lo.style = osc_styles.timecodesBar
+
+    local sb_r = geo.x - padX
+
+
+    -- Seekbar
+    geo = { x = sb_l, y = geo.y, an = geo.an,
+            w = math.max(0, sb_r - sb_l), h = geo.h }
+    new_element("bgbar1", "box")
+    lo = add_layout("bgbar1")
+
+    lo.geometry = geo
+    lo.layer = 15
+    lo.style = osc_styles.timecodesBar
+    lo.alpha[1] =
+        math.min(255, user_opts.boxalpha + (255 - user_opts.boxalpha)*0.8)
+
+    lo = add_layout("seekbar")
+    lo.geometry = geo
+    lo.style = osc_styles.timecodes
+    lo.slider.border = 0
+    lo.slider.tooltip_style = osc_styles.timePosBar
+    lo.slider.tooltip_an = 5
+    lo.slider.stype = user_opts["seekbarstyle"]
+end
+
+layouts["topbar"] = function()
+    local osc_geo = {
+        x = -2,
+        y = 54 + user_opts.barmargin,
+        an = 1,
+        w = osc_param.playresx + 4,
+        h = 56,
+    }
+
+    local padX = 9
+    local padY = 3
+    local buttonW = 27
+    local tcW = (state.tc_ms) and 150 or 105
+    local tsW = 90
+    local minW = (buttonW + padX)*3 + (tcW + padX)*4 + (tsW + padX)*2
+
+    if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
+        osc_param.playresy = minW / osc_param.display_aspect
+        osc_param.playresx = osc_param.playresy * osc_param.display_aspect
+        osc_geo.y = 54 + user_opts.barmargin
+        osc_geo.w = osc_param.playresx + 4
+    end
+
+    local line1 = osc_geo.y - 36 - padY
+    local line2 = osc_geo.y - 9 - padY
+
+    osc_param.areas = {}
+
+    add_area("input", get_hitbox_coords(osc_geo.x, osc_geo.y, osc_geo.an,
+                                        osc_geo.w, osc_geo.h))
+
+    local sh_area_y0, sh_area_y1
+    sh_area_y0 = user_opts.barmargin
+    sh_area_y1 = (osc_geo.y + (osc_geo.h / 2)) +
+                 get_align(1 - (2*user_opts.deadzonesize),
+                 osc_param.playresy - (osc_geo.y + (osc_geo.h / 2)), 0, 0)
+    add_area("showhide", 0, sh_area_y0, osc_param.playresx, sh_area_y1)
+
+    local lo, geo
+
+    -- Background bar
+    new_element("bgbox", "box")
+    lo = add_layout("bgbox")
+
+    lo.geometry = osc_geo
+    lo.layer = 10
+    lo.style = osc_styles.box
+    lo.alpha[1] = user_opts.boxalpha
+
+
+    -- Playback control buttons
+    geo = { x = osc_geo.x + padX, y = line1, an = 4,
+            w = buttonW, h = 36 - padY*2 }
     lo = add_layout("playpause")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
@@ -1215,6 +1341,7 @@ layouts["bottombar"] = function()
     lo = add_layout("ch_next")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
+
 
     -- Left timecode
     geo = { x = geo.x + geo.w + padX + tcW, y = geo.y, an = 6,
@@ -1250,129 +1377,6 @@ layouts["bottombar"] = function()
 
 
     -- Seekbar
-    geo = { x = sb_l, y = geo.y, an = geo.an,
-            w = math.max(0, sb_r - sb_l), h = geo.h }
-    new_element("bgbar1", "box")
-    lo = add_layout("bgbar1")
-
-    lo.geometry = geo
-    lo.layer = 15
-    lo.style = osc_styles.timecodes
-    lo.alpha[1] =
-        math.min(255, user_opts.boxalpha + (255 - user_opts.boxalpha)*0.8)
-
-    lo = add_layout("seekbar")
-    lo.geometry = geo
-    lo.style = osc_styles.timecodes
-    lo.slider.border = 0
-    lo.slider.tooltip_style = osc_styles.timePos
-    lo.slider.tooltip_an = 5
-    lo.slider.stype = user_opts["seekbarstyle"]
-end
-
-layouts["topbar"] = function()
-    local osc_geo = {
-        x = -2,
-        y = 36 + user_opts.barmargin,
-        an = 1,
-        w = osc_param.playresx + 4,
-        h = 38,
-    }
-
-    local padX = 6
-    local padY = 2
-    local buttonW = 18
-    local tcW = (state.tc_ms) and 100 or 70
-    local tsW = 60
-    local minW = (buttonW + padX)*3 + (tcW + padX)*4 + (tsW + padX)*2
-
-    if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
-        osc_param.playresy = minW / osc_param.display_aspect
-        osc_param.playresx = osc_param.playresy * osc_param.display_aspect
-        osc_geo.y = 36 + user_opts.barmargin
-        osc_geo.w = osc_param.playresx + 4
-    end
-
-    local line1 = osc_geo.y - 24 - padY
-    local line2 = osc_geo.y - 6 - padY
-    local tc_width = (state.tc_ms) and 100 or 70
-
-    osc_param.areas = {}
-
-    add_area("input", get_hitbox_coords(osc_geo.x, osc_geo.y, osc_geo.an,
-                                        osc_geo.w, osc_geo.h))
-
-    local sh_area_y0, sh_area_y1
-    sh_area_y0 = user_opts.barmargin
-    sh_area_y1 = (osc_geo.y + (osc_geo.h / 2)) +
-                 get_align(1 - (2*user_opts.deadzonesize),
-                 osc_param.playresy - (osc_geo.y + (osc_geo.h / 2)), 0, 0)
-    add_area("showhide", 0, sh_area_y0, osc_param.playresx, sh_area_y1)
-
-    local lo, geo
-
-    -- Background bar
-    new_element("bgbox", "box")
-    lo = add_layout("bgbox")
-
-    lo.geometry = osc_geo
-    lo.layer = 10
-    lo.style = osc_styles.box
-    lo.alpha[1] = user_opts.boxalpha
-
-
-    -- Playback control buttons
-    geo = { x = osc_geo.x + padX, y = line1, an = 4,
-            w = buttonW, h = 24 - padY*2 }
-    lo = add_layout("playpause")
-    lo.geometry = geo
-    lo.style = osc_styles.smallButtonsL
-
-    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("ch_prev")
-    lo.geometry = geo
-    lo.style = osc_styles.smallButtonsL
-
-    geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("ch_next")
-    lo.geometry = geo
-    lo.style = osc_styles.smallButtonsL
-
-
-    -- Left timecode
-    geo = { x = geo.x + geo.w + padX + tc_width, y = geo.y, an = 6,
-            w = tcW, h = geo.h }
-    lo = add_layout("tc_left")
-    lo.geometry = geo
-    lo.style = osc_styles.timecodes
-
-    local sb_l = geo.x + padX
-
-
-    -- Track selection buttons
-    geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y, an = geo.an,
-            w = tsW, h = geo.h }
-    lo = add_layout("cy_sub")
-    lo.geometry = geo
-    lo.style = osc_styles.smallButtonsL
-
-    geo = { x = geo.x - geo.w - padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("cy_audio")
-    lo.geometry = geo
-    lo.style = osc_styles.smallButtonsL
-
-
-    -- Right timecode
-    geo = { x = geo.x - geo.w - padX - tc_width, y = geo.y, an = 4,
-            w = tcW, h = geo.h }
-    lo = add_layout("tc_right")
-    lo.geometry = geo
-    lo.style = osc_styles.timecodes
-
-    local sb_r = geo.x - padX
-
-
-    -- Seekbar
     geo = { x = sb_l, y = user_opts.barmargin, an = 7, w = math.max(0, sb_r - sb_l), h = geo.h }
     new_element("bgbar1", "box")
     lo = add_layout("bgbar1")
@@ -1387,13 +1391,13 @@ layouts["topbar"] = function()
     lo.geometry = geo
     lo.style = osc_styles.timecodes
     lo.slider.border = 0
-    lo.slider.tooltip_style = osc_styles.timePos
+    lo.slider.tooltip_style = osc_styles.timePosBar
     lo.slider.stype = user_opts["seekbarstyle"]
     lo.slider.tooltip_an = 5
 
 
     -- Playlist prev/next
-    geo = { x = osc_geo.x + padX, y = line2, an = 4, w = 12, h = 12 - padY }
+    geo = { x = osc_geo.x + padX, y = line2, an = 4, w = 18, h = 18 - padY }
     lo = add_layout("pl_prev")
     lo.geometry = geo
     lo.style = osc_styles.topButtons
@@ -1407,7 +1411,7 @@ layouts["topbar"] = function()
 
     -- Cache
     geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y,
-            an = 6, w = 100, h = geo.h }
+            an = 6, w = 150, h = geo.h }
     lo = add_layout("cache")
     lo.geometry = geo
     lo.style = osc_styles.vidtitle
@@ -1420,7 +1424,7 @@ layouts["topbar"] = function()
     lo = add_layout("title")
     lo.geometry = geo
     lo.style = osc_styles.vidtitle
-    lo.button.maxchars = math.floor(geo.w/4)
+    lo.button.maxchars = math.floor(geo.w/7)
 end
 
 -- Validate string type user options

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1129,9 +1129,20 @@ layouts["bottombar"] = function()
 
     local padX = 6
     local padY = 2
+    local buttonW = 18
+    local tcW = (state.tc_ms) and 100 or 70
+    local tsW = 60
+    local minW = (buttonW + padX)*3 + (tcW + padX)*4 + (tsW + padX)*2
+
+    if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
+        osc_param.playresy = minW / osc_param.display_aspect
+        osc_param.playresx = osc_param.playresy * osc_param.display_aspect
+        osc_geo.y = osc_param.playresy - 36 - user_opts.barmargin
+        osc_geo.w = osc_param.playresx + 4
+    end
+
     local line1 = osc_geo.y + 6 + padY
     local line2 = osc_geo.y + 24 + padY
-    local tc_width = (state.tc_ms) and 100 or 70
 
     osc_param.areas = {}
 
@@ -1185,7 +1196,7 @@ layouts["bottombar"] = function()
 
     -- Playback control buttons
     geo = { x = osc_geo.x + padX, y = line2, an = 4,
-            w = 18, h = 24 - padY*2}
+            w = buttonW, h = 24 - padY*2}
     lo = add_layout("playpause")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
@@ -1200,10 +1211,9 @@ layouts["bottombar"] = function()
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
 
-
     -- Left timecode
-    geo = { x = geo.x + geo.w + padX + tc_width, y = geo.y, an = 6,
-            w = tc_width, h = geo.h }
+    geo = { x = geo.x + geo.w + padX + tcW, y = geo.y, an = 6,
+            w = tcW, h = geo.h }
     lo = add_layout("tc_left")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1213,7 +1223,7 @@ layouts["bottombar"] = function()
 
     -- Track selection buttons
     geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y, an = geo.an,
-            w = 60, h = geo.h }
+            w = tsW, h = geo.h }
     lo = add_layout("cy_sub")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
@@ -1225,8 +1235,8 @@ layouts["bottombar"] = function()
 
 
     -- Right timecode
-    geo = { x = geo.x - geo.w - padX - tc_width, y = geo.y, an = 4,
-            w = tc_width, h = geo.h }
+    geo = { x = geo.x - geo.w - padX - tcW, y = geo.y, an = 4,
+            w = tcW, h = geo.h }
     lo = add_layout("tc_right")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1266,6 +1276,18 @@ layouts["topbar"] = function()
 
     local padX = 6
     local padY = 2
+    local buttonW = 18
+    local tcW = (state.tc_ms) and 100 or 70
+    local tsW = 60
+    local minW = (buttonW + padX)*3 + (tcW + padX)*4 + (tsW + padX)*2
+
+    if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
+        osc_param.playresy = minW / osc_param.display_aspect
+        osc_param.playresx = osc_param.playresy * osc_param.display_aspect
+        osc_geo.y = 36 + user_opts.barmargin
+        osc_geo.w = osc_param.playresx + 4
+    end
+
     local line1 = osc_geo.y - 24 - padY
     local line2 = osc_geo.y - 6 - padY
     local tc_width = (state.tc_ms) and 100 or 70
@@ -1296,7 +1318,7 @@ layouts["topbar"] = function()
 
     -- Playback control buttons
     geo = { x = osc_geo.x + padX, y = line1, an = 4,
-            w = 18, h = 24 - padY*2 }
+            w = buttonW, h = 24 - padY*2 }
     lo = add_layout("playpause")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
@@ -1314,7 +1336,7 @@ layouts["topbar"] = function()
 
     -- Left timecode
     geo = { x = geo.x + geo.w + padX + tc_width, y = geo.y, an = 6,
-            w = tc_width, h = geo.h }
+            w = tcW, h = geo.h }
     lo = add_layout("tc_left")
     lo.geometry = geo
     lo.style = osc_styles.timecodes
@@ -1324,7 +1346,7 @@ layouts["topbar"] = function()
 
     -- Track selection buttons
     geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y, an = geo.an,
-            w = 60, h = geo.h }
+            w = tsW, h = geo.h }
     lo = add_layout("cy_sub")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsL
@@ -1337,7 +1359,7 @@ layouts["topbar"] = function()
 
     -- Right timecode
     geo = { x = geo.x - geo.w - padX - tc_width, y = geo.y, an = 4,
-            w = tc_width, h = geo.h }
+            w = tcW, h = geo.h }
     lo = add_layout("tc_right")
     lo.geometry = geo
     lo.style = osc_styles.timecodes


### PR DESCRIPTION
- [x] [fix bottom/topbar when width too small to render all items properly](http://www.kirikoo.net/images/14Anonyme-20161025-225013.png)
  - ~~selectively disable elements when reaching a certain playresX/aspect?~~
  - use same code as box/slimbox and additionally scale after a certain min-width is reached
- [x] [fix chapter ticks with bar slider](http://i.wakku.to/Screen%20Shot%202016-10-26%20at%2000.04.30.png)
- ~~change default sub positioning to not be covered by osc~~
 - ~~`sub-margin-y=50` (this breaks box layout since subs are now covered by it)~~
 - ~~higher boxalpha (affects readability with white video)~~
- [X] _don't_ revert default layout to box, since ratio of people happier with bottombar looks to be about 1:1000
 - let 0.21.1 stay with layout=bottombar so all issues get fixed and if people still complain about it change in 0.22.0
 - ~~change before 0.21.1 and never hear about bottombar issues again~~

Ref: https://github.com/mpv-player/mpv/pull/3631, #3728 