### PR TITLE
cocoa fixes for key events

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -30,6 +30,7 @@ Interface changes
       input_size instead
     - add --sub-filter-sdh
     - add --sub-filter-sdh-harder
+    - remove --input-app-events option (macOS)
  --- mpv 0.24.0 ---
     - deprecate --hwdec-api and replace it with --opengl-hwdec-interop.
       The new option accepts both --hwdec values, as well as named backends.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2923,11 +2923,6 @@ Input
 
     (This option was renamed from ``--input-x11-keyboard``.)
 
-``--input-app-events=<yes|no>``
-    (OS X only)
-    Enable/disable application wide keyboard events so that keyboard shortcuts
-    can be processed without a window. Enabled by default (except for libmpv).
-
 OSD
 ---
 

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -24,7 +24,6 @@ stop-playback-on-init-failure=yes
 # OSX/Cocoa global input hooks
 input-appleremote=no
 input-media-keys=no
-input-app-events=no
 
 [encoding]
 vo=lavc

--- a/input/input.c
+++ b/input/input.c
@@ -168,7 +168,6 @@ struct input_opts {
     int use_alt_gr;
     int use_appleremote;
     int use_media_keys;
-    int use_app_events;
     int default_bindings;
     int enable_mouse_movements;
     int vo_key_input;
@@ -193,7 +192,6 @@ const struct m_sub_options input_config = {
 #if HAVE_COCOA
         OPT_FLAG("input-appleremote", use_appleremote, 0),
         OPT_FLAG("input-media-keys", use_media_keys, 0),
-        OPT_FLAG("input-app-events", use_app_events, M_OPT_FIXED),
 #endif
         OPT_FLAG("window-dragging", allow_win_drag, 0),
         OPT_REPLACED("input-x11-keyboard", "input-vo-keyboard"),
@@ -210,7 +208,6 @@ const struct m_sub_options input_config = {
 #if HAVE_COCOA
         .use_appleremote = 1,
         .use_media_keys = 1,
-        .use_app_events = 1,
 #endif
         .default_bindings = 1,
         .vo_key_input = 1,
@@ -1297,11 +1294,6 @@ void mp_input_load_config(struct input_ctx *ictx)
             parse_config_file(ictx, files[n], false);
         talloc_free(tmp);
     }
-
-#if HAVE_COCOA
-    if (ictx->opts->use_app_events)
-        cocoa_start_event_monitor();
-#endif
 
 #if defined(__MINGW32__)
     if (ictx->global->opts->input_file && *ictx->global->opts->input_file)

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -81,8 +81,8 @@ static void terminate_cocoa_application(void)
 
 - (void)sendEvent:(NSEvent *)event
 {
-    [super sendEvent:event];
-
+    if (![_eventsResponder processKeyEvent:event])
+        [super sendEvent:event];
     [_eventsResponder wakeup];
 }
 

--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -37,8 +37,6 @@ static const NSEventType NSEventTypeSystemDefined = NSSystemDefined;
 static const NSEventType NSEventTypeKeyDown = NSKeyDown;
 static const NSEventType NSEventTypeKeyUp = NSKeyUp;
 
-static const NSEventMask NSEventMaskKeyDown = NSKeyDownMask;
-static const NSEventMask NSEventMaskKeyUp = NSKeyUpMask;
 static const NSEventMask NSEventMaskLeftMouseUp = NSLeftMouseUpMask;
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_10)

--- a/osdep/macosx_events.h
+++ b/osdep/macosx_events.h
@@ -28,8 +28,6 @@ void cocoa_put_key(int keycode);
 void cocoa_put_key_with_modifiers(int keycode, int modifiers);
 void cocoa_put_key_event(void *event);
 
-void cocoa_start_event_monitor(void);
-
 void cocoa_init_apple_remote(void);
 void cocoa_uninit_apple_remote(void);
 

--- a/osdep/macosx_events_objc.h
+++ b/osdep/macosx_events_objc.h
@@ -42,4 +42,6 @@ struct input_ctx;
 
 - (void)handleFilesArray:(NSArray *)files;
 
+- (bool)processKeyEvent:(NSEvent *)event;
+
 @end

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -124,16 +124,6 @@
 
 - (BOOL)resignFirstResponder { return YES; }
 
-- (void)keyDown:(NSEvent *)event
-{
-    [self.adapter putKeyEvent:event];
-}
-
-- (void)keyUp:(NSEvent *)event
-{
-    [self.adapter putKeyEvent:event];
-}
-
 - (BOOL)canHideCursor
 {
     return !self.hasMouseDown && [self containsMouseLocation]

--- a/video/out/cocoa/mpvadapter.h
+++ b/video/out/cocoa/mpvadapter.h
@@ -21,7 +21,6 @@
 @interface MpvCocoaAdapter : NSObject<NSWindowDelegate>
 - (void)setNeedsResize;
 - (void)signalMouseMovement:(NSPoint)point;
-- (void)putKeyEvent:(NSEvent*)event;
 - (void)putKey:(int)mpkey withModifiers:(int)modifiers;
 - (void)putAxis:(int)mpkey delta:(float)delta;
 - (void)putCommand:(char*)cmd;

--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -70,6 +70,13 @@
     return self;
 }
 
+- (void)setStyleMask:(NSWindowStyleMask)style
+{
+    NSResponder *nR = [self firstResponder];
+    [super setStyleMask:style];
+    [self makeFirstResponder:nR];
+}
+
 - (void)toggleFullScreen:(id)sender
 {
     if (_is_animating)

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -810,9 +810,6 @@ static int vo_cocoa_fullscreen(struct vo *vo)
         return VO_NOTIMPL;
 
     [s->window toggleFullScreen:nil];
-    // for whatever reason sometimes cocoa doesn't create an up event on
-    // the fullscreen input key
-    cocoa_put_key(MP_INPUT_RELEASE_ALL);
 
     return VO_TRUE;
 }
@@ -953,11 +950,6 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
     [self recalcMovableByWindowBackground:point];
     if (!self.vout->cocoa->window_is_dragged)
         mp_input_set_mouse_pos(self.vout->input_ctx, point.x, point.y);
-}
-
-- (void)putKeyEvent:(NSEvent*)event
-{
-    cocoa_put_key_event(event);
 }
 
 - (void)putKey:(int)mpkey withModifiers:(int)modifiers


