### PR TITLE
js: add javascript scripting support using MuJS

### DIFF
--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -1,0 +1,336 @@
+JavaScript
+==========
+
+JavaScript support in mpv is near identical to its Lua support. Use this section
+as reference on differences and availability of APIs, but otherwise you should
+refer to the Lua documentation for API details and general scripting in mpv.
+
+Example
+-------
+
+JavaScript code which leaves fullscreen mode when the player is paused:
+
+::
+
+    function on_pause_change(name, value) {
+        if (value == true)
+            mp.set_property("fullscreen", "no");
+    }
+    mp.observe_property("pause", "bool", on_pause_change);
+
+
+Similarities with Lua
+---------------------
+
+mpv tries to load a script file as JavaScript if it has a ``.js`` extension, but
+otherwise, the documented Lua options, script directories, loading, etc apply to
+JavaScript files too.
+
+Script initialization and lifecycle is the same as with Lua, and most of the Lua
+functions at the modules ``mp``, ``mp.utils`` and ``mp.msg`` are available to
+JavaScript with identical APIs - including running commands, getting/setting
+properties, registering events/key-bindings/property-changes/hooks, etc.
+
+Differences from Lua
+--------------------
+
+No need to load modules. ``mp``, ``mp.utils`` and ``mp.msg`` are preloaded, and
+you can use e.g. ``var cwd = mp.utils.getcwd();`` without prior setup.
+``mp.options`` is currently not implemented, but ``mp.get_opt(...)`` is.
+
+Errors are slightly different. Where the Lua APIs return ``nil`` for error,
+the JavaScript ones return ``undefined``. Where Lua returns ``something, error``
+JavaScript returns only ``something`` - and makes ``error`` available via
+``mp.last_error()``. Note that only some of the functions have this additional
+``error`` value - typically the same ones which have it in Lua.
+
+Standard APIs are preferred. For instance ``setTimeout`` and ``JSON.stringify``
+are available, but ``mp.add_timeout`` and ``mp.utils.format_json`` are not.
+
+No standard library. This means that interaction with anything outside of mpv is
+limited to the available APIs, typically via ``mp.utils``. However, some file
+functions were added, and CommonJS ``require`` is available too - where the
+loaded modules have the same privileges as normal scripts.
+
+Language features - ECMAScript 5
+--------------------------------
+
+The scripting backend which mpv currently uses is MuJS - a compatible minimal
+ES5 interpreter. As such, ``String.substring`` is implemented for instance,
+while the common but non-standard ``String.substr`` is not. Please consult the
+MuJS pages on language features and platform support - http://mujs.com .
+
+Unsupported Lua APIs and their JS alternatives
+----------------------------------------------
+
+``mp.add_timeout(seconds, fn)``  JS: ``id = setTimeout(fn, ms)``
+
+``mp.add_periodic_timer(seconds, fn)``  JS: ``id = setInterval(fn, ms)``
+
+``mp.register_idle(fn)``  JS: ``id = setTimeout(fn)``
+
+``mp.unregister_idle(fn)``  JS:  ``clearTimeout(id)``
+
+``utils.parse_json(str [, trail])``  JS: ``JSON.parse(str)``
+
+``utils.format_json(v)``  JS: ``JSON.stringify(v)``
+
+``utils.to_string(v)``  see ``dump`` below.
+
+``mp.suspend()`` JS: none (deprecated).
+
+``mp.resume()`` JS: none (deprecated).
+
+``mp.resume_all()`` JS: none (deprecated).
+
+``mp.get_next_timeout()`` see event loop below.
+
+``mp.dispatch_events([allow_wait])`` see event loop below.
+
+``mp.options`` module is not implemented currently for JS.
+
+Scripting APIs - identical to Lua
+---------------------------------
+
+(LE) - Last-Error, indicates that ``mp.last_error()`` can be used after the
+call to test for success (empty string) or failure (non empty reason string).
+Otherwise, where the Lua APIs return ``nil`` on error, JS returns ``undefined``.
+
+``mp.command(string)`` (LE)
+
+``mp.commandv(arg1, arg2, ...)`` (LE)
+
+``mp.command_native(table [,def])`` (LE)
+
+``mp.get_property(name [,def])`` (LE)
+
+``mp.get_property_osd(name [,def])`` (LE)
+
+``mp.get_property_bool(name [,def])`` (LE)
+
+``mp.get_property_number(name [,def])`` (LE)
+
+``mp.get_property_native(name [,def])`` (LE)
+
+``mp.set_property(name, value)`` (LE)
+
+``mp.set_property_bool(name, value)`` (LE)
+
+``mp.set_property_number(name, value)`` (LE)
+
+``mp.set_property_native(name, value)`` (LE)
+
+``mp.get_time()``
+
+``mp.add_key_binding(key, name|fn [,fn [,flags]])``
+
+``mp.add_forced_key_binding(...)``
+
+``mp.remove_key_binding(name)``
+
+``mp.register_event(name, fn)``
+
+``mp.unregister_event(fn)``
+
+``mp.observe_property(name, type, fn)``
+
+``mp.unobserve_property(fn)``
+
+``mp.get_opt(key)``
+
+``mp.get_script_name()``
+
+``mp.osd_message(text [,duration])``
+
+``mp.get_wakeup_pipe()``
+
+``mp.enable_messages(level)``
+
+``mp.register_script_message(name, fn)``
+
+``mp.unregister_script_message(name)``
+
+``mp.msg.log(level, ...)``
+
+``mp.msg.fatal(...)``
+
+``mp.msg.error(...)``
+
+``mp.msg.warn(...)``
+
+``mp.msg.info(...)``
+
+``mp.msg.verbose(...)``
+
+``mp.msg.debug(...)``
+
+``mp.utils.getcwd()`` (LE)
+
+``mp.utils.readdir(path [, filter])`` (LE)
+
+``mp.utils.split_path(path)``
+
+``mp.utils.join_path(p1, p2)``
+
+``mp.utils.subprocess(t)``
+
+``mp.utils.subprocess_detached(t)``
+
+``mp.add_hook(type, priority, fn)``
+
+Additional utilities
+--------------------
+
+``mp.last_error()``
+    If used after an API call which updates last error, returns an empty string
+    if the API call succeeded, or a non-empty error reason string otherwise.
+
+``Error.stack`` (string)
+    When using ``try { ... } catch(e) { ... }``, then ``e.stack`` is the stack
+    trace of the error - if it was created using the ``Error(...)`` constructor.
+
+``print`` (global)
+    A convenient alias to ``mp.msg.info``.
+
+``dump`` (global)
+    Like ``print`` but also expands objects and arrays recursively.
+
+``mp.utils.getenv(name)``
+    Returns the value of the host environment variable ``name``, or empty str.
+
+``mp.utils.get_user_path(path)``
+    Expands (mpv) meta paths like ``~/x``, ``~~/y``, ``~~desktop/z`` etc.
+    ``read_file``, ``write_file`` and ``require`` already use this internaly.
+
+``mp.utils.read_file(fname [,max])``
+    Returns the content of file ``fname`` as string. If ``max`` is provided and
+    not negative, limit the read to ``max`` bytes.
+
+``mp.utils.write_file(fname, str)``
+    (Over)write file ``fname`` with text content ``str``. ``fname`` must be
+    prefixed with ``file://`` as simple protection against accidental arguments
+    switch, e.g. ``mp.utils.write_file("file://~/abc.txt", "hello world")``.
+
+Note: ``read_file`` and ``write_file`` throw on errors, allow text content only.
+
+``mp.get_time_ms()``
+    Same as ``mp.get_time()`` but in ms instead of seconds.
+
+``mp.get_script_file()``
+    Returns the file name of the current script.
+
+``exit()`` (global)
+    Make the script exit at the end of the current event loop iteration.
+    Note: please reomve added key bindings before calling ``exit()``.
+
+``mp.utils.compile_js(fname, content_str)``
+    Compiles the JS code ``content_str`` as file name ``fname`` (without loading
+    anything from the filesystem), and returns it as a function. Very similar
+    to a ``Function`` constructor, but shows at stack traces as ``fname``.
+
+Timers (global)
+---------------
+
+The standard HTML/node.js timers are available:
+
+``id = setTimeout(fn [,duration [,arg1 [,arg2...]]])``
+
+``id = setTimeout(code_string [,duration])``
+
+``clearTimeout(id)``
+
+``id = setInterval(fn [,duration [,arg1 [,arg2...]]])``
+
+``id = setInterval(code_string [,duration])``
+
+``clearInterval(id)``
+
+``setTimeout`` and ``setInterval`` return id, and later call ``fn`` (or execute
+``code_string``) after ``duration`` ms. Interval also repeat every ``duration``.
+
+``duration`` has a minimum and default value of 0, ``code_string`` is
+a plain string which is evaluated as JS code, and ``[,arg1 [,arg2..]]`` are used
+as arguments (if provided) when calling back ``fn``.
+
+The ``clear...(id)`` functions cancel timer ``id``, and are irreversible.
+
+Note: timers always call back asynchronously, e.g. ``setTimeout(fn)`` will never
+call ``fn`` before returning. ``fn`` will be called either at the end of this
+event loop iteration or at a later event loop iteration. This is true also for
+intervals - which also never call back twice at the same event loop iteration.
+
+Additionally, timers are processed after the event queue is empty, so it's valid
+to use ``setTimeout(fn)`` instead of Lua's ``mp.register_idle(fn)``.
+
+CommonJS modules and ``require(id)``
+------------------------------------
+
+CommonJS Modules are a standard system where scripts can export common functions
+for use by other scripts. A module is a script which adds properties (functions,
+etc) to its invisible ``exports`` object, which another script can access by
+loading it with ``require(module-id)`` - which returns that ``exports`` object.
+
+Modules and ``require`` are supported, standard compliant, and generally similar
+to node.js. However, most node.js modules won't run due to missing modules such
+as ``fs``, ``process``, etc, but some node.js modules with minimal dependencies
+do work. In general, this is for mpv modules and not a node.js replacement.
+
+A ``.js`` file extension is always added to ``id``, e.g. ``require("./foo")``
+will load the file ``./foo.js`` and return its ``exports`` object.
+
+An id is relative (to the script which ``require``'d it) if it starts with
+``./`` or ``../``. Otherwise, it's considered a "top-level id" (CommonJS term).
+
+Top level id is evaluated as absolute filesystem path if possible (e.g. ``/x/y``
+or ``~/x``). Otherwise, it's searched at ``scripts/modules.js/`` in mpv config
+dirs - in normal config search order. E.g. ``require("x")`` is searched as file
+``x.js`` at those dirs, and id ``foo/x`` is searched as file ``foo/x.js``.
+
+No ``global`` variable, but a module's ``this`` at its top lexical scope is the
+global object - also in strict mode. If you have a module which needs ``global``
+as the global object, you could do ``this.global = this;`` before ``require``.
+
+Functions and variables declared at a module don't pollute the global object.
+
+The event loop
+--------------
+
+The event loop poll/dispatch mpv events as long as the queue is not empty, then
+processes the timers, then waits for the next event, and repeats this forever.
+
+You could put this code at your script to replace the built-in event loop, and
+also print every event which mpv sends to your script:
+
+::
+
+    function mp_event_loop() {
+        var wait = 0;
+        do {
+            var e = mp.wait_event(wait);
+            dump(e);  // there could be a lot of prints...
+            if (e.event != "none") {
+                mp.dispatch_event(e);
+                wait = 0;
+            } else {
+                wait = mp.process_timers() / 1000;
+            }
+        } while (mp.keep_running);
+    }
+
+
+``mp_event_loop`` is a name which mpv tries to call after the script loads.
+The internal implementation is similar to this (without ``dump`` though..).
+
+``e = mp.wait_event(wait)`` returns when the next mpv event arrives, or after
+``wait`` seconds if positive and no mpv events arrived. ``wait`` value of 0
+returns immediately (with ``e.event == "none"`` if the queue is empty).
+
+``mp.dispatch_event(e)`` calls back the handlers registered for ``e.event``,
+if there are such (event handlers, property observers, script messages, etc).
+
+``mp.process_timers()`` calls back the already-added, non-canceled due timers,
+and returns the duration in ms till the next due timer (possibly 0), or -1 if
+there are no pending timers. Must not be called recursively.
+
+Note: ``exit()`` is also registered for the ``shutdown`` event, and its
+implementation is a simple ``mp.keep_running = false``.

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -847,6 +847,8 @@ works like in older mpv releases. The profiles are currently defined as follows:
 
 .. include:: lua.rst
 
+.. include:: javascript.rst
+
 .. include:: ipc.rst
 
 .. include:: changes.rst

--- a/options/options.c
+++ b/options/options.c
@@ -308,14 +308,16 @@ const m_option_t mp_opts[] = {
                M_OPT_FIXED | CONF_NOCFG | CONF_PRE_PARSE | M_OPT_FILE),
     OPT_STRINGLIST("reset-on-next-file", reset_options, 0),
 
-#if HAVE_LUA
+#if HAVE_LUA || HAVE_JAVASCRIPT
     OPT_STRINGLIST("script", script_files, M_OPT_FIXED | M_OPT_FILE),
     OPT_KEYVALUELIST("script-opts", script_opts, 0),
+    OPT_FLAG("load-scripts", auto_load_scripts, 0),
+#endif
+#if HAVE_LUA
     OPT_FLAG("osc", lua_load_osc, UPDATE_BUILTIN_SCRIPTS),
     OPT_FLAG("ytdl", lua_load_ytdl, UPDATE_BUILTIN_SCRIPTS),
     OPT_STRING("ytdl-format", lua_ytdl_format, 0),
     OPT_KEYVALUELIST("ytdl-raw-options", lua_ytdl_raw_options, 0),
-    OPT_FLAG("load-scripts", auto_load_scripts, 0),
 #endif
 
 // ------------------------- stream options --------------------

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -1,0 +1,1307 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <math.h>
+#include <stdint.h>
+
+#include <mujs.h>
+
+#include "osdep/io.h"
+#include "mpv_talloc.h"
+#include "common/common.h"
+#include "options/m_property.h"
+#include "common/msg.h"
+#include "common/msg_control.h"
+#include "options/m_option.h"
+#include "input/input.h"
+#include "options/path.h"
+#include "misc/bstr.h"
+#include "osdep/subprocess.h"
+#include "osdep/timer.h"
+#include "osdep/threads.h"
+#include "stream/stream.h"
+#include "sub/osd.h"
+#include "core.h"
+#include "command.h"
+#include "client.h"
+#include "libmpv/client.h"
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+// List of builtin modules and their contents as strings.
+// All these are generated from player/javascript/*.js
+static const char *const builtin_files[][3] = {
+    {"@/defaults.js",
+#   include "player/javascript/defaults.js.inc"
+    },
+    {0}
+};
+
+// Represents a loaded script. Each has its own js state.
+struct script_ctx {
+    const char *filename;
+    struct mpv_handle *client;
+    struct MPContext *mpctx;
+    struct mp_log *log;
+    char *last_error_str;
+};
+
+static struct script_ctx *jctx(js_State *J)
+{
+    return (struct script_ctx *)js_getcontext(J);
+}
+
+static mpv_handle *jclient(js_State *J)
+{
+    return jctx(J)->client;
+}
+
+/**********************************************************************
+ *  conventions, MuJS notes and vm errors
+ *********************************************************************/
+// - push_foo functions are called from C and push a value to the vm stack.
+//
+// - JavaScript C functions are code which the vm can call as a js function.
+//   By convention, script_bar and script__baz are js C functions. The former
+//   is exposed to end users as bar, and _baz is for internal use.
+//
+// - js C functions get a fresh vm stack with their arguments, and may
+//   manipulate their stack as they see fit. On exit, the vm considers the
+//   top value of their stack as their return value, and GC the rest.
+//
+// - js C function's stack[0] is "this", and the rest (1, 2, ...) are the args.
+//   On entry the stack has at least the number of args defined for the func,
+//   padded with undefined if called with less, or bigger if called with more.
+//
+// - Almost all vm APIs (js_*) may throw an error - a longjmp to the last
+//   recovery/catch point, which could skip releasing resources. Use protected
+//   code (e.g. js_pcall) between aquisition and release. Alternatively, use
+//   the autofree mechanism to manage it more easily. See more details below.
+//
+// - Unless named s_foo, all the functions at this file (inc. init) which
+//   touch the vm may throw, but either cleanup resources regardless (mostly
+//   autofree) or leave allocated resources on caller-provided talloc context
+//   which the caller should release, typically with autofree (e.g. makenode).
+//
+// - Functions named s_foo (safe foo) never throw, return 0 on success, else 1.
+
+/**********************************************************************
+ *  mpv scripting API error handling
+ *********************************************************************/
+// - Errors may be thrown on some cases - the reason is at the exception.
+//
+// - Some APIs also set last error which can be fetched with mp.last_error(),
+//   where empty string (false-y) is success, or an error string otherwise.
+//
+// - The rest of the APIs are guaranteed to return undefined on error or a
+//   true-thy value on success and may or may not set last error.
+//
+// - push_success, push_failure, push_status and pushed_error set last error.
+
+// iserr as true indicates an error, and if so, str may indicate a reason.
+// Internally ctx->last_error_str is never NULL, and empty indicates success.
+static void set_last_error(struct script_ctx *ctx, bool iserr, const char *str)
+{
+    ctx->last_error_str[0] = 0;
+    if (!iserr)
+        return;
+    if (!str || !str[0])
+        str = "Error";
+    ctx->last_error_str = talloc_strdup_append(ctx->last_error_str, str);
+}
+
+// For use only by wrappers at defaults.js.
+// arg: error string. Use empty string to indicate success.
+static void script__set_last_error(js_State *J)
+{
+    const char *e = js_tostring(J, 1);
+    set_last_error(jctx(J), e[0], e);
+}
+
+// mp.last_error() . args: none. return the last error without modifying it.
+static void script_last_error(js_State *J)
+{
+    js_pushstring(J, jctx(J)->last_error_str);
+}
+
+// Generic success for APIs which don't return an actual value.
+static void push_success(js_State *J)
+{
+    set_last_error(jctx(J), 0, NULL);
+    js_pushboolean(J, true);
+}
+
+// Doesn't (intentionally) throw. Just sets last_error and pushes undefined
+static void push_failure(js_State *J, const char *str)
+{
+    set_last_error(jctx(J), 1, str);
+    js_pushundefined(J);
+}
+
+// Most of the scripting APIs are either sending some values and getting status
+// code in return, or requesting some value while providing a default in case an
+// error happened. These simplify the C code for that and always set last_error.
+
+static void push_status(js_State *J, int err)
+{
+    if (err >= 0) {
+        push_success(J);
+    } else {
+        push_failure(J, mpv_error_string(err));
+    }
+}
+
+ // If err is success then return 0, else push the item at def and return 1
+static bool pushed_error(js_State *J, int err, int def)
+{
+    bool iserr = err < 0;
+    set_last_error(jctx(J), iserr, iserr ? mpv_error_string(err) : NULL);
+    if (!iserr)
+        return false;
+
+    js_copy(J, def);
+    return true;
+}
+
+/**********************************************************************
+ *  Autofree - care-free resource deallocation on vm errors, and otherwise
+ *********************************************************************/
+// - Autofree (af) functions are called with a talloc context argument which is
+//   freed after the function exits - either normally or because it threw an
+//   error, on the latter case it then re-throws the error after the cleanup.
+//
+//   Autofree js C functions should have an additional void* talloc arg and
+//   inserted into the vm using af_newcfunction, but otherwise used normally.
+//
+//  To wrap an autofree function af_TARGET in C:
+//  1. Create a wrapper s_TARGET which runs af_TARGET safely inside js_try.
+//  2. Use s_TARGET like so (always autofree, and throws if af_TARGET threw):
+//       void *af = talloc_new(NULL);
+//       int r = s_TARGET(J, ..., af);  // use J, af where the callee expects.
+//       talloc_free(af);
+//       if (r)
+//           js_throw(J);
+
+// add_af_file, add_af_dir, add_af_mpv_alloc take a valid FILE*/DIR*/char* value
+// respectively, and fclose/closedir/mpv_free it when the parent is freed.
+
+static void destruct_af_file(void *p)
+{
+    fclose(*(FILE**)p);
+}
+
+static void add_af_file(void *parent, FILE *f)
+{
+    FILE **pf = talloc(parent, FILE*);
+    *pf = f;
+    talloc_set_destructor(pf, destruct_af_file);
+}
+
+static void destruct_af_dir(void *p)
+{
+    closedir(*(DIR**)p);
+}
+
+static void add_af_dir(void *parent, DIR *d)
+{
+    DIR **pd = talloc(parent, DIR*);
+    *pd = d;
+    talloc_set_destructor(pd, destruct_af_dir);
+}
+
+static void destruct_af_mpv_alloc(void *p)
+{
+    mpv_free(*(char**)p);
+}
+
+static void add_af_mpv_alloc(void *parent, char *ma)
+{
+    char **p = talloc(parent, char*);
+    *p = ma;
+    talloc_set_destructor(p, destruct_af_mpv_alloc);
+}
+
+static void destruct_af_mpv_node(void *p)
+{
+    mpv_free_node_contents((mpv_node*)p);  // does nothing for MPV_FORMAT_NONE
+}
+
+// returns a new zeroed allocated struct mpv_node, and free it and its content
+// when the parent is freed.
+static mpv_node *new_af_mpv_node(void *parent)
+{
+    mpv_node *p = talloc_zero(parent, mpv_node);  // .format == MPV_FORMAT_NONE
+    talloc_set_destructor(p, destruct_af_mpv_node);
+    return p;
+}
+
+// Prototype for autofree functions which can be called from inside the vm.
+typedef void (*af_CFunction)(js_State*, void*);
+
+// safely run autofree js c function directly
+static int s_run_af_jsc(js_State *J, af_CFunction fn, void *af)
+{
+    if (js_try(J))
+        return 1;
+    fn(J, af);
+    js_endtry(J);
+    return 0;
+}
+
+// The trampoline function through which all autofree functions are called from
+// inside the vm. Obtains the target function address and autofree-call it.
+static void script__autofree(js_State *J)
+{
+    // The target function is at the "af_" property of this function instance.
+    js_currentfunction(J);
+    js_getproperty(J, -1, "af_");
+    af_CFunction fn = (af_CFunction)js_touserdata(J, -1, "af_fn");
+    js_pop(J, 2);
+
+    void *af = talloc_new(NULL);
+    int r = s_run_af_jsc(J, fn, af);
+    talloc_free(af);
+    if (r)
+        js_throw(J);
+}
+
+// Identical to js_newcfunction, but the function is inserted with an autofree
+// wrapper, and its prototype should have the additional af argument.
+static void af_newcfunction(js_State *J, af_CFunction fn, const char *name,
+                            int length)
+{
+    js_newcfunction(J, script__autofree, name, length);
+    js_pushnull(J);  // a prototype for the userdata object
+    js_newuserdata(J, "af_fn", fn, NULL);  // uses a "af_fn" verification tag
+    js_defproperty(J, -2, "af_", JS_READONLY | JS_DONTENUM | JS_DONTCONF);
+}
+
+/**********************************************************************
+ *  Initialization and file loading
+ *********************************************************************/
+
+static const char *get_builtin_file(const char *name)
+{
+    for (int n = 0; builtin_files[n][0]; n++) {
+        if (strcmp(builtin_files[n][0], name) == 0)
+            return builtin_files[n][1];
+    }
+    return NULL;
+}
+
+// Push up to limit bytes of file fname: from builtin_files, else from the OS.
+static void af_push_file(js_State *J, const char *fname, int limit, void *af)
+{
+    char *filename = mp_get_user_path(af, jctx(J)->mpctx->global, fname);
+    MP_VERBOSE(jctx(J), "Reading file '%s'\n", filename);
+    if (limit < 0)
+        limit = INT_MAX - 1;
+
+    const char *builtin = get_builtin_file(filename);
+    if (builtin) {
+        js_pushlstring(J, builtin, MIN(limit, strlen(builtin)));
+        return;
+    }
+
+    FILE *f = fopen(filename, "rb");
+    if (!f)
+        js_error(J, "cannot open file: '%s'", filename);
+    add_af_file(af, f);
+
+    int len = MIN(limit, 32 * 1024);  // initial allocation, size*2 strategy
+    int got = 0;
+    char *s = NULL;
+    while ((s = talloc_realloc(af, s, char, len))) {
+        int want = len - got;
+        int r = fread(s + got, 1, want, f);
+
+        if (feof(f) || (len == limit && r == want)) {
+            js_pushlstring(J, s, got + r);
+            return;
+        }
+        if (r != want)
+            js_error(J, "cannot read data from file: '%s'", filename);
+
+        got = got + r;
+        len = MIN(limit, len * 2);
+    }
+
+    js_error(J, "cannot allocate %d bytes for file: '%s'", len, filename);
+}
+
+// Safely run af_push_file.
+static int s_push_file(js_State *J, const char *fname, int limit, void *af)
+{
+    if (js_try(J))
+        return 1;
+    af_push_file(J, fname, limit, af);
+    js_endtry(J);
+    return 0;
+}
+
+// Called directly, push up to limit bytes of file fname (from builtin/os).
+static void push_file_content(js_State *J, const char *fname, int limit)
+{
+    void *af = talloc_new(NULL);
+    int r = s_push_file(J, fname, limit, af);
+    talloc_free(af);
+    if (r)
+        js_throw(J);
+}
+
+// utils.read_file(..). args: fname [,max]. returns [up to max] bytes as string.
+static void script_read_file(js_State *J)
+{
+    int limit = js_isundefined(J, 2) ? -1 : js_tonumber(J, 2);
+    push_file_content(J, js_tostring(J, 1), limit);
+}
+
+// Runs a file with the caller's this, leaves the stack as is.
+static void run_file(js_State *J, const char *fname)
+{
+    MP_VERBOSE(jctx(J), "Loading file %s\n", fname);
+    push_file_content(J, fname, -1);
+    js_loadstring(J, fname, js_tostring(J, -1));
+    js_copy(J, 0);  // use the caller's this
+    js_call(J, 0);
+    js_pop(J, 2);  // result, file content
+}
+
+// The spec defines .name and .message for Error objects. Most engines also set
+// a very convenient .stack = name + message + trace, but MuJS instead sets
+// .stackTrace = trace only. Normalize by adding such .stack if required.
+// Run this before anything such that we can get traces on any following errors.
+static const char *norm_err_proto_js = "\
+    if (Error().stackTrace && !Error().stack) {\
+        Object.defineProperty(Error.prototype, 'stack', {\
+            get: function() {\
+                return this.name + ': ' + this.message + this.stackTrace;\
+            }\
+        });\
+    }\
+";
+
+static void add_functions(js_State*, struct script_ctx*);
+
+// args: none. called as script, setup and run the main script
+static void script__run_script(js_State *J)
+{
+    js_loadstring(J, "@/norm_err.js", norm_err_proto_js);
+    js_copy(J, 0);
+    js_pcall(J, 0);
+
+    struct script_ctx *ctx = jctx(J);
+    add_functions(J, ctx);
+    run_file(J, "@/defaults.js");
+    run_file(J, ctx->filename);  // the main file to run
+
+    if (!js_hasproperty(J, 0, "mp_event_loop") || !js_iscallable(J, -1))
+        js_error(J, "no event loop function");
+    js_copy(J, 0);
+    js_call(J, 0); // mp_event_loop
+}
+
+// Safely set last error from stack top: stack trace or toString or generic.
+// May leave items on stack - the caller should detect and pop if it cares.
+static void s_top_to_last_error(struct script_ctx *ctx, js_State *J)
+{
+    set_last_error(ctx, 1, "unknown error");
+    if (js_try(J))
+        return;
+    if (js_isobject(J, -1))
+        js_hasproperty(J, -1, "stack");  // fetches it if exists
+    set_last_error(ctx, 1, js_tostring(J, -1));
+    js_endtry(J);
+}
+
+// MuJS can report warnings through this.
+static void report_handler(js_State *J, const char *msg)
+{
+    MP_WARN(jctx(J), "[JS] %s\n", msg);
+}
+
+// Safely setup the js vm for calling run_script.
+static int s_init_js(js_State *J, struct script_ctx *ctx)
+{
+    if (js_try(J))
+        return 1;
+    js_setcontext(J, ctx);
+    js_setreport(J, report_handler);
+    js_newcfunction(J, script__run_script, "run_script", 0);
+    js_pushglobal(J);  // 'this' for script__run_script
+    js_endtry(J);
+    return 0;
+}
+
+/**********************************************************************
+ *  Initialization - booting the script
+ *********************************************************************/
+// s_load_javascript: (entry point) creates the js vm, runs the script, returns
+//                    on script exit or uncaught js errors. Never throws.
+// script__run_script: - loads the built in functions and vars into the vm
+//                     - runs the default file[s] and the main script file
+//                     - calls mp_event_loop, returns on script-exit or throws.
+//
+// Note: init functions don't need autofree. They can use ctx as a talloc
+// context and free normally. If they throw - ctx is freed right afterwards.
+static int s_load_javascript(struct mpv_handle *client, const char *fname)
+{
+    struct script_ctx *ctx = talloc_ptrtype(NULL, ctx);
+    *ctx = (struct script_ctx) {
+        .client = client,
+        .mpctx = mp_client_get_core(client),
+        .log = mp_client_get_log(client),
+        .last_error_str = talloc_strdup(ctx, "Cannot initialize JavaScript"),
+        .filename = fname,
+    };
+
+    int r = -1;
+    js_State *J = js_newstate(NULL, NULL, 0);
+    if (!J || s_init_js(J, ctx))
+        goto error_out;
+
+    set_last_error(ctx, 0, NULL);
+    if (js_pcall(J, 0)) {  // script__run_script
+        s_top_to_last_error(ctx, J);
+        goto error_out;
+    }
+
+    r = 0;
+
+error_out:
+    if (r)
+        MP_FATAL(ctx, "%s\n", ctx->last_error_str);
+    if (J)
+        js_freestate(J);
+
+    talloc_free(ctx);
+    return r;
+}
+
+/**********************************************************************
+ *  Main mp.* scripting APIs and helpers
+ *********************************************************************/
+static void pushnode(js_State *J, mpv_node *node);
+static void makenode(void *ta_ctx, mpv_node *dst, js_State *J, int idx);
+
+// Return the index in opts of stack[idx] (or of def if undefined), else throws.
+static int checkopt(js_State *J, int idx, const char *def, const char *opts[],
+                    const char *desc)
+{
+    const char *opt = js_isundefined(J, idx) ? def : js_tostring(J, idx);
+    for (int i = 0; opts[i]; i++) {
+        if (strcmp(opt, opts[i]) == 0)
+            return i;
+    }
+    js_error(J, "Invalid %s '%s'", desc, opt);
+}
+
+// args: level as string and a variable numbers of args to print. adds final \n
+static void script_log(js_State *J)
+{
+    const char *level = js_tostring(J, 1);
+    int msgl = mp_msg_find_level(level);
+    if (msgl < 0)
+        js_error(J, "Invalid log level '%s'", level);
+
+    struct mp_log *log = jctx(J)->log;
+    for (int top = js_gettop(J), i = 2; i < top; i++)
+        mp_msg(log, msgl, (i == 2 ? "%s" : " %s"), js_tostring(J, i));
+    mp_msg(log, msgl, "\n");
+    push_success(J);
+}
+
+static void script_find_config_file(js_State *J, void *af)
+{
+    const char *fname = js_tostring(J, 1);
+    char *path = mp_find_config_file(af, jctx(J)->mpctx->global, fname);
+    if (path) {
+        js_pushstring(J, path);
+    } else {
+        push_failure(J, "not found");
+    }
+}
+
+static void script__request_event(js_State *J)
+{
+    const char *event = js_tostring(J, 1);
+    bool enable = js_toboolean(J, 2);
+
+    const char *name;
+    for (int n = 0; n < 256 && (name = mpv_event_name(n)); n++) {
+        if (strcmp(name, event) == 0) {
+            push_status(J, mpv_request_event(jclient(J), n, enable));
+            return;
+        }
+    }
+    push_failure(J, "Unknown event name");
+}
+
+static void script_enable_messages(js_State *J)
+{
+    const char *level = js_tostring(J, 1);
+    if (mp_msg_find_level(level) < 0)
+        js_error(J, "Invalid log level '%s'", level);
+    push_status(J, mpv_request_log_messages(jclient(J), level));
+}
+
+// args - command [with arguments] as string
+static void script_command(js_State *J)
+{
+    push_status(J, mpv_command_string(jclient(J), js_tostring(J, 1)));
+}
+
+// args: strings of command and then variable number of arguments
+static void script_commandv(js_State *J)
+{
+    const char *argv[MP_CMD_MAX_ARGS + 1];
+    int length = js_gettop(J) - 1;
+    if (length >= MP_ARRAY_SIZE(argv))
+        js_error(J, "Too many arguments");
+
+    for (int i = 0; i < length; i++)
+        argv[i] = js_tostring(J, 1 + i);
+    argv[length] = NULL;
+    push_status(J, mpv_command(jclient(J), argv));
+}
+
+// args: name, string value
+static void script_set_property(js_State *J)
+{
+    int e = mpv_set_property_string(jclient(J), js_tostring(J, 1),
+                                                js_tostring(J, 2));
+    push_status(J, e);
+}
+
+// args: name, boolean
+static void script_set_property_bool(js_State *J)
+{
+    int v = js_toboolean(J, 2);
+    int e = mpv_set_property(jclient(J), js_tostring(J, 1), MPV_FORMAT_FLAG, &v);
+    push_status(J, e);
+}
+
+// args: name [,def]
+static void script_get_property_number(js_State *J)
+{
+    double result;
+    const char *name = js_tostring(J, 1);
+    int e = mpv_get_property(jclient(J), name, MPV_FORMAT_DOUBLE, &result);
+    if (!pushed_error(J, e, 2))
+        js_pushnumber(J, result);
+}
+
+// args: name, native value
+static void script_set_property_native(js_State *J, void *af)
+{
+    mpv_node node;
+    makenode(af, &node, J, 2);
+    mpv_handle *h = jclient(J);
+    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_NODE, &node);
+    push_status(J, e);
+}
+
+// args: name [,def]
+static void script_get_property(js_State *J, void *af)
+{
+    mpv_handle *h = jclient(J);
+    char *res = NULL;
+    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_STRING, &res);
+    if (e >= 0)
+        add_af_mpv_alloc(af, res);
+    if (!pushed_error(J, e, 2))
+        js_pushstring(J, res);
+}
+
+// args: name [,def]
+static void script_get_property_bool(js_State *J)
+{
+    int result;
+    mpv_handle *h = jclient(J);
+    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_FLAG, &result);
+    if (!pushed_error(J, e, 2))
+        js_pushboolean(J, result);
+}
+
+// args: name, number
+static void script_set_property_number(js_State *J)
+{
+    double v = js_tonumber(J, 2);
+    mpv_handle *h = jclient(J);
+    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_DOUBLE, &v);
+    push_status(J, e);
+}
+
+// args: name [,def]
+static void script_get_property_native(js_State *J, void *af)
+{
+    const char *name = js_tostring(J, 1);
+    mpv_handle *h = jclient(J);
+    mpv_node *presult_node = new_af_mpv_node(af);
+    int e = mpv_get_property(h, name, MPV_FORMAT_NODE, presult_node);
+    if (!pushed_error(J, e, 2))
+        pushnode(J, presult_node);
+}
+
+// args: name [,def]
+static void script_get_property_osd(js_State *J, void *af)
+{
+    const char *name = js_tostring(J, 1);
+    mpv_handle *h = jclient(J);
+    char *res = NULL;
+    int e = mpv_get_property(h, name, MPV_FORMAT_OSD_STRING, &res);
+    if (e >= 0)
+        add_af_mpv_alloc(af, res);
+    if (!pushed_error(J, e, 2))
+        js_pushstring(J, res);
+}
+
+// args: id, name, type
+static void script__observe_property(js_State *J)
+{
+    const char *fmts[] = {"none", "native", "bool", "string", "number", NULL};
+    const mpv_format mf[] = {MPV_FORMAT_NONE, MPV_FORMAT_NODE, MPV_FORMAT_FLAG,
+                             MPV_FORMAT_STRING, MPV_FORMAT_DOUBLE};
+
+    mpv_format f = mf[checkopt(J, 3, "none", fmts, "observe type")];
+    int e = mpv_observe_property(jclient(J), js_tonumber(J, 1),
+                                             js_tostring(J, 2),
+                                             f);
+    push_status(J, e);
+}
+
+// args: id
+static void script__unobserve_property(js_State *J)
+{
+    int e = mpv_unobserve_property(jclient(J), js_tonumber(J, 1));
+    push_status(J, e);
+}
+
+// args: native (array of command and args, similar to commandv) [,def]
+static void script_command_native(js_State *J, void *af)
+{
+    mpv_node cmd;
+    makenode(af, &cmd, J, 1);
+    mpv_node *presult_node = new_af_mpv_node(af);
+    int e = mpv_command_node(jclient(J), &cmd, presult_node);
+    if (!pushed_error(J, e, 2))
+        pushnode(J, presult_node);
+}
+
+// args: none, result in millisec
+static void script_get_time_ms(js_State *J)
+{
+    js_pushnumber(J, mpv_get_time_us(jclient(J)) / (double)(1000));
+}
+
+static void script_set_osd_ass(js_State *J)
+{
+    struct script_ctx *ctx = jctx(J);
+    int res_x = js_tonumber(J, 1);
+    int res_y = js_tonumber(J, 2);
+    const char *text = js_tostring(J, 3);
+    osd_set_external(ctx->mpctx->osd, ctx->client, res_x, res_y, (char *)text);
+    mp_wakeup_core(ctx->mpctx);
+    push_success(J);
+}
+
+// push object with properties names (NULL terminated) with respective vals
+static void push_nums_obj(js_State *J, const char * const names[],
+                          const double vals[])
+{
+    js_newobject(J);
+    for (int i = 0; names[i]; i++) {
+        js_pushnumber(J, vals[i]);
+        js_setproperty(J, -2, names[i]);
+    }
+}
+
+// args: none, return: object with properties width, height, aspect
+static void script_get_osd_size(js_State *J)
+{
+    struct mp_osd_res r = osd_get_vo_res(jctx(J)->mpctx->osd);
+    double ar = 1.0 * r.w / MPMAX(r.h, 1) / (r.display_par ? r.display_par : 1);
+    const char * const names[] = {"width", "height", "aspect", NULL};
+    const double vals[] = {r.w, r.h, ar};
+    push_nums_obj(J, names, vals);
+}
+
+// args: none, return: object with properties top, bottom, left, right
+static void script_get_osd_margins(js_State *J)
+{
+    struct mp_osd_res r = osd_get_vo_res(jctx(J)->mpctx->osd);
+    const char * const names[] = {"left", "top", "right", "bottom", NULL};
+    const double vals[] = {r.ml, r.mt, r.mr, r.mb};
+    push_nums_obj(J, names, vals);
+}
+
+// args: none, return: object with properties x, y
+static void script_get_mouse_pos(js_State *J)
+{
+    int x, y;
+    mp_input_get_mouse_pos(jctx(J)->mpctx->input, &x, &y);
+    const char * const names[] = {"x", "y", NULL};
+    const double vals[] = {x, y};
+    push_nums_obj(J, names, vals);
+}
+
+// args: input-section-name, x0, y0, x1, y1
+static void script_input_set_section_mouse_area(js_State *J)
+{
+    char *section = (char *)js_tostring(J, 1);
+    mp_input_set_section_mouse_area(jctx(J)->mpctx->input, section,
+        js_tonumber(J, 2), js_tonumber(J, 3),   // x0, y0
+        js_tonumber(J, 4), js_tonumber(J, 5));  // x1, y1
+    push_success(J);
+}
+
+// args: time-in-ms [,format-string]
+static void script_format_time(js_State *J, void *af)
+{
+    double t = js_tonumber(J, 1);
+    const char *fmt = js_isundefined(J, 2) ? "%H:%M:%S" : js_tostring(J, 2);
+    char *r = talloc_steal(af, mp_format_time_fmt(fmt, t));
+    if (!r)
+        js_error(J, "Invalid time format string '%s'", fmt);
+    js_pushstring(J, r);
+}
+
+// TODO: untested
+static void script_get_wakeup_pipe(js_State *J)
+{
+    js_pushnumber(J, mpv_get_wakeup_pipe(jclient(J)));
+}
+
+/**********************************************************************
+ *  mp.utils
+ *********************************************************************/
+
+// args: [path [,filter]]
+static void script_readdir(js_State *J, void *af)
+{
+    //                    0      1        2       3
+    const char *filters[] = {"all", "files", "dirs", "normal", NULL};
+    const char *path = js_isundefined(J, 1) ? "." : js_tostring(J, 1);
+    int t = checkopt(J, 2, "normal", filters, "listing filter");
+
+    DIR *dir = opendir(path);
+    if (!dir) {
+        push_failure(J, "Cannot open dir");
+        return;
+    }
+    add_af_dir(af, dir);
+    set_last_error(jctx(J), 0, NULL);
+    js_newarray(J);  // the return value
+    char *fullpath = talloc_strdup(af, "");
+    struct dirent *e;
+    int n = 0;
+    while ((e = readdir(dir))) {
+        char *name = e->d_name;
+        if (t) {
+            if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+                continue;
+            if (fullpath)
+                fullpath[0] = '\0';
+            fullpath = talloc_asprintf_append(fullpath, "%s/%s", path, name);
+            struct stat st;
+            if (stat(fullpath, &st))
+                continue;
+            if (!(((t & 1) && S_ISREG(st.st_mode)) ||
+                  ((t & 2) && S_ISDIR(st.st_mode))))
+            {
+                continue;
+            }
+        }
+        js_pushstring(J, name);
+        js_setindex(J, -2, n++);
+    }
+}
+
+static void script_split_path(js_State *J)
+{
+    const char *p = js_tostring(J, 1);
+    bstr fname = mp_dirname(p);
+    js_newarray(J);
+    js_pushlstring(J, fname.start, fname.len);
+    js_setindex(J, -2, 0);
+    js_pushstring(J, mp_basename(p));
+    js_setindex(J, -2, 1);
+}
+
+static void script_join_path(js_State *J, void *af)
+{
+    js_pushstring(J, mp_path_join(af, js_tostring(J, 1), js_tostring(J, 2)));
+}
+
+static void script_get_user_path(js_State *J, void *af)
+{
+    const char *path = js_tostring(J, 1);
+    js_pushstring(J, mp_get_user_path(af, jctx(J)->mpctx->global, path));
+}
+
+struct subprocess_cb_ctx {
+    struct mp_log *log;
+    void *talloc_ctx;
+    int64_t max_size;
+    bstr output;
+    bstr err;
+};
+
+static void subprocess_stdout(void *p, char *data, size_t size)
+{
+    struct subprocess_cb_ctx *ctx = p;
+    if (ctx->output.len < ctx->max_size)
+        bstr_xappend(ctx->talloc_ctx, &ctx->output, (bstr){data, size});
+}
+
+static void subprocess_stderr(void *p, char *data, size_t size)
+{
+    struct subprocess_cb_ctx *ctx = p;
+    if (ctx->err.len < ctx->max_size)
+        bstr_xappend(ctx->talloc_ctx, &ctx->err, (bstr){data, size});
+    MP_INFO(ctx, "%.*s", (int)size, data);
+}
+
+// args: client invocation args object. TODO: use common backend for js/lua
+static void af_subprocess_common(js_State *J, int detach, void *af)
+{
+    struct script_ctx *ctx = jctx(J);
+    if (!js_isobject(J, 1))
+        js_error(J, "argument must be an object");
+
+    js_getproperty(J, 1, "args"); // args
+    int num_args = js_getlength(J, -1);
+    if (!num_args) // not using js_isarray to also accept array-like objects
+        js_error(J, "args must be an non-empty array");
+    char *args[256];
+    if (num_args > MP_ARRAY_SIZE(args) - 1) // last needs to be NULL
+        js_error(J, "too many arguments");
+    if (num_args < 1)
+        js_error(J, "program name missing");
+
+    for (int n = 0; n < num_args; n++) {
+        js_getindex(J, -1, n);
+        if (js_isundefined(J, -1))
+            js_error(J, "program arguments must be strings");
+        args[n] = talloc_strdup(af, js_tostring(J, -1));
+        js_pop(J, 1); // args
+    }
+    args[num_args] = NULL;
+
+    if (detach) {
+        mp_subprocess_detached(ctx->log, args);
+        push_success(J);
+        return;
+    }
+
+    struct mp_cancel *cancel = NULL;
+    if (js_hasproperty(J, 1, "cancellable") ? js_toboolean(J, -1) : true)
+        cancel = ctx->mpctx->playback_abort;
+
+    int64_t max_size = js_hasproperty(J, 1, "max_size") ? js_tointeger(J, -1)
+                                                        : 16 * 1024 * 1024;
+    struct subprocess_cb_ctx cb_ctx = {
+        .log = ctx->log,
+        .talloc_ctx = af,
+        .max_size = max_size,
+    };
+
+    char *error = NULL;
+    int status = mp_subprocess(args, cancel, &cb_ctx, subprocess_stdout,
+                               subprocess_stderr, &error);
+
+    js_newobject(J); // res
+    if (error) {
+        js_pushstring(J, error); // res e
+        js_setproperty(J, -2, "error"); // res
+    }
+    js_pushnumber(J, status); // res s
+    js_setproperty(J, -2, "status"); // res
+    js_pushlstring(J, cb_ctx.output.start, cb_ctx.output.len); // res d
+    js_setproperty(J, -2, "stdout"); // res
+    js_pushlstring(J, cb_ctx.err.start, cb_ctx.err.len);
+    js_setproperty(J, -2, "stderr");
+    js_pushboolean(J, status == MP_SUBPROCESS_EKILLED_BY_US); // res b
+    js_setproperty(J, -2, "killed_by_us"); // res
+}
+
+// args: client invocation args object (same also for _detached)
+static void script_subprocess(js_State *J, void *af)
+{
+    af_subprocess_common(J, 0, af);
+}
+
+static void script_subprocess_detached(js_State *J, void *af)
+{
+    af_subprocess_common(J, 1, af);
+}
+
+// args: prefixed file name, data (c-str)
+static void script_write_file(js_State *J, void *af)
+{
+    static const char *prefix = "file://";
+    const char *fname = js_tostring(J, 1);
+    const char *data = js_tostring(J, 2);
+    if (strstr(fname, prefix) != fname)  // simple protection for incorrect use
+        js_error(J, "File name must be prefixed with '%s'", prefix);
+    fname += strlen(prefix);
+    fname = mp_get_user_path(af, jctx(J)->mpctx->global, fname);
+    MP_VERBOSE(jctx(J), "Writing file '%s'\n", fname);
+
+    FILE *f = fopen(fname, "wb");
+    if (!f)
+        js_error(J, "Cannot open file for writing: '%s'", fname);
+    add_af_file(af, f);
+
+    int len = strlen(data);  // limited by terminating null
+    int wrote = fwrite(data, 1, len, f);
+    if (len != wrote)
+        js_error(J, "Cannot write to file: '%s'", fname);
+}
+
+// args: env var name
+static void script_getenv(js_State *J)
+{
+    js_pushstring(J, getenv(js_tostring(J, 1)));
+}
+
+// args: as-filename, content-string, returns the compiled result as a function
+static void script_compile_js(js_State *J)
+{
+    js_loadstring(J, js_tostring(J, 1), js_tostring(J, 2));
+}
+
+// args: true = print info (with the warning report function - no info report)
+static void script__gc(js_State *J)
+{
+    js_gc(J, js_toboolean(J, 1) ? 1 : 0);
+    push_success(J);
+}
+
+/**********************************************************************
+ *  Core functions: pushnode, makenode and the event loop backend
+ *********************************************************************/
+
+// pushes a js value/array/object from an mpv_node
+static void pushnode(js_State *J, mpv_node *node)
+{
+    int len;
+    switch (node->format) {
+    case MPV_FORMAT_NONE:   js_pushnull(J); break;
+    case MPV_FORMAT_STRING: js_pushstring(J, node->u.string); break;
+    case MPV_FORMAT_INT64:  js_pushnumber(J, node->u.int64); break;
+    case MPV_FORMAT_DOUBLE: js_pushnumber(J, node->u.double_); break;
+    case MPV_FORMAT_FLAG:   js_pushboolean(J, node->u.flag); break;
+    case MPV_FORMAT_NODE_ARRAY:
+        js_newarray(J);
+        len = node->u.list->num;
+        for (int n = 0; n < len; n++) {
+            pushnode(J, &node->u.list->values[n]);
+            js_setindex(J, -2, n);
+        }
+        break;
+    case MPV_FORMAT_NODE_MAP:
+        js_newobject(J);
+        len = node->u.list->num;
+        for (int n = 0; n < len; n++) {
+            pushnode(J, &node->u.list->values[n]);
+            js_setproperty(J, -2, node->u.list->keys[n]);
+        }
+        break;
+    default:
+        js_pushstring(J, "[UNSUPPORTED_MPV_FORMAT]");
+        break;
+    }
+}
+
+// For the object at stack index idx, extract the (own) property names into
+// keys array (and allocate it to accommodate) and return the number of keys.
+static int get_obj_properties(void *ta_ctx, char ***keys, js_State *J, int idx)
+{
+    int length = 0;
+    js_pushiterator(J, idx, 1);
+
+    *keys = talloc_new(ta_ctx);
+    const char *name;
+    while ((name = js_nextiterator(J, -1)))
+        MP_TARRAY_APPEND(ta_ctx, *keys, length, talloc_strdup(ta_ctx, name));
+
+    js_pop(J, 1);  // the iterator
+    return length;
+}
+
+// true if we don't lose (too much) precision when casting to int64
+static bool same_as_int64(double d)
+{
+    // The range checks also validly filter inf and nan, so behavior is defined
+    return d >= INT64_MIN && d <= INT64_MAX && d == (int64_t)d;
+}
+
+// From the js stack value/array/object at index idx
+static void makenode(void *ta_ctx, mpv_node *dst, js_State *J, int idx)
+{
+    if (js_isundefined(J, idx) || js_isnull(J, idx)) {
+        dst->format = MPV_FORMAT_NONE;
+
+    } else if (js_isboolean(J, idx)) {
+        dst->format = MPV_FORMAT_FLAG;
+        dst->u.flag = js_toboolean(J, idx);
+
+    } else if (js_isnumber(J, idx)) {
+        double val = js_tonumber(J, idx);
+        if (same_as_int64(val)) {  // use int, because we can
+            dst->format = MPV_FORMAT_INT64;
+            dst->u.int64 = val;
+        } else {
+            dst->format = MPV_FORMAT_DOUBLE;
+            dst->u.double_ = val;
+        }
+
+    } else if (js_isarray(J, idx)) {
+        dst->format = MPV_FORMAT_NODE_ARRAY;
+        dst->u.list = talloc(ta_ctx, struct mpv_node_list);
+        dst->u.list->keys = NULL;
+
+        int length = js_getlength(J, idx);
+        dst->u.list->num = length;
+        dst->u.list->values = talloc_array(ta_ctx, mpv_node, length);
+        for (int n = 0; n < length; n++) {
+            js_getindex(J, idx, n);
+            makenode(ta_ctx, &dst->u.list->values[n], J, -1);
+            js_pop(J, 1);
+        }
+
+    } else if (js_isobject(J, idx)) {
+        dst->format = MPV_FORMAT_NODE_MAP;
+        dst->u.list = talloc(ta_ctx, struct mpv_node_list);
+
+        int length = get_obj_properties(ta_ctx, &dst->u.list->keys, J, idx);
+        dst->u.list->num = length;
+        dst->u.list->values = talloc_array(ta_ctx, mpv_node, length);
+        for (int n = 0; n < length; n++) {
+            js_getproperty(J, idx, dst->u.list->keys[n]);
+            makenode(ta_ctx, &dst->u.list->values[n], J, -1);
+            js_pop(J, 1);
+        }
+
+    } else {  // string, or anything else as string
+        dst->format = MPV_FORMAT_STRING;
+        dst->u.string = talloc_strdup(ta_ctx, js_tostring(J, idx));
+    }
+}
+
+// args: wait in secs (infinite if negative) if mpv doesn't send events earlier.
+static void script_wait_event(js_State *J)
+{
+    int top = js_gettop(J);
+    double timeout = js_isnumber(J, 1) ? js_tonumber(J, 1) : -1;
+    mpv_event *event = mpv_wait_event(jclient(J), timeout);
+
+    js_newobject(J); // the reply
+    js_pushstring(J, mpv_event_name(event->event_id));
+    js_setproperty(J, -2, "event");  // reply.event (is an event name)
+
+    if (event->reply_userdata) {
+        js_pushnumber(J, event->reply_userdata);
+        js_setproperty(J, -2, "id");   // reply.id
+    }
+
+    if (event->error < 0) {
+        // TODO: untested
+        js_pushstring(J, mpv_error_string(event->error));
+        js_setproperty(J, -2, "error");  // reply.error
+    }
+
+    switch (event->event_id) {
+    case MPV_EVENT_LOG_MESSAGE: {
+        mpv_event_log_message *msg = event->data;
+
+        js_pushstring(J, msg->prefix);
+        js_setproperty(J, -2, "prefix");  // reply.prefix (e.g. "cplayer")
+        js_pushstring(J, msg->level);
+        js_setproperty(J, -2, "level");  // reply.level (e.g. "v" or "info")
+        js_pushstring(J, msg->text);
+        js_setproperty(J, -2, "text");  // reply.text
+        break;
+    }
+
+    case MPV_EVENT_CLIENT_MESSAGE: {
+        mpv_event_client_message *msg = event->data;
+
+        js_newarray(J);  // reply.args
+        for (int n = 0; n < msg->num_args; n++) {
+            js_pushstring(J, msg->args[n]);
+            js_setindex(J, -2, n);
+        }
+        js_setproperty(J, -2, "args");  // reply.args (is a strings array)
+        break;
+    }
+
+    case MPV_EVENT_END_FILE: {
+        mpv_event_end_file *eef = event->data;
+        const char *reason;
+
+        switch (eef->reason) {
+        case MPV_END_FILE_REASON_EOF: reason = "eof"; break;
+        case MPV_END_FILE_REASON_STOP: reason = "stop"; break;
+        case MPV_END_FILE_REASON_QUIT: reason = "quit"; break;
+        case MPV_END_FILE_REASON_ERROR: reason = "error"; break;
+        case MPV_END_FILE_REASON_REDIRECT: reason = "redirect"; break;
+        default:
+            reason = "unknown";
+        }
+        js_pushstring(J, reason);
+        js_setproperty(J, -2, "reason");  // reply.reason
+
+        if (eef->reason == MPV_END_FILE_REASON_ERROR) {
+            js_pushstring(J, mpv_error_string(eef->error));
+            js_setproperty(J, -2, "error");  // reply.error
+        }
+        break;
+    }
+
+    case MPV_EVENT_PROPERTY_CHANGE: {
+        mpv_event_property *prop = event->data;
+        js_pushstring(J, prop->name);
+        js_setproperty(J, -2, "name");  // reply.name (is a property name)
+
+        switch (prop->format) {
+        case MPV_FORMAT_NODE:   pushnode(J, prop->data); break;
+        case MPV_FORMAT_DOUBLE: js_pushnumber(J, *(double *)prop->data); break;
+        case MPV_FORMAT_INT64:  js_pushnumber(J, *(int64_t *)prop->data); break;
+        case MPV_FORMAT_FLAG:   js_pushboolean(J, *(int *)prop->data); break;
+        case MPV_FORMAT_STRING: js_pushstring(J, *(char **)prop->data); break;
+        default:
+            js_pushnull(J);  // also for FORMAT_NONE, e.g. observe type "none"
+        }
+        js_setproperty(J, -2, "data");  // reply.data (value as observed type)
+        break;
+    }
+    }  // switch (event->event_id)
+
+    assert(top == js_gettop(J) - 1);
+}
+
+/**********************************************************************
+ *  Script functions setup
+ *********************************************************************/
+#define FN_ENTRY(name, length) {#name, length, script_ ## name, NULL}
+#define AF_ENTRY(name, length) {#name, length, NULL, script_ ## name}
+struct fn_entry {
+    const char *name;
+    int length;
+    js_CFunction jsc_fn;
+    af_CFunction afc_fn;
+};
+
+// Names starting with underscore are wrapped at @defaults.js
+// FN_ENTRY is a normal js C function, AF_ENTRY is an autofree js C function.
+static const struct fn_entry main_fns[] = {
+    FN_ENTRY(log, 1),
+    FN_ENTRY(wait_event, 1),
+    FN_ENTRY(_request_event, 2),
+    AF_ENTRY(find_config_file, 1),
+    FN_ENTRY(command, 1),
+    FN_ENTRY(commandv, 0),
+    AF_ENTRY(command_native, 2),
+    FN_ENTRY(get_property_bool, 2),
+    FN_ENTRY(get_property_number, 2),
+    AF_ENTRY(get_property_native, 2),
+    AF_ENTRY(get_property, 2),
+    AF_ENTRY(get_property_osd, 2),
+    FN_ENTRY(set_property, 2),
+    FN_ENTRY(set_property_bool, 2),
+    FN_ENTRY(set_property_number, 2),
+    AF_ENTRY(set_property_native, 2),
+    FN_ENTRY(_observe_property, 3),
+    FN_ENTRY(_unobserve_property, 1),
+    FN_ENTRY(get_time_ms, 0),
+    AF_ENTRY(format_time, 2),
+    FN_ENTRY(enable_messages, 1),
+    FN_ENTRY(get_wakeup_pipe, 0),
+    FN_ENTRY(set_osd_ass, 3),
+    FN_ENTRY(get_osd_size, 0),
+    FN_ENTRY(get_osd_margins, 0),
+    FN_ENTRY(get_mouse_pos, 0),
+    FN_ENTRY(input_set_section_mouse_area, 5),
+    FN_ENTRY(last_error, 0),
+    FN_ENTRY(_set_last_error, 1),
+    {0}
+};
+
+static const struct fn_entry utils_fns[] = {
+    AF_ENTRY(readdir, 2),
+    FN_ENTRY(split_path, 1),
+    AF_ENTRY(join_path, 2),
+    AF_ENTRY(get_user_path, 1),
+    AF_ENTRY(subprocess, 1),
+    AF_ENTRY(subprocess_detached, 1),
+
+    FN_ENTRY(read_file, 2),
+    AF_ENTRY(write_file, 2),
+    FN_ENTRY(getenv, 1),
+    FN_ENTRY(compile_js, 2),
+    FN_ENTRY(_gc, 1),
+    {0}
+};
+
+// Adds an object <module> with the functions at e to the top object
+static void add_package_fns(js_State *J, const char *module,
+                            const struct fn_entry *e)
+{
+    js_newobject(J);
+    for (int n = 0; e[n].name; n++) {
+        if (e[n].jsc_fn) {
+            js_newcfunction(J, e[n].jsc_fn, e[n].name, e[n].length);
+        } else {
+            af_newcfunction(J, e[n].afc_fn, e[n].name, e[n].length);
+        }
+        js_setproperty(J, -2, e[n].name);
+    }
+    js_setproperty(J, -2, module);
+}
+
+// Called directly, adds functions/vars to the caller's this.
+static void add_functions(js_State *J, struct script_ctx *ctx)
+{
+    js_copy(J, 0);
+    add_package_fns(J, "mp", main_fns);
+    js_getproperty(J, 0, "mp");  // + this mp
+    add_package_fns(J, "utils", utils_fns);
+
+    js_pushstring(J, mpv_client_name(ctx->client));
+    js_setproperty(J, -2, "script_name");
+
+    js_pushstring(J, ctx->filename);
+    js_setproperty(J, -2, "script_file");
+
+    js_pop(J, 2);  // leave the stack as we got it
+}
+
+// main export of this file, used by cplayer to load js scripts
+const struct mp_scripting mp_scripting_js = {
+    .name = "javascript",
+    .file_ext = "js",
+    .load = s_load_javascript,
+};

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -1,0 +1,495 @@
+"use strict";
+(function main_default_js(g) {
+// - g is the global object.
+// - User callbacks called without 'this', global only if callee is non-strict.
+// - The names of function expressions are not required, but are used in stack
+//   traces. We name them where useful to show up (fname:#line always shows).
+
+mp.msg = { log: mp.log };
+mp.msg.verbose = mp.log.bind(null, "v");
+var levels = ["fatal", "error", "warn", "info", "debug"];
+levels.forEach(function(l) { mp.msg[l] = mp.log.bind(null, l) });
+
+// same as {} but without inherited stuff, e.g. o["toString"] doesn't exist.
+// used where we try to fetch items by keys which we don't absolutely trust.
+function new_cache() {
+    return Object.create(null, {});
+}
+
+/**********************************************************************
+ *  event handlers, property observers, client messages, hooks
+ *********************************************************************/
+var ehandlers = new_cache() // items of event-name: array of {maybe cb: fn}
+
+mp.register_event = function(name, fn) {
+    if (!ehandlers[name])
+        ehandlers[name] = [];
+    ehandlers[name] = ehandlers[name].concat([{cb: fn}]);  // replaces the arr
+    return mp._request_event(name, true);
+}
+
+mp.unregister_event = function(fn) {
+    for (var name in ehandlers) {
+        ehandlers[name] = ehandlers[name].filter(function(h) {
+                              if (h.cb != fn)
+                                  return true;
+                              delete h.cb;  // dispatch could have a ref to h
+                          });  // replacing, not mutating the array
+        if (!ehandlers[name].length) {
+            delete ehandlers[name];
+            mp._request_event(name, false);
+        }
+    }
+}
+
+// call only pre-registered handlers, but not ones which got unregistered
+function dispatch_event(e) {
+    var handlers = ehandlers[e.event];
+    if (handlers) {
+        for (var len = handlers.length, i = 0; i < len; i++) {
+            var cb = handlers[i].cb;  // 'handlers' won't mutate, but unregister
+            if (cb)                   // could remove cb from some items
+                cb(e);
+        }
+    }
+}
+
+//  ----- property observers -----
+var next_oid = 1,
+    observers = new_cache();  // items of id: fn
+
+mp.observe_property = function(name, format, fn) {
+    var id = next_oid++;
+    observers[id] = fn;
+    return mp._observe_property(id, name, format || undefined);  // allow null
+}
+
+mp.unobserve_property = function(fn) {
+    for (var id in observers) {
+        if (observers[id] == fn) {
+            delete observers[id];
+            mp._unobserve_property(id);
+        }
+    }
+}
+
+function notify_observer(e) {
+    var cb = observers[e.id];
+    if (cb)
+        cb(e.name, e.data);
+}
+
+//  -----  Client messages -----
+var messages = new_cache();  // items of name: fn
+
+// overrides name. no libmpv API to reg/unreg specific messages.
+mp.register_script_message = function(name, fn) {
+    messages[name] = fn;
+}
+
+mp.unregister_script_message = function(name) {
+    delete messages[name];
+}
+
+function dispatch_message(ev) {
+    var cb = ev.args.length ? messages[ev.args[0]] : false;
+    if (cb)
+        cb.apply(null, ev.args.slice(1));
+}
+
+//  ----- hooks -----
+var next_hid = 1,
+    hooks = new_cache();  // items of id: fn
+
+function hook_run(id, cont) {
+    var cb = hooks[id];
+    if (cb)
+        cb();
+    mp.commandv("hook-ack", cont);
+}
+
+mp.add_hook = function add_hook(name, pri, fn) {
+    if (next_hid == 1)  // doesn't really matter if we do it once or always
+        mp.register_script_message("hook_run", hook_run);
+    var id = next_hid++;
+    hooks[id] = fn;
+    return mp.commandv("hook-add", name, id, pri);
+}
+
+/**********************************************************************
+ *  key bindings
+ *********************************************************************/
+// binds: items of (binding) name which are objects of:
+// {cb: fn, forced: bool, maybe input: str, repeatable: bool, complex: bool}
+var binds = new_cache();
+
+function dispatch_key_binding(name, state) {
+    var cb = binds[name] ? binds[name].cb : false;
+    if (cb)  // "script-binding [<script_name>/]<name>" command was invoked
+        cb(state);
+}
+
+function update_input_sections() {
+    var def = [], forced = [];
+    for (var n in binds)  // Array.join() will later skip undefined .input
+        (binds[n].forced ? forced : def).push(binds[n].input);
+
+    var sect = "input_" + mp.script_name;
+    mp.commandv("define-section", sect, def.join("\n"), "default");
+    mp.commandv("enable-section", sect, "allow-hide-cursor+allow-vo-dragging");
+
+    sect = "input_forced_" + mp.script_name;
+    mp.commandv("define-section", sect, forced.join("\n"), "force");
+    mp.commandv("enable-section", sect, "allow-hide-cursor+allow-vo-dragging");
+}
+
+// name/opts maybe omitted. opts: object with optional bool members: repeatable,
+// complex, forced, or a string str which is evaluated as object {str: true}.
+var next_bid = 1;
+function add_binding(forced, key, name, fn, opts) {
+    if (typeof name == "function") {  // as if "name" is not part of the args
+        opts = fn;
+        fn = name;
+        name = "__keybinding" + next_bid++;  // new unique binding name
+    }
+    var key_data = {forced: forced};
+    switch (typeof opts) {  // merge opts into key_data
+        case "string": key_data[opts] = true; break;
+        case "object": for (var o in opts) key_data[o] = opts[o];
+    }
+
+    if (key_data.complex) {
+        mp.register_script_message(name, function msg_cb() {
+            fn({event: "press", is_mouse: false});
+        });
+        var KEY_STATES = { u: "up", d: "down", r: "repeat", p: "press" };
+        key_data.cb = function key_cb(state) {
+            fn({
+                event: KEY_STATES[state[0]] || "unknown",
+                is_mouse: state[1] == "m"
+            });
+        }
+    } else {
+        mp.register_script_message(name, fn);
+        key_data.cb = function key_cb(state) {
+            // Emulate the semantics at input.c: mouse emits on up, kb on down.
+            // Also, key repeat triggers the binding again.
+            var e = state[0],
+                emit = (state[1] == "m") ? (e == "u") : (e == "d");
+            if (emit || e == "p" || e == "r" && key_data.repeatable)
+                fn();
+        }
+    }
+
+    if (key)
+        key_data.input = key + " script-binding " + mp.script_name + "/" + name;
+    binds[name] = key_data;  // used by user and/or our (key) script-binding
+    update_input_sections();
+}
+
+mp.add_key_binding = add_binding.bind(null, false);
+mp.add_forced_key_binding = add_binding.bind(null, true);
+
+mp.remove_key_binding = function(name) {
+    mp.unregister_script_message(name);
+    delete binds[name];
+    update_input_sections();
+}
+
+/**********************************************************************
+ Timers: compatible HTML5 WindowTimers - set/clear Timeout/Interval
+ - Spec: https://www.w3.org/TR/html5/webappapis.html#timers
+ - Guaranteed to callback a-sync to [re-]insertion (event-loop wise).
+ - Guaranteed to callback by expiration order, or, if equal, by insertion order.
+ - Not guaranteed schedule accuracy, though intervals should have good average.
+ *********************************************************************/
+
+// pending 'timers' ordered by expiration: latest at index 0 (top fires first).
+// Earlier timers are quicker to handle - just push/pop or fewer items to shift.
+var next_tid = 1,
+    timers = [],  // while in process_timers, just insertion-ordered (push)
+    tset_is_push = false,  // signal set_timer that we're in process_timers
+    tcanceled = false,  // or object of items timer-id: true
+    now = mp.get_time_ms;  // just an alias
+
+function insert_sorted(arr, t) {
+    for (var i = arr.length - 1; i >= 0 && t.when >= arr[i].when; i--)
+        arr[i + 1] = arr[i];  // move up timers which fire earlier than t
+    arr[i + 1] = t;  // i is -1 or fires later than t
+}
+
+// args (is "arguments"): fn_or_str [,duration [,user_arg1 [, user_arg2 ...]]]
+function set_timer(repeat, args) {
+    var fos = args[0],
+        duration = Math.max(0, (args[1] || 0)),  // minimum and default are 0
+        t = {
+            id: next_tid++,
+            when: now() + duration,
+            interval: repeat ? duration : -1,
+            callback: (typeof fos == "function") ? fos : Function(fos),
+            args: (args.length < 3) ? false : [].slice.call(args, 2),
+        };
+
+    if (tset_is_push) {
+        timers.push(t);
+    } else {
+        insert_sorted(timers, t);
+    }
+    return t.id;
+}
+
+g.setTimeout  = function setTimeout()  { return set_timer(false, arguments) };
+g.setInterval = function setInterval() { return set_timer(true,  arguments) };
+
+g.clearTimeout = g.clearInterval = function(id) {
+    if (id < next_tid) {  // must ignore if not active timer id.
+        if (!tcanceled)
+            tcanceled = {};
+        tcanceled[id] = true;
+    }
+}
+
+// arr: ordered timers array. ret: -1: no timers, 0: due, positive: ms to wait
+function peek_wait(arr) {
+    return arr.length ? Math.max(0, arr[arr.length - 1].when - now()) : -1;
+}
+
+// Callback all due non-canceled timers which were inserted before calling us.
+// Returns wait in ms till the next timer (possibly 0), or -1 if nothing pends.
+function process_timers() {
+    var wait = peek_wait(timers);
+    if (wait != 0)
+        return wait;
+
+    var actives = timers;  // only process those already inserted by now
+    timers = [];  // we'll handle added new timers at the end of processing.
+    tset_is_push = true;  // signal set_timer to just push-insert
+
+    do {
+        var t = actives.pop();
+        if (tcanceled && tcanceled[t.id])
+            continue;
+
+        if (t.args) {
+            t.callback.apply(null, t.args);
+        } else {
+            (0, t.callback)();  // faster, nicer stack trace than t.cb.call()
+        }
+
+        if (t.interval >= 0) {
+            // allow 20 ms delay/clock-resolution/gc before we skip and reset
+            t.when = Math.max(now() - 20, t.when + t.interval);
+            timers.push(t);  // insertion order only
+        }
+    } while (peek_wait(actives) == 0);
+
+    // new 'timers' are insertion-ordered. remains of actives are fully ordered
+    timers.forEach(function(t) { insert_sorted(actives, t) });
+    timers = actives;  // now we're fully ordered again, and with all timers
+    tset_is_push = false;
+    if (tcanceled) {
+        timers = timers.filter(function(t) { return !tcanceled[t.id] });
+        tcanceled = false;
+    }
+    return peek_wait(timers);
+}
+
+/**********************************************************************
+ CommonJS module/require
+
+ Spec: http://wiki.commonjs.org/wiki/Modules/1.1.1
+ - All the mandatory requirements are implemented, all the unit tests pass.
+ - The implementation makes the following exception:
+   - Allows the chars [~@:\\] in module id for meta-dir/builtin/dos-drive/UNC.
+
+ Implementation choices beyond the specification:
+ - A module may assign to module.exports (rather than only to exports).
+ - A module's 'this' is the global object, also if it sets strict mode.
+   - No 'global'/'self'. Users can do "this.global = this;" before require(..)
+   - A module has "privacy of its top scope", runs in its own function context.
+ - No id identity with symlinks - a valid choice which others make too.
+ - require("X") always maps to "X.js" -> require("foo.js") is file "foo.js.js".
+ - Global modules search paths are 'scripts/modules.js/' in mpv config dirs.
+ - A main script could e.g. require("./abc") to load a non-global module.
+ - Module id supports mpv path enhancements, e.g. ~/foo, ~~/bar, ~~desktop/baz
+ *********************************************************************/
+
+// Internal meta top-dirs. Users should not rely on these names.
+var MODULES_META = "~~modules",
+    SCRIPTDIR_META = "~~scriptdir",  // relative script path -> meta absolute id
+    main_script = mp.utils.split_path(mp.script_file);  // -> [ path, file ]
+
+function resolve_module_file(id) {
+    var sep = id.indexOf("/"),
+        base = id.substring(0, sep),
+        rest = id.substring(sep + 1) + ".js";
+
+    if (base == SCRIPTDIR_META)
+        return mp.utils.join_path(main_script[0], rest);
+
+    if (base == MODULES_META) {
+        var path = mp.find_config_file("scripts/modules.js/" + rest);
+        if (!path)
+            throw(Error("Cannot find module file '" + rest + "'"));
+        return path;
+    }
+
+    return id + ".js";
+}
+
+// Delimiter '/', remove redundancies, prefix with modules meta-root if needed.
+// E.g. c:\x -> c:/x, or ./x//y/../z -> ./x/z, or utils/x -> ~~modules/utils/x .
+function canonicalize(id) {
+    var path = id.replace(/\\/g,"/").split("/"),
+        t = path[0],
+        base = [];
+
+    // if not strictly relative then must be top-level. figure out base/rest
+    if (t != "." && t != "..") {
+        // global module if it's not fs-root/home/dos-drive/builtin/meta-dir
+        if (!(t == "" || t == "~" || t[1] == ":" ||  t == "@" || t.match(/^~~/)))
+            path.unshift(MODULES_META);  // add an explicit modules meta-root
+
+        if (id.match(/^\\\\/))  // simple UNC handling, preserve leading \\srv
+            path = ["\\\\" + path[2]].concat(path.slice(3));  // [ \\srv, shr..]
+
+        if (t[1] == ":" && t.length > 2) {  // path: [ "c:relative", "path" ]
+            path[0] = t.substring(2);
+            path.unshift(t[0] + ":.");  //  ->  [ "c:.", "relative", "path" ]
+        }
+        base = [path.shift()];
+    }
+
+    // path is now logically relative. base, if not empty, is its [meta] root.
+    // normalize the relative part - always id-based (spec Module Id, 1.3.6).
+    var cr = [];  // canonicalized relative
+    for (var i = 0; i < path.length; i++) {
+        if (path[i] == "." || path[i] == "")
+            continue;
+        if (path[i] == ".." && cr.length && cr[cr.length - 1] != "..") {
+            cr.pop();
+            continue;
+        }
+        cr.push(path[i]);
+    }
+
+    if (!base.length && cr[0] != "..")
+        base = ["."];  // relative and not ../<stuff> so must start with ./
+    return base.concat(cr).join("/");
+}
+
+function resolve_module_id(base_id, new_id) {
+    new_id = canonicalize(new_id);
+    if (!new_id.match(/^\.\/|^\.\.\//))  // doesn't start with ./ or ../
+        return new_id;  // not relative, we don't care about base_id
+
+    var combined = mp.utils.join_path(mp.utils.split_path(base_id)[0], new_id);
+    return canonicalize(combined);
+}
+
+var req_cache = new_cache();  // global for all instances of require
+
+// ret: a require function instance which uses base_id to resolve relative id's
+function new_require(base_id) {
+    return function require(id) {
+        id = resolve_module_id(base_id, id);  // id is now top-level
+        if (req_cache[id])
+            return req_cache[id].exports;
+
+        var new_module = {id: id, exports: {}};
+        req_cache[id] = new_module;
+        try {
+            var filename = resolve_module_file(id);
+            // we need dedicated free vars + filename in traces + allow strict
+            var str = "mp._req = function(require, exports, module) {" +
+                          mp.utils.read_file(filename) +
+                      "\n;}";
+            mp.utils.compile_js(filename, str)();  // only runs the assignment
+            var tmp = mp._req;  // we have mp._req, or else we'd have thrown
+            delete mp._req;
+            tmp.call(g, new_require(id), new_module.exports, new_module);
+        } catch (e) {
+            delete req_cache[id];
+            throw(e);
+        }
+
+        return new_module.exports;
+    };
+}
+
+g.require = new_require(SCRIPTDIR_META + "/" + main_script[1]);
+
+/**********************************************************************
+ *  various
+ *********************************************************************/
+g.print = mp.msg.info;  // convenient alias
+mp.get_script_name = function() { return mp.script_name };
+mp.get_script_file = function() { return mp.script_file };
+mp.get_time = function() { return mp.get_time_ms() / 1000 };
+mp.utils.getcwd = function() { return mp.get_property("working-directory") };
+mp.dispatch_event = dispatch_event;
+mp.process_timers = process_timers;
+
+mp.get_opt = function(key, def) {
+    var v = mp.get_property_native("options/script-opts")[key];
+    return (typeof v != "undefined") ? v : def;
+}
+
+mp.osd_message = function osd_message(text, duration) {
+    mp.commandv("show_text", text, Math.round(1000 * (duration || -1)));
+}
+
+// ----- dump: like print, but expands objects/arrays recursively -----
+function replacer(k, v) {
+    var t = typeof v;
+    if (t == "function" || t == "undefined")
+        return "<" + t + ">";
+    if (Array.isArray(this) && t == "object" && v !== null) {  // "safe" mode
+        if (this.indexOf(v) >= 0)
+            return "<VISITED>";
+        this.push(v);
+    }
+    return v;
+}
+
+function obj2str(v) {
+    try {  // can process objects more than once, but throws on cycles
+        return JSON.stringify(v, replacer, 2);
+    } catch (e) { // simple safe: exclude visited objects, even if not cyclic
+        return JSON.stringify(v, replacer.bind([]), 2);
+    }
+}
+
+g.dump = function dump() {
+    var toprint = [];
+    for (var i = 0; i < arguments.length; i++) {
+        var v = arguments[i];
+        toprint.push((typeof v == "object") ? obj2str(v) : replacer(0, v));
+    }
+    print.apply(null, toprint);
+}
+
+/**********************************************************************
+ *  main listeners and event loop
+ *********************************************************************/
+mp.keep_running = true;
+g.exit = function() { mp.keep_running = false };  // user-facing too
+mp.register_event("shutdown", g.exit);
+mp.register_event("property-change", notify_observer);
+mp.register_event("client-message", dispatch_message);
+mp.register_script_message("key-binding", dispatch_key_binding);
+
+g.mp_event_loop = function mp_event_loop() {
+    var wait = 0;  // seconds
+    do {  // distapch events as long as they arrive, then do the timers
+        var e = mp.wait_event(wait);
+        if (e.event != "none") {
+            dispatch_event(e);
+            wait = 0;  // poll the next one
+        } else {
+            wait = process_timers() / 1000;
+        }
+    } while (mp.keep_running);
+};
+
+})(this)

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -38,6 +38,7 @@
 
 extern const struct mp_scripting mp_scripting_lua;
 extern const struct mp_scripting mp_scripting_cplugin;
+extern const struct mp_scripting mp_scripting_js;
 
 static const struct mp_scripting *const scripting_backends[] = {
 #if HAVE_LUA
@@ -45,6 +46,9 @@ static const struct mp_scripting *const scripting_backends[] = {
 #endif
 #if HAVE_CPLUGINS
     &mp_scripting_cplugin,
+#endif
+#if HAVE_JAVASCRIPT
+    &mp_scripting_js,
 #endif
     NULL
 };

--- a/wscript
+++ b/wscript
@@ -290,6 +290,10 @@ iconv support use --disable-iconv.",
         'desc' : 'Lua',
         'func': check_lua,
     }, {
+        'name' : '--javascript',
+        'desc' : 'Javascript (MuJS backend)',
+        'func':  check_statement('mujs.h', 'js_setreport(js_newstate(0, 0, 0), 0)', lib='mujs'),
+    }, {
         'name': '--libass',
         'desc': 'SSA/ASS support',
         'func': check_pkg_config('libass', '>= 0.12.1'),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -92,6 +92,12 @@ def build(ctx):
             target = os.path.splitext(fn)[0] + ".inc",
         )
 
+    ctx(
+        features = "file2string",
+        source = "player/javascript/defaults.js",
+        target = "player/javascript/defaults.js.inc",
+    )
+
     ctx(features = "ebml_header", target = "ebml_types.h")
     ctx(features = "ebml_definitions", target = "ebml_defs.c")
 
@@ -237,6 +243,7 @@ def build(ctx):
         ( "player/misc.c" ),
         ( "player/lavfi.c" ),
         ( "player/lua.c",                        "lua" ),
+        ( "player/javascript.c",                 "javascript" ),
         ( "player/osd.c" ),
         ( "player/playloop.c" ),
         ( "player/screenshot.c" ),


### PR DESCRIPTION
Implements JS with almost identical API to the Lua support.

Key differences from Lua:
- The global mp, mp.msg and mp.utils are always available.
- Instead of returning x, error, return x and expose mp.last_error().
- Timers are JS standard set/clear Timeout/Interval.
- Supports CommonJS modules/require.
- Added at mp.utils: getenv, read_file, write_file and few more.
- Global print and dump (expand objects) functions.
- mp.options currently not supported.

See DOCS/man/javascript.rst for more details.

--------------------
I agree that my changes can be relicensed to LGPL 2.1 or later.
