### PR TITLE
Fix missing config.h in mp_image.c

### DIFF
--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -463,7 +463,6 @@ static bool test_conversion(int in, int out)
 
 static int control(struct vf_instance *vf, int request, void* data)
 {
-    struct vf_priv_s *p = vf->priv;
     switch (request){
     case VFCTRL_SEEK_RESET:
         flush_frames(vf);

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -30,6 +30,7 @@
 
 #include "mpv_talloc.h"
 
+#include "config.h"
 #include "common/common.h"
 #include "mp_image.h"
 #include "sws_utils.h"


### PR DESCRIPTION
Introduced in 8f2ccba71bb4. Also silence an unused variable warning that was introduced in the same commit.