### PR TITLE
osx: initial Touch Bar support

### DIFF
--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -18,10 +18,15 @@
 #import <Cocoa/Cocoa.h>
 #include "osdep/macosx_application.h"
 
+struct mpv_event;
+
 @interface Application : NSApplication
+
 - (void)initialize_menu;
 - (void)registerSelector:(SEL)selector forKey:(MPMenuKey)key;
 - (void)stopPlayback;
+- (void)processEvent:(struct mpv_event *)event;
+- (void)queueCommand:(char *)cmd;
 
 @property(nonatomic, retain) NSMutableDictionary *menuItems;
 @property(nonatomic, retain) NSArray *files;

--- a/osdep/macosx_events.h
+++ b/osdep/macosx_events.h
@@ -22,6 +22,7 @@
 #include "input/keycodes.h"
 
 struct input_ctx;
+struct mpv_handle;
 
 void cocoa_put_key(int keycode);
 void cocoa_put_key_with_modifiers(int keycode, int modifiers);
@@ -36,5 +37,6 @@ void cocoa_init_media_keys(void);
 void cocoa_uninit_media_keys(void);
 
 void cocoa_set_input_context(struct input_ctx *input_context);
+void cocoa_set_mpv_handle(struct mpv_handle *ctx);
 
 #endif

--- a/osdep/macosx_events_objc.h
+++ b/osdep/macosx_events_objc.h
@@ -29,6 +29,8 @@ struct input_ctx;
 
 - (void)setInputContext:(struct input_ctx *)ctx;
 
+- (void)setIsApplication:(BOOL)isApplication;
+
 /// Blocks until inputContext is present.
 - (void)waitForInputContext;
 

--- a/osdep/macosx_touchbar.h
+++ b/osdep/macosx_touchbar.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <Cocoa/Cocoa.h>
+#import "osdep/macosx_application_objc.h"
+
+#define BASE_ID @"io.mpv.touchbar"
+static NSTouchBarCustomizationIdentifier customID = BASE_ID;
+static NSTouchBarItemIdentifier seekBar = BASE_ID ".seekbar";
+static NSTouchBarItemIdentifier play = BASE_ID ".play";
+static NSTouchBarItemIdentifier nextItem = BASE_ID ".nextItem";
+static NSTouchBarItemIdentifier previousItem = BASE_ID ".previousItem";
+static NSTouchBarItemIdentifier nextChapter = BASE_ID ".nextChapter";
+static NSTouchBarItemIdentifier previousChapter = BASE_ID ".previousChapter";
+static NSTouchBarItemIdentifier cycleAudio = BASE_ID ".cycleAudio";
+static NSTouchBarItemIdentifier cycleSubtitle = BASE_ID ".cycleSubtitle";
+static NSTouchBarItemIdentifier currentPosition = BASE_ID ".currentPosition";
+static NSTouchBarItemIdentifier timeLeft = BASE_ID ".timeLeft";
+
+struct mpv_event;
+
+@interface TouchBar : NSTouchBar <NSTouchBarDelegate>
+
+-(void)processEvent:(struct mpv_event *)event;
+
+@property(nonatomic, retain) Application *app;
+@property(nonatomic, retain) NSDictionary *touchbarItems;
+@property(nonatomic, assign) double duration;
+@property(nonatomic, assign) double position;
+
+@end

