### PR TITLE
Non-vulkan changes to enable vulkan support

### DIFF
--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -142,14 +142,17 @@ static void mp_compute_weights(struct filter_kernel *filter, double f,
 }
 
 // Fill the given array with weights for the range [0.0, 1.0]. The array is
-// interpreted as rectangular array of count * filter->size items.
+// interpreted as rectangular array of count * filter->size items, with a
+// stride of `stride` floats in between each array element. (For polar filters,
+// the `count` indicates the row size and filter->size/stride are ignored)
 //
 // There will be slight sampling error if these weights are used in a OpenGL
 // texture as LUT directly. The sampling point of a texel is located at its
 // center, so out_array[0] will end up at 0.5 / count instead of 0.0.
 // Correct lookup requires a linear coordinate mapping from [0.0, 1.0] to
 // [0.5 / count, 1.0 - 0.5 / count].
-void mp_compute_lut(struct filter_kernel *filter, int count, float *out_array)
+void mp_compute_lut(struct filter_kernel *filter, int count, int stride,
+                    float *out_array)
 {
     if (filter->polar) {
         filter->radius_cutoff = 0.0;
@@ -165,7 +168,7 @@ void mp_compute_lut(struct filter_kernel *filter, int count, float *out_array)
         // Compute a 2D array indexed by subpixel position
         for (int n = 0; n < count; n++) {
             mp_compute_weights(filter, n / (double)(count - 1),
-                               out_array + filter->size * n);
+                               out_array + stride * n);
         }
     }
 }

--- a/video/out/filter_kernels.h
+++ b/video/out/filter_kernels.h
@@ -50,6 +50,7 @@ const struct filter_kernel *mp_find_filter_kernel(const char *name);
 
 bool mp_init_filter(struct filter_kernel *filter, const int *sizes,
                     double scale);
-void mp_compute_lut(struct filter_kernel *filter, int count, float *out_array);
+void mp_compute_lut(struct filter_kernel *filter, int count, int stride,
+                    float *out_array);
 
 #endif /* MPLAYER_FILTER_KERNELS_H */

--- a/video/out/opengl/lcms.c
+++ b/video/out/opengl/lcms.c
@@ -370,7 +370,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
         return false;
 
     void *tmp = talloc_new(NULL);
-    uint16_t *output = talloc_array(tmp, uint16_t, s_r * s_g * s_b * 3);
+    uint16_t *output = talloc_array(tmp, uint16_t, s_r * s_g * s_b * 4);
     struct lut3d *lut = NULL;
     cmsContext cms = NULL;
 
@@ -380,7 +380,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
         // because we may change the parameter in the future or make it
         // customizable, same for the primaries.
         char *cache_info = talloc_asprintf(tmp,
-                "ver=1.3, intent=%d, size=%dx%dx%d, prim=%d, trc=%d, "
+                "ver=1.4, intent=%d, size=%dx%dx%d, prim=%d, trc=%d, "
                 "contrast=%d\n",
                 p->opts->intent, s_r, s_g, s_b, prim, trc, p->opts->contrast);
 
@@ -435,7 +435,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
     }
 
     cmsHTRANSFORM trafo = cmsCreateTransformTHR(cms, vid_hprofile, TYPE_RGB_16,
-                                                profile, TYPE_RGB_16,
+                                                profile, TYPE_RGBA_16,
                                                 p->opts->intent,
                                                 cmsFLAGS_HIGHRESPRECALC |
                                                 cmsFLAGS_BLACKPOINTCOMPENSATION);
@@ -454,7 +454,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
                 input[r * 3 + 1] = g * 65535 / (s_g - 1);
                 input[r * 3 + 2] = b * 65535 / (s_b - 1);
             }
-            size_t base = (b * s_r * s_g + g * s_r) * 3;
+            size_t base = (b * s_r * s_g + g * s_r) * 4;
             cmsDoTransform(trafo, input, output + base, s_r);
         }
     }

