### PR TITLE
build: rpi: rely on pkgconfig for compiler flags

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -4,7 +4,7 @@ from waflib import Utils
 import os
 
 __all__ = ["check_pthreads", "check_iconv", "check_lua", "check_oss_4front",
-           "check_cocoa", "check_openal"]
+           "check_cocoa", "check_openal", "check_rpi"]
 
 pthreads_program = load_fragment('pthreads.c')
 
@@ -127,3 +127,29 @@ def check_openal(ctx, dependency_identifier):
         if fn(ctx, dependency_identifier):
             return True
     return False
+
+def check_rpi(ctx, dependency_identifier):
+    # We need MMAL/bcm_host/dispmanx APIs.
+    # Upstream keeps pkgconfig files in '/opt/vc/lib/pkgconfig'.
+    # See https://github.com/raspberrypi/userland/issues/245
+    # PKG_CONFIG_SYSROOT_DIR helps with cross compilation.
+    prev_pkg_path = os.getenv('PKG_CONFIG_PATH', '')
+    os.environ['PKG_CONFIG_PATH'] = os.pathsep.join(
+        filter(None, [os.path.join(os.getenv('PKG_CONFIG_SYSROOT_DIR', '/'),
+                                   'opt/vc/lib/pkgconfig'),
+                      prev_pkg_path]))
+
+    checks = [
+        check_pkg_config('bcm_host', uselib_store='bcm_host'),
+        check_pkg_config('egl'),
+        check_pkg_config('glesv2'),
+        check_cc(lib=['mmal_core', 'mmal_util', 'mmal_vc_client'], use=['bcm_host']),
+        # We still need all OpenGL symbols, because the vo_opengl code is
+        # generic and supports anything from GLES2/OpenGL 2.1 to OpenGL 4 core.
+        check_statement('GL/gl.h', '(void)GL_RGB32F'),     # arbitrary OpenGL 3.0 symbol
+        check_statement('GL/gl.h', '(void)GL_LUMINANCE16') # arbitrary OpenGL legacy-only symbol
+    ]
+
+    ret = all((fn(ctx, dependency_identifier) for fn in checks))
+    os.environ['PKG_CONFIG_PATH'] = prev_pkg_path
+    return ret

--- a/wscript
+++ b/wscript
@@ -738,27 +738,9 @@ video_output_features = [
         'desc': 'Android support',
         'func': check_statement('android/api-level.h', '(void)__ANDROID__'),  # arbitrary android-specific header
     }, {
-        # We need MMAL/bcm_host/dispmanx APIs. Also, most RPI distros require
-        # every project to hardcode the paths to the include directories. Also,
-        # these headers are so broken that they spam tons of warnings by merely
-        # including them (compensate with -isystem and -fgnu89-inline).
         'name': '--rpi',
         'desc': 'Raspberry Pi support',
-        'func': compose_checks(
-            check_cc(cflags="-isystem/opt/vc/include/ "+
-                            "-isystem/opt/vc/include/interface/vcos/pthreads " +
-                            "-isystem/opt/vc/include/interface/vmcs_host/linux " +
-                            "-fgnu89-inline",
-                     linkflags="-L/opt/vc/lib",
-                     header_name="bcm_host.h",
-                     lib=['mmal_core', 'mmal_util', 'mmal_vc_client', 'bcm_host']),
-            # We still need all OpenGL symbols, because the vo_opengl code is
-            # generic and supports anything from GLES2/OpenGL 2.1 to OpenGL 4 core.
-            check_cc(lib="EGL"),
-            check_cc(lib="GLESv2"),
-            check_statement('GL/gl.h', '(void)GL_RGB32F'),     # arbitrary OpenGL 3.0 symbol
-            check_statement('GL/gl.h', '(void)GL_LUMINANCE16') # arbitrary OpenGL legacy-only symbol
-        ),
+        'func': check_rpi,
     }, {
         'name': '--standard-gl',
         'desc': 'Desktop standard OpenGL support',


### PR DESCRIPTION
Upstream provides pkgconfig files for quite some time now [1,2].
Use them to determine the required flags instead of hard coding.

This makes cross-compilation easy, which I dare to say is important for
many raspberry-pi users. This also prevents picking libEGL and libGLESv2
from mesa when they are present, which can happen with the current code.

Good distros should put these pkgconfig files into default pkg-config
search path or populate PKG_CONFIG_PATH for users. However, be nice to
everybody and manually look into '/opt/vc/lib/pkgconfig' just in case.
Hence the PKG_CONFIG_PATH mangling.

1: https://github.com/raspberrypi/userland/issues/245
2: https://github.com/raspberrypi/userland/commit/05d60a01d53dca363bb4286594db1826ffff8762

This PR also automatically solves the problem described in #4075.