### PR TITLE
macOS menubar refactor

### DIFF
--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -18,14 +18,7 @@
 #ifndef MPV_MACOSX_APPLICATION
 #define MPV_MACOSX_APPLICATION
 
-// Menu Keys identifing menu items
-typedef enum {
-    MPM_H_SIZE,
-    MPM_N_SIZE,
-    MPM_D_SIZE,
-    MPM_MINIMIZE,
-    MPM_ZOOM,
-} MPMenuKey;
+#include "osdep/macosx_menubar.h"
 
 // multithreaded wrapper for mpv_main
 int cocoa_main(int argc, char *argv[]);

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -47,21 +47,6 @@ static pthread_t playback_thread_id;
     EventsResponder *_eventsResponder;
 }
 
-- (NSMenuItem *)menuItemWithParent:(NSMenu *)parent
-                             title:(NSString *)title
-                            action:(SEL)selector
-                     keyEquivalent:(NSString*)key;
-
-- (NSMenuItem *)mainMenuItemWithParent:(NSMenu *)parent
-                                 child:(NSMenu *)child;
-- (void)registerMenuItem:(NSMenuItem*)menuItem forKey:(MPMenuKey)key;
-- (NSMenu *)appleMenuWithMainMenu:(NSMenu *)mainMenu;
-- (NSMenu *)videoMenu;
-- (NSMenu *)windowMenu;
-@end
-
-@interface NSApplication (NiblessAdditions)
-- (void)setAppleMenu:(NSMenu *)aMenu;
 @end
 
 static Application *mpv_shared_app(void)
@@ -76,7 +61,7 @@ static void terminate_cocoa_application(void)
 }
 
 @implementation Application
-@synthesize menuItems = _menu_items;
+@synthesize menuBar = _menu_Bar;
 @synthesize openCount = _open_count;
 
 - (void)sendEvent:(NSEvent *)event
@@ -89,7 +74,6 @@ static void terminate_cocoa_application(void)
 - (id)init
 {
     if (self = [super init]) {
-        self.menuItems = [[[NSMutableDictionary alloc] init] autorelease];
         _eventsResponder = [EventsResponder sharedInstance];
 
         NSAppleEventManager *em = [NSAppleEventManager sharedAppleEventManager];
@@ -125,11 +109,6 @@ static void terminate_cocoa_application(void)
         currentPosition, timeLeft];
     return tBar;
 }
-
-- (void)toggleTouchBarMenu
-{
-    [NSApp toggleTouchBarCustomizationPalette:self];
-}
 #endif
 
 - (void)processEvent:(struct mpv_event *)event
@@ -145,115 +124,10 @@ static void terminate_cocoa_application(void)
     [_eventsResponder queueCommand:cmd];
 }
 