--- a/osdep/macosx_touchbar.m
+++ b/osdep/macosx_touchbar.m
@@ -1,0 +1,272 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "player/client.h"
+#import "macosx_touchbar.h"
+
+@implementation TouchBar
+
+@synthesize app = _app;
+@synthesize touchbarItems = _touchbar_items;
+@synthesize duration = _duration;
+@synthesize position = _position;
+
+- (id)init
+{
+    if (self = [super init]) {
+        self.touchbarItems = @{
+            seekBar: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type": @"slider",
+                @"name": @"Seek Bar",
+                @"cmd":  @"seek %f absolute-percent"
+            }],
+            play: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":     @"button",
+                @"name":     @"Play Button",
+                @"cmd":      @"cycle pause",
+                @"image":    [NSImage imageNamed:NSImageNameTouchBarPauseTemplate],
+                @"imageAlt": [NSImage imageNamed:NSImageNameTouchBarPlayTemplate]
+            }],
+            previousItem: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Previous Playlist Item",
+                @"cmd":   @"playlist-prev",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarGoBackTemplate]
+            }],
+            nextItem: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Next Playlist Item",
+                @"cmd":   @"playlist-next",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarGoForwardTemplate]
+            }],
+            previousChapter: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Previous Chapter",
+                @"cmd":   @"add chapter -1",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarSkipBackTemplate]
+            }],
+            nextChapter: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Next Chapter",
+                @"cmd":   @"add chapter 1",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarSkipAheadTemplate]
+            }],
+            cycleAudio: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Cycle Audio",
+                @"cmd":   @"cycle audio",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarAudioInputTemplate]
+            }],
+            cycleSubtitle: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type":  @"button",
+                @"name":  @"Cycle Subtitle",
+                @"cmd":   @"cycle sub",
+                @"image": [NSImage imageNamed:NSImageNameTouchBarComposeTemplate]
+            }],
+            currentPosition: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type": @"text",
+                @"name": @"Current Position"
+            }],
+            timeLeft: [NSMutableDictionary dictionaryWithDictionary:@{
+                @"type": @"text",
+                @"name": @"Time Left"
+            }]
+        };
+    }
+    return self;
+}
+
+-(void)processEvent:(struct mpv_event *)event
+{
+    switch (event->event_id) {
+    case MPV_EVENT_END_FILE: {
+        self.position = 0;
+        self.duration = 0;
+        break;
+    }
+    case MPV_EVENT_PROPERTY_CHANGE: {
+        [self handlePropertyChange:(mpv_event_property *)event->data];
+        break;
+    }
+    }
+}
+
+-(void)handlePropertyChange:(struct mpv_event_property *)property
+{
+    NSString *name = [NSString stringWithUTF8String:property->name];
+    mpv_format format = property->format;
+
+    if ([name isEqualToString:@"time-pos"] && format == MPV_FORMAT_DOUBLE) {
+        self.position = *(double *)property->data;
+        self.position = self.position < 0 ? 0 : self.position;
+        [self updateTouchBarTimeItems];
+    } else if ([name isEqualToString:@"duration"] && format == MPV_FORMAT_DOUBLE) {
+        self.duration = *(double *)property->data;
+        [self updateTouchBarTimeItems];
+    } else if ([name isEqualToString:@"pause"] && format == MPV_FORMAT_FLAG) {
+        NSButton *playButton = self.touchbarItems[play][@"view"];
+        if (*(int *)property->data) {
+            playButton.image = self.touchbarItems[play][@"imageAlt"];
+        } else {
+            playButton.image = self.touchbarItems[play][@"image"];
+        }
+    }
+}
+
+- (nullable NSTouchBarItem *)touchBar:(NSTouchBar *)touchBar
+                makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
+{
+    if ([self.touchbarItems[identifier][@"type"] isEqualToString:@"slider"]) {
+        NSSliderTouchBarItem *tbItem = [[NSSliderTouchBarItem alloc] initWithIdentifier:identifier];
+        tbItem.slider.minValue = 0.0f;
+        tbItem.slider.maxValue = 100.0f;
+        tbItem.target = self;
+        tbItem.action = @selector(seekbarChanged:);
+        tbItem.customizationLabel = self.touchbarItems[identifier][@"name"];
+        [self.touchbarItems[identifier] setObject:tbItem.slider forKey:@"view"];
+        return tbItem;
+    } else if ([self.touchbarItems[identifier][@"type"] isEqualToString:@"button"]) {
+        NSCustomTouchBarItem *tbItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSImage *tbImage = self.touchbarItems[identifier][@"image"];
+        NSButton *tbButton = [NSButton buttonWithImage:tbImage target:self action:@selector(buttonAction:)];
+        tbItem.view = tbButton;
+        tbItem.customizationLabel = self.touchbarItems[identifier][@"name"];
+        [self.touchbarItems[identifier] setObject:tbButton forKey:@"view"];
+        return tbItem;
+    } else if ([self.touchbarItems[identifier][@"type"] isEqualToString:@"text"]) {
+        NSCustomTouchBarItem *tbItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSTextField *tbText = [NSTextField labelWithString:@"0:00"];
+        tbText.alignment = NSTextAlignmentCenter;
+        tbItem.view = tbText;
+        tbItem.customizationLabel = self.touchbarItems[identifier][@"name"];
+        [self.touchbarItems[identifier] setObject:tbText forKey:@"view"];
+        return tbItem;
+    }
+
+    return nil;
+}
+
+- (NSString *)formatTime:(int)time
+{
+    int seconds = time % 60;
+    int minutes = (time / 60) % 60;
+    int hours = time / (60 * 60);
+
+    NSString *stime = hours > 0 ? [NSString stringWithFormat:@"%d:", hours] : @"";
+    stime = (stime.length > 0 || minutes > 9) ?
+        [NSString stringWithFormat:@"%@%02d:", stime, minutes] :
+        [NSString stringWithFormat:@"%d:", minutes];
+    stime = [NSString stringWithFormat:@"%@%02d", stime, seconds];
+
+    return stime;
+}
+
+- (void)removeConstraintForIdentifier:(NSTouchBarItemIdentifier)identifier
+{
+    NSTextField *field = self.touchbarItems[identifier][@"view"];
+    [field removeConstraint:self.touchbarItems[identifier][@"constrain"]];
+}
+
+- (void)applyConstraintFromString:(NSString *)string
+                    forIdentifier:(NSTouchBarItemIdentifier)identifier
+{
+    NSTextField *field = self.touchbarItems[identifier][@"view"];
+    if (field) {
+        NSString *fString = [[string componentsSeparatedByCharactersInSet:
+            [NSCharacterSet decimalDigitCharacterSet]] componentsJoinedByString:@"0"];
+        NSTextField *textField = [NSTextField labelWithString:fString];
+        NSSize size = [textField frame].size;
+
+        NSLayoutConstraint *con =
+            [NSLayoutConstraint constraintWithItem:field
+                                         attribute:NSLayoutAttributeWidth
+                                         relatedBy:NSLayoutRelationEqual
+                                            toItem:nil
+                                         attribute:NSLayoutAttributeNotAnAttribute
+                                        multiplier:1.0
+                                          constant:(int)ceil(size.width*1.1)];
+        [field addConstraint:con];
+        [self.touchbarItems[identifier] setObject:con forKey:@"constrain"];
+    }
+}
+
+- (void)updateTouchBarTimeItemConstrains
+{
+    [self removeConstraintForIdentifier:currentPosition];
+    [self removeConstraintForIdentifier:timeLeft];
+
+    if (self.duration <= 0) {
+        [self applyConstraintFromString:[self formatTime:self.position]
+                          forIdentifier:currentPosition];
+    } else {
+        NSString *durFormat = [self formatTime:self.duration];
+
+        [self applyConstraintFromString:durFormat forIdentifier:currentPosition];
+        [self applyConstraintFromString:[NSString stringWithFormat:@"-%@", durFormat]
+                          forIdentifier:timeLeft];
+    }
+}
+
+- (void)updateTouchBarTimeItems
+{
+    NSSlider *seekSlider = self.touchbarItems[seekBar][@"view"];
+    NSTextField *curPosItem = self.touchbarItems[currentPosition][@"view"];
+    NSTextField *timeLeftItem = self.touchbarItems[timeLeft][@"view"];
+
+    if (self.duration <= 0) {
+        seekSlider.enabled = NO;
+        seekSlider.doubleValue = 0;
+        timeLeftItem.stringValue = @"";
+    }
+    else {
+        seekSlider.enabled = YES;
+        if (!seekSlider.highlighted)
+            seekSlider.doubleValue = (self.position/self.duration)*100;
+        int left = (int)(floor(self.duration)-floor(self.position));
+        NSString *leftFormat = [self formatTime:left];
+        timeLeftItem.stringValue = [NSString stringWithFormat:@"-%@", leftFormat];
+    }
+    NSString *posFormat = [self formatTime:(int)floor(self.position)];
+    curPosItem.stringValue = posFormat;
+
+    [self updateTouchBarTimeItemConstrains];
+}
+
+- (NSString *)getIdentifierFromView:(id)view
+{
+    NSString *identifier;
+    for (identifier in self.touchbarItems)
+        if([self.touchbarItems[identifier][@"view"] isEqual:view])
+            break;
+    return identifier;
+}
+
+- (void)buttonAction:(NSButton *)sender
+{
+    NSString *identifier = [self getIdentifierFromView:sender];
+    [self.app queueCommand:(char *)[self.touchbarItems[identifier][@"cmd"] UTF8String]];
+}
+
+- (void)seekbarChanged:(NSSliderTouchBarItem *)sender
+{
+    NSString *identifier = [self getIdentifierFromView:sender.slider];
+    NSString *seek = [NSString stringWithFormat:
+        self.touchbarItems[identifier][@"cmd"], sender.slider.doubleValue];
+    [self.app queueCommand:(char *)[seek UTF8String]];
+}
+
+@end

