### PR TITLE
osc: replace length property with duration

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1766,7 +1766,7 @@ function osc_init()
             end
         else
             if state.tc_ms then
-                return (mp.get_property_osd("length/full"))
+                return (mp.get_property_osd("duration/full"))
             else
                 return (mp.get_property_osd("duration"))
             end


### PR DESCRIPTION
Length property is deprecated and no longer works. This fixes a bug when the total file duration wasn't visible if the option to display milliseconds was activated.