### PR TITLE
command: added vo-list, ao-list properties

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1939,8 +1939,26 @@ Property list
 ``current-vo``
     Current video output driver (name as used with ``--vo``).
 
+``vo-list``
+    List of available decoders to be used with ``--vo``.
+
+    ``name``
+        Name of output driver that can be passed to ``--vo``.
+
+    ``description``
+        Description of output driver.
+
 ``current-ao``
     Current audio output driver (name as used with ``--ao``).
+
+``ao-list``
+    List of available decoders to be used with ``--ao``.
+
+    ``name``
+        Name of output driver that can be passed to ``--ao``.
+
+    ``description``
+        Description of output driver.
 
 ``audio-out-detected-device``
     Return the audio device selected by the AO driver (only implemented for


### PR DESCRIPTION
I added vo-list and ao-list properties to allow libmpv clients to retrieve info on available video and audio output drivers. I have tested this and it does work. This fufills the feature request I originally asked about in #3799.

I was unsure of how to name the m_property_read_obj_list utility function, but it seems to fit the naming convention. I'm also not sure if it should be put in m_property.h/c, considering it's only used here, so I've left it as a static function in command.c (but I can move it if you feel it'd be better to).

I agree that my changes can be relicensed to LGPL 2.1 or later.

