### PR TITLE
vo_opengl: hwdec_cuda: Support P016 output surfaces

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -703,8 +703,8 @@ Video
         mechanism in the opengl output path. To use this deinterlacing you
         must pass the option: ``vd-lavc-o=deint=[weave|bob|adaptive]``. Pass
         ``weave`` to not attempt any deinterlacing.
-        10bit HEVC is available if the hardware supports it but it will be
-        rounded down to 8 bits.
+        10 and 12bit HEVC is available if the hardware supports it and a
+        sufficiently new driver (> 375.xx) is used.
 
         ``cuda-copy`` has the same behaviour as ``cuda`` - including the ability
         to deinterlace inside the decoder. However, traditional deinterlacing

--- a/video/decode/cuda.c
+++ b/video/decode/cuda.c
@@ -21,6 +21,7 @@
 #include <libavutil/hwcontext_cuda.h>
 
 #include "common/av_common.h"
+#include "video/fmt-conversion.h"
 #include "video/decode/lavc.h"
 
 typedef struct CUVIDContext {
@@ -114,7 +115,7 @@ static void uninit(struct lavc_ctx *ctx)
 static struct mp_image *process_image(struct lavc_ctx *ctx, struct mp_image *img)
 {
     if (img->imgfmt == IMGFMT_CUDA)
-        img->params.hw_subfmt = IMGFMT_NV12;
+        img->params.hw_subfmt = pixfmt2imgfmt(ctx->avctx->sw_pix_fmt);
     return img;
 }
 

--- a/video/fmt-conversion.c
+++ b/video/fmt-conversion.c
@@ -112,6 +112,9 @@ static const struct {
 #ifdef AV_PIX_FMT_P010
     {IMGFMT_P010, AV_PIX_FMT_P010},
 #endif
+#ifdef AV_PIX_FMT_P016
+    {IMGFMT_P016, AV_PIX_FMT_P016},
+#endif
 
     {0, AV_PIX_FMT_NONE}
 };

--- a/video/img_format.h
+++ b/video/img_format.h
@@ -151,8 +151,10 @@ enum mp_imgfmt {
     IMGFMT_NV12,
     IMGFMT_NV21,
 
-    // Like IMGFMT_NV12, but with 16 bits per component
+    // Like IMGFMT_NV12, but with 10 bits per component (and 6 bits of padding)
     IMGFMT_P010,
+    // Like IMGFMT_NV12, but with 16 bits per component
+    IMGFMT_P016,
 
     // RGB/BGR Formats
 


### PR DESCRIPTION
These patches add support for handling P010/P016 output surfaces from the cuvid decoder. Separate changes in ffmpeg are required to actually output such surfaces for 10/12bit content but things will continue to work as before without them.