### PR TITLE
win32: window styles improvements

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1112,10 +1112,15 @@ static void update_screen_rect(struct vo_w32_state *w32)
 
 static DWORD update_style(struct vo_w32_state *w32, DWORD style)
 {
-    const DWORD NO_FRAME = WS_OVERLAPPED;
-    const DWORD FRAME = WS_OVERLAPPEDWINDOW | WS_SIZEBOX;
-    style &= ~(NO_FRAME | FRAME);
-    style |= (w32->opts->border && !w32->current_fs) ? FRAME : NO_FRAME;
+    const DWORD NO_FRAME = WS_OVERLAPPED | WS_MINIMIZEBOX;
+    const DWORD FRAME = WS_OVERLAPPEDWINDOW;
+    const DWORD FULLSCREEN = NO_FRAME | WS_SYSMENU;
+    style &= ~(NO_FRAME | FRAME | FULLSCREEN);
+    if (w32->current_fs) {
+        style |= FULLSCREEN;
+    } else {
+        style |= w32->opts->border ? FRAME : NO_FRAME;
+    }
     return style;
 }
 


### PR DESCRIPTION
A few improvements and bug fixes to the window styles:

- Added `WS_MINIMIZEBOX` to the `NO_FRAME` styles, which allows minimizing the borderless or fullscreen window by clicking on the taskbar button or pressing <kbd>Win</kbd>+<kbd>↓</kbd> hotkey.

- I didn't add the `WS_MAXIMIZEBOX` style because it will break the fullscreen switching once the borderless windows is maximized by <kbd>Win</kbd>+<kbd>↑</kbd> hotkey. Also there's no much sense in maximizing the borderless window, since there's no difference between that and just switching to fullscreen.
---
- Removed `WS_SIZEBOX` from the `FRAME` styles, since it is already included in `WS_OVERLAPPEDWINDOW` (`WS_SIZEBOX` is the same as `WS_THICKFRAME` according to MSDN)
---
- Added `FULLSCREEN` styles set which is the same as `NO_FRAME` but with `WS_SYSMENU` style added.
It fixes #2229 (which was always reproducable for me) and probably fixes #2451 (can't confirm this because I never could reproduce it).

- I didn't add `WS_SYSMENU` to `NO_FRAME` because it will break the `WM_NCHITTEST` events, so it will be impossible to resize the borderless window by mouse. Probably it's a Microsoft bug.

Tested on Windows 7 and 10.