### PR TITLE
osx: menu improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /mpv.app
 /version.h
 /input/input_conf.h
+/player/mpv_conf.h
 /tags
 /TAGS
 /video/out/x11_icon.inc

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -61,7 +61,7 @@ static void terminate_cocoa_application(void)
 }
 
 @implementation Application
-@synthesize menuBar = _menu_Bar;
+@synthesize menuBar = _menu_bar;
 @synthesize openCount = _open_count;
 
 - (void)sendEvent:(NSEvent *)event

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -124,6 +124,11 @@ static NSString *default_input_conf = @
                     }],
                     @{ @"name": @"separator" },
                     [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Close",
+                        @"action"     : @"performClose:",
+                        @"key"        : @"w",
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
                         @"name"       : @"Save Screenshot",
                         @"action"     : @"cmd:",
                         @"key"        : @"",

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -85,9 +85,29 @@ static NSString *default_input_conf = @
                     }],
                     @{ @"name": @"separator" },
                     [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Services",
+                        @"key"        : @"",
+                    }],
+                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
                         @"name"       : @"Hide mpv",
                         @"action"     : @"hide:",
                         @"key"        : @"h",
+                        @"target"     : NSApp
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Hide Others",
+                        @"action"     : @"hideOtherApplications:",
+                        @"key"        : @"h",
+                        @"modifiers"  : [NSNumber numberWithUnsignedInteger:
+                            NSEventModifierFlagCommand |
+                            NSEventModifierFlagOption],
+                        @"target"     : NSApp
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Show All",
+                        @"action"     : @"unhideAllApplications:",
+                        @"key"        : @"",
                         @"target"     : NSApp
                     }],
                     @{ @"name": @"separator" },
@@ -165,6 +185,11 @@ static NSString *default_input_conf = @
                         @"name"       : @"Paste",
                         @"action"     : @"paste:",
                         @"key"        : @"v"
+                    }],
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Delete",
+                        @"action"     : @"delete:",
+                        @"key"        : @""
                     }],
                     [NSMutableDictionary dictionaryWithDictionary:@{
                         @"name"       : @"Select All",
@@ -601,6 +626,12 @@ static NSString *default_input_conf = @
                 NSMenuItem *iItem = [menu addItemWithTitle:subMenu[@"name"]
                                action:NSSelectorFromString(subMenu[@"action"])
                         keyEquivalent:subMenu[@"key"]];
+                if (subMenu[@"modifiers"]) {
+                    [iItem setKeyEquivalentModifierMask:[subMenu[@"modifiers"] unsignedIntegerValue]];
+                }
+                if ([subMenu[@"name"] isEqual:@"Services"]) {
+                    iItem.submenu = NSApp.servicesMenu = [NSMenu alloc];
+                }
                 [iItem setTarget:subMenu[@"target"]];
                 [subMenu setObject:iItem forKey:@"menuItem"];
             }

--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -45,7 +45,7 @@
 @synthesize targetScreen = _target_screen;
 @synthesize previousScreen = _previous_screen;
 @synthesize currentScreen = _current_screen;
-@synthesize unfScreen = _unf_Screen;
+@synthesize unfScreen = _unf_screen;
 - (id)initWithContentRect:(NSRect)content_rect
                 styleMask:(NSWindowStyleMask)style_mask
                   backing:(NSBackingStoreType)buffering_type

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -89,6 +89,12 @@ def build(ctx):
 
     ctx(
         features = "file2string",
+        source = "etc/mpv.conf",
+        target = "player/mpv_conf.h",
+    )
+
+    ctx(
+        features = "file2string",
         source = "etc/builtin.conf",
         target = "player/builtin_conf.inc",
     )


### PR DESCRIPTION
- Improve user experience for preferences menu items:

    Instead of telling the user to create files/directories herself if no configuration file already exists, create an example one in `~/.config/mpv` (from [etc/input.conf](https://github.com/nathan/mpv/blob/osx-menu-improvements/etc/input.conf) or [etc/mpv.conf](https://github.com/nathan/mpv/blob/osx-menu-improvements/etc/mpv.conf)) and open it.

- Add missing standard menu items: (fixes #4797)
    - mpv > Services
    - mpv > Hide Others
    - mpv > Show All
    - File > Close
    - Edit > Delete