### PR TITLE
Fix Android compilation by disabling glob()

### DIFF
--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -115,6 +115,7 @@ static mf_t *open_mf_pattern(void *talloc_ctx, struct mp_log *log, char *filenam
 
     char *fname = talloc_size(mf, strlen(filename) + 32);
 
+#if HAVE_GLOB
     if (!strchr(filename, '%')) {
         strcpy(fname, filename);
         if (!strchr(filename, '*'))
@@ -137,6 +138,7 @@ static mf_t *open_mf_pattern(void *talloc_ctx, struct mp_log *log, char *filenam
         globfree(&gg);
         goto exit_mf;
     }
+#endif
 
     mp_info(log, "search expr: %s\n", filename);
 

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -28,7 +28,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#if HAVE_POSIX
+#if HAVE_GLOB_POSIX
 #include <glob.h>
 #endif
 

--- a/wscript
+++ b/wscript
@@ -234,11 +234,21 @@ iconv support use --disable-iconv.",
         'deps': [ 'win32-desktop' ],
         'deps_neg': [ 'posix' ],
     }, {
+        'name': 'glob-posix',
+        'desc': 'glob() POSIX support',
+        'deps_neg': [ 'os-win32', 'os-cygwin' ],
+        'func': check_statement('glob.h', 'glob("filename", 0, 0, 0)'),
+    }, {
         'name': 'glob-win32',
         'desc': 'glob() win32 replacement',
         'deps_neg': [ 'posix' ],
         'deps_any': [ 'os-win32', 'os-cygwin' ],
         'func': check_true
+    }, {
+        'name': 'glob',
+        'desc': 'any glob() support',
+        'deps_any': [ 'glob-posix', 'glob-win32' ],
+        'func': check_true,
     }, {
         'name': 'fchmod',
         'desc': 'fchmod()',

--- a/wscript
+++ b/wscript
@@ -137,6 +137,10 @@ main_dependencies = [
         'func': check_statement(['poll.h', 'unistd.h', 'sys/mman.h'],
             'struct pollfd pfd; poll(&pfd, 1, 0); fork(); int f[2]; pipe(f); munmap(f,0)'),
     }, {
+        'name': '--android',
+        'desc': 'Android environment',
+        'func': check_statement('android/api-level.h', '(void)__ANDROID__'),  # arbitrary android-specific header
+    }, {
         'name': 'posix-or-mingw',
         'desc': 'development environment',
         'deps_any': [ 'posix', 'mingw' ],
@@ -701,10 +705,6 @@ video_output_features = [
         'desc': 'Direct3D support',
         'deps': [ 'win32-desktop' ],
         'func': check_cc(header_name='d3d9.h'),
-    }, {
-        'name': '--android',
-        'desc': 'Android support',
-        'func': check_statement('android/api-level.h', '(void)__ANDROID__'),  # arbitrary android-specific header
     }, {
         'name': '--rpi',
         'desc': 'Raspberry Pi support',


### PR DESCRIPTION
Android stdlib contains the things that mpv's POSIX check checks for,
but unfortunately not glob.

This fixes Android compilation broken in 70a70b9da .