### PR TITLE
scripting: expand --script filename for C plugins

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -190,10 +190,8 @@ static void add_functions(struct script_ctx *ctx);
 static void load_file(lua_State *L, const char *fname)
 {
     struct script_ctx *ctx = get_ctx(L);
-    char *res_name = mp_get_user_path(NULL, ctx->mpctx->global, fname);
-    MP_VERBOSE(ctx, "loading file %s\n", res_name);
-    int r = luaL_loadfile(L, res_name);
-    talloc_free(res_name); // careful to not leak this on Lua errors
+    MP_VERBOSE(ctx, "loading file %s\n", fname);
+    int r = luaL_loadfile(L, fname);
     if (r)
         lua_error(L);
     lua_call(L, 0, 0);

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -215,8 +215,11 @@ void mp_load_scripts(struct MPContext *mpctx)
     // Load scripts from options
     char **files = mpctx->opts->script_files;
     for (int n = 0; files && files[n]; n++) {
-        if (files[n][0])
-            mp_load_script(mpctx, files[n]);
+        if (files[n][0]) {
+            char *path = mp_get_user_path(NULL, mpctx->global, files[n]);
+            mp_load_script(mpctx, path);
+            talloc_free(path);
+        }
     }
     if (!mpctx->opts->auto_load_scripts)
         return;


### PR DESCRIPTION
Currently expansion of filename (eg. `~/plugin.so` -> `/home/yourname/plugin.so`) is in lua specific code. Moved to common code so can be used by both lua and C plugins.

I agree that my changes can be relicensed to LGPL 2.1 or later.
