### PR TITLE
manpage: Remove documentation to use 'I' to show filename on the OSD

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -165,9 +165,6 @@ Ctrl s
     Take a screenshot, as the window shows it (with subtitles, OSD, and scaled
     video).
 
-I
-    Show filename on the OSD.
-
 PGUP and PGDWN
     Seek to the beginning of the previous/next chapter. In most cases,
     "previous" will actually go to the beginning of the current chapter; see


### PR DESCRIPTION
A relic of mplayer had 'I' as the keybind to show the filename of the
currently playing file on the OSD. mpv does not do this by default.
This commit removes this incorrect information from the mpv manage.

Fixes #4536 

