### PR TITLE
vo_opengl: enable compute shader for mesa

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -357,6 +357,11 @@ static const struct gl_functions gl_functions[] = {
             {0},
         },
     },
+    {
+        .ver_core = 430,
+        .extension = "GL_ARB_arrays_of_arrays",
+        .provides = MPGL_CAP_NESTED_ARRAY,
+    },
     // Swap control, always an OS specific extension
     // The OSX code loads this manually.
     {
@@ -618,6 +623,10 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
         gl->mpgl_caps |= MPGL_CAP_SW;
         mp_verbose(log, "Detected suspected software renderer.\n");
     }
+
+    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
+    if (gl->DispatchCompute && gl->BindImageTexture)
+        gl->mpgl_caps |= MPGL_CAP_COMPUTE_SHADER;
 
     // Provided for simpler handling if no framebuffer support is available.
     if (!gl->BindFramebuffer)

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -55,6 +55,8 @@ enum {
     MPGL_CAP_ARB_FLOAT          = (1 << 19),    // GL_ARB_texture_float
     MPGL_CAP_EXT_CR_HFLOAT      = (1 << 20),    // GL_EXT_color_buffer_half_float
     MPGL_CAP_SSBO               = (1 << 21),    // GL_ARB_shader_storage_buffer_object
+    MPGL_CAP_COMPUTE_SHADER     = (1 << 22),    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
+    MPGL_CAP_NESTED_ARRAY       = (1 << 23),    // GL_ARB_arrays_of_arrays
 
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -777,6 +777,8 @@ void gl_sc_uniform_image2D(struct gl_shader_cache *sc, char *name, GLuint textur
 void gl_sc_ssbo(struct gl_shader_cache *sc, char *name, GLuint ssbo,
                 char *format, ...)
 {
+    gl_sc_enable_extension(sc, "GL_ARB_shader_storage_buffer_object");
+
     struct sc_buffer *b = find_buffer(sc, name);
     b->binding = sc->next_buffer_binding++;
     b->ssbo = ssbo;
@@ -1179,6 +1181,11 @@ struct mp_pass_perf gl_sc_generate(struct gl_shader_cache *sc, GLenum type)
     // set up shader text (header + uniforms + body)
     bstr *header = &sc->tmp[0];
     ADD(header, "#version %d%s\n", gl->glsl_version, gl->es >= 300 ? " es" : "");
+    if (type == GL_COMPUTE_SHADER) {
+        // This extension cannot be enabled in fragment shader. Enable it as
+        // an exception for compute shader.
+        ADD(header, "#extension GL_ARB_compute_shader : enable\n");
+    }
     for (int n = 0; n < sc->num_exts; n++)
         ADD(header, "#extension %s : enable\n", sc->exts[n]);
     if (gl->es) {

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -241,6 +241,7 @@ void pass_compute_polar(struct gl_shader_cache *sc, struct scaler *scaler,
     gl_sc_uniform_tex(sc, "lut", scaler->gl_target, scaler->gl_lut);
 
     // Load all relevant texels into shmem
+    gl_sc_enable_extension(sc, "GL_ARB_arrays_of_arrays");
     for (int c = 0; c < components; c++)
         GLSLHF("shared float in%d[%d][%d];\n", c, ih, iw);
 


### PR DESCRIPTION
Mesa 17.1 supports compute shader but not full specs of OpenGL 4.3.
Change the code to detect OpenGL extension `GL_ARB_compute_shader`
rather than OpenGL version `4.3`.

The compute polar code also utilized OpenGL extension
`GL_ARB_arrays_of_arrays`, so add it as a requirement as well.

Tested with Intel HD 4000 graphics card on Linux (Mesa 17.1.4). Upscaling
1280x720 video to 1920x1080 with `scale=ewa_lanczossharp`.

    pass rendering time: 46.3 ms -> 18.5ms
