### PR TITLE
cocoa: mouse event and cursor refactor

### DIFF
--- a/video/out/cocoa/events_view.h
+++ b/video/out/cocoa/events_view.h
@@ -21,5 +21,4 @@
 @interface MpvEventsView : NSView <NSDraggingDestination>
 @property(nonatomic, retain) MpvCocoaAdapter *adapter;
 - (BOOL)canHideCursor;
-- (void)signalMousePosition;
 @end

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -74,6 +74,9 @@
                                      userInfo:nil] autorelease];
 
     [self addTrackingArea:self.tracker];
+
+    if (![self containsMouseLocation])
+        [self.adapter putKey:MP_KEY_MOUSE_LEAVE withModifiers:0];
 }
 
 - (NSPoint)mouseLocation
@@ -148,8 +151,6 @@
 
     if (self.clearing)
         return;
-
-    [self signalMousePosition];
 }
 
 - (NSPoint)convertPointToPixels:(NSPoint)point
@@ -160,14 +161,6 @@
     // coordinate system
     point.y = -point.y;
     return point;
-}
-
-- (void)signalMousePosition
-{
-    NSPoint p = [self convertPointToPixels:[self mouseLocation]];
-    p.x = MIN(MAX(p.x, 0), self.bounds.size.width-1);
-    p.y = MIN(MAX(p.y, 0), self.bounds.size.height-1);
-    [self.adapter signalMouseMovement:p];
 }
 
 - (void)signalMouseMovement:(NSEvent *)event

--- a/video/out/cocoa/mpvadapter.h
+++ b/video/out/cocoa/mpvadapter.h
@@ -28,7 +28,6 @@
 - (void)handleFilesArray:(NSArray *)files;
 - (void)didChangeWindowedScreenProfile:(NSNotification *)notification;
 - (void)performAsyncResize:(NSSize)size;
-- (void)didChangeMousePosition;
 
 - (BOOL)isInFullScreenMode;
 - (BOOL)keyboardEnabled;

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -73,6 +73,10 @@ struct vo_cocoa_state {
     NSInteger window_level;
     int fullscreen;
 
+    bool cursor_visibility;
+    bool cursor_visibility_wanted;
+    bool cursor_needs_set;
+
     bool embedded; // wether we are embedding in another GUI
 
     IOPMAssertionID power_mgmt_assertion;
@@ -106,8 +110,6 @@ struct vo_cocoa_state {
     bool vo_ready;                      // the VO is in a state in which it can
                                         // render frames
     int frame_w, frame_h;               // dimensions of the frame rendered
-
-    NSCursor *blankCursor;
 
     char *window_title;
 };
@@ -336,13 +338,10 @@ void vo_cocoa_init(struct vo *vo)
         .power_mgmt_assertion = kIOPMNullAssertionID,
         .log = mp_log_new(s, vo->log, "cocoa"),
         .embedded = vo->opts->WinID >= 0,
+        .cursor_visibility = true,
+        .cursor_visibility_wanted = true,
         .fullscreen = 0,
     };
-    if (!s->embedded) {
-        NSImage* blankImage = [[NSImage alloc] initWithSize:NSMakeSize(1, 1)];
-        s->blankCursor = [[NSCursor alloc] initWithImage:blankImage hotSpot:NSZeroPoint];
-        [blankImage release];
-    }
     pthread_mutex_init(&s->lock, NULL);
     pthread_cond_init(&s->wakeup, NULL);
     pthread_mutex_init(&s->sync_lock, NULL);
@@ -358,6 +357,22 @@ void vo_cocoa_init(struct vo *vo)
     }
 }
 
