### PR TITLE
player: print audio channel info in print_stream when available

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -132,7 +132,10 @@ static void print_stream(struct MPContext *mpctx, struct track *t)
     if (t->title)
         APPEND(b, " '%s'", t->title);
     const char *codec = s ? s->codec->codec : NULL;
-    APPEND(b, " (%s)", codec ? codec : "<unknown>");
+    if (codec && s->codec->channels.num)
+        APPEND(b, " (%s, %s)", codec, mp_chmap_to_str(&s->codec->channels));
+    else
+        APPEND(b, " (%s)", codec ? codec : "<unknown>");
     if (t->is_external)
         APPEND(b, " (external)");
     MP_INFO(mpctx, "%s\n", b);


### PR DESCRIPTION
before:
```
 (+) Video --vid=1 (h264)
 (+) Audio --aid=1 --alang=msa (aac_latm)
     Audio --aid=2 (aac_latm)
     Subs  --sid=1 --slang=ENG (dvb_subtitle)
     Subs  --sid=2 --slang=MSA (dvb_subtitle)
```

after:
```
 (+) Video --vid=1 (h264)
 (+) Audio --aid=1 --alang=msa (aac_latm, 5.1)
     Audio --aid=2 (aac_latm, stereo)
     Subs  --sid=1 --slang=ENG (dvb_subtitle)
     Subs  --sid=2 --slang=MSA (dvb_subtitle)
```