--- a/player/main.c
+++ b/player/main.c
@@ -455,6 +455,11 @@ int mp_initialize(struct MPContext *mpctx, char **options)
 
     MP_STATS(mpctx, "start init");
 
+#if HAVE_COCOA
+    mpv_handle *ctx = mp_new_client(mpctx->clients, "osx");
+    cocoa_set_mpv_handle(ctx);
+#endif
+
 #if HAVE_ENCODING
     if (opts->encode_opts->file && opts->encode_opts->file[0]) {
         mpctx->encode_lavc_ctx = encode_lavc_init(opts->encode_opts,

--- a/waftools/fragments/touchbar.m
+++ b/waftools/fragments/touchbar.m
@@ -1,0 +1,7 @@
+#import <AppKit/AppKit.h>
+
+int main(int argc, char **argv)
+{
+    [[NSTouchBar alloc] init];
+    return 0;
+}

--- a/wscript
+++ b/wscript
@@ -902,7 +902,16 @@ standalone_features = [
         'desc': 'Apple Remote support',
         'deps': [ 'cocoa' ],
         'func': check_true
-    }
+    }, {
+        'name': '--macos-touchbar',
+        'desc': 'macOS Touch Bar support',
+        'deps': [ 'cocoa' ],
+        'func': check_cc(
+            fragment=load_fragment('touchbar.m'),
+            framework_name=['AppKit'],
+            compile_filename='test-touchbar.m',
+            linkflags='-fobjc-arc')
+     }
 ]
 
 _INSTALL_DIRS_LIST = [

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -416,6 +416,7 @@ def build(ctx):
         ( "osdep/ar/HIDRemote.m",                "apple-remote" ),
         ( "osdep/macosx_application.m",          "cocoa" ),
         ( "osdep/macosx_events.m",               "cocoa" ),
+        ( "osdep/macosx_touchbar.m",             "macos-touchbar" ),
         ( "osdep/semaphore_osx.c" ),
         ( "osdep/subprocess.c" ),
         ( "osdep/subprocess-posix.c",            "posix-spawn" ),


### PR DESCRIPTION
this partially implements support for the features wanted in issue #3943. the missing part is support for the `MediaPlayer` framework. though like @rcombs mentioned, from his tests there is a problem with the MediaPlayer support and when mpv is started from CLI. it only works completely when started from the bundle.

i tested building it on 10.10 and it worked, though i couldn't test playback because it was in a VM. visually it can probably be improved, though i'll leave major changes for another time. i wasn't sure if i should use the input_context or the mpv_handle for touchbar inputs. i decided to use the old mechanic, the input_context, like the rest of the code.

for the header/license text i just copied what is used in all the other files.

how it looks:
![](https://cloud.githubusercontent.com/assets/680386/23348087/6e94f750-fca7-11e6-9a70-1ed0ac6681dc.png)
![](https://cloud.githubusercontent.com/assets/680386/23348086/6e2dfadc-fca7-11e6-911f-0a3aaa88bae2.png)
