### PR TITLE
cocoa: change background color to white

### DIFF
--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -44,7 +44,7 @@
                                 styleMask:style_mask
                                   backing:buffering_type
                                     defer:flag]) {
-        [self setBackgroundColor:[NSColor blackColor]];
+        [self setBackgroundColor:[NSColor whiteColor]];
         [self setMinSize:NSMakeSize(50,50)];
     }
     return self;


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.

New "vibrancy" feature in OSX 10.10 added see-through for most components. Default background color is white for most windows, but mpv had black for some reason.

Current:
![](http://i.imgur.com/zeUse7y.png)
With white background:
![](http://i.imgur.com/2K9T8zd.png)