+static void vo_cocoa_update_cursor(struct vo *vo, bool forceVisible)
+{
+    struct vo_cocoa_state *s = vo->cocoa;
+
+    if (s->embedded)
+        return;
+
+    if ((forceVisible || s->cursor_visibility_wanted) && !s->cursor_visibility) {
+        [NSCursor unhide];
+        s->cursor_visibility = YES;
+    } else if (!s->cursor_visibility_wanted && s->cursor_visibility) {
+        [NSCursor hide];
+        s->cursor_visibility = NO;
+    }
+}
+
 static int vo_cocoa_set_cursor_visibility(struct vo *vo, bool *visible)
 {
     struct vo_cocoa_state *s = vo->cocoa;
@@ -365,15 +380,15 @@ static int vo_cocoa_set_cursor_visibility(struct vo *vo, bool *visible)
     if (s->embedded)
         return VO_NOTIMPL;
 
-    MpvEventsView *v = (MpvEventsView *) s->view;
-
-    if (*visible) {
-        [[NSCursor arrowCursor] set];
-    } else if ([v canHideCursor] && s->blankCursor) {
-        [s->blankCursor set];
+    if (s->view) {
+        MpvEventsView *v = (MpvEventsView *) s->view;
+        s->cursor_visibility_wanted = !(!*visible && [v canHideCursor]);
+        vo_cocoa_update_cursor(vo, false);
     } else {
-        *visible = true;
+        s->cursor_visibility_wanted = *visible;
+        s->cursor_needs_set = true;
     }
+    *visible = s->cursor_visibility;
 
     return VO_TRUE;
 }
@@ -392,6 +407,7 @@ void vo_cocoa_uninit(struct vo *vo)
     run_on_main_thread(vo, ^{
         // if using --wid + libmpv there's no window to release
         if (s->window) {
+            vo_cocoa_update_cursor(vo, true);
             [s->window setDelegate:nil];
             [s->window close];
         }
@@ -415,9 +431,6 @@ void vo_cocoa_uninit(struct vo *vo)
 
         [s->view removeFromSuperview];
         [s->view release];
-
-        if (!s->embedded)
-            [s->blankCursor release];
 
         pthread_cond_destroy(&s->sync_wakeup);
         pthread_mutex_destroy(&s->sync_lock);
@@ -548,8 +561,6 @@ static void create_ui(struct vo *vo, struct mp_rect *win, int geo_flags)
     view.adapter = adapter;
     s->view = view;
     [parent addSubview:s->view];
-    // update the cursor position now that the view has been added.
-    [view signalMousePosition];
     s->adapter = adapter;
 
     cocoa_register_menu_item_action(MPM_H_SIZE,   @selector(halfSize));
@@ -1012,20 +1023,20 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
     flag_events(self.vout, VO_EVENT_ICC_PROFILE_CHANGED);
 }
 
-- (void)didChangeMousePosition
-{
-    struct vo_cocoa_state *s = self.vout->cocoa;
-    [(MpvEventsView *)s->view signalMousePosition];
-}
-
 - (void)windowDidResignKey:(NSNotification *)notification
 {
-    [self didChangeMousePosition];
+    vo_cocoa_update_cursor(self.vout, true);
 }
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
-    [self didChangeMousePosition];
+    struct vo_cocoa_state *s = self.vout->cocoa;
+    if (s->cursor_needs_set) {
+        vo_cocoa_set_cursor_visibility(self.vout, &s->cursor_visibility_wanted);
+        s->cursor_needs_set = false;
+    } else {
+        vo_cocoa_update_cursor(self.vout, false);
+    }
 }
 
 - (void)windowDidMiniaturize:(NSNotification *)notification


### PR DESCRIPTION
first of all i am going to squash both commits since the second commit depends on the first one. i kept them separate for now since both commits fixed separate things and i tested them individually.

i tried to simplify the mouse event handling a bit and removed some special cases that each tried to fix a problem a previous change introduced without getting to the root of the problem. i believe and hope that this should be fixed now and no unnecessary mouse movements should be reported any more.

for the second commit i had to change the cursor visibility code (yet again). all current problems i know of could be fixed with slight adjustments to the current code, besides issue #3856. i am not quite sure how the macOS notifications are implemented but they don't trigger any events and i couldn't detect them in any simple way. they 'steal' the cursor focus and change the cursor back to the default arrow and mpv couldn't recover from this state. so instead of using a blank image for the cursor i changed it to the NSCursor hide and unhide methods. every hide call must have a corresponding unhide call so i made sure the cursor is only hidden/shown when it is really needed. i also made sure that previous reported problems, that the current implementation fixed, are still fixed (#503 #513). 

i would appreciate some testing since this is quite an important user facing change.