### PR TITLE
use AV_INPUT_BUFFER_PADDING_SIZE instead of deprecated one

### DIFF
--- a/common/av_common.c
+++ b/common/av_common.c
@@ -42,7 +42,7 @@ int mp_lavc_set_extradata(AVCodecContext *avctx, void *ptr, int size)
     if (size) {
         av_free(avctx->extradata);
         avctx->extradata_size = 0;
-        avctx->extradata = av_mallocz(size + FF_INPUT_BUFFER_PADDING_SIZE);
+        avctx->extradata = av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE);
         if (!avctx->extradata)
             return -1;
         avctx->extradata_size = size;
@@ -79,7 +79,7 @@ AVCodecParameters *mp_codec_params_to_av(struct mp_codec_params *c)
     avp->codec_tag = c->codec_tag;
     if (c->extradata_size) {
         avp->extradata =
-            av_mallocz(c->extradata_size + FF_INPUT_BUFFER_PADDING_SIZE);
+            av_mallocz(c->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
         if (!avp->extradata)
             goto error;
         avp->extradata_size = c->extradata_size;

--- a/common/av_common.h
+++ b/common/av_common.h
@@ -24,6 +24,9 @@
 #include <libavutil/rational.h>
 #include <libavcodec/avcodec.h>
 
+#ifndef AV_INPUT_BUFFER_PADDING_SIZE
+#define AV_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+#endif
 struct mp_decoder_list;
 struct demux_packet;
 struct mp_codec_params;

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -397,7 +397,7 @@ static int lavf_check_file(demuxer_t *demuxer, enum demux_check check)
         // Disable file-extension matching with normal checks
         .filename = check <= DEMUX_CHECK_REQUEST ? priv->filename : "",
         .buf_size = 0,
-        .buf = av_mallocz(PROBE_BUF_SIZE + FF_INPUT_BUFFER_PADDING_SIZE),
+        .buf = av_mallocz(PROBE_BUF_SIZE + AV_INPUT_BUFFER_PADDING_SIZE),
     };
     if (!avpd.buf)
         return -1;

--- a/demux/packet.c
+++ b/demux/packet.c
@@ -94,7 +94,7 @@ void demux_packet_shorten(struct demux_packet *dp, size_t len)
 {
     assert(len <= dp->len);
     dp->len = len;
-    memset(dp->buffer + dp->len, 0, FF_INPUT_BUFFER_PADDING_SIZE);
+    memset(dp->buffer + dp->len, 0, AV_INPUT_BUFFER_PADDING_SIZE);
 }
 
 void free_demux_packet(struct demux_packet *dp)


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.
