### PR TITLE
sd_lavc: Free extradata in case of init error

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -113,6 +113,8 @@ static int init(struct sd *sd)
 
  error:
     MP_FATAL(sd, "Could not open libavcodec subtitle decoder\n");
+    if (ctx)
+        av_free(ctx->extradata);
     av_free(ctx);
     talloc_free(priv);
     return -1;


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
