### PR TITLE
(WIP) add support for UBOs and use them where required/available

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -352,6 +352,11 @@ static const struct gl_functions gl_functions[] = {
         },
     },
     {
+        .ver_core = 310,
+        .extension = "GL_ARB_uniform_buffer_object",
+        .provides = MPGL_CAP_UBO,
+    },
+    {
         .ver_core = 430,
         .extension = "GL_ARB_shader_storage_buffer_object",
         .provides = MPGL_CAP_SSBO,

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -628,7 +628,7 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
         if (shader && sscanf(shader, "%d.%d", &glsl_major, &glsl_minor) == 2)
             gl->glsl_version = glsl_major * 100 + glsl_minor;
         // restrict GLSL version to be forwards compatible
-        gl->glsl_version = MPMIN(gl->glsl_version, 430);
+        gl->glsl_version = MPMIN(gl->glsl_version, 440);
     }
 
     if (is_software_gl(gl)) {

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -54,9 +54,10 @@ enum {
     MPGL_CAP_EXT16              = (1 << 18),    // GL_EXT_texture_norm16
     MPGL_CAP_ARB_FLOAT          = (1 << 19),    // GL_ARB_texture_float
     MPGL_CAP_EXT_CR_HFLOAT      = (1 << 20),    // GL_EXT_color_buffer_half_float
-    MPGL_CAP_SSBO               = (1 << 21),    // GL_ARB_shader_storage_buffer_object
-    MPGL_CAP_COMPUTE_SHADER     = (1 << 22),    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
-    MPGL_CAP_NESTED_ARRAY       = (1 << 23),    // GL_ARB_arrays_of_arrays
+    MPGL_CAP_UBO                = (1 << 21),    // GL_ARB_uniform_buffer_object
+    MPGL_CAP_SSBO               = (1 << 22),    // GL_ARB_shader_storage_buffer_object
+    MPGL_CAP_COMPUTE_SHADER     = (1 << 23),    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
+    MPGL_CAP_NESTED_ARRAY       = (1 << 24),    // GL_ARB_arrays_of_arrays
 
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };

--- a/video/out/opengl/gl_utils.c
+++ b/video/out/opengl/gl_utils.c
@@ -156,7 +156,7 @@ static void gl_vao_enable_attribs(struct gl_vao *vao)
 
         gl->EnableVertexAttribArray(n);
         gl->VertexAttribPointer(n, e->dim_v, type, normalized,
-                                vao->stride, (void *)(intptr_t)e->binding);
+                                vao->stride, (void *)(intptr_t)e->offset);
     }
 }
 

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -182,6 +182,7 @@ struct ra_renderpass_input {
     int dim_v;              // vector dimension (1 for non-vector and non-matrix)
     int dim_m;              // additional matrix dimension (dim_v x dim_m)
     // Vertex data: byte offset of the attribute into the vertex struct
+    size_t offset;
     // RA_VARTYPE_TEX: texture unit
     // RA_VARTYPE_IMG_W: image unit
     // RA_VARTYPE_BUF_* buffer binding point

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -43,9 +43,10 @@ enum {
     RA_CAP_BLIT           = 1 << 2, // supports ra_fns.blit
     RA_CAP_COMPUTE        = 1 << 3, // supports compute shaders
     RA_CAP_DIRECT_UPLOAD  = 1 << 4, // supports tex_upload without ra_buf
-    RA_CAP_BUF_RW         = 1 << 5, // supports RA_VARTYPE_BUF_RW
-    RA_CAP_NESTED_ARRAY   = 1 << 6, // supports nested arrays
-    RA_CAP_SHARED_BINDING = 1 << 7, // sampler/image/buffer namespaces are disjoint
+    RA_CAP_BUF_RO         = 1 << 5, // supports RA_VARTYPE_BUF_RO
+    RA_CAP_BUF_RW         = 1 << 6, // supports RA_VARTYPE_BUF_RW
+    RA_CAP_NESTED_ARRAY   = 1 << 7, // supports nested arrays
+    RA_CAP_SHARED_BINDING = 1 << 8, // sampler/image/buffer namespaces are disjoint
 };
 
 enum ra_ctype {
@@ -140,8 +141,9 @@ struct ra_tex_upload_params {
 // operation, although it shouldn't technically prohibit anything
 enum ra_buf_type {
     RA_BUF_TYPE_INVALID,
-    RA_BUF_TYPE_TEX_UPLOAD, // texture upload buffer (pixel buffer object)
-    RA_BUF_TYPE_SHADER_STORAGE // shader buffer, used for RA_VARTYPE_BUF_RW
+    RA_BUF_TYPE_TEX_UPLOAD,     // texture upload buffer (pixel buffer object)
+    RA_BUF_TYPE_SHADER_STORAGE, // shader buffer (SSBO), for RA_VARTYPE_BUF_RW
+    RA_BUF_TYPE_UNIFORM,        // uniform buffer (UBO), for RA_VARTYPE_BUF_RO
 };
 
 struct ra_buf_params {
@@ -175,7 +177,10 @@ enum ra_vartype {
                                 // write-only (W) image for compute shaders
                                 // ra_tex.params.storage_dst must be true
     RA_VARTYPE_BYTE_UNORM,      // C: uint8_t, GLSL: int, vec* (vertex data only)
-    RA_VARTYPE_BUF_RW,          // C: ra_buf*, GLSL: buffer block
+    RA_VARTYPE_BUF_RO,          // C: ra_buf*, GLSL: uniform buffer block
+                                // buf type must be RA_BUF_TYPE_UNIFORM
+    RA_VARTYPE_BUF_RW,          // C: ra_buf*, GLSL: shader storage buffer block
+                                // buf type must be RA_BUF_TYPE_SHADER_STORAGE
     RA_VARTYPE_COUNT
 };
 

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -47,6 +47,7 @@ enum {
     RA_CAP_BUF_RW         = 1 << 6, // supports RA_VARTYPE_BUF_RW
     RA_CAP_NESTED_ARRAY   = 1 << 7, // supports nested arrays
     RA_CAP_SHARED_BINDING = 1 << 8, // sampler/image/buffer namespaces are disjoint
+    RA_CAP_GLOBAL_UNIFORM = 1 << 9, // supports using "naked" uniforms (not UBO)
 };
 
 enum ra_ctype {

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -90,6 +90,7 @@ struct ra_tex_params {
     const struct ra_format *format;
     bool render_src;        // must be useable as source texture in a shader
     bool render_dst;        // must be useable as target texture in a shader
+    bool storage_dst;       // must be usable as a storage image (RA_VARTYPE_IMG_W)
     bool blit_src;          // must be usable as a blit source
     bool blit_dst;          // must be usable as a blit destination
     bool host_mutable;      // texture may be updated with tex_upload
@@ -170,6 +171,7 @@ enum ra_vartype {
                                 // ra_tex.params.render_src must be true
     RA_VARTYPE_IMG_W,           // C: ra_tex*, GLSL: various image types
                                 // write-only (W) image for compute shaders
+                                // ra_tex.params.storage_dst must be true
     RA_VARTYPE_BYTE_UNORM,      // C: uint8_t, GLSL: int, vec* (vertex data only)
     RA_VARTYPE_BUF_RW,          // C: ra_buf*, GLSL: buffer block
 };

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -45,6 +45,7 @@ enum {
     RA_CAP_DIRECT_UPLOAD  = 1 << 4, // supports tex_upload without ra_buf
     RA_CAP_BUF_RW         = 1 << 5, // supports RA_VARTYPE_BUF_RW
     RA_CAP_NESTED_ARRAY   = 1 << 6, // supports nested arrays
+    RA_CAP_SHARED_BINDING = 1 << 7, // sampler/image/buffer namespaces are disjoint
 };
 
 enum ra_ctype {
@@ -174,6 +175,7 @@ enum ra_vartype {
                                 // ra_tex.params.storage_dst must be true
     RA_VARTYPE_BYTE_UNORM,      // C: uint8_t, GLSL: int, vec* (vertex data only)
     RA_VARTYPE_BUF_RW,          // C: ra_buf*, GLSL: buffer block
+    RA_VARTYPE_COUNT
 };
 
 // Represents a uniform, texture input parameter, and similar things.
@@ -189,6 +191,8 @@ struct ra_renderpass_input {
     // RA_VARTYPE_IMG_W: image unit
     // RA_VARTYPE_BUF_* buffer binding point
     // Other uniforms: unused
+    // If RA_CAP_SHARED_BINDING is set, these may only be unique per input type.
+    // Otherwise, these must be unique for all input values.
     int binding;
 };
 

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -128,7 +128,8 @@ struct ra_tex_upload_params {
     // Uploading from buffer:
     struct ra_buf *buf; // Buffer to upload from (mutually exclusive with `src`)
     size_t buf_offset;  // Start of data within buffer (bytes)
-    // Uploading directly: (requires RA_CAP_DIRECT_UPLOAD)
+    // Uploading directly: (Note: If RA_CAP_DIRECT_UPLOAD is not set, then this
+    // will be internally translated to a tex_upload buffer by the RA)
     const void *src;    // Address of data
     // For 2D textures only:
     struct mp_rect *rc; // Region to upload. NULL means entire image

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -893,18 +893,20 @@ static void update_uniform(struct ra *ra, struct ra_renderpass *pass,
         }
         break;
     }
-    case RA_VARTYPE_IMG_W: /* fall through */
+    case RA_VARTYPE_IMG_W: {
+        struct ra_tex *tex = *(struct ra_tex **)val->data;
+        struct ra_tex_gl *tex_gl = tex->priv;
+        assert(tex->params.storage_dst);
+        gl->BindImageTexture(input->binding, tex_gl->texture, 0, GL_FALSE, 0,
+                             GL_WRITE_ONLY, tex_gl->internal_format);
+        break;
+    }
     case RA_VARTYPE_TEX: {
         struct ra_tex *tex = *(struct ra_tex **)val->data;
         struct ra_tex_gl *tex_gl = tex->priv;
         assert(tex->params.render_src);
-        if (input->type == RA_VARTYPE_TEX) {
-            gl->ActiveTexture(GL_TEXTURE0 + input->binding);
-            gl->BindTexture(tex_gl->target, tex_gl->texture);
-        } else {
-            gl->BindImageTexture(input->binding, tex_gl->texture, 0, GL_FALSE, 0,
-                                 GL_WRITE_ONLY, tex_gl->internal_format);
-        }
+        gl->ActiveTexture(GL_TEXTURE0 + input->binding);
+        gl->BindTexture(tex_gl->target, tex_gl->texture);
         break;
     }
     case RA_VARTYPE_BUF_RW: {

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -97,6 +97,7 @@ static int ra_init_gl(struct ra *ra, GL *gl)
     static const int caps_map[][2] = {
         {RA_CAP_DIRECT_UPLOAD,      0},
         {RA_CAP_SHARED_BINDING,     0},
+        {RA_CAP_GLOBAL_UNIFORM,     0},
         {RA_CAP_TEX_1D,             MPGL_CAP_1D_TEX},
         {RA_CAP_TEX_3D,             MPGL_CAP_3D_TEX},
         {RA_CAP_COMPUTE,            MPGL_CAP_COMPUTE_SHADER},

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -91,21 +91,26 @@ static int ra_init_gl(struct ra *ra, GL *gl)
     ra_gl_set_debug(ra, true);
 
     ra->fns = &ra_fns_gl;
-    ra->caps = RA_CAP_DIRECT_UPLOAD;
-    if (gl->mpgl_caps & MPGL_CAP_1D_TEX)
-        ra->caps |= RA_CAP_TEX_1D;
-    if (gl->mpgl_caps & MPGL_CAP_3D_TEX)
-        ra->caps |= RA_CAP_TEX_3D;
-    if (gl->BlitFramebuffer)
-        ra->caps |= RA_CAP_BLIT;
-    if (gl->mpgl_caps & MPGL_CAP_COMPUTE_SHADER)
-        ra->caps |= RA_CAP_COMPUTE;
-    if (gl->mpgl_caps & MPGL_CAP_NESTED_ARRAY)
-        ra->caps |= RA_CAP_NESTED_ARRAY;
-    if (gl->mpgl_caps & MPGL_CAP_SSBO)
-        ra->caps |= RA_CAP_BUF_RW;
     ra->glsl_version = gl->glsl_version;
     ra->glsl_es = gl->es > 0;
+
+    static const int caps_map[][2] = {
+        {RA_CAP_DIRECT_UPLOAD,      0},
+        {RA_CAP_SHARED_BINDING,     0},
+        {RA_CAP_TEX_1D,             MPGL_CAP_1D_TEX},
+        {RA_CAP_TEX_3D,             MPGL_CAP_3D_TEX},
+        {RA_CAP_COMPUTE,            MPGL_CAP_COMPUTE_SHADER},
+        {RA_CAP_NESTED_ARRAY,       MPGL_CAP_NESTED_ARRAY},
+        {RA_CAP_BUF_RW,             MPGL_CAP_SSBO},
+    };
+
+    for (int i = 0; i < MP_ARRAY_SIZE(caps_map); i++) {
+        if ((gl->mpgl_caps & caps_map[i][1]) == caps_map[i][1])
+            ra->caps |= caps_map[i][0];
+    }
+
+    if (gl->BlitFramebuffer)
+        ra->caps |= RA_CAP_BLIT;
 
     int gl_fmt_features = gl_format_feature_flags(gl);
 

--- a/video/out/opengl/shader_cache.c
+++ b/video/out/opengl/shader_cache.c
@@ -277,6 +277,7 @@ void gl_sc_uniform_image2D_wo(struct gl_shader_cache *sc, const char *name,
 void gl_sc_ssbo(struct gl_shader_cache *sc, char *name, struct ra_buf *buf,
                 char *format, ...)
 {
+    assert(sc->ra->caps & RA_CAP_BUF_RW);
     gl_sc_enable_extension(sc, "GL_ARB_shader_storage_buffer_object");
 
     struct sc_uniform *u = find_uniform(sc, name);
@@ -525,6 +526,10 @@ static void add_uniforms(struct gl_shader_cache *sc, bstr *dst)
         case RA_VARTYPE_TEX:
         case RA_VARTYPE_IMG_W:
             ADD(dst, "uniform %s %s;\n", u->glsl_type, u->input.name);
+            break;
+        case RA_VARTYPE_BUF_RO:
+            ADD(dst, "layout(std140, binding=%d) uniform %s { %s };\n",
+                u->input.binding, u->input.name, u->buffer_format);
             break;
         case RA_VARTYPE_BUF_RW:
             ADD(dst, "layout(std430, binding=%d) buffer %s { %s };\n",

--- a/video/out/opengl/shader_cache.c
+++ b/video/out/opengl/shader_cache.c
@@ -32,10 +32,17 @@ struct sc_uniform {
     const char *glsl_type;
     union uniform_val v;
     char *buffer_format;
+    // for UBO entries: these are all assumed to be arrays as far as updating
+    // is concerned. ("regular" values are treated like arrays of length 1)
+    size_t ubo_length;  // number of array elements (or 0 if not using UBO)
+    size_t ubo_rowsize; // size of data in each array row
+    size_t ubo_stride;  // stride of each array row
+    size_t ubo_offset;  // byte offset within the uniform buffer
 };
 
 struct sc_cached_uniform {
     union uniform_val v;
+    int index; // for ra_renderpass_input_val
 };
 
 struct sc_entry {
@@ -44,6 +51,8 @@ struct sc_entry {
     int num_cached_uniforms;
     bstr total;
     struct timer_pool *timer;
+    struct ra_buf *ubo;
+    int ubo_index; // for ra_renderpass_input_val.index
 };
 
 struct gl_shader_cache {
@@ -72,6 +81,9 @@ struct gl_shader_cache {
 
     struct sc_uniform *uniforms;
     int num_uniforms;
+
+    int ubo_binding;
+    size_t ubo_size;
 
     struct ra_renderpass_input_val *values;
     int num_values;
@@ -114,6 +126,8 @@ static void gl_sc_reset(struct gl_shader_cache *sc)
     for (int n = 0; n < sc->num_uniforms; n++)
         talloc_free((void *)sc->uniforms[n].input.name);
     sc->num_uniforms = 0;
+    sc->ubo_binding = 0;
+    sc->ubo_size = 0;
     for (int i = 0; i < RA_VARTYPE_COUNT; i++)
         sc->next_binding[i] = 0;
     sc->current_shader = NULL;
@@ -127,6 +141,8 @@ static void sc_flush_cache(struct gl_shader_cache *sc)
 
     for (int n = 0; n < sc->num_entries; n++) {
         struct sc_entry *e = sc->entries[n];
+        if (e->ubo)
+            ra_buf_free(sc->ra, &e->ubo);
         if (e->pass)
             sc->ra->fns->renderpass_destroy(sc->ra, e->pass);
         timer_pool_destroy(e->timer);
@@ -239,6 +255,50 @@ static int gl_sc_next_binding(struct gl_shader_cache *sc, enum ra_vartype type)
     }
 }
 
+// Updates the UBO metadata for the given sc_uniform. Assumes type, dim_v and
+// dim_m are already set. Computes the correct alignment, size and array stride
+// as per the std140 specification.
+static void update_ubo_params(struct gl_shader_cache *sc, struct sc_uniform *u)
+{
+    if (!(sc->ra->caps & RA_CAP_BUF_RO))
+        return;
+
+    // Using UBOs with explicit layout(offset) like we do requires GLSL version
+    // 440 or higher. In theory the UBO code can also use older versions, but
+    // just try and avoid potential headaches. This also ensures they're only
+    // used on drivers that are probably modern enough to actually support them
+    // correctly.
+    if (sc->ra->glsl_version < 440)
+        return;
+
+    size_t el_size;
+    switch (u->input.type) {
+    case RA_VARTYPE_INT:   el_size = sizeof(int);   break;
+    case RA_VARTYPE_FLOAT: el_size = sizeof(float); break;
+    default: abort();
+    }
+
+    u->ubo_rowsize = el_size * u->input.dim_v;
+
+    // std140 packing rules:
+    // 1. The alignment of generic values is their size in bytes
+    // 2. The alignment of vectors is the vector length * the base count, with
+    // the exception of vec3 which is always aligned like vec4
+    // 3. The alignment of arrays is that of the element size rounded up to
+    // the nearest multiple of vec4
+    // 4. Matrices are treated like arrays of vectors
+    // 5. Arrays/matrices are laid out with a stride equal to the alignment
+    u->ubo_stride = u->ubo_rowsize;
+    if (u->input.dim_v == 3)
+        u->ubo_stride += el_size;
+    if (u->input.dim_m > 1)
+        u->ubo_stride = MP_ALIGN_UP(u->ubo_stride, sizeof(float[4]));
+
+    u->ubo_offset = MP_ALIGN_UP(sc->ubo_size, u->ubo_stride);
+    u->ubo_length = u->input.dim_m;
+    sc->ubo_size = u->ubo_offset + u->ubo_stride * u->ubo_length;
+}
+
 void gl_sc_uniform_texture(struct gl_shader_cache *sc, char *name,
                            struct ra_tex *tex)
 {
@@ -297,6 +357,7 @@ void gl_sc_uniform_f(struct gl_shader_cache *sc, char *name, float f)
     struct sc_uniform *u = find_uniform(sc, name);
     u->input.type = RA_VARTYPE_FLOAT;
     u->glsl_type = "float";
+    update_ubo_params(sc, u);
     u->v.f[0] = f;
 }
 
@@ -305,6 +366,7 @@ void gl_sc_uniform_i(struct gl_shader_cache *sc, char *name, int i)
     struct sc_uniform *u = find_uniform(sc, name);
     u->input.type = RA_VARTYPE_INT;
     u->glsl_type = "int";
+    update_ubo_params(sc, u);
     u->v.i[0] = i;
 }
 
@@ -314,6 +376,7 @@ void gl_sc_uniform_vec2(struct gl_shader_cache *sc, char *name, float f[2])
     u->input.type = RA_VARTYPE_FLOAT;
     u->input.dim_v = 2;
     u->glsl_type = "vec2";
+    update_ubo_params(sc, u);
     u->v.f[0] = f[0];
     u->v.f[1] = f[1];
 }
@@ -324,6 +387,7 @@ void gl_sc_uniform_vec3(struct gl_shader_cache *sc, char *name, GLfloat f[3])
     u->input.type = RA_VARTYPE_FLOAT;
     u->input.dim_v = 3;
     u->glsl_type = "vec3";
+    update_ubo_params(sc, u);
     u->v.f[0] = f[0];
     u->v.f[1] = f[1];
     u->v.f[2] = f[2];
@@ -342,6 +406,7 @@ void gl_sc_uniform_mat2(struct gl_shader_cache *sc, char *name,
     u->input.dim_v = 2;
     u->input.dim_m = 2;
     u->glsl_type = "mat2";
+    update_ubo_params(sc, u);
     for (int n = 0; n < 4; n++)
         u->v.f[n] = v[n];
     if (transpose)
@@ -363,6 +428,7 @@ void gl_sc_uniform_mat3(struct gl_shader_cache *sc, char *name,
     u->input.dim_v = 3;
     u->input.dim_m = 3;
     u->glsl_type = "mat3";
+    update_ubo_params(sc, u);
     for (int n = 0; n < 9; n++)
         u->v.f[n] = v[n];
     if (transpose)
@@ -408,6 +474,20 @@ static const char *vao_glsl_type(const struct ra_renderpass_input *e)
     }
 }
 
+static void update_ubo(struct ra *ra, struct ra_buf *ubo, struct sc_uniform *u)
+{
+    uintptr_t src = (uintptr_t) &u->v;
+    size_t dst = u->ubo_offset;
+    size_t src_stride = u->ubo_rowsize;
+    size_t dst_stride = u->ubo_stride;
+
+    for (int i = 0; i < u->ubo_length; i++) {
+        ra->fns->buf_update(ra, ubo, dst, (void *)src, src_stride);
+        src += src_stride;
+        dst += dst_stride;
+    }
+}
+
 static void update_uniform(struct gl_shader_cache *sc, struct sc_entry *e,
                            struct sc_uniform *u, int n)
 {
@@ -420,11 +500,17 @@ static void update_uniform(struct gl_shader_cache *sc, struct sc_entry *e,
 
     if (changed) {
         un->v = u->v;
-        struct ra_renderpass_input_val value = {
-            .index = n,
-            .data = &un->v,
-        };
-        MP_TARRAY_APPEND(sc, sc->values, sc->num_values, value);
+
+        if (u->ubo_length) {
+            assert(e->ubo);
+            update_ubo(sc->ra, e->ubo, u);
+        } else {
+            struct ra_renderpass_input_val value = {
+                .index = un->index,
+                .data = &un->v,
+            };
+            MP_TARRAY_APPEND(sc, sc->values, sc->num_values, value);
+        }
     }
 }
 
@@ -434,8 +520,10 @@ void gl_sc_set_cache_dir(struct gl_shader_cache *sc, const char *dir)
     sc->cache_dir = talloc_strdup(sc, dir);
 }
 
-static void create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
+static bool create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
 {
+    bool ret = false;
+
     void *tmp = talloc_new(NULL);
     struct ra_renderpass_params params = sc->params;
 
@@ -490,10 +578,37 @@ static void create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
         }
     }
 
-    entry->pass = sc->ra->fns->renderpass_create(sc->ra, &params);
+    // If using a UBO, also make sure to add it as an input value so the RA
+    // can see it
+    if (sc->ubo_size) {
+        entry->ubo_index = sc->params.num_inputs;
+        struct ra_renderpass_input ubo_input = {
+            .name = "UBO",
+            .type = RA_VARTYPE_BUF_RO,
+            .dim_v = 1,
+            .dim_m = 1,
+            .binding = sc->ubo_binding,
+        };
+        MP_TARRAY_APPEND(sc, params.inputs, params.num_inputs, ubo_input);
+    }
 
+    entry->pass = sc->ra->fns->renderpass_create(sc->ra, &params);
     if (!entry->pass)
-        sc->error_state = true;
+        goto error;
+
+    if (sc->ubo_size) {
+        struct ra_buf_params ubo_params = {
+            .type = RA_BUF_TYPE_UNIFORM,
+            .size = sc->ubo_size,
+            .host_mutable = true,
+        };
+
+        entry->ubo = ra_buf_create(sc->ra, &ubo_params);
+        if (!entry->ubo) {
+            MP_ERR(sc, "Failed creating uniform buffer!\n");
+            goto error;
+        }
+    }
 
     if (entry->pass && cache_filename) {
         bstr nc = entry->pass->params.cached_program;
@@ -510,7 +625,11 @@ static void create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
         }
     }
 
+    ret = true;
+
+error:
     talloc_free(tmp);
+    return ret;
 }
 
 #define ADD(x, ...) bstr_xappend_asprintf(sc, (x), __VA_ARGS__)
@@ -518,11 +637,28 @@ static void create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
 
 static void add_uniforms(struct gl_shader_cache *sc, bstr *dst)
 {
+    // Add all of the UBO entries separately as members of their own buffer
+    if (sc->ubo_size > 0) {
+        ADD(dst, "layout(std140, binding=%d) uniform UBO {\n", sc->ubo_binding);
+        for (int n = 0; n < sc->num_uniforms; n++) {
+            struct sc_uniform *u = &sc->uniforms[n];
+            if (!u->ubo_length)
+                continue;
+            ADD(dst, "layout(offset=%zu) %s %s;\n", u->ubo_offset,
+                u->glsl_type, u->input.name);
+        }
+        ADD(dst, "};\n");
+    }
+
     for (int n = 0; n < sc->num_uniforms; n++) {
         struct sc_uniform *u = &sc->uniforms[n];
+        if (u->ubo_length)
+            continue;
         switch (u->input.type) {
         case RA_VARTYPE_INT:
         case RA_VARTYPE_FLOAT:
+            assert(sc->ra->caps & RA_CAP_GLOBAL_UNIFORM);
+            // fall through
         case RA_VARTYPE_TEX:
         case RA_VARTYPE_IMG_W:
             ADD(dst, "uniform %s %s;\n", u->glsl_type, u->input.name);
@@ -563,6 +699,10 @@ static void gl_sc_generate(struct gl_shader_cache *sc, enum ra_renderpass_type t
 
     // gl_sc_set_vertex_format() must always be called
     assert(sc->params.vertex_attribs);
+
+    // If using a UBO, pick a binding (needed for shader generation)
+    if (sc->ubo_size)
+        sc->ubo_binding = gl_sc_next_binding(sc, RA_VARTYPE_BUF_RO);
 
     for (int n = 0; n < MP_ARRAY_SIZE(sc->tmp); n++)
         sc->tmp[n].len = 0;
@@ -710,23 +850,35 @@ static void gl_sc_generate(struct gl_shader_cache *sc, enum ra_renderpass_type t
         };
         for (int n = 0; n < sc->num_uniforms; n++) {
             struct sc_cached_uniform u = {0};
+            if (!sc->uniforms[n].ubo_length) {
+                u.index = sc->params.num_inputs;
+                MP_TARRAY_APPEND(sc, sc->params.inputs, sc->params.num_inputs,
+                                 sc->uniforms[n].input);
+            }
             MP_TARRAY_APPEND(entry, entry->cached_uniforms,
                              entry->num_cached_uniforms, u);
-            MP_TARRAY_APPEND(sc, sc->params.inputs, sc->params.num_inputs,
-                             sc->uniforms[n].input);
         }
-        create_pass(sc, entry);
+        if (!create_pass(sc, entry))
+            sc->error_state = true;
         MP_TARRAY_APPEND(sc, sc->entries, sc->num_entries, entry);
     }
-    if (!entry->pass)
+    if (sc->error_state)
         return;
 
     assert(sc->num_uniforms == entry->num_cached_uniforms);
-    assert(sc->num_uniforms == entry->pass->params.num_inputs);
 
     sc->num_values = 0;
     for (int n = 0; n < sc->num_uniforms; n++)
         update_uniform(sc, entry, &sc->uniforms[n], n);
+
+    // If we're using a UBO, make sure to bind it as well
+    if (sc->ubo_size) {
+        struct ra_renderpass_input_val ubo_val = {
+            .index = entry->ubo_index,
+            .data = &entry->ubo,
+        };
+        MP_TARRAY_APPEND(sc, sc->values, sc->num_values, ubo_val);
+    }
 
     sc->current_shader = entry;
 }

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -174,6 +174,7 @@ bool fbotex_change(struct fbotex *fbo, struct ra *ra, struct mp_log *log,
         .src_linear = true,
         .render_src = true,
         .render_dst = true,
+        .storage_dst = true,
         .blit_src = true,
     };
 


### PR DESCRIPTION
I've also made the corresponding changes “in parallel” to ra_vk, but I want to merge this on the OpenGL side of things first to get your feedback, prevent it from diverging, and (hopefully) maybe also improve the OpenGL uniform performance.

If we decide it's either not worth it for OpenGL or want to make it toggleable, I've written it in such a way that this would be a trivial one-line change: `bool ubo_supported` in `gl_sc_find_uniform()`. Remove the bool and the check that depends on it, or also check an extra “bool use_ubo” or whatever. Whatever we end up doing for OpenGL, all of this code is required for vulkan anyway, and doing the UBO shit inside shader_cache (as opposed to ra_vk) gives us the greatest flexibility moving forward and also makes the code simpler. (Since the shader_cache also needs to generate the UBO spec)

Last commit is WIP (still need to actually *update* the UBO, but that should be no more than 5-10 lines of ra_buf_update boilerplate). Also introduces some unrelated “cleanup” commits.