### PR TITLE
Fix image uniforms for older OpenGL

### DIFF
--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -759,6 +759,8 @@ static const char *mp_image2D_type(GLenum access)
 void gl_sc_uniform_image2D(struct gl_shader_cache *sc, char *name, GLuint texture,
                            GLuint iformat, GLenum access)
 {
+    gl_sc_enable_extension(sc, "GL_ARB_shader_image_load_store");
+
     struct sc_uniform *u = find_uniform(sc, name);
     u->type = UT_i;
     u->size = 1;


### PR DESCRIPTION
Someone reported this error with an older Intel GPU: https://pastebin.com/raw/gWv2zzUM

I think this is the right solution.