-#define _R(P, T, E, K) \
-    { \
-        NSMenuItem *tmp = [self menuItemWithParent:(P) title:(T) \
-                                            action:nil keyEquivalent:(E)]; \
-        [self registerMenuItem:tmp forKey:(K)]; \
-    }
-
-- (NSMenu *)appleMenuWithMainMenu:(NSMenu *)mainMenu
-{
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Apple Menu"];
-    [self mainMenuItemWithParent:mainMenu child:menu];
-    [self menuItemWithParent:menu title:@"Hide mpv"
-                      action:@selector(hide:) keyEquivalent: @"h"];
-    [menu addItem:[NSMenuItem separatorItem]];
-    [self menuItemWithParent:menu title:@"Quit mpv"
-                      action:@selector(stopPlayback) keyEquivalent: @"q"];
-    return [menu autorelease];
-}
-
-- (NSMenu *)videoMenu
-{
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Video"];
-    _R(menu, @"Half Size",   @"0", MPM_H_SIZE)
-    _R(menu, @"Normal Size", @"1", MPM_N_SIZE)
-    _R(menu, @"Double Size", @"2", MPM_D_SIZE)
-    return [menu autorelease];
-}
-
-- (NSMenu *)windowMenu
-{
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Window"];
-    _R(menu, @"Minimize", @"m", MPM_MINIMIZE)
-    _R(menu, @"Zoom",     @"z", MPM_ZOOM)
-
-#if HAVE_MACOS_TOUCHBAR
-    if ([self respondsToSelector:@selector(touchBar)]) {
-        [menu addItem:[NSMenuItem separatorItem]];
-        [self menuItemWithParent:menu title:@"Customize Touch Bar…"
-                          action:@selector(toggleTouchBarMenu) keyEquivalent: @""];
-    }
-#endif
-
-    return [menu autorelease];
-}
-
-- (void)initialize_menu
-{
-    NSMenu *main_menu = [[NSMenu new] autorelease];
-    [NSApp setMainMenu:main_menu];
-    [NSApp setAppleMenu:[self appleMenuWithMainMenu:main_menu]];
-
-    [NSApp mainMenuItemWithParent:main_menu child:[self videoMenu]];
-    [NSApp mainMenuItemWithParent:main_menu child:[self windowMenu]];
-}
-
-#undef _R
-
-- (void)stopPlayback
-{
-    [self stopMPV:"quit"];
-}
-
-- (void)stopPlaybackAndRememberPosition
-{
-    [self stopMPV:"quit-watch-later"];
-}
-
 - (void)stopMPV:(char *)cmd
 {
     if (![_eventsResponder queueCommand:cmd])
         terminate_cocoa_application();
-}
-
-- (void)registerMenuItem:(NSMenuItem*)menuItem forKey:(MPMenuKey)key
-{
-    [self.menuItems setObject:menuItem forKey:[NSNumber numberWithInt:key]];
-}
-
-- (void)registerSelector:(SEL)action forKey:(MPMenuKey)key
-{
-    NSNumber *boxedKey = [NSNumber numberWithInt:key];
-    NSMenuItem *item   = [self.menuItems objectForKey:boxedKey];
-    if (item) {
-        [item setAction:action];
-    }
-}
-
-- (NSMenuItem *)menuItemWithParent:(NSMenu *)parent
-                             title:(NSString *)title
-                            action:(SEL)action
-                     keyEquivalent:(NSString*)key
-{
-
-    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title
-                                                  action:action
-                                           keyEquivalent:key];
-    [parent addItem:item];
-    return [item autorelease];
-}
-
-- (NSMenuItem *)mainMenuItemWithParent:(NSMenu *)parent
-                                 child:(NSMenu *)child
-{
-    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@""
-                                                  action:nil
-                                           keyEquivalent:@""];
-    [item setSubmenu:child];
-    [parent addItem:item];
-    return [item autorelease];
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
@@ -268,7 +142,7 @@ static void terminate_cocoa_application(void)
 - (void)handleQuitEvent:(NSAppleEventDescriptor *)event
          withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
-    [self stopPlayback];
+    [self stopMPV:"quit"];
 }
 
 - (void)getUrl:(NSAppleEventDescriptor *)event
@@ -325,14 +199,14 @@ static void *playback_thread(void *ctx_obj)
 void cocoa_register_menu_item_action(MPMenuKey key, void* action)
 {
     if (application_instantiated)
-        [NSApp registerSelector:(SEL)action forKey:key];
+        [[NSApp menuBar] registerSelector:(SEL)action forKey:key];
 }
 
 static void init_cocoa_application(bool regular)
 {
     NSApp = mpv_shared_app();
     [NSApp setDelegate:NSApp];
-    [NSApp initialize_menu];
+    [NSApp setMenuBar:[[MenuBar alloc] init]];
 
     // Will be set to Regular from cocoa_common during UI creation so that we
     // don't create an icon when playing audio only files.

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -66,7 +66,7 @@ static void terminate_cocoa_application(void)
 
 - (void)sendEvent:(NSEvent *)event
 {
-    if (![_eventsResponder processKeyEvent:event])
+    if ([self modalWindow] || ![_eventsResponder processKeyEvent:event])
         [super sendEvent:event];
     [_eventsResponder wakeup];
 }
@@ -166,6 +166,11 @@ static void terminate_cocoa_application(void)
         mpv_shared_app().openCount--;
         return;
     }
