### PR TITLE
sub: minor sdh filter fixes

### DIFF
--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -132,6 +132,7 @@ static void skip_speaker_label(struct sd *sd, char **rpp, struct buffer *buf)
                     (filter_harder || mp_isupper(rp[0]) || rp[0] == 'l')) ||
                    mp_isdigit(rp[0]) ||
                    rp[0] == ' ' || rp[0] == '\'' ||
+                   (filter_harder && (rp[0] == '(' || rp[0] == ')')) ||
                    rp[0] == '#' || rp[0] == '.' || rp[0] == ',') {
             rp++;
         } else {
@@ -151,7 +152,7 @@ static void skip_speaker_label(struct sd *sd, char **rpp, struct buffer *buf)
     } else if (rp[0] == '\\' && rp[1] == 'N') {
         // line end follows - skip it as line is empty
         rp += 2;
-    } else if (rp[0] == ' ' || filter_harder) {
+    } else if (rp[0] == ' ') {
         while (rp[0] == ' ') {
             rp++;
         }


### PR DESCRIPTION
When doing harder filtering not require a space after : results
in lines with a clock (like 10:05) to be taken as a speaker label.
So require a space after : even when doing harder filtering as
missing space is very uncommon.
Some like to add text in parentheses in the speaker label,
like XXX (loud):  or just (loud):
allow parantheses when doing harder filtering