--- a/video/out/opengl/ra.h
+++ b/video/out/opengl/ra.h
@@ -10,6 +10,7 @@ struct ra {
 
     int glsl_version;       // GLSL version (e.g. 300 => 3.0)
     bool glsl_es;           // use ES dialect
+    bool glsl_vulkan;       // use vulkan dialect
 
     struct mp_log *log;
 
@@ -240,7 +241,8 @@ struct ra_renderpass_params {
 
     // --- type==RA_RENDERPASS_TYPE_RASTER only
 
-    // Describes the format of the vertex data.
+    // Describes the format of the vertex data. When using ra.glsl_vulkan,
+    // the order of this array must match the vertex attribute locations.
     struct ra_renderpass_input *vertex_attribs;
     int num_vertex_attribs;
     int vertex_stride;

--- a/video/out/opengl/shader_cache.c
+++ b/video/out/opengl/shader_cache.c
@@ -660,6 +660,12 @@ static void add_uniforms(struct gl_shader_cache *sc, bstr *dst)
             // fall through
         case RA_VARTYPE_TEX:
         case RA_VARTYPE_IMG_W:
+            // Vulkan requires explicitly assigning the bindings in the shader
+            // source. For OpenGL it's optional, but requires higher GL version
+            // so we don't do it (and instead have ra_gl update the bindings
+            // after program creation).
+            if (sc->ra->glsl_vulkan)
+                ADD(dst, "layout(binding=%d) ", u->input.binding);
             ADD(dst, "uniform %s %s;\n", u->glsl_type, u->input.name);
             break;
         case RA_VARTYPE_BUF_RO:
@@ -670,7 +676,6 @@ static void add_uniforms(struct gl_shader_cache *sc, bstr *dst)
             ADD(dst, "layout(std430, binding=%d) buffer %s { %s };\n",
                 u->input.binding, u->input.name, u->buffer_format);
             break;
-        default: abort();
         }
     }
 }
@@ -726,10 +731,17 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
     }
 
     if (glsl_version >= 130) {
-        ADD(header, "#define texture1D texture\n");
-        ADD(header, "#define texture3D texture\n");
+        ADD(header, "#define tex1D texture\n");
+        ADD(header, "#define tex3D texture\n");
     } else {
+        ADD(header, "#define tex1D texture1D\n");
+        ADD(header, "#define tex3D texture3D\n");
         ADD(header, "#define texture texture2D\n");
+    }
+
+    if (sc->ra->glsl_vulkan && type == RA_RENDERPASS_TYPE_COMPUTE) {
+        ADD(header, "#define gl_GlobalInvocationIndex "
+                    "(gl_WorkGroupID * gl_WorkGroupSize + gl_LocalInvocationID)\n");
     }
 
     // Additional helpers.
@@ -753,16 +765,19 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
         for (int n = 0; n < sc->params.num_vertex_attribs; n++) {
             const struct ra_renderpass_input *e = &sc->params.vertex_attribs[n];
             const char *glsl_type = vao_glsl_type(e);
+            char loc[32] = {0};
+            if (sc->ra->glsl_vulkan)
+                mp_tprintf_buf(loc, sizeof(loc), "layout(location=%d) ", n);
             if (strcmp(e->name, "position") == 0) {
                 // setting raster pos. requires setting gl_Position magic variable
                 assert(e->dim_v == 2 && e->type == RA_VARTYPE_FLOAT);
-                ADD(vert_head, "%s vec2 vertex_position;\n", vert_in);
+                ADD(vert_head, "%s%s vec2 vertex_position;\n", loc, vert_in);
                 ADD(vert_body, "gl_Position = vec4(vertex_position, 1.0, 1.0);\n");
             } else {
-                ADD(vert_head, "%s %s vertex_%s;\n", vert_in, glsl_type, e->name);
-                ADD(vert_head, "%s %s %s;\n", vert_out, glsl_type, e->name);
+                ADD(vert_head, "%s%s %s vertex_%s;\n", loc, vert_in, glsl_type, e->name);
+                ADD(vert_head, "%s%s %s %s;\n", loc, vert_out, glsl_type, e->name);
                 ADD(vert_body, "%s = vertex_%s;\n", e->name, e->name);
-                ADD(frag_vaos, "%s %s %s;\n", frag_in, glsl_type, e->name);
+                ADD(frag_vaos, "%s%s %s %s;\n", loc, frag_in, glsl_type, e->name);
             }
         }
         ADD(vert_body, "}\n");