+    [self openFiles:filenames];
+}
+
+- (void)openFiles:(NSArray *)filenames
+{
     SEL cmpsel = @selector(localizedStandardCompare:);
     NSArray *files = [filenames sortedArrayUsingSelector:cmpsel];
     [_eventsResponder handleFilesArray:files];

--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -26,6 +26,7 @@ struct mpv_event;
 - (void)processEvent:(struct mpv_event *)event;
 - (void)queueCommand:(char *)cmd;
 - (void)stopMPV:(char *)cmd;
+- (void)openFiles:(NSArray *)filenames;
 
 @property(nonatomic, retain) MenuBar *menuBar;
 @property(nonatomic, retain) NSArray *files;

--- a/osdep/macosx_menubar.h
+++ b/osdep/macosx_menubar.h
@@ -15,19 +15,16 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#import <Cocoa/Cocoa.h>
-#include "osdep/macosx_application.h"
-#import "osdep/macosx_menubar_objc.h"
+#ifndef MPV_MACOSX_MENU
+#define MPV_MACOSX_MENU
 
-struct mpv_event;
+// Menu Keys identifing menu items
+typedef enum {
+    MPM_H_SIZE,
+    MPM_N_SIZE,
+    MPM_D_SIZE,
+    MPM_MINIMIZE,
+    MPM_ZOOM,
+} MPMenuKey;
 
-@interface Application : NSApplication
-
-- (void)processEvent:(struct mpv_event *)event;
-- (void)queueCommand:(char *)cmd;
-- (void)stopMPV:(char *)cmd;
-
-@property(nonatomic, retain) MenuBar *menuBar;
-@property(nonatomic, retain) NSArray *files;
-@property(nonatomic, assign) size_t openCount;
-@end
+#endif /* MPV_MACOSX_MENU */

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -16,131 +16,732 @@
  */
 
 #include "config.h"
+#include "common/common.h"
 
 #import "macosx_menubar_objc.h"
 #import "osdep/macosx_application_objc.h"
 
 @implementation MenuBar
-
-@synthesize menuItems = _menu_items;
+{
+    NSArray *menuTree;
+}
 
 - (id)init
 {
     if (self = [super init]) {
-        self.menuItems = [[[NSMutableDictionary alloc] init] autorelease];
+        NSUserDefaults *userDefaults =[NSUserDefaults standardUserDefaults];
+        [userDefaults setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
+        [userDefaults setBool:YES forKey:@"NSDisabledDictationMenuItem"];
+        [userDefaults setBool:YES forKey:@"NSDisabledCharacterPaletteMenuItem"];
 
-        NSMenu *main_menu = [[NSMenu new] autorelease];
-        [NSApp setMainMenu:main_menu];
-        [NSApp performSelector:@selector(setAppleMenu:)
-                    withObject:[self appleMenuWithMainMenu:main_menu]];
+        menuTree = @[
+            @{
+                @"name": @"Apple",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"About mpv",
+                        @"action"     : @"about",
+                        @"key"        : @"",
+                        @"target"     : self
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Preferences…",
+                        @"action"     : @"preferences:",
+                        @"key"        : @",",
+                        @"target"     : self,
+                        @"file"       : @"mpv.conf",
+                        @"alertTitle1": @"No Application found to open your config file.",
+                        @"alertText1" : @"Please open the mpv.conf file with "
+                                        "your preferred text editor in the now "
+                                        "open folder to edit your config.",
+                        @"alertTitle2": @"No config file found.",
+                        @"alertText2" : @"Please create a mpv.conf file with your "
+                                        "preferred text editor in the now open folder.",
+                        @"alertTitle3": @"No config path or file found.",
+                        @"alertText3" : @"Please create the following path ~/.config/mpv/ "
+                                        "and a mpv.conf file within with your preferred "
+                                        "text editor."
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Keyboard Shortcuts Config…",
+                        @"action"     : @"preferences:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"file"       : @"input.conf",
+                        @"alertTitle1": @"No Application found to open your config file.",
+                        @"alertText1" : @"Please open the input.conf file with "
+                                        "your preferred text editor in the now "
+                                        "open folder to edit your config.",
+                        @"alertTitle2": @"No config file found.",
+                        @"alertText2" : @"Please create a input.conf file with your "
+                                        "preferred text editor in the now open folder.",
+                        @"alertTitle3": @"No config path or file found.",
+                        @"alertText3" : @"Please create the following path ~/.config/mpv/ "
+                                        "and a input.conf file within with your preferred "
+                                        "text editor."
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Hide mpv",
+                        @"action"     : @"hide:",
+                        @"key"        : @"h",
+                        @"target"     : NSApp
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Quit and Remember Position",
+                        @"action"     : @"quit:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"quit-watch-later"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Quit mpv",
+                        @"action"     : @"quit:",
+                        @"key"        : @"q",
+                        @"target"     : self,
+                        @"cmd"        : @"quit"
+                    }]
+                ]
+            },
+            @{
+                @"name": @"File",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Open File…",
+                        @"action"     : @"openFile",
+                        @"key"        : @"o",
+                        @"target"     : self
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Open URL…",
+                        @"action"     : @"openURL",
+                        @"key"        : @"O",
+                        @"target"     : self
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Save Screenshot",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"async screenshot"
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Edit",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Undo",
+                        @"action"     : @"undo:",
+                        @"key"        : @"z"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Redo",
+                        @"action"     : @"redo:",
+                        @"key"        : @"Z"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Cut",
+                        @"action"     : @"cut:",
+                        @"key"        : @"x"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Copy",
+                        @"action"     : @"copy:",
+                        @"key"        : @"c"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Paste",
+                        @"action"     : @"paste:",
+                        @"key"        : @"v"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Select All",
+                        @"action"     : @"selectAll:",
+                        @"key"        : @"a"
+                    }]
+                ]
+            },
+            @{
+                @"name": @"View",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Fullscreen",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle fullscreen"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Float on Top",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle ontop"
+                    }],
+#if HAVE_MACOS_TOUCHBAR
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Customize Touch Bar…",
+                        @"action"     : @"toggleTouchBarCustomizationPalette:",
+                        @"key"        : @"",
+                        @"target"     : NSApp
+                    }]
+#endif
+                ]
+            },
+            @{
+                @"name": @"Video",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Zoom Out",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add panscan -0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Zoom In",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add panscan 0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Reset Zoom",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set panscan 0"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Aspect Ratio 4:3",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set video-aspect \"4:3\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Aspect Ratio 16:9",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set video-aspect \"16:9\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Aspect Ratio 1.85:1",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set video-aspect \"1.85:1\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Aspect Ratio 2.35:1",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set video-aspect \"2.35:1\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Reset Aspect Ratio",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set video-aspect \"-1\""
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Half Size",
+                        @"key"        : @"0",
+                        @"cmdSpecial" : [NSNumber numberWithInt:MPM_H_SIZE]
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Normal Size",
+                        @"key"        : @"1",
+                        @"cmdSpecial" : [NSNumber numberWithInt:MPM_N_SIZE]
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Double Size",
+                        @"key"        : @"2",
+                        @"cmdSpecial" : [NSNumber numberWithInt:MPM_D_SIZE]
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Audio",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Next Audio Track",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle audio"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Previous Audio Track",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle audio down"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Mute",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle mute"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Play Audio Later",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add audio-delay 0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Play Audio Earlier",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add audio-delay -0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Reset Audio Delay",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set audio-delay 0.0 "
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Subtitle",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Next Subtitle Track",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle sub"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Previous Subtitle Track",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle sub down"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Force Style",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle-values sub-ass-override \"force\" \"no\""
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Display Subtitles Later",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add sub-delay 0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Display Subtitles Earlier",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add sub-delay -0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Reset Subtitle Delay",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set sub-delay 0.0"
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Playback",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Pause",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle pause"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Increase Speed",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add speed 0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Decrease Speed",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add speed -0.1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Reset Speed",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"set speed 1.0"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Show Playlist",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"script-message osc-playlist"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Show Chapters",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"script-message osc-chapterlist"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Show Tracks",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"script-message osc-tracklist"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Next File",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"playlist-next"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Previous File",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"playlist-prev"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Loop File",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle-values loop-file \"inf\" \"no\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Toggle Loop Playlist",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"cycle-values loop-playlist \"inf\" \"no\""
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Shuffle",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"playlist-shuffle"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Next Chapter",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add chapter 1"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Previous Chapter",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"add chapter -1"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Step Forward",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"frame-step"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Step Backward",
+                        @"action"     : @"cmd:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"cmd"        : @"frame-back-step"
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Window",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Minimize",
+                        @"key"        : @"m",
+                        @"cmdSpecial" : [NSNumber numberWithInt:MPM_MINIMIZE]
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Zoom",
+                        @"key"        : @"z",
+                        @"cmdSpecial" : [NSNumber numberWithInt:MPM_ZOOM]
+                    }]
+                ]
+            },
+            @{
+                @"name": @"Help",
+                @"menu": @[
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"mpv Website…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://mpv.io"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"mpv on github…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://github.com/mpv-player/mpv"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Online Manual…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://mpv.io/manual/master/"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Online Wiki…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://github.com/mpv-player/mpv/wiki"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Release Notes…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://github.com/mpv-player/mpv/blob/master/RELEASE_NOTES"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Keyboard Shortcuts…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://github.com/mpv-player/mpv/blob/master/etc/input.conf"
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Report Issue…",
+                        @"action"     : @"url:",
+                        @"key"        : @"",
+                        @"target"     : self,
+                        @"url"        : @"https://github.com/mpv-player/mpv/issues/new"
+                    }]
+                ]
+            }
+        ];
 
