### PR TITLE
wscript: move install dirs setting to after C compiler check

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -166,11 +166,8 @@ Or, compile and install both libmpv and mpv:
 ./waf configure CC=gcc.exe --check-c-compiler=gcc --enable-libmpv-shared --prefix=/mingw64
 ./waf install
 
-# waf installs libmpv to the wrong directory, so fix it up
-mv -f /mingw64/bin/pkgconfig/mpv.pc /mingw64/lib/pkgconfig/
-mv -f /mingw64/bin/libmpv.dll.a /mingw64/lib/
-sed -i 's_/mingw64/bin_/mingw64/lib_' /mingw64/lib/pkgconfig/mpv.pc
-rmdir /mingw64/bin/pkgconfig
+# waf installs libmpv dll to the wrong directory, so fix it up
+mv -f /mingw64/lib/mpv-1.dll /mingw64/bin/
 ```
 
 Linking libmpv with MSVC programs

--- a/wscript
+++ b/wscript
@@ -1053,6 +1053,12 @@ def configure(ctx):
     ctx.find_program('rst2pdf',   var='RST2PDF',   mandatory=False)
     ctx.find_program(windres,     var='WINDRES',   mandatory=False)
 
+    ctx.load('compiler_c')
+    ctx.load('waf_customizations')
+    ctx.load('dependencies')
+    ctx.load('detections.compiler')
+    ctx.load('detections.devices')
+
     for ident, _, _ in _INSTALL_DIRS_LIST:
         varname = ident.upper()
         ctx.env[varname] = getattr(ctx.options, ident)
@@ -1060,12 +1066,6 @@ def configure(ctx):
         # keep substituting vars, until the paths are fully expanded
         while re.match('\$\{([^}]+)\}', ctx.env[varname]):
             ctx.env[varname] = Utils.subst_vars(ctx.env[varname], ctx.env)
-
-    ctx.load('compiler_c')
-    ctx.load('waf_customizations')
-    ctx.load('dependencies')
-    ctx.load('detections.compiler')
-    ctx.load('detections.devices')
 
     ctx.parse_dependencies(build_options)
     ctx.parse_dependencies(main_dependencies)


### PR DESCRIPTION
This fixes waf setting the wrong LIBDIR for DEST_OS=win32 in
waflib/Tools/c_config.py:get_cc_version()

Any scripts assuming the implib and pkgconfig are in the wrong
place should be changed to move the .dll instead.

@rossy