### PR TITLE
vo_opengl: move tex_upload abstraction to ra.c

### DIFF
--- a/video/out/opengl/osd.h
+++ b/video/out/opengl/osd.h
@@ -9,7 +9,7 @@
 #include "sub/osd.h"
 
 struct mpgl_osd *mpgl_osd_init(struct ra *ra, struct mp_log *log,
-                               struct osd_state *osd, bool want_pbo);
+                               struct osd_state *osd);
 void mpgl_osd_destroy(struct mpgl_osd *ctx);
 
 void mpgl_osd_generate(struct mpgl_osd *ctx, struct mp_osd_res res, double pts,

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -30,6 +30,11 @@ struct ra {
     // formats should have a lower index. (E.g. GLES3 should put rg8 before la.)
     struct ra_format **formats;
     int num_formats;
+
+    // Accelerate texture uploads via an extra PBO even when
+    // RA_CAP_DIRECT_UPLOAD is supported. This is basically only relevant for
+    // OpenGL. Set by the RA user.
+    bool use_pbo;
 };
 
 enum {

--- a/video/out/opengl/utils.h
+++ b/video/out/opengl/utils.h
@@ -69,6 +69,25 @@ struct fbodst {
 
 void gl_transform_ortho_fbodst(struct gl_transform *t, struct fbodst fbo);
 
+// A pool of buffers, which can grow as needed
+struct ra_buf_pool {
+    struct ra_buf_params current_params;
+    struct ra_buf **buffers;
+    int num_buffers;
+    int index;
+};
+
+void ra_buf_pool_uninit(struct ra *ra, struct ra_buf_pool *pool);
+
+// Note: params->initial_data is *not* supported
+struct ra_buf *ra_buf_pool_get(struct ra *ra, struct ra_buf_pool *pool,
+                               const struct ra_buf_params *params);
+
+// Helper that wraps ra_tex_upload using texture upload buffers to ensure that
+// params->buf is always set. This is intended for RA-internal usage.
+bool ra_tex_upload_pbo(struct ra *ra, struct ra_buf_pool *pbo,
+                       const struct ra_tex_upload_params *params);
+
 struct fbotex {
     struct ra *ra;
     struct ra_tex *tex;
@@ -82,21 +101,6 @@ bool fbotex_change(struct fbotex *fbo, struct ra *ra, struct mp_log *log,
 #define FBOTEX_FUZZY_W 1
 #define FBOTEX_FUZZY_H 2
 #define FBOTEX_FUZZY (FBOTEX_FUZZY_W | FBOTEX_FUZZY_H)
-
-#define NUM_PBO_BUFFERS 3
-
-// A wrapper around tex_upload that uses PBOs internally if requested or
-// required
-struct tex_upload {
-    size_t buffer_size;
-    struct ra_buf *buffers[NUM_PBO_BUFFERS];
-    int index;
-};
-
-bool tex_upload(struct ra *ra, struct tex_upload *pbo, bool want_pbo,
-                const struct ra_tex_upload_params *params);
-
-void tex_upload_uninit(struct ra *ra, struct tex_upload *pbo);
 
 // A wrapper around ra_timer that does result pooling, averaging etc.
 struct timer_pool;


### PR DESCRIPTION
This way, users of RA don't have to keep track of the boilerplate; it's
implicitly part of `struct ra` / `struct ra_tex` and the new function
`ra_tex_upload`.

Another approach would be to remove RA_CAP_DIRECT_UPLOAD and make this
function internal / called by each RA implementation as needed, but I
think we should move as much complexity out of the ra implementation and
into abstract code if we can.

As an aside, this also lets us more accurately determine whether or not
PBO upload is active.