### PR TITLE
wscript: substitute cplugins linker flag for macOS compatiblity

### DIFF
--- a/wscript
+++ b/wscript
@@ -72,7 +72,7 @@ build_options = [
         'desc': 'C plugins',
         'deps': [ 'libdl' ],
         'default': 'disable',
-        'func': check_cc(linkflags=['-Wl,-export-dynamic']),
+        'func': check_cc(linkflags=['-rdynamic']),
     }, {
         'name': 'dlopen',
         'desc': 'dlopen',
@@ -1033,7 +1033,7 @@ def configure(ctx):
         # not linked against libmpv. The C plugin needs to be able to pick
         # up the libmpv symbols from the binary. We still restrict the set
         # of exported symbols via mpv.def.
-        ctx.env.LINKFLAGS += ['-Wl,-export-dynamic']
+        ctx.env.LINKFLAGS += ['-rdynamic']
 
     ctx.store_dependencies_lists()
 


### PR DESCRIPTION
For an unknown reason, '-Wl -export-dynamic' doesn't work anymore
on the last macOS build (10.12.3 with Apple LLVM 8.0.0) so forcing
cplugins is useless because the check fails. Replacing the linker
option with its substitute '-rdynamic' do the trick.
Because black magic.

NB: I've only tested the flag with macOS but it shouldn't make any difference to anyone.