### PR TITLE
Add support for loading *.txt subtitles

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -34,7 +34,7 @@
 
 static const char *const sub_exts[] = {"utf", "utf8", "utf-8", "idx", "sub",
                                        "srt", "rt", "ssa", "ass", "mks", "vtt",
-                                       "sup", "scc",
+                                       "sup", "scc", "txt"
                                        NULL};
 
 static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",


### PR DESCRIPTION
Please add txt file extension as subtitle file format as it is the most popular subtitle file extension in Poland (I don't know how about other countries/languages).

I agree that my changes can be relicensed to LGPL 2.1 or later.
