### PR TITLE
osc: fix crashes related to field eventresponder being nil

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2072,6 +2072,7 @@ function process_event(source, what)
             if n == 0 then
                 --click on background (does not work)
             elseif n > 0 and not (n > #elements) and
+                not (elements[n].eventresponder == nil) and
                 not (elements[n].eventresponder[source .. "_" .. what] == nil) then
 
                 if mouse_hit(elements[n]) then


### PR DESCRIPTION
I'm still getting some crashes after issue #3210 was fixed in commit 5beb2306904b4437b5acf136b02aeaa073c351c7. It's hard to reproduce those crashes, they happen maybe once a month, so I guess it could be a race condition. But in any case, I don't see anything wrong in applying some defensive programming here.

For reference, here is what was happening on 0.23.0-1 from Debian testing:
```
  Playing: ytdl://usL5CeP_row
   (+) Video --vid=1 (*) (h264)
    (+) Audio --aid=1 --alang=und (*) (aac)
    [osc]
    [osc] stack traceback:
    [osc]	  @osc.lua:2074: in function 'process_event'
    [osc]	  @osc.lua:2246: in function 'cb'
    [osc]	  mp.defaults:107: in function 'fn'
    [osc]	  mp.defaults:60: in function 'handler'
    [osc]	  mp.defaults:339: in function 'handler'
    [osc]	  mp.defaults:448: in function 'call_event_handlers'
    [osc]	  mp.defaults:485: in function 'dispatch_events'
    [osc]	  mp.defaults:441: in function <mp.defaults:440>
    [osc]	  [C]: in ?
    [osc]	  [C]: in ?
    [osc] Lua error: @osc.lua:2074: attempt to index field 'eventresponder' (a nil value)
```
Note that the location is different from where issue #3210 happens.

I agree that my changes can be relicensed to LGPL 2.1 or later.