### PR TITLE
x11: Defer positioning and resizing until after window is mapped.

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1495,7 +1495,6 @@ static void vo_x11_map_window(struct vo *vo, struct mp_rect rc)
 {
     struct vo_x11_state *x11 = vo->x11;
 
-    vo_x11_move_resize(vo, true, true, rc);
     vo_x11_decoration(vo, vo->opts->border);
 
     if (vo->opts->fullscreen && (x11->wm_type & vo_wm_FULLSCREEN)) {
@@ -1537,6 +1536,7 @@ static void vo_x11_map_window(struct vo *vo, struct mp_rect rc)
         events |= KeyPressMask | KeyReleaseMask;
     vo_x11_selectinput_witherr(vo, x11->display, x11->window, events);
     XMapWindow(x11->display, x11->window);
+    vo_x11_move_resize(vo, true, true, rc);
 
     if (vo->opts->fullscreen && (x11->wm_type & vo_wm_FULLSCREEN))
         x11_set_ewmh_state(x11, "_NET_WM_STATE_FULLSCREEN", 1);


### PR DESCRIPTION
As far as I can tell, X11 is not obligated to honor changes in a window's
dimensions or screen coordinates until it's mapped with XMapWindow, so
vo_x11_move_resize needs to be placed below the mapping in order to
have any consistent effect.

Fixes #4070.
