### PR TITLE
context_dxinterop: lock rendertarget after present when swapping buffers

### DIFF
--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -565,12 +565,6 @@ static void dxinterop_swap_buffers(MPGLContext *ctx)
         return;
     }
 
-    if (!gl->DXLockObjectsNV(p->device_h, 1, &p->rtarget_h)) {
-        MP_ERR(ctx->vo, "Couldn't lock rendertarget after stretchrect: %s\n",
-               mp_LastError_to_str());
-        return;
-    }
-
     hr = IDirect3DDevice9Ex_PresentEx(p->device, NULL, NULL, NULL, NULL, 0);
     switch (hr) {
     case D3DERR_DEVICELOST:
@@ -578,10 +572,15 @@ static void dxinterop_swap_buffers(MPGLContext *ctx)
         MP_VERBOSE(ctx->vo, "Direct3D device lost! Resetting.\n");
         p->lost_device = true;
         dxinterop_reset(ctx);
-        break;
+        return;
     default:
         if (FAILED(hr))
             MP_ERR(ctx->vo, "Failed to present: %s\n", mp_HRESULT_to_str(hr));
+    }
+
+    if (!gl->DXLockObjectsNV(p->device_h, 1, &p->rtarget_h)) {
+        MP_ERR(ctx->vo, "Couldn't lock rendertarget after present: %s\n",
+               mp_LastError_to_str());
     }
 }
 


### PR DESCRIPTION
Moves the DXLockObjectsNV call to after PresentEx. This fixes an issue
where the presented image is a single frame late. This may be due to
DXLockObjectsNV locking the render target before StretchRect is done.
The spec indicates that the lock call should provide synchronization
for the resource, so this may be due to a driver bug.

Fix #4480.
Tested on Windows 10 with Nvidia driver 382.53.

I agree that my changes can be relicensed to LGPL 2.1 or later.