### PR TITLE
manpage: state that hwdec=d3d11va requires Windows 8+

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -640,8 +640,8 @@ Video
                 ``--opengl-backend=dxinterop`` (Windows only)
     :dxva2-copy: copies video back to system RAM (Windows only)
     :d3d11va:   requires ``--vo=opengl`` with ``--opengl-backend=angle``
-                (Windows only)
-    :d3d11va-copy: copies video back to system RAM (Windows only)
+                (Windows 8+ only)
+    :d3d11va-copy: copies video back to system RAM (Windows 8+ only)
     :mediacodec: copies video back to system RAM (Android only)
     :rpi:       requires ``--vo=opengl`` (Raspberry Pi only - default if available)
     :rpi-copy:  copies video back to system RAM (Raspberry Pi only)


### PR DESCRIPTION
As the manual entry for --hwdec states that d3d11va and d3d11va-copy require Windows, it can be assumed that it also works for Windows 7. Since it doesn't, according to https://github.com/mpv-player/mpv/issues/3285#issuecomment-228593539, and personal testing, updating the manual accordingly and making the hwdec OS requirements for ANGLE in line with videotoolbox, where OS version is stated.

I agree that my changes can be relicensed to LGPL 2.1 or later.
