### PR TITLE
Fix typo in waf-buildsystem.rst

### DIFF
--- a/DOCS/waf-buildsystem.rst
+++ b/DOCS/waf-buildsystem.rst
@@ -146,7 +146,7 @@ mpv's custom build step on top of waf
 
 Build step is pretty much vanilla waf. The only difference being that the list
 of source files can contain both strings or tuples. If a tuple is found,
-the second element in the tuple will the used to match the features detected
+the second element in the tuple will be used to match the features detected
 in the configure step (the ``name`` field described above). If this feature
 was not enabled during configure, the source file will not be compiled in.
 


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
