### PR TITLE
Reinterpret some verbosity levels and update --log-file

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -403,7 +403,7 @@ Program Behavior
 
 ``--log-file=<path>``
     Opens the given path for writing, and print log messages to it. Existing
-    files will be truncated. The log level always corresponds to ``-v``,
+    files will be truncated. The log level always corresponds to ``-v -v``,
     regardless of terminal verbosity levels.
 
 ``--config-dir=<path>``

--- a/common/av_log.c
+++ b/common/av_log.c
@@ -65,9 +65,9 @@ static bool log_print_prefix = true;
 static int av_log_level_to_mp_level(int av_level)
 {
     if (av_level > AV_LOG_VERBOSE)
-        return MSGL_DEBUG;
+        return MSGL_TRACE;
     if (av_level > AV_LOG_INFO)
-        return MSGL_V;
+        return MSGL_DEBUG;
     if (av_level > AV_LOG_WARNING)
         return MSGL_V;
     if (av_level > AV_LOG_ERROR)

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -793,7 +793,7 @@ int encode_lavc_write_frame(struct encode_lavc_context *ctx, AVStream *stream,
     if (ctx->header_written <= 0)
         return -1;
 
-    MP_DBG(ctx,
+    MP_TRACE(ctx,
         "write frame: stream %d ptsi %d (%f) dtsi %d (%f) size %d\n",
         (int)packet->stream_index,
         (int)packet->pts,

--- a/common/msg.c
+++ b/common/msg.c
@@ -120,7 +120,7 @@ static void update_loglevel(struct mp_log *log)
     for (int n = 0; n < log->root->num_buffers; n++)
         log->level = MPMAX(log->level, log->root->buffers[n]->level);
     if (log->root->log_file)
-        log->level = MPMAX(log->level, MSGL_V);
+        log->level = MPMAX(log->level, MSGL_DEBUG);
     if (log->root->stats_file)
         log->level = MPMAX(log->level, MSGL_STATS);
     atomic_store(&log->reload_counter, atomic_load(&log->root->reload_counter));
@@ -285,7 +285,7 @@ static void write_log_file(struct mp_log *log, int lev, char *text)
 {
     struct mp_log_root *root = log->root;
 
-    if (lev > MSGL_V || !root->log_file)
+    if (lev > MSGL_DEBUG || !root->log_file)
         return;
 
     fprintf(root->log_file, "[%8.3f][%c][%s] %s",

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -583,9 +583,9 @@ void demux_add_packet(struct sh_stream *stream, demux_packet_t *dp)
     if (ds->base_ts == MP_NOPTS_VALUE)
         ds->base_ts = ds->last_ts;
 
-    MP_DBG(in, "append packet to %s: size=%d pts=%f dts=%f pos=%"PRIi64" "
-           "[num=%zd size=%zd]\n", stream_type_name(stream->type),
-           dp->len, dp->pts, dp->dts, dp->pos, ds->packs, ds->bytes);
+    MP_TRACE(in, "append packet to %s: size=%d pts=%f dts=%f pos=%"PRIi64" "
+             "[num=%zd size=%zd]\n", stream_type_name(stream->type),
+             dp->len, dp->pts, dp->dts, dp->pos, ds->packs, ds->bytes);
 
     if (ds->in->wakeup_cb && !ds->head->next)
         ds->in->wakeup_cb(ds->in->wakeup_cb_ctx);
@@ -614,8 +614,8 @@ static bool read_packet(struct demux_internal *in)
             ds->last_ts >= ds->base_ts)
             read_more |= ds->last_ts - ds->base_ts < in->min_secs;
     }
-    MP_DBG(in, "packets=%zd, bytes=%zd, active=%d, more=%d\n",
-           packs, bytes, active, read_more);
+    MP_TRACE(in, "packets=%zd, bytes=%zd, active=%d, more=%d\n",
+             packs, bytes, active, read_more);
     if (packs >= in->max_packs || bytes >= in->max_bytes) {
         if (!in->warned_queue_overflow) {
             in->warned_queue_overflow = true;

--- a/input/input.c
+++ b/input/input.c
@@ -468,7 +468,7 @@ static mp_cmd_t *get_cmd_from_keys(struct input_ctx *ictx, char *force_section,
             return mp_input_parse_cmd_strv(ictx->log, (const char*[]){"quit", 0});
         int msgl = MSGL_WARN;
         if (MP_KEY_IS_MOUSE_MOVE(code))
-            msgl = MSGL_DEBUG;
+            msgl = MSGL_TRACE;
         char *key_buf = mp_input_get_key_combo_name(&code, 1);
         MP_MSG(ictx, msgl, "No key binding found for key '%s'.\n", key_buf);
         talloc_free(key_buf);
@@ -478,8 +478,8 @@ static mp_cmd_t *get_cmd_from_keys(struct input_ctx *ictx, char *force_section,
     if (ret) {
         ret->input_section = cmd->owner->section;
         ret->key_name = talloc_steal(ret, mp_input_get_key_combo_name(&code, 1));
-        MP_DBG(ictx, "key '%s' -> '%s' in '%s'\n",
-               ret->key_name, cmd->cmd, ret->input_section);
+        MP_TRACE(ictx, "key '%s' -> '%s' in '%s'\n",
+                 ret->key_name, cmd->cmd, ret->input_section);
         ret->is_mouse_button = code & MP_KEY_EMIT_ON_UP;
     } else {
         char *key_buf = mp_input_get_key_combo_name(&code, 1);
@@ -501,8 +501,8 @@ static void update_mouse_section(struct input_ctx *ictx)
     ictx->mouse_section = new_section;
 
     if (strcmp(old, ictx->mouse_section) != 0) {
-        MP_DBG(ictx, "input: switch section %s -> %s\n",
-               old, ictx->mouse_section);
+        MP_TRACE(ictx, "input: switch section %s -> %s\n",
+                 old, ictx->mouse_section);
         mp_input_queue_cmd(ictx, get_cmd_from_keys(ictx, old, MP_KEY_MOUSE_LEAVE));
     }
 }
@@ -561,9 +561,9 @@ static void interpret_key(struct input_ctx *ictx, int code, double scale,
 
     if (mp_msg_test(ictx->log, MSGL_DEBUG)) {
         char *key = mp_input_get_key_name(code);
-        MP_DBG(ictx, "key code=%#x '%s'%s%s\n",
-               code, key, (state & MP_KEY_STATE_DOWN) ? " down" : "",
-               (state & MP_KEY_STATE_UP) ? " up" : "");
+        MP_TRACE(ictx, "key code=%#x '%s'%s%s\n",
+                 code, key, (state & MP_KEY_STATE_DOWN) ? " down" : "",
+                 (state & MP_KEY_STATE_UP) ? " up" : "");
         talloc_free(key);
     }
 
@@ -708,7 +708,7 @@ static void mp_input_feed_key(struct input_ctx *ictx, int code, double scale,
     code = mp_normalize_keycode(code);
     int unmod = code & ~MP_KEY_MODIFIER_MASK;
     if (code == MP_INPUT_RELEASE_ALL) {
-        MP_DBG(ictx, "release all\n");
+        MP_TRACE(ictx, "release all\n");
         release_down_cmd(ictx, false);
         return;
     }
@@ -816,7 +816,7 @@ void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y)
 void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y)
 {
     input_lock(ictx);
-    MP_DBG(ictx, "mouse move %d/%d\n", x, y);
+    MP_TRACE(ictx, "mouse move %d/%d\n", x, y);
 
     if (ictx->mouse_vo_x == x && ictx->mouse_vo_y == y) {
         input_unlock(ictx);
@@ -832,7 +832,7 @@ void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y)
             x = x * 1.0 / (dst->x1 - dst->x0) * (src->x1 - src->x0) + src->x0;
             y = y * 1.0 / (dst->y1 - dst->y0) * (src->y1 - src->y0) + src->y0;
         }
-        MP_DBG(ictx, "-> %d/%d\n", x, y);
+        MP_TRACE(ictx, "-> %d/%d\n", x, y);
     }
 
     ictx->mouse_event_counter++;

--- a/options/m_config.c
+++ b/options/m_config.c
@@ -900,8 +900,8 @@ int m_config_set_option_cli(struct m_config *config, struct bstr name,
         goto done;
 
     if (r == 2) {
-        MP_VERBOSE(config, "Setting option '%.*s' = '%.*s' (flags = %d)\n",
-                   BSTR_P(name), BSTR_P(param), flags);
+        MP_DBG(config, "Setting option '%.*s' = '%.*s' (flags = %d)\n",
+               BSTR_P(name), BSTR_P(param), flags);
     }
 
     union m_option_value val = {0};
@@ -952,8 +952,8 @@ int m_config_set_option_node(struct m_config *config, bstr name,
 
     if (mp_msg_test(config->log, MSGL_V)) {
         char *s = m_option_type_node.print(NULL, data);
-        MP_VERBOSE(config, "Setting option '%.*s' = %s (flags = %d) -> %d\n",
-                   BSTR_P(name), s ? s : "?", flags, r);
+        MP_DBG(config, "Setting option '%.*s' = %s (flags = %d) -> %d\n",
+               BSTR_P(name), s ? s : "?", flags, r);
         talloc_free(s);
     }
 

--- a/options/path.c
+++ b/options/path.c
@@ -98,7 +98,7 @@ char *mp_find_user_config_file(void *talloc_ctx, struct mpv_global *global,
     if (res)
         res = mp_path_join(talloc_ctx, res, filename);
     talloc_free(tmp);
-    MP_VERBOSE(global, "config path: '%s' -> '%s'\n", filename, res ? res : "-");
+    MP_DBG(global, "config path: '%s' -> '%s'\n", filename, res ? res : "-");
     return res;
 }
 
@@ -119,12 +119,12 @@ static char **mp_find_all_config_files_limited(void *talloc_ctx,
 
             char *file = mp_path_join_bstr(ret, bstr0(dir), fn);
             if (mp_path_exists(file)) {
-                MP_VERBOSE(global, "config path: '%.*s' -> '%s'\n",
-                           BSTR_P(fn), file);
+                MP_DBG(global, "config path: '%.*s' -> '%s'\n",
+                        BSTR_P(fn), file);
                 MP_TARRAY_APPEND(NULL, ret, num_ret, file);
             } else {
-                MP_VERBOSE(global, "config path: '%.*s' -/-> '%s'\n",
-                           BSTR_P(fn), file);
+                MP_DBG(global, "config path: '%.*s' -/-> '%s'\n",
+                        BSTR_P(fn), file);
             }
         }
     }
@@ -189,7 +189,7 @@ char *mp_get_user_path(void *talloc_ctx, struct mpv_global *global,
     }
     if (!res)
         res = talloc_strdup(talloc_ctx, path);
-    MP_VERBOSE(global, "user path: '%s' -> '%s'\n", path, res);
+    MP_DBG(global, "user path: '%s' -> '%s'\n", path, res);
     return res;
 }
 

--- a/player/command.c
+++ b/player/command.c
@@ -4860,7 +4860,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     int osdl = msg_osd ? 1 : OSD_LEVEL_INVISIBLE;
     bool async = cmd->flags & MP_ASYNC_CMD;
 
-    mp_cmd_dump(mpctx->log, cmd->id == MP_CMD_IGNORE ? MSGL_DEBUG : MSGL_V,
+    mp_cmd_dump(mpctx->log, cmd->id == MP_CMD_IGNORE ? MSGL_TRACE : MSGL_DEBUG,
                 "Run command:", cmd);
 
     if (cmd->flags & MP_EXPAND_PROPERTIES) {

--- a/player/lua.c
+++ b/player/lua.c
@@ -190,7 +190,7 @@ static void add_functions(struct script_ctx *ctx);
 static void load_file(lua_State *L, const char *fname)
 {
     struct script_ctx *ctx = get_ctx(L);
-    MP_VERBOSE(ctx, "loading file %s\n", fname);
+    MP_DBG(ctx, "loading file %s\n", fname);
     int r = luaL_loadfile(L, fname);
     if (r)
         lua_error(L);
@@ -219,7 +219,7 @@ static int load_builtin(lua_State *L)
 static void require(lua_State *L, const char *name)
 {
     struct script_ctx *ctx = get_ctx(L);
-    MP_VERBOSE(ctx, "loading %s\n", name);
+    MP_DBG(ctx, "loading %s\n", name);
     // Lazy, but better than calling the "require" function manually
     char buf[80];
     snprintf(buf, sizeof(buf), "require '%s'", name);

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -440,6 +440,7 @@ mp.msg = {
     info = function(...) return mp.log("info", ...) end,
     verbose = function(...) return mp.log("v", ...) end,
     debug = function(...) return mp.log("debug", ...) end,
+    trace = function(...) return mp.log("trace", ...) end,
 }
 
 _G.print = mp.msg.info

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1876,7 +1876,7 @@ function show_osc()
     -- show when disabled can happen (e.g. mouse_move) due to async/delayed unbinding
     if not state.enabled then return end
 
-    msg.debug("show_osc")
+    msg.trace("show_osc")
     --remember last time of invocation (mouse move)
     state.showtime = mp.get_time()
 
@@ -1888,7 +1888,7 @@ function show_osc()
 end
 
 function hide_osc()
-    msg.debug("hide_osc")
+    msg.trace("hide_osc")
     if not state.enabled then
         -- typically hide happens at render() from tick(), but now tick() is
         -- no-op and won't render again to remove the osc, so do that manually.
@@ -1932,7 +1932,7 @@ end
 
 function timer_start()
     if not (state.timer_active) then
-        msg.debug("timer start")
+        msg.trace("timer start")
 
         if (state.timer == nil) then
             -- create new timer
@@ -1948,7 +1948,7 @@ end
 
 function timer_stop()
     if (state.timer_active) then
-        msg.debug("timer stop")
+        msg.trace("timer stop")
 
         if not (state.timer == nil) then
             -- kill timer
@@ -1974,12 +1974,12 @@ function request_init()
 end
 
 function render_wipe()
-    msg.debug("render_wipe()")
+    msg.trace("render_wipe()")
     mp.set_osd_ass(0, 0, "{}")
 end
 
 function render()
-    msg.debug("rendering")
+    msg.trace("rendering")
     local current_screen_sizeX, current_screen_sizeY, aspect = mp.get_osd_size()
     local mouseX, mouseY = get_virt_mouse_pos()
     local now = mp.get_time()
@@ -2182,7 +2182,7 @@ function tick()
     if (state.idle) then
 
         -- render idle message
-        msg.debug("idle message")
+        msg.trace("idle message")
         local icon_x, icon_y = 320 - 26, 140
 
         local ass = assdraw.ass_new()

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -140,7 +140,7 @@ int mp_load_script(struct MPContext *mpctx, const char *fname)
     }
     arg->log = mp_client_get_log(arg->client);
 
-    MP_VERBOSE(arg, "Loading %s %s...\n", backend->name, fname);
+    MP_DBG(arg, "Loading %s %s...\n", backend->name, fname);
 
     pthread_t thread;
     if (pthread_create(&thread, NULL, script_thread, arg)) {
@@ -150,7 +150,7 @@ int mp_load_script(struct MPContext *mpctx, const char *fname)
     }
 
     wait_loaded(mpctx);
-    MP_VERBOSE(mpctx, "Done loading %s.\n", fname);
+    MP_DBG(mpctx, "Done loading %s.\n", fname);
 
     return 0;
 }

--- a/player/video.c
+++ b/player/video.c
@@ -1076,10 +1076,10 @@ static void handle_display_sync_frame(struct MPContext *mpctx,
     double prev_error = mpctx->display_sync_error;
     mpctx->display_sync_error += frame_duration - num_vsyncs * vsync;
 
-    MP_DBG(mpctx, "s=%f vsyncs=%d dur=%f ratio=%f err=%.20f (%f/%f)\n",
-           mpctx->speed_factor_v, num_vsyncs, adjusted_duration, ratio,
-           mpctx->display_sync_error, mpctx->display_sync_error / vsync,
-           mpctx->display_sync_error / frame_duration);
+    MP_TRACE(mpctx, "s=%f vsyncs=%d dur=%f ratio=%f err=%.20f (%f/%f)\n",
+            mpctx->speed_factor_v, num_vsyncs, adjusted_duration, ratio,
+            mpctx->display_sync_error, mpctx->display_sync_error / vsync,
+            mpctx->display_sync_error / frame_duration);
 
     MP_STATS(mpctx, "value %f avdiff", av_diff);
 

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -248,10 +248,10 @@ static int open_internal(const stream_info_t *sinfo, const char *url, int flags,
         s->access_references = opt;
     }
 
-    MP_VERBOSE(s, "Opening %s\n", url);
+    MP_DBG(s, "Opening %s\n", url);
 
     if ((s->mode & STREAM_WRITE) && !sinfo->can_write) {
-        MP_VERBOSE(s, "No write access implemented.\n");
+        MP_DBG(s, "No write access implemented.\n");
         talloc_free(s);
         return STREAM_NO_MATCH;
     }
@@ -273,7 +273,7 @@ static int open_internal(const stream_info_t *sinfo, const char *url, int flags,
     if (s->mime_type)
         MP_VERBOSE(s, "Mime-type: '%s'\n", s->mime_type);
 
-    MP_VERBOSE(s, "Stream opened successfully.\n");
+    MP_DBG(s, "Stream opened successfully.\n");
 
     *ret = s;
     return STREAM_OK;

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -109,8 +109,8 @@ static const int map_ass_level[] = {
     MSGL_INFO,
     MSGL_V,
     MSGL_V,
-    MSGL_V,             // 5 application recommended level
-    MSGL_DEBUG,
+    MSGL_DEBUG,         // 5 application recommended level
+    MSGL_TRACE,
     MSGL_TRACE,         // 7 "verbose DEBUG"
 };
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -968,16 +968,16 @@ static int get_buffer2_direct(AVCodecContext *avctx, AVFrame *pic, int flags)
         p->dr_w = w;
         p->dr_h = h;
         p->dr_stride_align = stride_align;
-        MP_VERBOSE(p, "DR parameter change to %dx%d %s align=%d\n", w, h,
-                   mp_imgfmt_to_name(imgfmt), stride_align);
+        MP_DBG(p, "DR parameter change to %dx%d %s align=%d\n", w, h,
+               mp_imgfmt_to_name(imgfmt), stride_align);
     }
 
     struct mp_image *img = mp_image_pool_get_no_alloc(p->dr_pool, imgfmt, w, h);
     if (!img) {
-        MP_VERBOSE(p, "Allocating new DR image...\n");
+        MP_DBG(p, "Allocating new DR image...\n");
         img = vo_get_image(vd->vo, imgfmt, w, h, stride_align);
         if (!img) {
-            MP_VERBOSE(p, "...failed..\n");
+            MP_DBG(p, "...failed..\n");
             goto fallback;
         }
 

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -260,7 +260,7 @@ static void VS_CC vs_frame_done(void *userData, const VSFrameRef *f, int n,
     // If these assertions fail, n is an unrequested frame (or filtered twice).
     assert(n >= p->out_frameno && n < p->out_frameno + p->max_requests);
     int index = n - p->out_frameno;
-    MP_DBG(vf, "filtered frame %d (%d)\n", n, index);
+    MP_TRACE(vf, "filtered frame %d (%d)\n", n, index);
     assert(p->requested[index] == &dummy_img);
 
     struct mp_image *res = NULL;
@@ -328,7 +328,7 @@ static bool locked_read_output(struct vf_instance *vf)
             //       infiltGetFrame (if it does, we would deadlock)
             p->requested[n] = (struct mp_image *)&dummy_img;
             p->failed = false;
-            MP_DBG(vf, "requesting frame %d (%d)\n", p->out_frameno + n, n);
+            MP_TRACE(vf, "requesting frame %d (%d)\n", p->out_frameno + n, n);
             p->vsapi->getFrameAsync(p->out_frameno + n, p->out_node,
                                     vs_frame_done, vf);
         }
@@ -463,7 +463,7 @@ static const VSFrameRef *VS_CC infiltGetFrame(int frameno, int activationReason,
     VSFrameRef *ret = NULL;
 
     pthread_mutex_lock(&p->lock);
-    MP_DBG(vf, "VS asking for frame %d (at %d)\n", frameno, p->in_frameno);
+    MP_TRACE(vf, "VS asking for frame %d (at %d)\n", frameno, p->in_frameno);
     while (1) {
         if (p->shutdown) {
             p->vsapi->setFilterError("EOF or filter reinit/uninit", frameCtx);

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -144,7 +144,7 @@ void gl_sc_reset(struct gl_shader_cache *sc)
 
 static void sc_flush_cache(struct gl_shader_cache *sc)
 {
-    MP_VERBOSE(sc, "flushing shader cache\n");
+    MP_DBG(sc, "flushing shader cache\n");
 
     for (int n = 0; n < sc->num_entries; n++) {
         struct sc_entry *e = sc->entries[n];
@@ -554,15 +554,6 @@ static bool create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
     void *tmp = talloc_new(NULL);
     struct ra_renderpass_params params = sc->params;
 
-    MP_VERBOSE(sc, "new shader program:\n");
-    if (sc->header_text.len) {
-        MP_VERBOSE(sc, "header:\n");
-        mp_log_source(sc->log, MSGL_V, sc->header_text.start);
-        MP_VERBOSE(sc, "body:\n");
-    }
-    if (sc->text.len)
-        mp_log_source(sc->log, MSGL_V, sc->text.start);
-
     const char *cache_header = "mpv shader cache v1\n";
     char *cache_filename = NULL;
     char *cache_dir = NULL;
@@ -587,7 +578,7 @@ static bool create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
 
         cache_filename = mp_path_join(tmp, cache_dir, hashstr);
         if (stat(cache_filename, &(struct stat){0}) == 0) {
-            MP_VERBOSE(sc, "Trying to load shader from disk...\n");
+            MP_DBG(sc, "Trying to load shader from disk...\n");
             struct bstr cachedata =
                 stream_read_file(cache_filename, tmp, sc->global, 1000000000);
             if (bstr_eatstart0(&cachedata, cache_header))
@@ -637,7 +628,7 @@ static bool create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
         if (nc.len && !bstr_equals(params.cached_program, nc)) {
             mp_mkdirp(cache_dir);
 
-            MP_VERBOSE(sc, "Writing shader cache file: %s\n", cache_filename);
+            MP_DBG(sc, "Writing shader cache file: %s\n", cache_filename);
             FILE *out = fopen(cache_filename, "wb");
             if (out) {
                 fwrite(cache_header, strlen(cache_header), 1, out);

--- a/video/out/gpu/utils.c
+++ b/video/out/gpu/utils.c
@@ -177,7 +177,7 @@ bool ra_tex_resize(struct ra *ra, struct mp_log *log, struct ra_tex **tex,
             return true;
     }
 
-    mp_verbose(log, "Resizing texture: %dx%d\n", w, h);
+    mp_dbg(log, "Resizing texture: %dx%d\n", w, h);
 
     if (!fmt || !fmt->renderable || !fmt->linear_filter) {
         mp_err(log, "Format %s not supported.\n", fmt ? fmt->name : "(unset)");

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1039,11 +1039,11 @@ static void pass_report_performance(struct gl_video *p)
     for (int i = 0; i < VO_PASS_PERF_MAX; i++) {
         struct pass_info *pass = &p->pass[i];
         if (pass->desc.len) {
-            MP_DBG(p, "pass '%.*s': last %dus avg %dus peak %dus\n",
-                   BSTR_P(pass->desc),
-                   (int)pass->perf.last/1000,
-                   (int)pass->perf.avg/1000,
-                   (int)pass->perf.peak/1000);
+            MP_TRACE(p, "pass '%.*s': last %dus avg %dus peak %dus\n",
+                     BSTR_P(pass->desc),
+                     (int)pass->perf.last/1000,
+                     (int)pass->perf.avg/1000,
+                     (int)pass->perf.peak/1000);
         }
     }
 }
@@ -1379,8 +1379,8 @@ static bool pass_hook_setup_binds(struct gl_video *p, const char *name,
         struct image bind_img;
         if (!saved_img_find(p, bind_name, &bind_img)) {
             // Clean up texture bindings and move on to the next hook
-            MP_DBG(p, "Skipping hook on %s due to no texture named %s.\n",
-                   name, bind_name);
+            MP_TRACE(p, "Skipping hook on %s due to no texture named %s.\n",
+                     name, bind_name);
             p->num_pass_imgs -= t;
             return false;
         }
@@ -1411,7 +1411,7 @@ static struct image pass_hook(struct gl_video *p, const char *name,
 
     saved_img_store(p, name, img);
 
-    MP_DBG(p, "Running hooks for %s\n", name);
+    MP_TRACE(p, "Running hooks for %s\n", name);
     for (int i = 0; i < p->num_tex_hooks; i++) {
         struct tex_hook *hook = &p->tex_hooks[i];
 
@@ -1426,7 +1426,7 @@ static struct image pass_hook(struct gl_video *p, const char *name,
 found:
         // Check the hook's condition
         if (hook->cond && !hook->cond(p, img, hook->priv)) {
-            MP_DBG(p, "Skipping hook on %s due to condition.\n", name);
+            MP_TRACE(p, "Skipping hook on %s due to condition.\n", name);
             continue;
         }
 
@@ -2058,7 +2058,6 @@ static void pass_read_video(struct gl_video *p)
     struct mp_rect_f src = {0.0, 0.0, p->image_params.w, p->image_params.h};
     struct mp_rect_f ref = src;
     gl_transform_rect(p->texture_offset, &ref);
-    MP_DBG(p, "ref rect: {%f %f} {%f %f}\n", ref.x0, ref.y0, ref.x1, ref.y1);
 
     // Explicitly scale all of the textures that don't match
     for (int n = 0; n < 4; n++) {
@@ -2069,9 +2068,6 @@ static void pass_read_video(struct gl_video *p)
         // exact same source rectangle.
         struct mp_rect_f rect = src;
         gl_transform_rect(offsets[n], &rect);
-        MP_DBG(p, "rect[%d]: {%f %f} {%f %f}\n", n,
-               rect.x0, rect.y0, rect.x1, rect.y1);
-
         if (mp_rect_f_seq(ref, rect))
             continue;
 
@@ -2083,8 +2079,6 @@ static void pass_read_video(struct gl_video *p)
                   {0.0, (ref.y1 - ref.y0) / (rect.y1 - rect.y0)}},
             .t = {ref.x0, ref.y0},
         };
-        MP_DBG(p, "-> fix[%d] = {%f %f} + off {%f %f}\n", n,
-               fix.m[0][0], fix.m[1][1], fix.t[0], fix.t[1]);
 
         // Since the scale in texture space is different from the scale in
         // absolute terms, we have to scale the coefficients down to be
@@ -2098,8 +2092,6 @@ static void pass_read_video(struct gl_video *p)
             MPSWAP(double, scale.m[0][0], scale.m[1][1]);
 
         gl_transform_trans(scale, &fix);
-        MP_DBG(p, "-> scaled[%d] = {%f %f} + off {%f %f}\n", n,
-               fix.m[0][0], fix.m[1][1], fix.t[0], fix.t[1]);
 
         // Since the texture transform is a function of the texture coordinates
         // to texture space, rather than the other way around, we have to
@@ -2981,8 +2973,8 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
             assert(id == i);
         }
 
-        MP_DBG(p, "inter frame dur: %f vsync: %f, mix: %f\n",
-               t->ideal_frame_duration, t->vsync_interval, mix);
+        MP_TRACE(p, "inter frame dur: %f vsync: %f, mix: %f\n",
+                 t->ideal_frame_duration, t->vsync_interval, mix);
         p->is_interpolated = true;
     }
     pass_draw_to_screen(p, fbo);
@@ -3753,8 +3745,8 @@ void gl_video_set_ambient_lux(struct gl_video *p, int lux)
 {
     if (p->opts.gamma_auto) {
         p->opts.gamma = gl_video_scale_ambient_lux(16.0, 256.0, 1.0, 1.2, lux);
-        MP_VERBOSE(p, "ambient light changed: %d lux (gamma: %f)\n", lux,
-                   p->opts.gamma);
+        MP_TRACE(p, "ambient light changed: %d lux (gamma: %f)\n", lux,
+                 p->opts.gamma);
     }
 }
 

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -773,7 +773,7 @@ static GLuint load_program(struct ra *ra, const struct ra_renderpass_params *p,
         GLint status = 0;
         gl->GetProgramiv(prog, GL_LINK_STATUS, &status);
         if (status) {
-            MP_VERBOSE(ra, "Loading binary program succeeded.\n");
+            MP_DBG(ra, "Loading binary program succeeded.\n");
         } else {
             gl->DeleteProgram(prog);
             prog = 0;


### PR DESCRIPTION
I wanted to cut down the amount of spam in MSGL_V, and provide a clearer distinction between MSGL_DEBUG and MSGL_TRACE. So this is my new set of internal “rules” for what level means what:

1. Does it print information about the file, or key information regarding mpv's interaction with the system that the user is very likely to both understand and care about? -> MSGL_V

2. Does it print debugging information about mpv internal behavior that advanced users may understand, which are useful for debugging mpv, and which isn't too spam-heavy? -> MSGL_DEBUG

3. Does it continuously print noisy debug message about benign events like decoding more output, rendering more frames or moving the mouse? Is it only useful to the person writing the code in question? -> MSGL_TRACE

If in doubt, the distinction between MSGL_DEBUG and MSGL_TRACE is whether or not it prints the message only once or whether it gets continuously spammed. If it's printed only once (e.g. the GPU format dump and input section parsing noise), it's fair game for MSGL_DEBUG.

The main motivation reason for this is not just cutting down the amount of useless crap in `-v` but also making `-v -v` the new default for `--log-file`

The basic output for `-v` is now pretty concise, looking something like this on a typical file:

```
[cplayer] Command line options: '--no-audio' 'EFgyfHAsOwg.mp4' '-v'
[cplayer] mpv 0.27.0-76-g24c59143c5-dirty (C) 2000-2017 mpv/MPlayer/mplayer2 projects
[cplayer]  built on Thu Sep 28 12:38:32 CEST 2017
[cplayer] ffmpeg library versions:
[cplayer]    libavutil       55.76.100
[cplayer]    libavcodec      57.106.101
[cplayer]    libavformat     57.82.101
[cplayer]    libswscale      4.7.103
[cplayer]    libavfilter     6.106.100
[cplayer]    libswresample   2.8.100
[cplayer] ffmpeg version: N-87359-g67da2685e0
[cplayer] 
[cplayer] Configuration: ./waf configure
[cplayer] List of enabled features: 51 alsa asm atomics avutil-content-light-level avutil-icc-profile avutil-imgcpy-uc avutil-spherical build-date cplayer cplugins cuda-hwaccel debug-build drm egl-drm egl-helpers egl-x11 encoding fchmod gbm gbm.h gl gl-wayland gl-x11 glibc-thread-name glob glob-posix gnuc gpl iconv is_ffmpeg jpeg lcms2 libaf libass libass-osd libav libavcodec libavdevice libbluray libdl libm librt linux-fstatfs lua nanosleep optimize oss-audio posix posix-or-mingw posix-spawn posix-spawn-native pthreads pulse rubberband shaderc shm stdatomic termios uchardet vaapi vaapi-drm vaapi-egl vaapi-glx vaapi-hwaccel vaapi-x-egl vaapi-x11 vdpau vdpau-gl-x11 vdpau-hwaccel vt.h vulkan wayland x11 xv zlib
[cplayer] Reading config file /home/nand/.mpv/config
[cplayer] Option af-toggle: Label audnorm not found
[input] Parsing input config file /home/nand/.mpv/input.conf
[input] Input config file /home/nand/.mpv/input.conf parsed: 68 binds
[ytdl_hook] lua-settings/ytdl_hook.conf not found. 
[skipchapters] lua-settings/skipchapters.conf not found. 
[cplayer] Playing: EFgyfHAsOwg.mp4
[cplayer] Running hook: ytdl_hook/on_load
[demux] Trying demuxers for level=normal.
[lavf] Found 'mov,mp4,m4a,3gp,3g2,mj2' at score=100 size=2048.
[demux] Detected file format: mov,mp4,m4a,3gp,3g2,mj2 (libavformat)
[cplayer] Opening done: EFgyfHAsOwg.mp4
[find_files] Loading external files in .
[cplayer] Running hook: ytdl_hook/on_preloaded
[cplayer] Running hook: visualizer/on_preloaded
[cplayer] Set property: options/lavfi-complex="" -> 1
[cplayer]  (+) Video --vid=1 (*) (h264 1920x1080 25.000fps)
[cplayer]      Audio --aid=1 --alang=und (*) (aac 2ch 44100Hz)
[vo/gpu] Probing for best GPU context.
[vo/gpu/opengl] Initializing GPU context 'x11probe'
[vo/gpu/x11] X11 opening display: :0
[vo/gpu/x11] X11 running at 4096x2160 (":0" => local display)
[vo/gpu/x11] Assuming DPI scale 2 for prescaling. This can be disabled with --hidpi-window-scale=no.
[vo/gpu/x11] Detected wm supports NetWM.
[vo/gpu/x11] Detected wm supports FULLSCREEN state.
[vo/gpu/x11] Display 0 (DP-0): [0, 0, 4096, 2160] @ 59.998457 FPS
[vo/gpu/x11] Current display FPS: 59.998457
[vo/gpu/opengl] GLX chose FB config with ID 0xad
[vo/gpu/opengl] GLX chose visual with ID 0x27
[vo/gpu/opengl] Creating OpenGL 4.4 context...
[vo/gpu] GL_VERSION='4.4.0 NVIDIA 384.69'
[vo/gpu] Detected desktop OpenGL 4.4.
[vo/gpu] GL_VENDOR='NVIDIA Corporation'
[vo/gpu] GL_RENDERER='GeForce GTX 970/PCIe/SSE2'
[vo/gpu] GL_SHADING_LANGUAGE_VERSION='4.40 NVIDIA via Cg compiler'
[vo/gpu] Loaded extension GLX_SGI_swap_control.
[vo/gpu] Loaded extension GLX_SGI_video_sync.
[vo/gpu] Loaded extension GL_NV_vdpau_interop.
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Querying ICC profile...
[vo/gpu] Assuming 59.998457 FPS for display sync.
[vd] Container reported FPS: 25.000000
[vd] Codec list:
[vd]     h264 - H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
[vd]     h264_cuvid (h264) - Nvidia CUVID H264 decoder
[vd] Opening video decoder h264
[vd] Using software decoding.
[vd] Detected 32 logical cores.
[vd] Requesting 16 threads for decoding.
[vd] Selected video codec: h264 (H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10)
[cplayer] Starting playback...
[vd] Decoder format: 1920x1080 yuv420p auto/auto/auto/auto CL=mpeg2/4/h264 (auto 0.000000/0.000000/0.000000)
[vf] Video filter chain:
[vf]   [in] 1920x1080 yuv420p bt.709/bt.709/bt.1886/limited SP=1.000000 CL=mpeg2/4/h264
[vf]   [out] 1920x1080 yuv420p bt.709/bt.709/bt.1886/limited SP=1.000000 CL=mpeg2/4/h264
[cplayer] VO: [gpu] 1920x1080 yuv420p
[cplayer] VO: Description: Shader-based GPU Renderer
[vo/gpu/x11] not waiting for MapNotify
[vo/gpu] Resize: 3840x2160
[vo/gpu] Window size: 3840x2160
[vo/gpu] Video source: 1920x1080 (1:1)
[vo/gpu] Video display: (0, 0) 1920x1080 -> (0, 0) 3840x2160
[vo/gpu] Video scale: 2.000000/2.000000
[vo/gpu] OSD borders: l=0 t=0 r=0 b=0
[vo/gpu] Video borders: l=0 t=0 r=0 b=0
[vo/gpu] Reported display depth: 8
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Texture for plane 0: 1920x1080
[vo/gpu] Texture for plane 1: 960x540
[vo/gpu] Texture for plane 2: 960x540
[vo/gpu] Querying ICC profile...
[vo/gpu/x11] Retrieving ICC profile for display: 0
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Resize: 2046x2126
[vo/gpu] Window size: 2046x2126
[vo/gpu] Video source: 1920x1080 (1:1)
[vo/gpu] Video display: (0, 0) 1920x1080 -> (0, 488) 2046x1150
[vo/gpu] Video scale: 1.065625/1.064815
[vo/gpu] OSD borders: l=0 t=488 r=0 b=488
[vo/gpu] Video borders: l=0 t=488 r=0 b=488
[vo/gpu] Reported display depth: 8
[vo/gpu] DR enabled: yes
[vo/gpu] Opening 3D LUT cache in file '/tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C'.
[vo/gpu] Dither to 8.
[cplayer] first video frame after restart shown
[term-msg] Resolution: 1920x1080, Framerate: 25.000 Hz
[cplayer] playback restart complete
[statusline] V: 00:00:00.000 / 00:03:45.698 (0%) DS: 2.000/0
[cplayer] Can't find script 'osc' for script-message-to.
[vo/gpu/x11] Disabling screensaver.
[statusline] V: 00:00:00.000 / 00:03:45.698 (0%) DS: 2.500/0
[osd/libass] Shaper: FriBidi 0.19.7 (SIMPLE) HarfBuzz-ng 1.5.1 (COMPLEX)
[osd/libass] Setting up fonts...
[osd/libass] Using font provider fontconfig
[osd/libass] Done.
[statusline] V: 00:00:01.600 / 00:03:45.698 (0%) DS: 2.405/0
[cplayer] EOF code: 6  
[vd] Uninit video.
[vo/gpu/x11] Enabling screensaver.
[cplayer] finished playback, success (reason 3)
[cplayer] 
[cplayer] 
[cplayer] Exiting... (Quit)
[image] Exiting...
[autocrop] Exiting...
[visualizer] Exiting...
[easybox] Exiting...
[auto_profiles] Exiting...
[skipchapters] Exiting...
[easycrop] Exiting...
[ytdl_hook] Exiting...
[progressbar] Exiting...
[stats] Exiting...
[vo/gpu/x11] uninit ...
```

By contrast, this is what `-v -v` looks like:

```
[cplayer] Command line options: '--no-audio' 'EFgyfHAsOwg.mp4' '-v' '-v'
[cplayer] mpv 0.27.0-76-g24c59143c5-dirty (C) 2000-2017 mpv/MPlayer/mplayer2 projects
[cplayer]  built on Thu Sep 28 12:38:32 CEST 2017
[cplayer] ffmpeg library versions:
[cplayer]    libavutil       55.76.100
[cplayer]    libavcodec      57.106.101
[cplayer]    libavformat     57.82.101
[cplayer]    libswscale      4.7.103
[cplayer]    libavfilter     6.106.100
[cplayer]    libswresample   2.8.100
[cplayer] ffmpeg version: N-87359-g67da2685e0
[cplayer] 
[cplayer] Configuration: ./waf configure
[cplayer] List of enabled features: 51 alsa asm atomics avutil-content-light-level avutil-icc-profile avutil-imgcpy-uc avutil-spherical build-date cplayer cplugins cuda-hwaccel debug-build drm egl-drm egl-helpers egl-x11 encoding fchmod gbm gbm.h gl gl-wayland gl-x11 glibc-thread-name glob glob-posix gnuc gpl iconv is_ffmpeg jpeg lcms2 libaf libass libass-osd libav libavcodec libavdevice libbluray libdl libm librt linux-fstatfs lua nanosleep optimize oss-audio posix posix-or-mingw posix-spawn posix-spawn-native pthreads pulse rubberband shaderc shm stdatomic termios uchardet vaapi vaapi-drm vaapi-egl vaapi-glx vaapi-hwaccel vaapi-x-egl vaapi-x11 vdpau vdpau-gl-x11 vdpau-hwaccel vt.h vulkan wayland x11 xv zlib
[global] config path: '' -> '/home/nand/.config/mpv'
[global] config path: 'encoding-profiles.conf' -/-> '/home/nand/.config/mpv/encoding-profiles.conf'
[global] config path: 'encoding-profiles.conf' -/-> '/home/nand/.mpv/encoding-profiles.conf'
[global] config path: 'encoding-profiles.conf' -/-> '/usr/local/etc/mpv/encoding-profiles.conf'
[global] config path: 'mpv.conf' -/-> '/home/nand/.config/mpv/mpv.conf'
[global] config path: 'config' -/-> '/home/nand/.config/mpv/config'
[global] config path: 'mpv.conf' -/-> '/home/nand/.mpv/mpv.conf'
[global] config path: 'config' -> '/home/nand/.mpv/config'
[global] config path: 'mpv.conf' -/-> '/usr/local/etc/mpv/mpv.conf'
[global] config path: 'config' -/-> '/usr/local/etc/mpv/config'
[cplayer] Reading config file /home/nand/.mpv/config
[cplayer] Option af-toggle: Label audnorm not found
[cplayer] Setting option 'vo' = 'gpu' (flags = 4)
[cplayer] Setting option 'gpu-api' = 'opengl' (flags = 4)
[cplayer] Setting option 'profile' = 'gpu-hq' (flags = 4)
[cplayer] Setting option 'scale' = 'spline36' (flags = 4)
[cplayer] Setting option 'cscale' = 'spline36' (flags = 4)
[cplayer] Setting option 'dscale' = 'mitchell' (flags = 4)
[cplayer] Setting option 'dither-depth' = 'auto' (flags = 4)
[cplayer] Setting option 'correct-downscaling' = 'yes' (flags = 4)
[cplayer] Setting option 'sigmoid-upscaling' = 'yes' (flags = 4)
[cplayer] Setting option 'deband' = 'yes' (flags = 4)
[cplayer] Setting option 'vd-lavc-dr' = 'yes' (flags = 4)
[cplayer] Setting option 'opengl-pbo' = 'yes' (flags = 4)
[cplayer] Setting option 'scale' = 'haasnsoft' (flags = 4)
[cplayer] Setting option 'scale-clamp' = '0.2' (flags = 4)
[cplayer] Setting option 'cscale' = 'ewa_lanczos' (flags = 4)
[cplayer] Setting option 'icc-profile-auto' = 'yes' (flags = 4)
[cplayer] Setting option 'icc-cache-dir' = '/tmp/mpv-icc' (flags = 4)
[cplayer] Setting option 'gpu-shader-cache-dir' = '/tmp/mpv-shaders/' (flags = 4)
[cplayer] Setting option 'video-sync' = 'display-resample' (flags = 4)
[cplayer] Setting option 'interpolation' = 'yes' (flags = 4)
[cplayer] Setting option 'tscale' = 'oversample' (flags = 4)
[cplayer] Setting option 'blend-subtitles' = 'yes' (flags = 4)
[cplayer] Setting option 'deband-iterations' = '2' (flags = 4)
[cplayer] Setting option 'deband-range' = '12' (flags = 4)
[cplayer] Setting option 'temporal-dither' = 'yes' (flags = 4)
[cplayer] Setting option 'vf-defaults' = 'yadif:interlaced-only=no' (flags = 4)
[cplayer] Setting option 'cache' = 'auto' (flags = 4)
[cplayer] Setting option 'cache-default' = '2000000' (flags = 4)
[cplayer] Setting option 'cache-backbuffer' = '1000000' (flags = 4)
[cplayer] Setting option 'cache-initial' = '1000' (flags = 4)
[cplayer] Setting option 'cache-seek-min' = '2000' (flags = 4)
[cplayer] Setting option 'ytdl' = 'yes' (flags = 4)
[cplayer] Setting option 'ytdl-format' = '(bestvideo[vcodec=vp9.2]/bestvideo[vcodec=vp9][fps>30]/bestvideo[vcodec=vp9][height>=1080]/bestvideo[fps>30]/bestvideo[height>720])+(bestaudio[acodec=opus]/bestaudio)/best' (flags = 4)
[cplayer] Setting option 'ao' = 'pulse' (flags = 4)
[cplayer] Setting option 'pulse-buffer' = '250' (flags = 4)
[cplayer] Setting option 'pulse-latency-hacks' = 'yes' (flags = 4)
[cplayer] Setting option 'volume' = '50' (flags = 4)
[cplayer] Setting option 'volume-max' = '100' (flags = 4)
[cplayer] Setting option 'audio-pitch-correction' = 'no' (flags = 4)
[cplayer] Setting option 'audio-normalize-downmix' = 'yes' (flags = 4)
[cplayer] Setting option 'audio-device' = 'alsa_output.usb-Yoyodyne_Consulting_ODAC-revB-01.iec958-stereo' (flags = 4)
[cplayer] Setting option 'af-add' = '@audnorm:!loudnorm=I=-25:TP=-1.5:LRA=1' (flags = 4)
[cplayer] Setting option 'af-add' = '@dynnorm:!dynaudnorm=f=200:g=5:r=0.1' (flags = 4)
[cplayer] Setting option 'audio-display' = 'no' (flags = 4)
[cplayer] Setting option 'fullscreen' = 'no' (flags = 4)
[cplayer] Setting option 'msg-color' = 'yes' (flags = 4)
[cplayer] Setting option 'screenshot-directory' = '/mem' (flags = 4)
[cplayer] Setting option 'load-unsafe-playlists' = 'yes' (flags = 4)
[cplayer] Setting option 'osc' = 'no' (flags = 4)
[cplayer] Setting option 'slang' = 'eng,en,enUS,en-US' (flags = 4)
[cplayer] Setting option 'alang' = 'jpn,jp,eng,en,enUS,en-US' (flags = 4)
[cplayer] Setting option 'ytdl-raw-options' = 'sub-lang="en,eng,enUS,en-US",write-sub=' (flags = 4)
[cplayer] Setting option 'term-playing-msg' = 'Resolution: ${width}x${height}, Framerate: ${container-fps} Hz' (flags = 4)
[cplayer] Setting option 'osd-font-size' = '20' (flags = 4)
[cplayer] Setting option 'osd-color' = '#ffffffff' (flags = 4)
[cplayer] Setting option 'osd-border-color' = '#ff151515' (flags = 4)
[cplayer] Setting option 'osd-border-size' = '2' (flags = 4)
[cplayer] Setting option 'osd-shadow-offset' = '1' (flags = 4)
[cplayer] Setting option 'osd-shadow-color' = '#11000000' (flags = 4)
[cplayer] Setting option 'osd-fractions' = '' (flags = 4)
[cplayer] Setting option 'sub-ass-force-style' = 'Kerning=yes' (flags = 4)
[cplayer] Setting option 'sub-ass-override' = 'scale' (flags = 4)
[cplayer] Setting option 'sub-scale' = '0.5' (flags = 4)
[cplayer] Setting option 'sub-pos' = '60' (flags = 4)
[cplayer] Setting option 'sub-font' = 'Liberation Sans' (flags = 4)
[cplayer] Setting option 'sub-font-size' = '70' (flags = 4)
[cplayer] Setting option 'sub-margin-y' = '50' (flags = 4)
[cplayer] Setting option 'sub-color' = '#FFFFFFFF' (flags = 4)
[cplayer] Setting option 'sub-border-color' = '#FF151515' (flags = 4)
[cplayer] Setting option 'sub-border-size' = '6' (flags = 4)
[cplayer] Setting option 'sub-shadow-offset' = '1' (flags = 4)
[cplayer] Setting option 'sub-shadow-color' = '#33000000' (flags = 4)
[cplayer] Setting option 'sub-spacing' = '0.5' (flags = 4)
[cplayer] Setting option 'sub-scale-by-window' = 'no' (flags = 4)
[cplayer] Setting option 'audio' = 'no' (flags = 8)
[cplayer] Setting option 'v' = '' (flags = 8)
[cplayer] Setting option 'v' = '' (flags = 8)
[input] add: section='default' key='MBTN_LEFT' builtin cmd='ignore              # don't do anything' location='<builtin>:1'
[input] add: section='default' key='MBTN_LEFT_DBL' builtin cmd='cycle fullscreen    # toggle fullscreen on/off' location='<builtin>:1'
[input] add: section='default' key='MBTN_RIGHT' builtin cmd='cycle pause         # toggle pause on/off' location='<builtin>:1'
[input] add: section='default' key='WHEEL_UP' builtin cmd='seek 10' location='<builtin>:1'
[input] add: section='default' key='WHEEL_DOWN' builtin cmd='seek -10' location='<builtin>:1'
[input] add: section='default' key='WHEEL_LEFT' builtin cmd='add volume -2' location='<builtin>:1'
[input] add: section='default' key='WHEEL_RIGHT' builtin cmd='add volume 2' location='<builtin>:1'
[input] add: section='default' key='RIGHT' builtin cmd='seek  5' location='<builtin>:1'
[input] add: section='default' key='LEFT' builtin cmd='seek -5' location='<builtin>:1'
[input] add: section='default' key='UP' builtin cmd='seek  60' location='<builtin>:1'
[input] add: section='default' key='DOWN' builtin cmd='seek -60' location='<builtin>:1'
[input] add: section='default' key='Shift+RIGHT' builtin cmd='no-osd seek  1 exact' location='<builtin>:1'
[input] add: section='default' key='Shift+LEFT' builtin cmd='no-osd seek -1 exact' location='<builtin>:1'
[input] add: section='default' key='Shift+UP' builtin cmd='no-osd seek  5 exact' location='<builtin>:1'
[input] add: section='default' key='Shift+DOWN' builtin cmd='no-osd seek -5 exact' location='<builtin>:1'
[input] add: section='default' key='Ctrl+LEFT' builtin cmd='no-osd sub-seek -1' location='<builtin>:1'
[input] add: section='default' key='Ctrl+RIGHT' builtin cmd='no-osd sub-seek  1' location='<builtin>:1'
[input] add: section='default' key='PGUP' builtin cmd='add chapter 1                     # skip to next chapter' location='<builtin>:1'
[input] add: section='default' key='PGDWN' builtin cmd='add chapter -1                   # skip to previous chapter' location='<builtin>:1'
[input] add: section='default' key='Shift+PGUP' builtin cmd='seek 600' location='<builtin>:1'
[input] add: section='default' key='Shift+PGDWN' builtin cmd='seek -600' location='<builtin>:1'
[input] add: section='default' key='[' builtin cmd='multiply speed 0.9091                # scale playback speed' location='<builtin>:1'
[input] add: section='default' key=']' builtin cmd='multiply speed 1.1' location='<builtin>:1'
[input] add: section='default' key='{' builtin cmd='multiply speed 0.5' location='<builtin>:1'
[input] add: section='default' key='}' builtin cmd='multiply speed 2.0' location='<builtin>:1'
[input] add: section='default' key='BS' builtin cmd='set speed 1.0                       # reset speed to normal' location='<builtin>:1'
[input] add: section='default' key='q' builtin cmd='quit' location='<builtin>:1'
[input] add: section='default' key='Q' builtin cmd='quit-watch-later' location='<builtin>:1'
[input] add: section='encode' key='q' builtin cmd='quit 4' location='<builtin>:1'
[input] add: section='default' key='ESC' builtin cmd='set fullscreen no' location='<builtin>:1'
[input] add: section='encode' key='ESC' builtin cmd='quit 4' location='<builtin>:1'
[input] add: section='default' key='p' builtin cmd='cycle pause                          # toggle pause/playback mode' location='<builtin>:1'
[input] add: section='default' key='.' builtin cmd='frame-step                           # advance one frame and pause' location='<builtin>:1'
[input] add: section='default' key=',' builtin cmd='frame-back-step                      # go back by one frame and pause' location='<builtin>:1'
[input] add: section='default' key='SPACE' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='>' builtin cmd='playlist-next                        # skip to next file' location='<builtin>:1'
[input] add: section='default' key='ENTER' builtin cmd='playlist-next                    # skip to next file' location='<builtin>:1'
[input] add: section='default' key='<' builtin cmd='playlist-prev                        # skip to previous file' location='<builtin>:1'
[input] add: section='default' key='O' builtin cmd='no-osd cycle-values osd-level 3 1    # cycle through OSD mode' location='<builtin>:1'
[input] add: section='default' key='o' builtin cmd='show-progress' location='<builtin>:1'
[input] add: section='default' key='P' builtin cmd='show-progress' location='<builtin>:1'
[input] add: section='default' key='z' builtin cmd='add sub-delay -0.1                   # subtract 100 ms delay from subs' location='<builtin>:1'
[input] add: section='default' key='x' builtin cmd='add sub-delay +0.1                   # add' location='<builtin>:1'
[input] add: section='default' key='Ctrl++' builtin cmd='add audio-delay 0.100           # this changes audio/video sync' location='<builtin>:1'
[input] add: section='default' key='Ctrl+-' builtin cmd='add audio-delay -0.100' location='<builtin>:1'
[input] add: section='default' key='9' builtin cmd='add volume -2' location='<builtin>:1'
[input] add: section='default' key='/' builtin cmd='add volume -2' location='<builtin>:1'
[input] add: section='default' key='0' builtin cmd='add volume 2' location='<builtin>:1'
[input] add: section='default' key='*' builtin cmd='add volume 2' location='<builtin>:1'
[input] add: section='default' key='m' builtin cmd='cycle mute' location='<builtin>:1'
[input] add: section='default' key='1' builtin cmd='add contrast -1' location='<builtin>:1'
[input] add: section='default' key='2' builtin cmd='add contrast 1' location='<builtin>:1'
[input] add: section='default' key='3' builtin cmd='add brightness -1' location='<builtin>:1'
[input] add: section='default' key='4' builtin cmd='add brightness 1' location='<builtin>:1'
[input] add: section='default' key='5' builtin cmd='add gamma -1' location='<builtin>:1'
[input] add: section='default' key='6' builtin cmd='add gamma 1' location='<builtin>:1'
[input] add: section='default' key='7' builtin cmd='add saturation -1' location='<builtin>:1'
[input] add: section='default' key='8' builtin cmd='add saturation 1' location='<builtin>:1'
[input] add: section='default' key='Alt+0' builtin cmd='set window-scale 0.5' location='<builtin>:1'
[input] add: section='default' key='Alt+1' builtin cmd='set window-scale 1.0' location='<builtin>:1'
[input] add: section='default' key='Alt+2' builtin cmd='set window-scale 2.0' location='<builtin>:1'
[input] add: section='default' key='d' builtin cmd='cycle deinterlace' location='<builtin>:1'
[input] add: section='default' key='r' builtin cmd='add sub-pos -1                       # move subtitles up' location='<builtin>:1'
[input] add: section='default' key='t' builtin cmd='add sub-pos +1                       #                down' location='<builtin>:1'
[input] add: section='default' key='v' builtin cmd='cycle sub-visibility' location='<builtin>:1'
[input] add: section='default' key='V' builtin cmd='cycle sub-ass-vsfilter-aspect-compat' location='<builtin>:1'
[input] add: section='default' key='u' builtin cmd='cycle-values sub-ass-override "force" "no"' location='<builtin>:1'
[input] add: section='default' key='j' builtin cmd='cycle sub                            # cycle through subtitles' location='<builtin>:1'
[input] add: section='default' key='J' builtin cmd='cycle sub down                       # ...backwards' location='<builtin>:1'
[input] add: section='default' key='SHARP' builtin cmd='cycle audio                      # switch audio streams' location='<builtin>:1'
[input] add: section='default' key='_' builtin cmd='cycle video' location='<builtin>:1'
[input] add: section='default' key='T' builtin cmd='cycle ontop                          # toggle video window ontop of other windows' location='<builtin>:1'
[input] add: section='default' key='f' builtin cmd='cycle fullscreen                     # toggle fullscreen' location='<builtin>:1'
[input] add: section='default' key='s' builtin cmd='async screenshot                     # take a screenshot' location='<builtin>:1'
[input] add: section='default' key='S' builtin cmd='async screenshot video               # ...without subtitles' location='<builtin>:1'
[input] add: section='default' key='Ctrl+s' builtin cmd='async screenshot window         # ...with subtitles and OSD, and scaled' location='<builtin>:1'
[input] add: section='default' key='Alt+s' builtin cmd='screenshot each-frame            # automatically screenshot every frame' location='<builtin>:1'
[input] add: section='default' key='w' builtin cmd='add panscan -0.1                     # zoom out with -panscan 0 -fs' location='<builtin>:1'
[input] add: section='default' key='e' builtin cmd='add panscan +0.1                     #      in' location='<builtin>:1'
[input] add: section='default' key='A' builtin cmd='cycle-values video-aspect "16:9" "4:3" "2.35:1" "-1"' location='<builtin>:1'
[input] add: section='default' key='POWER' builtin cmd='quit' location='<builtin>:1'
[input] add: section='default' key='PLAY' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='PAUSE' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='PLAYPAUSE' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='STOP' builtin cmd='quit' location='<builtin>:1'
[input] add: section='default' key='FORWARD' builtin cmd='seek 60' location='<builtin>:1'
[input] add: section='default' key='REWIND' builtin cmd='seek -60' location='<builtin>:1'
[input] add: section='default' key='NEXT' builtin cmd='playlist-next' location='<builtin>:1'
[input] add: section='default' key='PREV' builtin cmd='playlist-prev' location='<builtin>:1'
[input] add: section='default' key='VOLUME_UP' builtin cmd='add volume 2' location='<builtin>:1'
[input] add: section='default' key='VOLUME_DOWN' builtin cmd='add volume -2' location='<builtin>:1'
[input] add: section='default' key='MUTE' builtin cmd='cycle mute' location='<builtin>:1'
[input] add: section='default' key='CLOSE_WIN' builtin cmd='quit' location='<builtin>:1'
[input] add: section='encode' key='CLOSE_WIN' builtin cmd='quit 4' location='<builtin>:1'
[input] add: section='default' key='E' builtin cmd='cycle edition                        # next edition' location='<builtin>:1'
[input] add: section='default' key='l' builtin cmd='ab-loop                              # Set/clear A-B loop points' location='<builtin>:1'
[input] add: section='default' key='L' builtin cmd='cycle-values loop-file "inf" "no"    # toggle infinite looping' location='<builtin>:1'
[input] add: section='default' key='Ctrl+c' builtin cmd='quit 4' location='<builtin>:1'
[input] add: section='default' key='AR_PLAY' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='AR_PLAY_HOLD' builtin cmd='quit' location='<builtin>:1'
[input] add: section='default' key='AR_CENTER' builtin cmd='cycle pause' location='<builtin>:1'
[input] add: section='default' key='AR_CENTER_HOLD' builtin cmd='quit' location='<builtin>:1'
[input] add: section='default' key='AR_NEXT' builtin cmd='seek 10' location='<builtin>:1'
[input] add: section='default' key='AR_NEXT_HOLD' builtin cmd='seek 120' location='<builtin>:1'
[input] add: section='default' key='AR_PREV' builtin cmd='seek -10' location='<builtin>:1'
[input] add: section='default' key='AR_PREV_HOLD' builtin cmd='seek -120' location='<builtin>:1'
[input] add: section='default' key='AR_MENU' builtin cmd='show-progress' location='<builtin>:1'
[input] add: section='default' key='AR_MENU_HOLD' builtin cmd='cycle mute' location='<builtin>:1'
[input] add: section='default' key='AR_VUP' builtin cmd='add volume 2' location='<builtin>:1'
[input] add: section='default' key='AR_VUP_HOLD' builtin cmd='add chapter 1' location='<builtin>:1'
[input] add: section='default' key='AR_VDOWN' builtin cmd='add volume -2' location='<builtin>:1'
[input] add: section='default' key='AR_VDOWN_HOLD' builtin cmd='add chapter -1' location='<builtin>:1'
[input] add: section='default' key='!' builtin cmd='add chapter -1                       # skip to previous chapter' location='<builtin>:1'
[input] add: section='default' key='@' builtin cmd='add chapter 1                        #         next' location='<builtin>:1'
[global] config path: 'input.conf' -/-> '/home/nand/.config/mpv/input.conf'
[global] config path: 'input.conf' -> '/home/nand/.mpv/input.conf'
[global] config path: 'input.conf' -/-> '/usr/local/etc/mpv/input.conf'
[global] user path: '/home/nand/.mpv/input.conf' -> '/home/nand/.mpv/input.conf'
[bdmv/bluray] Opening /home/nand/.mpv/input.conf
[file] Opening /home/nand/.mpv/input.conf
[file] Stream opened successfully.
[input] Parsing input config file /home/nand/.mpv/input.conf
[input] add: section='default' key='RIGHT' cmd='seek 10' location='/home/nand/.mpv/input.conf:4'
[input] add: section='default' key='LEFT' cmd='seek -10' location='/home/nand/.mpv/input.conf:5'
[input] add: section='default' key='UP' cmd='seek 60' location='/home/nand/.mpv/input.conf:6'
[input] add: section='default' key='DOWN' cmd='seek -60' location='/home/nand/.mpv/input.conf:7'
[input] add: section='default' key='Shift+RIGHT' cmd='no-osd seek  1 exact' location='/home/nand/.mpv/input.conf:9'
[input] add: section='default' key='Shift+LEFT' cmd='no-osd seek -1 exact' location='/home/nand/.mpv/input.conf:10'
[input] add: section='default' key='Shift+UP' cmd='no-osd seek  5 exact' location='/home/nand/.mpv/input.conf:11'
[input] add: section='default' key='Shift+DOWN' cmd='no-osd seek -5 exact' location='/home/nand/.mpv/input.conf:12'
[input] add: section='default' key=';' cmd='no-osd sub-seek -1' location='/home/nand/.mpv/input.conf:14'
[input] add: section='default' key=''' cmd='no-osd sub-seek 1' location='/home/nand/.mpv/input.conf:15'
[input] add: section='default' key='+' cmd='add audio-delay 0.100' location='/home/nand/.mpv/input.conf:18'
[input] add: section='default' key='-' cmd='add audio-delay -0.100' location='/home/nand/.mpv/input.conf:19'
[input] add: section='default' key='{' cmd='multiply speed 0.9091' location='/home/nand/.mpv/input.conf:20'
[input] add: section='default' key='}' cmd='multiply speed 1.1' location='/home/nand/.mpv/input.conf:21'
[input] add: section='default' key='M' cmd='af toggle format=channels=1' location='/home/nand/.mpv/input.conf:23'
[input] add: section='default' key='ENTER' cmd='playlist-next force' location='/home/nand/.mpv/input.conf:26'
[input] add: section='default' key='ESC' cmd='ignore' location='/home/nand/.mpv/input.conf:27'
[input] add: section='default' key='!' cmd='add contrast -1' location='/home/nand/.mpv/input.conf:30'
[input] add: section='default' key='@' cmd='add contrast 1' location='/home/nand/.mpv/input.conf:31'
[input] add: section='default' key='1' cmd='add brightness -1' location='/home/nand/.mpv/input.conf:32'
[input] add: section='default' key='2' cmd='add brightness 1' location='/home/nand/.mpv/input.conf:33'
[input] add: section='default' key='$' cmd='add saturation -1' location='/home/nand/.mpv/input.conf:34'
[input] add: section='default' key='%' cmd='add saturation 1' location='/home/nand/.mpv/input.conf:35'
[input] add: section='default' key='4' cmd='add hue -1' location='/home/nand/.mpv/input.conf:36'
[input] add: section='default' key='5' cmd='add hue 1' location='/home/nand/.mpv/input.conf:37'
[input] add: section='default' key='^' cmd='add gamma -1' location='/home/nand/.mpv/input.conf:38'
[input] add: section='default' key='&' cmd='add gamma 1' location='/home/nand/.mpv/input.conf:39'
[input] add: section='default' key='Alt+!' cmd='add brightness -1' location='/home/nand/.mpv/input.conf:42'
[input] add: section='default' key='Alt+@' cmd='add brightness 1' location='/home/nand/.mpv/input.conf:43'
[input] add: section='default' key='Alt+$' cmd='add hue -1' location='/home/nand/.mpv/input.conf:44'
[input] add: section='default' key='Alt+%' cmd='add hue 1' location='/home/nand/.mpv/input.conf:45'
[input] add: section='default' key='SHARP' cmd='cycle audio' location='/home/nand/.mpv/input.conf:47'
[input] add: section='default' key='[' cmd='add volume -1' location='/home/nand/.mpv/input.conf:49'
[input] add: section='default' key=']' cmd='add volume 1' location='/home/nand/.mpv/input.conf:50'
[input] add: section='default' key='(' cmd='add balance -0.1' location='/home/nand/.mpv/input.conf:51'
[input] add: section='default' key=')' cmd='add balance 0.1' location='/home/nand/.mpv/input.conf:52'
[input] add: section='default' key='PGUP' cmd='add chapter -1' location='/home/nand/.mpv/input.conf:55'
[input] add: section='default' key='PGDWN' cmd='add chapter 1' location='/home/nand/.mpv/input.conf:56'
[input] add: section='default' key='F1' cmd='show-text ${track-list}' location='/home/nand/.mpv/input.conf:59'
[input] add: section='default' key='F2' cmd='show-text ${chapter-list}' location='/home/nand/.mpv/input.conf:60'
[input] add: section='default' key='`' cmd='show-text ${playlist}' location='/home/nand/.mpv/input.conf:61'
[input] add: section='default' key='i' cmd='cycle interpolation' location='/home/nand/.mpv/input.conf:64'
[input] add: section='default' key='d' cmd='cycle deband' location='/home/nand/.mpv/input.conf:65'
[input] add: section='default' key='D' cmd='cycle deinterlace' location='/home/nand/.mpv/input.conf:66'
[input] add: section='default' key='c' cmd='cycle icc-profile-auto' location='/home/nand/.mpv/input.conf:67'
[input] add: section='default' key='Ctrl+LEFT' cmd='add video-pan-x 0.1' location='/home/nand/.mpv/input.conf:70'
[input] add: section='default' key='Ctrl+RIGHT' cmd='add video-pan-x -0.1' location='/home/nand/.mpv/input.conf:71'
[input] add: section='default' key='Ctrl+UP' cmd='add video-pan-y 0.1' location='/home/nand/.mpv/input.conf:72'
[input] add: section='default' key='Ctrl+DOWN' cmd='add video-pan-y -0.1' location='/home/nand/.mpv/input.conf:73'
[input] add: section='default' key='Ctrl++' cmd='add video-zoom 0.1' location='/home/nand/.mpv/input.conf:74'
[input] add: section='default' key='Ctrl+-' cmd='add video-zoom -0.1' location='/home/nand/.mpv/input.conf:75'
[input] add: section='default' key='Alt+w' cmd='set panscan 0' location='/home/nand/.mpv/input.conf:78'
[input] add: section='default' key='Alt+e' cmd='set panscan 1' location='/home/nand/.mpv/input.conf:79'
[input] add: section='default' key='WHEEL_UP' cmd='ignore' location='/home/nand/.mpv/input.conf:82'
[input] add: section='default' key='WHEEL_DOWN' cmd='ignore' location='/home/nand/.mpv/input.conf:83'
[input] add: section='default' key='PAUSE' cmd='ignore' location='/home/nand/.mpv/input.conf:84'
[input] add: section='default' key='f' cmd='ignore' location='/home/nand/.mpv/input.conf:87'
[input] add: section='default' key='F' cmd='cycle fullscreen' location='/home/nand/.mpv/input.conf:88'
[input] add: section='default' key='S' cmd='screenshot window' location='/home/nand/.mpv/input.conf:91'
[input] add: section='default' key='t' cmd='show-text "${vo-passes}"' location='/home/nand/.mpv/input.conf:94'
[input] add: section='default' key='V' cmd='show-text "${vsync-jitter}"' location='/home/nand/.mpv/input.conf:95'
[input] add: section='default' key='L' cmd='cycle-values loop-file inf no' location='/home/nand/.mpv/input.conf:98'
[input] add: section='default' key='n' cmd='af toggle @audnorm' location='/home/nand/.mpv/input.conf:99'
[input] add: section='default' key='N' cmd='af toggle @dynnorm' location='/home/nand/.mpv/input.conf:100'
[input] add: section='default' key='A' cmd='cycle-values video-aspect "16:9" "4:3" "2.35:1" "no" "-1"' location='/home/nand/.mpv/input.conf:101'
[input] add: section='default' key='H' cmd='cycle-values tone-mapping hable mobius' location='/home/nand/.mpv/input.conf:102'
[input] add: section='default' key='u' cmd='cycle-values sub-ass-override "force" "scale"' location='/home/nand/.mpv/input.conf:103'
[input] add: section='default' key='R' cmd='cycle-values opengl-shaders "~~/shaders/ravu-r3-yuv.hook" "~~/shaders/ravu-r3.hook" ""' location='/home/nand/.mpv/input.conf:104'
[input] Input config file /home/nand/.mpv/input.conf parsed: 68 binds
[ytdl_hook] Loading lua script @ytdl_hook.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[ytdl_hook] loading mp.defaults
[ytdl_hook] loading @ytdl_hook.lua
[ytdl_hook] reading options for ytdl_hook 
[global] config path: 'lua-settings/ytdl_hook.conf' -/-> '/home/nand/.config/mpv/lua-settings/ytdl_hook.conf'
[global] config path: 'lua-settings/ytdl_hook.conf' -/-> '/home/nand/.mpv/lua-settings/ytdl_hook.conf'
[global] config path: 'lua-settings/ytdl_hook.conf' -/-> '/usr/local/etc/mpv/lua-settings/ytdl_hook.conf'
[ytdl_hook] lua-settings/ytdl_hook.conf not found. 
[cplayer] Run command: hook-add, flags=0, args=[on_load, 1, 10]
[cplayer] Run command: hook-add, flags=0, args=[on_preloaded, 2, 10]
[cplayer] Done loading @ytdl_hook.lua.
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[progressbar] Loading lua script /home/nand/.mpv/scripts/progressbar.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[progressbar] loading mp.defaults
[progressbar] loading file /home/nand/.mpv/scripts/progressbar.lua
[progressbar] reading options for torque-progressbar 
[global] config path: 'lua-settings/torque-progressbar.conf' -/-> '/home/nand/.config/mpv/lua-settings/torque-progressbar.conf'
[global] config path: 'lua-settings/torque-progressbar.conf' -> '/home/nand/.mpv/lua-settings/torque-progressbar.conf'
[cplayer] Run command: define-section, flags=0, args=[input_progressbar, mouse_btn0 script-binding progressbar/left-click
[cplayer] , default]
[input] add: section='input_progressbar' key='MBTN_LEFT' builtin cmd='script-binding progressbar/left-click' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_progressbar, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_progressbar, mouse_btn0 script-binding progressbar/left-click
[cplayer] , default]
[input] add: section='input_progressbar' key='MBTN_LEFT' builtin cmd='script-binding progressbar/left-click' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_forced_progressbar 12
[input]  input_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_progressbar, mouse_leave script-binding progressbar/mouse-leave
[cplayer] , force]
[input] add: section='input_forced_progressbar' key='MOUSE_LEAVE' cmd='script-binding progressbar/mouse-leave' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_forced_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_progressbar, mouse_btn0 script-binding progressbar/left-click
[cplayer] , default]
[input] add: section='input_progressbar' key='MBTN_LEFT' builtin cmd='script-binding progressbar/left-click' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_forced_progressbar 12
[input]  input_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_progressbar, mouse_leave script-binding progressbar/mouse-leave
[cplayer] mouse_enter script-binding progressbar/mouse-enter
[cplayer] , force]
[input] add: section='input_forced_progressbar' key='MOUSE_LEAVE' cmd='script-binding progressbar/mouse-leave' location='<api>:1'
[input] add: section='input_forced_progressbar' key='MOUSE_ENTER' cmd='script-binding progressbar/mouse-enter' location='<api>:2'
[cplayer] Run command: enable-section, flags=0, args=[input_forced_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_progressbar, tab script-binding progressbar/request-display
[cplayer] mouse_btn0 script-binding progressbar/left-click
[cplayer] , default]
[input] add: section='input_progressbar' key='TAB' builtin cmd='script-binding progressbar/request-display' location='<api>:1'
[input] add: section='input_progressbar' key='MBTN_LEFT' builtin cmd='script-binding progressbar/left-click' location='<api>:2'
[cplayer] Run command: enable-section, flags=0, args=[input_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_forced_progressbar 12
[input]  input_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_progressbar, mouse_leave script-binding progressbar/mouse-leave
[cplayer] mouse_enter script-binding progressbar/mouse-enter
[cplayer] , force]
[input] add: section='input_forced_progressbar' key='MOUSE_LEAVE' cmd='script-binding progressbar/mouse-leave' location='<api>:1'
[input] add: section='input_forced_progressbar' key='MOUSE_ENTER' cmd='script-binding progressbar/mouse-enter' location='<api>:2'
[cplayer] Run command: enable-section, flags=0, args=[input_forced_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_progressbar, mouse_btn0 script-binding progressbar/left-click
[cplayer] c script-binding progressbar/toggle-inactive-bar
[cplayer] tab script-binding progressbar/request-display
[cplayer] , default]
[input] add: section='input_progressbar' key='MBTN_LEFT' builtin cmd='script-binding progressbar/left-click' location='<api>:1'
[input] add: section='input_progressbar' key='c' builtin cmd='script-binding progressbar/toggle-inactive-bar' location='<api>:2'
[input] add: section='input_progressbar' key='TAB' builtin cmd='script-binding progressbar/request-display' location='<api>:3'
[cplayer] Run command: enable-section, flags=0, args=[input_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_forced_progressbar 12
[input]  input_progressbar 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_progressbar, mouse_leave script-binding progressbar/mouse-leave
[cplayer] mouse_enter script-binding progressbar/mouse-enter
[cplayer] , force]
[input] add: section='input_forced_progressbar' key='MOUSE_LEAVE' cmd='script-binding progressbar/mouse-leave' location='<api>:1'
[input] add: section='input_forced_progressbar' key='MOUSE_ENTER' cmd='script-binding progressbar/mouse-enter' location='<api>:2'
[cplayer] Run command: enable-section, flags=0, args=[input_forced_progressbar, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_progressbar'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[cplayer] Done loading /home/nand/.mpv/scripts/progressbar.lua.
[image] Loading lua script /home/nand/.mpv/scripts/image.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[image] loading mp.defaults
[image] loading file /home/nand/.mpv/scripts/image.lua
[cplayer] Run command: define-section, flags=0, args=[input_image, , default]
[cplayer] Run command: enable-section, flags=0, args=[input_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_image, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[cplayer] Run command: define-section, flags=0, args=[input_image, , default]
[cplayer] Run command: enable-section, flags=0, args=[input_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_forced_image 12
[input]  input_image 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_image, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[cplayer] Run command: define-section, flags=0, args=[input_image, , default]
[cplayer] Run command: enable-section, flags=0, args=[input_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_forced_image 12
[input]  input_image 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_image, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_image, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_image'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[cplayer] Done loading /home/nand/.mpv/scripts/image.lua.
[autocrop] Loading lua script /home/nand/.mpv/scripts/autocrop.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[autocrop] loading mp.defaults
[autocrop] loading file /home/nand/.mpv/scripts/autocrop.lua
[cplayer] Run command: define-section, flags=0, args=[input_autocrop, C script-binding autocrop/auto_crop
[cplayer] , default]
[input] add: section='input_autocrop' key='C' builtin cmd='script-binding autocrop/auto_crop' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_autocrop, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_autocrop'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_autocrop, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_autocrop, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_autocrop'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[cplayer] Done loading /home/nand/.mpv/scripts/autocrop.lua.
[visualizer] Loading lua script /home/nand/.mpv/scripts/visualizer.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[visualizer] loading mp.defaults
[visualizer] loading file /home/nand/.mpv/scripts/visualizer.lua
[visualizer] reading options for visualizer 
[global] config path: 'lua-settings/visualizer.conf' -/-> '/home/nand/.config/mpv/lua-settings/visualizer.conf'
[global] config path: 'lua-settings/visualizer.conf' -> '/home/nand/.mpv/lua-settings/visualizer.conf'
[cplayer] Run command: hook-add, flags=0, args=[on_preloaded, 1, 50]
[cplayer] Done loading /home/nand/.mpv/scripts/visualizer.lua.
[stats] Loading lua script /home/nand/.mpv/scripts/stats.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[stats] loading mp.defaults
[stats] loading file /home/nand/.mpv/scripts/stats.lua
[stats] reading options for stats 
[global] config path: 'lua-settings/stats.conf' -/-> '/home/nand/.config/mpv/lua-settings/stats.conf'
[global] config path: 'lua-settings/stats.conf' -> '/home/nand/.mpv/lua-settings/stats.conf'
[cplayer] Run command: define-section, flags=0, args=[input_stats, J script-binding stats/display-stats
[cplayer] , default]
[input] add: section='input_stats' key='J' builtin cmd='script-binding stats/display-stats' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_stats, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_stats, J script-binding stats/display-stats
[cplayer] , default]
[input] add: section='input_stats' key='J' builtin cmd='script-binding stats/display-stats' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_forced_stats 12
[input]  input_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_stats, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_stats, J script-binding stats/display-stats
[cplayer] , default]
[input] add: section='input_stats' key='J' builtin cmd='script-binding stats/display-stats' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_forced_stats 12
[input]  input_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_stats, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_stats, J script-binding stats/display-stats
[cplayer] , default]
[input] add: section='input_stats' key='J' builtin cmd='script-binding stats/display-stats' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_forced_stats 12
[input]  input_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_stats, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_stats, T script-binding stats/display-stats-toggle
[cplayer] J script-binding stats/display-stats
[cplayer] , default]
[input] add: section='input_stats' key='T' builtin cmd='script-binding stats/display-stats-toggle' location='<api>:1'
[input] add: section='input_stats' key='J' builtin cmd='script-binding stats/display-stats' location='<api>:2'
[cplayer] Run command: enable-section, flags=0, args=[input_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_forced_stats 12
[input]  input_stats 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_stats, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_stats, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_stats'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[cplayer] Done loading /home/nand/.mpv/scripts/stats.lua.
[auto_profiles] Loading lua script /home/nand/.mpv/scripts/auto-profiles.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[auto_profiles] loading mp.defaults
[auto_profiles] loading file /home/nand/.mpv/scripts/auto-profiles.lua
[cplayer] Done loading /home/nand/.mpv/scripts/auto-profiles.lua.
[skipchapters] Loading lua script /home/nand/.mpv/scripts/skipchapters.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[skipchapters] loading mp.defaults
[skipchapters] loading file /home/nand/.mpv/scripts/skipchapters.lua
[skipchapters] reading options for skipchapters 
[global] config path: 'lua-settings/skipchapters.conf' -/-> '/home/nand/.config/mpv/lua-settings/skipchapters.conf'
[global] config path: 'lua-settings/skipchapters.conf' -/-> '/home/nand/.mpv/lua-settings/skipchapters.conf'
[global] config path: 'lua-settings/skipchapters.conf' -/-> '/usr/local/etc/mpv/lua-settings/skipchapters.conf'
[skipchapters] lua-settings/skipchapters.conf not found. 
[cplayer] Done loading /home/nand/.mpv/scripts/skipchapters.lua.
[easycrop] Loading lua script /home/nand/.mpv/scripts/easycrop.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[easycrop] loading mp.defaults
[easycrop] loading file /home/nand/.mpv/scripts/easycrop.lua
[cplayer] Run command: define-section, flags=0, args=[input_easycrop, b script-binding easycrop/easy_crop
[cplayer] , default]
[input] add: section='input_easycrop' key='b' builtin cmd='script-binding easycrop/easy_crop' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_easycrop, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_easycrop'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[input]  input_easycrop 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_easycrop, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_easycrop, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_easycrop'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[input]  input_easycrop 12
[input]  input_forced_easycrop 12
[cplayer] Done loading /home/nand/.mpv/scripts/easycrop.lua.
[easybox] Loading lua script /home/nand/.mpv/scripts/easybox.lua...
[global] config path: 'scripts' -/-> '/home/nand/.config/mpv/scripts'
[global] config path: 'scripts' -> '/home/nand/.mpv/scripts'
[global] config path: 'scripts' -/-> '/usr/local/etc/mpv/scripts'
[easybox] loading mp.defaults
[easybox] loading file /home/nand/.mpv/scripts/easybox.lua
[cplayer] Run command: define-section, flags=0, args=[input_easybox, B script-binding easybox/easy_box
[cplayer] , default]
[input] add: section='input_easybox' key='B' builtin cmd='script-binding easybox/easy_box' location='<api>:1'
[cplayer] Run command: enable-section, flags=0, args=[input_easybox, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_easybox'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[input]  input_easycrop 12
[input]  input_forced_easycrop 12
[input]  input_easybox 12
[cplayer] Run command: define-section, flags=0, args=[input_forced_easybox, , force]
[cplayer] Run command: enable-section, flags=0, args=[input_forced_easybox, allow-hide-cursor+allow-vo-dragging]
[input] enable section 'input_forced_easybox'
[input] active section stack:
[input]  default 12
[input]  input_progressbar 12
[input]  input_forced_progressbar 12
[input]  input_image 12
[input]  input_forced_image 12
[input]  input_autocrop 12
[input]  input_forced_autocrop 12
[input]  input_stats 12
[input]  input_forced_stats 12
[input]  input_easycrop 12
[input]  input_forced_easycrop 12
[input]  input_easybox 12
[input]  input_forced_easybox 12
[cplayer] Done loading /home/nand/.mpv/scripts/easybox.lua.
[global] config path: 'watch_later' -> '/home/nand/.config/mpv/watch_later'
[cplayer] Playing: EFgyfHAsOwg.mp4
[cplayer] Running hook: ytdl_hook/on_load
[ytdl_hook] script running time: 1.2999999999999e-05 seconds 
[cplayer] Run command: hook-ack, flags=0, args=[on_load]
[bdmv/bluray] Opening EFgyfHAsOwg.mp4
[file] Opening EFgyfHAsOwg.mp4
[file] Stream opened successfully.
[demux] Trying demuxers for level=normal.
[demux] Trying demuxer: disc (force-level: normal)
[demux] Trying demuxer: edl (force-level: normal)
[demux] Trying demuxer: cue (force-level: normal)
[demux] Trying demuxer: rawaudio (force-level: normal)
[demux] Trying demuxer: rawvideo (force-level: normal)
[demux] Trying demuxer: mkv (force-level: normal)
[demux] Trying demuxer: rar (force-level: normal)
[demux] Trying demuxer: lavf (force-level: normal)
[lavf] Found 'mov,mp4,m4a,3gp,3g2,mj2' at score=100 size=2048.
[demux] Detected file format: mov,mp4,m4a,3gp,3g2,mj2 (libavformat)
[cplayer] Opening done: EFgyfHAsOwg.mp4
[find_files] Loading external files in .
[global] config path: 'sub' -/-> '/home/nand/.config/mpv/sub'
[global] config path: 'sub' -/-> '/home/nand/.mpv/sub'
[global] config path: 'sub' -/-> '/usr/local/etc/mpv/sub'
[cplayer] Running hook: ytdl_hook/on_preloaded
[cplayer] Run command: hook-ack, flags=0, args=[on_preloaded]
[cplayer] Running hook: visualizer/on_preloaded
[cplayer] Set property: options/lavfi-complex="" -> 1
[cplayer] Run command: hook-ack, flags=0, args=[on_preloaded]
[cplayer]  (+) Video --vid=1 (*) (h264 1920x1080 25.000fps)
[cplayer]      Audio --aid=1 --alang=und (*) (aac 2ch 44100Hz)
[vo/gpu] Probing for best GPU context.
[vo/gpu/opengl] Initializing GPU context 'x11probe'
[vo/gpu/x11] X11 opening display: :0
[vo/gpu/x11] X11 running at 4096x2160 (":0" => local display)
[vo/gpu/x11] Assuming DPI scale 2 for prescaling. This can be disabled with --hidpi-window-scale=no.
[vo/gpu/x11] Detected wm supports NetWM.
[vo/gpu/x11] Detected wm supports FULLSCREEN state.
[vo/gpu/x11] Display 0 (DP-0): [0, 0, 4096, 2160] @ 59.998457 FPS
[vo/gpu/x11] Current display FPS: 59.998457
[vo/gpu/opengl] GLX chose FB config with ID 0xad
[vo/gpu/opengl] GLX chose visual with ID 0x27
[vo/gpu/opengl] Creating OpenGL 4.4 context...
[vo/gpu] GL_VERSION='4.4.0 NVIDIA 384.69'
[vo/gpu] Detected desktop OpenGL 4.4.
[vo/gpu] GL_VENDOR='NVIDIA Corporation'
[vo/gpu] GL_RENDERER='GeForce GTX 970/PCIe/SSE2'
[vo/gpu] GL_SHADING_LANGUAGE_VERSION='4.40 NVIDIA via Cg compiler'
[vo/gpu] Combined OpenGL extensions string:
[vo/gpu] GLX_EXT_visual_info GLX_EXT_visual_rating GLX_EXT_import_context GLX_SGIX_fbconfig GLX_SGIX_pbuffer GLX_SGI_video_sync GLX_SGI_swap_control GLX_EXT_swap_control GLX_EXT_swap_control_tear GLX_EXT_texture_from_pixmap GLX_EXT_buffer_age GLX_ARB_create_context GLX_ARB_create_context_profile GLX_EXT_create_context_es_profile GLX_EXT_create_context_es2_profile GLX_ARB_create_context_robustness GLX_NV_delay_before_swap GLX_EXT_stereo_tree GLX_ARB_context_flush_control GLX_NV_robustness_video_memory_purge GLX_ARB_multisample GLX_NV_float_buffer GLX_ARB_fbconfig_float GLX_EXT_framebuffer_sRGB GLX_NV_copy_image GLX_ARB_get_proc_address  GL_AMD_multi_draw_indirect GL_AMD_seamless_cubemap_per_texture GL_AMD_vertex_shader_viewport_index GL_AMD_vertex_shader_layer GL_ARB_arrays_of_arrays GL_ARB_base_instance GL_ARB_bindless_texture GL_ARB_blend_func_extended GL_ARB_buffer_storage GL_ARB_clear_buffer_object GL_ARB_clear_texture GL_ARB_clip_control GL_ARB_color_buffer_float GL_ARB_compressed_texture_pixel_storage GL_ARB_conservative_depth GL_ARB_compute_shader GL_ARB_compute_variable_group_size GL_ARB_conditional_render_inverted GL_ARB_copy_buffer GL_ARB_copy_image GL_ARB_cull_distance GL_ARB_debug_output GL_ARB_depth_buffer_float GL_ARB_depth_clamp GL_ARB_depth_texture GL_ARB_derivative_control GL_ARB_direct_state_access GL_ARB_draw_buffers GL_ARB_draw_buffers_blend GL_ARB_draw_indirect GL_ARB_draw_elements_base_vertex GL_ARB_draw_instanced GL_ARB_enhanced_layouts GL_ARB_ES2_compatibility GL_ARB_ES3_compatibility GL_ARB_ES3_1_compatibility GL_ARB_ES3_2_compatibility GL_ARB_explicit_attrib_location GL_ARB_explicit_uniform_location GL_ARB_fragment_coord_conventions GL_ARB_fragment_layer_viewport GL_ARB_fragment_program GL_ARB_fragment_program_shadow GL_ARB_fragment_shader GL_ARB_fragment_shader_interlock GL_ARB_framebuffer_no_attachments GL_ARB_framebuffer_object GL_ARB_framebuffer_sRGB GL_ARB_geometry_shader4 GL_ARB_get_program_binary GL_ARB_get_texture_sub_image GL_ARB_gl_spirv GL_ARB_gpu_shader5 GL_ARB_gpu_shader_fp64 GL_ARB_gpu_shader_int64 GL_ARB_half_float_pixel GL_ARB_half_float_vertex GL_ARB_imaging GL_ARB_indirect_parameters GL_ARB_instanced_arrays GL_ARB_internalformat_query GL_ARB_internalformat_query2 GL_ARB_invalidate_subdata GL_ARB_map_buffer_alignment GL_ARB_map_buffer_range GL_ARB_multi_bind GL_ARB_multi_draw_indirect GL_ARB_multisample GL_ARB_multitexture GL_ARB_occlusion_query GL_ARB_occlusion_query2 GL_ARB_parallel_shader_compile GL_ARB_pipeline_statistics_query GL_ARB_pixel_buffer_object GL_ARB_point_parameters GL_ARB_point_sprite GL_ARB_post_depth_coverage GL_ARB_program_interface_query GL_ARB_provoking_vertex GL_ARB_query_buffer_object GL_ARB_robust_buffer_access_behavior GL_ARB_robustness GL_ARB_sample_locations GL_ARB_sample_shading GL_ARB_sampler_objects GL_ARB_seamless_cube_map GL_ARB_seamless_cubemap_per_texture GL_ARB_separate_shader_objects GL_ARB_shader_atomic_counter_ops GL_ARB_shader_atomic_counters GL_ARB_shader_ballot GL_ARB_shader_bit_encoding GL_ARB_shader_clock GL_ARB_shader_draw_parameters GL_ARB_shader_group_vote GL_ARB_shader_image_load_store GL_ARB_shader_image_size GL_ARB_shader_objects GL_ARB_shader_precision GL_ARB_shader_storage_buffer_object GL_ARB_shader_subroutine GL_ARB_shader_texture_image_samples GL_ARB_shader_texture_lod GL_ARB_shading_language_100 GL_ARB_shader_viewport_layer_array GL_ARB_shading_language_420pack GL_ARB_shading_language_include GL_ARB_shading_language_packing GL_ARB_shadow GL_ARB_sparse_buffer GL_ARB_sparse_texture GL_ARB_sparse_texture2 GL_ARB_sparse_texture_clamp GL_ARB_stencil_texturing GL_ARB_sync GL_ARB_tessellation_shader GL_ARB_texture_barrier GL_ARB_texture_border_clamp GL_ARB_texture_buffer_object GL_ARB_texture_buffer_object_rgb32 GL_ARB_texture_buffer_range GL_ARB_texture_compression GL_ARB_texture_compression_bptc GL_ARB_texture_compression_rgtc GL_ARB_texture_cube_map GL_ARB_texture_cube_map_array GL_ARB_texture_env_add GL_ARB_texture_env_combine GL_ARB_texture_env_crossbar GL_ARB_texture_env_dot3 GL_ARB_texture_filter_minmax GL_ARB_texture_float GL_ARB_texture_gather GL_ARB_texture_mirror_clamp_to_edge GL_ARB_texture_mirrored_repeat GL_ARB_texture_multisample GL_ARB_texture_non_power_of_two GL_ARB_texture_query_levels GL_ARB_texture_query_lod GL_ARB_texture_rectangle GL_ARB_texture_rg GL_ARB_texture_rgb10_a2ui GL_ARB_texture_stencil8 GL_ARB_texture_storage GL_ARB_texture_storage_multisample GL_ARB_texture_swizzle GL_ARB_texture_view GL_ARB_timer_query GL_ARB_transform_feedback2 GL_ARB_transform_feedback3 GL_ARB_transform_feedback_instanced GL_ARB_transform_feedback_overflow_query GL_ARB_transpose_matrix GL_ARB_uniform_buffer_object GL_ARB_vertex_array_bgra GL_ARB_vertex_array_object GL_ARB_vertex_attrib_64bit GL_ARB_vertex_attrib_binding GL_ARB_vertex_buffer_object GL_ARB_vertex_program GL_ARB_vertex_shader GL_ARB_vertex_type_10f_11f_11f_rev GL_ARB_vertex_type_2_10_10_10_rev GL_ARB_viewport_array GL_ARB_window_pos GL_ATI_draw_buffers GL_ATI_texture_float GL_ATI_texture_mirror_once GL_S3_s3tc GL_EXT_texture_env_add GL_EXT_abgr GL_EXT_bgra GL_EXT_bindable_uniform GL_EXT_blend_color GL_EXT_blend_equation_separate GL_EXT_blend_func_separate GL_EXT_blend_minmax GL_EXT_blend_subtract GL_EXT_compiled_vertex_array GL_EXT_Cg_shader GL_EXT_depth_bounds_test GL_EXT_direct_state_access GL_EXT_draw_buffers2 GL_EXT_draw_instanced GL_EXT_draw_range_elements GL_EXT_fog_coord GL_EXT_framebuffer_blit GL_EXT_framebuffer_multisample GL_EXTX_framebuffer_mixed_formats GL_EXT_framebuffer_multisample_blit_scaled GL_EXT_framebuffer_object GL_EXT_framebuffer_sRGB GL_EXT_geometry_shader4 GL_EXT_gpu_program_parameters GL_EXT_gpu_shader4 GL_EXT_multi_draw_arrays GL_EXT_packed_depth_stencil GL_EXT_packed_float GL_EXT_packed_pixels GL_EXT_pixel_buffer_object GL_EXT_point_parameters GL_EXT_polygon_offset_clamp GL_EXT_post_depth_coverage GL_EXT_provoking_vertex GL_EXT_raster_multisample GL_EXT_rescale_normal GL_EXT_secondary_color GL_EXT_separate_shader_objects GL_EXT_separate_specular_color GL_EXT_shader_image_load_formatted GL_EXT_shader_image_load_store GL_EXT_shader_integer_mix GL_EXT_shadow_funcs GL_EXT_sparse_texture2 GL_EXT_stencil_two_side GL_EXT_stencil_wrap GL_EXT_texture3D GL_EXT_texture_array GL_EXT_texture_buffer_object GL_EXT_texture_compression_dxt1 GL_EXT_texture_compression_latc GL_EXT_texture_compression_rgtc GL_EXT_texture_compression_s3tc GL_EXT_texture_cube_map GL_EXT_texture_edge_clamp GL_EXT_texture_env_combine GL_EXT_texture_env_dot3 GL_EXT_texture_filter_anisotropic GL_EXT_texture_filter_minmax GL_EXT_texture_integer GL_EXT_texture_lod GL_EXT_texture_lod_bias GL_EXT_texture_mirror_clamp GL_EXT_texture_object GL_EXT_texture_shared_exponent GL_EXT_texture_sRGB GL_EXT_texture_sRGB_decode GL_EXT_texture_storage GL_EXT_texture_swizzle GL_EXT_timer_query GL_EXT_transform_feedback2 GL_EXT_vertex_array GL_EXT_vertex_array_bgra GL_EXT_vertex_attrib_64bit GL_EXT_window_rectangles GL_EXT_x11_sync_object GL_EXT_import_sync_object GL_NV_robustness_video_memory_purge GL_IBM_rasterpos_clip GL_IBM_texture_mirrored_repeat GL_KHR_context_flush_control GL_KHR_debug GL_EXT_memory_object GL_EXT_memory_object_fd GL_KHR_no_error GL_KHR_robust_buffer_access_behavior GL_KHR_robustness GL_EXT_semaphore GL_EXT_semaphore_fd GL_KTX_buffer_region GL_NV_alpha_to_coverage_dither_control GL_NV_bindless_multi_draw_indirect GL_NV_bindless_multi_draw_indirect_count GL_NV_bindless_texture GL_NV_blend_equation_advanced GL_NV_blend_equation_advanced_coherent GL_NV_blend_square GL_NV_command_list GL_NV_compute_program5 GL_NV_conditional_render GL_NV_conservative_raster GL_NV_conservative_raster_dilate GL_NV_copy_depth_to_color GL_NV_copy_image GL_NV_depth_buffer_float GL_NV_depth_clamp GL_NV_draw_texture GL_NV_draw_vulkan_image GL_NV_ES1_1_compatibility GL_NV_ES3_1_compatibility GL_NV_explicit_multisample GL_NV_fence GL_NV_fill_rectangle GL_NV_float_buffer GL_NV_fog_distance GL_NV_fragment_coverage_to_color GL_NV_fragment_program GL_NV_fragment_program_option GL_NV_fragment_program2 GL_NV_fragment_shader_interlock GL_NV_framebuffer_mixed_samples GL_NV_framebuffer_multisample_coverage GL_NV_geometry_shader4 GL_NV_geometry_shader_passthrough GL_NV_gpu_program4 GL_NV_internalformat_sample_query GL_NV_gpu_program4_1 GL_NV_gpu_program5 GL_NV_gpu_program5_mem_extended GL_NV_gpu_program_fp64 GL_NV_gpu_shader5 GL_NV_half_float GL_NV_light_max_exponent GL_NV_multisample_coverage GL_NV_multisample_filter_hint GL_NV_occlusion_query GL_NV_packed_depth_stencil GL_NV_parameter_buffer_object GL_NV_parameter_buffer_object2 GL_NV_path_rendering GL_NV_path_rendering_shared_edge GL_NV_pixel_data_range GL_NV_point_sprite GL_NV_primitive_restart GL_NV_register_combiners GL_NV_register_combiners2 GL_NV_sample_locations GL_NV_sample_mask_override_coverage GL_NV_shader_atomic_counters GL_NV_shader_atomic_float GL_NV_shader_atomic_fp16_vector GL_NV_shader_atomic_int64 GL_NV_shader_buffer_load GL_NV_shader_storage_buffer_object GL_NV_texgen_reflection GL_NV_texture_barrier GL_NV_texture_compression_vtc GL_NV_texture_env_combine4 GL_NV_texture_multisample GL_NV_texture_rectangle GL_NV_texture_shader GL_NV_texture_shader2 GL_NV_texture_shader3 GL_NV_transform_feedback GL_NV_transform_feedback2 GL_NV_uniform_buffer_unified_memory GL_NV_vdpau_interop GL_NV_vertex_array_range GL_NV_vertex_array_range2 GL_NV_vertex_attrib_integer_64bit GL_NV_vertex_buffer_unified_memory GL_NV_vertex_program GL_NV_vertex_program1_1 GL_NV_vertex_program2 GL_NV_vertex_program2_option GL_NV_vertex_program3 GL_NV_viewport_array2 GL_NV_viewport_swizzle GL_NVX_conditional_render GL_NVX_gpu_memory_info GL_NVX_nvenc_interop GL_NV_shader_thread_group GL_NV_shader_thread_shuffle GL_KHR_blend_equation_advanced GL_KHR_blend_equation_advanced_coherent GL_SGIS_generate_mipmap GL_SGIS_texture_lod GL_SGIX_depth_texture GL_SGIX_shadow GL_SUN_slice_accum
[vo/gpu] Loaded extension GLX_SGI_swap_control.
[vo/gpu] Loaded extension GLX_SGI_video_sync.
[vo/gpu] Loaded extension GL_NV_vdpau_interop.
[vo/gpu/opengl] Texture formats:
[vo/gpu/opengl]   NAME       COMP*TYPE SIZE        DEPTH PER COMP.
[vo/gpu/opengl]   r8         1*unorm   1B    LF CR {8}
[vo/gpu/opengl]   rg8        2*unorm   2B    LF CR {8 8}
[vo/gpu/opengl]   rgb8       3*unorm   3B    LF CR {8 8 8}
[vo/gpu/opengl]   rgba8      4*unorm   4B    LF CR {8 8 8 8}
[vo/gpu/opengl]   r16        1*unorm   2B    LF CR {16}
[vo/gpu/opengl]   rg16       2*unorm   4B    LF CR {16 16}
[vo/gpu/opengl]   rgb16      3*unorm   6B    LF CR {16 16 16}
[vo/gpu/opengl]   rgba16     4*unorm   8B    LF CR {16 16 16 16}
[vo/gpu/opengl]   r8ui       1*uint    1B       CR {8}
[vo/gpu/opengl]   rg8ui      2*uint    2B       CR {8 8}
[vo/gpu/opengl]   rgb8ui     3*uint    3B          {8 8 8}
[vo/gpu/opengl]   rgba8ui    4*uint    4B       CR {8 8 8 8}
[vo/gpu/opengl]   r16ui      1*uint    2B       CR {16}
[vo/gpu/opengl]   rg16ui     2*uint    4B       CR {16 16}
[vo/gpu/opengl]   rgb16ui    3*uint    6B          {16 16 16}
[vo/gpu/opengl]   rgba16ui   4*uint    8B       CR {16 16 16 16}
[vo/gpu/opengl]   r16f       1*float   4B    LF CR {32/16}
[vo/gpu/opengl]   rg16f      2*float   8B    LF CR {32/16 32/16}
[vo/gpu/opengl]   rgb16f     3*float  12B    LF CR {32/16 32/16 32/16}
[vo/gpu/opengl]   rgba16f    4*float  16B    LF CR {32/16 32/16 32/16 32/16}
[vo/gpu/opengl]   r32f       1*float   4B    LF CR {32}
[vo/gpu/opengl]   rg32f      2*float   8B    LF CR {32 32}
[vo/gpu/opengl]   rgb32f     3*float  12B    LF CR {32 32 32}
[vo/gpu/opengl]   rgba32f    4*float  16B    LF CR {32 32 32 32}
[vo/gpu/opengl]   rgb10_a2   4*unorm   4B    LF CR {0/10 0/10 0/10 0/2}
[vo/gpu/opengl]   rgba12     4*unorm   8B    LF CR {16/8 16/8 16/8 16/8}
[vo/gpu/opengl]   rgb10      3*unorm   6B    LF CR {16/10 16/10 16/10}
[vo/gpu/opengl]   rgb565     3*unorm   2B    LF    {0/8 0/8 0/8}
[vo/gpu/opengl]  LA = LUMINANCE_ALPHA hack format
[vo/gpu/opengl]  LF = linear filterable
[vo/gpu/opengl]  CR = can be used for render targets
[vo/gpu/opengl] Image formats:
[vo/gpu/opengl]   yuv444p => 3 planes 1x1 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   yuv420p => 3 planes 2x2 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   gray => 1 planes 1x1 8/0 [r8] (r)
[vo/gpu/opengl]   gray16 => 1 planes 1x1 16/0 [r16] (r)
[vo/gpu/opengl]   uyvy422
[vo/gpu/opengl]   nv12 => 2 planes 2x2 8/0 [r8/rg8] (r/gb)
[vo/gpu/opengl]   p010 => 2 planes 2x2 16/6 [r16/rg16] (r/gb)
[vo/gpu/opengl]   argb => 1 planes 1x1 8/0 [rgba8] (argb)
[vo/gpu/opengl]   bgra => 1 planes 1x1 8/0 [rgba8] (bgra)
[vo/gpu/opengl]   abgr => 1 planes 1x1 8/0 [rgba8] (abgr)
[vo/gpu/opengl]   rgba => 1 planes 1x1 8/0 [rgba8] (rgba)
[vo/gpu/opengl]   bgr24 => 1 planes 1x1 8/0 [rgb8] (bgr)
[vo/gpu/opengl]   rgb24 => 1 planes 1x1 8/0 [rgb8] (rgb)
[vo/gpu/opengl]   0rgb => 1 planes 1x1 8/0 [rgba8] (_rgb)
[vo/gpu/opengl]   bgr0 => 1 planes 1x1 8/0 [rgba8] (bgr)
[vo/gpu/opengl]   0bgr => 1 planes 1x1 8/0 [rgba8] (_bgr)
[vo/gpu/opengl]   rgb0 => 1 planes 1x1 8/0 [rgba8] (rgb)
[vo/gpu/opengl]   rgb565 => 1 planes 1x1 0/0 [rgb565] (rgb)
[vo/gpu/opengl]   vdpau
[vo/gpu/opengl]   vdpau_output
[vo/gpu/opengl]   vaapi
[vo/gpu/opengl]   d3d11_nv12
[vo/gpu/opengl]   d3d11_rgb
[vo/gpu/opengl]   dxva2_vld
[vo/gpu/opengl]   mmal
[vo/gpu/opengl]   videotoolbox
[vo/gpu/opengl]   cuda
[vo/gpu/opengl]   yuyv422
[vo/gpu/opengl]   yuv422p => 3 planes 2x1 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   yuv410p => 3 planes 4x4 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   yuv411p => 3 planes 4x1 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   monow
[vo/gpu/opengl]   monob
[vo/gpu/opengl]   pal8
[vo/gpu/opengl]   yuvj422p => 3 planes 2x1 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   xvmcmc
[vo/gpu/opengl]   xvmcidct
[vo/gpu/opengl]   uyyvyy411
[vo/gpu/opengl]   bgr8
[vo/gpu/opengl]   bgr4
[vo/gpu/opengl]   bgr4_byte
[vo/gpu/opengl]   rgb8
[vo/gpu/opengl]   rgb4
[vo/gpu/opengl]   rgb4_byte
[vo/gpu/opengl]   nv21 => 2 planes 2x2 8/0 [r8/rg8] (r/bg)
[vo/gpu/opengl]   gray16be
[vo/gpu/opengl]   yuv440p => 3 planes 1x2 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   yuvj440p => 3 planes 1x2 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   yuva420p => 4 planes 2x2 8/0 [r8/r8/r8/r8] (r/g/b/a)
[vo/gpu/opengl]   vdpau_h264
[vo/gpu/opengl]   vdpau_mpeg1
[vo/gpu/opengl]   vdpau_mpeg2
[vo/gpu/opengl]   vdpau_wmv3
[vo/gpu/opengl]   vdpau_vc1
[vo/gpu/opengl]   rgb48be
[vo/gpu/opengl]   rgb48 => 1 planes 1x1 16/0 [rgb16] (rgb)
[vo/gpu/opengl]   rgb565be
[vo/gpu/opengl]   rgb555be
[vo/gpu/opengl]   rgb555
[vo/gpu/opengl]   bgr565be
[vo/gpu/opengl]   bgr565
[vo/gpu/opengl]   bgr555be
[vo/gpu/opengl]   bgr555
[vo/gpu/opengl]   vaapi_moco
[vo/gpu/opengl]   vaapi_idct
[vo/gpu/opengl]   yuv420p16 => 3 planes 2x2 16/0 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv420p16be
[vo/gpu/opengl]   yuv422p16 => 3 planes 2x1 16/0 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv422p16be
[vo/gpu/opengl]   yuv444p16 => 3 planes 1x1 16/0 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv444p16be
[vo/gpu/opengl]   vdpau_mpeg4
[vo/gpu/opengl]   rgb444
[vo/gpu/opengl]   rgb444be
[vo/gpu/opengl]   bgr444
[vo/gpu/opengl]   bgr444be
[vo/gpu/opengl]   ya8 => 1 planes 1x1 8/0 [rg8] (ra)
[vo/gpu/opengl]   bgr48be
[vo/gpu/opengl]   bgr48 => 1 planes 1x1 16/0 [rgb16] (bgr)
[vo/gpu/opengl]   yuv420p9be
[vo/gpu/opengl]   yuv420p9 => 3 planes 2x2 16/-7 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv420p10be
[vo/gpu/opengl]   yuv420p10 => 3 planes 2x2 16/-6 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv422p10be
[vo/gpu/opengl]   yuv422p10 => 3 planes 2x1 16/-6 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv444p9be
[vo/gpu/opengl]   yuv444p9 => 3 planes 1x1 16/-7 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv444p10be
[vo/gpu/opengl]   yuv444p10 => 3 planes 1x1 16/-6 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv422p9be
[vo/gpu/opengl]   yuv422p9 => 3 planes 2x1 16/-7 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   vda_vld
[vo/gpu/opengl]   gbrp => 3 planes 1x1 8/0 [r8/r8/r8] (g/b/r)
[vo/gpu/opengl]   gbrp9be
[vo/gpu/opengl]   gbrp9 => 3 planes 1x1 16/-7 [r16/r16/r16] (g/b/r)
[vo/gpu/opengl]   gbrp10be
[vo/gpu/opengl]   gbrp10 => 3 planes 1x1 16/-6 [r16/r16/r16] (g/b/r)
[vo/gpu/opengl]   gbrp16be
[vo/gpu/opengl]   gbrp16 => 3 planes 1x1 16/0 [r16/r16/r16] (g/b/r)
[vo/gpu/opengl]   yuva422p => 4 planes 2x1 8/0 [r8/r8/r8/r8] (r/g/b/a)
[vo/gpu/opengl]   yuva444p => 4 planes 1x1 8/0 [r8/r8/r8/r8] (r/g/b/a)
[vo/gpu/opengl]   yuva420p9be
[vo/gpu/opengl]   yuva420p9 => 4 planes 2x2 16/-7 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva422p9be
[vo/gpu/opengl]   yuva422p9 => 4 planes 2x1 16/-7 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva444p9be
[vo/gpu/opengl]   yuva444p9 => 4 planes 1x1 16/-7 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva420p10be
[vo/gpu/opengl]   yuva420p10 => 4 planes 2x2 16/-6 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva422p10be
[vo/gpu/opengl]   yuva422p10 => 4 planes 2x1 16/-6 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva444p10be
[vo/gpu/opengl]   yuva444p10 => 4 planes 1x1 16/-6 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva420p16be
[vo/gpu/opengl]   yuva420p16 => 4 planes 2x2 16/0 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva422p16be
[vo/gpu/opengl]   yuva422p16 => 4 planes 2x1 16/0 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   yuva444p16be
[vo/gpu/opengl]   yuva444p16 => 4 planes 1x1 16/0 [r16/r16/r16/r16] (r/g/b/a)
[vo/gpu/opengl]   xyz12 => 1 planes 1x1 16/4 [rgb16] (rgb)
[vo/gpu/opengl]   xyz12be
[vo/gpu/opengl]   nv16 => 2 planes 2x1 8/0 [r8/rg8] (r/gb)
[vo/gpu/opengl]   nv20 => 2 planes 2x1 16/-6 [r16/rg16] (r/gb)
[vo/gpu/opengl]   nv20be
[vo/gpu/opengl]   rgba64be
[vo/gpu/opengl]   rgba64 => 1 planes 1x1 16/0 [rgba16] (rgba)
[vo/gpu/opengl]   bgra64be
[vo/gpu/opengl]   bgra64 => 1 planes 1x1 16/0 [rgba16] (bgra)
[vo/gpu/opengl]   yvyu422
[vo/gpu/opengl]   vda
[vo/gpu/opengl]   ya16be
[vo/gpu/opengl]   ya16 => 1 planes 1x1 16/0 [rg16] (ra)
[vo/gpu/opengl]   gbrap => 4 planes 1x1 8/0 [r8/r8/r8/r8] (g/b/r/a)
[vo/gpu/opengl]   gbrap16be
[vo/gpu/opengl]   gbrap16 => 4 planes 1x1 16/0 [r16/r16/r16/r16] (g/b/r/a)
[vo/gpu/opengl]   qsv
[vo/gpu/opengl]   d3d11va_vld
[vo/gpu/opengl]   yuv420p12be
[vo/gpu/opengl]   yuv420p12 => 3 planes 2x2 16/-4 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv420p14be
[vo/gpu/opengl]   yuv420p14 => 3 planes 2x2 16/-2 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv422p12be
[vo/gpu/opengl]   yuv422p12 => 3 planes 2x1 16/-4 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv422p14be
[vo/gpu/opengl]   yuv422p14 => 3 planes 2x1 16/-2 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv444p12be
[vo/gpu/opengl]   yuv444p12 => 3 planes 1x1 16/-4 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv444p14be
[vo/gpu/opengl]   yuv444p14 => 3 planes 1x1 16/-2 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   gbrp12be
[vo/gpu/opengl]   gbrp12 => 3 planes 1x1 16/-4 [r16/r16/r16] (g/b/r)
[vo/gpu/opengl]   gbrp14be
[vo/gpu/opengl]   gbrp14 => 3 planes 1x1 16/-2 [r16/r16/r16] (g/b/r)
[vo/gpu/opengl]   yuvj411p => 3 planes 4x1 8/0 [r8/r8/r8] (r/g/b)
[vo/gpu/opengl]   bayer_bggr8
[vo/gpu/opengl]   bayer_rggb8
[vo/gpu/opengl]   bayer_gbrg8
[vo/gpu/opengl]   bayer_grbg8
[vo/gpu/opengl]   bayer_bggr16
[vo/gpu/opengl]   bayer_bggr16be
[vo/gpu/opengl]   bayer_rggb16
[vo/gpu/opengl]   bayer_rggb16be
[vo/gpu/opengl]   bayer_gbrg16
[vo/gpu/opengl]   bayer_gbrg16be
[vo/gpu/opengl]   bayer_grbg16
[vo/gpu/opengl]   bayer_grbg16be
[vo/gpu/opengl]   yuv440p10 => 3 planes 1x2 16/-6 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv440p10be
[vo/gpu/opengl]   yuv440p12 => 3 planes 1x2 16/-4 [r16/r16/r16] (r/g/b)
[vo/gpu/opengl]   yuv440p12be
[vo/gpu/opengl]   ayuv64 => 1 planes 1x1 16/0 [rgba16] (argb)
[vo/gpu/opengl]   ayuv64be
[vo/gpu/opengl]   videotoolbox_vl
[vo/gpu/opengl]   p010be
[vo/gpu/opengl]   gbrap12be
[vo/gpu/opengl]   gbrap12 => 4 planes 1x1 16/-4 [r16/r16/r16/r16] (g/b/r/a)
[vo/gpu/opengl]   gbrap10be
[vo/gpu/opengl]   gbrap10 => 4 planes 1x1 16/-6 [r16/r16/r16/r16] (g/b/r/a)
[vo/gpu/opengl]   mediacodec
[vo/gpu/opengl]   gray12be
[vo/gpu/opengl]   gray12 => 1 planes 1x1 16/-4 [r16] (r)
[vo/gpu/opengl]   gray10be
[vo/gpu/opengl]   gray10 => 1 planes 1x1 16/-6 [r16] (r)
[vo/gpu/opengl]   p016 => 2 planes 2x2 16/0 [r16/rg16] (r/gb)
[vo/gpu/opengl]   p016be
[vo/gpu/opengl]   d3d11
[vo/gpu/opengl]   gray9be
[vo/gpu/opengl]   gray9 => 1 planes 1x1 16/-7 [r16] (r)
[vo/gpu/opengl]   gbrpf32be
[vo/gpu/opengl]   gbrpf32 => 3 planes 1x1 32/0 [r16f/r16f/r16f] (g/b/r)
[vo/gpu/opengl]   gbrapf32be
[vo/gpu/opengl]   gbrapf32 => 4 planes 1x1 32/0 [r16f/r16f/r16f/r16f] (g/b/r/a)
[vo/gpu/opengl]   drm_prime
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Resizing texture: 16x16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Querying ICC profile...
[vo/gpu] Assuming 59.998457 FPS for display sync.
[vd] Container reported FPS: 25.000000
[vd] Codec list:
[vd]     h264 - H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
[vd]     h264_cuvid (h264) - Nvidia CUVID H264 decoder
[vd] Opening video decoder h264
[vd] Using software decoding.
[vd] Detected 32 logical cores.
[vd] Requesting 16 threads for decoding.
[vd] Selected video codec: h264 (H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10)
[cplayer] Starting playback...
[ffmpeg/video] h264: Reinit context to 1920x1088, pix_fmt: yuv420p
[vd] DR parameter change to 1920x1090 yuv420p align=32
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Allocating new DR image...
[vd] Decoder format: 1920x1080 yuv420p auto/auto/auto/auto CL=mpeg2/4/h264 (auto 0.000000/0.000000/0.000000)
[vd] Allocating new DR image...
[vf] Video filter chain:
[vf]   [in] 1920x1080 yuv420p bt.709/bt.709/bt.1886/limited SP=1.000000 CL=mpeg2/4/h264
[vf]   [out] 1920x1080 yuv420p bt.709/bt.709/bt.1886/limited SP=1.000000 CL=mpeg2/4/h264
[cplayer] VO: [gpu] 1920x1080 yuv420p
[cplayer] VO: Description: Shader-based GPU Renderer
[vd] Allocating new DR image...
[vo/gpu] screen size: 4096x2160
[vo/gpu/x11] not waiting for MapNotify
[vo/gpu] Resize: 3840x2160
[vo/gpu] Window size: 3840x2160
[vo/gpu] Video source: 1920x1080 (1:1)
[vo/gpu] Video display: (0, 0) 1920x1080 -> (0, 0) 3840x2160
[vo/gpu] Video scale: 2.000000/2.000000
[vo/gpu] OSD borders: l=0 t=0 r=0 b=0
[vo/gpu] Video borders: l=0 t=0 r=0 b=0
[vo/gpu] Reported display depth: 8
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Resizing texture: 16x16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Texture for plane 0: 1920x1080
[vo/gpu] Texture for plane 1: 960x540
[vo/gpu] Texture for plane 2: 960x540
[vo/gpu] Querying ICC profile...
[vo/gpu/x11] Retrieving ICC profile for display: 0
[vo/gpu] Testing FBO format rgba16
[vo/gpu] Resizing texture: 16x16
[vo/gpu] Using FBO format rgba16.
[vo/gpu] Resize: 2046x2126
[vo/gpu] Window size: 2046x2126
[vo/gpu] Video source: 1920x1080 (1:1)
[vo/gpu] Video display: (0, 0) 1920x1080 -> (0, 488) 2046x1150
[vo/gpu] Video scale: 1.065625/1.064815
[vo/gpu] OSD borders: l=0 t=488 r=0 b=488
[vo/gpu] Video borders: l=0 t=488 r=0 b=488
[vo/gpu] Reported display depth: 8
[vo/gpu] DR enabled: yes
[vo/gpu] Resizing texture: 960x540
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/E8486B11F7A0DA8C110ED7210D1C5C05A9A113D9F6EC07BF0C455391CA2EC2B4' -> '/tmp/mpv-shaders/E8486B11F7A0DA8C110ED7210D1C5C05A9A113D9F6EC07BF0C455391CA2EC2B4'
[bdmv/bluray] Opening /tmp/mpv-shaders/E8486B11F7A0DA8C110ED7210D1C5C05A9A113D9F6EC07BF0C455391CA2EC2B4
[file] Opening /tmp/mpv-shaders/E8486B11F7A0DA8C110ED7210D1C5C05A9A113D9F6EC07BF0C455391CA2EC2B4
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 1920x1080
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/C342733FE5BA5DE2FB902C7E3290BCF17DD65BF0C0DA53C408EEFABAA62BCACE' -> '/tmp/mpv-shaders/C342733FE5BA5DE2FB902C7E3290BCF17DD65BF0C0DA53C408EEFABAA62BCACE'
[bdmv/bluray] Opening /tmp/mpv-shaders/C342733FE5BA5DE2FB902C7E3290BCF17DD65BF0C0DA53C408EEFABAA62BCACE
[file] Opening /tmp/mpv-shaders/C342733FE5BA5DE2FB902C7E3290BCF17DD65BF0C0DA53C408EEFABAA62BCACE
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 960x540
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/67DB0CF3C3B2A48F8D1B41CA1BAD9125077C0FA47F8EA9E110F7B32B4DF806AA' -> '/tmp/mpv-shaders/67DB0CF3C3B2A48F8D1B41CA1BAD9125077C0FA47F8EA9E110F7B32B4DF806AA'
[bdmv/bluray] Opening /tmp/mpv-shaders/67DB0CF3C3B2A48F8D1B41CA1BAD9125077C0FA47F8EA9E110F7B32B4DF806AA
[file] Opening /tmp/mpv-shaders/67DB0CF3C3B2A48F8D1B41CA1BAD9125077C0FA47F8EA9E110F7B32B4DF806AA
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 1920x1080
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/89B896742DDED2C8FFAEC71125ADB574FADDC19C21FE65771CC9439798607B20' -> '/tmp/mpv-shaders/89B896742DDED2C8FFAEC71125ADB574FADDC19C21FE65771CC9439798607B20'
[bdmv/bluray] Opening /tmp/mpv-shaders/89B896742DDED2C8FFAEC71125ADB574FADDC19C21FE65771CC9439798607B20
[file] Opening /tmp/mpv-shaders/89B896742DDED2C8FFAEC71125ADB574FADDC19C21FE65771CC9439798607B20
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 1920x1080
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/F6BF592BE3AB9735E32E76C1DA431FD99DE0A5F02E88359E5A0799068FBD6233' -> '/tmp/mpv-shaders/F6BF592BE3AB9735E32E76C1DA431FD99DE0A5F02E88359E5A0799068FBD6233'
[bdmv/bluray] Opening /tmp/mpv-shaders/F6BF592BE3AB9735E32E76C1DA431FD99DE0A5F02E88359E5A0799068FBD6233
[file] Opening /tmp/mpv-shaders/F6BF592BE3AB9735E32E76C1DA431FD99DE0A5F02E88359E5A0799068FBD6233
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 2046x1150
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/85BED25BE584630D7E72CF12038721FFA3BA8D5198C553A4A9CFE4393B1A222B' -> '/tmp/mpv-shaders/85BED25BE584630D7E72CF12038721FFA3BA8D5198C553A4A9CFE4393B1A222B'
[bdmv/bluray] Opening /tmp/mpv-shaders/85BED25BE584630D7E72CF12038721FFA3BA8D5198C553A4A9CFE4393B1A222B
[file] Opening /tmp/mpv-shaders/85BED25BE584630D7E72CF12038721FFA3BA8D5198C553A4A9CFE4393B1A222B
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 2046x1150
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/50C14635B69F86239311B3024275D35D9F1981E0A613431D6075344EA166AC84' -> '/tmp/mpv-shaders/50C14635B69F86239311B3024275D35D9F1981E0A613431D6075344EA166AC84'
[bdmv/bluray] Opening /tmp/mpv-shaders/50C14635B69F86239311B3024275D35D9F1981E0A613431D6075344EA166AC84
[file] Opening /tmp/mpv-shaders/50C14635B69F86239311B3024275D35D9F1981E0A613431D6075344EA166AC84
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/CE6B88F1AA8921F95BC44573307AE3AB860E4F22F52FA8B5B618D5B4A54214B7' -> '/tmp/mpv-shaders/CE6B88F1AA8921F95BC44573307AE3AB860E4F22F52FA8B5B618D5B4A54214B7'
[bdmv/bluray] Opening /tmp/mpv-shaders/CE6B88F1AA8921F95BC44573307AE3AB860E4F22F52FA8B5B618D5B4A54214B7
[file] Opening /tmp/mpv-shaders/CE6B88F1AA8921F95BC44573307AE3AB860E4F22F52FA8B5B618D5B4A54214B7
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/AE882F0FA9CF53A32842F46807D04E80B40B77E2A60CD2D3D00FFCFE74511FDA' -> '/tmp/mpv-shaders/AE882F0FA9CF53A32842F46807D04E80B40B77E2A60CD2D3D00FFCFE74511FDA'
[bdmv/bluray] Opening /tmp/mpv-shaders/AE882F0FA9CF53A32842F46807D04E80B40B77E2A60CD2D3D00FFCFE74511FDA
[file] Opening /tmp/mpv-shaders/AE882F0FA9CF53A32842F46807D04E80B40B77E2A60CD2D3D00FFCFE74511FDA
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/B3A5E05E4A33830714874DA9F63BB638AC3EE50520CFE20F6CF4AB3F0208B3C0' -> '/tmp/mpv-shaders/B3A5E05E4A33830714874DA9F63BB638AC3EE50520CFE20F6CF4AB3F0208B3C0'
[bdmv/bluray] Opening /tmp/mpv-shaders/B3A5E05E4A33830714874DA9F63BB638AC3EE50520CFE20F6CF4AB3F0208B3C0
[file] Opening /tmp/mpv-shaders/B3A5E05E4A33830714874DA9F63BB638AC3EE50520CFE20F6CF4AB3F0208B3C0
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[vo/gpu] Resizing texture: 2046x1150
[global] user path: '/tmp/mpv-icc' -> '/tmp/mpv-icc'
[vo/gpu] Opening 3D LUT cache in file '/tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C'.
[global] user path: '/tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C' -> '/tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C'
[bdmv/bluray] Opening /tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C
[file] Opening /tmp/mpv-icc/7EEF1581782F3E1B9A61DB028283BEEC78743E008F9739CDFC86F16F4596E09C
[file] Stream opened successfully.
[vo/gpu] Dither to 8.
[global] user path: '/tmp/mpv-shaders/' -> '/tmp/mpv-shaders/'
[vo/gpu] Trying to load shader from disk...
[global] user path: '/tmp/mpv-shaders/86226C19D3E5C8BD39E5392757B48767BED43257F650C2D6E48840C806AA36CF' -> '/tmp/mpv-shaders/86226C19D3E5C8BD39E5392757B48767BED43257F650C2D6E48840C806AA36CF'
[bdmv/bluray] Opening /tmp/mpv-shaders/86226C19D3E5C8BD39E5392757B48767BED43257F650C2D6E48840C806AA36CF
[file] Opening /tmp/mpv-shaders/86226C19D3E5C8BD39E5392757B48767BED43257F650C2D6E48840C806AA36CF
[file] Stream opened successfully.
[vo/gpu/opengl] Loading binary program succeeded.
[cplayer] first video frame after restart shown
[term-msg] Resolution: 1920x1080, Framerate: 25.000 Hz
[cplayer] playback restart complete
[statusline] V: 00:00:00.000 / 00:03:45.698 (0%) DS: 2.000/0
[cplayer] Run command: script-message-to, flags=9, args=[osc, disable-osc]
[cplayer] Can't find script 'osc' for script-message-to.
[vd] Allocating new DR image...
[vo/gpu/x11] Disabling screensaver.
[vd] Allocating new DR image...
[statusline] V: 00:00:00.000 / 00:03:45.698 (0%) DS: 2.500/0
[global] config path: 'fonts' -/-> '/home/nand/.config/mpv/fonts'
[global] config path: 'fonts' -/-> '/home/nand/.mpv/fonts'
[global] config path: 'fonts' -/-> '/usr/local/etc/mpv/fonts'
[osd/libass] Shaper: FriBidi 0.19.7 (SIMPLE) HarfBuzz-ng 1.5.1 (COMPLEX)
[global] config path: 'subfont.ttf' -/-> '/home/nand/.config/mpv/subfont.ttf'
[global] config path: 'subfont.ttf' -/-> '/home/nand/.mpv/subfont.ttf'
[global] config path: 'subfont.ttf' -/-> '/usr/local/etc/mpv/subfont.ttf'
[global] config path: 'fonts.conf' -/-> '/home/nand/.config/mpv/fonts.conf'
[global] config path: 'fonts.conf' -/-> '/home/nand/.mpv/fonts.conf'
[global] config path: 'fonts.conf' -/-> '/usr/local/etc/mpv/fonts.conf'
[osd/libass] Setting up fonts...
[osd/libass] Using font provider fontconfig
[osd/libass] Done.
[vo/gpu] Resizing texture: 2046x1150
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.040 / 00:03:45.698 (0%) DS: 2.333/0
[vd] Allocating new DR image...
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.080 / 00:03:45.698 (0%) DS: 2.500/0
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.120 / 00:03:45.698 (0%) DS: 2.400/0
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.160 / 00:03:45.698 (0%) DS: 2.333/0
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.200 / 00:03:45.698 (0%) DS: 2.429/0
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.240 / 00:03:45.698 (0%) DS: 2.375/0
[vo/gpu] Resizing texture: 2046x1150
[statusline] V: 00:00:00.440 / 00:03:45.698 (0%) DS: 2.385/0
[vd] Allocating new DR image...
[statusline] V: 00:00:01.640 / 00:03:45.698 (0%) DS: 2.395/0
[cplayer] Run command: quit, flags=9, args=[0]
[cplayer] EOF code: 6  
[vd] Uninit video.
[vo/gpu/x11] Enabling screensaver.
[cplayer] finished playback, success (reason 3)
[cplayer] 
[cplayer] 
[cplayer] Exiting... (Quit)
[skipchapters] Exiting...
[ytdl_hook] Exiting...
[image] Exiting...
[auto_profiles] Exiting...
[easybox] Exiting...
[stats] Exiting...
[progressbar] Exiting...
[visualizer] Exiting...
[autocrop] Exiting...
[easycrop] Exiting...
[vo/gpu] flushing shader cache
[vo/gpu/x11] uninit ...
```

Some of this stuff probably still makes more sense in a different message level, but consider this sort of an RFC. Do you even agree with this?
