### PR TITLE
 ao_wasapi: try correct initial format

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -169,10 +169,13 @@ static void set_waveformat_with_ao(WAVEFORMATEXTENSIBLE *wformat, struct ao *ao)
     af_get_best_sample_formats(ao->format, alt_formats);
     for (int n = 0; alt_formats[n]; n++) {
         for (int i = 0; wasapi_formats[i].mp_format; i++) {
-            if (wasapi_formats[i].mp_format == alt_formats[n])
+            if (wasapi_formats[i].mp_format == alt_formats[n]) {
                 format = wasapi_formats[i];
+                goto found_format;
+            }
         }
     }
+ found_format:
 
     set_waveformat(wformat, format, ao->samplerate, &channels);
 }

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -945,15 +945,15 @@ HRESULT wasapi_thread_init(struct ao *ao)
 
     ao->format = af_fmt_from_planar(ao->format);
 
-retry: ;
+retry:
     if (state->deviceID) {
         hr = load_device(ao->log, &state->pDevice, state->deviceID);
         EXIT_ON_ERROR(hr);
 
         MP_DBG(ao, "Activating pAudioClient interface\n");
         hr = IMMDeviceActivator_Activate(state->pDevice, &IID_IAudioClient,
-                                        CLSCTX_ALL, NULL,
-                                        (void **)&state->pAudioClient);
+                                         CLSCTX_ALL, NULL,
+                                         (void **)&state->pAudioClient);
         EXIT_ON_ERROR(hr);
     } else {
         MP_VERBOSE(ao, "Trying UWP wrapper.\n");


### PR DESCRIPTION
The loop to select the native wasapi_format for the incoming audio was
not breaking correctly when it found the most desirable format. It
therefore executed completely leaving the least desirable format (u8) as
the choice.