### PR TITLE
ao: Modify ao driver order to match typical usage (maybe)

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -62,6 +62,9 @@ static const struct ao_driver * const audio_out_drivers[] = {
 #if HAVE_PULSE
     &audio_out_pulse,
 #endif
+#if HAVE_JACK
+    &audio_out_jack,
+#endif
 #if HAVE_ALSA
     &audio_out_alsa,
 #endif
@@ -72,9 +75,6 @@ static const struct ao_driver * const audio_out_drivers[] = {
     &audio_out_oss,
 #endif
     // wrappers:
-#if HAVE_JACK
-    &audio_out_jack,
-#endif
 #if HAVE_OPENAL
     &audio_out_openal,
 #endif


### PR DESCRIPTION
When the audio-device parameter is set to auto in the original order,
if there are two or more audio devices on the computer, the ALSA
device is selected even if the Jack process is running.

I agree that my changes can be relicensed to LGPL 2.1 or later.
