### PR TITLE
vo_opengl: use GLX_MESA_swap_control where available

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -384,6 +384,13 @@ static const struct gl_functions gl_functions[] = {
         },
     },
     {
+        .extension = "GLX_MESA_swap_control",
+        .functions = (const struct gl_function[]) {
+            DEF_FN_NAME(SwapInterval, "glXSwapIntervalMESA"),
+            {0},
+        },
+    },
+    {
         .extension = "WGL_EXT_swap_control",
         .functions = (const struct gl_function[]) {
             DEF_FN_NAME(SwapInterval, "wglSwapIntervalEXT"),


### PR DESCRIPTION
This overrides the use of GLX_SGI_swap_control, because apparently
GLX_SGI_swap_control doesn't support SwapInterval(0), but the
GLX_MESA_swap_interval does.

Of course, everybody except mesa just accepts SwapInterval(0) even for
GLX_SGI_swap_control, but mesa needs to be the special snowflake here
and reject it, forcing us to load their stupid named extension instead.

Meanwhile khronos has done nothing except spit out GLX_EXT_swap_control
(not to be confused with GL_EXT_swap_control, which is exported by
WGL_EXT_swap_control), that doesn't fix the problem because mesa doesn't
implement it anyway.

What a fucking mess.

## Note

PR because I'm not sure if this is the sane way to “override” the function. Both GLX_SGI_swap_control and GLX_MESA_swap_control are present, so mpv will actually load both - the latter will override the former. Is that okay/good?