### PR TITLE
vo_drm: fallback to vo_wait_default if VT switcher is not available

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -250,6 +250,8 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
         int64_t wait_us = until_time_us - mp_time_us();
         int timeout_ms = MPCLAMP((wait_us + 500) / 1000, 0, 10000);
         vt_switcher_poll(&p->vt_switcher, timeout_ms);
+    } else {
+        vo_wait_default(vo, until_time_us);
     }
 }
 


### PR DESCRIPTION
When the drm video output is used under VT with a terminal multiplexer
like screen, the VT_SETMODE ioctl call will fail since the controlling
terminal is a pseudoterminal instead of a real one, thus the VT switcher
will be unavailable.

The problem is, the wait_events function inside vo_drm.c will test for
this, and will do nothing if the switcher is not active. Normally, this
would not be noticed, however, when you pause a video, or if you're playing
multiple image files, mpv will suddenly starts to busy waiting on a single
core.

I confirmed this by building mpv with gprof support, in a few seconds,
wait_events got called about 90 million times.

So I added a fallback, when the VT switcher is not availble, just use the
vo_wait_default function. I tested it and it's working well so far.

I agree that my changes can be relicensed to LGPL 2.1 or later.