### PR TITLE
win32: provide fnmatch replacement

### DIFF
--- a/options/m_config.c
+++ b/options/m_config.c
@@ -31,6 +31,8 @@
 
 #if HAVE_FNMATCH
 #include <fnmatch.h>
+#elif defined(_WIN32)
+#include <shlwapi.h>
 #endif
 
 #include "libmpv/client.h"
@@ -958,6 +960,9 @@ void m_config_print_option_list(const struct m_config *config, const char *name)
             continue;
 #if HAVE_FNMATCH
         if (fnmatch(name, co->name, 0))
+            continue;
+#elif defined(_WIN32)
+        if (!PathMatchSpecA(co->name, name))
             continue;
 #endif
         MP_INFO(config, " %s%-30s", prefix, co->name);

--- a/wscript
+++ b/wscript
@@ -143,7 +143,7 @@ main_dependencies = [
         'name': 'win32',
         'desc': 'win32',
         'deps_any': [ 'os-win32', 'os-cygwin' ],
-        'func': check_cc(lib=['winmm', 'gdi32', 'ole32', 'uuid', 'avrt', 'dwmapi']),
+        'func': check_cc(lib=['winmm', 'gdi32', 'ole32', 'uuid', 'avrt', 'dwmapi', 'shlwapi']),
     }, {
         'name': '--win32-internal-pthreads',
         'desc': 'internal pthread wrapper for win32 (Vista+)',


### PR DESCRIPTION
It finally allows searching options with wildcard pattern on Windows, e.g. `mpv --h=*scale*`.

Previously mpv returned all possible options, no matter what pattern is passed by the user.