-        [self mainMenuItemWithParent:main_menu child:[self videoMenu]];
-        [self mainMenuItemWithParent:main_menu child:[self windowMenu]];
+        [NSApp setMainMenu:[self mainMenu]];
     }
 
     return self;
 }
 
-- (NSMenu *)appleMenuWithMainMenu:(NSMenu *)mainMenu
+- (NSMenu *)mainMenu
 {
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Apple Menu"];
-    [self mainMenuItemWithParent:mainMenu child:menu];
-    [self menuItemWithParent:menu title:@"Hide mpv" action:@selector(hide:)
-                          keyEquivalent: @"h" target:NSApp];
-    [menu addItem:[NSMenuItem separatorItem]];
-    [self menuItemWithParent:menu title:@"Quit mpv" action:@selector(quit)
-                          keyEquivalent:@"q" target:self];
-    return [menu autorelease];
-}
+    NSMenu *mainMenu = [[NSMenu alloc] initWithTitle:@"MainMenu"];
 
-#define _R(P, T, E, K) \
-    { \
-        NSMenuItem *tmp = [self menuItemWithParent:(P) title:(T) \
-                                            action:nil keyEquivalent:(E) \
-                                            target:nil]; \
-        [self registerMenuItem:tmp forKey:(K)]; \
-    }
+    for(id mMenu in menuTree) {
+        NSMenu *menu = [[NSMenu alloc] initWithTitle:mMenu[@"name"]];
+        NSMenuItem *mItem = [mainMenu addItemWithTitle:mMenu[@"name"]
+                                                action:nil
+                                         keyEquivalent:@""];
+        [mainMenu setSubmenu:menu forItem:mItem];
 
-- (NSMenu *)videoMenu
-{
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Video"];
-    _R(menu, @"Half Size",   @"0", MPM_H_SIZE)
-    _R(menu, @"Normal Size", @"1", MPM_N_SIZE)
-    _R(menu, @"Double Size", @"2", MPM_D_SIZE)
-    return [menu autorelease];
-}
-
-- (NSMenu *)windowMenu
-{
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Window"];
-    _R(menu, @"Minimize", @"m", MPM_MINIMIZE)
-    _R(menu, @"Zoom",     @"z", MPM_ZOOM)
-
+        for(id subMenu in mMenu[@"menu"]) {
 #if HAVE_MACOS_TOUCHBAR
-    if ([NSApp respondsToSelector:@selector(touchBar)]) {
-        [menu addItem:[NSMenuItem separatorItem]];
-        [self menuItemWithParent:menu title:@"Customize Touch Bar…"
-                          action:@selector(toggleTouchBarMenu)
-                   keyEquivalent:@"" target:self];
-    }
+            if ([subMenu[@"action"] isEqual:@"toggleTouchBarCustomizationPalette:"]) {
+                if (![NSApp respondsToSelector:@selector(touchBar)])
+                    continue;
+            }
 #endif
+            if ([subMenu[@"name"] isEqual:@"separator"]) {
+                [menu addItem:[NSMenuItem separatorItem]];
+            } else {
+                NSMenuItem *iItem = [menu addItemWithTitle:subMenu[@"name"]
+                               action:NSSelectorFromString(subMenu[@"action"])
+                        keyEquivalent:subMenu[@"key"]];
+                [iItem setTarget:subMenu[@"target"]];
+                [subMenu setObject:iItem forKey:@"menuItem"];
+            }
+        }
+    }
 
-    return [menu autorelease];
+    return mainMenu;
 }
 
