### PR TITLE
video/out/opengl: Prioritize Wayland over X11

### DIFF
--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -65,6 +65,9 @@ static const struct mpgl_driver *const backends[] = {
 #if HAVE_GL_DXINTEROP
     &mpgl_driver_dxinterop,
 #endif
+#if HAVE_GL_WAYLAND
+    &mpgl_driver_wayland,
+#endif
 #if HAVE_GL_X11
     &mpgl_driver_x11_probe,
 #endif
@@ -73,9 +76,6 @@ static const struct mpgl_driver *const backends[] = {
 #endif
 #if HAVE_GL_X11
     &mpgl_driver_x11,
-#endif
-#if HAVE_GL_WAYLAND
-    &mpgl_driver_wayland,
 #endif
 #if HAVE_EGL_DRM
     &mpgl_driver_drm,


### PR DESCRIPTION
This fixes bug LP: #1698287. The problem was that in a Gnome Shell
Wayland session both X11 (Xwayland) and Wayland are available. But
choosing X11 results in an unusable VO for VAAPI. The simple fix is
to choose Wayland over X11 if both are present.
