### PR TITLE
vd_lavc: remove videotoolbox hacks

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -868,9 +868,7 @@ static void handle_err(struct dec_video *vd)
 
     if (ctx->hwdec) {
         ctx->hwdec_fail_count += 1;
-        // The FFmpeg VT hwaccel is buggy and can crash after 1 broken frame.
-        bool vt = ctx->hwdec && ctx->hwdec->type == HWDEC_VIDEOTOOLBOX;
-        if (ctx->hwdec_fail_count >= opts->software_fallback || vt)
+        if (ctx->hwdec_fail_count >= opts->software_fallback)
             ctx->hwdec_failed = true;
     }
 }


### PR DESCRIPTION
This was a work-around for a memory corruption bug in ffmpeg, and can be removed once the upstream bug has been fixed.