### PR TITLE
rpi build: Fix linking errors

### DIFF
--- a/wscript
+++ b/wscript
@@ -745,10 +745,11 @@ video_output_features = [
                             "-fgnu89-inline",
                      linkflags="-L/opt/vc/lib",
                      header_name="bcm_host.h",
-                     lib=['mmal_core', 'mmal_util', 'mmal_vc_client', 'bcm_host']),
+                     lib=['mmal_core', 'mmal_util', 'mmal_vc_client',
+                         'bcm_host', 'vchostif']),
             # We still need all OpenGL symbols, because the vo_opengl code is
             # generic and supports anything from GLES2/OpenGL 2.1 to OpenGL 4 core.
-            check_cc(lib="EGL"),
+            check_cc(linkflags="-lbrcmGLESv2", lib="EGL"),
             check_cc(lib="GLESv2"),
         ),
     } , {


### PR DESCRIPTION
Fixed an issue whereby libbcm_host, libvchostif and libbrcmGLESv2
libraries were not being linked to, causing undefined references during
configuration and build stages.

This issue may be reproduced by cross compiling mpv with rpi video
output enabled "--enable-rpi", using buildroot.

Tested working by compiling and playing 1080p h264 encoded video on a
Raspberry Pi 1 Model B+.

Signed-off-by: Mahyar Koshkouei <mahyar.koshkouei@gmail.com>

I agree that my changes can be relicensed to LGPL 2.1 or later.