-#undef _R
-
-- (NSMenuItem *)mainMenuItemWithParent:(NSMenu *)parent
-                                 child:(NSMenu *)child
+- (void)about
 {
-    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@""
-                                                  action:nil
-                                           keyEquivalent:@""];
-    [item setSubmenu:child];
-    [parent addItem:item];
-    return [item autorelease];
+    NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
+        @"mpv", @"ApplicationName",
+        [self getMPVIcon], @"ApplicationIcon",
+         @"Copyright © 2000-2017 mpv/MPlayer/mplayer2 projects", @"Copyright",
+        [NSString stringWithUTF8String:mpv_version], @"ApplicationVersion",
+        nil];
+    [NSApp orderFrontStandardAboutPanelWithOptions:options];
 }
 
-- (NSMenuItem *)menuItemWithParent:(NSMenu *)parent
-                             title:(NSString *)title
-                            action:(SEL)action
-                     keyEquivalent:(NSString*)key
-                            target:(id)target
+- (void)preferences:(NSMenuItem *)menuItem
 {
+    NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSMutableDictionary *mItemDict = [self getDictFromMenuItem:menuItem];
+    NSArray *configPaths  = @[
+        [NSString stringWithFormat:@"%@/.mpv/", NSHomeDirectory()],
+        [NSString stringWithFormat:@"%@/.config/mpv/", NSHomeDirectory()]];
 
-    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title
-                                                  action:action
-                                           keyEquivalent:key];
-    if (target)
-        [item setTarget:target];
-    [parent addItem:item];
-    return [item autorelease];
+    for (id path in configPaths) {
+        NSString *fileP = [path stringByAppendingString:mItemDict[@"file"]];
+        if ([fileManager fileExistsAtPath:fileP]){
+            if ([workspace openFile:fileP])
+                return;
+            [workspace openFile:path];
+            [self alertWithTitle:mItemDict[@"alertTitle1"]
+                         andText:mItemDict[@"alertText1"]];
+            return;
+        }
+        if ([workspace openFile:path]) {
+            [self alertWithTitle:mItemDict[@"alertTitle2"]
+                         andText:mItemDict[@"alertText2"]];
+            return;
+        }
+    }
+
+    [self alertWithTitle:mItemDict[@"alertTitle3"]
+                 andText:mItemDict[@"alertText3"]];
 }
 
