### PR TITLE
vo_opengl: make compute shaders more flexible

### DIFF
--- a/video/out/opengl/user_shaders.c
+++ b/video/out/opengl/user_shaders.c
@@ -259,7 +259,14 @@ static bool parse_hook(struct mp_log *log, struct bstr *body,
         }
 
         if (bstr_eatstart0(&line, "COMPUTE")) {
-            if (bstr_sscanf(line, "%d %d", &out->compute_w, &out->compute_h) != 2) {
+            struct compute_info *ci = &out->compute;
+            int num = bstr_sscanf(line, "%d %d %d %d", &ci->block_w, &ci->block_h,
+                                  &ci->threads_w, &ci->threads_h);
+
+            if (num == 2 || num == 4) {
+                ci->active = true;
+                ci->directly_writes = true;
+            } else {
                 mp_err(log, "Error while parsing COMPUTE!\n");
                 return false;
             }

--- a/video/out/opengl/user_shaders.h
+++ b/video/out/opengl/user_shaders.h
@@ -55,6 +55,13 @@ struct szexp {
     } val;
 };
 
+struct compute_info {
+    bool active;
+    int block_w, block_h;     // Block size (each block corresponds to one WG)
+    int threads_w, threads_h; // How many threads form a working group
+    bool directly_writes;     // If true, shader is assumed to imageStore(out_image)
+};
+
 struct gl_user_shader_hook {
     struct bstr pass_desc;
     struct bstr hook_tex[SHADER_MAX_HOOKS];
@@ -66,8 +73,7 @@ struct gl_user_shader_hook {
     struct szexp height[MAX_SZEXP_SIZE];
     struct szexp cond[MAX_SZEXP_SIZE];
     int components;
-    int compute_w;
-    int compute_h;
+    struct compute_info compute;
 };
 
 struct gl_user_shader_tex {

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -768,8 +768,8 @@ static const char *mp_image2D_type(GLenum access)
     }
 }
 
-void gl_sc_uniform_image2D(struct gl_shader_cache *sc, char *name, GLuint texture,
-                           GLuint iformat, GLenum access)
+void gl_sc_uniform_image2D(struct gl_shader_cache *sc, const char *name,
+                           GLuint texture, GLuint iformat, GLenum access)
 {
     gl_sc_enable_extension(sc, "GL_ARB_shader_image_load_store");
 

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -150,8 +150,8 @@ void gl_sc_uniform_tex(struct gl_shader_cache *sc, char *name, GLenum target,
 void gl_sc_uniform_texture(struct gl_shader_cache *sc, char *name,
                            struct ra_tex *tex);
 void gl_sc_uniform_tex_ui(struct gl_shader_cache *sc, char *name, GLuint texture);
-void gl_sc_uniform_image2D(struct gl_shader_cache *sc, char *name, GLuint texture,
-                           GLuint iformat, GLenum access);
+void gl_sc_uniform_image2D(struct gl_shader_cache *sc, const char *name,
+                           GLuint texture, GLuint iformat, GLenum access);
 void gl_sc_ssbo(struct gl_shader_cache *sc, char *name, GLuint ssbo,
                 char *format, ...) PRINTF_ATTRIBUTE(4, 5);
 void gl_sc_uniform_f(struct gl_shader_cache *sc, char *name, GLfloat f);


### PR DESCRIPTION
This allows users to do their own custom sample writing, mainly meant to
address use cases such as RAVU. Also clean up the compute shader code a
bit.