### PR TITLE
vo_gpu: convert some static arrays into dynamic arrays (including VAO)

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3972,10 +3972,6 @@ The following video options are currently all specific to ``--vo=gpu`` and
     ``--tscale`` are separable convolution filters (use ``--tscale=help`` to
     get a list). The default is ``mitchell``.
 
-    Note that the maximum supported filter radius is currently 3, due to
-    limitations in the number of video textures that can be loaded
-    simultaneously.
-
 ``--scale-param1=<value>``, ``--scale-param2=<value>``, ``--cscale-param1=<value>``, ``--cscale-param2=<value>``, ``--dscale-param1=<value>``, ``--dscale-param2=<value>``, ``--tscale-param1=<value>``, ``--tscale-param2=<value>``
     Set filter parameters. Ignored if the filter is not tunable. Currently,
     this affects the following filter parameters:

--- a/video/out/gpu/osd.c
+++ b/video/out/gpu/osd.c
@@ -47,7 +47,6 @@ static const struct ra_renderpass_input vertex_vao[] = {
     {"position",  RA_VARTYPE_FLOAT,      2, 1, offsetof(struct vertex, position)},
     {"texcoord" , RA_VARTYPE_FLOAT,      2, 1, offsetof(struct vertex, texcoord)},
     {"ass_color", RA_VARTYPE_BYTE_UNORM, 4, 1, offsetof(struct vertex, ass_color)},
-    {0}
 };
 
 struct mpgl_osd_part {
@@ -231,8 +230,6 @@ bool mpgl_osd_draw_prepare(struct mpgl_osd *ctx, int index,
         abort();
     }
 
-    gl_sc_set_vertex_format(sc, vertex_vao, sizeof(struct vertex));
-
     return true;
 }
 
@@ -317,7 +314,8 @@ void mpgl_osd_draw_finish(struct mpgl_osd *ctx, int index,
     const int *factors = &blend_factors[part->format][0];
     gl_sc_blend(sc, factors[0], factors[1], factors[2], factors[3]);
 
-    gl_sc_dispatch_draw(sc, fbo.tex, part->vertices, part->num_vertices);
+    gl_sc_dispatch_draw(sc, fbo.tex, vertex_vao, MP_ARRAY_SIZE(vertex_vao),
+                        sizeof(struct vertex), part->vertices, part->num_vertices);
 }
 
 static void set_res(struct mpgl_osd *ctx, struct mp_osd_res res, int stereo_mode)

--- a/video/out/gpu/shader_cache.h
+++ b/video/out/gpu/shader_cache.h
@@ -43,9 +43,6 @@ void gl_sc_uniform_mat2(struct gl_shader_cache *sc, char *name,
                         bool transpose, float *v);
 void gl_sc_uniform_mat3(struct gl_shader_cache *sc, char *name,
                         bool transpose, float *v);
