### PR TITLE
audio: fix packed 24 bit output and enable it in wasapi

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -703,7 +703,7 @@ static void convert_plane(int type, void *data, int num_samples)
 
 // data[n] contains the pointer to the first sample of the n-th plane, in the
 // format implied by fmt->src_fmt. src_fmt also controls whether the data is
-// all in one plane, or of there is a plane per channel.
+// all in one plane, or if there is a plane per channel.
 void ao_convert_inplace(struct ao_convert_fmt *fmt, void **data, int num_samples)
 {
     int type = get_conv_type(fmt);

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -82,7 +82,7 @@ static const struct wasapi_sample_fmt wasapi_formats[] = {
     // compatible, assume LSBs are ignored
     {AF_FORMAT_S32,     32, 24, &KSDATAFORMAT_SUBTYPE_PCM},
     // aka S24 (with conversion) - untested, thus commented.
-    //{AF_FORMAT_S32,     24, 24, &KSDATAFORMAT_SUBTYPE_PCM},
+    {AF_FORMAT_S32,     24, 24, &KSDATAFORMAT_SUBTYPE_PCM},
     {AF_FORMAT_FLOAT,   32, 32, &KSDATAFORMAT_SUBTYPE_IEEE_FLOAT},
     {AF_FORMAT_S_AC3,   16, 16, &mp_KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL},
     {AF_FORMAT_S_DTS,   16, 16, &mp_KSDATAFORMAT_SUBTYPE_IEC61937_DTS},

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -372,9 +372,9 @@ static bool search_sample_formats(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat,
 static bool search_samplerates(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat,
                                struct mp_chmap *channels)
 {
-    // try list of typical sample rates (requests welcome)
-    int try[] = {8000, 11025, 16000, 22050, 32000, 44100, 48000, 88200, 96000,
-                 176400, 192000, 352800, 384000, 0};
+    // put common samplerates first so that we find format early
+    int try[] = {48000, 44100, 96000, 88200, 192000, 176400,
+                 32000, 22050, 11025, 8000, 16000, 352800, 384000, 0};
 
     // get a list of supported rates
     int n = 0;
@@ -410,7 +410,7 @@ static bool search_channels(struct ao *ao, WAVEFORMATEXTENSIBLE *wformat)
     struct mp_chmap entry;
     // put common layouts first so that we find sample rate/format early
     char *channel_layouts[] =
-        {"mono", "stereo", "2.1", "4.0", "5.0", "5.1", "6.1", "7.1",
+        {"stereo", "5.1", "7.1", "6.1", "mono", "2.1", "4.0", "5.0",
          "3.0", "3.0(back)",
          "quad", "quad(side)", "3.1",
          "5.0(side)", "4.1",

--- a/misc/ring.c
+++ b/misc/ring.c
@@ -27,8 +27,8 @@
 struct mp_ring {
     uint8_t  *buffer;
 
-    /* Positions of the first readable/writeable chunks. Do not read this
-     * fields but use the atomic private accessors `mp_ring_get_wpos`
+    /* Positions of the first readable/writeable chunks. Do not read these
+     * fields. Use the atomic private accessors `mp_ring_get_wpos`
      * and `mp_ring_get_rpos`. */
     atomic_ullong rpos, wpos;
 };


### PR DESCRIPTION
audio/out: correct copy length in ao_read_data_converted 

Previously, the entire convert_buffer was being copied to the destination without
regard to the fact that it may be packed and therefore smaller.

The allocated conversion buffer was also way to big

bytes * (channels * samples) ** 2

instead of

bytes * channels * samples

----

ao_wasapi: reorder channels and samplerates to speed up search

This shouldn't affect which are chosen, but it should speed up the search by
putting more common configurations earlier so that a working sample format and
sample rates can be found sooner obviating the need to search them for each
iteration of the outer loops.

--- 

fix some typos