### PR TITLE
vo_opengl: fix getting EGL display in DRM driver

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -76,11 +76,26 @@ struct priv {
     struct vt_switcher vt_switcher;
 };
 
+static EGLDisplay *get_egl_display(void *device)
+{
+    PFNEGLGETPLATFORMDISPLAYEXTPROC ptr_eglGetPlatformDisplayEXT =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)
+        eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (ptr_eglGetPlatformDisplayEXT)
+    {
+        EGLDisplay display = ptr_eglGetPlatformDisplayEXT(
+            EGL_PLATFORM_GBM_KHR, device, NULL);
+        if (display != EGL_NO_DISPLAY)
+            return display;
+    }
+    return eglGetDisplay(device);
+}
+
 static bool init_egl(struct MPGLContext *ctx, int flags)
 {
     struct priv *p = ctx->priv;
     MP_VERBOSE(ctx->vo, "Initializing EGL\n");
-    p->egl.display = eglGetDisplay(p->gbm.device);
+    p->egl.display = get_egl_display(p->gbm.device);
     if (p->egl.display == EGL_NO_DISPLAY) {
         MP_ERR(ctx->vo, "Failed to get EGL display.\n");
         return false;


### PR DESCRIPTION
See: https://github.com/libretro/RetroArch/pull/4826
See: #4297

I decided to use `PFNEGLGETPLATFORMDISPLAYEXTPROC` after all, because we use this in `context_angle.c` too.