### PR TITLE
cocoa: improve bundle situation

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -173,7 +173,7 @@
       </dict>
     </array>
     <key>CFBundleExecutable</key>
-    <string>mpv</string>
+    <string>mpv-wrapper.sh</string>
     <key>CFBundleIconFile</key>
     <string>icon</string>
     <key>CFBundleIdentifier</key>

--- a/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper.sh
+++ b/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export MPVBUNDLE="true"
+$SHELL -l -c "$(dirname "$0")/mpv --player-operation-mode=pseudo-gui"

--- a/TOOLS/osxbundle/mpv.app/Contents/Resources/mpv.conf
+++ b/TOOLS/osxbundle/mpv.app/Contents/Resources/mpv.conf
@@ -1,1 +1,0 @@
-player-operation-mode=pseudo-gui


### PR DESCRIPTION
since this fixes the same thing as #4095 and some additional issues i decided to open another PR.

other than this. i believe we don't need to check for and remove the "-psn_" argument anymore since the wrapper doesn't pass any arguments, that were passed to the wrapper, to the mpv binary. we also don't need it anymore for the heuristic if it were started from the bundle. it was replaced we a simpler environment variable based check.

the second commit is a bit debatable as in, what login level should be used? just using 'warn' might be not enough since it doesn't log what file was opened/played.