### PR TITLE
cocoa: fix window size in certain circumstances

### DIFF
--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -332,11 +332,6 @@
            display:NO];
 }
 
-- (void)updateWindowFrame:(NSSize)newSize
-{
-    _unfs_content_frame = [self frameRect:_unfs_content_frame forCenteredContentSize:newSize];
-}
-
 - (void)tryDequeueSize
 {
     if (_queued_video_size.width <= 0.0 || _queued_video_size.height <= 0.0)
@@ -349,9 +344,8 @@
 
 - (void)queueNewVideoSize:(NSSize)newSize
 {
-    if ([self.adapter isInFullScreenMode]) {
-        [self updateWindowFrame:newSize];
-    } else {
+    _unfs_content_frame = [self frameRect:_unfs_content_frame forCenteredContentSize:newSize];
+    if (![self.adapter isInFullScreenMode]) {
         if (NSEqualSizes(_queued_video_size, newSize))
             return;
         _queued_video_size = newSize;


### PR DESCRIPTION
fixes the first issue from #3944.

i can't completely remember why i only set this when in fullscreen, but i believe it is a remnant of a different attempt when i tested my initial native-fs attempt. i removed the functions since it is only used at one place. it was initially in a function because i used it at several places and it did more than just setting one variable. it was since refactored and simplified and doesn't have a purpose anymore.