### PR TITLE
config: auto profiles for media

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -589,10 +589,34 @@ Some profiles are loaded automatically. The following example demonstrates this:
         profile-desc="profile for .flv files"
         vf=flip
 
+        [media.no-video]
+        profile-desc="profile for no video track is selected"
+        audio-client-name=mpvmusik
+
+        [media.video]
+        profile-desc="profile for a video track is selected"
+        keep-open=yes
+
+        [media.no_audio]
+        profile-desc="profile for no audio track is selected"
+
+        [media.mono]
+        profile-desc="profile for audio track selected is mono"
+        audio-channels=2
+
+        [media.stereo]
+        profile-desc="profile for audio track selected is stereo"
+
+        [media.surround]
+        profile-desc="profile for audio track selected have more then 2 channels"
+
 The profile name follows the schema ``type.name``, where type can be
 ``protocol`` for the input/output protocol in use (see ``--list-protocols``),
 and ``extension`` for the extension of the path of the currently played file
 (*not* the file format).
+
+The media profiles are loaded late after tracks are selected so some
+options may not work.
 
 This feature is very limited, and there are no other auto profiles.
 

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -161,6 +161,25 @@ void mp_load_auto_profiles(struct MPContext *mpctx)
         mp_auto_load_profile(mpctx, "ao", bstr0(opts->audio_driver_list[0].name));
 }
 
+void mp_load_media_profiles(struct MPContext *mpctx, bool no_video_tracks, int audio_channels)
+{
+    if (no_video_tracks) {
+        mp_auto_load_profile(mpctx, "media", bstr0("no-video"));
+    } else {
+        mp_auto_load_profile(mpctx, "media", bstr0("video"));
+    }
+    if (!audio_channels) {
+        mp_auto_load_profile(mpctx, "media", bstr0("no-audio"));
+    } else if (audio_channels == 1) {
+        mp_auto_load_profile(mpctx, "media", bstr0("mono"));
+    } else if (audio_channels == 2) {
+        mp_auto_load_profile(mpctx, "media", bstr0("stereo"));
+    } else {
+        mp_auto_load_profile(mpctx, "media", bstr0("surround"));
+    }
+}
+
+
 #define MP_WATCH_LATER_CONF "watch_later"
 
 static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,

--- a/player/core.h
+++ b/player/core.h
@@ -478,6 +478,7 @@ void reload_audio_output(struct MPContext *mpctx);
 // configfiles.c
 void mp_parse_cfgfiles(struct MPContext *mpctx);
 void mp_load_auto_profiles(struct MPContext *mpctx);
+void mp_load_media_profiles(struct MPContext *mpctx, bool no_video_tracks, int audio_channels);
 void mp_get_resume_defaults(struct MPContext *mpctx);
 void mp_load_playback_resume(struct MPContext *mpctx, const char *file);
 void mp_write_watch_later_conf(struct MPContext *mpctx);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1190,6 +1190,14 @@ reopen_file:
         }
     }
 
+    // load auto media profiles
+    bool no_video_tracks = !mpctx->current_track[0][STREAM_VIDEO] ||
+         mpctx->current_track[0][STREAM_VIDEO]->attached_picture;
+    struct sh_stream *s = mpctx->current_track[0][STREAM_AUDIO] ?
+                          mpctx->current_track[0][STREAM_AUDIO]->stream : NULL;
+    int audio_channels =  s ? s->codec->channels.num : 0;
+    mp_load_media_profiles(mpctx, no_video_tracks, audio_channels);
+
     for (int n = 0; n < mpctx->num_tracks; n++)
         reselect_demux_stream(mpctx, mpctx->tracks[n]);
 


### PR DESCRIPTION
Add auto loaded configuration profiles for selected media contents.
Will be loaded late after media tracks are selected so some
options may not work as expected.

My need for having special versions of options related to media contents are no longer needed with this.
