### PR TITLE
dvb: move priv allocation to dvb_open

### DIFF
--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -931,6 +931,7 @@ static int dvb_open(stream_t *stream)
       return STREAM_ERROR;
     }
 
+    stream->priv = mp_get_config_group(stream, stream->global, &stream_dvb_conf);
     dvb_state_t* state = dvb_get_state(stream);
 
     dvb_priv_t *p = stream->priv;
@@ -1009,7 +1010,6 @@ dvb_state_t *dvb_get_state(stream_t *stream)
     }
     struct mp_log *log = stream->log;
     struct mpv_global *global = stream->global;
-    stream->priv = mp_get_config_group(stream, stream->global, &stream_dvb_conf);
     dvb_priv_t *priv = stream->priv;
     int type, size;
     char filename[30], *name;


### PR DESCRIPTION
This fixes a crash when changing channels; previously stream->priv would not
be initialized when dvb_get_state reused the existing state.

Signed-off-by: Thomas VanSelus <tvanselus@diospyros.us>

I tested this as far as building with and without and verifying the crash went away when pressing 'H' or 'K'.  Segfault was observed on 64 bit Slackware with a HVR-1250/CX23885 tuner, but I expect that doesn't matter.  

I agree that my changes can be relicensed to LGPL 2.1 or later.
