### PR TITLE
cocoa: add an option to disable the native macOS fullscreen

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2477,6 +2477,10 @@ Window
     as having the same size as on none-HiDPI resolutions. This is the default OS X
     behavior.
 
+``--native-fs``, ``--no-native-fs``
+    (OS X only)
+    Uses the native fullscreen mechanism of the OS (default: yes).
+
 ``--monitorpixelaspect=<ratio>``
     Set the aspect of a single pixel of your monitor or TV screen (default:
     1). A value of 1 means square pixels (correct for (almost?) all LCDs). See

--- a/options/options.c
+++ b/options/options.c
@@ -162,6 +162,7 @@ static const m_option_t mp_vo_opt_list[] = {
     OPT_FLAG("keepaspect", keepaspect, UPDATE_VIDEOPOS),
     OPT_FLAG("keepaspect-window", keepaspect_window, 0),
     OPT_FLAG("hidpi-window-scale", hidpi_window_scale, 0),
+    OPT_FLAG("native-fs", native_fs, 0),
 #if HAVE_X11
     OPT_CHOICE("x11-netwm", x11_netwm, 0,
                ({"auto", 0}, {"no", -1}, {"yes", 1})),
@@ -196,6 +197,7 @@ const struct m_sub_options vo_sub_opts = {
         .keepaspect = 1,
         .keepaspect_window = 1,
         .hidpi_window_scale = 1,
+        .native_fs = 1,
         .taskbar_progress = 1,
         .snap_window = 0,
         .border = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -40,6 +40,7 @@ typedef struct mp_vo_opts {
     int keepaspect;
     int keepaspect_window;
     int hidpi_window_scale;
+    int native_fs;
 
     int64_t WinID;
 

--- a/video/out/cocoa/mpvadapter.h
+++ b/video/out/cocoa/mpvadapter.h
@@ -28,8 +28,11 @@
 - (void)didChangeWindowedScreenProfile:(NSNotification *)notification;
 - (void)performAsyncResize:(NSSize)size;
 - (void)windowDidChangePhysicalScreen;
+- (void)windowDidEnterFullScreen;
+- (void)windowDidExitFullScreen;
 
 - (BOOL)isInFullScreenMode;
+- (BOOL)wantsNativeFullscreen;
 - (BOOL)keyboardEnabled;
 - (BOOL)mouseEnabled;
 

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -1014,6 +1014,11 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
     return self.vout->cocoa->fullscreen;
 }
 
+- (BOOL)wantsNativeFullscreen
+{
+    return self.vout->opts->native_fs;
+}
+
 - (NSScreen *)getTargetScreen
 {
     struct vo_cocoa_state *s = self.vout->cocoa;
@@ -1039,7 +1044,7 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
     flag_events(self.vout, VO_EVENT_WIN_STATE);
 }
 
-- (void)windowDidEnterFullScreen:(NSNotification *)notification
+- (void)windowDidEnterFullScreen
 {
     struct vo_cocoa_state *s = self.vout->cocoa;
     s->fullscreen = 1;
@@ -1047,7 +1052,7 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
     vo_cocoa_anim_unlock(self.vout);
 }
 
-- (void)windowDidExitFullScreen:(NSNotification *)notification
+- (void)windowDidExitFullScreen
 {
     struct vo_cocoa_state *s = self.vout->cocoa;
     s->fullscreen = 0;


### PR DESCRIPTION
rather self explanatory.

i tried to keep the code of the none-native fullscreen as separate as possible, so it is a bit easier to maintain. though it leads to some minor code duplications.