### PR TITLE
vo_tct: use terminfo

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -93,7 +93,9 @@ const struct vo_driver *const video_out_drivers[] =
     &video_out_null,
     // should not be auto-selected
     &video_out_image,
+#if HAVE_NCURSES
     &video_out_tct,
+#endif
 #if HAVE_CACA
     &video_out_caca,
 #endif

--- a/wscript
+++ b/wscript
@@ -824,8 +824,16 @@ video_output_features = [
         'desc': 'EGL helper functions',
         'deps_any': [ 'egl-x11', 'mali-fbdev', 'rpi', 'gl-wayland', 'egl-drm' ],
         'func': check_true
-    }
-]
+    }, {
+        'name': '--ncurses',
+        'desc': 'ncurses',
+        'func': check_pkg_config('ncurses'),
+    }, {
+        'name': '--tct',
+        'desc': 'True-color terminal',
+        'deps': [ 'ncurses' ],
+        'func': check_true,
+    }]
 
 hwaccel_features = [
     {

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -378,7 +378,7 @@ def build(ctx):
         ( "video/out/vo_opengl.c",               "gl" ),
         ( "video/out/vo_opengl_cb.c",            "gl" ),
         ( "video/out/vo_sdl.c",                  "sdl2" ),
-        ( "video/out/vo_tct.c" ),
+        ( "video/out/vo_tct.c",                  "ncurses" ),
         ( "video/out/vo_vaapi.c",                "vaapi-x11" ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),
         ( "video/out/vo_wayland.c",              "wayland" ),


### PR DESCRIPTION
Terminals define control codes differently, using hardcoded escape codes
is not the best way to go about it.

This adds a dependency to ncurses to access the terminal capabilities to
print the proper control codes.

I agree that my changes can be relicensed to LGPL 2.1 or later.