### PR TITLE
Vulkan revision 2

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4267,7 +4267,8 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Controls the number of VkQueues used for rendering (limited by how many
     your device supports). In theory, using more queues could enable some
     parallelism between frames (when using a ``--swapchain-depth`` higher than
-    1). (Default: 1)
+    1), but it can also slow things down on hardware where there's no true
+    parallelism between queues. (Default: 1)
 
 ``--d3d11-warp=<yes|no|auto>``
     Use WARP (Windows Advanced Rasterization Platform) with the D3D11 GPU

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4269,10 +4269,6 @@ The following video options are currently all specific to ``--vo=gpu`` and
     parallelism between frames (when using a ``--swapchain-depth`` higher than
     1). (Default: 1)
 
-    NOTE: Setting this to a value higher than 1 may cause graphical corruption,
-    as mpv's vulkan implementation currently does not try and protect textures
-    against concurrent access.
-
 ``--d3d11-warp=<yes|no|auto>``
     Use WARP (Windows Advanced Rasterization Platform) with the D3D11 GPU
     backend (default: auto). This is a high performance software renderer. By

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4270,6 +4270,23 @@ The following video options are currently all specific to ``--vo=gpu`` and
     1), but it can also slow things down on hardware where there's no true
     parallelism between queues. (Default: 1)
 
+``--vulkan-async-transfer``
+    Enables the use of async transfer queues on supported vulkan devices. Using
+    them allows transfer operations like texture uploads and blits to happen
+    concurrently with the actual rendering, thus improving overall throughput
+    and power consumption. Enabled by default, and should be relatively safe.
+
+``--vulkan-async-compute``
+    Enables the use of async compute queues on supported vulkan devices. Using
+    this, in theory, allows out-of-order scheduling of compute shaders with
+    graphics shaders, thus enabling the hardware to do more effective work while
+    waiting for pipeline bubbles and memory operations. Not beneficial on all
+    GPUs. It's worth noting that if async compute is enabled, and the device
+    supports more compute queues than graphics queues (bound by the restrictions
+    set by ``--vulkan-queue-count``), mpv will internally try and prefer the
+    use of compute shaders over fragment shaders wherever possible. Not enabled
+    by default, since it seems to cause issues with some drivers.
+
 ``--d3d11-warp=<yes|no|auto>``
     Use WARP (Windows Advanced Rasterization Platform) with the D3D11 GPU
     backend (default: auto). This is a high performance software renderer. By

--- a/ta/ta_talloc.h
+++ b/ta/ta_talloc.h
@@ -124,6 +124,13 @@ char *ta_talloc_asprintf_append_buffer(char *s, const char *fmt, ...) TA_PRF(2, 
         (idxvar)--;                                 \
     } while (0)
 
+// Returns whether or not there was any element to pop.
+#define MP_TARRAY_POP(p, idxvar, out)               \
+    ((idxvar) > 0                                   \
+        ? (*(out) = (p)[--(idxvar)], true)          \
+        : false                                     \
+    )
+
 #define talloc_struct(ctx, type, ...) \
     talloc_memdup(ctx, &(type) TA_EXPAND_ARGS(__VA_ARGS__), sizeof(type))
 

