### PR TITLE
win32: fix for wm_syscommand

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -786,7 +786,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         PostQuitMessage(0);
         break;
     case WM_SYSCOMMAND:
-        switch (wParam) {
+        switch (wParam & 0xFFF0) {
         case SC_SCREENSAVE:
         case SC_MONITORPOWER:
             if (w32->disable_screensaver) {


### PR DESCRIPTION
According to MSDN, in [WM_SYSCOMMAND](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646360(v=vs.85).aspx) messages, the four low-order
bits of the wParam parameter are used internally by the system.
To obtain the correct result when testing the value of wParam,
an application must combine the value 0xFFF0 with the wParam
value by using the bitwise AND operator.