### PR TITLE
cocoa: add border cycling

### DIFF
--- a/video/out/cocoa/window.h
+++ b/video/out/cocoa/window.h
@@ -27,4 +27,5 @@
 - (BOOL)canBecomeKeyWindow;
 - (BOOL)canBecomeMainWindow;
 - (void)mulSize:(float)multiplier;
+- (void)updateBorder:(int)border;
 @end

--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -212,6 +212,34 @@
     [self.adapter putCommand:cmd];
 }
 
+- (void)updateBorder:(int)border
+{
+    int borderStyle = NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|
+                 NSWindowStyleMaskMiniaturizable;
+    if (border) {
+        int window_mask = [self styleMask] & ~NSWindowStyleMaskBorderless;
+        window_mask |= borderStyle;
+        [self setStyleMask:window_mask];
+    } else {
+        int window_mask = [self styleMask] & ~borderStyle;
+        window_mask |= NSWindowStyleMaskBorderless;
+        [self setStyleMask:window_mask];
+    }
+
+    if (![self.adapter isInFullScreenMode]) {
+        // XXX: workaround to force redrawing of window decoration
+        if (border) {
+            NSRect frame = [self frame];
+            frame.size.width += 1;
+            [self setFrame:frame display:YES];
+            frame.size.width -= 1;
+            [self setFrame:frame display:YES];
+        }
+
+        [self setContentAspectRatio:_unfs_content_frame.size];
+    }
+}
+
 - (NSRect)frameRect:(NSRect)f forCenteredContentSize:(NSSize)ns
 {
     NSRect cr  = [self contentRectForFrameRect:f];

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -532,6 +532,20 @@ static int cocoa_set_window_title(struct vo *vo)
     return VO_TRUE;
 }
 
+static int vo_cocoa_window_border(struct vo *vo)
+{
+    struct vo_cocoa_state *s = vo->cocoa;
+    if (s->embedded)
+        return VO_NOTIMPL;
+
+    struct mp_vo_opts *opts = vo->opts;
+    [s->window updateBorder:opts->border];
+    if (opts->border)
+        cocoa_set_window_title(vo);
+
+    return VO_TRUE;
+}
+
 static void cocoa_screen_reconfiguration_observer(
     CGDirectDisplayID display, CGDisplayChangeSummaryFlags flags, void *ctx)
 {
@@ -727,6 +741,8 @@ static int vo_cocoa_control_on_main_thread(struct vo *vo, int request, void *arg
         return VO_TRUE;
     case VOCTRL_ONTOP:
         return vo_cocoa_ontop(vo);
+    case VOCTRL_BORDER:
+        return vo_cocoa_window_border(vo);
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {
         int *sz = arg;
         NSSize size = [s->view frame].size;


### PR DESCRIPTION
there is one minor issue. if you cycle the border it doesn't properly redraw the title bar and the transparent part of the rounded corner is missing. resizing the window manually fixes it. so a possible workaround would be to temporarily resize the window by a pixel. though this seems a bit hacky. i couldn't find a method which would update the window decoration.

![screen shot 2016-12-15 at 01 24 22](https://cloud.githubusercontent.com/assets/680386/21207217/296d6e98-c267-11e6-862a-8e7950d88550.png)
