### PR TITLE
Fix --egl-angle-lib for waf 1.9

### DIFF
--- a/wscript
+++ b/wscript
@@ -663,8 +663,10 @@ video_output_features = [
         'groups': [ 'gl' ],
         'func': check_statement(['EGL/egl.h'],
                                 'eglCreateWindowSurface(0, 0, 0, 0)',
-                                cflags="-DGL_APICALL= -DEGLAPI= -DANGLE_NO_ALIASES -DANGLE_EXPORT=",
-                                lib=['EGL', 'GLESv2', 'dxguid', 'd3d9', 'gdi32', 'stdc++'])
+                                cflags=['-DGL_APICALL=', '-DEGLAPI=',
+                                        '-DANGLE_NO_ALIASES', '-DANGLE_EXPORT='],
+                                lib=['EGL', 'GLESv2', 'dxguid', 'd3d9',
+                                     'gdi32', 'stdc++'])
     } , {
         'name': '--vdpau',
         'desc': 'VDPAU acceleration',


### PR DESCRIPTION
This seems to be what's breaking the AppVeyor build.