--- a/video/out/gpu/osd.c
+++ b/video/out/gpu/osd.c
@@ -314,7 +314,7 @@ void mpgl_osd_draw_finish(struct mpgl_osd *ctx, int index,
     const int *factors = &blend_factors[part->format][0];
     gl_sc_blend(sc, factors[0], factors[1], factors[2], factors[3]);
 
-    gl_sc_dispatch_draw(sc, fbo.tex, vertex_vao, MP_ARRAY_SIZE(vertex_vao),
+    gl_sc_dispatch_draw(sc, fbo.tex, false, vertex_vao, MP_ARRAY_SIZE(vertex_vao),
                         sizeof(struct vertex), part->vertices, part->num_vertices);
 }
 

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -285,6 +285,9 @@ struct ra_renderpass_params {
     enum ra_blend blend_src_alpha;
     enum ra_blend blend_dst_alpha;
 
+    // If true, the contents of `target` not written to will become undefined
+    bool invalidate_target;
+
     // --- type==RA_RENDERPASS_TYPE_COMPUTE only
 
     // Shader text, like vertex_shader/frag_shader.

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -53,6 +53,7 @@ enum {
     RA_CAP_GLOBAL_UNIFORM = 1 << 8, // supports using "naked" uniforms (not UBO)
     RA_CAP_GATHER         = 1 << 9, // supports textureGather in GLSL
     RA_CAP_FRAGCOORD      = 1 << 10, // supports reading from gl_FragCoord
+    RA_CAP_PARALLEL_COMPUTE  = 1 << 11, // supports parallel compute shaders
 };
 
 enum ra_ctype {

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -85,6 +85,8 @@ struct ra_format {
                             // only applies to 2-component textures
     bool linear_filter;     // linear filtering available from shader
     bool renderable;        // can be used for render targets
+    bool dummy_format;      // is not a real ra_format but a fake one (e.g. FBO).
+                            // dummy formats cannot be used to create textures
 
     // If not 0, the format represents some sort of packed fringe format, whose
     // shader representation is given by the special_imgfmt_desc pointer.

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -786,11 +786,6 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
         ADD(header, "#define texture texture2D\n");
     }
 
-    if (sc->ra->glsl_vulkan && type == RA_RENDERPASS_TYPE_COMPUTE) {
-        ADD(header, "#define gl_GlobalInvocationIndex "
-                    "(gl_WorkGroupID * gl_WorkGroupSize + gl_LocalInvocationID)\n");
-    }
-
     // Additional helpers.
     ADD(header, "#define LUT_POS(x, lut_size)"
                 " mix(0.5 / (lut_size), 1.0 - 0.5 / (lut_size), (x))\n");

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -974,13 +974,14 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
 }
 
 struct mp_pass_perf gl_sc_dispatch_draw(struct gl_shader_cache *sc,
-                                        struct ra_tex *target,
+                                        struct ra_tex *target, bool discard,
                                         const struct ra_renderpass_input *vao,
                                         int vao_len, size_t vertex_stride,
                                         void *vertices, size_t num_vertices)
 {
     struct timer_pool *timer = NULL;
 
+    sc->params.invalidate_target = discard;
     gl_sc_generate(sc, RA_RENDERPASS_TYPE_RASTER, target->params.format,
                    vao, vao_len, vertex_stride);
     if (!sc->current_shader)

--- a/video/out/gpu/shader_cache.h
+++ b/video/out/gpu/shader_cache.h
@@ -50,7 +50,7 @@ void gl_sc_blend(struct gl_shader_cache *sc,
                  enum ra_blend blend_dst_alpha);
 void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name);
 struct mp_pass_perf gl_sc_dispatch_draw(struct gl_shader_cache *sc,
-                                        struct ra_tex *target,
+                                        struct ra_tex *target, bool discard,
                                         const struct ra_renderpass_input *vao,
                                         int vao_len, size_t vertex_stride,
                                         void *ptr, size_t num);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1134,7 +1134,7 @@ static void dispatch_compute(struct gl_video *p, int w, int h,
 }
 
 static struct mp_pass_perf render_pass_quad(struct gl_video *p,
-                                            struct ra_fbo fbo,
+                                            struct ra_fbo fbo, bool discard,
                                             const struct mp_rect *dst)
 {
     // The first element is reserved for `vec2 position`
@@ -1192,15 +1192,15 @@ static struct mp_pass_perf render_pass_quad(struct gl_video *p,
             &p->tmp_vertex[num_vertex_attribs * 1],
             vertex_stride);
 
-    return gl_sc_dispatch_draw(p->sc, fbo.tex, p->vao, num_vertex_attribs,
+    return gl_sc_dispatch_draw(p->sc, fbo.tex, discard, p->vao, num_vertex_attribs,
                                vertex_stride, p->tmp_vertex, num_vertices);
 }
 
 static void finish_pass_fbo(struct gl_video *p, struct ra_fbo fbo,
-                            const struct mp_rect *dst)
+                            bool discard, const struct mp_rect *dst)
 {
     pass_prepare_src_tex(p);
-    pass_record(p, render_pass_quad(p, fbo, dst));
+    pass_record(p, render_pass_quad(p, fbo, discard, dst));
     debug_check_gl(p, "after rendering");
     cleanup_binds(p);
 }
@@ -1229,7 +1229,7 @@ static void finish_pass_tex(struct gl_video *p, struct ra_tex **dst_tex,
         debug_check_gl(p, "after dispatching compute shader");
     } else {
         struct ra_fbo fbo = { .tex = *dst_tex, };
-        finish_pass_fbo(p, fbo, &(struct mp_rect){0, 0, w, h});
+        finish_pass_fbo(p, fbo, true, &(struct mp_rect){0, 0, w, h});
     }
 }
 
@@ -2788,7 +2788,7 @@ static void pass_draw_to_screen(struct gl_video *p, struct ra_fbo fbo)
 
     pass_dither(p);
     pass_describe(p, "output to screen");
-    finish_pass_fbo(p, fbo, &p->dst_rect);
+    finish_pass_fbo(p, fbo, false, &p->dst_rect);
 }
 
 static bool update_surface(struct gl_video *p, struct mp_image *mpi,
@@ -3194,7 +3194,7 @@ static void reinterleave_vdpau(struct gl_video *p,
         const struct ra_format *fmt = ra_find_unorm_format(p->ra, 1, comps);
         ra_tex_resize(p->ra, p->log, tex, w, h * 2, fmt);
         struct ra_fbo fbo = { *tex };
-        finish_pass_fbo(p, fbo, &(struct mp_rect){0, 0, w, h * 2});
+        finish_pass_fbo(p, fbo, true, &(struct mp_rect){0, 0, w, h * 2});
 
         output[n] = *tex;
     }

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3058,9 +3058,15 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
                 if (frame->num_vsyncs > 1 && frame->display_synced &&
                     !p->dumb_mode && (p->ra->caps & RA_CAP_BLIT))
                 {
+                    // Attempt to use the same format as the destination FBO
+                    // if possible. Some RAs use a wrapped dummy format here,
+                    // so fall back to the fbo_format in that case.
+                    const struct ra_format *fmt = fbo.tex->params.format;
+                    if (fmt->dummy_format)
+                        fmt = p->fbo_format;
                     bool r = ra_tex_resize(p->ra, p->log, &p->output_tex,
                                            fbo.tex->params.w, fbo.tex->params.h,
-                                           p->fbo_format);
+                                           fmt);
                     if (r) {
                         dest_fbo = (struct ra_fbo) { p->output_tex };
                         p->output_tex_valid = true;

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1218,6 +1218,11 @@ static void finish_pass_tex(struct gl_video *p, struct ra_tex **dst_tex,
         return;
     }
 
+    // If RA_CAP_PARALLEL_COMPUTE is set, try to prefer compute shaders
+    // over fragment shaders wherever possible.
+    if (!p->pass_compute.active && (p->ra->caps & RA_CAP_PARALLEL_COMPUTE))
+        pass_is_compute(p, 16, 16);
+
     if (p->pass_compute.active) {
         gl_sc_uniform_image2D_wo(p->sc, "out_image", *dst_tex);
         if (!p->pass_compute.directly_writes)

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -996,6 +996,10 @@ static void gl_renderpass_run(struct ra *ra,
         assert(params->target->params.render_dst);
         assert(params->target->params.format == pass->params.target_format);
         gl->BindFramebuffer(GL_FRAMEBUFFER, target_gl->fbo);
+        if (pass->params.invalidate_target && gl->InvalidateFramebuffer) {
+            GLenum fb = target_gl->fbo ? GL_COLOR_ATTACHMENT0 : GL_COLOR;
+            gl->InvalidateFramebuffer(GL_FRAMEBUFFER, 1, &fb);
+        }
         gl->Viewport(params->viewport.x0, params->viewport.y0,
                      mp_rect_w(params->viewport),
                      mp_rect_h(params->viewport));

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -283,6 +283,8 @@ static struct ra_tex *gl_tex_create(struct ra *ra,
                                     const struct ra_tex_params *params)
 {
     GL *gl = ra_gl_get(ra);
+    assert(!params->format->dummy_format);
+
     struct ra_tex *tex = gl_tex_create_blank(ra, params);
     if (!tex)
         return NULL;
@@ -382,6 +384,7 @@ static const struct ra_format fbo_dummy_format = {
         .flags = F_CR,
     },
     .renderable = true,
+    .dummy_format = true,
 };
 
 // Create a ra_tex that merely wraps an existing framebuffer. gl_fbo can be 0

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -53,6 +53,10 @@ struct mpvk_ctx {
     struct vk_cmd *last_cmd; // most recently submitted (pending) command
     struct spirv_compiler *spirv; // GLSL -> SPIR-V compiler
 
+    // Common pool of signals, to avoid having to re-create these objects often
+    struct vk_signal **signals;
+    int num_signals;
+
     // Cached capabilities
     VkPhysicalDeviceLimits limits;
 };

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -48,10 +48,23 @@ struct mpvk_ctx {
     VkSurfaceKHR surf;
     VkSurfaceFormatKHR surf_format; // picked at surface initialization time
 
-    struct vk_malloc *alloc; // memory allocator for this device
-    struct vk_cmdpool *pool; // primary command pool for this device
-    struct vk_cmd *last_cmd; // most recently submitted (pending) command
+    struct vk_malloc *alloc;      // memory allocator for this device
     struct spirv_compiler *spirv; // GLSL -> SPIR-V compiler
+    struct vk_cmdpool **pools;    // command pools (one per queue family)
+    int num_pools;
+    struct vk_cmd *last_cmd;      // most recently submitted command
+
+    // Queued/pending commands. These are shared for the entire mpvk_ctx to
+    // ensure submission and callbacks are FIFO
+    struct vk_cmd **cmds_queued;  // recorded but not yet submitted
+    struct vk_cmd **cmds_pending; // submitted but not completed
+    int num_cmds_queued;
+    int num_cmds_pending;
+
+    // Pointers into *pools
+    struct vk_cmdpool *pool_graphics; // required
+    struct vk_cmdpool *pool_compute;  // optional
+    struct vk_cmdpool *pool_transfer; // optional
 
     // Common pool of signals, to avoid having to re-create these objects often
     struct vk_signal **signals;

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -50,7 +50,7 @@ struct mpvk_ctx {
 
     struct vk_malloc *alloc; // memory allocator for this device
     struct vk_cmdpool *pool; // primary command pool for this device
-    struct vk_cmd *last_cmd; // most recently submitted command
+    struct vk_cmd *last_cmd; // most recently submitted (pending) command
     struct spirv_compiler *spirv; // GLSL -> SPIR-V compiler
 
     // Cached capabilities

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -104,9 +104,16 @@ const struct m_sub_options vulkan_conf = {
                    {"immediate",    SWAP_IMMEDIATE})),
         OPT_INTRANGE("vulkan-queue-count", dev_opts.queue_count, 0, 1, 8,
                      OPTDEF_INT(1)),
+        OPT_FLAG("vulkan-async-transfer", dev_opts.async_transfer, 0),
+        OPT_FLAG("vulkan-async-compute", dev_opts.async_compute, 0),
         {0}
     },
-    .size = sizeof(struct vulkan_opts)
+    .size = sizeof(struct vulkan_opts),
+    .defaults = &(struct vulkan_opts) {
+        .dev_opts = {
+            .async_transfer = 1,
+        },
+    },
 };
 
 struct priv {

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -447,8 +447,10 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
     if (!p->swapchain)
         goto error;
 
+    MP_TRACE(vk, "vkAcquireNextImageKHR signals %p\n",
+             (void *)p->sems_in[p->idx_sems]);
+
     uint32_t imgidx = 0;
-    MP_TRACE(vk, "vkAcquireNextImageKHR\n");
     VkResult res = vkAcquireNextImageKHR(vk->dev, p->swapchain, UINT64_MAX,
                                          p->sems_in[p->idx_sems], NULL,
                                          &imgidx);
@@ -518,6 +520,7 @@ static bool submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
         .pImageIndices = &p->last_imgidx,
     };
 
+    MP_TRACE(vk, "vkQueuePresentKHR waits on %p\n", (void *)p->sems_out[semidx]);
     VK(vkQueuePresentKHR(queue, &pinfo));
     return true;
 

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -446,27 +446,43 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
     struct priv *p = sw->priv;
     struct mpvk_ctx *vk = p->vk;
     if (!p->swapchain)
-        goto error;
+        return false;
 
     MP_TRACE(vk, "vkAcquireNextImageKHR signals %p\n",
              (void *)p->sems_in[p->idx_sems]);
 
-    uint32_t imgidx = 0;
-    VkResult res = vkAcquireNextImageKHR(vk->dev, p->swapchain, UINT64_MAX,
-                                         p->sems_in[p->idx_sems], NULL,
-                                         &imgidx);
-    if (res == VK_ERROR_OUT_OF_DATE_KHR)
-        goto error; // just return in this case
-    VK_ASSERT(res, "Failed acquiring swapchain image");
+    for (int attempts = 0; attempts < 2; attempts++) {
+        uint32_t imgidx = 0;
+        VkResult res = vkAcquireNextImageKHR(vk->dev, p->swapchain, UINT64_MAX,
+                                             p->sems_in[p->idx_sems], NULL,
+                                             &imgidx);
 
-    p->last_imgidx = imgidx;
-    *out_fbo = (struct ra_fbo) {
-        .tex = p->images[imgidx],
-        .flip = false,
-    };
-    return true;
+        switch (res) {
+        case VK_SUCCESS:
+            p->last_imgidx = imgidx;
+            *out_fbo = (struct ra_fbo) {
+                .tex = p->images[imgidx],
+                .flip = false,
+            };
+            return true;
 
-error:
+        case VK_ERROR_OUT_OF_DATE_KHR: {
+            // In these cases try recreating the swapchain
+            int w = p->w, h = p->h;
+            p->w = p->h = 0; // invalidate the current state
+            if (!ra_vk_ctx_resize(sw, w, h))
+                return false;
+            continue;
+        }
+
+        default:
+            MP_ERR(vk, "Failed acquiring swapchain image: %s\n", vk_err(res));
+            return false;
+        }
+    }
+
+    // If we've exhausted the number of attempts to recreate the swapchain,
+    // just give up silently.
     return false;
 }
 
@@ -481,11 +497,11 @@ static bool submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
     struct ra *ra = sw->ctx->ra;
     struct mpvk_ctx *vk = p->vk;
     if (!p->swapchain)
-        goto error;
+        return false;
 
     struct vk_cmd *cmd = ra_vk_submit(ra, p->images[p->last_imgidx]);
     if (!cmd)
-        goto error;
+        return false;
 
     int semidx = p->idx_sems++;
     p->idx_sems %= p->num_sems;
@@ -503,7 +519,7 @@ static bool submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
 
     vk_cmd_queue(vk, cmd);
     if (!mpvk_flush_commands(vk))
-        goto error;
+        return false;
 
     // Older nvidia drivers can spontaneously combust when submitting to the
     // same queue as we're rendering from, in a multi-queue scenario. Safest
@@ -522,11 +538,22 @@ static bool submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
     };
 
     MP_TRACE(vk, "vkQueuePresentKHR waits on %p\n", (void *)p->sems_out[semidx]);
-    VK(vkQueuePresentKHR(queue, &pinfo));
-    return true;
+    VkResult res = vkQueuePresentKHR(queue, &pinfo);
+    switch (res) {
+    case VK_SUCCESS:
+    case VK_SUBOPTIMAL_KHR:
+        return true;
 
-error:
-    return false;
+    case VK_ERROR_OUT_OF_DATE_KHR:
+        // We can silently ignore this error, since the next start_frame will
+        // recreate the swapchain automatically.
+        return true;
+
+    default:
+        MP_ERR(vk, "Failed presenting to queue %p: %s\n", (void *)queue,
+               vk_err(res));
+        return false;
+    }
 }
 
 static void swap_buffers(struct ra_swapchain *sw)

