### PR TITLE
ytdl_hook: increase limits and rework edl joining

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -1154,7 +1154,7 @@ static int script_subprocess(lua_State *L)
     lua_pop(L, 1); // -
 
     lua_getfield(L, 1, "max_size"); // m
-    int64_t max_size = lua_isnil(L, -1) ? 16 * 1024 * 1024 : lua_tointeger(L, -1);
+    int64_t max_size = lua_isnil(L, -1) ? 64 * 1024 * 1024 : lua_tointeger(L, -1);
 
     struct subprocess_cb_ctx cb_ctx = {
         .log = ctx->log,

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -96,11 +96,13 @@ local function edl_track_joined(fragments, protocol, is_live)
 
     local edl = "edl://"
     local offset = 1
+    local parts = {}
 
     if (protocol == "http_dash_segments") and
         not fragments[1].duration and not is_live then
         -- assume MP4 DASH initialization segment
-        edl = edl .. "!mp4_dash,init=" .. edl_escape(fragments[1].url) .. ";"
+        table.insert(parts,
+            "!mp4_dash,init=" .. edl_escape(fragments[1].url))
         offset = 2
 
         -- Check remaining fragments for duration;
@@ -116,13 +118,13 @@ local function edl_track_joined(fragments, protocol, is_live)
 
     for i = offset, #fragments do
         local fragment = fragments[i]
-        edl = edl .. edl_escape(fragment.url)
+        table.insert(parts, edl_escape(fragment.url))
         if fragment.duration then
-            edl = edl..",length="..fragment.duration
+            parts[#parts] =
+                parts[#parts] .. ",length="..fragment.duration
         end
-        edl = edl .. ";"
     end
-    return edl
+    return edl .. table.concat(parts, ";") .. ";"
 end
 
 local function add_single_video(json)


### PR DESCRIPTION
With string joining I was seeing 2GB usage on mpv before lua complaining about "not enough memory".
Using a temporary string allocated inside the last for-loop and joining that with the edl was still going to 1.5GB but worked better.
Using table.insert instead mpv/lua doesn't go beyond tens of MB and seems faster too.

Should fix https://github.com/mpv-player/mpv/issues/4355 at least until the 64MB limit is reached again.