### PR TITLE
ao_wasapi_utils: remove unused variable

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -857,7 +857,6 @@ static LPWSTR select_device(struct mp_log *l, struct device_desc *d)
 
 bstr wasapi_get_specified_device_string(struct ao *ao)
 {
-    struct wasapi_state *state = ao->priv;
     return bstr_strip(bstr0(ao->device));
 }
 


### PR DESCRIPTION
Introduced in 1a2319f3e4cc42c680e2fd3ba30022c7a9adf3fe
Produced a warning during compilation on Windows.