### PR TITLE
vo_opengl: hwdec_cuda: Support separate decode and display devices

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4802,6 +4802,16 @@ The following video options are currently all specific to ``--vo=opengl`` and
     This option might be silently removed in the future, if ANGLE fixes shader
     compilation speed.
 
+``--cuda-decode-device=<auto|0..>``
+    Choose the GPU device used for decoding when using the ``cuda`` hwdec.
+
+    By default, the device that is being used to provide OpenGL output will
+    also be used for decoding (and in the vast majority of cases, only one
+    GPU will be present).
+
+    Note that when using the ``cuda-copy`` hwdec, a different option must be
+    passed: ``--vd-lavc-o=gpu=<0..>``.
+
 Miscellaneous
 -------------
 

--- a/options/options.c
+++ b/options/options.c
@@ -728,6 +728,11 @@ const m_option_t mp_opts[] = {
                ({"no", -1}, {"auto", 0}, {"windowed", 1}, {"yes", 2})),
 #endif
 
+#if HAVE_CUDA_HWACCEL
+    OPT_CHOICE_OR_INT("cuda-decode-device", cuda_device, 0,
+                      0, INT_MAX, ({"auto", -1})),
+#endif
+
 #if HAVE_ENCODING
     OPT_SUBSTRUCT("", encode_opts, encode_config, 0),
 #endif
@@ -973,6 +978,8 @@ const struct MPOpts mp_default_opts = {
         "Performer", "Title", "Track", "icy-title", "service_name",
         NULL
     },
+
+    .cuda_device = -1,
 };
 
 #endif /* MPLAYER_CFG_MPLAYER_H */

--- a/options/options.h
+++ b/options/options.h
@@ -336,6 +336,8 @@ typedef struct MPOpts {
     struct angle_opts *angle_opts;
     struct cocoa_opts *cocoa_opts;
     struct dvd_opts *dvd_opts;
+
+    int cuda_device;
 } MPOpts;
 
 struct dvd_opts {

--- a/video/out/opengl/cuda_dynamic.h
+++ b/video/out/opengl/cuda_dynamic.h
@@ -94,6 +94,7 @@ typedef CUresult CUDAAPI tcuCtxCreate_v2(CUcontext *pctx, unsigned int flags, CU
 typedef CUresult CUDAAPI tcuCtxPushCurrent_v2(CUcontext *pctx);
 typedef CUresult CUDAAPI tcuCtxPopCurrent_v2(CUcontext *pctx);
 typedef CUresult CUDAAPI tcuCtxDestroy_v2(CUcontext ctx);
+typedef CUresult CUDAAPI tcuDeviceGet(CUdevice *pdevice, int ordinal);
 typedef CUresult CUDAAPI tcuMemcpy2D_v2(const CUDA_MEMCPY2D *pcopy);
 typedef CUresult CUDAAPI tcuGetErrorName(CUresult error, const char** pstr);
 typedef CUresult CUDAAPI tcuGetErrorString(CUresult error, const char** pstr);
@@ -110,6 +111,7 @@ typedef CUresult CUDAAPI tcuGraphicsSubResourceGetMappedArray(CUarray* pArray, C
     FN(cuCtxPushCurrent_v2, tcuCtxPushCurrent_v2) \
     FN(cuCtxPopCurrent_v2, tcuCtxPopCurrent_v2) \
     FN(cuCtxDestroy_v2, tcuCtxDestroy_v2) \
+    FN(cuDeviceGet, tcuDeviceGet) \
     FN(cuMemcpy2D_v2, tcuMemcpy2D_v2) \
     FN(cuGetErrorName, tcuGetErrorName) \
     FN(cuGetErrorString, tcuGetErrorString) \
@@ -130,6 +132,7 @@ CUDA_FNS(CUDA_EXT_DECL)
 #define cuCtxPushCurrent mpv_cuCtxPushCurrent_v2
 #define cuCtxPopCurrent mpv_cuCtxPopCurrent_v2
 #define cuCtxDestroy mpv_cuCtxDestroy_v2
+#define cuDeviceGet mpv_cuDeviceGet
 #define cuMemcpy2D mpv_cuMemcpy2D_v2
 #define cuGetErrorName mpv_cuGetErrorName
 #define cuGetErrorString mpv_cuGetErrorString


### PR DESCRIPTION
In a multi GPU scenario, it may be desirable to use different GPUs
for decode and display responsibilities. For example, if a secondary
GPU has better video decoding capabilities.

In such a scenario, we need to initialise a separate context for each
GPU, and use the display context in hwdec_cuda, while passing the
decode context to avcodec.

Once that's done, the actually hand-off between the two GPUs is
transparent to us (It happens during the cuMemcpy2D operation which
copies the decoded frame from a cuda buffer to the OpenGL texture).

In the end, the bulk of the work is around introducing a new
configuration option to specify the decode device.