### PR TITLE
sub: add justify of subtitles

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -32,6 +32,8 @@ Interface changes
         - "vo-drop-frame-count" to "frame-drop-count"
       The old names still work, but are deprecated.
     - remove the --stream-capture option and property. No replacement.
+    - add --sub-justify
+    - add --sub-ass-justify
  --- mpv 0.23.0 ---
     - remove deprecated vf_vdpaurb (use "--hwdec=vdpau-copy" instead)
     - the following properties now have new semantics:

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1976,6 +1976,18 @@ Subtitles
     Vertical position (default: ``bottom``).
     Details see ``--sub-align-x``.
 
+``--sub-justify=<auto|left|center|right>``
+    Control how multi line subs are justified irrespective of where they
+    are aligned (default: ``auto`` which justifies as defined by
+    ``--sub-align-y``).
+    Left justification is recommended to make the subs easier to read
+    as it is easier for the eyes.
+
+``--sub-ass-justify=<yes|no>``
+    Applies justification as defined by ``--sub-justify`` on ASS subtitles
+    if ``--sub-ass-style-override`` is not set to ``no``.
+    Default: ``no``.
+
 ``--sub-shadow-color=<color>``
     See ``--sub-color``. Color used for sub text shadow.
 

--- a/options/options.c
+++ b/options/options.c
@@ -500,6 +500,7 @@ const m_option_t mp_opts[] = {
                ({"none", 0}, {"light", 1}, {"normal", 2}, {"native", 3})),
     OPT_CHOICE("sub-ass-shaper", ass_shaper, UPDATE_OSD,
                ({"simple", 0}, {"complex", 1})),
+    OPT_FLAG("sub-ass-justify", ass_justify, 0),
     OPT_CHOICE("sub-ass-style-override", ass_style_override, UPDATE_OSD,
                ({"no", 0}, {"yes", 1}, {"force", 3}, {"signfs", 4}, {"strip", 5})),
     OPT_FLAG("sub-scale-by-window", sub_scale_by_window, UPDATE_OSD),

--- a/options/options.h
+++ b/options/options.h
@@ -281,6 +281,7 @@ typedef struct MPOpts {
     int ass_style_override;
     int ass_hinting;
     int ass_shaper;
+    int ass_justify;
     int sub_clear_on_seek;
     int teletext_page;
 

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -78,6 +78,9 @@ void mp_ass_set_style(ASS_Style *style, double res_y,
     style->ScaleX = 1.;
     style->ScaleY = 1.;
     style->Alignment = 1 + (opts->align_x + 1) + (opts->align_y + 2) % 3 * 4;
+#ifdef ASS_JUSTIFY_LEFT
+    style->Justify = opts->justify;
+#endif
     style->Blur = opts->blur;
     style->Bold = opts->bold;
     style->Italic = opts->italic;

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -62,6 +62,8 @@ static const m_option_t style_opts[] = {
     OPT_FLOATRANGE("blur", blur, 0, 0, 20),
     OPT_FLAG("bold", bold, 0),
     OPT_FLAG("italic", italic, 0),
+    OPT_CHOICE("justify", justify, 0,
+               ({"auto", 0}, {"left", 1}, {"center", 2}, {"right", 3})),
     {0}
 };
 

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -134,6 +134,7 @@ struct osd_style_opts {
     float blur;
     int bold;
     int italic;
+    int justify;
 };
 
 extern const struct m_sub_options osd_style_conf;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -23,6 +23,7 @@
 
 #include <libavutil/common.h>
 #include <ass/ass.h>
+#include <ass/ass_types.h>
 
 #include "mpv_talloc.h"
 
@@ -332,6 +333,10 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
 #if LIBASS_VERSION >= 0x01201001
     if (converted)
         set_force_flags |= ASS_OVERRIDE_BIT_ALIGNMENT;
+#endif
+#ifdef ASS_JUSTIFY_AUTO
+    if ((converted || opts->ass_style_override) && opts->ass_justify)
+        set_force_flags |= ASS_OVERRIDE_BIT_JUSTIFY;
 #endif
     ass_set_selective_style_override_enabled(priv, set_force_flags);
     ASS_Style style = {0};

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -23,7 +23,6 @@
 
 #include <libavutil/common.h>
 #include <ass/ass.h>
-#include <ass/ass_types.h>
 
 #include "mpv_talloc.h"
 


### PR DESCRIPTION
To make it easier for the eyes, multi line subtitles should
be left justified (for most languages).
This adds an option to define how subtitles are to be justified
indendently of how they are aligned.
Also add option to enable --sub-justify to be applied on ASS subtitles.

I agree that my changes can be relicensed to LGPL 2.1 or later.
