### PR TITLE
manpage: add table of contents to the HTML version

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -9,6 +9,8 @@ a media player
 :Manual section: 1
 :Manual group: multimedia
 
+.. contents:: Table of Contents
+
 SYNOPSIS
 ========
 

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -28,7 +28,7 @@ def _build_man(ctx):
         name         = 'rst2man',
         target       = 'DOCS/man/mpv.1',
         source       = 'DOCS/man/mpv.rst',
-        rule         = '${RST2MAN} ${SRC} ${TGT}',
+        rule         = '${RST2MAN} --strip-elements-with-class=contents ${SRC} ${TGT}',
         install_path = ctx.env.MANDIR + '/man1')
 
     _add_rst_manual_dependencies(ctx)


### PR DESCRIPTION
The HTML manual is really long, so a TOC really helps:

![mpv html-with-toc](https://cloud.githubusercontent.com/assets/4149852/21165226/1488ba6a-c16c-11e6-9a47-a615516bcb47.png)

I'm not limiting the TOC depth at the moment, but we can easily add `depth` to the `contents` directive.

<del>Unfortunately the `contents` directive is processed by both `rst2man` and `rst2html`, and my current way to keep it out of `mpv.1` is pretty ugly. It would be great if someone could think of a better approach.</del>

---

I agree that my changes can be relicensed to LGPL 2.1 or later.

