### PR TITLE
filter_kernels: Minor corrections for filter windowing and radius.

### DIFF
--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -100,14 +100,14 @@ static double sample_window(struct filter_window *kernel, double x)
 
     // All windows are symmetric, this makes life easier
     x = fabs(x);
-    if (x >= kernel->radius)
-        return 0.0;
 
     // Stretch and taper the window size as needed
     x = kernel->blur > 0.0 ? x / kernel->blur : x;
     x = x <= kernel->taper ? 0.0 : (x - kernel->taper) / (1 - kernel->taper);
 
-    return kernel->weight(kernel, x);
+    if (x < kernel->radius)
+        return kernel->weight(kernel, x);
+    return 0.0;
 }
 
 // Evaluate a filter's kernel and window at a given absolute position

--- a/video/out/filter_kernels.h
+++ b/video/out/filter_kernels.h
@@ -34,7 +34,10 @@ struct filter_kernel {
     bool polar;         // whether or not the filter uses polar coordinates
     // The following values are set by mp_init_filter() at runtime.
     int size;           // number of coefficients (may depend on radius)
-    double inv_scale;   // scale factor (<1.0 is upscale, >1.0 downscale)
+    double filter_scale;  // Factor to convert the mathematical filter
+                          // function radius to the possibly wider
+                          // (in the case of downsampling) filter sample
+                          // radius.
 };
 
 extern const struct filter_window mp_filter_windows[];

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -3400,6 +3400,9 @@ void gl_video_configure_queue(struct gl_video *p, struct vo *vo)
         const struct filter_kernel *kernel =
             mp_find_filter_kernel(p->opts.scaler[SCALER_TSCALE].kernel.name);
         if (kernel) {
+            // filter_scale wouldn't be correctly initialized were we to use it here.
+            // This is fine since we're always upsampling, but beware if downsampling
+            // is added!
             double radius = kernel->f.radius;
             radius = radius > 0 ? radius : p->opts.scaler[SCALER_TSCALE].radius;
             queue_size += 1 + ceil(radius);

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -107,8 +107,8 @@ void pass_sample_separated_gen(struct gl_shader_cache *sc, struct scaler *scaler
 
 void pass_sample_polar(struct gl_shader_cache *sc, struct scaler *scaler)
 {
-    double radius = scaler->kernel->f.radius;
-    int bound = (int)ceil(radius);
+    double radius = scaler->kernel->f.radius * scaler->kernel->filter_scale;
+    int bound = ceil(radius);
     bool use_ar = scaler->conf.antiring > 0;
     GLSL(color = vec4(0.0);)
     GLSLF("{\n");


### PR DESCRIPTION
These fixes are not particularly visually perceptible in normal use, but correct what I believe to be some mathematical errors in the calculations for video output resampling filter kernels, particularly when downsampling.

bd9a574 should have no effect when upsampling.  85a4125 affects downsampling and upsampling, but only for filters that use intrinsic blur/sharpen such as EWALanczosSharp.

These patches have been tested and they compile properly and produce correct output for me, both when using EWALanczosSharp and temporal Mitchell filtering.

I agree that my changes can be relicensed to LGPL 2.1 or later.