-void gl_sc_set_vertex_format(struct gl_shader_cache *sc,
-                             const struct ra_renderpass_input *vertex_attribs,
-                             int vertex_stride);
 void gl_sc_blend(struct gl_shader_cache *sc,
                  enum ra_blend blend_src_rgb,
                  enum ra_blend blend_dst_rgb,
@@ -54,6 +51,8 @@ void gl_sc_blend(struct gl_shader_cache *sc,
 void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name);
 struct mp_pass_perf gl_sc_dispatch_draw(struct gl_shader_cache *sc,
                                         struct ra_tex *target,
+                                        const struct ra_renderpass_input *vao,
+                                        int vao_len, size_t vertex_stride,
                                         void *ptr, size_t num);
 struct mp_pass_perf gl_sc_dispatch_compute(struct gl_shader_cache *sc,
                                            int w, int h, int d);

--- a/video/out/gpu/user_shaders.h
+++ b/video/out/gpu/user_shaders.h
@@ -22,7 +22,7 @@
 #include "ra.h"
 
 #define SHADER_MAX_HOOKS 16
-#define SHADER_MAX_BINDS 6
+#define SHADER_MAX_BINDS 16
 #define MAX_SZEXP_SIZE 32
 
 enum szexp_op {

--- a/video/out/gpu/user_shaders.h
+++ b/video/out/gpu/user_shaders.h
@@ -21,10 +21,8 @@
 #include "utils.h"
 #include "ra.h"
 
-#define SHADER_MAX_PASSES 32
 #define SHADER_MAX_HOOKS 16
 #define SHADER_MAX_BINDS 6
-#define SHADER_MAX_SAVED 64
 #define MAX_SZEXP_SIZE 32
 
 enum szexp_op {

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -135,7 +135,7 @@ struct saved_img {
 struct tex_hook {
     const char *save_tex;
     const char *hook_tex[SHADER_MAX_HOOKS];
-    const char *bind_tex[TEXUNIT_VIDEO_NUM];
+    const char *bind_tex[SHADER_MAX_BINDS];
     int components; // how many components are relevant (0 = same as input)
     void *priv; // this gets talloc_freed when the tex_hook is removed
     void (*hook)(struct gl_video *p, struct image img, // generates GLSL
@@ -161,7 +161,7 @@ struct pass_info {
     struct mp_pass_perf perf;
 };
 
-#define PASS_INFO_MAX (SHADER_MAX_PASSES + 32)
+#define PASS_INFO_MAX 64
 
 struct dr_buffer {
     struct ra_buf *buf;
@@ -224,14 +224,18 @@ struct gl_video {
     struct ra_tex *screen_tex;
     struct ra_tex *output_tex;
     struct ra_tex *vdpau_deinterleave_tex[2];
+    struct ra_tex **hook_textures;
+    int num_hook_textures;
+    int idx_hook_textures;
+
     struct ra_buf *hdr_peak_ssbo;
     struct surface surfaces[SURFACES_MAX];
 
     // user pass descriptions and textures
-    struct tex_hook tex_hooks[SHADER_MAX_PASSES];
-    int tex_hook_num;
-    struct gl_user_shader_tex user_textures[SHADER_MAX_PASSES];
-    int user_tex_num;
+    struct tex_hook *tex_hooks;
+    int num_tex_hooks;
+    struct gl_user_shader_tex *user_textures;
+    int num_user_textures;
 
     int surface_idx;
     int surface_now;
@@ -249,9 +253,15 @@ struct gl_video {
     struct mp_osd_res osd_rect; // OSD size/margins
 
     // temporary during rendering
-    struct image pass_img[TEXUNIT_VIDEO_NUM];
     struct compute_info pass_compute; // compute shader metadata for this pass
+    struct image pass_img[TEXUNIT_VIDEO_NUM]; // bound images for this pass
     int pass_img_num;
+    struct saved_img *saved_imgs;     // saved (named) images for this frame
+    int num_saved_imgs;
+
+    // effective current texture metadata - this will essentially affect the
+    // next render pass target, as well as implicitly tracking what needs to
+    // be done with the image
     int texture_w, texture_h;
     struct gl_transform texture_offset; // texture transform without rotation
     int components;
@@ -266,12 +276,6 @@ struct gl_video {
     struct timer_pool *upload_timer;
     struct timer_pool *blit_timer;
     struct timer_pool *osd_timer;
-
-    // intermediate textures
-    struct saved_img saved_img[SHADER_MAX_SAVED];
-    int saved_img_num;
-    struct ra_tex *hook_fbos[SHADER_MAX_SAVED];
-    int hook_fbo_num;
 
     int frames_uploaded;
     int frames_rendered;
@@ -478,14 +482,14 @@ static void gl_video_reset_surfaces(struct gl_video *p)
 
 static void gl_video_reset_hooks(struct gl_video *p)
 {
-    for (int i = 0; i < p->tex_hook_num; i++)
+    for (int i = 0; i < p->num_tex_hooks; i++)
         talloc_free(p->tex_hooks[i].priv);
 
-    for (int i = 0; i < p->user_tex_num; i++)
+    for (int i = 0; i < p->num_user_textures; i++)
         ra_tex_free(p->ra, &p->user_textures[i].tex);
 
-    p->tex_hook_num = 0;
-    p->user_tex_num = 0;
+    p->num_tex_hooks = 0;
+    p->num_user_textures = 0;
 }
 
 static inline int surface_wrap(int id)
@@ -523,8 +527,8 @@ static void uninit_rendering(struct gl_video *p)
     for (int n = 0; n < SURFACES_MAX; n++)
         ra_tex_free(p->ra, &p->surfaces[n].tex);
 
-    for (int n = 0; n < SHADER_MAX_SAVED; n++)
-        ra_tex_free(p->ra, &p->hook_fbos[n]);
+    for (int n = 0; n < p->num_hook_textures; n++)
+        ra_tex_free(p->ra, &p->hook_textures[n]);
 
     for (int n = 0; n < 2; n++)
         ra_tex_free(p->ra, &p->vdpau_deinterleave_tex[n]);
@@ -1307,9 +1311,9 @@ static bool saved_img_find(struct gl_video *p, const char *name,
     if (!name || !out)
         return false;
 
-    for (int i = 0; i < p->saved_img_num; i++) {
-        if (strcmp(p->saved_img[i].name, name) == 0) {
-            *out = p->saved_img[i].img;
+    for (int i = 0; i < p->num_saved_imgs; i++) {
+        if (strcmp(p->saved_imgs[i].name, name) == 0) {
+            *out = p->saved_imgs[i].img;
             return true;
         }
     }
@@ -1322,18 +1326,17 @@ static void saved_img_store(struct gl_video *p, const char *name,
 {
     assert(name);
 
-    for (int i = 0; i < p->saved_img_num; i++) {
-        if (strcmp(p->saved_img[i].name, name) == 0) {
-            p->saved_img[i].img = img;
+    for (int i = 0; i < p->num_saved_imgs; i++) {
+        if (strcmp(p->saved_imgs[i].name, name) == 0) {
+            p->saved_imgs[i].img = img;
             return;
         }
     }
 
-    assert(p->saved_img_num < SHADER_MAX_SAVED);
-    p->saved_img[p->saved_img_num++] = (struct saved_img) {
+    MP_TARRAY_APPEND(p, p->saved_imgs, p->num_saved_imgs, (struct saved_img) {
         .name = name,
         .img = img
-    };
+    });
 }
 
 static bool pass_hook_setup_binds(struct gl_video *p, const char *name,
@@ -1356,7 +1359,7 @@ static bool pass_hook_setup_binds(struct gl_video *p, const char *name,
         // BIND can also be used to load user-defined textures, in which
         // case we will directly load them as a uniform instead of
         // generating the hook_prelude boilerplate
-        for (int u = 0; u < p->user_tex_num; u++) {
+        for (int u = 0; u < p->num_user_textures; u++) {
             struct gl_user_shader_tex *utex = &p->user_textures[u];
             if (bstr_equals0(utex->name, bind_name)) {
                 gl_sc_uniform_texture(p->sc, bind_name, utex->tex);
@@ -1381,10 +1384,18 @@ next_bind: ;
     return true;
 }
 
+static struct ra_tex **next_hook_tex(struct gl_video *p)
+{
+    if (p->idx_hook_textures == p->num_hook_textures)
+        MP_TARRAY_APPEND(p, p->hook_textures, p->num_hook_textures, NULL);
+
+    return &p->hook_textures[p->idx_hook_textures++];
+}
+
 // Process hooks for a plane, saving the result and returning a new image
 // If 'trans' is NULL, the shader is forbidden from transforming img
 static struct image pass_hook(struct gl_video *p, const char *name,
-                                struct image img, struct gl_transform *trans)
+                              struct image img, struct gl_transform *trans)
 {
     if (!name)
         return img;
@@ -1392,7 +1403,7 @@ static struct image pass_hook(struct gl_video *p, const char *name,
     saved_img_store(p, name, img);
 
     MP_DBG(p, "Running hooks for %s\n", name);
-    for (int i = 0; i < p->tex_hook_num; i++) {
+    for (int i = 0; i < p->num_tex_hooks; i++) {
         struct tex_hook *hook = &p->tex_hooks[i];
 
         // Figure out if this pass hooks this texture
@@ -1427,12 +1438,10 @@ found:
         int w = lroundf(fabs(sz.x1 - sz.x0));
         int h = lroundf(fabs(sz.y1 - sz.y0));
 
-        assert(p->hook_fbo_num < SHADER_MAX_SAVED);
-        struct ra_tex **fbo = &p->hook_fbos[p->hook_fbo_num++];
-        finish_pass_tex(p, fbo, w, h);
-
+        struct ra_tex **tex = next_hook_tex(p);
+        finish_pass_tex(p, tex, w, h);
         const char *store_name = hook->save_tex ? hook->save_tex : name;
-        struct image saved_img = image_wrap(*fbo, img.type, comps);
+        struct image saved_img = image_wrap(*tex, img.type, comps);
 
         // If the texture we're saving overwrites the "current" texture, also
         // update the tex parameter so that the future loop cycles will use the
@@ -1466,7 +1475,7 @@ static void pass_opt_hook_point(struct gl_video *p, const char *name,
     if (!name)
         return;
 
-    for (int i = 0; i < p->tex_hook_num; i++) {
+    for (int i = 0; i < p->num_tex_hooks; i++) {
         struct tex_hook *hook = &p->tex_hooks[i];
 
         for (int h = 0; h < SHADER_MAX_HOOKS; h++) {
@@ -1483,11 +1492,9 @@ static void pass_opt_hook_point(struct gl_video *p, const char *name,
     // Nothing uses this texture, don't bother storing it
     return;
 
-found:
-    assert(p->hook_fbo_num < SHADER_MAX_SAVED);
-    struct ra_tex **tex = &p->hook_fbos[p->hook_fbo_num++];
+found: ;
+    struct ra_tex **tex = next_hook_tex(p);
     finish_pass_tex(p, tex, p->texture_w, p->texture_h);
-
     struct image img = image_wrap(*tex, PLANE_RGB, p->components);
     img = pass_hook(p, name, img, tex_trans);
     copy_image(p, &(int){0}, img);
@@ -1781,18 +1788,6 @@ static bool image_equiv(struct image a, struct image b)
            gl_transform_eq(a.transform, b.transform);
 }
 
-static bool add_hook(struct gl_video *p, struct tex_hook hook)
-{
-    if (p->tex_hook_num < SHADER_MAX_PASSES) {
-        p->tex_hooks[p->tex_hook_num++] = hook;
-        return true;
-    } else {
-        MP_ERR(p, "Too many passes! Limit is %d.\n", SHADER_MAX_PASSES);
-        talloc_free(hook.priv);
-        return false;
-    }
-}
-
 static void deband_hook(struct gl_video *p, struct image img,
                         struct gl_transform *trans, void *priv)
 {
@@ -1839,10 +1834,10 @@ static bool szexp_lookup(void *priv, struct bstr var, float size[2])
         return true;
     }
 
-    for (int o = 0; o < p->saved_img_num; o++) {
-        if (bstr_equals0(var, p->saved_img[o].name)) {
-            size[0] = p->saved_img[o].img.w;
-            size[1] = p->saved_img[o].img.h;
+    for (int o = 0; o < p->num_saved_imgs; o++) {
+        if (bstr_equals0(var, p->saved_imgs[o].name)) {
+            size[0] = p->saved_imgs[o].img.w;
+            size[1] = p->saved_imgs[o].img.h;
             return true;
         }
     }
@@ -1908,27 +1903,22 @@ static bool add_user_hook(void *priv, struct gl_user_shader_hook hook)
     for (int h = 0; h < SHADER_MAX_BINDS; h++)
         texhook.bind_tex[h] = bstrdup0(copy, hook.bind_tex[h]);
 
-    return add_hook(p, texhook);
+    MP_TARRAY_APPEND(p, p->tex_hooks, p->num_tex_hooks, texhook);
+    return true;
 }
 
 static bool add_user_tex(void *priv, struct gl_user_shader_tex tex)
 {
     struct gl_video *p = priv;
 
-    if (p->user_tex_num == SHADER_MAX_PASSES) {
-        MP_ERR(p, "Too many textures! Limit is %d.\n", SHADER_MAX_PASSES);
-        goto err;
-    }
-
     tex.tex = ra_tex_create(p->ra, &tex.params);
     TA_FREEP(&tex.params.initial_data);
 
-    p->user_textures[p->user_tex_num++] = tex;
-    return true;
+    if (!tex.tex)
+        return false;
 
-err:
-    talloc_free(tex.params.initial_data);
-    return false;
+    MP_TARRAY_APPEND(p, p->user_textures, p->num_user_textures, tex);
+    return true;
 }
 
 static void load_user_shaders(struct gl_video *p, char **shaders)
@@ -1947,7 +1937,7 @@ static void gl_video_setup_hooks(struct gl_video *p)
     gl_video_reset_hooks(p);
 
     if (p->opts.deband) {
-        add_hook(p, (struct tex_hook) {
+        MP_TARRAY_APPEND(p, p->tex_hooks, p->num_tex_hooks, (struct tex_hook) {
             .hook_tex = {"LUMA", "CHROMA", "RGB", "XYZ"},
             .bind_tex = {"HOOKED"},
             .hook = deband_hook,
@@ -1955,7 +1945,7 @@ static void gl_video_setup_hooks(struct gl_video *p)
     }
 
     if (p->opts.unsharp != 0.0) {
-        add_hook(p, (struct tex_hook) {
+        MP_TARRAY_APPEND(p, p->tex_hooks, p->num_tex_hooks, (struct tex_hook) {
             .hook_tex = {"MAIN"},
             .bind_tex = {"HOOKED"},
             .hook = unsharp_hook,
@@ -2673,8 +2663,8 @@ static bool pass_render_frame(struct gl_video *p, struct mp_image *mpi, uint64_t
     p->texture_h = p->image_params.h;
     p->texture_offset = identity_trans;
     p->components = 0;
-    p->saved_img_num = 0;
-    p->hook_fbo_num = 0;
+    p->num_saved_imgs = 0;
+    p->idx_hook_textures = 0;
     p->use_linear = false;
 
     // try uploading the frame

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -145,8 +145,6 @@ struct pass_info {
     struct mp_pass_perf perf;
 };
 
-#define PASS_INFO_MAX 64
-
 struct dr_buffer {
     struct ra_buf *buf;
     // The mpi reference will keep the data from being recycled (or from other
@@ -260,8 +258,8 @@ struct gl_video {
     float user_gamma;
 
     // pass info / metrics
-    struct pass_info pass_fresh[PASS_INFO_MAX];
-    struct pass_info pass_redraw[PASS_INFO_MAX];
+    struct pass_info pass_fresh[VO_PASS_PERF_MAX];
+    struct pass_info pass_redraw[VO_PASS_PERF_MAX];
     struct pass_info *pass;
     int pass_idx;
     struct timer_pool *upload_timer;
@@ -993,7 +991,7 @@ static void uninit_video(struct gl_video *p)
 
 static void pass_record(struct gl_video *p, struct mp_pass_perf perf)
 {
-    if (!p->pass || p->pass_idx == PASS_INFO_MAX)
+    if (!p->pass || p->pass_idx == VO_PASS_PERF_MAX)
         return;
 
     struct pass_info *pass = &p->pass[p->pass_idx];
@@ -1008,7 +1006,7 @@ static void pass_record(struct gl_video *p, struct mp_pass_perf perf)
 PRINTF_ATTRIBUTE(2, 3)
 static void pass_describe(struct gl_video *p, const char *textf, ...)
 {
-    if (!p->pass || p->pass_idx == PASS_INFO_MAX)
+    if (!p->pass || p->pass_idx == VO_PASS_PERF_MAX)
         return;
 
     struct pass_info *pass = &p->pass[p->pass_idx];
@@ -1027,7 +1025,7 @@ static void pass_info_reset(struct gl_video *p, bool is_redraw)
     p->pass = is_redraw ? p->pass_redraw : p->pass_fresh;
     p->pass_idx = 0;
 
-    for (int i = 0; i < PASS_INFO_MAX; i++) {
+    for (int i = 0; i < VO_PASS_PERF_MAX; i++) {
         p->pass[i].desc.len = 0;
         p->pass[i].perf = (struct mp_pass_perf){0};
     }
@@ -1038,7 +1036,7 @@ static void pass_report_performance(struct gl_video *p)
     if (!p->pass)
         return;
 
-    for (int i = 0; i < PASS_INFO_MAX; i++) {
+    for (int i = 0; i < VO_PASS_PERF_MAX; i++) {
         struct pass_info *pass = &p->pass[i];
         if (pass->desc.len) {
             MP_DBG(p, "pass '%.*s': last %dus avg %dus peak %dus\n",
@@ -3152,7 +3150,7 @@ void gl_video_resize(struct gl_video *p,
 
 static void frame_perf_data(struct pass_info pass[], struct mp_frame_perf *out)
 {
-    for (int i = 0; i < PASS_INFO_MAX; i++) {
+    for (int i = 0; i < VO_PASS_PERF_MAX; i++) {
         if (!pass[i].desc.len)
             break;
         out->perf[out->count] = pass[i].perf;
@@ -3499,7 +3497,7 @@ void gl_video_uninit(struct gl_video *p)
     timer_pool_destroy(p->blit_timer);
     timer_pool_destroy(p->osd_timer);
 
-    for (int i = 0; i < PASS_INFO_MAX; i++) {
+    for (int i = 0; i < VO_PASS_PERF_MAX; i++) {
         talloc_free(p->pass_fresh[i].desc.start);
         talloc_free(p->pass_redraw[i].desc.start);
     }

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -60,26 +60,10 @@ static const char *const fixed_tscale_filters[] = {
 // must be sorted, and terminated with 0
 int filter_sizes[] =
     {2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 0};
-int tscale_sizes[] = {2, 4, 6, 0}; // limited by TEXUNIT_VIDEO_NUM
+int tscale_sizes[] = {2, 4, 6, 8, 0};
 
 struct vertex_pt {
     float x, y;
-};
-
-struct vertex {
-    struct vertex_pt position;
-    struct vertex_pt texcoord[TEXUNIT_VIDEO_NUM];
-};
-
-static const struct ra_renderpass_input vertex_vao[] = {
-    {"position",  RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, position)},
-    {"texcoord0", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[0])},
-    {"texcoord1", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[1])},
-    {"texcoord2", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[2])},
-    {"texcoord3", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[3])},
-    {"texcoord4", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[4])},
-    {"texcoord5", RA_VARTYPE_FLOAT, 2, 1, offsetof(struct vertex, texcoord[5])},
-    {0}
 };
 
 struct texplane {
@@ -215,6 +199,13 @@ struct gl_video {
     bool dumb_mode;
     bool forced_dumb_mode;
 
+    // Cached vertex array, to avoid re-allocation per frame. For simplicity,
+    // our vertex format is simply a list of `vertex_pt`s, since this greatly
+    // simplifies offset calculation at the cost of (unneeded) flexibility.
+    struct vertex_pt *tmp_vertex;
+    struct ra_renderpass_input *vao;
+    int vao_len;
+
     const struct ra_format *fbo_format;
     struct ra_tex *merge_tex[4];
     struct ra_tex *scale_tex[4];
@@ -254,8 +245,8 @@ struct gl_video {
 
     // temporary during rendering
     struct compute_info pass_compute; // compute shader metadata for this pass
-    struct image pass_img[TEXUNIT_VIDEO_NUM]; // bound images for this pass
-    int pass_img_num;
+    struct image *pass_imgs;          // bound images for this pass
+    int num_pass_imgs;
     struct saved_img *saved_imgs;     // saved (named) images for this frame
     int num_saved_imgs;
 
@@ -633,13 +624,12 @@ static struct image image_wrap(struct ra_tex *tex, enum plane_type type,
     };
 }
 
-// Bind an image to a free texture unit and return its ID. At most
-// TEXUNIT_VIDEO_NUM texture units can be bound at once
+// Bind an image to a free texture unit and return its ID.
 static int pass_bind(struct gl_video *p, struct image img)
 {
-    assert(p->pass_img_num < TEXUNIT_VIDEO_NUM);
-    p->pass_img[p->pass_img_num] = img;
-    return p->pass_img_num++;
+    int idx = p->num_pass_imgs;
+    MP_TARRAY_APPEND(p, p->pass_imgs, p->num_pass_imgs, img);
+    return idx;
 }
 
 // Rotation by 90° and flipping.
@@ -1064,8 +1054,8 @@ static void pass_prepare_src_tex(struct gl_video *p)
 {
     struct gl_shader_cache *sc = p->sc;
 
-    for (int n = 0; n < p->pass_img_num; n++) {
-        struct image *s = &p->pass_img[n];
+    for (int n = 0; n < p->num_pass_imgs; n++) {
+        struct image *s = &p->pass_imgs[n];
         if (!s->tex)
             continue;
 
@@ -1089,6 +1079,11 @@ static void pass_prepare_src_tex(struct gl_video *p)
     }
 }
 
+static void cleanup_binds(struct gl_video *p)
+{
+    p->num_pass_imgs = 0;
+}
+
 // Sets the appropriate compute shader metadata for an implicit compute pass
 // bw/bh: block size
 static void pass_is_compute(struct gl_video *p, int bw, int bh)
@@ -1098,12 +1093,6 @@ static void pass_is_compute(struct gl_video *p, int bw, int bh)
         .block_w = bw,
         .block_h = bh,
     };
-}
-
-static void cleanup_binds(struct gl_video *p)
-{
-    memset(&p->pass_img, 0, sizeof(p->pass_img));
-    p->pass_img_num = 0;
 }
 
 // w/h: the width/height of the compute shader's operating domain (e.g. the
@@ -1117,7 +1106,6 @@ static void dispatch_compute(struct gl_video *p, int w, int h,
             info.threads_h > 0 ? info.threads_h : info.block_h);
 
     pass_prepare_src_tex(p);
-    gl_sc_set_vertex_format(p->sc, vertex_vao, sizeof(struct vertex));
 
     // Since we don't actually have vertices, we pretend for convenience
     // reasons that we do and calculate the right texture coordinates based on
@@ -1125,14 +1113,13 @@ static void dispatch_compute(struct gl_video *p, int w, int h,
     gl_sc_uniform_vec2(p->sc, "out_scale", (float[2]){ 1.0 / w, 1.0 / h });
     PRELUDE("#define outcoord(id) (out_scale * (vec2(id) + vec2(0.5)))\n");
 
-    for (int n = 0; n < TEXUNIT_VIDEO_NUM; n++) {
-        struct image *s = &p->pass_img[n];
+    for (int n = 0; n < p->num_pass_imgs; n++) {
+        struct image *s = &p->pass_imgs[n];
         if (!s->tex)
             continue;
 
         // We need to rescale the coordinates to the true texture size
-        char tex_scale[32];
-        snprintf(tex_scale, sizeof(tex_scale), "tex_scale%d", n);
+        char *tex_scale = mp_tprintf(32, "tex_scale%d", n);
         gl_sc_uniform_vec2(p->sc, tex_scale, (float[2]){
                 (float)s->w / s->tex->params.w,
                 (float)s->h / s->tex->params.h,
@@ -1157,7 +1144,24 @@ static struct mp_pass_perf render_pass_quad(struct gl_video *p,
                                             struct ra_fbo fbo,
                                             const struct mp_rect *dst)
 {
-    struct vertex va[6] = {0};
+    // The first element is reserved for `vec2 position`
+    int num_vertex_attribs = 1 + p->num_pass_imgs;
+    size_t vertex_stride = num_vertex_attribs * sizeof(struct vertex_pt);
+
+    // Expand the VAO if necessary
+    while (p->vao_len < num_vertex_attribs) {
+        MP_TARRAY_APPEND(p, p->vao, p->vao_len, (struct ra_renderpass_input) {
+            .name = talloc_asprintf(p, "texcoord%d", p->vao_len - 1),
+            .type = RA_VARTYPE_FLOAT,
+            .dim_v = 2,
+            .dim_m = 1,
+            .offset = p->vao_len * sizeof(struct vertex_pt),
+        });
+    }
+
+    int num_vertices = 6; // quad as triangle list
+    int num_attribs_total = num_vertices * num_vertex_attribs;
+    MP_TARRAY_GROW(p, p->tmp_vertex, num_attribs_total);
 
     struct gl_transform t;
     gl_transform_ortho_fbo(&t, fbo);
@@ -1168,11 +1172,12 @@ static struct mp_pass_perf render_pass_quad(struct gl_video *p,
     gl_transform_vec(t, &x[1], &y[1]);
 
     for (int n = 0; n < 4; n++) {
-        struct vertex *v = &va[n];
-        v->position.x = x[n / 2];
-        v->position.y = y[n % 2];
-        for (int i = 0; i < p->pass_img_num; i++) {
-            struct image *s = &p->pass_img[i];
+        struct vertex_pt *vs = &p->tmp_vertex[num_vertex_attribs * n];
+        // vec2 position in idx 0
+        vs[0].x = x[n / 2];
+        vs[0].y = y[n % 2];
+        for (int i = 0; i < p->num_pass_imgs; i++) {
+            struct image *s = &p->pass_imgs[i];
             if (!s->tex)
                 continue;
             struct gl_transform tr = s->transform;
@@ -1180,22 +1185,28 @@ static struct mp_pass_perf render_pass_quad(struct gl_video *p,
             float ty = (n % 2) * s->h;
             gl_transform_vec(tr, &tx, &ty);
             bool rect = s->tex->params.non_normalized;
-            v->texcoord[i].x = tx / (rect ? 1 : s->tex->params.w);
-            v->texcoord[i].y = ty / (rect ? 1 : s->tex->params.h);
+            // vec2 texcoordN in idx N+1
+            vs[i + 1].x = tx / (rect ? 1 : s->tex->params.w);
+            vs[i + 1].y = ty / (rect ? 1 : s->tex->params.h);
         }
     }
 
-    va[4] = va[2];
-    va[5] = va[1];
+    memmove(&p->tmp_vertex[num_vertex_attribs * 4],
+            &p->tmp_vertex[num_vertex_attribs * 2],
+            vertex_stride);
 
-    return gl_sc_dispatch_draw(p->sc, fbo.tex, va, 6);
+    memmove(&p->tmp_vertex[num_vertex_attribs * 5],
+            &p->tmp_vertex[num_vertex_attribs * 1],
+            vertex_stride);
+
+    return gl_sc_dispatch_draw(p->sc, fbo.tex, p->vao, p->vao_len, vertex_stride,
+                               p->tmp_vertex, num_vertices);
 }
 
 static void finish_pass_fbo(struct gl_video *p, struct ra_fbo fbo,
                             const struct mp_rect *dst)
 {
     pass_prepare_src_tex(p);
-    gl_sc_set_vertex_format(p->sc, vertex_vao, sizeof(struct vertex));
     pass_record(p, render_pass_quad(p, fbo, dst));
     debug_check_gl(p, "after rendering");
     cleanup_binds(p);
@@ -1342,7 +1353,7 @@ static void saved_img_store(struct gl_video *p, const char *name,
 static bool pass_hook_setup_binds(struct gl_video *p, const char *name,
                                   struct image img, struct tex_hook *hook)
 {
-    for (int t = 0; t < TEXUNIT_VIDEO_NUM; t++) {
+    for (int t = 0; t < SHADER_MAX_BINDS; t++) {
         char *bind_name = (char *)hook->bind_tex[t];
 
         if (!bind_name)
@@ -1372,7 +1383,7 @@ static bool pass_hook_setup_binds(struct gl_video *p, const char *name,
             // Clean up texture bindings and move on to the next hook
             MP_DBG(p, "Skipping hook on %s due to no texture named %s.\n",
                    name, bind_name);
-            p->pass_img_num -= t;
+            p->num_pass_imgs -= t;
             return false;
         }
 
@@ -1483,7 +1494,7 @@ static void pass_opt_hook_point(struct gl_video *p, const char *name,
                 goto found;
         }
 
-        for (int b = 0; b < TEXUNIT_VIDEO_NUM; b++) {
+        for (int b = 0; b < SHADER_MAX_BINDS; b++) {
             if (hook->bind_tex[b] && strcmp(hook->bind_tex[b], name) == 0)
                 goto found;
         }
@@ -2857,7 +2868,6 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
     } else {
         assert(tscale->kernel && !tscale->kernel->polar);
         size = ceil(tscale->kernel->size);
-        assert(size <= TEXUNIT_VIDEO_NUM);
     }
 
     int radius = size/2;
@@ -3582,6 +3592,14 @@ struct gl_video *gl_video_init(struct ra *ra, struct mp_log *log,
     p->opts = *opts;
     for (int n = 0; n < SCALER_COUNT; n++)
         p->scaler[n] = (struct scaler){.index = n};
+    // our VAO always has the vec2 position as the first element
+    MP_TARRAY_APPEND(p, p->vao, p->vao_len, (struct ra_renderpass_input) {
+        .name = "position",
+        .type = RA_VARTYPE_FLOAT,
+        .dim_v = 2,
+        .dim_m = 1,
+        .offset = 0,
+    });
     init_gl(p);
     reinit_from_options(p);
     return p;

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -28,10 +28,6 @@
 #include "video/csputils.h"
 #include "video/out/filter_kernels.h"
 
-// Assume we have this many texture units for sourcing additional passes.
-// The actual texture unit assignment is dynamic.
-#define TEXUNIT_VIDEO_NUM 6
-
 struct scaler_fun {
     char *name;
     float params[2];


### PR DESCRIPTION
The VAO change is perhaps the most significant. The other are just internal refactoring, because I apparently wrote all of this code before discovering the `MP_TARRAY_*` abstraction.

Dynamic VAO required some more involved changes apart from blind dumb refactoring, so it's an extra commit. I'm not entirely happy with the way the vertex data is filled, but it'll suffice for our needs and I don't expect this function to change much.

This lifts some of vo_gpu's historical limitations (like radius 3 tscale) and makes the code both more efficient (fewer redundant array iterations) and modern. We also stop loading unused texture coordinates in the fragment shader, which *can* add up.