### PR TITLE
Improve osc title readability

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -658,8 +658,15 @@ function render_elements(master_ass)
             end
 
             local maxchars = element.layout.button.maxchars
-
             if not (maxchars == nil) and (#buttontext > maxchars) then
+                if (#buttontext > maxchars+20) then
+                    while (#buttontext > maxchars+20) do
+                        buttontext = buttontext:gsub(".[\128-\191]*$", "")
+                    end
+                    buttontext = buttontext .. "..."
+                end
+                local _, nchars2 = buttontext:gsub(".[\128-\191]*", "")
+                local stretch = (maxchars/#buttontext)*100
                 buttontext = string.format("{\\fscx%f}",
                     (maxchars/#buttontext)*100) .. buttontext
             end
@@ -944,7 +951,7 @@ layouts["box"] = function ()
     lo = add_layout("title")
     lo.geometry = {x = posX, y = titlerowY, an = 8, w = 496, h = 12}
     lo.style = osc_styles.vidtitle
-    lo.button.maxchars = 90
+    lo.button.maxchars = 80
 
     lo = add_layout("pl_prev")
     lo.geometry =

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1224,8 +1224,9 @@ layouts["bottombar"] = function()
             w = t_r - t_l, h = geo.h }
     lo = add_layout("title")
     lo.geometry = geo
-    lo.style = osc_styles.vidtitleBar
-    lo.button.maxchars = math.floor(geo.w/7)
+    lo.style = string.format("%s{\\clip(%f,%f,%f,%f)}",
+        osc_styles.vidtitleBar,
+        geo.x, geo.y-geo.h/2, geo.w, geo.y+geo.h/2)
 
 
     -- Playback control buttons
@@ -1450,8 +1451,9 @@ layouts["topbar"] = function()
             w = t_r - t_l, h = geo.h }
     lo = add_layout("title")
     lo.geometry = geo
-    lo.style = osc_styles.vidtitleBar
-    lo.button.maxchars = math.floor(geo.w/7)
+    lo.style = string.format("%s{\\clip(%f,%f,%f,%f)}",
+        osc_styles.vidtitleBar,
+        geo.x, geo.y-geo.h/2, geo.w, geo.y+geo.h/2)
 end
 
 -- Validate string type user options


### PR DESCRIPTION
### bottombar/topbar change
before:
![image](https://i.fsbn.eu/1MeH.png)
after:
![image](https://i.fsbn.eu/9ArP.png)

---

### box change
#### before
![image](https://i.fsbn.eu/xaJy.png)
after:
*until 100 chars*
![image](https://i.fsbn.eu/djnY.png)
after 100 chars:
![image](https://i.fsbn.eu/3dwq.png)