### PR TITLE
OSX add option to force dedicated GPU

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4392,6 +4392,12 @@ The following video options are currently all specific to ``--vo=opengl`` and
 
     Windows 8+ with ANGLE only.
 
+``--cocoa-force-dedicated-gpu=<yes|no>``
+    Deactivates the automatic graphics switching and forces the dedicated GPU.
+    (default: no)
+
+    OS X only.
+
 ``--opengl-sw``
     Continue even if a software renderer is detected.
 

--- a/options/options.c
+++ b/options/options.c
@@ -92,6 +92,7 @@ extern const struct m_obj_list vo_obj_list;
 extern const struct m_obj_list ao_obj_list;
 
 extern const struct m_sub_options angle_conf;
+extern const struct m_sub_options cocoa_conf;
 
 const struct m_opt_choice_alternatives mp_hwdec_names[] = {
     {"no",          HWDEC_NONE},
@@ -706,6 +707,10 @@ const m_option_t mp_opts[] = {
 
 #if HAVE_EGL_ANGLE
     OPT_SUBSTRUCT("", angle_opts, angle_conf, 0),
+#endif
+
+#if HAVE_GL_COCOA
+    OPT_SUBSTRUCT("", cocoa_opts, cocoa_conf, 0),
 #endif
 
 #if HAVE_GL_WIN32

--- a/options/options.h
+++ b/options/options.h
@@ -327,6 +327,7 @@ typedef struct MPOpts {
 
     struct gl_video_opts *gl_video_opts;
     struct angle_opts *angle_opts;
+    struct cocoa_opts *cocoa_opts;
     struct dvd_opts *dvd_opts;
 } MPOpts;
 

--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -51,31 +51,4 @@ static const NSEventModifierFlags NSEventModifierFlagCommand =  NSCommandKeyMask
 static const NSEventModifierFlags NSEventModifierFlagOption = NSAlternateKeyMask;
 #endif
 
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_8)
-@interface NSArray (SubscriptingAdditions)
-- (id)objectAtIndexedSubscript:(NSUInteger)index;
-@end
-
-@interface NSMutableArray (SubscriptingAdditions)
-- (void)setObject: (id)object atIndexedSubscript:(NSUInteger)index;
-@end
-
-@interface NSDictionary (SubscriptingAdditions)
-- (id)objectForKeyedSubscript:(id)key;
-@end
-
-@interface NSMutableDictionary (SubscriptingAdditions)
-- (void)setObject: (id)object forKeyedSubscript:(id)key;
-@end
-
-#if __has_feature(objc_bool)
-    #define YES  __objc_yes
-    #define NO   __objc_no
-#else
-    #define YES  ((BOOL)1)
-    #define NO   ((BOOL)0)
-#endif
-
-#endif
-
 #endif /* MPV_MACOSX_COMPAT */

--- a/osdep/macosx_versions.h
+++ b/osdep/macosx_versions.h
@@ -18,10 +18,6 @@
 #ifndef MPV_MACOSX_VERSIONS
 #define MPV_MACOSX_VERSIONS
 
-#if !defined(MAC_OS_X_VERSION_10_8)
-#    define MAC_OS_X_VERSION_10_8 1080
-#endif
-
 #if !defined(MAC_OS_X_VERSION_10_9)
 #    define MAC_OS_X_VERSION_10_9 1090
 #endif

--- a/video/out/opengl/context_cocoa.c
+++ b/video/out/opengl/context_cocoa.c
@@ -55,11 +55,9 @@ static CGLError test_gl_version(struct vo *vo,
         kCGLPFAOpenGLProfile,
         (CGLPixelFormatAttribute) version,
         kCGLPFAAccelerated,
-        #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_8
         // leave this as the last entry of the array to not break the fallback
         // code
         kCGLPFASupportsAutomaticGraphicsSwitching,
-        #endif
         0
     };
 


### PR DESCRIPTION
i can't test it myself and i also don't feel very strongly about it. it fixes #3242 and possibly partially #3653. it could also be used as a workaround for #2371.

i dropped support for OS X 10.7 and earlier to simplify the context creation which is a bit buggy because of the if directive. in some circumstances it could remove kCGLPFAAccelerated instead of kCGLPFASupportsAutomaticGraphicsSwitching, which would only be fixable with another if directive. 10.7 isn't supported officially anymore anyway