### PR TITLE
tv: Zero-out newly-allocated handle in tv_new_handle()

### DIFF
--- a/stream/tv.c
+++ b/stream/tv.c
@@ -145,7 +145,7 @@ const struct m_sub_options tv_params_conf = {
 
 tvi_handle_t *tv_new_handle(int size, struct mp_log *log, const tvi_functions_t *functions)
 {
-    tvi_handle_t *h = malloc(sizeof(*h));
+    tvi_handle_t *h = calloc(1, sizeof(*h));
 
     if (!h)
         return NULL;
@@ -159,12 +159,9 @@ tvi_handle_t *tv_new_handle(int size, struct mp_log *log, const tvi_functions_t 
 
     h->log        = log;
     h->functions  = functions;
-    h->seq        = 0;
     h->chanlist   = -1;
-    h->chanlist_s = NULL;
     h->norm       = -1;
     h->channel    = -1;
-    h->scan       = NULL;
 
     return h;
 }


### PR DESCRIPTION
Some fields (notably tv_channel_list) were left uninitialized,
potentially causing problems later on.

Fixes #4096

I agree that my changes can be relicensed to LGPL 2.1 or later.