-- (void)registerMenuItem:(NSMenuItem*)menuItem forKey:(MPMenuKey)key
+- (void)quit:(NSMenuItem *)menuItem
 {
-    [self.menuItems setObject:menuItem forKey:[NSNumber numberWithInt:key]];
+    NSString *cmd = [self getDictFromMenuItem:menuItem][@"cmd"];
+    [(Application *)NSApp stopMPV:(char *)[cmd UTF8String]];
+}
+
+- (void)openFile
+{
+    NSOpenPanel *panel = [[NSOpenPanel alloc] init];
+    [panel setCanChooseDirectories:YES];
+    [panel setAllowsMultipleSelection:YES];
+
+    if ([panel runModal] == NSFileHandlingPanelOKButton){
+        NSMutableArray *fileArray = [[NSMutableArray alloc] init];
+        for (id url in [panel URLs])
+            [fileArray addObject:[url path]];
+        [(Application *)NSApp openFiles:fileArray];
+    }
+}
+
+- (void)openURL
+{
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Open URL"];
+    [alert addButtonWithTitle:@"Ok"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert setIcon:[self getMPVIcon]];
+
+    NSTextField *input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 300, 24)];
+    [input setPlaceholderString:@"URL"];
+    [alert setAccessoryView:input];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [input becomeFirstResponder];
+    });
+
+    if ([alert runModal] == NSAlertFirstButtonReturn && [input stringValue].length > 0) {
+        NSArray *url = [NSArray arrayWithObjects:[input stringValue], nil];
+        [(Application *)NSApp openFiles:url];
+    }
+}
+
+- (void)cmd:(NSMenuItem *)menuItem
+{
+    NSString *cmd = [self getDictFromMenuItem:menuItem][@"cmd"];
+    [(Application *)NSApp queueCommand:(char *)[cmd UTF8String]];
+}
+
+- (void)url:(NSMenuItem *)menuItem
+{
+    NSString *url = [self getDictFromMenuItem:menuItem][@"url"];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+}
+
+static const char macosx_icon[] =
+#include "osdep/macosx_icon.inc"
+;
+
+- (NSImage *)getMPVIcon
+{
+    NSData *icon_data = [NSData dataWithBytesNoCopy:(void *)macosx_icon
+                                             length:sizeof(macosx_icon)
+                                       freeWhenDone:NO];
+    return [[NSImage alloc] initWithData:icon_data];
+}
+
+- (void)alertWithTitle:(NSString *)title andText:(NSString *)text
+{
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:title];
+    [alert setInformativeText:text];
+    [alert addButtonWithTitle:@"Ok"];
+    [alert setIcon:[self getMPVIcon]];
+    [alert runModal];
+}
+
+- (NSMutableDictionary *)getDictFromMenuItem:(NSMenuItem *)menuItem
+{
+    for(id mMenu in menuTree) {
+        for(id subMenu in mMenu[@"menu"]) {
+            if([subMenu[@"menuItem"] isEqual:menuItem])
+                return subMenu;
+        }
+    }
+
+    return nil;
 }
 
 - (void)registerSelector:(SEL)action forKey:(MPMenuKey)key
 {
-    NSNumber *boxedKey = [NSNumber numberWithInt:key];
-    NSMenuItem *item   = [self.menuItems objectForKey:boxedKey];
-    if (item) {
-        [item setAction:action];
+    for(id mMenu in menuTree) {
+        for(id subMenu in mMenu[@"menu"]) {
+            if([subMenu[@"cmdSpecial"] isEqual:[NSNumber numberWithInt:key]]) {
+                [subMenu[@"menuItem"] setAction:action];
+                return;
+            }
+        }
     }
-}
-
-#if HAVE_MACOS_TOUCHBAR
-- (void)toggleTouchBarMenu
-{
-    [NSApp toggleTouchBarCustomizationPalette:self];
-}
-#endif
-
-- (void)quit
-{
-    [(Application *)NSApp stopMPV:"quit"];
 }
 
 @end

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -1,0 +1,146 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#import "macosx_menubar_objc.h"
+#import "osdep/macosx_application_objc.h"
+
+@implementation MenuBar
+
+@synthesize menuItems = _menu_items;
+
+- (id)init
+{
+    if (self = [super init]) {
+        self.menuItems = [[[NSMutableDictionary alloc] init] autorelease];
+
+        NSMenu *main_menu = [[NSMenu new] autorelease];
+        [NSApp setMainMenu:main_menu];
+        [NSApp performSelector:@selector(setAppleMenu:)
+                    withObject:[self appleMenuWithMainMenu:main_menu]];
+
+        [self mainMenuItemWithParent:main_menu child:[self videoMenu]];
+        [self mainMenuItemWithParent:main_menu child:[self windowMenu]];
+    }
+
+    return self;
+}
+
+- (NSMenu *)appleMenuWithMainMenu:(NSMenu *)mainMenu
+{
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Apple Menu"];
+    [self mainMenuItemWithParent:mainMenu child:menu];
+    [self menuItemWithParent:menu title:@"Hide mpv" action:@selector(hide:)
+                          keyEquivalent: @"h" target:NSApp];
+    [menu addItem:[NSMenuItem separatorItem]];
+    [self menuItemWithParent:menu title:@"Quit mpv" action:@selector(quit)
+                          keyEquivalent:@"q" target:self];
+    return [menu autorelease];
+}
+
+#define _R(P, T, E, K) \
+    { \
+        NSMenuItem *tmp = [self menuItemWithParent:(P) title:(T) \
+                                            action:nil keyEquivalent:(E) \
+                                            target:nil]; \
+        [self registerMenuItem:tmp forKey:(K)]; \
+    }
+
+- (NSMenu *)videoMenu
+{
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Video"];
+    _R(menu, @"Half Size",   @"0", MPM_H_SIZE)
+    _R(menu, @"Normal Size", @"1", MPM_N_SIZE)
+    _R(menu, @"Double Size", @"2", MPM_D_SIZE)
+    return [menu autorelease];
+}
+
+- (NSMenu *)windowMenu
+{
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Window"];
+    _R(menu, @"Minimize", @"m", MPM_MINIMIZE)
+    _R(menu, @"Zoom",     @"z", MPM_ZOOM)
+
+#if HAVE_MACOS_TOUCHBAR
+    if ([NSApp respondsToSelector:@selector(touchBar)]) {
+        [menu addItem:[NSMenuItem separatorItem]];
+        [self menuItemWithParent:menu title:@"Customize Touch Bar…"
+                          action:@selector(toggleTouchBarMenu)
+                   keyEquivalent:@"" target:self];
+    }
+#endif
+
+    return [menu autorelease];
+}
+
+#undef _R
+
+- (NSMenuItem *)mainMenuItemWithParent:(NSMenu *)parent
+                                 child:(NSMenu *)child
+{
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@""
+                                                  action:nil
+                                           keyEquivalent:@""];
+    [item setSubmenu:child];
+    [parent addItem:item];
+    return [item autorelease];
+}
+
+- (NSMenuItem *)menuItemWithParent:(NSMenu *)parent
+                             title:(NSString *)title
+                            action:(SEL)action
+                     keyEquivalent:(NSString*)key
+                            target:(id)target
+{
+
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title
+                                                  action:action
+                                           keyEquivalent:key];
+    if (target)
+        [item setTarget:target];
+    [parent addItem:item];
+    return [item autorelease];
+}
+
+- (void)registerMenuItem:(NSMenuItem*)menuItem forKey:(MPMenuKey)key
+{
+    [self.menuItems setObject:menuItem forKey:[NSNumber numberWithInt:key]];
+}
+
+- (void)registerSelector:(SEL)action forKey:(MPMenuKey)key
+{
+    NSNumber *boxedKey = [NSNumber numberWithInt:key];
+    NSMenuItem *item   = [self.menuItems objectForKey:boxedKey];
+    if (item) {
+        [item setAction:action];
+    }
+}
+
+#if HAVE_MACOS_TOUCHBAR
+- (void)toggleTouchBarMenu
+{
+    [NSApp toggleTouchBarCustomizationPalette:self];
+}
+#endif
+
+- (void)quit
+{
+    [(Application *)NSApp stopMPV:"quit"];
+}
+
+@end

