### PR TITLE
external_files: parse ~ in --{sub,audio}-paths

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -261,9 +261,13 @@ static void load_paths(struct mpv_global *global, struct subfn **slist,
                        char *cfg_path, int type)
 {
     for (int i = 0; paths && paths[i]; i++) {
-        char *path = mp_path_join_bstr(*slist, mp_dirname(fname),
-                                       bstr0(paths[i]));
-        append_dir_subtitles(global, slist, nsubs, bstr0(path), fname, 0, type);
+        char *expanded_path = mp_get_user_path(NULL, global, paths[i]);
+        char *path = mp_path_join_bstr(
+            *slist, mp_dirname(fname),
+            bstr0(expanded_path ? expanded_path : paths[i]));
+        append_dir_subtitles(global, slist, nsubs, bstr0(path),
+                             fname, 0, type);
+        talloc_free(expanded_path);
     }
 
     // Load subtitles in ~/.mpv/sub (or similar) limiting sub fuzziness


### PR DESCRIPTION
#4469 

Path lookups with `--sub-paths=subs:~/src/subs` when playing `~/video/something/something.mkv` (before filtering and sorting):

Before

- `/home/rr-/video/something/`
- `/home/rr-/video/something/subs`
- `/home/rr-/video/something/~/src/subs`

After

- `/home/rr-/video/something/`
- `/home/rr-/video/something/subs`
- `subs`
- `/home/rr-/video/something/~/src/subs`
- `/home/rr-/src/subs`
