### PR TITLE
win32: change the log level of 'move window' msg

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -727,7 +727,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         signal_events(w32, VO_EVENT_WIN_STATE);
 
         update_display_info(w32);  // if we moved between monitors
-        MP_VERBOSE(w32, "move window: %d:%d\n", w32->window_x, w32->window_y);
+        MP_DBG(w32, "move window: %d:%d\n", w32->window_x, w32->window_y);
         break;
     }
     case WM_SIZE: {


### PR DESCRIPTION
Can this line be removed please? It is really annoying since it spams terminal a lot and it's really hard to see other console messages.