### PR TITLE
player: integrate stats.lua

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -877,6 +877,8 @@ works like in older mpv releases. The profiles are currently defined as follows:
 
 .. include:: osc.rst
 
+.. include:: stats.rst
+
 .. include:: lua.rst
 
 .. include:: javascript.rst

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -1,0 +1,162 @@
+STATS
+=====
+
+This builtin script displays information and statistics for the currently
+played file. It is enabled by default if mpv was compiled with Lua support.
+It can be disabled entirely using the ``--stats=no`` option.
+
+Usage
+-----
+
+The following key bindings are active by default unless something else is
+already bound to them:
+
+====   ==============================================
+i      Show stats for a fixed duration
+I      Toggle stats (shown until toggled again)
+====   ==============================================
+
+While the stats are visible on screen the following key bindings are active,
+regardless of existing bindings. They allow you to switch between *pages* of
+stats:
+
+====   ==================
+1      Show usual stats
+2      Show frame timings
+====   ==================
+
+Font
+~~~~
+
+For optimal visual experience, a font with support for many font weights and
+monospaced digits is recommended. By default, the open source font
+`Source Sans Pro <https://github.com/adobe-fonts/source-sans-pro>`_ is used.
+
+Configuration
+-------------
+
+This script can be customized through a config file ``lua-settings/stats.conf``
+placed in mpv's user directory and through the ``--script-opts`` command-line
+option. The configuration syntax is described in `ON SCREEN CONTROLLER`_.
+
+Configurable Options
+~~~~~~~~~~~~~~~~~~~~
+
+``key_oneshot``
+    Default: i
+``key_toggle``
+    Default: I
+
+    Key bindings to display stats.
+
+``key_page_1``
+    Default: 1
+``key_page_2``
+    Default: 2
+
+    Key bindings for page switching while stats are displayed.
+
+``duration``
+    Default: 4
+
+    How long the stats are shown in seconds (oneshot).
+
+``redraw_delay``
+    Default: 1
+
+    How long it takes to refresh the displayed stats in seconds (toggling).
+
+``persistent_overlay``
+    Default: false
+
+    When false, other scripts printing text to the screen can overwrite the
+    displayed stats. When true, displayed stats are persistently shown for the
+    respective duration. This can result in overlapping text when multiple
+    scripts decide to print text at the same time.
+
+``plot_perfdata``
+    Default: true
+
+    Show graphs for performance data (page 2).
+
+``plot_vsync_ratio``
+    Default: true
+``plot_vsync_jitter``
+    Default: true
+
+    Show graphs for vsync and jitter values (page 1). Only when toggled.
+
+``flush_graph_data``
+    Default: true
+
+    Clear data buffers used for drawing graphs when toggling.
+
+``font``
+    Default: Source Sans Pro
+
+    Font name. Should support as many font weights as possible for optimal
+    visual experience.
+
+``font_mono``
+    Default: Source Sans Pro
+
+    Font name for parts where monospaced characters are necessary to align
+    text. Currently, monospaced digits are sufficient.
+
+``font_size``
+    Default: 8
+
+    Font size used to render text.
+
+``font_color``
+    Default: FFFFFF
+
+    Font color.
+
+``border_size``
+    Default: 0.8
+
+    Size of border drawn around the font.
+
+``border_color``
+    Default: 262626
+
+    Color of drawn border.
+
+``alpha``
+    Default: 11
+
+    Transparency for drawn text.
+
+``plot_bg_border_color``
+    Default: 0000FF
+
+    Border color used for drawing graphs.
+
+``plot_bg_color``
+    Default: 262626
+
+    Background color used for drawing graphs.
+
+``plot_color``
+    Default: FFFFFF
+
+    Color used for drawing graphs.
+
+Note: colors are given as hexadecimal values and use ASS tag order: BBGGRR
+(blue green red).
+
+Different key bindings
+~~~~~~~~~~~~~~~~~~~~~~
+
+A different key binding can be defined with the aforementioned options
+``key_oneshot`` and ``key_toggle`` but also with commands in ``input.conf``,
+for example::
+
+    e script-binding stats/display-stats
+    E script-binding stats/display-stats-toggle
+
+Using ``input.conf``, it is also possible to directly display a certain page::
+
+    i script-binding stats/display-page-1
+    e script-binding stats/display-page-2

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -400,7 +400,7 @@ struct m_option {
 #define UPDATE_TERM             (1 << 7)  // terminal options
 #define UPDATE_DEINT            (1 << 8)  // --deinterlace
 #define UPDATE_OSD              (1 << 10) // related to OSD rendering
-#define UPDATE_BUILTIN_SCRIPTS  (1 << 11) // osc/ytdl
+#define UPDATE_BUILTIN_SCRIPTS  (1 << 11) // osc/ytdl/stats
 #define UPDATE_IMGPAR           (1 << 12) // video image params overrides
 #define UPDATE_INPUT            (1 << 13) // mostly --input-* options
 #define UPDATE_AUDIO            (1 << 14) // --audio-channels etc.

--- a/options/options.c
+++ b/options/options.c
@@ -301,6 +301,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("ytdl", lua_load_ytdl, UPDATE_BUILTIN_SCRIPTS),
     OPT_STRING("ytdl-format", lua_ytdl_format, 0),
     OPT_KEYVALUELIST("ytdl-raw-options", lua_ytdl_raw_options, 0),
+    OPT_FLAG("stats", lua_load_stats, UPDATE_BUILTIN_SCRIPTS),
 #endif
 
 // ------------------------- stream options --------------------
@@ -863,6 +864,7 @@ const struct MPOpts mp_default_opts = {
     .lua_load_ytdl = 1,
     .lua_ytdl_format = NULL,
     .lua_ytdl_raw_options = NULL,
+    .lua_load_stats = 1,
 #endif
     .auto_load_scripts = 1,
     .loop_times = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -90,6 +90,7 @@ typedef struct MPOpts {
     int lua_load_ytdl;
     char *lua_ytdl_format;
     char **lua_ytdl_raw_options;
+    int lua_load_stats;
 
     int auto_load_scripts;
 

--- a/player/lua.c
+++ b/player/lua.c
@@ -69,6 +69,9 @@ static const char * const builtin_lua_scripts[][2] = {
     {"@ytdl_hook.lua",
 #   include "player/lua/ytdl_hook.inc"
     },
+    {"@stats.lua",
+#   include "player/lua/stats.inc"
+    },
     {0}
 };
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -21,8 +21,6 @@ local o = {
     duration = 4,
     redraw_delay = 1,                -- acts as duration in the toggling case
     ass_formatting = true,
-    timing_warning = true,
-    timing_warning_th = 0.85,        -- *no* warning threshold (warning when > target_fps * timing_warning_th)
     print_perfdata_passes = false,   -- when true, print the full information about all passes
     filter_params_max_length = 100,  -- a filter list longer than this many characters will be shown one filter per line instead
     debug = false,
@@ -294,26 +292,10 @@ local function append_perfdata(s, dedicated_page)
         end
     end
 
-    -- Highlight i with a red border when t exceeds the time for one frame
-    -- or yellow when it exceeds a given threshold
-    local function hl(i, t)
-        if t == nil then
-            t = i
-        end
-
+    -- Pretty print measured time
+    local function pp(i)
         -- rescale to microseconds for a saner display
-        i = i / 1000
-
-        if o.timing_warning and target_fps > 0 then
-            if t > target_fps then
-                return format("{\\bord0.5}{\\3c&H0000FF&}%05d{\\bord%s}{\\3c&H%s&}",
-                                i, o.border_size, o.border_color)
-            elseif t > (target_fps * o.timing_warning_th) then
-                return format("{\\bord0.5}{\\1c&H00DDDD&}%05d{\\bord%s}{\\1c&H%s&}",
-                                i, o.border_size, o.font_color)
-            end
-        end
-        return format("%05d", i)
+        return format("%05d", i / 1000)
     end
 
     -- Format n/m with a font weight based on the ratio
@@ -340,8 +322,8 @@ local function append_perfdata(s, dedicated_page)
 
             for _, pass in ipairs(data) do
                 s[#s+1] = format(f, o.nl, o.indent, o.indent,
-                                 o.font_mono, hl(pass["last"], last_s[frame]),
-                                 hl(pass["avg"], avg_s[frame]), hl(pass["peak"]),
+                                 o.font_mono, pp(pass["last"]),
+                                 pp(pass["avg"]), pp(pass["peak"]),
                                  o.prefix_sep .. o.prefix_sep, p(pass["last"], last_s[frame]),
                                  o.font, o.prefix_sep, o.prefix_sep, pass["desc"])
 
@@ -354,13 +336,13 @@ local function append_perfdata(s, dedicated_page)
 
             -- Print sum of timing values as "Total"
             s[#s+1] = format(f, o.nl, o.indent, o.indent,
-                             o.font_mono, hl(last_s[frame]),
-                             hl(avg_s[frame]), hl(peak_s[frame]), "", "", o.font,
+                             o.font_mono, pp(last_s[frame]),
+                             pp(avg_s[frame]), pp(peak_s[frame]), "", "", o.font,
                              o.prefix_sep, o.prefix_sep, b("Total"))
         else
             -- for the simplified view, we just print the sum of each pass
             s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
-                            hl(last_s[frame]), hl(avg_s[frame]), hl(peak_s[frame]),
+                            pp(last_s[frame]), pp(avg_s[frame]), pp(peak_s[frame]),
                             "", "", o.font, o.prefix_sep, o.prefix_sep,
                             frame:gsub("^%l", string.upper))
         end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -91,7 +91,9 @@ function add_file(s)
     s[sec] = ""
 
     append_property(s, sec, "filename", {prefix="File:", nl="", indent=""})
-    append_property(s, sec, "metadata/title", {prefix="Title:"})
+    if not (mp.get_property_osd("filename") == mp.get_property_osd("media-title")) then
+        append_property(s, sec, "media-title", {prefix="Title:"})
+    end
     append_property(s, sec, "chapter", {prefix="Chapter:"})
     if append_property(s, sec, "cache-used", {prefix="Cache:"}) then
         append_property(s, sec, "demuxer-cache-duration",

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -305,8 +305,14 @@ end
 mp.add_key_binding(o.key_oneshot, "display_stats", print_stats, {repeatable=true})
 if pcall(function() timer:is_enabled() end) then
     mp.add_key_binding(o.key_toggle, "display_stats_toggle", toggle_stats, {repeatable=false})
+    mp.register_event("video-reconfig",
+                    function()
+                        if timer:is_enabled() then
+                            print_stats(o.redraw_delay + 1)
+                        end
+                    end)
 else
     local txt = "Please upgrade mpv to toggle stats"
     mp.add_key_binding(o.key_toggle, "display_stats_toggle",
-                       function() print(txt) ; mp.osd_message(txt) end, {repeatable=false})
+                    function() print(txt) ; mp.osd_message(txt) end, {repeatable=false})
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -235,7 +235,9 @@ local function append_perfdata(s)
     end
 
     local ds = mp.get_property_bool("display-sync-active", false)
-    local target_fps = ds and mp.get_property_number("display-fps", 0) or mp.get_property_number("fps", 0)
+    local target_fps = ds and mp.get_property_number("display-fps", 0)
+                       or mp.get_property_number("container-fps", 0)
+                       or mp.get_property_number("fps", 0)
     if target_fps > 0 then target_fps = 1 / target_fps * 1e6 end
 
     local last_s = vo_p["render-last"] + vo_p["present-last"] + vo_p["upload-last"]

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -348,9 +348,10 @@ local function add_video(s)
     append_property(s, "window-scale", {prefix="Window Scale:"})
     append_property(s, "video-params/aspect", {prefix="Aspect Ratio:"})
     append_property(s, "video-params/pixelformat", {prefix="Pixel Format:"})
-    append_property(s, "video-params/colormatrix", {prefix="Colormatrix:"})
-    append_property(s, "video-params/primaries", {prefix="Primaries:"})
-    append_property(s, "video-params/gamma", {prefix="Gamma:"})
+    local cmat = append_property(s, "video-params/colormatrix", {prefix="Colormatrix:"})
+    local prims = append_property(s, "video-params/primaries", 
+                                  {prefix="Primaries:", nl=cmat and "" or o.nl})
+    append_property(s, "video-params/gamma", {prefix="Gamma:", nl=prims and "" or o.nl})
     append_property(s, "video-params/colorlevels", {prefix="Levels:"})
     append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -154,7 +154,7 @@ function add_video(s)
     end
     append_property(s, sec, "window-scale", {prefix="Window Scale:"})
     append_property(s, sec, "video-params/aspect", {prefix="Aspect Ratio:"})
-    append_property(s, sec, "video-params/pixelformat", {prefix="Pixel format:"})
+    append_property(s, sec, "video-params/pixelformat", {prefix="Pixel Format:"})
     append_property(s, sec, "video-params/colormatrix", {prefix="Colormatrix:"})
     append_property(s, sec, "video-params/primaries", {prefix="Primaries:"})
     append_property(s, sec, "video-params/gamma", {prefix="Gamma:"})

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -185,7 +185,8 @@ local function append_perfdata(s)
 
     local last_s = vo_p["render-last"] + vo_p["present-last"] + vo_p["upload-last"]
     local avg_s = vo_p["render-avg"] + vo_p["present-avg"] + vo_p["upload-avg"]
-    local peak_s = vo_p["render-peak"] + vo_p["present-peak"] + vo_p["upload-peak"]
+    --local peak_s = vo_p["render-peak"] + vo_p["present-peak"] + vo_p["upload-peak"]
+    local peak_s = -math.huge
 
     -- highlight i with a red border when t exceeds the time for one frame
     -- or yellow when it exceeds a given threshold

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -452,7 +452,14 @@ local function add_file(s)
     if not (mp.get_property_osd("filename") == mp.get_property_osd("media-title")) then
         append_property(s, "media-title", {prefix="Title:"})
     end
-    append_property(s, "chapter", {prefix="Chapter:"})
+
+    local ch_index = mp.get_property_number("chapter")
+    if ch_index and ch_index >= 0 then
+        append_property(s, "chapter-list/" .. tostring(ch_index) .. "/title", {prefix="Chapter:"})
+        append_property(s, "chapter-list/count",
+                        {prefix="(" .. tostring(ch_index + 1) .. "/", suffix=")", nl="",
+                         indent=" ", prefix_sep=" ", no_prefix_markup=true})
+    end
     if append_property(s, "cache-used", {prefix="Cache:"}) then
         append_property(s, "demuxer-cache-duration",
                         {prefix="+", suffix=" sec", nl="", indent=o.prefix_sep,

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -92,6 +92,9 @@ function add_file(s)
         append_property(s, sec, "demuxer-cache-duration",
                         {prefix="+", suffix=" sec", nl="", indent=o.prefix_sep,
                          prefix_sep="", no_prefix_markup=true})
+        append_property(s, sec, "cache-speed",
+                        {prefix="", suffix="", nl="", indent=o.prefix_sep,
+                         prefix_sep="", no_prefix_markup=true})
     end
 end
 
@@ -271,7 +274,5 @@ end
 function b(t)
     return o.b1 .. t .. o.b0
 end
-
-
 
 mp.add_key_binding("i", mp.get_script_name(), main, {repeatable=true})

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -262,7 +262,7 @@ local function append_property(s, prop, attr, excluded)
 end
 
 
-local function append_perfdata(s, full)
+local function append_perfdata(s, dedicated_page)
     local vo_p = mp.get_property_native("vo-passes")
     if not vo_p then
         return
@@ -317,23 +317,23 @@ local function append_perfdata(s, full)
         return format("{\\b%d}%02d{\\b0}%%", w, i * 100)
     end
 
-    s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", o.nl, o.indent,
+    s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", dedicated_page and "" or o.nl, dedicated_page and "" or o.indent,
                      b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
                      "(last/average/peak  μs)", o.font_size)
 
     for frame, data in pairs(vo_p) do
-        local f = "%s%s{\\fn%s}%s / %s / %s %s%s{\\fn%s}%s%s"
+        local f = "%s%s%s{\\fn%s}%s / %s / %s %s%s{\\fn%s}%s%s%s"
 
-        if full then
-            s[#s+1] = format("%s%s%s%s:", o.nl, o.indent, o.indent,
+        if dedicated_page then
+            s[#s+1] = format("%s%s%s:", o.nl, o.indent,
                              b(frame:gsub("^%l", string.upper)))
 
             for _, pass in ipairs(data) do
-                s[#s+1] = format(f, o.nl, o.indent .. o.indent .. o.indent,
+                s[#s+1] = format(f, o.nl, o.indent, o.indent,
                                  o.font_mono, hl(pass["last"], last_s[frame]),
                                  hl(pass["avg"], avg_s[frame]), hl(pass["peak"]),
                                  o.prefix_sep .. o.prefix_sep, p(pass["last"], last_s[frame]),
-                                 o.font, o.prefix_sep .. o.prefix_sep, pass["desc"])
+                                 o.font, o.prefix_sep, o.prefix_sep, pass["desc"])
 
                 if o.plot_perfdata and o.use_ass then
                     s[#s+1] = generate_graph(pass["samples"], pass["count"],
@@ -343,15 +343,15 @@ local function append_perfdata(s, full)
             end
 
             -- Print sum of timing values as "Total"
-            s[#s+1] = format(f, o.nl, o.indent .. o.indent .. o.indent,
+            s[#s+1] = format(f, o.nl, o.indent, o.indent,
                              o.font_mono, hl(last_s[frame]),
                              hl(avg_s[frame]), hl(peak_s[frame]), "", "", o.font,
-                             o.prefix_sep .. o.prefix_sep, b("Total"))
+                             o.prefix_sep, o.prefix_sep, b("Total"))
         else
             -- for the simplified view, we just print the sum of each pass
-            s[#s+1] = format(f, o.nl, o.indent .. o.indent, o.font_mono,
+            s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                             hl(last_s[frame]), hl(avg_s[frame]), hl(peak_s[frame]),
-                            "", "", o.font, o.prefix_sep .. o.prefix_sep,
+                            "", "", o.font, o.prefix_sep, o.prefix_sep,
                             frame:gsub("^%l", string.upper))
         end
     end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -304,5 +304,7 @@ mp.add_key_binding(o.key_oneshot, "display_stats", print_stats, {repeatable=true
 if pcall(function() timer:is_enabled() end) then
     mp.add_key_binding(o.key_toggle, "display_stats_toggle", toggle_stats, {repeatable=false})
 else
-    print("To use continious display of stats please upgrade mpv")
+    local txt = "Please upgrade mpv to toggle stats"
+    mp.add_key_binding(o.key_toggle, "display_stats_toggle",
+                       function() print(txt) ; mp.osd_message(txt) end, {repeatable=false})
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -317,9 +317,8 @@ local function append_perfdata(s, dedicated_page)
         return format("{\\b%d}%02d%%{\\b0}", w, i * 100)
     end
 
-    local title = "Frame Timings" .. (mp.get_property_bool("vd-lavc-dr", false) and " (DR):" or ":")
     s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", dedicated_page and "" or o.nl, dedicated_page and "" or o.indent,
-                     b(title), o.prefix_sep, o.font_size * 0.66,
+                     b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
                      "(last/average/peak  μs)", o.font_size)
 
     for frame, data in pairs(vo_p) do

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -544,7 +544,7 @@ local function add_page_bindings()
     end
 
     for k, _ in pairs(pages) do
-        mp.add_forced_key_binding(k, k, a(k), {repeatable=false})
+        mp.add_forced_key_binding(k, k, a(k), {repeatable=true})
     end
 end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -55,7 +55,7 @@ local o = {
 options.read_options(o)
 
 
-function main(duration)
+function print_stats(duration)
     local stats = {
         header = "",
         file = "",
@@ -286,23 +286,23 @@ function b(t)
 end
 
 
-local timer = mp.add_periodic_timer(o.redraw_delay - 0.1, function() main(o.redraw_delay) end)
+local timer = mp.add_periodic_timer(o.redraw_delay - 0.1, function() print_stats(o.redraw_delay) end)
 timer:kill()
 
-function periodic_main()
+function toggle_stats()
     if timer:is_enabled() then
         timer:kill()
         mp.osd_message("", 0)
     else
         timer:resume()
-        main(o.redraw_delay)
+        print_stats(o.redraw_delay)
     end
 end
 
 
-mp.add_key_binding(o.key_oneshot, "display_stats", main, {repeatable=true})
+mp.add_key_binding(o.key_oneshot, "display_stats", print_stats, {repeatable=true})
 if pcall(function() timer:is_enabled() end) then
-    mp.add_key_binding(o.key_toggle, "display_stats_toggle", periodic_main, {repeatable=false})
+    mp.add_key_binding(o.key_toggle, "display_stats_toggle", toggle_stats, {repeatable=false})
 else
     print("To use continious display of stats please upgrade mpv")
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -40,7 +40,7 @@ local o = {
     -- Text style
     font = "Source Sans Pro",
     font_mono = "Source Sans Pro",   -- monospaced digits are sufficient
-    font_size = 9,
+    font_size = 8,
     font_color = "FFFFFF",
     border_size = 0.8,
     border_color = "262626",

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -336,7 +336,8 @@ local function add_video(s)
         append_property(s, "estimated-display-fps",
                         {prefix="Display FPS:", suffix=" (estimated)"})
     end
-    if append_property(s, "fps", {prefix="FPS:", suffix=" (specified)"}) then
+    if append_property(s, "container-fps", {prefix="FPS:", suffix=" (specified)"}) or
+        append_property(s, "fps", {prefix="FPS:", suffix=" (specified)"}) then
         append_property(s, "estimated-vf-fps",
                         {suffix=" (estimated)", nl="", indent=""})
     else

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -20,7 +20,7 @@ local o = {
     ass_formatting = true,
     timing_warning = true,
     timing_warning_th = 0.85,        -- *no* warning threshold (warning when > target_fps * timing_warning_th)
-    timing_total = false,
+    print_perfdata_total = false,    -- prints an additional line adding up the perfdata lines
     debug = false,
 
     -- Graph options and style
@@ -296,7 +296,7 @@ local function append_perfdata(s)
     s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                     hl(vo_p["upload-last"], last_s), hl(vo_p["upload-avg"], avg_s),
                     hl(vo_p["upload-peak"], -math.huge), o.font, o.prefix_sep, usuffix)
-    if o.timing_total then
+    if o.print_perfdata_total then
         s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                         hl(last_s, last_s), hl(avg_s, avg_s),
                         hl(peak_s, peak_s), o.font, o.prefix_sep, o.prefix_sep .. "Total")

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -107,10 +107,15 @@ function add_video(s)
     end
 
     if append_property(s, sec, "video-codec", {prefix="Video:", nl="", indent=""}) then
-        append_property(s, sec, "hwdec-active",
+        if not append_property(s, sec, "hwdec-current",
+                        {prefix="(hwdec:", nl="", indent=" ",
+                         no_prefix_markup=true, suffix=")"},
+                        {no=true, [""]=true}) then
+            append_property(s, sec, "hwdec-active",
                         {prefix="(hwdec)", nl="", indent=" ",
                          no_prefix_markup=true, no_value=true},
                         {no=true})
+        end
     end
     append_property(s, sec, "avsync", {prefix="A-V:"})
     if append_property(s, sec, "drop-frame-count", {prefix="Dropped:"}) then

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -17,7 +17,6 @@ local o = {
 
     duration = 3,
     redraw_delay = 1,                -- acts as duration in the toggling case
-    timing_warning = true,
     ass_formatting = true,
     debug = false,
 
@@ -25,6 +24,8 @@ local o = {
     plot_graphs = true,
     skip_frames = 5,
     global_max = true,
+    timing_warning = true,
+    timing_warning_th = 0.85,         -- *no* warning threshold (warning when > dfps * timing_warning_th)
     plot_bg_border_color = "0000FF",
     plot_bg_color = "262626",
     plot_color = "FFFFFF",
@@ -178,10 +179,16 @@ local function append_perfdata(s)
     local peak_s = vo_p["render-peak"] + vo_p["present-peak"] + vo_p["upload-peak"]
 
     -- highlight i with a red border when t exceeds the time for one frame
+    -- or yellow when it exceeds a given threshold
     local function hl(i, t)
-        if o.timing_warning and t > dfps and dfps > 0 then
-            return format("{\\bord0.5}{\\3c&H0000FF&}%05d{\\bord%s}{\\3c&H%s&}",
-                            i, o.border_size, o.border_color)
+        if o.timing_warning and dfps > 0 then
+            if t > dfps then
+                return format("{\\bord0.5}{\\3c&H0000FF&}%05d{\\bord%s}{\\3c&H%s&}",
+                                i, o.border_size, o.border_color)
+            elseif t > (dfps * o.timing_warning_th) then
+                return format("{\\bord0.5}{\\1c&H00DDDD&}%05d{\\bord%s}{\\1c&H%s&}",
+                                i, o.border_size, o.font_color)
+            end
         end
         return format("%05d", i)
     end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -23,7 +23,7 @@ local o = {
     ass_formatting = true,
     timing_warning = true,
     timing_warning_th = 0.85,        -- *no* warning threshold (warning when > target_fps * timing_warning_th)
-    print_perfdata_total = false,    -- prints an additional line adding up the perfdata lines
+    print_perfdata_total = true,     -- prints an additional line adding up the perfdata lines
     print_perfdata_passes = false,   -- when true, print the full information about all passes
     debug = false,
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -288,7 +288,7 @@ function b(t)
 end
 
 
-local timer = mp.add_periodic_timer(o.redraw_delay - 0.1, function() print_stats(o.redraw_delay) end)
+local timer = mp.add_periodic_timer(o.redraw_delay, function() print_stats(o.redraw_delay + 1) end)
 timer:kill()
 
 function toggle_stats()
@@ -297,7 +297,7 @@ function toggle_stats()
         mp.osd_message("", 0)
     else
         timer:resume()
-        print_stats(o.redraw_delay)
+        print_stats(o.redraw_delay + 1)
     end
 end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -185,8 +185,7 @@ local function append_perfdata(s)
 
     local last_s = vo_p["render-last"] + vo_p["present-last"] + vo_p["upload-last"]
     local avg_s = vo_p["render-avg"] + vo_p["present-avg"] + vo_p["upload-avg"]
-    --local peak_s = vo_p["render-peak"] + vo_p["present-peak"] + vo_p["upload-peak"]
-    local peak_s = -math.huge
+    local peak_s = vo_p["render-peak"] + vo_p["present-peak"] + vo_p["upload-peak"]
 
     -- highlight i with a red border when t exceeds the time for one frame
     -- or yellow when it exceeds a given threshold
@@ -239,13 +238,13 @@ local function append_perfdata(s)
     local f = "%s%s%s{\\fn%s}%s / %s / %s{\\fn%s}%s%s"
     s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                     hl(vo_p["render-last"], last_s), hl(vo_p["render-avg"], avg_s),
-                    hl(vo_p["render-peak"], peak_s), o.font, o.prefix_sep, rsuffix)
+                    hl(vo_p["render-peak"], -math.huge), o.font, o.prefix_sep, rsuffix)
     s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                     hl(vo_p["present-last"], last_s), hl(vo_p["present-avg"], avg_s),
-                    hl(vo_p["present-peak"], peak_s), o.font, o.prefix_sep, psuffix)
+                    hl(vo_p["present-peak"], -math.huge), o.font, o.prefix_sep, psuffix)
     s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                     hl(vo_p["upload-last"], last_s), hl(vo_p["upload-avg"], avg_s),
-                    hl(vo_p["upload-peak"], peak_s), o.font, o.prefix_sep, usuffix)
+                    hl(vo_p["upload-peak"], -math.huge), o.font, o.prefix_sep, usuffix)
     if o.timing_total then
         s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                         hl(last_s, last_s), hl(avg_s, avg_s),

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -554,14 +554,6 @@ end
 timer = mp.add_periodic_timer(o.redraw_delay, function() print_stats(o.redraw_delay + 1) end)
 timer:kill()
 
--- Check if timer has required method
-if not pcall(function() timer:is_enabled() end) then
-    local txt = "Stats.lua: your version of mpv does not possess required functionality. \nPlease upgrade mpv or use an older version of this script."
-    print(txt)
-    mp.osd_message(txt, 15)
-    return
-end
-
 -- Single invocation key binding
 mp.add_key_binding(o.key_oneshot, "display_stats", print_stats, {repeatable=true})
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -65,19 +65,26 @@ local o = {
 options.read_options(o)
 
 local format = string.format
+-- Buffer for the "last" value of performance data for render/present/upload 
 local plast = {{0}, {0}, {0}}
+-- Position in buffer
 local ppos = 1
+-- Length of buffer
 local plen = 50
+-- Function used to record performance data
 local recorder = nil
-local timer
-
+-- Timer used for toggling
+local timer = nil
+-- Save these sequences locally as we'll need them a lot
+local ass_start = mp.get_property_osd("osd-ass-cc/0")
+local ass_stop = mp.get_property_osd("osd-ass-cc/1")
 
 
 local function set_ASS(b)
     if not o.ass_formatting then
         return ""
     end
-    return mp.get_property_osd("osd-ass-cc/" .. (b and "0" or "1"))
+    return b and ass_start or ass_stop
 end
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -340,7 +340,7 @@ local function add_video(s)
         append_property(s, "estimated-vf-fps",
                         {prefix="FPS:", suffix=" (estimated)"})
     end
-    if append_property(s, "video-speed-correction", {prefix="DS:"}) then
+    if append_property(s, "video-speed-correction", {prefix="DS:"}, {["+0.00000%"]=true}) then
         append_property(s, "audio-speed-correction",
                         {prefix="/", nl="", indent=" ", prefix_sep=" ", no_prefix_markup=true})
     end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -496,21 +496,13 @@ end
 
 -- Returns an ASS string with "normal" stats
 local function default_stats()
-    local stats = {
-        header = {},
-        file = {},
-        video = {},
-        audio = {},
-    }
-
+    local stats = {}
     eval_ass_formatting()
-    add_header(stats.header)
-    add_file(stats.file)
-    add_video(stats.video)
-    add_audio(stats.audio)
-
-    return table.concat(stats.header) .. table.concat(stats.file) ..
-           table.concat(stats.video) .. table.concat(stats.audio)
+    add_header(stats)
+    add_file(stats)
+    add_video(stats)
+    add_audio(stats)
+    return table.concat(stats)
 end
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -372,6 +372,9 @@ local function append_display_sync(s)
                         {prefix="DS:" .. o.prefix_sep .. " - / ", prefix_sep=""})
     end
 
+    append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
+    append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
+
     -- As we need to plot some graphs we print jitter and ratio on their own lines
     if toggle_timer:is_enabled() and (o.plot_vsync_ratio or o.plot_vsync_jitter) and o.use_ass then
         local ratio_graph = ""
@@ -426,10 +429,8 @@ local function add_video(s)
                         {no=true, [""]=true})
     end
     append_property(s, "avsync", {prefix="A-V:"})
-    if append_property(s, compat("decoder-frame-drop-count"), {prefix="Dropped:"}) then
-        append_property(s, compat("frame-drop-count"), {prefix="VO:", nl=""})
-        append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
-        append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
+    if append_property(s, compat("decoder-frame-drop-count"), {prefix="Dropped Frames:", suffix=" (decoder)"}) then
+        append_property(s, compat("frame-drop-count"), {suffix=" (output)", nl="", indent=""})
     end
     if append_property(s, "display-fps", {prefix="Display FPS:", suffix=" (specified)"}) then
         append_property(s, "estimated-display-fps",

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -69,12 +69,11 @@ timer:kill()
 
 
 function print_stats(duration)
-    --local start = mp.get_time()
     local stats = {
-        header = "",
-        file = "",
-        video = "",
-        audio = ""
+        header = {},
+        file = {},
+        video = {},
+        audio = {},
     }
 
     o.ass_formatting = o.ass_formatting and has_vo_window()
@@ -91,30 +90,28 @@ function print_stats(duration)
         end
     end
 
-    add_header(stats)
-    add_file(stats)
-    add_video(stats)
-    add_audio(stats)
+    add_header(stats.header)
+    add_file(stats.file)
+    add_video(stats.video)
+    add_audio(stats.audio)
 
-    mp.osd_message(join_stats(stats), duration or o.duration)
-    --print("main: " .. mp.get_time() - start)
+    mp.osd_message(table.concat(stats.header) .. table.concat(stats.file) ..
+                   table.concat(stats.video) .. table.concat(stats.audio),
+                   duration or o.duration)
 end
 
 
 function add_file(s)
-    local sec = "file"
-    s[sec] = ""
-
-    append_property(s, sec, "filename", {prefix="File:", nl="", indent=""})
+    append_property(s, "filename", {prefix="File:", nl="", indent=""})
     if not (mp.get_property_osd("filename") == mp.get_property_osd("media-title")) then
-        append_property(s, sec, "media-title", {prefix="Title:"})
+        append_property(s, "media-title", {prefix="Title:"})
     end
-    append_property(s, sec, "chapter", {prefix="Chapter:"})
-    if append_property(s, sec, "cache-used", {prefix="Cache:"}) then
-        append_property(s, sec, "demuxer-cache-duration",
+    append_property(s, "chapter", {prefix="Chapter:"})
+    if append_property(s, "cache-used", {prefix="Cache:"}) then
+        append_property(s, "demuxer-cache-duration",
                         {prefix="+", suffix=" sec", nl="", indent=o.prefix_sep,
                          prefix_sep="", no_prefix_markup=true})
-        append_property(s, sec, "cache-speed",
+        append_property(s, "cache-speed",
                         {prefix="", suffix="", nl="", indent=o.prefix_sep,
                          prefix_sep="", no_prefix_markup=true})
     end
@@ -122,81 +119,77 @@ end
 
 
 function add_video(s)
-    local sec = "video"
-    s[sec] = ""
     if not has_video() then
         return
     end
 
-    if append_property(s, sec, "video-codec", {prefix="Video:", nl="", indent=""}) then
-        if not append_property(s, sec, "hwdec-current",
+    if append_property(s, "video-codec", {prefix=o.nl .. o.nl .. "Video:", nl="", indent=""}) then
+        if not append_property(s, "hwdec-current",
                         {prefix="(hwdec:", nl="", indent=" ",
                          no_prefix_markup=true, suffix=")"},
                         {no=true, [""]=true}) then
-            append_property(s, sec, "hwdec-active",
+            append_property(s, "hwdec-active",
                         {prefix="(hwdec)", nl="", indent=" ",
                          no_prefix_markup=true, no_value=true},
                         {no=true})
         end
     end
-    append_property(s, sec, "avsync", {prefix="A-V:"})
-    if append_property(s, sec, "drop-frame-count", {prefix="Dropped:"}) then
-        append_property(s, sec, "vo-drop-frame-count", {prefix="VO:", nl=""})
-        append_property(s, sec, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
-        append_property(s, sec, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
+    append_property(s, "avsync", {prefix="A-V:"})
+    if append_property(s, "drop-frame-count", {prefix="Dropped:"}) then
+        append_property(s, "vo-drop-frame-count", {prefix="VO:", nl=""})
+        append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
+        append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
     end
-    if append_property(s, sec, "display-fps", {prefix="Display FPS:", suffix=" (specified)"}) then
-        append_property(s, sec, "estimated-display-fps",
+    if append_property(s, "display-fps", {prefix="Display FPS:", suffix=" (specified)"}) then
+        append_property(s, "estimated-display-fps",
                         {suffix=" (estimated)", nl="", indent=""})
     else
-        append_property(s, sec, "estimated-display-fps",
+        append_property(s, "estimated-display-fps",
                         {prefix="Display FPS:", suffix=" (estimated)"})
     end
-    if append_property(s, sec, "fps", {prefix="FPS:", suffix=" (specified)"}) then
-        append_property(s, sec, "estimated-vf-fps",
+    if append_property(s, "fps", {prefix="FPS:", suffix=" (specified)"}) then
+        append_property(s, "estimated-vf-fps",
                         {suffix=" (estimated)", nl="", indent=""})
     else
-        append_property(s, sec, "estimated-vf-fps",
+        append_property(s, "estimated-vf-fps",
                         {prefix="FPS:", suffix=" (estimated)"})
     end
-    if append_property(s, sec, "video-speed-correction", {prefix="DS:"}) then
-        append_property(s, sec, "audio-speed-correction",
+    if append_property(s, "video-speed-correction", {prefix="DS:"}) then
+        append_property(s, "audio-speed-correction",
                         {prefix="/", nl="", indent=" ", prefix_sep=" ", no_prefix_markup=true})
     end
 
-    append_perfdata(s, sec)
+    append_perfdata(s)
 
-    if append_property(s, sec, "video-params/w", {prefix="Native Resolution:"}) then
-        append_property(s, sec, "video-params/h",
+    if append_property(s, "video-params/w", {prefix="Native Resolution:"}) then
+        append_property(s, "video-params/h",
                         {prefix="x", nl="", indent=" ", prefix_sep=" ", no_prefix_markup=true})
     end
-    append_property(s, sec, "window-scale", {prefix="Window Scale:"})
-    append_property(s, sec, "video-params/aspect", {prefix="Aspect Ratio:"})
-    append_property(s, sec, "video-params/pixelformat", {prefix="Pixel Format:"})
-    append_property(s, sec, "video-params/colormatrix", {prefix="Colormatrix:"})
-    append_property(s, sec, "video-params/primaries", {prefix="Primaries:"})
-    append_property(s, sec, "video-params/gamma", {prefix="Gamma:"})
-    append_property(s, sec, "video-params/colorlevels", {prefix="Levels:"})
-    append_property(s, sec, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
+    append_property(s, "window-scale", {prefix="Window Scale:"})
+    append_property(s, "video-params/aspect", {prefix="Aspect Ratio:"})
+    append_property(s, "video-params/pixelformat", {prefix="Pixel Format:"})
+    append_property(s, "video-params/colormatrix", {prefix="Colormatrix:"})
+    append_property(s, "video-params/primaries", {prefix="Primaries:"})
+    append_property(s, "video-params/gamma", {prefix="Gamma:"})
+    append_property(s, "video-params/colorlevels", {prefix="Levels:"})
+    append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
 end
 
 
 function add_audio(s)
-    local sec = "audio"
-    s[sec] = ""
     if not has_audio() then
         return
     end
 
-    append_property(s, sec, "audio-codec", {prefix="Audio:", nl="", indent=""})
-    append_property(s, sec, "audio-params/samplerate", {prefix="Sample Rate:", suffix=" Hz"})
-    append_property(s, sec, "audio-params/channel-count", {prefix="Channels:"})
-    append_property(s, sec, "packet-audio-bitrate", {prefix="Bitrate:", suffix=" kbps"})
+    append_property(s, "audio-codec", {prefix=o.nl .. o.nl .. "Audio:", nl="", indent=""})
+    append_property(s, "audio-params/samplerate", {prefix="Sample Rate:", suffix=" Hz"})
+    append_property(s, "audio-params/channel-count", {prefix="Channels:"})
+    append_property(s, "packet-audio-bitrate", {prefix="Bitrate:", suffix=" kbps"})
 end
 
 
 function add_header(s)
-    s.header = text_style()
+    s[1] = text_style()
 end
 
 
@@ -220,15 +213,14 @@ end
 -- is skipped and not appended.
 -- Returns `false` in case nothing was appended, otherwise `true`.
 --
--- s       : Table containing key `sec`.
--- sec     : Existing key in table `s`, value treated as a string.
+-- s       : Table containing strings.
 -- property: The property to query and format (based on its OSD representation).
 -- attr    : Optional table to overwrite certain (formatting) attributes for
 --           this property.
 -- exclude : Optional table containing keys which are considered invalid values
 --           for this property. Specifying this will replace empty string as
 --           default invalid value (nil is always invalid).
-function append_property(s, sec, prop, attr, excluded)
+function append_property(s, prop, attr, excluded)
     excluded = excluded or {[""] = true}
     local ret = mp.get_property_osd(prop)
     if not ret or excluded[ret] then
@@ -247,8 +239,8 @@ function append_property(s, sec, prop, attr, excluded)
     attr.prefix = attr.no_prefix_markup and attr.prefix or b(attr.prefix)
     ret = attr.no_value and "" or ret
 
-    s[sec] = format("%s%s%s%s%s%s%s", s[sec], attr.nl, attr.indent,
-                    attr.prefix, attr.prefix_sep, no_ASS(ret), attr.suffix)
+    s[#s+1] = format("%s%s%s%s%s%s", attr.nl, attr.indent,
+                     attr.prefix, attr.prefix_sep, no_ASS(ret), attr.suffix)
     return true
 end
 
@@ -317,7 +309,7 @@ function record_perfdata(skip)
 end
 
 
-function append_perfdata(s, sec)
+function append_perfdata(s)
     local vo_p = mp.get_property_native("vo-performance")
     if not vo_p then
         return
@@ -349,15 +341,15 @@ function append_perfdata(s, sec)
         return i
     end
 
-    s[sec] = format("%s%s%s%s%s%s / %s / %s μs %s", s[sec], o.nl, o.indent, b("Render Time:"),
-                    o.prefix_sep, hl(vo_p["render-last"], last_s), hl(vo_p["render-avg"], avg_s),
-                    hl(vo_p["render-peak"], peak_s), graph_render)
-    s[sec] = format("%s%s%s%s%s%s / %s / %s μs %s", s[sec], o.nl, o.indent, b("Present Time:"),
-                    o.prefix_sep, hl(vo_p["present-last"], last_s), hl(vo_p["present-avg"], avg_s),
-                    hl(vo_p["present-peak"], peak_s), graph_present)
-    s[sec] = format("%s%s%s%s%s%s / %s / %s μs %s", s[sec], o.nl, o.indent, b("Upload Time:"),
-                    o.prefix_sep, hl(vo_p["upload-last"], last_s), hl(vo_p["upload-avg"], avg_s),
-                    hl(vo_p["upload-peak"], peak_s), graph_upload)
+    s[#s+1] = format("%s%s%s%s%s / %s / %s μs %s", o.nl, o.indent, b("Render Time:"),
+                     o.prefix_sep, hl(vo_p["render-last"], last_s), hl(vo_p["render-avg"], avg_s),
+                     hl(vo_p["render-peak"], peak_s), graph_render)
+    s[#s+1] = format("%s%s%s%s%s / %s / %s μs %s", o.nl, o.indent, b("Present Time:"),
+                     o.prefix_sep, hl(vo_p["present-last"], last_s), hl(vo_p["present-avg"], avg_s),
+                     hl(vo_p["present-peak"], peak_s), graph_present)
+    s[#s+1] = format("%s%s%s%s%s / %s / %s μs %s", o.nl, o.indent, b("Upload Time:"),
+                     o.prefix_sep, hl(vo_p["upload-last"], last_s), hl(vo_p["upload-avg"], avg_s),
+                     hl(vo_p["upload-peak"], peak_s), graph_upload)
 end
 
 
@@ -371,20 +363,6 @@ function set_ASS(b)
         return ""
     end
     return mp.get_property_osd("osd-ass-cc/" .. (b and "0" or "1"))
-end
-
-
-function join_stats(s)
-    r = s.header .. s.file
-
-    if s.video and s.video ~= "" then
-        r = r .. o.nl .. o.nl .. s.video
-    end
-    if s.audio and s.audio ~= "" then
-        r = r .. o.nl .. o.nl .. s.audio
-    end
-
-    return r
 end
 
 
@@ -456,3 +434,5 @@ mp.register_event("video-reconfig",
                 print_stats(o.redraw_delay + 1)
             end
         end)
+
+print("test")

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -19,7 +19,7 @@ local o = {
     redraw_delay = 1,                -- acts as duration in the toggling case
     ass_formatting = true,
     timing_warning = true,
-    timing_warning_th = 0.85,         -- *no* warning threshold (warning when > dfps * timing_warning_th)
+    timing_warning_th = 0.85,        -- *no* warning threshold (warning when > dfps * timing_warning_th)
     timing_total = false,
     debug = false,
 
@@ -214,7 +214,7 @@ local function append_perfdata(s)
         usuffix = generate_graph(plast[3], max[3], 0.8)
 
         s[#s+1] = format("%s%s%s%s{\\fs%s}%s%s%s{\\fs%s}", o.nl, o.indent,
-                         b("Timings:"), o.prefix_sep, o.font_size * 0.66,
+                         b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
                          "Render  ⏎  Present  ⏎  Upload", o.prefix_sep,
                          "(last/average/peak  μs)", o.font_size)
     else
@@ -223,7 +223,7 @@ local function append_perfdata(s)
         usuffix = o.prefix_sep .. "Upload"
 
         s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", o.nl, o.indent,
-                         b("Timings:"), o.prefix_sep, o.font_size * 0.66,
+                         b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
                          "(last/average/peak  μs)", o.font_size)
     end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -306,7 +306,7 @@ local function append_perfdata(s)
 end
 
 
-function append_display_sync(s)
+local function append_display_sync(s)
     if not mp.get_property_bool("display-sync-active", false) then
         return
     end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -354,11 +354,21 @@ local function add_video(s)
     append_property(s, "window-scale", {prefix="Window Scale:"})
     append_property(s, "video-params/aspect", {prefix="Aspect Ratio:"})
     append_property(s, "video-params/pixelformat", {prefix="Pixel Format:"})
-    local cmat = append_property(s, "video-params/colormatrix", {prefix="Colormatrix:"})
-    local prims = append_property(s, "video-params/primaries", 
-                                  {prefix="Primaries:", nl=cmat and "" or o.nl})
-    append_property(s, "video-params/gamma", {prefix="Gamma:", nl=prims and "" or o.nl})
-    append_property(s, "video-params/colorlevels", {prefix="Levels:"})
+
+    -- Group these together to save vertical space
+    local prim = append_property(s, "video-params/primaries", {prefix="Primaries:"})
+    local cmat = append_property(s, "video-params/colormatrix",
+                                 {prefix="Colormatrix:", nl=prim and "" or o.nl})
+    append_property(s, "video-params/colorlevels", {prefix="Levels:", nl=cmat and "" or o.nl})
+
+    -- Append HDR metadata conditionally (only when present and interesting)
+    local hdrpeak = mp.get_property_number("video-params/sig-peak", 0)
+    local hdrinfo = ""
+    if hdrpeak > 0 then
+        hdrinfo = " (HDR peak: " .. hdrpeak .. " cd/m²)"
+    end
+
+    append_property(s, "video-params/gamma", {prefix="Gamma:", suffix=hdrinfo})
     append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
 end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -18,14 +18,15 @@ local o = {
     duration = 3,
     redraw_delay = 1,                -- acts as duration in the toggling case
     ass_formatting = true,
+    timing_warning = true,
+    timing_warning_th = 0.85,         -- *no* warning threshold (warning when > dfps * timing_warning_th)
+    timing_total = false,
     debug = false,
 
     -- Graph options and style
     plot_graphs = true,
     skip_frames = 5,
     global_max = true,
-    timing_warning = true,
-    timing_warning_th = 0.85,         -- *no* warning threshold (warning when > dfps * timing_warning_th)
     plot_bg_border_color = "0000FF",
     plot_bg_color = "262626",
     plot_color = "FFFFFF",
@@ -160,8 +161,8 @@ local function generate_graph(values, v_max, scale)
 
     local bg_box = format("{\\bord0.5}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
                           o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
-    return format("\\h\\h\\h{\\r}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}{\\r}%s",
-                  y_offset, bg_box, o.plot_color, table.concat(s), text_style())
+    return format("%s{\\r}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}{\\r}%s",
+                  o.prefix_sep, y_offset, bg_box, o.plot_color, table.concat(s), text_style())
 end
 
 
@@ -217,9 +218,9 @@ local function append_perfdata(s)
                          "Render  ⏎  Present  ⏎  Upload", o.prefix_sep,
                          "(last/average/peak  μs)", o.font_size)
     else
-        rsuffix = "Render"
-        psuffix = "Present"
-        usuffix = "Upload"
+        rsuffix = o.prefix_sep .. "Render"
+        psuffix = o.prefix_sep .. "Present"
+        usuffix = o.prefix_sep .. "Upload"
 
         s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", o.nl, o.indent,
                          b("Timings:"), o.prefix_sep, o.font_size * 0.66,
@@ -236,6 +237,11 @@ local function append_perfdata(s)
     s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
                     hl(vo_p["upload-last"], last_s), hl(vo_p["upload-avg"], avg_s),
                     hl(vo_p["upload-peak"], peak_s), o.font, o.prefix_sep, usuffix)
+    if o.timing_total then
+        s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,
+                        hl(last_s, last_s), hl(avg_s, avg_s),
+                        hl(peak_s, peak_s), o.font, o.prefix_sep, o.prefix_sep .. "Total")
+    end
 end
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -23,7 +23,6 @@ local o = {
     ass_formatting = true,
     timing_warning = true,
     timing_warning_th = 0.85,        -- *no* warning threshold (warning when > target_fps * timing_warning_th)
-    print_perfdata_total = true,     -- prints an additional line adding up the perfdata lines
     print_perfdata_passes = false,   -- when true, print the full information about all passes
     debug = false,
 
@@ -330,12 +329,10 @@ local function append_perfdata(s, full)
                 end
             end
 
-            if o.print_perfdata_total then
-                s[#s+1] = format(f, o.nl, o.indent .. o.indent .. o.indent,
-                                 o.font_mono, hl(last_s[frame]),
-                                 hl(avg_s[frame]), hl(peak_s[frame]), o.font,
-                                 o.prefix_sep, o.prefix_sep, b("Total"))
-            end
+            s[#s+1] = format(f, o.nl, o.indent .. o.indent .. o.indent,
+                             o.font_mono, hl(last_s[frame]),
+                             hl(avg_s[frame]), hl(peak_s[frame]), o.font,
+                             o.prefix_sep, o.prefix_sep, b("Total"))
         else
             -- for the simplified view, we just print the sum of each pass
             s[#s+1] = format(f, o.nl, o.indent .. o.indent, o.font_mono,

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -57,11 +57,11 @@ local o = {
 
     -- Text formatting
     -- With ASS
-    nl = "\\N",
-    indent = "\\h\\h\\h\\h\\h",
-    prefix_sep = "\\h\\h",
-    b1 = "{\\b1}",
-    b0 = "{\\b0}",
+    ass_nl = "\\N",
+    ass_indent = "\\h\\h\\h\\h\\h",
+    ass_prefix_sep = "\\h\\h",
+    ass_b1 = "{\\b1}",
+    ass_b0 = "{\\b0}",
     -- Without ASS
     no_ass_nl = "\n",
     no_ass_indent = "\t",
@@ -118,7 +118,7 @@ end
 
 
 local function set_ASS(b)
-    if not o.ass_formatting then
+    if not o.use_ass then
         return ""
     end
     return b and ass_start or ass_stop
@@ -136,7 +136,7 @@ end
 
 
 local function text_style()
-    if not o.ass_formatting then
+    if not o.use_ass then
         return ""
     end
     if o.custom_header and o.custom_header ~= "" then
@@ -323,7 +323,7 @@ local function append_perfdata(s, full)
                                  hl(pass["avg"], avg_s[frame]), hl(pass["peak"]),
                                  o.font, o.prefix_sep, o.prefix_sep, pass["desc"])
 
-                if o.plot_perfdata and o.ass_formatting then
+                if o.plot_perfdata and o.use_ass then
                     s[#s+1] = generate_graph(pass["samples"], pass["count"],
                                              pass["count"], pass["peak"],
                                              pass["avg"], 0.9, 0.25)
@@ -362,7 +362,7 @@ local function append_display_sync(s)
     end
 
     -- As we need to plot some graphs we print jitter and ratio on their own lines
-    if toggle_timer:is_enabled() and (o.plot_vsync_ratio or o.plot_vsync_jitter) and o.ass_formatting then
+    if toggle_timer:is_enabled() and (o.plot_vsync_ratio or o.plot_vsync_jitter) and o.use_ass then
         local ratio_graph = ""
         local jitter_graph = ""
         if o.plot_vsync_ratio then
@@ -478,8 +478,14 @@ end
 
 -- Determine whether ASS formatting shall/can be used
 local function eval_ass_formatting()
-    o.ass_formatting = o.ass_formatting and has_vo_window()
-    if not o.ass_formatting then
+    o.use_ass = o.ass_formatting and has_vo_window()
+    if o.use_ass then
+        o.nl = o.ass_nl
+        o.indent = o.ass_indent
+        o.prefix_sep = o.ass_prefix_sep
+        o.b1 = o.ass_b1
+        o.b0 = o.ass_b0
+    else
         o.nl = o.no_ass_nl
         o.indent = o.no_ass_indent
         o.prefix_sep = o.no_ass_prefix_sep

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -314,7 +314,7 @@ local function append_perfdata(s, dedicated_page)
         end
         -- Calculate font weight. 100 is minimum, 400 is normal, 700 bold, 900 is max
         local w = (700 * math.sqrt(i)) + 200
-        return format("{\\b%d}%02d{\\b0}%%", w, i * 100)
+        return format("{\\b%d}%02d%%{\\b0}", w, i * 100)
     end
 
     s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", dedicated_page and "" or o.nl, dedicated_page and "" or o.indent,

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -197,7 +197,7 @@ local function append_perfdata(s)
 
     local rsuffix, psuffix, usuffix
 
-    if o.plot_graphs and timer:is_enabled() then
+    if o.plot_graphs and o.ass_formatting and timer:is_enabled() then
         local max = {1, 1, 1}
         for e = 1, plen do
             if plast[1][e] and plast[1][e] > max[1] then max[1] = plast[1][e] end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -320,28 +320,23 @@ local function append_display_sync(s)
                         {prefix="DS:" .. o.prefix_sep .. " - / ", prefix_sep=""})
     end
 
-    -- Since no graph is needed we can print ratio/jitter on the same line and save some space
-    if not (o.plot_vsync_ratio or o.plot_vsync_jitter) then
-        local vratio = append_property(s, "vsync-ratio", {prefix="VSync Ratio:"})
-        append_property(s, "vsync-jitter", {prefix="VSync Jitter:", nl=vratio and "" or o.nl})
-        return
-    end
-
-    -- As we potentially need to plot some graphs we print jitter and ratio on
-    -- their own lines so we have the same layout when toggled (= drawing graphs)
-    local ratio_graph = ""
-    local jitter_graph = ""
-    if o.ass_formatting and timer:is_enabled() then
+    -- As we need to plot some graphs we print jitter and ratio on their own lines
+    if timer:is_enabled() and (o.plot_vsync_ratio or o.plot_vsync_jitter) and o.ass_formatting then
+        local ratio_graph = ""
+        local jitter_graph = ""
         if o.plot_vsync_ratio then
             ratio_graph = generate_graph(vsratio_buf, vsratio_buf.pos, vsratio_buf.len, vsratio_buf.max, 0.8)
         end
         if o.plot_vsync_jitter then
             jitter_graph = generate_graph(vsjitter_buf, vsjitter_buf.pos, vsjitter_buf.len, vsjitter_buf.max, 0.8)
         end
+        append_property(s, "vsync-ratio", {prefix="VSync Ratio:", suffix=o.prefix_sep .. ratio_graph})
+        append_property(s, "vsync-jitter", {prefix="VSync Jitter:", suffix=o.prefix_sep .. jitter_graph})
+    else
+        -- Since no graph is needed we can print ratio/jitter on the same line and save some space
+        local vratio = append_property(s, "vsync-ratio", {prefix="VSync Ratio:"})
+        append_property(s, "vsync-jitter", {prefix="VSync Jitter:", nl="" or o.nl})
     end
-
-    append_property(s, "vsync-ratio", {prefix="VSync Ratio:", suffix=o.prefix_sep .. ratio_graph})
-    append_property(s, "vsync-jitter", {prefix="VSync Jitter:", suffix=o.prefix_sep .. jitter_graph})
 end
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -139,29 +139,27 @@ local function has_ansi()
 end
 
 
-local function generate_graph(values, v_max, scale)
-    -- check if at least one value was recorded yet
-    if ppos < 1 then
+local function generate_graph(values, i, len, v_max, scale)
+    -- check if at least one value was recorded yet (we assume lua-style 1-indexing)
+    if i < 1 then
         return ""
     end
 
     local x_tics = 1
-    local x_max = (plen - 1) * x_tics
+    local x_max = (len - 1) * x_tics
     local y_offset = o.border_size
     local y_max = o.font_size * 0.66
     local x = 0
 
-
-    local i = ppos
     local s = {format("m 0 0 n %f %f l ", x, y_max - (y_max * values[i] / v_max * scale))}
-    i = ((i - 2) % plen) + 1
+    i = ((i - 2) % len) + 1
 
-    for p = 1, plen - 1 do
+    for p = 1, len - 1 do
         if values[i] then
             x = x - x_tics
             s[#s+1] = format("%f %f ", x, y_max - (y_max * values[i] / v_max * scale))
         end
-        i = ((i - 2) % plen) + 1
+        i = ((i - 2) % len) + 1
     end
 
     s[#s+1] = format("%f %f %f %f", x, y_max, 0, y_max)
@@ -217,9 +215,9 @@ local function append_perfdata(s)
             max[2], max[3] = max[1], max[1]
         end
 
-        rsuffix = generate_graph(plast[1], max[1], 0.8)
-        psuffix = generate_graph(plast[2], max[2], 0.8)
-        usuffix = generate_graph(plast[3], max[3], 0.8)
+        rsuffix = generate_graph(plast[1], ppos, plen, max[1], 0.8)
+        psuffix = generate_graph(plast[2], ppos, plen, max[2], 0.8)
+        usuffix = generate_graph(plast[3], ppos, plen, max[3], 0.8)
 
         s[#s+1] = format("%s%s%s%s{\\fs%s}%s%s%s{\\fs%s}", o.nl, o.indent,
                          b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -430,8 +430,8 @@ local function add_video(s)
     -- Append HDR metadata conditionally (only when present and interesting)
     local hdrpeak = mp.get_property_number("video-params/sig-peak", 0)
     local hdrinfo = ""
-    if hdrpeak > 0 then
-        hdrinfo = " (HDR peak: " .. hdrpeak .. " cd/m²)"
+    if hdrpeak > 1 then
+        hdrinfo = " (HDR peak: " .. hdrpeak .. ")"
     end
 
     append_property(s, "video-params/gamma", {prefix="Gamma:", suffix=hdrinfo})

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -318,15 +318,10 @@ local function add_video(s)
     end
 
     if append_property(s, "video-codec", {prefix=o.nl .. o.nl .. "Video:", nl="", indent=""}) then
-        if not append_property(s, "hwdec-current",
+        append_property(s, "hwdec-current",
                         {prefix="(hwdec:", nl="", indent=" ",
                          no_prefix_markup=true, suffix=")"},
-                        {no=true, [""]=true}) then
-            append_property(s, "hwdec-active",
-                        {prefix="(hwdec)", nl="", indent=" ",
-                         no_prefix_markup=true, no_value=true},
-                        {no=true})
-        end
+                        {no=true, [""]=true})
     end
     append_property(s, "avsync", {prefix="A-V:"})
     if append_property(s, "drop-frame-count", {prefix="Dropped:"}) then

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -317,8 +317,9 @@ local function append_perfdata(s, dedicated_page)
         return format("{\\b%d}%02d%%{\\b0}", w, i * 100)
     end
 
+    local title = "Frame Timings" .. (mp.get_property_bool("vd-lavc-dr", false) and " (DR):" or ":")
     s[#s+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}", dedicated_page and "" or o.nl, dedicated_page and "" or o.indent,
-                     b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
+                     b(title), o.prefix_sep, o.font_size * 0.66,
                      "(last/average/peak  μs)", o.font_size)
 
     for frame, data in pairs(vo_p) do

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -524,7 +524,7 @@ end
 
 -- Returns an ASS string with stats about filters/profiles/shaders
 local function filter_stats()
-    return "filters/profiles/shaders"
+    return "coming soon"
 end
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -142,7 +142,7 @@ local function text_style()
     if o.custom_header and o.custom_header ~= "" then
         return set_ASS(true) .. o.custom_header
     else
-        return format("%s{\\fs%d}{\\fn%s}{\\bord%f}{\\3c&H%s&}{\\1c&H%s&}{\\alpha&H%s&}{\\xshad%f}{\\yshad%f}{\\4c&H%s&}",
+        return format("%s{\\r}{\\an7}{\\fs%d}{\\fn%s}{\\bord%f}{\\3c&H%s&}{\\1c&H%s&}{\\alpha&H%s&}{\\xshad%f}{\\yshad%f}{\\4c&H%s&}",
                         set_ASS(true), o.font_size, o.font, o.border_size,
                         o.border_color, o.font_color, o.alpha, o.shadow_x_offset,
                         o.shadow_y_offset, o.shadow_color)
@@ -220,7 +220,7 @@ local function generate_graph(values, i, len, v_max, v_avg, scale, x_tics)
 
     local bg_box = format("{\\bord0.5}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
                           o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
-    return format("%s{\\r}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}{\\r}%s",
+    return format("%s{\\r}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
                   o.prefix_sep, y_offset, bg_box, o.plot_color, table.concat(s), text_style())
 end
 
@@ -382,7 +382,7 @@ end
 
 
 local function add_header(s)
-    s[1] = text_style()
+    s[#s+1] = text_style()
 end
 
 
@@ -530,7 +530,7 @@ end
 
 -- Call the function for `page` and print it to OSD
 local function print_page(page, duration)
-    mp.osd_message(pages[page](), duration or o.duration)
+    mp.osd_message(pages[page].f(), duration or o.duration)
 end
 
 
@@ -634,9 +634,9 @@ end
 -- Current page and <page key>:<page function> mapping
 curr_page = o.key_page_1
 pages = {
-    [o.key_page_1] = default_stats,
-    [o.key_page_2] = vo_stats,
-    [o.key_page_3] = filter_stats,
+    [o.key_page_1] = { f = default_stats, desc = "Default" },
+    [o.key_page_2] = { f = vo_stats, desc = "Extended Frame Timings" },
+    [o.key_page_3] = { f = filter_stats, desc = "Dummy" },
 }
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -259,13 +259,13 @@ end
 -- is skipped and not appended.
 -- Returns `false` in case nothing was appended, otherwise `true`.
 --
--- s       : Table containing strings.
--- property: The property to query and format (based on its OSD representation).
--- attr    : Optional table to overwrite certain (formatting) attributes for
---           this property.
--- exclude : Optional table containing keys which are considered invalid values
---           for this property. Specifying this will replace empty string as
---           default invalid value (nil is always invalid).
+-- s      : Table containing strings.
+-- prop   : The property to query and format (based on its OSD representation).
+-- attr   : Optional table to overwrite certain (formatting) attributes for
+--          this property.
+-- exclude: Optional table containing keys which are considered invalid values
+--          for this property. Specifying this will replace empty string as
+--          default invalid value (nil is always invalid).
 local function append_property(s, prop, attr, excluded)
     excluded = excluded or {[""] = true}
     local ret = mp.get_property_osd(prop)

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -374,7 +374,11 @@ local function add_video(s)
                         {no=true, [""]=true})
     end
     append_property(s, "avsync", {prefix="A-V:"})
-    if append_property(s, "drop-frame-count", {prefix="Dropped:"}) then
+    if append_property(s, "decoder-frame-drop-count", {prefix="Dropped:"}) then
+        append_property(s, "frame-drop-count", {prefix="VO:", nl=""})
+        append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
+        append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
+    elseif append_property(s, "drop-frame-count", {prefix="Dropped:"}) then
         append_property(s, "vo-drop-frame-count", {prefix="VO:", nl=""})
         append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
         append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -378,6 +378,7 @@ local function add_video(s)
         append_property(s, "frame-drop-count", {prefix="VO:", nl=""})
         append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})
         append_property(s, "vo-delayed-frame-count", {prefix="Delayed:", nl=""})
+    -- Deprecated FPS properties for backwards compatibility
     elseif append_property(s, "drop-frame-count", {prefix="Dropped:"}) then
         append_property(s, "vo-drop-frame-count", {prefix="VO:", nl=""})
         append_property(s, "mistimed-frame-count", {prefix="Mistimed:", nl=""})

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -138,7 +138,16 @@ local function has_ansi()
     return true
 end
 
-
+-- Generate a graph from the given values.
+-- Returns an ASS formatted vector drawing as string.
+--
+-- values: Array/Table of numbers representing the data. Used like a ring buffer
+--         it will get iterated backwards `len` times starting at position `i`.
+-- i     : Index of the latest data value in `values`.
+-- len   : The length/amount of numbers in `values`.
+-- v_max : The maximum number in `values`. It is used to scale all data
+--         values to a range of 0 to `v_max`.
+-- scale : A value that will be multiplied with all data values.
 local function generate_graph(values, i, len, v_max, scale)
     -- check if at least one value was recorded yet (we assume lua-style 1-indexing)
     if i < 1 then

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -220,6 +220,7 @@ void mp_load_builtin_scripts(struct MPContext *mpctx)
 {
     load_builtin_script(mpctx, mpctx->opts->lua_load_osc, "@osc.lua");
     load_builtin_script(mpctx, mpctx->opts->lua_load_ytdl, "@ytdl_hook.lua");
+    load_builtin_script(mpctx, mpctx->opts->lua_load_stats, "@stats.lua");
 }
 
 void mp_load_scripts(struct MPContext *mpctx)

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -100,7 +100,7 @@ def build(ctx):
     )
 
     lua_files = ["defaults.lua", "assdraw.lua", "options.lua", "osc.lua",
-                 "ytdl_hook.lua"]
+                 "ytdl_hook.lua", "stats.lua"]
 
     for fn in lua_files:
         fn = "player/lua/" + fn

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -4,7 +4,7 @@ import os
 def _add_rst_manual_dependencies(ctx):
     manpage_sources_basenames = """
         options.rst ao.rst vo.rst af.rst vf.rst encode.rst
-        input.rst osc.rst lua.rst ipc.rst changes.rst""".split()
+        input.rst osc.rst stats.rst lua.rst ipc.rst changes.rst""".split()
 
     manpage_sources = ['DOCS/man/'+x for x in manpage_sources_basenames]
 


### PR DESCRIPTION
Well then, let's try this.
Naturally, I'd continue maintaining/extending the script.

In case this would get accepted, there are a few things to do before merging:
- [x] License: the script is currently licensed GPL 2.0, I guess that's incompatible. All contributors (except one) are also active mpv contributors so re-licensing shouldn't be a big deal 
- [x] ~Should I add a `stats=no` here? https://github.com/mpv-player/mpv/blob/master/etc/builtin.conf#L20~ verdict: not needed
- [x] Documentation: similar to the OSC (although at smaller scale) it has a few options. Should I create a documentation similar to the OSC? I'll wait with writing that until I know if this gets accepted though. Can also add it with a follow-up PR.

Regarding default options: any specific wishes? Doesn't collide with default bindings right now, as far as I can see. One more thing: the script can do both, print using `mp.osd_message()` (can get overwritten by other printed text) and `mp.set_osd_ass()` (persistent but might overlap with other printed text). What would be a sane default (as in: best user experience) for that?