### PR TITLE
mpv-wrapper.sh: Fix failure to launch for csh/tcsh users

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper.sh
+++ b/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export MPVBUNDLE="true"
-$SHELL -l -c "$(dirname "$0")/mpv --player-operation-mode=pseudo-gui"
+exec "$(dirname $0)"/mpv --player-operation-mode=pseudo-gui


### PR DESCRIPTION
If the default shell of the user is set to csh/tcsh, the use of "$SHELL -l -c" will fail to launch mpv because -l and -c cannot be used together with csh/tcsh.
The use of exec fixes the failure to launch.

I agree that my changes can be relicensed to LGPL 2.1 or later.

**Update**: My apologies for not following commit conventions. I'm new at this, and it was late when I wrote it up.

The current build of mpv on Mac OS X uses mpv-wrapper.sh as the CFBundleExecutable to launch mpv in the bundle. If you attempt to launch bundle in any way, mpv.app will fail to launch if the user's default shell is either csh or tcsh. Technically, what happens is that the bundle appears to launch, then disappears, without any error message.

If the default shell of the user (as set by the chsh command) on Mac OS X is set to either csh or tcsh, the bundle will fail to launch. That's because the use of -l with -c in csh/tcsh is not an allowed combination (and will result in an unhelpful "Unknown option: `-l'" message). So when $SHELL is evaluated, it returns csh/tcsh for users with those default shells, and the last line of the wrapper results in an illegal command.

The vast majority of Mac OS X users will have their default shells set to bash, but because of the way this issue manifests, the bundle will silently fail to launch, without any clue as to why it does. It took me a half hour to figure out that the cause of the issue was the new wrapper script, and longer to figure out that it was the use of $SHELL-l -c in the script that was causing the failure. This may only affect a small number of users, but tcsh was the default shell in 10.2 and before.

The use of exec should also preserve any PATH variables from the shell, which was another issue the wrapper was adopted for. In my limited testing, the PATH variable was exported.