### PR TITLE
vo_opengl/cuda_dynamic: Use explicit cast to silence warnings on windows

### DIFF
--- a/video/out/opengl/cuda_dynamic.c
+++ b/video/out/opengl/cuda_dynamic.c
@@ -49,7 +49,7 @@ static void cuda_do_load(void)
     }
 
 #define CUDA_LOAD_SYMBOL(NAME, TYPE) \
-    NAME = dlsym(lib, #NAME); if (!NAME) return;
+    NAME = (TYPE *)dlsym(lib, #NAME); if (!NAME) return;
 
     CUDA_FNS(CUDA_LOAD_SYMBOL)
 


### PR DESCRIPTION
Fixes #3834

I can't test it, but I think the cast is the right thing to do.