### PR DESCRIPTION
this fixes two bugs. one where some key presses are not reported correctly. @pigoz already noticed this behaviour with his [initial native-fs](https://github.com/mpv-player/mpv/commit/31a80aa1d4c7c5a2f6dc6965aed404326b362d02#diff-3a9bee9141665c32c50a7a49664f5ba5R744) implementation. the other wasn't noticed since it only happens with a borderless window and `--input-app-events=no`, which is activated by default. fixes part of issue #3944.

first some insight on the second bug. it can be reproduced with `mpv --no-config --input-app-events=no --no-border` and toggling fullscreen. it will lead to key inputs not working anymore and the "no key input" error sound. after quite a bit of testing i could establish that the change from a NSWindowStyleMaskBorderless style mask to a style mask without NSWindowStyleMaskBorderless causes the first responder to change (to the window, from our events view) without the usual resignFirstResponder > becomeFirstResponder routine. i also found [this](http://stackoverflow.com/questions/32885006/what-changed-the-next-responder-of-my-nswindow) related issue after getting to the core of the problem.

a small [log](https://0x0.st/tK9.txt) i made to demonstrate the problem. three cases one borderless (broken), one with border (working) and the last one borderless with the fix. i just started mpv and toggled fullscreen. the debug output are basically the FirstResponder related methods of our events view and the window and for the fullscreen toggling. the last part of the lines is the current first responder. in all cases our first responder is  changes to "MpvEventsView" when mpv is started. in the first case it changes to "MpvVideoWindow" after toggling fs without triggering the first responder routines. in the last fixed case we can see that the setStyleMask is called by out fullscreen function and that the first responder is changed back to the our events view (MpvVideoWindow > MpvEventsView), it also triggers the usual first responder routine.

in some [older apple docs](http://web.archive.org/web/20150923082535/https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSWindow_Class/#//apple_ref/occ/instm/NSWindow/setStyleMask:) it is mentioned for setStyleMask:

> Some style mask changes cause the view hierarchy to be rebuilt.

that is probably the cause of the problem, that the rebuilt causes the first responder to be reset. but that is just my assumption.

the first bug could have two possible causes. one is the same as the one mentioned above, that changes in the style mask causes the hierarchy to be rebuilt. every key press done in that time might not be reported properly and that is the cause of mpv being unresponsive. the other causes could be the event monitor. for some weird reason the [official docs](https://developer.apple.com/reference/appkit/nsevent/1534971-addlocalmonitorforeventsmatching) mention under **Special Considerations** that KeyDown events are supported but doesn't mention KeyUp events. it still worked but not properly/in all cases. i decided to remove the event monitor and use the first event entry point instead.

the reason why i open a PR instead of pushing directly, i am not sure if we should keep the EvenMonitor around. the description of it said:

> Enable/disable application wide keyboard events so that keyboard shortcuts
    can be processed without a window. Enabled by default (except for libmpv).

in the case of mpv i don't see a reason to disable keyboard events when we don't have a window. though it removes the possibility to easily activate key events when using libmpv. i kinda want to know what @pigoz thinks about this. the [commit](https://github.com/mpv-player/mpv/commit/dba2b90d9a34055e98c9216bd305a5cb4fb01a3a) that added this option.