### PR TITLE
cocoa: consistent normalisation when searching for external files

### DIFF
--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -234,5 +234,9 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
 #endif
 
 failure:
-    return bstr_sanitize_utf8_latin1(NULL, buf);
+    if (flags & MP_NO_LATIN1_FALLBACK) {
+        return buf;
+    } else {
+        return bstr_sanitize_utf8_latin1(NULL, buf);
+    }
 }

--- a/misc/charset_conv.h
+++ b/misc/charset_conv.h
@@ -10,6 +10,7 @@ enum {
     MP_ICONV_VERBOSE = 1,       // print errors instead of failing silently
     MP_ICONV_ALLOW_CUTOFF = 2,  // allow partial input data
     MP_STRICT_UTF8 = 4,         // don't fall back to UTF-8-BROKEN when guessing
+    MP_NO_LATIN1_FALLBACK = 8,  // fall back to input buffer instead of latin1
 };
 
 bool mp_charset_is_utf8(const char *user_cp);

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -10,6 +10,7 @@
 #include "common/global.h"
 #include "common/msg.h"
 #include "misc/ctype.h"
+#include "misc/charset_conv.h"
 #include "options/options.h"
 #include "options/path.h"
 #include "external_files.h"
@@ -97,10 +98,15 @@ static void append_dir_subtitles(struct mpv_global *global,
     if (mp_is_url(bstr0(fname)))
         goto out;
 
-    struct bstr f_fname = bstr0(mp_basename(fname));
+    struct bstr f_fbname = bstr0(mp_basename(fname));
+    struct bstr f_fname = mp_iconv_to_utf8(log, f_fbname,
+                                           "UTF-8-MAC", MP_NO_LATIN1_FALLBACK);
     struct bstr f_fname_noext = bstrdup(tmpmem, bstr_strip_ext(f_fname));
     bstr_lower(f_fname_noext);
     struct bstr f_fname_trim = bstr_strip(f_fname_noext);
+
+    if (f_fbname.start != f_fname.start)
+        talloc_steal(tmpmem, f_fname.start);
 
     // 0 = nothing
     // 1 = any subtitle file
@@ -113,14 +119,18 @@ static void append_dir_subtitles(struct mpv_global *global,
     mp_verbose(log, "Loading external files in %.*s\n", BSTR_P(path));
     struct dirent *de;
     while ((de = readdir(d))) {
-        struct bstr dename = bstr0(de->d_name);
         void *tmpmem2 = talloc_new(tmpmem);
-
+        struct bstr den = bstr0(de->d_name);
+        struct bstr dename = mp_iconv_to_utf8(log, den,
+                                              "UTF-8-MAC", MP_NO_LATIN1_FALLBACK);
         // retrieve various parts of the filename
         struct bstr tmp_fname_noext = bstrdup(tmpmem2, bstr_strip_ext(dename));
         bstr_lower(tmp_fname_noext);
         struct bstr tmp_fname_ext = bstr_get_ext(dename);
         struct bstr tmp_fname_trim = bstr_strip(tmp_fname_noext);
+
+        if (den.start != dename.start)
+            talloc_steal(tmpmem2, dename.start);
 
         // check what it is (most likely)
         int type = test_ext(tmp_fname_ext);


### PR DESCRIPTION
this is an attempt to fix #4016 without breaking something else again. i am not too sure if i handled the memory management properly, specifically the `talloc_steal` calls.