### PR TITLE
wayland: destroy input before closing the display connection

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -946,8 +946,8 @@ void vo_wayland_uninit(struct vo *vo)
     struct vo_wayland_state *wl = vo->wayland;
     destroy_cursor(wl);
     destroy_window(wl);
-    destroy_display(wl);
     destroy_input(wl);
+    destroy_display(wl);
     for (int n = 0; n < 2; n++)
         close(wl->wakeup_pipe[n]);
     talloc_free(wl);


### PR DESCRIPTION
Fixes a segfault introduced in libwayland e8ad23266f36521215dcd7cfcc524e0ef67d66dd, where a poison value has been introduced to catch this kind of use-after-free bug.