### PR TITLE
Make sure reinit_window_state() is called synchronized

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1826,8 +1826,11 @@ int vo_w32_control(struct vo *vo, int *events, int request, void *arg)
             vo->dheight = w32->dh;
             mp_dispatch_unlock(w32->dispatch);
         }
-        if (*events & VO_EVENT_FULLSCREEN_STATE)
+        if (*events & VO_EVENT_FULLSCREEN_STATE) {
+            mp_dispatch_lock(w32->dispatch);
             reinit_window_state(w32);
+            mp_dispatch_unlock(w32->dispatch);
+        }
         return VO_TRUE;
     } else {
         int r;


### PR DESCRIPTION
I don't know if it's okay to call reinit_window_state() from the VO thread at all, but this is probably an improvement.