### PR TITLE
ad_spdif: Fix crash when spdif muxer is not available

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -71,6 +71,7 @@ static void uninit(struct dec_audio *da)
             av_freep(&lavf_ctx->pb->buffer);
         av_freep(&lavf_ctx->pb);
         avformat_free_context(lavf_ctx);
+        spdif_ctx->lavf_ctx = NULL;
     }
 }
 


### PR DESCRIPTION
Currently, if init_filter fails after lavf_ctx is allocated, uninit is called
which frees lavf_ctx, but doesn't clear the pointer in spdif_ctx. So, on the
next call of decode_packet, it thinks it is already initialized and uses it,
resulting in a crash on my system.