### PR TITLE
playloop: add option to keep playing on keep-open

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -31,6 +31,7 @@ Interface changes
     - add --sub-filter-sdh
     - add --sub-filter-sdh-harder
     - remove --input-app-events option (macOS)
+    - add --keep-open-playing
  --- mpv 0.24.0 ---
     - deprecate --hwdec-api and replace it with --opengl-hwdec-interop.
       The new option accepts both --hwdec values, as well as named backends.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2089,6 +2089,11 @@ Window
     file.mkv normally, then fail to open ``/dev/null``, then exit). (In
     mpv 0.8.0, ``always`` was introduced, which restores the old behavior.)
 
+``--keep-open-playing=<yes|no>``
+    Instead of pausing when ``--keep-open`` is active, just stop at end of file
+    and continue playing forward when you seek backwards until end where it
+    stops again. Default: ``no``.
+
 ``--image-display-duration=<seconds|inf>``
     If the current file is an image, play the image for the given amount of
     seconds (default: 1). ``inf`` means the file is kept open forever (until

--- a/options/options.c
+++ b/options/options.c
@@ -354,6 +354,7 @@ const m_option_t mp_opts[] = {
                ({"no", 0},
                 {"yes", 1},
                 {"always", 2})),
+    OPT_FLAG("keep-open-playing", keep_open_playing, 0),
     OPT_DOUBLE("image-display-duration", image_display_duration,
                M_OPT_RANGE, 0, INFINITY),
 
@@ -909,6 +910,7 @@ const struct MPOpts mp_default_opts = {
     .play_frames = -1,
     .rebase_start_time = 1,
     .keep_open = 0,
+    .keep_open_playing = 0,
     .image_display_duration = 1.0,
     .stream_id = { { [STREAM_AUDIO] = -1,
                      [STREAM_VIDEO] = -1,

--- a/options/options.h
+++ b/options/options.h
@@ -200,6 +200,7 @@ typedef struct MPOpts {
     char *watch_later_directory;
     int pause;
     int keep_open;
+    int keep_open_playing;
     double image_display_duration;
     char *lavfi_complex;
     int stream_id[2][STREAM_TYPE_COUNT];

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -830,7 +830,7 @@ static void handle_keep_open(struct MPContext *mpctx)
                 seek_to_last_frame(mpctx);
             mpctx->playback_pts = mpctx->last_vo_pts;
         }
-        if (!mpctx->opts->pause)
+        if (!opts->keep_open_playing && !mpctx->opts->pause)
             pause_player(mpctx);
     }
 }


### PR DESCRIPTION
Instead of pausing if --keep-open is active, stop
at end but continue playing if seeking backwards.
And the stop again when end is reached.

For example ffplay works this way and I feel it is much more they way I want keep-open to work.