### PR TITLE
vo_opengl: fix blue screen issues and image stalls

### DIFF
--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2801,8 +2801,8 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame, int fbo)
             bool is_new = frame->frame_id != p->image.id;
 
             // Redrawing a frame might update subtitles.
-            if (!frame->repeat && p->opts.blend_subs)
-                is_new = false;
+            if (frame->repeat && p->opts.blend_subs)
+                is_new = true;
 
             if (is_new || !p->output_fbo_valid) {
                 p->output_fbo_valid = false;
@@ -2974,9 +2974,6 @@ static bool gl_video_upload_image(struct gl_video *p, struct mp_image *mpi,
 {
     GL *gl = p->gl;
     struct video_image *vimg = &p->image;
-
-    if (vimg->id == id)
-        return true;
 
     unref_current_image(p);
 


### PR DESCRIPTION
The logic seems to have been flipped around for some reason. (Judging by
the comment, the intent was to force a redraw when using blend-subtitles
so that a changed subtitle would still register on a redrawn frame.
Although I doubt the legitimacy of this intent, this fix simply makes
the logic match the comment)

The second check that was in gl_video_upload_image was removed because
it was self-defeating: by duplicating the check from is_new, it skipped
the upload entirely even in cases where it was necessary (e.g. due to
is_new being set to true by this branch, or by the output FBO being
invalid). The skip logic is supposed to be handled in
gl_video_render_frame, not gl_video_upload_image.

Fixes #3758 and #3764.