### PR TITLE
wscript: Fix cuda test to actually work when cuda SDK is not present

### DIFF
--- a/video/out/opengl/cuda_dynamic.h
+++ b/video/out/opengl/cuda_dynamic.h
@@ -19,7 +19,7 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if !defined(MPV_CUDA_DYNAMIC_H) && !defined(CUDA_VERSION)
+#ifndef MPV_CUDA_DYNAMIC_H
 #define MPV_CUDA_DYNAMIC_H
 
 #include <stdbool.h>

--- a/waftools/fragments/cuda.c
+++ b/waftools/fragments/cuda.c
@@ -1,0 +1,12 @@
+#define CUDA_VERSION 7050
+
+typedef void * CUcontext;
+
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_cuda.h>
+
+int main(int argc, char *argv[]) {
+    enum AVHWDeviceType type = AV_HWDEVICE_TYPE_CUDA;
+    AVCUDADeviceContextInternal *foo;
+    return 0;
+}

--- a/wscript
+++ b/wscript
@@ -922,9 +922,8 @@ hwaccel_features = [
     }, {
         'name': '--cuda-hwaccel',
         'desc': 'CUDA hwaccel',
-        'func': check_statement('libavutil/hwcontext_cuda.h',
-                                'AVCUDADeviceContextInternal* foo',
-                                use='libav'),
+        'func': check_cc(fragment=load_fragment('cuda.c'),
+                         use='libav'),
     }, {
         'name': 'sse4-intrinsics',
         'desc': 'GCC SSE4 intrinsics for GPU memcpy',


### PR DESCRIPTION
The test ended up failing if cuda.h wasn't present, even if cuda.h
isn't used during the actual build.

This test is attempting to establish if the ffmpeg being built
against has dynlink_cuda support.