### PR TITLE
Use the new thread naming API on Windows

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -22,6 +22,7 @@
 #include <libavutil/mathematics.h>
 
 #include "options/m_option.h"
+#include "osdep/threads.h"
 #include "osdep/timer.h"
 #include "osdep/io.h"
 #include "misc/dispatch.h"
@@ -196,6 +197,7 @@ static DWORD __stdcall AudioThread(void *lpParameter)
 {
     struct ao *ao = lpParameter;
     struct wasapi_state *state = ao->priv;
+    mpthread_set_name("wasapi event");
     CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 
     state->init_ret = wasapi_thread_init(ao);

--- a/osdep/threads.c
+++ b/osdep/threads.c
@@ -47,7 +47,7 @@ void mpthread_set_name(const char *name)
         tname[15] = '\0'; // glibc-checked kernel limit
         pthread_setname_np(pthread_self(), tname);
     }
-#elif HAVE_BSD_THREAD_NAME
+#elif HAVE_WIN32_INTERNAL_PTHREADS || HAVE_BSD_THREAD_NAME
     pthread_set_name_np(pthread_self(), tname);
 #elif HAVE_NETBSD_THREAD_NAME
     pthread_setname_np(pthread_self(), "%s", (void *)tname);

--- a/osdep/win32/include/pthread.h
+++ b/osdep/win32/include/pthread.h
@@ -33,6 +33,7 @@
 #define pthread_join m_pthread_join
 #define pthread_detach m_pthread_detach
 #define pthread_create m_pthread_create
+#define pthread_set_name_np m_pthread_set_name_np
 
 #define pthread_once_t INIT_ONCE
 #define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
@@ -96,5 +97,7 @@ int pthread_detach(pthread_t thread);
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                    void *(*start_routine) (void *), void *arg);
+
+void pthread_set_name_np(pthread_t thread, const char *name);
 
 #endif


### PR DESCRIPTION
This finally works in Visual Studio 2017 15.3 Preview. Hopefully other debuggers add support.

![image](https://cloud.githubusercontent.com/assets/162837/26157538/cffd6646-3b5c-11e7-9bf6-9b7b4d1f4f02.png)
