### PR TITLE
cocoa: modify $PATH variable when started from bundle

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -353,6 +353,30 @@ static bool bundle_started_from_finder(int argc, char **argv)
     }
 }
 
+static void init_path_for_bundle()
+{
+    NSTask *shell_task = [[[NSTask alloc] init] autorelease];
+    NSPipe *shell_out = [NSPipe pipe];
+    NSDictionary *env = [[NSProcessInfo processInfo] environment];
+    NSString *shell_path = [env objectForKey:@"SHELL"];
+
+    [shell_task setLaunchPath:shell_path];
+    [shell_task setArguments:@[@"-l", @"-c", @"echo $PATH"]];
+    [shell_task setStandardOutput:shell_out];
+    [shell_task launch];
+    [shell_task waitUntilExit];
+
+    NSFileHandle *read_handle = [shell_out fileHandleForReading];
+    NSData *read_data = [read_handle readDataToEndOfFile];
+    NSString *path = [[[NSString alloc] initWithData:read_data
+                     encoding:NSUTF8StringEncoding] autorelease];
+    [read_handle closeFile];
+
+    NSString *path_bundle = [env objectForKey:@"PATH"];
+    NSString *path_new = [NSString stringWithFormat:@"%@:%@", path_bundle, path];
+    setenv("PATH", [path_new UTF8String], 1);
+}
+
 int cocoa_main(int argc, char *argv[])
 {
     @autoreleasepool {
@@ -368,6 +392,7 @@ int cocoa_main(int argc, char *argv[])
                 argv[1] = NULL;
             }
             macosx_redirect_output_to_logfile("mpv");
+            init_path_for_bundle();
             init_cocoa_application(true);
         } else {
             for (int i = 1; i < argc; i++)


### PR DESCRIPTION
this seems a bit weird but i couldn't think of a better way of doing it.

1. get the path to the current/standard shell
2. launch a new task with the shell and echo the $PATH (couldn't find a different way of getting the $PATH of standard shell)
3. append the shell $PATH to the bundle $PATH and set it as new $PATH var

i still wonder if i should concatenate the old and new $PATH or just simply replace it instead? also this is how it looks on my system.
```
Old ENV $PATH: /usr/bin:/bin:/usr/sbin:/sbin
Shell Binary path: /bin/bash
Shell $PATH: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
New ENV $PATH: /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
```