### PR TITLE
osc: fix crashes when dragging seekbar across file changes

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2058,7 +2058,8 @@ function process_event(source, what)
 
             if n == 0 then
                 --click on background (does not work)
-            elseif n > 0 and not (elements[n].eventresponder[source .. "_" .. what] == nil) then
+            elseif n > 0 and not (n > #elements) and
+                not (elements[n].eventresponder[source .. "_" .. what] == nil) then
 
                 if mouse_hit(elements[n]) then
                     elements[n].eventresponder[source .. "_" .. what](elements[n])
@@ -2090,7 +2091,7 @@ function process_event(source, what)
 
             local n = state.active_element
 
-            if not (elements[n].eventresponder == nil) then
+            if not (n > #elements) and not (elements[n].eventresponder == nil) then
                 if not (elements[n].eventresponder[source] == nil) then
                     elements[n].eventresponder[source](elements[n])
                 end


### PR DESCRIPTION
@ChrisK2 

I didn't understand why, though, since reproduction is kinda hard to trigger.