### PR TITLE
Update man page for fonts.conf and subfont.ttf

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1002,6 +1002,10 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
 ``~/.config/mpv/subfont.ttf``
     fallback subtitle font
 
+``~/.config/mpv/fonts/``
+    Font files in this directory are used by mpv/libass for subtitles. Useful
+    if you do not want to install fonts to your system.
+
 ``~/.config/mpv/scripts/``
     All files in this directory are loaded as if they were passed to the
     ``--script`` option. They are loaded in alphabetical order, and sub-directories

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1001,6 +1001,8 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
     fonts.conf in this file or mpv would not know about fonts that you already
     have in the system.
 
+    Only available when libass is built with fontconfig.
+
 ``~/.config/mpv/subfont.ttf``
     fallback subtitle font
 

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1011,7 +1011,7 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
     if you do not want to install fonts to your system. Note that files in this
     directory are loaded into memory before being used by mpv. If you have a
     lot of fonts, consider using fonts.conf (see above) to include additional
-    fonts, which is more memory-effient.
+    fonts, which is more memory-efficient.
 
 ``~/.config/mpv/scripts/``
     All files in this directory are loaded as if they were passed to the

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -997,14 +997,19 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
     key bindings (see `INPUT.CONF`_ section)
 
 ``~/.config/mpv/fonts.conf``
-    fontconfig fonts.conf that is customized for mpv
+    Fontconfig fonts.conf that is customized for mpv. You should include system
+    fonts.conf in this file or mpv would not know about fonts that you already
+    have in the system.
 
 ``~/.config/mpv/subfont.ttf``
     fallback subtitle font
 
 ``~/.config/mpv/fonts/``
     Font files in this directory are used by mpv/libass for subtitles. Useful
-    if you do not want to install fonts to your system.
+    if you do not want to install fonts to your system. Note that files in this
+    directory are loaded into memory before being used by mpv. If you have a
+    lot of fonts, consider using fonts.conf (see above) to include additional
+    fonts, which is more memory-effient.
 
 ``~/.config/mpv/scripts/``
     All files in this directory are loaded as if they were passed to the

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -996,6 +996,12 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
 ``~/.config/mpv/input.conf``
     key bindings (see `INPUT.CONF`_ section)
 
+``~/.config/mpv/fonts.conf``
+    fontconfig fonts.conf that is customized for mpv
+
+``~/.config/mpv/subfont.ttf``
+    fallback subtitle font
+
 ``~/.config/mpv/scripts/``
     All files in this directory are loaded as if they were passed to the
     ``--script`` option. They are loaded in alphabetical order, and sub-directories


### PR DESCRIPTION
Update man page for fonts.conf and subfont.ttf. These are two
undocumented features in mpv. They were only hardcoded into sub/ass_mp.c
and could not be found anywhere else in the entire codebase. Git log
reveals that fonts.conf was added in 2013 while subfont.ttf was brought
in by a ancient patch of mplayer in 2002...

These are two quite useful undocumented features when you do not want to
mess up with global fonts.conf to include more fonts for anime fansubs.

I agree that my changes can be relicensed to LGPL 2.1 or later.
