### PR TITLE
[RFC] ytdl_hook blacklist

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -531,6 +531,26 @@ Program Behavior
 
     If the script can't do anything with an URL, it will do nothing.
 
+    The `exclude` script option accepts a comma-separated list of URL patterns
+    which mpv should not use with youtube-dl. The patterns are matched after
+    the ``http(s)://`` part of the URL.
+
+    ``^`` matches the beginning of the URL, ``$`` matches its end, and you
+    should use ``%`` before any of the characters ``^$()%,.[]*+-?`` to match
+    that character.
+
+    .. admonition:: Example
+
+        ``--script-opts=ytdl_hook-exclude='^youtube%.com'`` will exclude any
+            URL that starts with ``http://youtube.com`` or
+            ``https://youtube.com``.
+        ``--script-opts=ytdl_hook-exclude='%.mkv$,%.mp4$'`` will exclude any
+            URL that ends with ``.mkv`` or ``.mp4``.
+
+    See more `lua patterns here`__.
+    __ https://www.lua.org/manual/5.1/manual.html#5.4.1
+
+
 ``--ytdl-format=<best|worst|mp4|webm|...>``
     Video format/quality that is directly passed to youtube-dl. The possible
     values are specific to the website and the video, for a given url the

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -243,6 +243,7 @@ end
 
 mp.add_hook("on_load", 10, function ()
     local url = mp.get_property("stream-open-filename")
+    local start_time = os.clock()
 
     if (url:find("http://") == 1) or (url:find("https://") == 1)
         or (url:find("ytdl://") == 1) then
@@ -319,6 +320,7 @@ mp.add_hook("on_load", 10, function ()
         end
 
         msg.verbose("youtube-dl succeeded!")
+        msg.debug('ytdl parsing took '..os.clock()-start_time..' seconds')
 
         -- what did we get?
         if not (json["direct"] == nil) and (json["direct"] == true) then
@@ -424,6 +426,7 @@ mp.add_hook("on_load", 10, function ()
             add_single_video(json)
         end
     end
+    msg.debug('script running time: '..os.clock()-start_time..' seconds')
 end)
 
 


### PR DESCRIPTION
Requested in IRC for sites which youtube-dl seems to have trouble with parsing (private sites with http auth), or, with direct URLs, saving whole 2 seconds.