### PR TITLE
Android: posix_spawn(p) replacement

### DIFF
--- a/osdep/android/posix-spawn.c
+++ b/osdep/android/posix-spawn.c
@@ -1,0 +1,72 @@
+/*
+ * posix-spawn replacement for Android
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <unistd.h>
+#include <errno.h>
+#include "osdep/android/posix-spawn.h"
+
+int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *fa, int fd, int newfd)
+{
+    if (fa->used >= MAX_FILE_ACTIONS)
+        return -1;
+    fa->action[fa->used].filedes = fd;
+    fa->action[fa->used].newfiledes = newfd;
+    fa->used++;
+    return 0;
+}
+
+int posix_spawn_file_actions_init(posix_spawn_file_actions_t *fa)
+{
+    fa->used = 0;
+    return 0;
+}
+
+int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *fa)
+{
+    return 0;
+}
+
+int posix_spawnp(pid_t *pid, const char *file,
+    const posix_spawn_file_actions_t *fa,
+    const posix_spawnattr_t *attrp,
+    char *const argv[], char *const envp[])
+{
+    pid_t p;
+
+    if (attrp != NULL)
+        return EINVAL;
+
+    p = fork();
+    if (p == -1)
+        return errno;
+
+    if (p == 0) {
+        for (int i = 0; i < fa->used; i++) {
+            int err = dup2(fa->action[i].filedes, fa->action[i].newfiledes);
+            if (err == -1)
+                goto fail;
+        }
+        execvpe(file, argv, envp);
+fail:
+        _exit(127);
+    }
+
+    *pid = p;
+    return 0;
+}

--- a/osdep/android/posix-spawn.h
+++ b/osdep/android/posix-spawn.h
@@ -1,0 +1,43 @@
+/*
+ * posix-spawn replacement for Android
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <sys/types.h>
+
+#define MAX_FILE_ACTIONS 4
+
+typedef struct {
+    char dummy;
+} posix_spawnattr_t; /* unsupported */
+
+typedef struct {
+    int used;
+    struct {
+        int filedes, newfiledes;
+    } action[MAX_FILE_ACTIONS];
+} posix_spawn_file_actions_t;
+
+int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t*, int, int);
+int posix_spawn_file_actions_init(posix_spawn_file_actions_t*);
+int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t*);
+
+int posix_spawnp(pid_t*, const char*,
+    const posix_spawn_file_actions_t*, const posix_spawnattr_t *,
+    char *const [], char *const []);

--- a/osdep/posix-spawn.h
+++ b/osdep/posix-spawn.h
@@ -1,0 +1,27 @@
+/*
+ * posix-spawn wrapper
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef __ANDROID__
+// posix_spawn(p) does not exist at all on Android
+#include "osdep/android/posix-spawn.h"
+#else
+#include <spawn.h>
+#endif

--- a/osdep/subprocess-posix.c
+++ b/osdep/subprocess-posix.c
@@ -15,7 +15,7 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <spawn.h>
+#include "osdep/posix-spawn.h"
 #include <poll.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/wscript
+++ b/wscript
@@ -222,11 +222,21 @@ iconv support use --disable-iconv.",
         'desc': 'nanosleep',
         'func': check_statement('time.h', 'nanosleep(0,0)')
     }, {
-        'name': 'posix-spawn',
-        'desc': 'POSIX spawnp()/kill()',
+        'name': 'posix-spawn-native',
+        'desc': 'spawnp()/kill() POSIX support',
         'func': check_statement(['spawn.h', 'signal.h'],
             'posix_spawnp(0,0,0,0,0,0); kill(0,0)'),
         'deps_neg': ['mingw'],
+    }, {
+        'name': 'posix-spawn-android',
+        'desc': 'spawnp()/kill() Android replacement',
+        'func': check_true,
+        'deps_any': ['android'],
+    },{
+        'name': 'posix-spawn',
+        'desc': 'any spawnp()/kill() support',
+        'deps_any': ['posix-spawn-native', 'posix-spawn-android'],
+        'func': check_true,
     }, {
         'name': 'win32-pipes',
         'desc': 'Windows pipe support',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -478,6 +478,7 @@ def build(ctx):
         ( "osdep/mpv.rc",                        "win32-executable" ),
         ( "osdep/win32/pthread.c",               "win32-internal-pthreads"),
         ( "osdep/android/strnlen.c",             "android"),
+        ( "osdep/android/posix-spawn.c",         "android"),
 
         ## tree_allocator
         "ta/ta.c", "ta/ta_talloc.c", "ta/ta_utils.c"


### PR DESCRIPTION
Android's libc strikes again..

~~I only implemented posix_spawn (instead of posix_spawn<b>p</b>) because stuff like `youtube-dl` (which is the primary usecase) can't be installed system-wide on Android anyway.~~

Tested
* Compiles and works on Android for its intended purpose
* posix-spawn detection still works on ordinary Linux systems