### PR TITLE
[RFC] encoding_profiles.conf: update and remove deprecated stuff

### DIFF
--- a/etc/encoding-profiles.conf
+++ b/etc/encoding-profiles.conf
@@ -12,7 +12,7 @@
 # will be loaded instead.
 #
 # Then, list all profiles by
-#   mpv -profile help | grep enc-
+#   mpv -profile help -o - | grep enc-
 #
 # The following kinds of encoding profiles exist:
 #   enc-a-*:  initialize an audio codec including good defaults
@@ -27,7 +27,7 @@
 # options, or even switch to another codec.
 #
 # You can view the exact options a profile sets by
-#   mpv -show-profile enc-to-bb-9000
+#   mpv -show-profile enc-to-hp-slate-7
 #
 # Examples:
 #   mpv -profile enc-to-dvdpal -o outfile.mpg infile.mkv
@@ -38,8 +38,8 @@
 # audio codecs #
 ################
 [enc-a-aac]
-profile-desc = "AAC (libfaac or FFmpeg)"
-oac = libfdk_aac,libfaac,libvo_aacenc,aac
+profile-desc = "AAC (libfdk-aac or FFmpeg)"
+oac = libfdk_aac,aac
 oacopts = b=96k
 
 [enc-a-ac3]
@@ -54,8 +54,14 @@ oacopts = b=128k
 
 [enc-a-vorbis]
 profile-desc = "Vorbis (libvorbis)"
-oac = libvorbis,vorbis
+oac = libvorbis
 oacopts = qscale=3
+
+[enc-a-opus]
+profile-desc = "Opus (libopus)"
+oac = libopus
+audio-samplerate = 48000
+oacopts = b=96k
 
 ################
 # video codecs #
@@ -84,7 +90,12 @@ ovcopts = qscale=4
 [enc-v-vp8]
 profile-desc = "VP8 (libvpx)"
 ovc = libvpx
-ovcopts = qmin=4,b=10000000k # ought to be enough for anyone; for CBR use, set b=; for VBR use, set qmin= to quality
+ovcopts = speed=0,lag-in-frames=8,slices=2,threads=0,b=2M,crf=10,qmin=0,qmax=36
+
+[enc-v-vp9]
+profile-desc = "VP9 (libvpx)"
+ovc = libvpx-vp9
+ovcopts = speed=6,lag-in-frames=8,slices=2,threads=0,crf=18,qmin=0,qmax=36
 
 ###########
 # formats #
@@ -115,11 +126,11 @@ profile = enc-a-aac
 ofopts-clr = yes
 
 [enc-f-webm]
-profile-desc = "VP8 + Vorbis (for WebM)"
+profile-desc = "VP9 + Opus (for WebM)"
 of = webm
 ocopyts = yes
-profile = enc-v-vp8
-profile = enc-a-vorbis
+profile = enc-v-vp9
+profile = enc-a-opus
 ofopts-clr = yes
 
 ##################
@@ -149,13 +160,6 @@ ovfirst = yes # dvdauthor needs this
 audio-samplerate = 48000
 ovcopts-add = g=18,b=6000000,maxrate=9000000,minrate=0,bufsize=1835008
 
-[enc-to-bb-9000]
-profile-desc = "MP4 for Blackberry Bold 9000"
-profile = enc-f-mp4
-vf-add = dsize=480:360:0:2,scale=w=0:h=0,dsize=-1:-1 # native screen res, letterbox
-ovcopts-add = maxrate=1500k,bufsize=1000k,rc_init_occupancy=900k,refs=1,profile=baseline
-omaxfps = 30
-
 [enc-to-nok-n900]
 profile-desc = "MP4 for Nokia N900"
 profile = enc-f-mp4
@@ -168,55 +172,13 @@ omaxfps = 30
 profile-desc = "3GP for Nokia 6300"
 profile = enc-f-3gp
 ofps = 25
-vf-add = scale=w=176:h=144
+vf-add = lavfi=graph="scale=176:144"
 audio-samplerate = 16000
 audio-channels = 1
 oacopts-add = b=32k
 
-[enc-to-psp]
-profile-desc = "MP4 for PlayStation Portable"
-profile = enc-f-mp4
-ofps = 30000/1001
-vf-add = scale=w=480:h=272,dsize=480:270
-audio-samplerate = 48000
-audio-channels = 2
-ovcopts-add = b=512k,profile=baseline
-
-[enc-to-iphone-noscale]
-profile-desc = "MP4 for iPhone (no scaling)"
-profile = enc-f-mp4
-oautofps = yes # iphone supports 30fps max
-ovcopts-add = maxrate=2500k,bufsize=1000k,rc_init_occupancy=900k,level=30,profile=baseline
-omaxfps = 30
-
-[enc-to-iphone]
-profile-desc = "MP4 for iPhone (480x320)"
-profile = enc-to-iphone-noscale
-vf-add = dsize=480:320:1:2,scale=w=0:h=0,dsize=-1:-1 # panscan
-omaxfps = 30
-
-[enc-to-iphone-4]
-profile-desc = "MP4 for iPhone 4 (960x640)"
-profile = enc-to-iphone-noscale
-vf-add = dsize=960:480:1:2,scale=w=0:h=0,dsize=-1:-1 # panscan
-omaxfps = 30
-
-[enc-to-iphone-5]
-profile-desc = "MP4 for iPhone 5 (1136x640)"
-profile = enc-to-iphone-noscale
-vf-add = dsize=1136:480:1:2,scale=w=0:h=0,dsize=-1:-1 # panscan
-omaxfps = 30
-
 [enc-to-hp-slate-7]
 profile-desc = "MP4 for HP Slate 7 (1024x600, crazy aspect)"
-profile = enc-f-mp4
-omaxfps = 30
-ovcopts-add = profile=high
-# DW = 1024, DH = 600, DAR = 97:54 (=> SAR = 2425:2304)
-vf-add = lavfi=graph="scale=floor(min(1024*min(1\,dar/(97/54))\,in_w*max(1\,sar/(2425/2304)))/2+0.5)*2:floor(min(600*min((97/54)/dar\,1)\,in_h*max((2425/2304)/sar\,1))/2+0.5)*2,setsar=sar=1"
-
-[enc-to-hp-slate-7-git]
-profile-desc = "MP4 for HP Slate 7 (1024x600, crazy aspect), FFmpeg-git"
 profile = enc-f-mp4
 omaxfps = 30
 ovcopts-add = profile=high

--- a/etc/encoding-profiles.conf
+++ b/etc/encoding-profiles.conf
@@ -53,13 +53,13 @@ oac = libmp3lame
 oacopts = b=128k
 
 [enc-a-vorbis]
-profile-desc = "Vorbis (libvorbis)"
-oac = libvorbis
+profile-desc = "Vorbis (libvorbis or FFmpeg)"
+oac = libvorbis,vorbis
 oacopts = qscale=3
 
 [enc-a-opus]
-profile-desc = "Opus (libopus)"
-oac = libopus
+profile-desc = "Opus (libopus or FFmpeg)"
+oac = libopus,opus
 audio-samplerate = 48000
 oacopts = b=96k
 


### PR DESCRIPTION
- libfaac and libvo_aacenc were removed from FFmpeg
- remove native vorbis encoder since it needs strict=experimental
- add libopus profile
- modify vp8's ovcopts and add vp9
- switch enc-f-webm to vp9 + opus

- remove obsolete devices profiles using deprecated filters
