### PR TITLE
--opengl-backend: support multiple backends

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4480,9 +4480,10 @@ The following video options are currently all specific to ``--vo=opengl`` and
     Continue even if a software renderer is detected.
 
 ``--opengl-backend=<sys>``
-    The value ``auto`` (the default) selects the windowing backend. You can
-    also pass ``help`` to get a complete list of compiled in backends (sorted
-    by autoprobe order).
+    Specify a priority list of windowing backends to use with OpenGL. The value
+    ``auto`` (the default) automatically probes for the most suitable backend.
+    You can also pass ``help`` to get a complete list of compiled in backends
+    (sorted by autoprobe order).
 
     auto
         auto-select (default)

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -141,22 +141,7 @@ static int mpgl_find_backend(const char *name)
     return -2;
 }
 
-int mpgl_validate_backend_opt(struct mp_log *log, const struct m_option *opt,
-                              struct bstr name, struct bstr param)
-{
-    if (bstr_equals0(param, "help")) {
-        mp_info(log, "OpenGL windowing backends:\n");
-        mp_info(log, "    auto (autodetect)\n");
-        for (int n = 0; n < MP_ARRAY_SIZE(backends); n++)
-            mp_info(log, "    %s\n", backends[n]->name);
-        return M_OPT_EXIT;
-    }
-    char s[20];
-    snprintf(s, sizeof(s), "%.*s", BSTR_P(param));
-    return mpgl_find_backend(s) >= -1 ? 1 : M_OPT_INVALID;
-}
-
-static void *get_native_display(const char *name)
+static void *get_native_display(void *pctx, const char *name)
 {
     MPGLContext *ctx = pctx;
     if (!ctx->native_display_type || !name)

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -91,6 +91,14 @@ static const struct mpgl_driver *const backends[] = {
 
 static bool get_desc(struct m_obj_desc *dst, int index)
 {
+    if (index == 0) {
+        *dst = (struct m_obj_desc) {
+            .name = "auto",
+            .description = "automatically select most suitable backend"
+        };
+        return true;
+    }
+    index--;
     if (index >= MP_ARRAY_SIZE(backends) - 1)
         return false;
     const struct mpgl_driver *driver = backends[index];
@@ -107,8 +115,6 @@ static bool get_desc(struct m_obj_desc *dst, int index)
 const struct m_obj_list mpgl_backend_list = {
     .get_desc = get_desc,
     .description = "OpenGL windowing backends",
-    .allow_unknown_entries = true,
-    .allow_disable_entries = true,
     .allow_trailer = true,
     .disallow_positional_parameters = true,
 };
@@ -218,13 +224,8 @@ MPGLContext *mpgl_init(struct vo *vo, struct m_obj_settings *backend_list, int v
         for (n = 0; backend_list[n].name; n++) {
             // Something like "--opengl-backend=name," allows fallback to autoprobing.
             int index = mpgl_find_backend(backend_list[n].name);
-            if (index == -1 || strlen(backend_list[n].name) == 0)
+            if (index < 0 || strlen(backend_list[n].name) == 0)
                 goto autoprobe;
-            if (index == -2) {
-                MP_FATAL(vo, "Unknown opengl backend '%s'\n", backend_list[n].name);
-                exit(-2);
-                return NULL;
-            }
             ctx = init_backend(vo, backends[index], true, vo_flags);
             if (ctx)
                 break;

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -100,17 +100,13 @@ typedef struct MPGLContext {
     void *priv;
 } MPGLContext;
 
-MPGLContext *mpgl_init(struct vo *vo, const char *backend_name, int vo_flags);
+MPGLContext *mpgl_init(struct vo *vo, struct m_obj_settings *backend_list, int vo_flags);
 void mpgl_uninit(MPGLContext *ctx);
 int mpgl_reconfig_window(struct MPGLContext *ctx);
 int mpgl_control(struct MPGLContext *ctx, int *events, int request, void *arg);
 void mpgl_start_frame(struct MPGLContext *ctx);
 void mpgl_swap_buffers(struct MPGLContext *ctx);
 
-int mpgl_find_backend(const char *name);
-
-struct m_option;
-int mpgl_validate_backend_opt(struct mp_log *log, const struct m_option *opt,
-                              struct bstr name, struct bstr param);
+extern const struct m_obj_list mpgl_backend_list;
 
 #endif

--- a/video/out/vo_opengl.c
+++ b/video/out/vo_opengl.c
@@ -55,7 +55,7 @@ struct vo_opengl_opts {
     int allow_sw;
     int swap_interval;
     int vsync_fences;
-    char *backend;
+    struct m_obj_settings *backend_list;
     int es;
     int pattern[2];
 };
@@ -383,7 +383,7 @@ static int preinit(struct vo *vo)
     if (p->opts.allow_sw)
         vo_flags |= VOFLAG_SW;
 
-    p->glctx = mpgl_init(vo, p->opts.backend, vo_flags);
+    p->glctx = mpgl_init(vo, p->opts.backend_list, vo_flags);
     if (!p->glctx)
         goto err_out;
     p->gl = p->glctx->gl;
@@ -438,8 +438,7 @@ const struct vo_driver video_out_opengl = {
         OPT_FLAG("opengl-waitvsync", opts.waitvsync, 0),
         OPT_INT("opengl-swapinterval", opts.swap_interval, 0),
         OPT_FLAG("opengl-debug", opts.use_gl_debug, 0),
-        OPT_STRING_VALIDATE("opengl-backend", opts.backend, 0,
-                            mpgl_validate_backend_opt),
+        OPT_SETTINGSLIST("opengl-backend", opts.backend_list, 0, &mpgl_backend_list ),
         OPT_FLAG("opengl-sw", opts.allow_sw, 0),
         OPT_CHOICE("opengl-es", opts.es, 0, ({"no", -1}, {"auto", 0},
                                              {"yes", 1}, {"force2", 2})),


### PR DESCRIPTION
See also: https://github.com/mpv-player/mpv/issues/4382

Will attempt each backend specified in order. The x11 backend is still preferred, even on wayland, but the user can now use --opengl-backend=wayland,x11 to prefer wayland and fall back to x11 if wayland is unavailable.

I agree that my changes can be relicensed to LGPL 2.1 or later.
