### PR TITLE
vo: add support for direct rendering

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -415,6 +415,7 @@ int init_video_decoder(struct MPContext *mpctx, struct track *track)
     d_video->header = track->stream;
     d_video->codec = track->stream->codec;
     d_video->fps = d_video->header->codec->fps;
+    d_video->vo = mpctx->vo_chain->vo;
 
     // Note: at least mpv_opengl_cb_uninit_gl() relies on being able to get
     //       rid of all references to the VO by destroying the VO chain. Thus,

--- a/video/decode/dec_video.h
+++ b/video/decode/dec_video.h
@@ -37,6 +37,7 @@ struct dec_video {
     struct mp_hwdec_devices *hwdec_devs; // video output hwdec handles
     struct sh_stream *header;
     struct mp_codec_params *codec;
+    struct vo *vo; // required for direct rendering into video memory
 
     char *decoder_desc;
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -703,8 +703,7 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
 
 // Copy properties and data of the AVFrame into the mp_image, without taking
 // care of memory management issues.
-static void mp_image_copy_fields_from_av_frame(struct mp_image *dst,
-                                               struct AVFrame *src)
+void mp_image_copy_fields_from_av_frame(struct mp_image *dst, struct AVFrame *src)
 {
     mp_image_setfmt(dst, pixfmt2imgfmt(src->format));
     mp_image_set_size(dst, src->width, src->height);

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -153,6 +153,7 @@ void mp_image_set_attributes(struct mp_image *image,
                              const struct mp_image_params *params);
 
 struct AVFrame;
+void mp_image_copy_fields_from_av_frame(struct mp_image *dst, struct AVFrame *src);
 struct mp_image *mp_image_from_av_frame(struct AVFrame *av_frame);
 struct AVFrame *mp_image_to_av_frame(struct mp_image *img);
 struct AVFrame *mp_image_to_av_frame_and_unref(struct mp_image *img);


### PR DESCRIPTION
Here's also some usage pseudocode (look in my mpv master branch's vo_vulkan code for actual working stuff):

    size_t tot_size = 0;

    for (int i = 0; i < frame->planes; i++){
        frame->width[i]  = par->w >> dsc.xs[i];
        frame->height[i] = par->h >> dsc.ys[i];

        /* Must be generated by avcodec_align_dimensions2() */
        int aw = buf->aligned_width  >> dsc.xs[i];
        int ah = buf->aligned_height >> dsc.ys[i];
        int as = buf->stride_alignment[i];

        /* Stride must satisfy 2 alignments - lavc and the device's */
        frame->linesize[i] = FFALIGN(aw * dsc.bytes[i], as);
        frame->linesize[i] = FFALIGN(frame->linesize[i], <DEVICE_STRIDE_ALIGNMENT>);
        frame->linesize_samples[i] = frame->linesize[i] / dsc.bytes[i];

        /* The plane offset should be specially aligned for the best performance */
        frame->p_size[i]   = FFALIGN(frame->linesize[i] * ah, <DEVICE_PLANE_ALIGNMENT>);
        frame->p_offset[i] = tot_size;
        tot_size += frame->p_size[i];
    }

    <allocate stuff here>

    for (int i = 0; i < frame->planes; i++)
        frame->data[i] = frame->buf.mem + frame->p_offset[i];

    memcpy(buf->data, frame->data, frame->planes*sizeof(buf->data[0]));
    memcpy(buf->linesize, f->linesize, frame->planes*sizeof(buf->linesize[0]));
    buf->total_size = frame->buf.size;
    buf->release_buffer = release_frame;
    buf->opaque = frame;