### PR TITLE
Some fixes for mingw-w64/Clang

### DIFF
--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -10,7 +10,7 @@
 /** Use gcc attribute to check printf fns.  a1 is the 1-based index of
  * the parameter containing the format, and a2 the index of the first
  * argument. **/
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && !defined(__clang__)
 // MinGW maps "printf" to the non-standard MSVCRT functions, even if
 // __USE_MINGW_ANSI_STDIO is defined and set to 1. We need to use "gnu_printf",
 // which isn't necessarily available on other GCC compatible compilers.

--- a/osdep/win32-console-wrapper.c
+++ b/osdep/win32-console-wrapper.c
@@ -36,8 +36,8 @@ void cr_perror(const wchar_t *prefix)
 
 int cr_runproc(wchar_t *name, wchar_t *cmdline)
 {
-    STARTUPINFO si;
-    STARTUPINFO our_si;
+    STARTUPINFOW si;
+    STARTUPINFOW our_si;
     PROCESS_INFORMATION pi;
     DWORD retval = 1;
 
@@ -50,7 +50,7 @@ int cr_runproc(wchar_t *name, wchar_t *cmdline)
 
     // Copy the list of inherited CRT file descriptors to the new process
     our_si.cb = sizeof(our_si);
-    GetStartupInfo(&our_si);
+    GetStartupInfoW(&our_si);
     si.lpReserved2 = our_si.lpReserved2;
     si.cbReserved2 = our_si.cbReserved2;
 

--- a/ta/ta.h
+++ b/ta/ta.h
@@ -27,7 +27,7 @@
 #endif
 
 // Broken crap with __USE_MINGW_ANSI_STDIO
-#ifdef __MINGW32__
+#if defined(__MINGW32__) && defined(__GNUC__) && !defined(__clang__)
 #undef TA_PRF
 #define TA_PRF(a1, a2) __attribute__ ((format (gnu_printf, a1, a2)))
 #endif

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -401,7 +401,7 @@ static void vsync_skip_detection(struct vo *vo)
     }
     int64_t desync = diff / in->num_vsync_samples;
     if (in->drop_point > window * 2 &&
-        labs(desync - desync_early) >= in->vsync_interval * 3 / 4)
+        llabs(desync - desync_early) >= in->vsync_interval * 3 / 4)
     {
         // Assume a drop. An underflow can technically speaking not be a drop
         // (it's up to the driver what this is supposed to mean), but no reason

--- a/video/out/vo_direct3d.c
+++ b/video/out/vo_direct3d.c
@@ -1466,13 +1466,13 @@ static mp_image_t *get_window_screenshot(d3d_priv *priv)
     POINT pt;
     D3DLOCKED_RECT locked_rect;
     int width, height;
+    IDirect3DSurface9 *surface = NULL;
 
     if (FAILED(IDirect3DDevice9_GetDisplayMode(priv->d3d_device, 0, &mode))) {
         MP_ERR(priv, "GetDisplayMode failed.\n");
         goto error_exit;
     }
 
-    IDirect3DSurface9 *surface = NULL;
     if (FAILED(IDirect3DDevice9_CreateOffscreenPlainSurface(priv->d3d_device,
         mode.Width, mode.Height, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &surface,
         NULL)))

--- a/wscript
+++ b/wscript
@@ -119,7 +119,7 @@ main_dependencies = [
         'name': 'mingw',
         'desc': 'MinGW',
         'deps': [ 'os-win32' ],
-        'func': check_statement('stddef.h', 'int x = __MINGW32__;'
+        'func': check_statement('stdlib.h', 'int x = __MINGW32__;'
                                             'int y = __MINGW64_VERSION_MAJOR'),
     }, {
         'name': 'posix',


### PR DESCRIPTION
This should get mpv on mingw-w64/Clang into a mostly-working state, and it fixes some minor issues that Clang found.