### PR TITLE
vo_opengl: hwdec_cuda: fix crash when trying to use hwdec=cuda if cud…

### DIFF
--- a/video/out/opengl/hwdec_cuda.c
+++ b/video/out/opengl/hwdec_cuda.c
@@ -155,6 +155,7 @@ static int cuda_create(struct gl_hwdec *hw)
     bool loaded = cuda_load();
     if (!loaded) {
         MP_ERR(hw, "Failed to load CUDA symbols\n");
+        return -1;
     }
 
     ret = CHECK_CU(cuInit(0));


### PR DESCRIPTION
If CUDA SDK wasn't installed, mpv crashed immediately with the message "Failed to load CUDA symbols". Mpv should fall back to software decoding instead of crashing.
This commit fixes it.

I agree that my changes can be relicensed to LGPL 2.1 or later.