### PR TITLE
vo_opengl: implement explicit flushing for --vd-lavc-dr

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4153,9 +4153,19 @@ The following video options are currently all specific to ``--vo=opengl`` and
     Set this to ``-1`` to disable this logic.
 
 ``--opengl-pbo``
-    Enable use of PBOs. On some drivers this can be faster, especially if the
-    source video size is huge (e.g. so called "4K" video). On other drivers it
-    might be slower or cause latency issues.
+    Enable use of PBOs for the stand-alone texture upload path. On some drivers
+    this can be faster, especially if the source video size is huge (e.g. so
+    called "4K" video). On other drivers it might be slower or cause latency
+    issues. This option has no effect when using direct rendering
+    (``-vd-lavc-dr=yes``), which always uses PBOs regardless of this setting.
+
+ ``--opengl-pbo-explicit-flush``
+    By default, PBOs in use for direct rendering (``--vd-lavc-dr=yes``) will be
+    mapped coherently and never flushed. In theory, this could be bad for
+    performance. Enabling this option will map the PBOs non-coherently instead,
+    and use explicit flushing a few vsyncs ahead of time (currently 2). Could
+    perhaps help with direct rendering performance on some drivers. This option
+    has no interaction with ``--opengl-pbo``.
 
 ``--dither-depth=<N|no|auto>``
     Set dither target depth to N. Default: no.

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -174,6 +174,7 @@ static const struct gl_functions gl_functions[] = {
             DEF_FN(BlitFramebuffer),
             DEF_FN(GetStringi),
             DEF_FN(MapBufferRange),
+            DEF_FN(FlushMappedBufferRange),
             // for ES 3.0
             DEF_FN(ReadBuffer),
             DEF_FN(UnmapBuffer),

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -127,6 +127,7 @@ struct GL {
     void (GLAPIENTRY *BindBufferBase)(GLenum, GLuint, GLuint);
     GLvoid * (GLAPIENTRY *MapBufferRange)(GLenum, GLintptr, GLsizeiptr,
                                           GLbitfield);
+    void (GLAPIENTRY *FlushMappedBufferRange)(GLenum, GLintptr, GLsizeiptr);
     GLboolean (GLAPIENTRY *UnmapBuffer)(GLenum);
     void (GLAPIENTRY *BufferData)(GLenum, intptr_t, const GLvoid *, GLenum);
     void (GLAPIENTRY *BufferSubData)(GLenum, GLintptr, GLsizeiptr, const GLvoid *);

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -178,6 +178,7 @@ struct dr_buffer {
     void *ptr;
     size_t size;
     GLuint pbo;
+    bool flushed;
     // While a PBO is read-accessed by GL, we must not write to the mapped data.
     // The fence tells us when GL is done, and the mpi reference will keep the
     // data from being recycled (or from other references gaining write access).
@@ -374,6 +375,7 @@ const struct m_sub_options gl_video_conf = {
         OPT_FLOAT("tone-mapping-param", tone_mapping_param, 0),
         OPT_FLOAT("tone-mapping-desaturate", tone_mapping_desat, 0),
         OPT_FLAG("opengl-pbo", pbo, 0),
+        OPT_FLAG("opengl-pbo-explicit-flush", pbo_explicit_flush, 0),
         SCALER_OPTS("scale",  SCALER_SCALE),
         SCALER_OPTS("dscale", SCALER_DSCALE),
         SCALER_OPTS("cscale", SCALER_CSCALE),
@@ -966,6 +968,18 @@ static struct dr_buffer *gl_find_dr_buffer(struct gl_video *p, uint8_t *ptr)
     return NULL;
 }
 
+// This only flushes when required
+static void gl_flush_dr_buffer(struct gl_video *p, struct dr_buffer *buf)
+{
+    GL *gl = p->gl;
+    if (buf && !buf->flushed && p->opts.pbo_explicit_flush) {
+        gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, buf->pbo);
+        gl->FlushMappedBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, buf->size);
+        gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+        buf->flushed = true;
+    }
+}
+
 static void gc_pending_dr_fences(struct gl_video *p, bool force)
 {
     GL *gl = p->gl;
@@ -980,6 +994,7 @@ again:;
         if (res == GL_ALREADY_SIGNALED || force) {
             gl->DeleteSync(buffer->fence);
             buffer->fence = NULL;
+            buffer->flushed = false;
             // Unreferencing the image could cause gl_video_dr_free_buffer()
             // to be called by the talloc destructor (if it was the last
             // reference). This will implicitly invalidate the buffer pointer
@@ -2868,7 +2883,7 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
     // it only barely matters at the very beginning of playback, and this way
     // makes the code much more linear.
     int surface_dst = fbosurface_wrap(p->surface_idx + 1);
-    for (int i = 0; i < t->num_frames; i++) {
+    for (int i = 0; i < MPMIN(t->num_frames, radius + 1); i++) {
         // Avoid overwriting data we might still need
         if (surface_dst == surface_bse - 1)
             break;
@@ -3107,6 +3122,13 @@ done:
 
     debug_check_gl(p, "after video rendering");
 
+    // Flush some future buffers for performance. This loop is a fancy no-op
+    // when not using direct rendering, or when flushing is not required.
+    for (int n = 0; n < frame->num_frames; n++) {
+        for (int m = 0; m < p->plane_count; m++)
+            gl_flush_dr_buffer(p, gl_find_dr_buffer(p, frame->frames[n]->planes[m]));
+    }
+
     gl->BindFramebuffer(GL_FRAMEBUFFER, fbo);
 
     if (p->osd) {
@@ -3297,6 +3319,7 @@ static bool pass_upload_image(struct gl_video *p, struct mp_image *mpi, uint64_t
         struct dr_buffer *mapped = gl_find_dr_buffer(p, mpi->planes[n]);
         if (mapped) {
             assert(mapped->pbo > 0);
+            gl_flush_dr_buffer(p, mapped);
             gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, mapped->pbo);
             uintptr_t offset = mpi->planes[n] - (uint8_t *)mapped->ptr;
             gl_upload_tex(gl, plane->gl_target,
@@ -3749,6 +3772,9 @@ void gl_video_configure_queue(struct gl_video *p, struct vo *vo)
         }
     }
 
+    if (p->opts.pbo_explicit_flush)
+        queue_size += 2; // add some extra frames to flush ahead of time
+
     vo_set_queue_params(vo, 0, queue_size);
 }
 
@@ -3861,13 +3887,19 @@ void *gl_video_dr_alloc_buffer(struct gl_video *p, size_t size)
         .size = size,
     };
 
-    unsigned flags = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
-                     GL_MAP_COHERENT_BIT;
+    unsigned flags = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT;
+    unsigned mapflags = 0;
+
+    if (p->opts.pbo_explicit_flush) {
+        mapflags |= GL_MAP_FLUSH_EXPLICIT_BIT;
+    } else {
+        flags |= GL_MAP_COHERENT_BIT;
+    }
 
     gl->GenBuffers(1, &buffer->pbo);
     gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer->pbo);
-    gl->BufferStorage(GL_PIXEL_UNPACK_BUFFER, size, NULL, flags);
-    buffer->ptr = gl->MapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, size, flags);
+    gl->BufferStorage(GL_PIXEL_UNPACK_BUFFER, size, NULL, flags | GL_CLIENT_STORAGE_BIT);
+    buffer->ptr = gl->MapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, size, flags | mapflags);
     gl->BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
     if (!buffer->ptr) {
         gl_check_error(p->gl, p->log, "mapping buffer");

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -122,6 +122,7 @@ struct gl_video_opts {
     float sigmoid_slope;
     int scaler_resizes_only;
     int pbo;
+    int pbo_explicit_flush;
     int dither_depth;
     int dither_algo;
     int dither_size;


### PR DESCRIPTION
This could maybe help. Who knows. Needs testing.

The change to the interpolation code is to avoid trying to render more
frames than strictly necessary. (We can no longer just rely on the
t->num_frames because that could also include the extra 2 frames from
p->opts.pbo_explicit_flush)

I'm not sure if we should actually merge this. (Apart from the documentation change to --opengl-pbo, perhaps?) I just want to give it some exposure to hopefully see if it actually helps in any environment. It doesn't for nvidia.