### PR TITLE
build: rpi: add missing linker flags to fix build

### DIFF
--- a/wscript
+++ b/wscript
@@ -754,7 +754,7 @@ video_output_features = [
                      lib=['mmal_core', 'mmal_util', 'mmal_vc_client', 'bcm_host']),
             # We still need all OpenGL symbols, because the vo_opengl code is
             # generic and supports anything from GLES2/OpenGL 2.1 to OpenGL 4 core.
-            check_cc(lib="EGL"),
+            check_cc(lib="EGL", linkflags="-lGLESv2"),
             check_cc(lib="GLESv2"),
             check_statement('GL/gl.h', '(void)GL_RGB32F'),     # arbitrary OpenGL 3.0 symbol
             check_statement('GL/gl.h', '(void)GL_LUMINANCE16') # arbitrary OpenGL legacy-only symbol


### PR DESCRIPTION
See https://www.raspberrypi.org/forums/viewtopic.php?f=67&t=20005&p=194090
and https://github.com/raspberrypi/firmware/issues/110

Raspberry-pi upstream also adds '-lGLESv2' when EGL is used:
https://github.com/raspberrypi/userland/blob/master/pkgconfig/egl.pc.in

Otherwise build fails with this error: https://paste.pound-python.org/show/axxdabjWJCf3UJdIRVga/