@@ -772,8 +787,10 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
         // fragment shader; still requires adding used uniforms and VAO elements
         frag = &sc->tmp[4];
         ADD_BSTR(frag, *header);
-        if (glsl_version >= 130)
-            ADD(frag, "out vec4 out_color;\n");
+        if (glsl_version >= 130) {
+            ADD(frag, "%sout vec4 out_color;\n",
+                sc->ra->glsl_vulkan ? "layout(location=0) " : "");
+        }
         ADD_BSTR(frag, *frag_vaos);
         add_uniforms(sc, frag);
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -569,10 +569,10 @@ static bool gl_video_get_lut3d(struct gl_video *p, enum mp_csp_prim prim,
 
     // GLES3 doesn't provide filtered 16 bit integer textures
     // GLES2 doesn't even provide 3D textures
-    const struct ra_format *fmt = ra_find_unorm_format(p->ra, 2, 3);
+    const struct ra_format *fmt = ra_find_unorm_format(p->ra, 2, 4);
     if (!fmt || !(p->ra->caps & RA_CAP_TEX_3D)) {
         p->use_lut_3d = false;
-        MP_WARN(p, "Disabling color management (no RGB16 3D textures).\n");
+        MP_WARN(p, "Disabling color management (no RGBA16 3D textures).\n");
         return false;
     }
 

--- a/video/out/opengl/video.c
+++ b/video/out/opengl/video.c
@@ -2466,7 +2466,7 @@ static void pass_colormanage(struct gl_video *p, struct mp_colorspace src, bool 
         GLSL(vec3 cpos;)
         for (int i = 0; i < 3; i++)
             GLSLF("cpos[%d] = LUT_POS(color[%d], %d.0);\n", i, i, p->lut_3d_size[i]);
-        GLSL(color.rgb = texture3D(lut_3d, cpos).rgb;)
+        GLSL(color.rgb = tex3D(lut_3d, cpos).rgb;)
     }
 }
 

--- a/video/out/opengl/video_shaders.c
+++ b/video/out/opengl/video_shaders.c
@@ -122,7 +122,7 @@ static void polar_sample(struct gl_shader_cache *sc, struct scaler *scaler,
 
     // get the weight for this pixel
     if (scaler->lut->params.dimensions == 1) {
-        GLSLF("w = texture1D(lut, LUT_POS(d * 1.0/%f, %d.0)).r;\n",
+        GLSLF("w = tex1D(lut, LUT_POS(d * 1.0/%f, %d.0)).r;\n",
               radius, scaler->lut_size);
     } else {
         GLSLF("w = texture(lut, vec2(0.5, LUT_POS(d * 1.0/%f, %d.0))).r;\n",


### PR DESCRIPTION
This is a summary of the changes I've had to make to RA/SC/video.c in my vulkan branch. Merging this ahead of time to make squashing/rebasing vo_vulkan itself easier, and also keep the changes to ra etc. separate from the addition of new files (for better git blame/history).

Once this is in, I can start squashing and preparing the vulkan branch for merging. (Which is now in a pretty useable state, with no major bugs or missing features left - only improvements like switching to glslang or using a better memory allocator)

I've verified that the shaders we produce are correct even under GL_KHR_vulkan_glsl semantics (which VK_NV_glsl_shader deviates from).