### PR TITLE
Add support for Vulkan on Windows

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -49,6 +49,7 @@ extern const struct ra_ctx_fns ra_ctx_vdpauglx;
 
 /* Vulkan */
 extern const struct ra_ctx_fns ra_ctx_vulkan_wayland;
+extern const struct ra_ctx_fns ra_ctx_vulkan_win;
 extern const struct ra_ctx_fns ra_ctx_vulkan_xlib;
 
 static const struct ra_ctx_fns *contexts[] = {
@@ -93,6 +94,9 @@ static const struct ra_ctx_fns *contexts[] = {
 // Vulkan contexts:
 #if HAVE_VULKAN
 
+#if HAVE_WIN32_DESKTOP
+    &ra_ctx_vulkan_win,
+#endif
 #if HAVE_WAYLAND
     &ra_ctx_vulkan_wayland,
 #endif

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -19,6 +19,9 @@
 #if HAVE_X11
 #define VK_USE_PLATFORM_XLIB_KHR
 #endif
+#if HAVE_WIN32_DESKTOP
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
 
 #include <vulkan/vulkan.h>
 

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -1,0 +1,105 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "video/out/gpu/context.h"
+#include "video/out/w32_common.h"
+
+#include "common.h"
+#include "context.h"
+#include "utils.h"
+
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
+
+struct priv {
+    struct mpvk_ctx vk;
+};
+
+static void win_uninit(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+
+    ra_vk_ctx_uninit(ctx);
+    mpvk_uninit(&p->vk);
+    vo_w32_uninit(ctx->vo);
+}
+
+static bool win_init(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
+    struct mpvk_ctx *vk = &p->vk;
+    int msgl = ctx->opts.probing ? MSGL_V : MSGL_ERR;
+
+    if (!mpvk_instance_init(vk, ctx->log, VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+                            ctx->opts.debug))
+        goto error;
+
+    if (!vo_w32_init(ctx->vo))
+        goto error;
+
+    VkWin32SurfaceCreateInfoKHR wininfo = {
+         .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+         .hinstance = HINST_THISCOMPONENT,
+         .hwnd = vo_w32_hwnd(ctx->vo),
+    };
+
+    VkResult res = vkCreateWin32SurfaceKHR(vk->inst, &wininfo, MPVK_ALLOCATOR,
+                                           &vk->surf);
+    if (res != VK_SUCCESS) {
+        MP_MSG(ctx, msgl, "Failed creating Windows surface: %s\n", vk_err(res));
+        goto error;
+    }
+
+    if (!ra_vk_ctx_init(ctx, vk, VK_PRESENT_MODE_FIFO_KHR))
+        goto error;
+
+    return true;
+
+error:
+    win_uninit(ctx);
+    return false;
+}
+
+static bool resize(struct ra_ctx *ctx)
+{
+    return ra_vk_ctx_resize(ctx->swapchain, ctx->vo->dwidth, ctx->vo->dheight);
+}
+
+static bool win_reconfig(struct ra_ctx *ctx)
+{
+    vo_w32_config(ctx->vo);
+    return resize(ctx);
+}
+
+static int win_control(struct ra_ctx *ctx, int *events, int request, void *arg)
+{
+    int ret = vo_w32_control(ctx->vo, events, request, arg);
+    if (*events & VO_EVENT_RESIZE) {
+        if (!resize(ctx))
+            return VO_ERROR;
+    }
+    return ret;
+}
+
+const struct ra_ctx_fns ra_ctx_vulkan_win = {
+    .type           = "vulkan",
+    .name           = "win",
+    .reconfig       = win_reconfig,
+    .control        = win_control,
+    .init           = win_init,
+    .uninit         = win_uninit,
+};

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -451,6 +451,7 @@ def build(ctx):
         ( "video/out/vulkan/context.c",          "vulkan" ),
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
+        ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
         ( "video/out/vulkan/spirv_nvidia.c",     "vulkan" ),
         ( "video/out/win32/exclusive_hack.c",    "gl-win32" ),
         ( "video/out/wayland_common.c",          "wayland" ),


### PR DESCRIPTION
This has been tested and seems to work.

One problem is that mpv spams messages like this on resize:
```
[vo/gpu/vulkan] Requested width 1392 does not match current width 1395
[vo/gpu/vulkan] Requested height 783 does not match current height 784
[vo/gpu/vulkan] Requested width 1419 does not match current width 1423
[vo/gpu/vulkan] Requested height 798 does not match current height 800
```

I think this is because resizing on Windows happens asynchronously from the perspective of the vo thread. Resizing still works though.