### PR TITLE
Miscelaneous wasapi fixes

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -984,10 +984,13 @@ retry:
         EXIT_ON_ERROR(hr);
     }
 
-    MP_DBG(ao, "Probing formats\n");
-    if (!find_formats(ao)) {
-        hr = E_FAIL;
-        EXIT_ON_ERROR(hr);
+    // In the event of an align hack, we've already done this.
+    if (!align_hack) {
+        MP_DBG(ao, "Probing formats\n");
+        if (!find_formats(ao)) {
+            hr = E_FAIL;
+            EXIT_ON_ERROR(hr);
+        }
     }
 
     MP_DBG(ao, "Fixing format\n");

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -996,7 +996,7 @@ retry:
         // According to MSDN, we must use this as base after the failure.
         IAudioClient_GetBufferSize(state->pAudioClient,
                                    &state->bufferFrameCount);
-        SAFE_RELEASE(state->pAudioClient);
+        wasapi_thread_uninit(ao);
         align_hack = true;
         MP_WARN(ao, "This appears to require a weird Windows 7 hack. Retrying.\n");
         goto retry;

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -640,7 +640,6 @@ static HRESULT fix_format(struct ao *ao, bool align_hack)
              * state->bufferFrameCount));
     }
 
-    // in exclusive mode, these should all be the same
     REFERENCE_TIME bufferPeriod =
         state->share_mode == AUDCLNT_SHAREMODE_EXCLUSIVE ? bufferDuration : 0;
 


### PR DESCRIPTION
The biggest change here is that the format search is not repeated during the align hack. I actually found that my laptop's integrated sound chip does actually require this hack for playing 24 bit audio in exclusive mode, so consider this tested.

Interestingly, I wasn't able to reproduce the DEVICE_IN_USE / DEVICE_INVALIDATED errors. The associated retry might be a future candidate for removal, but for now play it safe and leave as is.