### PR TITLE
vo_opengl: implement rudimentary support for 360° video

### DIFF
--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -403,6 +403,7 @@ const struct m_sub_options gl_video_conf = {
         OPT_FLAG("deband", deband, 0),
         OPT_SUBSTRUCT("deband", deband_opts, deband_conf, 0),
         OPT_FLOAT("sharpen", unsharp, 0),
+        OPT_FLAG("un360", un360, 0),
         OPT_INTRANGE("opengl-tex-pad-x", tex_pad_x, 0, 0, 4096),
         OPT_INTRANGE("opengl-tex-pad-y", tex_pad_y, 0, 0, 4096),
         OPT_SUBSTRUCT("", icc_opts, mp_icc_conf, 0),
@@ -1812,6 +1813,14 @@ static void unsharp_hook(struct gl_video *p, struct img_tex tex,
     pass_sample_unsharp(p->sc, p->opts.unsharp);
 }
 
+static void un360_hook(struct gl_video *p, struct img_tex text,
+                       struct gl_transform *trans, void *priv)
+{
+    pass_describe(p, "project equirectangular video");
+    GLSLF("#define M_PI 3.1415926535897932384626433832795\n");
+    pass_sample_un360(p->sc);
+}
+
 struct szexp_ctx {
     struct gl_video *p;
     struct img_tex tex;
@@ -1962,6 +1971,14 @@ static void gl_video_setup_hooks(struct gl_video *p)
             .hook_tex = {"MAIN"},
             .bind_tex = {"HOOKED"},
             .hook = unsharp_hook,
+        });
+    }
+
+    if (p->opts.un360) {
+        add_hook(p, (struct tex_hook) {
+            .hook_tex = {"MAINPRESUB"},
+            .bind_tex = {"HOOKED"},
+            .hook = un360_hook,
         });
     }
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1817,7 +1817,6 @@ static void un360_hook(struct gl_video *p, struct img_tex text,
                        struct gl_transform *trans, void *priv)
 {
     pass_describe(p, "project equirectangular video");
-    GLSLF("#define M_PI 3.1415926535897932384626433832795\n");
     pass_sample_un360(p->sc);
 }
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -1817,7 +1817,9 @@ static void un360_hook(struct gl_video *p, struct img_tex text,
                        struct gl_transform *trans, void *priv)
 {
     pass_describe(p, "project equirectangular video");
-    pass_sample_un360(p->sc);
+    float w = p->dst_rect.x1 - p->dst_rect.x0;
+    float h = p->dst_rect.y1 - p->dst_rect.y0;
+    pass_sample_un360(p->sc, w, h);
 }
 
 struct szexp_ctx {

--- a/video/out/opengl/video.h
+++ b/video/out/opengl/video.h
@@ -138,6 +138,7 @@ struct gl_video_opts {
     int deband;
     struct deband_opts *deband_opts;
     float unsharp;
+    int un360;
     int tex_pad_x, tex_pad_y;
     struct mp_icc_opts *icc_opts;
     int early_flush;

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -877,15 +877,18 @@ void pass_sample_un360(struct gl_shader_cache *sc, float w, float h) {
     float fov = M_PI/2;
     float yaw = M_PI*1;
     float pitch = M_PI/2*0;
+    float roll = M_PI/2*0;
 
     GLSLF("{\n");
     float t = tan(fov/2);
     float c = cos(pitch);
     float s = sin(pitch);
     float r = h/w;
-    float m[3][3] = {{2*t,        0,      0},
-                     {  0, 2*t*r*c, 2*t*r*s},
-                     { -t,-t*r*c-s,-t*r*s+c}};
+    float sR = sin(roll);
+    float cR = cos(roll);
+    float m[3][3] = {{      2*cR*t,       -2*sR*t*c,       -2*sR*t*s},
+                     {    2*sR*t*r,      2*cR*t*c*r,      2*cR*t*s*r},
+                     {-t*(cR+sR*r), t*c*(sR-cR*r)-s, t*s*(sR-cR*r)+c}};
     gl_sc_uniform_mat3(sc, "m", true, &m[0][0]);
     gl_sc_uniform_f(sc, "yaw", yaw);
 

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -875,17 +875,17 @@ void pass_sample_unsharp(struct gl_shader_cache *sc, float param) {
 
 void pass_sample_un360(struct gl_shader_cache *sc) {
     GLSLF("{\n");
-    GLSL(float fov = M_PI/2;)
-    GLSL(float theta0 = M_PI;)
-    GLSL(float phi0 = M_PI/2;)
-    GLSL(float focal_x = .5/tan(fov/2);)
-    GLSL(float focal_y = .5/tan(fov/4);)
+    gl_sc_uniform_f(sc, "fov", M_PI/2);
+    gl_sc_uniform_f(sc, "theta0", M_PI);
+    gl_sc_uniform_f(sc, "phi0", M_PI/2);
 
+    GLSL(const float focal_x = .5/tan(fov/2);)
+    GLSL(const float focal_y = .5/tan(fov/4);)
     GLSL(float theta = atan(HOOKED_pos.x-.5, focal_x);)
     GLSL(float phi = atan(HOOKED_pos.y-.5, focal_y);)
-    GLSL(float x = (theta+theta0)/(2*M_PI);)
+    GLSLF("float x = (theta+theta0)/%f;\n", 2*M_PI);
     GLSL(if (x < 0 || x > 1) x -= floor(x);)
-    GLSL(float y = (phi+phi0)/M_PI;)
+    GLSLF("float y = (phi+phi0)/%f;\n", M_PI);
     GLSL(if (y < 0) color = HOOKED_tex(vec2(x+.5-round(x),-y));)
     GLSL(else if (y > 1) color = HOOKED_tex(vec2(x+.5-round(x),2-y));)
     GLSL(else color = HOOKED_tex(vec2(x,y));)

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -875,27 +875,27 @@ void pass_sample_unsharp(struct gl_shader_cache *sc, float param) {
 
 void pass_sample_un360(struct gl_shader_cache *sc, float w, float h) {
     float fov = M_PI/2;
-    float theta0 = M_PI;
-    float phi0 = M_PI/2*0;
+    float yaw = M_PI*1;
+    float pitch = M_PI/2*0;
 
     GLSLF("{\n");
     float t = tan(fov/2);
-    float c = cos(phi0);
-    float s = sin(phi0);
+    float c = cos(pitch);
+    float s = sin(pitch);
     float r = h/w;
     float m[3][3] = {{2*t,        0,      0},
                      {  0, 2*t*r*c, 2*t*r*s},
                      { -t,-t*r*c-s,-t*r*s+c}};
     gl_sc_uniform_mat3(sc, "m", true, &m[0][0]);
-    gl_sc_uniform_f(sc, "theta0", theta0);
+    gl_sc_uniform_f(sc, "yaw", yaw);
 
     GLSL(vec3 p = vec3(HOOKED_pos, 1.0) * m;)
 
     GLSL(float theta = atan(p.x, p.z);)
     GLSL(float phi = atan(p.y, length(p.xz));)
 
-    GLSLF("p.x = fract(%f * (theta + theta0));\n", 1.0 / (2 * M_PI));
-    GLSLF("p.y = %f * (phi + %f);\n", 1.0 / M_PI, M_PI / 2.0);
+    GLSLF("p.x = fract(%f * (theta + yaw));\n", 1.0 / (2 * M_PI));
+    GLSLF("p.y = .5 + %f * phi;\n", 1.0 / M_PI);
     GLSL(color = HOOKED_tex(p.xy);)
     GLSLF("}\n");
 }

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -872,3 +872,22 @@ void pass_sample_unsharp(struct gl_shader_cache *sc, float param) {
     GLSLF("color = p + t * %f;\n", param);
     GLSLF("}\n");
 }
+
+void pass_sample_un360(struct gl_shader_cache *sc) {
+    GLSLF("{\n");
+    GLSL(float fov = M_PI/2;)
+    GLSL(float theta0 = M_PI;)
+    GLSL(float phi0 = M_PI/2;)
+    GLSL(float focal_x = .5/tan(fov/2);)
+    GLSL(float focal_y = .5/tan(fov/4);)
+
+    GLSL(float theta = atan(HOOKED_pos.x-.5, focal_x);)
+    GLSL(float phi = atan(HOOKED_pos.y-.5, focal_y);)
+    GLSL(float x = (theta+theta0)/(2*M_PI);)
+    GLSL(if (x < 0 || x > 1) x -= floor(x);)
+    GLSL(float y = (phi+phi0)/M_PI;)
+    GLSL(if (y < 0) color = HOOKED_tex(vec2(x+.5-round(x),-y));)
+    GLSL(else if (y > 1) color = HOOKED_tex(vec2(x+.5-round(x),2-y));)
+    GLSL(else color = HOOKED_tex(vec2(x,y));)
+    GLSLF("}\n");
+}

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -52,5 +52,6 @@ void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
                         AVLFG *lfg);
 
 void pass_sample_unsharp(struct gl_shader_cache *sc, float param);
+void pass_sample_un360(struct gl_shader_cache *sc);
 
 #endif

--- a/video/out/opengl/video_shaders.h
+++ b/video/out/opengl/video_shaders.h
@@ -52,6 +52,6 @@ void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
                         AVLFG *lfg);
 
 void pass_sample_unsharp(struct gl_shader_cache *sc, float param);
-void pass_sample_un360(struct gl_shader_cache *sc);
+void pass_sample_un360(struct gl_shader_cache *sc, float w, float h);
 
 #endif


### PR DESCRIPTION
Implements the user shader I shared in https://github.com/mpv-player/mpv/issues/2280 and can be extended upon to make the view changeable during runtime.

I agree that my changes can be relicensed to LGPL 2.1 or later.
