### PR TITLE
Improve axis input with non-scalable commands, and use MP_AXIS on Windows

### DIFF
--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -72,6 +72,7 @@ const struct mp_cmd_def mp_cmds[] = {
                       {"exact", 32|16})),
     },
     .allow_auto_repeat = true,
+    .scalable = true,
   },
   { MP_CMD_REVERT_SEEK, "revert-seek", {
       OARG_FLAGS(0, ({"mark", 1})),
@@ -148,12 +149,15 @@ const struct mp_cmd_def mp_cmds[] = {
 
   { MP_CMD_SET, "set", { ARG_STRING,  ARG_STRING } },
   { MP_CMD_ADD, "add", { ARG_STRING, OARG_DOUBLE(1) },
-    .allow_auto_repeat = true},
+    .allow_auto_repeat = true,
+    .scalable = true,
+  },
   { MP_CMD_CYCLE, "cycle", {
       ARG_STRING,
       OARG_CYCLEDIR(1),
     },
-    .allow_auto_repeat = true
+    .allow_auto_repeat = true,
+    .scalable = true,
   },
   { MP_CMD_MULTIPLY, "multiply", { ARG_STRING, ARG_DOUBLE },
     .allow_auto_repeat = true},
@@ -346,6 +350,11 @@ bool mp_input_is_repeatable_cmd(struct mp_cmd *cmd)
     return (cmd->def && cmd->def->allow_auto_repeat) ||
            cmd->id == MP_CMD_COMMAND_LIST ||
            (cmd->flags & MP_ALLOW_REPEAT);
+}
+
+bool mp_input_is_scalable_cmd(struct mp_cmd *cmd)
+{
+    return cmd->def && cmd->def->scalable;
 }
 
 void mp_print_cmd_list(struct mp_log *out)

--- a/input/cmd_list.h
+++ b/input/cmd_list.h
@@ -32,6 +32,7 @@ struct mp_cmd_def {
     bool allow_auto_repeat; // react to repeated key events
     bool on_updown;     // always emit it on both up and down key events
     bool vararg;        // last argument can be given 0 to multiple times
+    bool scalable;
 };
 
 extern const struct mp_cmd_def mp_cmds[];
@@ -130,6 +131,8 @@ bool mp_input_is_maybe_abort_cmd(struct mp_cmd *cmd);
 bool mp_input_is_abort_cmd(struct mp_cmd *cmd);
 
 bool mp_input_is_repeatable_cmd(struct mp_cmd *cmd);
+
+bool mp_input_is_scalable_cmd(struct mp_cmd *cmd);
 
 struct bstr;
 bool mp_replace_legacy_cmd(void *talloc_ctx, struct bstr *s);

--- a/input/cmd_parse.c
+++ b/input/cmd_parse.c
@@ -140,7 +140,7 @@ struct mp_cmd *mp_input_parse_cmd_node(struct mp_log *log, mpv_node *node)
 {
     struct mp_cmd *cmd = talloc_ptrtype(NULL, cmd);
     talloc_set_destructor(cmd, destroy_cmd);
-    *cmd = (struct mp_cmd) { .scale = 1, };
+    *cmd = (struct mp_cmd) { .scale = 1, .scale_units = 1 };
 
     if (node->format != MPV_FORMAT_NODE_ARRAY)
         goto error;
@@ -254,6 +254,7 @@ static struct mp_cmd *parse_cmd_str(struct mp_log *log, void *tmp,
     *cmd = (struct mp_cmd) {
         .flags = MP_ON_OSD_AUTO | MP_EXPAND_PROPERTIES,
         .scale = 1,
+        .scale_units = 1,
     };
 
     ctx->str = bstr_lstrip(ctx->str);

--- a/input/input.c
+++ b/input/input.c
@@ -618,11 +618,13 @@ static void interpret_key(struct input_ctx *ictx, int code, double scale,
 
     if (mp_input_is_scalable_cmd(cmd)) {
         cmd->scale = scale;
+        cmd->scale_units = scale_units;
         mp_input_queue_cmd(ictx, cmd);
     } else {
         // Non-scalable commands won't understand cmd->scale, so synthesize
         // multiple commands with cmd->scale = 1
         cmd->scale = 1;
+        cmd->scale_units = 1;
         // Avoid spamming the player with too many commands
         scale_units = FFMIN(scale_units, 20);
         for (int i = 0; i < scale_units - 1; i++)

--- a/input/input.h
+++ b/input/input.h
@@ -85,6 +85,7 @@ typedef struct mp_cmd {
     int mouse_x, mouse_y;
     struct mp_cmd *queue_next;
     double scale;               // for scaling numeric arguments
+    int scale_units;
     const struct mp_cmd_def *def;
     char *sender; // name of the client API user which sent this
     char *key_name; // string representation of the key binding

--- a/input/keycodes.h
+++ b/input/keycodes.h
@@ -172,6 +172,10 @@
 #define MP_AXIS_DOWN      (MP_AXIS_BASE+1)
 #define MP_AXIS_LEFT      (MP_AXIS_BASE+2)
 #define MP_AXIS_RIGHT     (MP_AXIS_BASE+3)
+#define MP_AXIS_END       (MP_AXIS_BASE+4)
+
+#define MP_KEY_IS_AXIS(code) \
+    ((code) >= MP_AXIS_BASE && (code) < MP_AXIS_END)
 
 // Reserved area. Can be used for keys that have no explicit names assigned,
 // but should be mappable by the user anyway.
@@ -195,10 +199,12 @@
 
 // Whether to dispatch the key binding by current mouse position.
 #define MP_KEY_DEPENDS_ON_MOUSE_POS(code) \
-    (MP_KEY_IS_MOUSE_CLICK(code) || (code) == MP_KEY_MOUSE_MOVE)
+    (MP_KEY_IS_MOUSE_CLICK(code) || MP_KEY_IS_AXIS(code) || \
+     (code) == MP_KEY_MOUSE_MOVE)
 
 #define MP_KEY_IS_MOUSE(code) \
-    (MP_KEY_IS_MOUSE_CLICK(code) || MP_KEY_IS_MOUSE_MOVE(code))
+    (MP_KEY_IS_MOUSE_CLICK(code) || MP_KEY_IS_AXIS(code) || \
+     MP_KEY_IS_MOUSE_MOVE(code))
 
 // No input source should generate this.
 #define MP_KEY_UNMAPPED (MP_KEY_INTERN+4)

--- a/player/command.c
+++ b/player/command.c
@@ -4786,6 +4786,20 @@ static bool check_property_autorepeat(char *property,  struct MPContext *mpctx)
     return true;
 }
 
+// Whether changes to this property (add/cycle cmds) benefit from cmd->scale
+static bool check_property_scalable(char *property, struct MPContext *mpctx)
+{
+    struct m_option prop = {0};
+    if (mp_property_do(property, M_PROPERTY_GET_TYPE, &prop, mpctx) <= 0)
+        return true;
+
+    // These properties are backed by a floating-point number
+    return prop.type == &m_option_type_float ||
+           prop.type == &m_option_type_double ||
+           prop.type == &m_option_type_time ||
+           prop.type == &m_option_type_aspect;
+}
+
 static struct mpv_node *add_map_entry(struct mpv_node *dst, const char *key)
 {
     struct mpv_node_list *list = dst->u.list;
@@ -4928,27 +4942,35 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     case MP_CMD_CYCLE:
     {
         char *property = cmd->args[0].v.s;
-        struct m_property_switch_arg s = {
-            .inc = cmd->args[1].v.d * cmd->scale,
-            .wrap = cmd->id == MP_CMD_CYCLE,
-        };
         if (cmd->repeated && !check_property_autorepeat(property, mpctx)) {
             MP_VERBOSE(mpctx, "Dropping command '%.*s' from auto-repeated key.\n",
                        BSTR_P(cmd->original));
             break;
         }
-        int r = mp_property_do(property, M_PROPERTY_SWITCH, &s, mpctx);
-        if (r == M_PROPERTY_OK || r == M_PROPERTY_UNAVAILABLE) {
-            show_property_osd(mpctx, property, on_osd);
-        } else if (r == M_PROPERTY_UNKNOWN) {
-            set_osd_msg(mpctx, osdl, osd_duration,
-                        "Unknown property: '%s'", property);
-            return -1;
-        } else if (r <= 0) {
-            set_osd_msg(mpctx, osdl, osd_duration,
-                        "Failed to increment property '%s' by %g",
-                        property, s.inc);
-            return -1;
+        double scale = 1;
+        int scale_units = cmd->scale_units;
+        if (check_property_scalable(property, mpctx)) {
+            scale = cmd->scale;
+            scale_units = 1;
+        }
+        for (int i = 0; i < scale_units; i++) {
+            struct m_property_switch_arg s = {
+                .inc = cmd->args[1].v.d * scale,
+                .wrap = cmd->id == MP_CMD_CYCLE,
+            };
+            int r = mp_property_do(property, M_PROPERTY_SWITCH, &s, mpctx);
+            if (r == M_PROPERTY_OK || r == M_PROPERTY_UNAVAILABLE) {
+                show_property_osd(mpctx, property, on_osd);
+            } else if (r == M_PROPERTY_UNKNOWN) {
+                set_osd_msg(mpctx, osdl, osd_duration,
+                            "Unknown property: '%s'", property);
+                return -1;
+            } else if (r <= 0) {
+                set_osd_msg(mpctx, osdl, osd_duration,
+                            "Failed to increment property '%s' by %g",
+                            property, s.inc);
+                return -1;
+            }
         }
         break;
     }

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1097,11 +1097,11 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         return TRUE;
     case WM_XBUTTONDOWN:
         handle_mouse_down(w32,
-                          HIWORD(wParam) == 1 ? MP_MOUSE_BTN5 : MP_MOUSE_BTN6,
+                          HIWORD(wParam) == 1 ? MP_MOUSE_BTN7 : MP_MOUSE_BTN8,
                           GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
         break;
     case WM_XBUTTONUP:
-        handle_mouse_up(w32, HIWORD(wParam) == 1 ? MP_MOUSE_BTN5 : MP_MOUSE_BTN6);
+        handle_mouse_up(w32, HIWORD(wParam) == 1 ? MP_MOUSE_BTN7 : MP_MOUSE_BTN8);
         break;
     case WM_DISPLAYCHANGE:
         force_update_display_info(w32);


### PR DESCRIPTION
This changes how axis input works with non-scalable commands (commands other than seek and add/cycle) so the command is only fired when the user has scrolled one full unit. It also changes w32_common to emit MP_AXIS_* events instead of MP_MOUSE_BTN* for the scroll wheel.

In general, I want to remove the distinction between MP_AXIS_* and MP_MOUSE_BTN{3,4,5,6}, since they tend to cause user confusion and the one that's used depends on the operating system and the hardware (touchpads or notched scroll wheels.) The next step would probably be deprecating MP_MOUSE_BTN{3,4,5,6} in favour of MP_AXIS_* and/or synthesizing MP_MOUSE_BTN* input when MP_AXIS_* events are received (this isn't done yet.)