--- a/video/out/vulkan/formats.c
+++ b/video/out/vulkan/formats.c
@@ -25,7 +25,7 @@ const struct vk_format vk_formats[] = {
     {"rg4",      VK_FORMAT_R4G4_UNORM_PACK8,          2,  1,   {4,  4         }, RA_CTYPE_UNORM },
     {"rgba4",    VK_FORMAT_R4G4B4A4_UNORM_PACK16,     4,  2,   {4,  4,  4,  4 }, RA_CTYPE_UNORM },
     {"rgb565",   VK_FORMAT_R5G6B5_UNORM_PACK16,       3,  2,   {5,  6,  5     }, RA_CTYPE_UNORM },
-    {"rgb565a1", VK_FORMAT_R5G5B5A1_UNORM_PACK16,     4,  2,   {5,  5,  5,  1 }, RA_CTYPE_UNORM },
+    {"rgb5a1",   VK_FORMAT_R5G5B5A1_UNORM_PACK16,     4,  2,   {5,  5,  5,  1 }, RA_CTYPE_UNORM },
 
     // Float formats (native formats, hf = half float, df = double float)
     {"r16hf",    VK_FORMAT_R16_SFLOAT,                1,  2,   {16            }, RA_CTYPE_FLOAT },
@@ -46,7 +46,7 @@ const struct vk_format vk_formats[] = {
     {"bgra8",    VK_FORMAT_B8G8R8A8_UNORM,            4,  4,   {8,  8,  8,  8 }, RA_CTYPE_UNORM, true },
     {"bgra4",    VK_FORMAT_B4G4R4A4_UNORM_PACK16,     4,  2,   {4,  4,  4,  4 }, RA_CTYPE_UNORM, true },
     {"bgr565",   VK_FORMAT_B5G6R5_UNORM_PACK16,       3,  2,   {5,  6,  5     }, RA_CTYPE_UNORM, true },
-    {"bgr565a1", VK_FORMAT_B5G5R5A1_UNORM_PACK16,     4,  2,   {5,  5,  5,  1 }, RA_CTYPE_UNORM, true },
+    {"bgr5a1",   VK_FORMAT_B5G5R5A1_UNORM_PACK16,     4,  2,   {5,  5,  5,  1 }, RA_CTYPE_UNORM, true },
     {"a1rgb5",   VK_FORMAT_A1R5G5B5_UNORM_PACK16,     4,  2,   {1,  5,  5,  5 }, RA_CTYPE_UNORM, true },
     {"a2rgb10",  VK_FORMAT_A2R10G10B10_UNORM_PACK32,  4,  4,   {2,  10, 10, 10}, RA_CTYPE_UNORM, true },
     {"a2bgr10",  VK_FORMAT_A2B10G10R10_UNORM_PACK32,  4,  4,   {2,  10, 10, 10}, RA_CTYPE_UNORM, true },

--- a/video/out/vulkan/malloc.c
+++ b/video/out/vulkan/malloc.c
@@ -147,7 +147,6 @@ static struct vk_slab *slab_alloc(struct mpvk_ctx *vk, struct vk_heap *heap,
             .usage = heap->usage,
             .sharingMode = vk->num_pools > 1 ? VK_SHARING_MODE_CONCURRENT
                                              : VK_SHARING_MODE_EXCLUSIVE,
-            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
             .queueFamilyIndexCount = vk->num_pools,
             .pQueueFamilyIndices = qfs,
         };

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -241,9 +241,13 @@ error:
 }
 
 // Boilerplate wrapper around vkCreateRenderPass to ensure passes remain
-// compatible
+// compatible. The renderpass will automatically transition the image out of
+// initialLayout and into finalLayout.
 static VkResult vk_create_render_pass(VkDevice dev, const struct ra_format *fmt,
-                                      bool load_fbo, VkRenderPass *out)
+                                      VkAttachmentLoadOp loadOp,
+                                      VkImageLayout initialLayout,
+                                      VkImageLayout finalLayout,
+                                      VkRenderPass *out)
 {
     struct vk_format *vk_fmt = fmt->priv;
     assert(fmt->renderable);
@@ -254,12 +258,10 @@ static VkResult vk_create_render_pass(VkDevice dev, const struct ra_format *fmt,
         .pAttachments = &(VkAttachmentDescription) {
             .format = vk_fmt->iformat,
             .samples = VK_SAMPLE_COUNT_1_BIT,
-            .loadOp = load_fbo ? VK_ATTACHMENT_LOAD_OP_LOAD
-                               : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+            .loadOp = loadOp,
             .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
-            .initialLayout = load_fbo ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-                                      : VK_IMAGE_LAYOUT_UNDEFINED,
-            .finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            .initialLayout = initialLayout,
+            .finalLayout = finalLayout,
         },
         .subpassCount = 1,
         .pSubpasses = &(VkSubpassDescription) {
@@ -291,16 +293,21 @@ struct ra_tex_vk {
     struct ra_buf_pool pbo;
     // "current" metadata, can change during the course of execution
     VkImageLayout current_layout;
-    VkPipelineStageFlags current_stage;
     VkAccessFlags current_access;
+    // the signal guards reuse, and can be NULL
+    struct vk_signal *sig;
+    VkPipelineStageFlags sig_stage;
 };
 
 // Small helper to ease image barrier creation. if `discard` is set, the contents
 // of the image will be undefined after the barrier
-static void tex_barrier(struct vk_cmd *cmd, struct ra_tex_vk *tex_vk,
-                        VkPipelineStageFlags newStage, VkAccessFlags newAccess,
+static void tex_barrier(struct ra *ra, struct vk_cmd *cmd, struct ra_tex *tex,
+                        VkPipelineStageFlags stage, VkAccessFlags newAccess,
                         VkImageLayout newLayout, bool discard)
 {
+    struct mpvk_ctx *vk = ra_vk_get(ra);
+    struct ra_tex_vk *tex_vk = tex->priv;
+
     VkImageMemoryBarrier imgBarrier = {
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .oldLayout = tex_vk->current_layout,
@@ -318,16 +325,38 @@ static void tex_barrier(struct vk_cmd *cmd, struct ra_tex_vk *tex_vk,
         imgBarrier.srcAccessMask = 0;
     }
 
+    VkEvent event = NULL;
+    vk_cmd_wait(vk, cmd, &tex_vk->sig, stage, &event);
+
+    // Image barriers are redundant if there's nothing to be done
     if (imgBarrier.oldLayout != imgBarrier.newLayout ||
         imgBarrier.srcAccessMask != imgBarrier.dstAccessMask)
     {
-        vkCmdPipelineBarrier(cmd->buf, tex_vk->current_stage, newStage, 0,
-                             0, NULL, 0, NULL, 1, &imgBarrier);
+        if (event) {
+            vkCmdWaitEvents(cmd->buf, 1, &event, tex_vk->sig_stage,
+                            stage, 0, NULL, 0, NULL, 1, &imgBarrier);
+        } else {
+            // If we're not using an event, then the source stage is irrelevant
+            // because we're coming from a different queue anyway, so we can
+            // safely set it to TOP_OF_PIPE.
+            vkCmdPipelineBarrier(cmd->buf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                 stage, 0, 0, NULL, 0, NULL, 1, &imgBarrier);
+        }
     }
 
-    tex_vk->current_stage = newStage;
     tex_vk->current_layout = newLayout;
     tex_vk->current_access = newAccess;
+}
+
+static void tex_signal(struct ra *ra, struct vk_cmd *cmd, struct ra_tex *tex,
+                       VkPipelineStageFlags stage)
+{
+    struct ra_tex_vk *tex_vk = tex->priv;
+    struct mpvk_ctx *vk = ra_vk_get(ra);
+    assert(!tex_vk->sig);
+
+    tex_vk->sig = vk_cmd_signal(vk, cmd, stage);
+    tex_vk->sig_stage = stage;
 }
 
 static void vk_tex_destroy(struct ra *ra, struct ra_tex *tex)
@@ -339,6 +368,7 @@ static void vk_tex_destroy(struct ra *ra, struct ra_tex *tex)
     struct ra_tex_vk *tex_vk = tex->priv;
 
     ra_buf_pool_uninit(ra, &tex_vk->pbo);
+    vk_signal_destroy(vk, &tex_vk->sig);
     vkDestroyFramebuffer(vk->dev, tex_vk->framebuffer, MPVK_ALLOCATOR);
     vkDestroyRenderPass(vk->dev, tex_vk->dummyPass, MPVK_ALLOCATOR);
     vkDestroySampler(vk->dev, tex_vk->sampler, MPVK_ALLOCATOR);
@@ -363,7 +393,6 @@ static bool vk_init_image(struct ra *ra, struct ra_tex *tex)
     assert(tex_vk->img);
 
     tex_vk->current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
-    tex_vk->current_stage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     tex_vk->current_access = 0;
 
     if (params->render_src || params->render_dst) {
@@ -410,7 +439,11 @@ static bool vk_init_image(struct ra *ra, struct ra_tex *tex)
         // Framebuffers need to be created against a specific render pass
         // layout, so we need to temporarily create a skeleton/dummy render
         // pass for vulkan to figure out the compatibility
-        VK(vk_create_render_pass(vk->dev, params->format, false, &tex_vk->dummyPass));
+        VK(vk_create_render_pass(vk->dev, params->format,
+                                 VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                 VK_IMAGE_LAYOUT_UNDEFINED,
+                                 VK_IMAGE_LAYOUT_UNDEFINED,
+                                 &tex_vk->dummyPass));
 
         VkFramebufferCreateInfo finfo = {
             .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
@@ -804,13 +837,15 @@ static bool vk_tex_upload(struct ra *ra,
     buf_barrier(ra, cmd, buf, VK_PIPELINE_STAGE_TRANSFER_BIT,
                 VK_ACCESS_TRANSFER_READ_BIT, region.bufferOffset, size);
 
-    tex_barrier(cmd, tex_vk, VK_PIPELINE_STAGE_TRANSFER_BIT,
+    tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_TRANSFER_BIT,
                 VK_ACCESS_TRANSFER_WRITE_BIT,
                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 params->invalidate);
 
     vkCmdCopyBufferToImage(cmd->buf, buf_vk->slice.buf, tex_vk->img,
                            tex_vk->current_layout, 1, &region);
+
+    tex_signal(ra, cmd, tex, VK_PIPELINE_STAGE_TRANSFER_BIT);
 
     return true;
 
@@ -826,6 +861,10 @@ struct ra_renderpass_vk {
     VkPipeline pipe;
     VkPipelineLayout pipeLayout;
     VkRenderPass renderPass;
+    VkImageLayout initialLayout;
+    VkImageLayout finalLayout;
+    VkAccessFlags initialAccess;
+    VkAccessFlags finalAccess;
     // Descriptor set (bindings)
     VkDescriptorSetLayout dsLayout;
     VkDescriptorPool dsPool;
@@ -1153,8 +1192,23 @@ static struct ra_renderpass *vk_renderpass_create(struct ra *ra,
                 goto error;
             }
         }
-        VK(vk_create_render_pass(vk->dev, params->target_format,
-                                 params->enable_blend, &pass_vk->renderPass));
+
+        // This is the most common case, so optimize towards it. In this case,
+        // the renderpass will take care of almost all layout transitions
+        pass_vk->initialLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        pass_vk->initialAccess = VK_ACCESS_SHADER_READ_BIT;
+        pass_vk->finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        pass_vk->finalAccess = VK_ACCESS_SHADER_READ_BIT;
+        VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+
+        // If we're blending, then we need to explicitly load the previous
+        // contents of the color attachment
+        if (pass->params.enable_blend)
+            loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+
+        VK(vk_create_render_pass(vk->dev, params->target_format, loadOp,
+                                 pass_vk->initialLayout, pass_vk->finalLayout,
+                                 &pass_vk->renderPass));
 
         static const VkBlendFactor blendFactors[] = {
             [RA_BLEND_ZERO]                = VK_BLEND_FACTOR_ZERO,
@@ -1307,6 +1361,11 @@ error:
     return pass;
 }
 
+static const VkPipelineStageFlags passStages[] = {
+    [RA_RENDERPASS_TYPE_RASTER]  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+    [RA_RENDERPASS_TYPE_COMPUTE] = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+};
+
 static void vk_update_descriptor(struct ra *ra, struct vk_cmd *cmd,
                                  struct ra_renderpass *pass,
                                  struct ra_renderpass_input_val val,
@@ -1324,18 +1383,13 @@ static void vk_update_descriptor(struct ra *ra, struct vk_cmd *cmd,
         .descriptorType = dsType[inp->type],
     };
 
-    static const VkPipelineStageFlags passStages[] = {
-        [RA_RENDERPASS_TYPE_RASTER]  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-        [RA_RENDERPASS_TYPE_COMPUTE] = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-    };
-
     switch (inp->type) {
     case RA_VARTYPE_TEX: {
         struct ra_tex *tex = *(struct ra_tex **)val.data;
         struct ra_tex_vk *tex_vk = tex->priv;
 
         assert(tex->params.render_src);
-        tex_barrier(cmd, tex_vk, passStages[pass->params.type],
+        tex_barrier(ra, cmd, tex, passStages[pass->params.type],
                     VK_ACCESS_SHADER_READ_BIT,
                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, false);
 
@@ -1354,7 +1408,7 @@ static void vk_update_descriptor(struct ra *ra, struct vk_cmd *cmd,
         struct ra_tex_vk *tex_vk = tex->priv;
 
         assert(tex->params.storage_dst);
-        tex_barrier(cmd, tex_vk, passStages[pass->params.type],
+        tex_barrier(ra, cmd, tex, passStages[pass->params.type],
                     VK_ACCESS_SHADER_WRITE_BIT,
                     VK_IMAGE_LAYOUT_GENERAL, false);
 
@@ -1387,6 +1441,22 @@ static void vk_update_descriptor(struct ra *ra, struct vk_cmd *cmd,
         };
 
         wds->pBufferInfo = binfo;
+        break;
+    }
+    }
+}
+
+static void vk_release_descriptor(struct ra *ra, struct vk_cmd *cmd,
+                                  struct ra_renderpass *pass,
+                                  struct ra_renderpass_input_val val)
+{
+    struct ra_renderpass_input *inp = &pass->params.inputs[val.index];
+
+    switch (inp->type) {
+    case RA_VARTYPE_IMG_W:
+    case RA_VARTYPE_TEX: {
+        struct ra_tex *tex = *(struct ra_tex **)val.data;
+        tex_signal(ra, cmd, tex, passStages[pass->params.type]);
         break;
     }
     }
@@ -1464,13 +1534,9 @@ static void vk_renderpass_run(struct ra *ra,
         vkCmdBindVertexBuffers(cmd->buf, 0, 1, &buf_vk->slice.buf,
                                &buf_vk->slice.mem.offset);
 
-        if (pass->params.enable_blend) {
-            // Normally this transition is handled implicitly by the renderpass,
-            // but if we need to preserve the FBO we have to do it manually.
-            tex_barrier(cmd, tex_vk, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, false);
-        }
+        // The renderpass expects the images to be in a certain layout
+        tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                    pass_vk->initialAccess, pass_vk->initialLayout, false);
 
         VkViewport viewport = {
             .x = params->viewport.x0,
@@ -1499,13 +1565,20 @@ static void vk_renderpass_run(struct ra *ra,
         vkCmdEndRenderPass(cmd->buf);
 
         // The renderPass implicitly transitions the texture to this layout
-        tex_vk->current_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        tex_vk->current_access = VK_ACCESS_SHADER_READ_BIT;
-        tex_vk->current_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        tex_vk->current_layout = pass_vk->finalLayout;
+        tex_vk->current_access = pass_vk->finalAccess;
+        tex_signal(ra, cmd, tex, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
         break;
     }
     default: abort();
     };
+
+    for (int i = 0; i < params->num_values; i++)
+        vk_release_descriptor(ra, cmd, pass, params->values[i]);
+
+    // flush the work so far into its own command buffer, for better cross-frame
+    // granularity
+    vk_submit(ra);
 
 error:
     return;
@@ -1524,7 +1597,7 @@ static void vk_blit(struct ra *ra, struct ra_tex *dst, struct ra_tex *src,
     if (!cmd)
         return;
 
-    tex_barrier(cmd, src_vk, VK_PIPELINE_STAGE_TRANSFER_BIT,
+    tex_barrier(ra, cmd, src, VK_PIPELINE_STAGE_TRANSFER_BIT,
                 VK_ACCESS_TRANSFER_READ_BIT,
                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                 false);
@@ -1534,7 +1607,7 @@ static void vk_blit(struct ra *ra, struct ra_tex *dst, struct ra_tex *src,
                    dst_rc->x1 == dst->params.w &&
                    dst_rc->y1 == dst->params.h;
 
-    tex_barrier(cmd, dst_vk, VK_PIPELINE_STAGE_TRANSFER_BIT,
+    tex_barrier(ra, cmd, dst, VK_PIPELINE_STAGE_TRANSFER_BIT,
                 VK_ACCESS_TRANSFER_WRITE_BIT,
                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 discard);
@@ -1548,6 +1621,9 @@ static void vk_blit(struct ra *ra, struct ra_tex *dst, struct ra_tex *src,
 
     vkCmdBlitImage(cmd->buf, src_vk->img, src_vk->current_layout, dst_vk->img,
                    dst_vk->current_layout, 1, &region, VK_FILTER_NEAREST);
+
+    tex_signal(ra, cmd, src, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    tex_signal(ra, cmd, dst, VK_PIPELINE_STAGE_TRANSFER_BIT);
 }
 
 static void vk_clear(struct ra *ra, struct ra_tex *tex, float color[4],
@@ -1564,7 +1640,7 @@ static void vk_clear(struct ra *ra, struct ra_tex *tex, float color[4],
     struct mp_rect full = {0, 0, tex->params.w, tex->params.h};
     if (!rc || mp_rect_equals(rc, &full)) {
         // To clear the entire image, we can use the efficient clear command
-        tex_barrier(cmd, tex_vk, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_TRANSFER_BIT,
                     VK_ACCESS_TRANSFER_WRITE_BIT,
                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, true);
 
@@ -1574,6 +1650,8 @@ static void vk_clear(struct ra *ra, struct ra_tex *tex, float color[4],
 
         vkCmdClearColorImage(cmd->buf, tex_vk->img, tex_vk->current_layout,
                              &clearColor, 1, &vk_range);
+
+        tex_signal(ra, cmd, tex, VK_PIPELINE_STAGE_TRANSFER_BIT);
     } else {
         // To simulate per-region clearing, we blit from a 1x1 texture instead
         struct ra_tex_upload_params ul_params = {
@@ -1713,7 +1791,7 @@ struct vk_cmd *ra_vk_submit(struct ra *ra, struct ra_tex *tex)
 
     struct ra_tex_vk *tex_vk = tex->priv;
     assert(tex_vk->external_img);
-    tex_barrier(cmd, tex_vk, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
+    tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                 VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, false);
 
     // Return this directly instead of going through vk_submit

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -1849,8 +1849,9 @@ struct vk_cmd *ra_vk_submit(struct ra *ra, struct ra_tex *tex)
 
     struct ra_tex_vk *tex_vk = tex->priv;
     assert(tex_vk->external_img);
-    tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
-                VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, false);
+    tex_barrier(ra, cmd, tex, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                VK_ACCESS_MEMORY_READ_BIT, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                false);
 
     // Return this directly instead of going through vk_submit
     p->cmd = NULL;

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -75,7 +75,7 @@ static void vk_destroy_ra(struct ra *ra)
     struct mpvk_ctx *vk = ra_vk_get(ra);
 
     vk_flush(ra, NULL);
-    mpvk_dev_wait_idle(vk);
+    mpvk_dev_wait_cmds(vk, UINT64_MAX);
     ra_tex_free(ra, &p->clear_tex);
 
     talloc_free(ra);

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -511,6 +511,7 @@ static struct ra_tex *vk_tex_create(struct ra *ra,
                                     const struct ra_tex_params *params)
 {
     struct mpvk_ctx *vk = ra_vk_get(ra);
+    assert(!params->format->dummy_format);
 
     struct ra_tex *tex = talloc_zero(NULL, struct ra_tex);
     tex->params = *params;

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -481,7 +481,7 @@ static bool vk_init_image(struct ra *ra, struct ra_tex *tex)
         VK(vk_create_render_pass(vk->dev, params->format,
                                  VK_ATTACHMENT_LOAD_OP_DONT_CARE,
                                  VK_IMAGE_LAYOUT_UNDEFINED,
-                                 VK_IMAGE_LAYOUT_UNDEFINED,
+                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                                  &tex_vk->dummyPass));
 
         VkFramebufferCreateInfo finfo = {

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -208,8 +208,13 @@ struct ra *ra_create_vk(struct mpvk_ctx *vk, struct mp_log *log)
     ra->max_shmem = vk->limits.maxComputeSharedMemorySize;
     ra->max_pushc_size = vk->limits.maxPushConstantsSize;
 
-    if (vk->pool_compute)
+    if (vk->pool_compute) {
         ra->caps |= RA_CAP_COMPUTE;
+        // If we have more compute queues than graphics queues, we probably
+        // want to be using them. (This seems mostly relevant for AMD)
+        if (vk->pool_compute->num_queues > vk->pool_graphics->num_queues)
+            ra->caps |= RA_CAP_PARALLEL_COMPUTE;
+    }
 
     if (!vk_setup_formats(ra))
         goto error;

--- a/video/out/vulkan/ra_vk.h
+++ b/video/out/vulkan/ra_vk.h
@@ -16,6 +16,10 @@ VkDevice ra_vk_get_dev(struct ra *ra);
 struct ra_tex *ra_vk_wrap_swapchain_img(struct ra *ra, VkImage vkimg,
                                         VkSwapchainCreateInfoKHR info);
 
+// Associates an external semaphore (dependency) with a ra_tex, such that this
+// ra_tex will not be used by the ra_vk until the external semaphore fires.
+void ra_tex_vk_external_dep(struct ra *ra, struct ra_tex *tex, VkSemaphore dep);
+
 // This function finalizes rendering, transitions `tex` (which must be a
 // wrapped swapchain image) into a format suitable for presentation, and returns
 // the resulting command buffer (or NULL on error). The caller may add their

--- a/video/out/vulkan/ra_vk.h
+++ b/video/out/vulkan/ra_vk.h
@@ -18,13 +18,12 @@ struct ra_tex *ra_vk_wrap_swapchain_img(struct ra *ra, VkImage vkimg,
 
 // This function flushes the command buffers, transitions `tex` (which must be
 // a wrapped swapchain image) into a format suitable for presentation, and
-// submits the current rendering commands. The indicated semaphore must fire
-// before the submitted command can run. If `done` is non-NULL, it will be
-// set to a semaphore that fires once the command completes. If `inflight`
+// submits the current rendering commands. `acquired` must fire before the
+// command can run, and `done` will fire after it completes. If `inflight`
 // is non-NULL, it will be incremented when the command starts and decremented
 // when it completes.
 bool ra_vk_submit(struct ra *ra, struct ra_tex *tex, VkSemaphore acquired,
-                  VkSemaphore *done, int *inflight);
+                  VkSemaphore done, int *inflight);
 
 // May be called on a struct ra of any type. Returns NULL if the ra is not
 // a vulkan ra.

--- a/video/out/vulkan/ra_vk.h
+++ b/video/out/vulkan/ra_vk.h
@@ -16,14 +16,11 @@ VkDevice ra_vk_get_dev(struct ra *ra);
 struct ra_tex *ra_vk_wrap_swapchain_img(struct ra *ra, VkImage vkimg,
                                         VkSwapchainCreateInfoKHR info);
 
-// This function flushes the command buffers, transitions `tex` (which must be
-// a wrapped swapchain image) into a format suitable for presentation, and
-// submits the current rendering commands. `acquired` must fire before the
-// command can run, and `done` will fire after it completes. If `inflight`
-// is non-NULL, it will be incremented when the command starts and decremented
-// when it completes.
-bool ra_vk_submit(struct ra *ra, struct ra_tex *tex, VkSemaphore acquired,
-                  VkSemaphore done, int *inflight);
+// This function finalizes rendering, transitions `tex` (which must be a
+// wrapped swapchain image) into a format suitable for presentation, and returns
+// the resulting command buffer (or NULL on error). The caller may add their
+// own semaphores to this command buffer, and must submit it afterwards.
+struct vk_cmd *ra_vk_submit(struct ra *ra, struct ra_tex *tex);
 
 // May be called on a struct ra of any type. Returns NULL if the ra is not
 // a vulkan ra.

--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -519,14 +519,17 @@ bool mpvk_device_init(struct mpvk_ctx *vk, struct mpvk_device_opts opts)
         if (!pool)
             goto error;
         MP_TARRAY_APPEND(NULL, vk->pools, vk->num_pools, pool);
+
+        // Update the pool_* pointers based on the corresponding QF index
+        if (qf == idx_gfx)
+            vk->pool_graphics = pool;
+        if (qf == idx_comp)
+            vk->pool_compute = pool;
+        if (qf == idx_tf)
+            vk->pool_transfer = pool;
     }
 
-    vk->pool_graphics = vk->pools[idx_gfx];
-    vk->pool_compute  = idx_comp >= 0 ? vk->pools[idx_comp] : NULL;
-    vk->pool_transfer = idx_tf   >= 0 ? vk->pools[idx_tf] : NULL;
-
     vk_malloc_init(vk);
-
     talloc_free(tmp);
     return true;
 

--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -395,8 +395,13 @@ static int find_qf(VkQueueFamilyProperties *qfs, int qfnum, VkQueueFlags flags)
         if (!(qfs[i].queueFlags & flags))
             continue;
 
-        // QF is more specialized
-        if (idx < 0 || qfs[i].queueFlags < qfs[idx].queueFlags)
+        // QF is more specialized. Since we don't care about other bits like
+        // SPARSE_BIT, mask the ones we're interestew in
+        const VkQueueFlags mask = VK_QUEUE_GRAPHICS_BIT |
+                                  VK_QUEUE_TRANSFER_BIT |
+                                  VK_QUEUE_COMPUTE_BIT;
+
+        if (idx < 0 || (qfs[i].queueFlags & mask) < (qfs[idx].queueFlags & mask))
             idx = i;
 
         // QF has more queues (at the same specialization level)

--- a/video/out/vulkan/utils.h
+++ b/video/out/vulkan/utils.h
@@ -60,17 +60,15 @@ struct mpvk_device_opts {
 // Create a logical device and initialize the vk_cmdpools
 bool mpvk_device_init(struct mpvk_ctx *vk, struct mpvk_device_opts opts);
 
-// Wait until all commands submitted to all queues have completed
-void mpvk_pool_wait_idle(struct mpvk_ctx *vk, struct vk_cmdpool *pool);
-void mpvk_dev_wait_idle(struct mpvk_ctx *vk);
-
-// Wait until at least one command submitted to any queue has completed, and
-// process the callbacks. Good for event loops that need to delay until a
-// command completes. Will block at most `timeout` nanoseconds. If used with
-// 0, it only garbage collects completed commands without blocking.
-void mpvk_pool_poll_cmds(struct mpvk_ctx *vk, struct vk_cmdpool *pool,
+// Wait for all currently pending commands to have completed. This is the only
+// function that actually processes the callbacks. Will wait at most `timeout`
+// nanoseconds for the completion of each command. Using it with a value of
+// UINT64_MAX effectively means waiting until the pool/device is idle. The
+// timeout may also be passed as 0, in which case this function will not block,
+// but only poll for completed commands.
+void mpvk_pool_wait_cmds(struct mpvk_ctx *vk, struct vk_cmdpool *pool,
                          uint64_t timeout);
-void mpvk_dev_poll_cmds(struct mpvk_ctx *vk, uint32_t timeout);
+void mpvk_dev_wait_cmds(struct mpvk_ctx *vk, uint64_t timeout);
 
 // Since lots of vulkan operations need to be done lazily once the affected
 // resources are no longer in use, provide an abstraction for tracking these.
@@ -88,19 +86,18 @@ struct vk_callback {
 // This will essentially run once the device is completely idle.
 void vk_dev_callback(struct mpvk_ctx *vk, vk_cb callback, void *p, void *arg);
 
-#define MPVK_MAX_CMD_DEPS 8
-
 // Helper wrapper around command buffers that also track dependencies,
 // callbacks and synchronization primitives
 struct vk_cmd {
     struct vk_cmdpool *pool; // pool it was allocated from
-    VkCommandBuffer buf;
-    VkFence fence; // the fence guards cmd buffer reuse
-    VkSemaphore done; // the semaphore signals when execution is done
+    VkQueue queue;           // the submission queue (for recording/pending)
+    VkCommandBuffer buf;     // the command buffer itself
+    VkFence fence;           // the fence guards cmd buffer reuse
+    VkSemaphore done;        // the semaphore signals when execution is done
     // The semaphores represent dependencies that need to complete before
     // this command can be executed. These are *not* owned by the vk_cmd
-    VkSemaphore deps[MPVK_MAX_CMD_DEPS];
-    VkPipelineStageFlags depstages[MPVK_MAX_CMD_DEPS];
+    VkSemaphore *deps;
+    VkPipelineStageFlags *depstages;
     int num_deps;
     // Since VkFences are useless, we have to manually track "callbacks"
     // to fire once the VkFence completes. These are used for multiple purposes,
@@ -118,30 +115,29 @@ void vk_cmd_callback(struct vk_cmd *cmd, vk_cb callback, void *p, void *arg);
 void vk_cmd_dep(struct vk_cmd *cmd, VkSemaphore dep,
                 VkPipelineStageFlags depstage);
 
-#define MPVK_MAX_QUEUES 8
-#define MPVK_MAX_CMDS 64
-
 // Command pool / queue family hybrid abstraction
 struct vk_cmdpool {
     VkQueueFamilyProperties props;
-    uint32_t qf; // queue family index
+    int qf; // queue family index
     VkCommandPool pool;
-    VkQueue queues[MPVK_MAX_QUEUES];
-    int qcount;
-    int qindex;
+    VkQueue *queues;
+    int num_queues;
+    int idx_queues;
     // Command buffers associated with this queue
-    struct vk_cmd cmds[MPVK_MAX_CMDS];
-    int cindex;
-    int cindex_pending;
+    struct vk_cmd **cmds_available; // available for re-recording
+    struct vk_cmd **cmds_pending;   // submitted but not completed
+    int num_cmds_available;
+    int num_cmds_pending;
 };
 
-// Fetch the next command buffer from a command pool and begin recording to it.
+// Fetch a command buffer from a command pool and begin recording to it.
 // Returns NULL on failure.
 struct vk_cmd *vk_cmd_begin(struct mpvk_ctx *vk, struct vk_cmdpool *pool);
 
-// Finish the currently recording command buffer and submit it for execution.
+// Finish recording a command buffer and submit it for execution. This function
+// takes over ownership of *cmd, i.e. the caller should not touch it again.
 // If `done` is not NULL, it will be set to a semaphore that will signal once
-// the command completes. (And MUST have a corresponding semaphore wait)
+// the command completes.
 // Returns whether successful.
 bool vk_cmd_submit(struct mpvk_ctx *vk, struct vk_cmd *cmd, VkSemaphore *done);
 

--- a/video/out/vulkan/utils.h
+++ b/video/out/vulkan/utils.h
@@ -55,6 +55,8 @@ bool mpvk_pick_surface_format(struct mpvk_ctx *vk);
 
 struct mpvk_device_opts {
     int queue_count;    // number of queues to use
+    int async_transfer; // enable async transfer
+    int async_compute;  // enable async compute
 };
 
 // Create a logical device and initialize the vk_cmdpools


### PR DESCRIPTION
This improves on the major shortcomings of the ver1 design and enables full use of async transfers, async compute, multi-command queueing, event-based image barriers, safe FBO invalidation, better implicit renderpass layout transitions and more (tm).

It turns out that the VkSemaphore deadlock issue was an nvidia driver bug. This approach works after all, and scales well - especially now that I've refactored it to avoid using VkSemaphores for intra-frame dependencies as much as possible. There is now virtually no performance drop as a result of this refactor even without the fancy async transfer stuff. (And with async transfer on top, the performance goes through the roof again)

I probably won't actually merge this until the fixes for the nvidia deadlock issue make it into an actual driver release, but it would be good to get some testing (on other platforms) and code review out of the way.

NOTE: This is still not entirely optimal. Improvement avenues:

1. Try and avoid over-abusing CONCURRENT sharing mode (hard)
2. Try and avoid using VkEvents in trivial scenarios (instead use pipeline barriers). (trivial)
3. Try recreating VkSemaphores and re-using the VkEvents instead for already-submitted signals. (trivial)
4. Try improving the logic for when to split the command buffers to maximize performance. (easy-ish but annoying)
5. Try updating buffers from different queues depending on their type. (medium)
6. Try and use LOAD_OP_CLEAR to clear color attachments instead of doing the stupid 1x1 blit / vkClear thing. (easy-medium)
7. Allow recording timestamps from the COMPUTE queue as well as the GRAPHICS queue, to avoid over-submitting tiny command buffers. This should especially help for async compute. (easy)

And probably more that I've forgotten. Let the hate commence!