### PR TITLE
vo_opengl: hwdec_cuda: Don't include hwcontext headers

### DIFF
--- a/video/out/opengl/hwdec_cuda.c
+++ b/video/out/opengl/hwdec_cuda.c
@@ -27,14 +27,10 @@
  * when decoding 10bit streams (there is some hardware dithering going on).
  */
 
-#include <libavutil/hwcontext.h>
-
 #include "cuda_dynamic.h"
 #include "video/mp_image_pool.h"
 #include "hwdec.h"
 #include "video.h"
-
-#include <libavutil/hwcontext_cuda.h>
 
 struct priv {
     struct mp_hwdec_ctx hwctx;


### PR DESCRIPTION
After various simplifications, these includes simply aren't needed
now.