### PR TITLE
ao_oss: use --audio-device if --oss-device isn't set.

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -279,14 +279,21 @@ static int reopen_device(struct ao *ao, bool allow_format_changes)
     int format = ao->format;
     struct mp_chmap channels = ao->channels;
 
+    const char *device = PATH_DEV_DSP;
+    if (ao->device)
+        device = ao->device;
+    if (p->dsp && p->dsp[0])
+        device = p->dsp;
+
+    MP_VERBOSE(ao, "using '%s' dsp device\n", device);
 #ifdef __linux__
-    p->audio_fd = open(p->dsp, O_WRONLY | O_NONBLOCK);
+    p->audio_fd = open(device, O_WRONLY | O_NONBLOCK);
 #else
-    p->audio_fd = open(p->dsp, O_WRONLY);
+    p->audio_fd = open(device, O_WRONLY);
 #endif
     if (p->audio_fd < 0) {
         MP_ERR(ao, "Can't open audio device %s: %s\n",
-               p->dsp, mp_strerror(errno));
+               device, mp_strerror(errno));
         goto fail;
     }
 
@@ -443,7 +450,6 @@ static int init(struct ao *ao)
         p->oss_mixer_channel = SOUND_MIXER_PCM;
     }
 
-    MP_VERBOSE(ao, "using '%s' dsp device\n", p->dsp);
     MP_VERBOSE(ao, "using '%s' mixer device\n", p->oss_mixer_device);
     MP_VERBOSE(ao, "using '%s' mixer device\n", mixer_channels[p->oss_mixer_channel]);
 
@@ -643,8 +649,6 @@ const struct ao_driver audio_out_oss = {
         .buffersize = -1,
         .outburst = 512,
         .oss_mixer_channel = SOUND_MIXER_PCM,
-
-        .dsp = PATH_DEV_DSP,
         .oss_mixer_device = PATH_DEV_MIXER,
     },
     .options = (const struct m_option[]) {

--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -451,7 +451,7 @@ static int init(struct ao *ao)
     }
 
     MP_VERBOSE(ao, "using '%s' mixer device\n", p->oss_mixer_device);
-    MP_VERBOSE(ao, "using '%s' mixer device\n", mixer_channels[p->oss_mixer_channel]);
+    MP_VERBOSE(ao, "using '%s' mixer channel\n", mixer_channels[p->oss_mixer_channel]);
 
     ao->format = af_fmt_from_planar(ao->format);
 


### PR DESCRIPTION
Fall back on PATH_DEV_DSP if nothing is set.

This mirrors the behaviour of --audio-device / --alsa-device.

There doesn't appear to be a general way to list devices with oss, so
--audio-device=help doesn't list oss devices except for the default one if the
file exists.

Previously --audio-device was ignored entirely by ao_oss.

fixes #4122

I agree that my changes can be relicensed to LGPL 2.1 or later.