--- a/osdep/macosx_menubar_objc.h
+++ b/osdep/macosx_menubar_objc.h
@@ -22,6 +22,4 @@
 
 - (void)registerSelector:(SEL)action forKey:(MPMenuKey)key;
 
-@property(nonatomic, retain) NSMutableDictionary *menuItems;
-
 @end

--- a/osdep/macosx_menubar_objc.h
+++ b/osdep/macosx_menubar_objc.h
@@ -16,18 +16,12 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#include "osdep/macosx_application.h"
-#import "osdep/macosx_menubar_objc.h"
+#include "osdep/macosx_menubar.h"
 
-struct mpv_event;
+@interface MenuBar : NSObject
 
-@interface Application : NSApplication
+- (void)registerSelector:(SEL)action forKey:(MPMenuKey)key;
 
-- (void)processEvent:(struct mpv_event *)event;
-- (void)queueCommand:(char *)cmd;
-- (void)stopMPV:(char *)cmd;
+@property(nonatomic, retain) NSMutableDictionary *menuItems;
 
-@property(nonatomic, retain) MenuBar *menuBar;
-@property(nonatomic, retain) NSArray *files;
-@property(nonatomic, assign) size_t openCount;
 @end

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -457,6 +457,7 @@ def build(ctx):
         ( "osdep/ar/HIDRemote.m",                "apple-remote" ),
         ( "osdep/macosx_application.m",          "cocoa" ),
         ( "osdep/macosx_events.m",               "cocoa" ),
