### PR TITLE
add --ontop-level option for modifying ontop window level

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2130,6 +2130,14 @@ Window
     treated as exclusive fullscreen window that bypasses the Desktop Window
     Manager.
 
+``--ontop-level=<window|system|level>``
+    (OS X only)
+    Sets the level of an ontop window (default: window).
+
+    :window:  On top of all other windows.
+    :system:  On top of system elements like Taskbar, Menubar and Dock.
+    :level:   A level as integer.
+
 ``--border``, ``--no-border``
     Play video with window border and decorations. Since this is on by
     default, use ``--no-border`` to disable the standard window decorations.

--- a/options/options.c
+++ b/options/options.c
@@ -160,6 +160,8 @@ static const m_option_t mp_vo_opt_list[] = {
     OPT_FLAG("taskbar-progress", taskbar_progress, 0),
     OPT_FLAG("snap-window", snap_window, 0),
     OPT_FLAG("ontop", ontop, 0),
+    OPT_CHOICE_OR_INT("ontop-level", ontop_level, 0, 0, INT_MAX,
+                      ({"window", -1}, {"system", -2})),
     OPT_FLAG("border", border, 0),
     OPT_FLAG("fit-border", fit_border, 0),
     OPT_FLAG("on-all-workspaces", all_workspaces, 0),
@@ -233,6 +235,7 @@ const struct m_sub_options vo_sub_opts = {
         .window_scale = 1.0,
         .x11_bypass_compositor = 2,
         .mmcss_profile = "Playback",
+        .ontop_level = -1,
     },
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -12,6 +12,7 @@ typedef struct mp_vo_opts {
     int taskbar_progress;
     int snap_window;
     int ontop;
+    int ontop_level;
     int fullscreen;
     int border;
     int fit_border;


### PR DESCRIPTION
this adds an option to modify the ontop level. this could be reused on other platforms too. i added two predefined levels, which i thought were the most common use cases. additionally it's possible to just use an integer to define the level by hand.

i am not too sure if i should use the "cocoa" in the commit title or something more general, since the option can be used on other platforms in the future but it's only implemented on macOS so far.