### PR TITLE
cocoa: Change borderless windows to be rounded instead of square(10.10+)

### DIFF
--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -32,6 +32,7 @@ static const NSWindowStyleMask NSWindowStyleMaskMiniaturizable = NSMiniaturizabl
 static const NSWindowStyleMask NSWindowStyleMaskResizable = NSResizableWindowMask;
 static const NSWindowStyleMask NSWindowStyleMaskBorderless = NSBorderlessWindowMask;
 static const NSWindowStyleMask NSWindowStyleMaskFullScreen = NSFullScreenWindowMask;
+static const NSWindowStyleMask NSWindowStyleMaskFullSizeContentView = 15;
 
 static const NSEventType NSEventTypeSystemDefined = NSSystemDefined;
 static const NSEventType NSEventTypeKeyDown = NSKeyDown;

--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -32,7 +32,7 @@ static const NSWindowStyleMask NSWindowStyleMaskMiniaturizable = NSMiniaturizabl
 static const NSWindowStyleMask NSWindowStyleMaskResizable = NSResizableWindowMask;
 static const NSWindowStyleMask NSWindowStyleMaskBorderless = NSBorderlessWindowMask;
 static const NSWindowStyleMask NSWindowStyleMaskFullScreen = NSFullScreenWindowMask;
-static const NSWindowStyleMask NSWindowStyleMaskFullSizeContentView = 15;
+static const NSWindowStyleMask NSWindowStyleMaskFullSizeContentView = NSFullSizeContentViewWindowMask;
 
 static const NSEventType NSEventTypeSystemDefined = NSSystemDefined;
 static const NSEventType NSEventTypeKeyDown = NSKeyDown;

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -445,7 +445,13 @@ static MpvVideoWindow *create_window(NSRect rect, NSScreen *s, bool border,
         window_mask = NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|
                       NSWindowStyleMaskMiniaturizable|NSWindowStyleMaskResizable;
     } else {
-        window_mask = NSWindowStyleMaskBorderless|NSWindowStyleMaskResizable;
+        #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10)
+            window_mask = NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|
+                          NSWindowStyleMaskMiniaturizable|NSWindowStyleMaskResizable|
+                          NSWindowStyleMaskFullSizeContentView;
+        #else
+            window_mask = NSWindowStyleMaskBorderless|NSWindowStyleMaskResizable;
+        #endif
     }
 
     MpvVideoWindow *w =
@@ -456,6 +462,13 @@ static MpvVideoWindow *create_window(NSRect rect, NSScreen *s, bool border,
                                              screen:s];
     w.adapter = adapter;
     [w setDelegate: w];
+    
+    #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10)
+    if (!border) {
+        [w setTitlebarAppearsTransparent:YES];
+        [[w standardWindowButton:NSWindowCloseButton].superview.superview setHidden:YES];
+    }
+    #endif
 
     return w;
 }


### PR DESCRIPTION
![screen shot 2016-12-23 at 3 16 54 am](https://cloud.githubusercontent.com/assets/6215387/21448941/47888ee6-c8be-11e6-91d6-b6b9010ad8f6.png)

Only affects 10.10+, anything below will still use the square corners

I agree that my changes can be relicensed to LGPL 2.1 or later.