+        ( "osdep/macosx_menubar.m",              "cocoa" ),
         ( "osdep/macosx_touchbar.m",             "macos-touchbar" ),
         ( "osdep/semaphore_osx.c" ),
         ( "osdep/subprocess.c" ),


### PR DESCRIPTION
yeah this is just some eye candy because i felt like doing something simple. i put all the menubar related code into its own file since it would just mess up the application file.

in general this should make the life of unexperienced macOS users easier. i put things into the menu which i thought were commonly used, but feel free to suggest other functions you think should be added. i mostly didn't add any shortcuts (yet), though this can be discussed here too.

the "Preferences" menu item just opens the config file from two predefined locations in TextEdit. if no config file is found an alert is shown which asked the user to create one. this could probably improved.

the "Open File" menu item opens the usual open file dialog from macOS. it can open multiple files and folders.

the "Manual" menu item under Help opens the manual on mpv.io.

most useful feature is probably the Search in the help menu.

see below how the new menu looks like.
![1](https://user-images.githubusercontent.com/680386/28748035-7e33bb8c-74ad-11e7-9f38-b1f478cb9bc5.png)
![2](https://user-images.githubusercontent.com/680386/28748038-7e37c16e-74ad-11e7-98be-c5d4f8891748.png)
![3](https://user-images.githubusercontent.com/680386/28748036-7e33d798-74ad-11e7-8007-2b965462fa6a.png)
![4](https://user-images.githubusercontent.com/680386/28748037-7e3600e0-74ad-11e7-8743-d7673396b680.png)
![5](https://user-images.githubusercontent.com/680386/28748034-7e2fa60a-74ad-11e7-8d47-f6a53c0bb544.png)
![6](https://user-images.githubusercontent.com/680386/28748033-7e2f11a4-74ad-11e7-8146-ca8f3c73e783.png)
![7](https://user-images.githubusercontent.com/680386/28748039-7e49db6a-74ad-11e7-8f60-6de7f4657b0c.png)
![8](https://user-images.githubusercontent.com/680386/28748040-7e4c62c2-74ad-11e7-9acd-ade690a5a269.png)
![9](https://user-images.githubusercontent.com/680386/28748041-7e4db92e-74ad-11e7-9c85-dc4f270c222c.png)
![10](https://user-images.githubusercontent.com/680386/28748042-7e50f8be-74ad-11e7-8967-ba83cdf969ae.png)
![about](https://user-images.githubusercontent.com/680386/28748043-7e514d5a-74ad-11e7-8ac8-85d4d827271c.png)