### PR TITLE
OSD message: "Drop files or URLs to play here."

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2202,7 +2202,7 @@ function tick()
         ass:new_event()
         ass:pos(320, icon_y+65)
         ass:an(8)
-        ass:append("Drop files to play here.")
+        ass:append("Drop files or URLs to play here.")
         mp.set_osd_ass(640, 360, ass.text)
 
         if state.showhide_enabled then


### PR DESCRIPTION
Add "or URLs" to the default OSD message when mpv is launched without parameters.
Since this works flawlessly with youtube-dl integration, the fact that you can drop URLs directly to the window should be advertised more.


I agree that my changes can be relicensed to LGPL 2.1 or later.
