### PR TITLE
VO shablo

### DIFF
--- a/Copyright
+++ b/Copyright
@@ -113,6 +113,7 @@ The following files are still GPL:
     video/out/opengl/hwdec_vaglx.c  GPL
     video/out/vo_caca.c             unknown
     video/out/vo_direct3d.c         unknown
+    video/out/vo_shablo.c           LGPL
     video/out/vo_vaapi.c            probably impossible (some company's code)
     video/out/vo_vdpau.c            probably impossible (nVidia's code)
     video/out/vo_x11.c              probably impossible

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -433,97 +433,104 @@ Available video output drivers are:
         The names of the first 8 normal ANSI colors (0-7) and their light
         versions (8-F) are:
 
-            normal | light | color name
-            ---------------------------
-            0      |  8    | black
-            1      |  9    | red
-            2      |  A    | green
-            3      |  B    | yellow
-            4      |  C    | blue
-            5      |  D    | magenta
-            6      |  E    | cyan
-            7      |  F    | white
+            ======   =====   ==========
+            normal   light   color name
+            0        8       black
+            1        9       red
+            2        A       green
+            3        B       yellow
+            4        C       blue
+            5        D       magenta
+            6        E       cyan
+            7        F       white
+            ======   =====   ==========
 
         Available palettes with their 8 normal and 8 light #RRGGBB colors values
         are:
 
         vga
-            normal colors   light colors
-            -------------   ------------
-            0 | #444444     8 | #555555
-            1 | #aa0000     9 | #ff5555
-            2 | #00aa00     A | #55ff55
-            3 | #aa5500     B | #ffff55
-            4 | #0000aa     C | #5555ff
-            5 | #aa00aa     D | #ff55ff
-            6 | #00aaaa     E | #55ffff
-            7 | #aaaaaa     F | #ffffff
+            =   =======   =   =======
+            0   #444444   8   #555555
+            1   #aa0000   9   #ff5555
+            2   #00aa00   A   #55ff55
+            3   #aa5500   B   #ffff55
+            4   #0000aa   C   #5555ff
+            5   #aa00aa   D   #ff55ff
+            6   #00aaaa   E   #55ffff
+            7   #aaaaaa   F   #ffffff
+            =   =======   =   =======
+
         cmd
-            normal colors   light colors
-            -------------   ------------
-            0 | #000000     8 | #808080
-            1 | #800000     9 | #ff0000
-            2 | #008000     A | #00ff00
-            3 | #808000     B | #ffff00
-            4 | #000080     C | #0000ff
-            5 | #800080     D | #ff00ff
-            6 | #008080     E | #00ffff
-            7 | #c0c0c0     F | #ffffff
+            =   =======   =   =======
+            0   #000000   8   #808080
+            1   #800000   9   #ff0000
+            2   #008000   A   #00ff00
+            3   #808000   B   #ffff00
+            4   #000080   C   #0000ff
+            5   #800080   D   #ff00ff
+            6   #008080   E   #00ffff
+            7   #c0c0c0   F   #ffffff
+            =   =======   =   =======
+
         termapp
-            normal colors   light colors
-            -------------   ------------
-            0 | #000000     8 | #818383
-            1 | #c23621     9 | #fc391f
-            2 | #25bc26     A | #31e722
-            3 | #adad27     B | #eaec23
-            4 | #492ee1     C | #5833ff
-            5 | #d338d3     D | #f935f8
-            6 | #33bbc8     E | #14f0f0
-            7 | #cbcccd     F | #e9ebeb
+            =   =======   =   =======
+            0   #000000   8   #818383
+            1   #c23621   9   #fc391f
+            2   #25bc26   A   #31e722
+            3   #adad27   B   #eaec23
+            4   #492ee1   C   #5833ff
+            5   #d338d3   D   #f935f8
+            6   #33bbc8   E   #14f0f0
+            7   #cbcccd   F   #e9ebeb
+            =   =======   =   =======
+
         putty
-            normal colors   light colors
-            -------------   ------------
-            0 | #000000     8 | #555555
-            1 | #bb0000     9 | #ff5555
-            2 | #00bb00     A | #55ff55
-            3 | #bbbb00     B | #ffff55
-            4 | #0000bb     C | #5555ff
-            5 | #bb00bb     D | #ff55ff
-            6 | #00bbbb     E | #55ffff
-            7 | #bbbbbb     F | #ffffff
+            =   =======   =   =======
+            0   #000000   8   #555555
+            1   #bb0000   9   #ff5555
+            2   #00bb00   A   #55ff55
+            3   #bbbb00   B   #ffff55
+            4   #0000bb   C   #5555ff
+            5   #bb00bb   D   #ff55ff
+            6   #00bbbb   E   #55ffff
+            7   #bbbbbb   F   #ffffff
+            =   =======   =   =======
+
         mirc
-            normal colors   light colors
-            -------------   ------------
-            0 | #000000     8 | #7f7f7f
-            1 | #7f0000     9 | #ff0000
-            2 | #009300     A | #00fc00
-            3 | #fc7f00     B | #ffff00
-            4 | #00007f     C | #0000fc
-            5 | #9c009c     D | #ff00ff
-            6 | #009393     E | #00ffff
-            7 | #d2d2d2     F | #ffffff
+            =   =======   =   =======
+            0   #000000   8   #7f7f7f
+            1   #7f0000   9   #ff0000
+            2   #009300   A   #00fc00
+            3   #fc7f00   B   #ffff00
+            4   #00007f   C   #0000fc
+            5   #9c009c   D   #ff00ff
+            6   #009393   E   #00ffff
+            7   #d2d2d2   F   #ffffff
+            =   =======   =   =======
+
         xterm
-            normal colors   light colors
-            -------------   ------------
-            0 | #000000     8 | #7f7f7f
-            1 | #cd0000     9 | #ff0000
-            2 | #00cd00     A | #00ff00
-            3 | #cdcd00     B | #ffff00
-            4 | #0000ee     C | #5c5cff
-            5 | #cd00cd     D | #ff00ff
-            6 | #00cdcd     E | #00ffff
-            7 | #e5e5e5     F | #ffffff
+            =   =======   =   =======
+            0   #000000   8   #7f7f7f
+            1   #cd0000   9   #ff0000
+            2   #00cd00   A   #00ff00
+            3   #cdcd00   B   #ffff00
+            4   #0000ee   C   #5c5cff
+            5   #cd00cd   D   #ff00ff
+            6   #00cdcd   E   #00ffff
+            7   #e5e5e5   F   #ffffff
+            =   =======   =   =======
+
         human
-            normal colors   light colors
-            -------------   ------------
-            0 | #010101     8 | #808080
-            1 | #de382b     9 | #ff0000
-            2 | #39b54a     A | #00ff00
-            3 | #ffc706     B | #ffff00
-            4 | #006fb8     C | #0000ff
-            5 | #762671     D | #ff00ff
-            6 | #2cb5e9     E | #00ffff
-            7 | #cccccc     F | #ffffff
+            =   =======   =   =======
+            0   #010101   8   #808080
+            1   #de382b   9   #ff0000
+            2   #39b54a   A   #00ff00
+            3   #ffc706   B   #ffff00
+            4   #006fb8   C   #0000ff
+            5   #762671   D   #ff00ff
+            6   #2cb5e9   E   #00ffff
+            7   #cccccc   F   #ffffff
+            =   =======   =   =======
 
     ``--vo-shablo-dithering=<algo>`` (default: none)
         Use a color dithering algorithm to compensate for loss in color depth.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -417,10 +417,8 @@ Available video output drivers are:
         Assume each block of the terminal has the specified width (i.e. number
         of horizontal pixels).
 
-    ``--vo-shablo-color-depth-per-channel=<1-8>`` (default: 6)
-        Set the maximum color depth for each of the RGB channels.
-        The bigger the value, the better the result but also the more time and
-        memory will be needed at startup process.
+    ``--vo-shablo-lazy=<yes|no>`` (default: yes)
+        Do not precalculate an internal lookup table (reduces startup time).
 
     ``--vo-shablo-color-palette-preset=<preset>`` (default: vga)
         Assume the 8 (or 16) terminal colors look like the colors in the preset

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -425,6 +425,43 @@ Available video output drivers are:
         The bigger the value, the better the result but also the more time and
         memory will be needed at startup process.
 
+    ``--vo-shablo-color-palette-preset=<preset>`` (default: vga)
+        Assume the 8 (or 16) terminal colors look like the colors in the preset
+        <preset>.
+
+        .. note:: This is probably the most important switch since a wrong
+                  color palette could lead to color distortion.
+                  Make sure you get a palette that fits your terminal colors.
+
+        The names of the first 8 normal ANSI colors (0-7) and their light
+        versions (8-F) are:
+
+            normal | light | color name
+            ---------------------------
+            0      |  8    | black
+            1      |  9    | red
+            2      |  A    | green
+            3      |  B    | yellow
+            4      |  C    | blue
+            5      |  D    | magenta
+            6      |  E    | cyan
+            7      |  F    | white
+
+        Available palettes with their 8 normal and 8 light #RRGGBB colors values
+        are:
+
+        vga
+            normal colors   light colors
+            -------------   ------------
+            0 | #444444     8 | #555555
+            1 | #aa0000     9 | #ff5555
+            2 | #00aa00     A | #55ff55
+            3 | #aa5500     B | #ffff55
+            4 | #0000aa     C | #5555ff
+            5 | #aa00aa     D | #ff55ff
+            6 | #00aaaa     E | #55ffff
+            7 | #aaaaaa     F | #ffffff
+
     ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
         Assume that the terminal is capable of 16 background colors instead
         of 8.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -409,9 +409,6 @@ Available video output drivers are:
     U+2593, U+2588) and of ANSI-color terminals (8 colors or 16 colors).
     On Windows it requires an ANSI terminal such as mintty.
 
-    Currently, it is assumed that the 8 or 16 ANSI colors of the terminal look
-    like the VGA colors.
-
     ``--vo-shablo-block-height=<height>`` (default: 16)
         Assume each block of the terminal has the specified height (i.e. number
         of vertical pixels).

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -409,8 +409,8 @@ Available video output drivers are:
     U+2593, U+2588) and of ANSI-color terminals (8 colors or 16 colors).
     On Windows it requires an ANSI terminal such as mintty.
 
-    Currently, it is assumed that the ANSI colors of the terminal look like the
-    VGA colors. Also, only the first 8 ANSI colors of them are supported.
+    Currently, it is assumed that the 8 or 16 ANSI colors of the terminal look
+    like the VGA colors.
 
     ``--vo-shablo-block-height=<height>`` (default: 16)
         Assume each block of the terminal has the specified height (i.e. number
@@ -424,6 +424,22 @@ Available video output drivers are:
         Set the maximum color depth for each of the RGB channels.
         The bigger the value, the better the result but also the more time and
         memory will be needed at startup process.
+
+    ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
+        Assume that the terminal is capable of 16 background colors instead
+        of 8.
+
+        .. note:: Make sure the terminal can display all the 8 additional
+                  light background colors.
+                  Otherwise, the result might appear darker or weird.
+
+    ``--vo-shablo-fg-ext=<yes|no>`` (default: no)
+        Assume that the terminal is capable of 16 foreground colors instead
+        of 8.
+
+        .. note:: Make sure the terminal can display all the 8 additional
+                  light foreground colors.
+                  Otherwise, the result might appear darker or weird.
 
     ``--vo-shablo-width=<width>``  ``--vo-shablo-height=<height>``
         Assume the terminal has the specified character width and/or height.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -525,6 +525,17 @@ Available video output drivers are:
             6 | #2cb5e9     E | #00ffff
             7 | #cccccc     F | #ffffff
 
+    ``--vo-shablo-dithering=<algo>`` (default: none)
+        Use a color dithering algorithm to compensate for loss in color depth.
+
+        The lower the resolution is the more it will look like artifacts.
+        See ``--vo-shablo-width`` and `--vo-shablo-height`.
+
+        Following algorithms are available:
+
+        none
+            No dithering.
+
     ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
         Assume that the terminal is capable of 16 background colors instead
         of 8.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -535,6 +535,8 @@ Available video output drivers are:
 
         none
             No dithering.
+        fs
+            Dithering algorithm by Floyd and Steinberg.
 
     ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
         Assume that the terminal is capable of 16 background colors instead

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -400,6 +400,19 @@ Available video output drivers are:
     ``--vo-tct-256=<yes|no>`` (default: no)
         Use 256 colors - for terminals which don't support true color.
 
+``shablo`` (experimental; perhaps will be merged with tct)
+    ANSI-color Unicode art video output driver that works on a text console.
+    Different colors are emulated by combining differently shaded blocks with
+    different foreground and background colors.
+
+    Depends on support of Unicode characters for shaded blocks (U+2591, U+2592,
+    U+2593, U+2588) and of ANSI-color terminals (8 colors or 16 colors).
+    On Windows it requires an ANSI terminal such as mintty.
+
+    ``--vo-shablo-width=<width>``  ``--vo-shablo-height=<height>``
+        Assume the terminal has the specified character width and/or height.
+        These default to 80x25 if the terminal size cannot be determined.
+
 ``image``
     Output each frame into an image file in the current directory. Each file
     takes the frame number padded with leading zeros as name.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -461,6 +461,72 @@ Available video output drivers are:
             5 | #aa00aa     D | #ff55ff
             6 | #00aaaa     E | #55ffff
             7 | #aaaaaa     F | #ffffff
+        cmd
+            normal colors   light colors
+            -------------   ------------
+            0 | #000000     8 | #808080
+            1 | #800000     9 | #ff0000
+            2 | #008000     A | #00ff00
+            3 | #808000     B | #ffff00
+            4 | #000080     C | #0000ff
+            5 | #800080     D | #ff00ff
+            6 | #008080     E | #00ffff
+            7 | #c0c0c0     F | #ffffff
+        termapp
+            normal colors   light colors
+            -------------   ------------
+            0 | #000000     8 | #818383
+            1 | #c23621     9 | #fc391f
+            2 | #25bc26     A | #31e722
+            3 | #adad27     B | #eaec23
+            4 | #492ee1     C | #5833ff
+            5 | #d338d3     D | #f935f8
+            6 | #33bbc8     E | #14f0f0
+            7 | #cbcccd     F | #e9ebeb
+        putty
+            normal colors   light colors
+            -------------   ------------
+            0 | #000000     8 | #555555
+            1 | #bb0000     9 | #ff5555
+            2 | #00bb00     A | #55ff55
+            3 | #bbbb00     B | #ffff55
+            4 | #0000bb     C | #5555ff
+            5 | #bb00bb     D | #ff55ff
+            6 | #00bbbb     E | #55ffff
+            7 | #bbbbbb     F | #ffffff
+        mirc
+            normal colors   light colors
+            -------------   ------------
+            0 | #000000     8 | #7f7f7f
+            1 | #7f0000     9 | #ff0000
+            2 | #009300     A | #00fc00
+            3 | #fc7f00     B | #ffff00
+            4 | #00007f     C | #0000fc
+            5 | #9c009c     D | #ff00ff
+            6 | #009393     E | #00ffff
+            7 | #d2d2d2     F | #ffffff
+        xterm
+            normal colors   light colors
+            -------------   ------------
+            0 | #000000     8 | #7f7f7f
+            1 | #cd0000     9 | #ff0000
+            2 | #00cd00     A | #00ff00
+            3 | #cdcd00     B | #ffff00
+            4 | #0000ee     C | #5c5cff
+            5 | #cd00cd     D | #ff00ff
+            6 | #00cdcd     E | #00ffff
+            7 | #e5e5e5     F | #ffffff
+        human
+            normal colors   light colors
+            -------------   ------------
+            0 | #010101     8 | #808080
+            1 | #de382b     9 | #ff0000
+            2 | #39b54a     A | #00ff00
+            3 | #ffc706     B | #ffff00
+            4 | #006fb8     C | #0000ff
+            5 | #762671     D | #ff00ff
+            6 | #2cb5e9     E | #00ffff
+            7 | #cccccc     F | #ffffff
 
     ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
         Assume that the terminal is capable of 16 background colors instead

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -409,6 +409,9 @@ Available video output drivers are:
     U+2593, U+2588) and of ANSI-color terminals (8 colors or 16 colors).
     On Windows it requires an ANSI terminal such as mintty.
 
+    Currently, it is assumed that the ANSI colors of the terminal look like the
+    VGA colors. Also, only the first 8 ANSI colors of them are supported.
+
     ``--vo-shablo-block-height=<height>`` (default: 16)
         Assume each block of the terminal has the specified height (i.e. number
         of vertical pixels).
@@ -416,6 +419,11 @@ Available video output drivers are:
     ``--vo-shablo-block-width=<width>`` (default: 8)
         Assume each block of the terminal has the specified width (i.e. number
         of horizontal pixels).
+
+    ``--vo-shablo-color-depth-per-channel=<1-8>`` (default: 6)
+        Set the maximum color depth for each of the RGB channels.
+        The bigger the value, the better the result but also the more time and
+        memory will be needed at startup process.
 
     ``--vo-shablo-width=<width>``  ``--vo-shablo-height=<height>``
         Assume the terminal has the specified character width and/or height.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -409,6 +409,14 @@ Available video output drivers are:
     U+2593, U+2588) and of ANSI-color terminals (8 colors or 16 colors).
     On Windows it requires an ANSI terminal such as mintty.
 
+    ``--vo-shablo-block-height=<height>`` (default: 16)
+        Assume each block of the terminal has the specified height (i.e. number
+        of vertical pixels).
+
+    ``--vo-shablo-block-width=<width>`` (default: 8)
+        Assume each block of the terminal has the specified width (i.e. number
+        of horizontal pixels).
+
     ``--vo-shablo-width=<width>``  ``--vo-shablo-height=<height>``
         Assume the terminal has the specified character width and/or height.
         These default to 80x25 if the terminal size cannot be determined.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -537,6 +537,8 @@ Available video output drivers are:
             No dithering.
         fs
             Dithering algorithm by Floyd and Steinberg.
+        jjn
+            Dithering algorithm by Jarvis, Judice and Ninke.
 
     ``--vo-shablo-bg-ext=<yes|no>`` (default: no)
         Assume that the terminal is capable of 16 background colors instead

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -64,6 +64,7 @@ extern const struct vo_driver video_out_vaapi;
 extern const struct vo_driver video_out_wayland;
 extern const struct vo_driver video_out_rpi;
 extern const struct vo_driver video_out_tct;
+extern const struct vo_driver video_out_shablo;
 
 const struct vo_driver *const video_out_drivers[] =
 {
@@ -96,6 +97,7 @@ const struct vo_driver *const video_out_drivers[] =
     // should not be auto-selected
     &video_out_image,
     &video_out_tct,
+    &video_out_shablo,
 #if HAVE_CACA
     &video_out_caca,
 #endif

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -143,7 +143,8 @@ struct priv {
 };
 
 /* shade characters */
-static char* SHADE_CHARS[SHADES] = {
+static char* SHADE_CHARS[SHADES] =
+{
     " ", "\xe2\x96\x91", "\xe2\x96\x92", "\xe2\x96\x93", "\xe2\x96\x88"
 };
 
@@ -202,9 +203,15 @@ static uint32_t BASE_COLORS[COLOR_PALETTE_PRESETS][EXT_PALETTE_SIZE] =
 };
 
 /* used colors */
-static size_t fg_colors; // number of available foreground colors
-static size_t bg_colors; // number of available background colors
-static size_t color_palette_preset; // index of preset color palette
+
+// number of available foreground colors
+static size_t fg_colors;
+
+// number of available background colors
+static size_t bg_colors;
+
+// index of preset color palette
+static size_t color_palette_preset;
 
 /* used for quick calculations during playback */
 static uint8_t depth_mask;
@@ -236,19 +243,23 @@ static size_t reduced_fg_bg_sh_palette_indices_size;
 // the lab values (L*, a*, b*) of the reduced palette
 static double* reduced_fg_bg_sh_palette_lab = NULL;
 
-static int min_int(int a, int b) {
+static int min_int(int a, int b)
+{
     return a < b ? a : b;
 }
 
-static int max_int(int a, int b) {
+static int max_int(int a, int b)
+{
     return a > b ? a : b;
 }
 
-static double min_double(double a, double b) {
+static double min_double(double a, double b)
+{
     return a < b ? a : b;
 }
 
-static double max_double(double a, double b) {
+static double max_double(double a, double b)
+{
     return a > b ? a : b;
 }
 
@@ -259,7 +270,8 @@ static uint8_t* lookup_fg_bg_sh_2_ch_intensity_map(
         (bg + bg_colors * (fg))));
 }
 
-static uint16_t fg_bg_sh_2_shfgbg(uint8_t fg, uint8_t bg, uint8_t sh) {
+static uint16_t fg_bg_sh_2_shfgbg(uint8_t fg, uint8_t bg, uint8_t sh)
+{
     return ((uint16_t) sh << 8) | ((uint16_t) fg << 4) | ((uint16_t) bg);
 }
 
@@ -290,13 +302,15 @@ static void r_g_b_2_fg_bg_sh(uint8_t r, uint8_t g, uint8_t b,
     shfgbg_2_fg_bg_sh(shfgbg, fg, bg, sh);
 }
 
-static void rgb_2_r_g_b(uint32_t rgb, uint8_t* r, uint8_t* g, uint8_t* b) {
+static void rgb_2_r_g_b(uint32_t rgb, uint8_t* r, uint8_t* g, uint8_t* b)
+{
     *r = (rgb >> 16) & 0xff;
     *g = (rgb >> 8) & 0xff;
     *b = rgb & 0xff;
 }
 
-static uint32_t color_idx_2_rgb(uint8_t color_idx) {
+static uint32_t color_idx_2_rgb(uint8_t color_idx)
+{
     return BASE_COLORS[color_palette_preset][color_idx];
 }
 
@@ -310,7 +324,8 @@ static void color_idx_2_r_g_b(uint8_t color_idx,
 // The question to answer here is: What does (fg, bg, sh) look like,
 //     expressed as an RGB color?
 // Precondition: fg_colors and bg_colors must be initialized
-static uint8_t* calc_fg_bg_sh_ch_2_intensity_map(void) {
+static uint8_t* calc_fg_bg_sh_ch_2_intensity_map(void)
+{
     uint8_t *result = calloc(fg_bg_sh_ch_2_intensity_map_size,
         COLOR_CHANNELS * sizeof(uint8_t));
     if (result == NULL) {
@@ -374,7 +389,8 @@ static void r_g_b_2_x_y_z(uint8_t red, uint8_t green, uint8_t blue,
 #define Z_N_D65_2DEG 108.883
 
 // helper function to calculate cbrt(p/p_n) for CIELAB
-static double lab_cbrt(double p, double p_n) {
+static double lab_cbrt(double p, double p_n)
+{
     double ppn = p / p_n;
     return ppn < (216.0 / 24389.0) ?
         ((1.0 / 116.0) * (24389.0 / 27.0 * p / p_n + 16.0)) :
@@ -405,7 +421,8 @@ static void r_g_b_2_l_a_b(uint8_t r, uint8_t g, uint8_t b,
 }
 
 // sRGB to YUV: Y = 0.299 * R + 0.587 * G + 0.114 * B
-static double r_g_b_2_y(uint8_t r, uint8_t g, uint8_t b) {
+static double r_g_b_2_y(uint8_t r, uint8_t g, uint8_t b)
+{
     double sr = (double) r / 255.0;
     double sg = (double) g / 255.0;
     double sb = (double) b / 255.0;
@@ -426,7 +443,8 @@ static double get_y_dist_between_index_colors(
     return fabs(y2 - y1);
 }
 
-static bool is_gray(uint8_t r, uint8_t g, uint8_t b) {
+static bool is_gray(uint8_t r, uint8_t g, uint8_t b)
+{
     return r == g && g == b;
 }
 
@@ -550,8 +568,8 @@ static void calc_reduced_emulated_color_palette_helper(
 //    fg_colors and
 //    bg_colors must be initialized.
 static void calc_reduced_emulated_color_palette(
-    size_t* result_size, uint16_t** result
-) {
+    size_t* result_size, uint16_t** result)
+{
     uint16_t* res = calloc(fg_bg_sh_ch_2_intensity_map_size, sizeof(uint16_t));
     if (res == NULL) {
         result = NULL;
@@ -580,7 +598,8 @@ static void calc_reduced_emulated_color_palette(
 }
 
 // Calculates the CIELAB color values of the emulated color palette.
-static double* reduced_emulated_color_palette_to_lab(void) {
+static double* reduced_emulated_color_palette_to_lab(void)
+{
     double* res = calloc(reduced_fg_bg_sh_palette_indices_size,
         sizeof(double) * COLOR_CHANNELS);
     if (res == NULL) {
@@ -609,7 +628,8 @@ static double* reduced_emulated_color_palette_to_lab(void) {
 
 // Calculates the main lookup table (rgb -> shfgbg) by approximating
 // the rgb color using nearest neighbour applied in CIELAB color space.
-static uint16_t* calc_lookup_table(void) {
+static uint16_t* calc_lookup_table(void)
+{
     uint16_t* result = calloc(depth_size * depth_size * depth_size,
         sizeof(uint16_t));
     if (result == NULL) {
@@ -667,7 +687,8 @@ static uint16_t* calc_lookup_table(void) {
 
 // Initializes color palettes.
 static bool init(int new_color_palette_preset, int depth_per_channel,
-        bool light_fg_allowed, bool light_bg_allowed) {
+    bool light_fg_allowed, bool light_bg_allowed)
+{
     if (r_g_b_2_shfgbg_map != NULL) {
         return true;
     }
@@ -779,7 +800,8 @@ static bool prepare_color_error_array(size_t width, size_t height,
 }
 
 // Goes to the next entity for error diffusion dithering.
-static void dithering_advance_head(void) {
+static void dithering_advance_head(void)
+{
     int* advanced_head = color_error_head + COLOR_CHANNELS;
 
     // check edges
@@ -797,14 +819,16 @@ static void dithering_advance_head(void) {
 
 // Accumulates the error diffusion dithering error onto
 //     call-by-reference RGB values.
-static void dithering_pull_error(uint8_t* r, uint8_t* g, uint8_t* b) {
+static void dithering_pull_error(uint8_t* r, uint8_t* g, uint8_t* b)
+{
     *r = max_int(min_int((int) (*r) + color_error_head[CH_R], 0xff), 0);
     *g = max_int(min_int((int) (*g) + color_error_head[CH_G], 0xff), 0);
     *b = max_int(min_int((int) (*b) + color_error_head[CH_B], 0xff), 0);
 }
 
 // Little helper for Floyd&Steinberg dithering.
-static int dithering_fs_helper(int e) {
+static int dithering_fs_helper(int e)
+{
     return ((e >> 3) + 1) >> 1;
 }
 
@@ -851,7 +875,8 @@ static void dithering_fs_push_error(
 }
 
 // Little helper for Jarvis&Judice&Ninke dithering.
-static int dithering_jjn_helper(int e) {
+static int dithering_jjn_helper(int e)
+{
     return (e + 24) / 48;
 }
 
@@ -1018,7 +1043,8 @@ static void write_shaded(
     printf("\n");
 }
 
-static void get_win_size(struct vo *vo, int *out_width, int *out_height) {
+static void get_win_size(struct vo *vo, int *out_width, int *out_height)
+{
     struct priv *p = vo->priv;
     *out_width = DEFAULT_WIDTH;
     *out_height = DEFAULT_HEIGHT;

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -1,0 +1,239 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <config.h>
+
+#if HAVE_POSIX
+#include <sys/ioctl.h>
+#endif
+
+#include <libswscale/swscale.h>
+
+#include "options/m_config.h"
+#include "config.h"
+#include "vo.h"
+#include "sub/osd.h"
+#include "video/sws_utils.h"
+#include "video/mp_image.h"
+
+#define IMGFMT IMGFMT_BGR24
+
+#define ESC_HIDE_CURSOR "\e[?25l"
+#define ESC_RESTORE_CURSOR "\e[?25h"
+#define ESC_CLEAR_SCREEN "\e[2J"
+#define ESC_CLEAR_COLORS "\e[0m"
+#define ESC_GOTOXY "\e[%d;%df"
+#define ESC_COLOR8_BG "\e[4%cm"
+
+#define DEFAULT_WIDTH 80
+#define DEFAULT_HEIGHT 25
+
+struct vo_shablo_opts {
+    int width;   // 0 -> default
+    int height;  // 0 -> default
+};
+
+#define OPT_BASE_STRUCT struct vo_shablo_opts
+static const struct m_sub_options vo_shablo_conf = {
+    .opts = (const m_option_t[]) {
+        OPT_INT("vo-shablo-width", width, 0),
+        OPT_INT("vo-shablo-height", height, 0),
+        {0}
+    },
+    .defaults = &(const struct vo_shablo_opts) {
+    },
+    .size = sizeof(struct vo_shablo_opts),
+};
+
+struct priv {
+    struct vo_shablo_opts *opts;
+    size_t buffer_size;
+    char *buffer;
+    int swidth;
+    int sheight;
+    struct mp_image *frame;
+    struct mp_rect src;
+    struct mp_rect dst;
+    struct mp_sws_context *sws;
+};
+
+static void r_g_b_2_bg(uint8_t r, uint8_t g, uint8_t b, uint8_t* bg) {
+    *bg = ((r >= 0x80) ? 1 : 0) | ((g >= 0x80) ? 2 : 0) | ((b >= 0x80) ? 4 : 0);
+}
+
+// Writes the source image to stdout.
+static void write_shaded(
+    const int dwidth, const int dheight,
+    const int swidth, const int sheight,
+    const unsigned char *source, const int source_stride)
+{
+    assert(source);
+
+    // the big loops
+    const int tx = (dwidth - swidth) >> 1;
+    const int ty = (dheight - sheight) >> 1;
+    for (int y = 0; y < sheight; y++) {
+        const unsigned char *row = source + y * source_stride;
+        printf(ESC_GOTOXY, ty + y, tx);
+        for (int x = 0; x < swidth; x++) {
+            printf(ESC_CLEAR_COLORS);
+            unsigned char b = *row++;
+            unsigned char g = *row++;
+            unsigned char r = *row++;
+
+            // deduce color emulation
+            uint8_t bg_idx;
+            r_g_b_2_bg(r, g, b, &bg_idx);
+
+            // draw
+            unsigned char bg = '0' | (bg_idx & 0x7);
+
+            // draw bg color
+            printf(ESC_COLOR8_BG, bg);
+
+            // draw shade char
+            printf(" ");
+        }
+        printf(ESC_CLEAR_COLORS);
+    }
+    printf("\n");
+}
+
+static void get_win_size(struct vo *vo, int *out_width, int *out_height) {
+    struct priv *p = vo->priv;
+    *out_width = DEFAULT_WIDTH;
+    *out_height = DEFAULT_HEIGHT;
+#if HAVE_POSIX
+    struct winsize winsize;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &winsize) >= 0) {
+        *out_width = winsize.ws_col;
+        *out_height = winsize.ws_row;
+    }
+#endif
+
+    if (p->opts->width > 0)
+        *out_width = p->opts->width;
+    if (p->opts->height > 0)
+        *out_height = p->opts->height;
+}
+
+static int reconfig(struct vo *vo, struct mp_image_params *params)
+{
+    struct priv *p = vo->priv;
+
+    get_win_size(vo, &vo->dwidth, &vo->dheight);
+
+    struct mp_osd_res osd;
+    vo_get_src_dst_rects(vo, &p->src, &p->dst, &osd);
+    p->swidth = p->dst.x1 - p->dst.x0;
+    p->sheight = p->dst.y1 - p->dst.y0;
+
+    if (p->buffer)
+        free(p->buffer);
+
+    mp_sws_set_from_cmdline(p->sws, vo->opts->sws_opts);
+    p->sws->src = *params;
+    p->sws->dst = (struct mp_image_params) {
+        .imgfmt = IMGFMT,
+        .w = p->swidth,
+        .h = p->sheight,
+        .p_w = 1,
+        .p_h = 1,
+    };
+
+    p->frame = mp_image_alloc(IMGFMT, p->swidth, p->sheight);
+    if (!p->frame)
+        return -1;
+
+    if (mp_sws_reinit(p->sws) < 0)
+        return -1;
+
+    printf(ESC_HIDE_CURSOR);
+    printf(ESC_CLEAR_SCREEN);
+    vo->want_redraw = true;
+
+    return 0;
+}
+
+static void draw_image(struct vo *vo, mp_image_t *mpi)
+{
+    struct priv *p = vo->priv;
+    struct mp_image src = *mpi;
+    // XXX: pan, crop etc.
+    mp_sws_scale(p->sws, p->frame, &src);
+    talloc_free(mpi);
+}
+
+static void flip_page(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+    write_shaded(
+        vo->dwidth, vo->dheight, p->swidth, p->sheight,
+        p->frame->planes[0], p->frame->stride[0]);
+    fflush(stdout);
+}
+
+static void uninit(struct vo *vo)
+{
+    printf(ESC_RESTORE_CURSOR);
+    printf(ESC_CLEAR_SCREEN);
+    printf(ESC_GOTOXY, 0, 0);
+    struct priv *p = vo->priv;
+    if (p->buffer)
+        talloc_free(p->buffer);
+    if (p->sws)
+        talloc_free(p->sws);
+}
+
+static int preinit(struct vo *vo)
+{
+    // most terminal characters aren't 1:1, so we default to 2:1.
+    // if user passes their own value of choice, it'll be scaled accordingly.
+
+    struct priv *p = vo->priv;
+    p->opts = mp_get_config_group(vo, vo->global, &vo_shablo_conf);
+    vo->monitor_par = vo->opts->monitor_pixel_aspect * 2;
+    p->sws = mp_sws_alloc(vo);
+    return 0;
+}
+
+static int query_format(struct vo *vo, int format)
+{
+    return format == IMGFMT;
+}
+
+static int control(struct vo *vo, uint32_t request, void *data)
+{
+    return VO_NOTIMPL;
+}
+
+const struct vo_driver video_out_shablo = {
+    .name = "shablo",
+    .description = "shaded blocks for ANSI-color terminals (experimental)",
+    .preinit = preinit,
+    .query_format = query_format,
+    .reconfig = reconfig,
+    .control = control,
+    .draw_image = draw_image,
+    .flip_page = flip_page,
+    .uninit = uninit,
+    .priv_size = sizeof(struct priv),
+    .global_opts = &vo_shablo_conf,
+};
+

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -93,6 +93,8 @@ static const struct m_sub_options vo_shablo_conf = {
         {0}
     },
     .defaults = &(const struct vo_shablo_opts) {
+        .fg_ext = false,
+        .bg_ext = false,
         .color_palette_preset = COLOR_PALETTE_PRESET_VGA,
         .color_depth = 6,
         .block_width = DEFAULT_BLOCK_WIDTH,

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -35,7 +35,13 @@
 #define IMGFMT IMGFMT_BGR24
 
 #define COLOR_PALETTE_PRESET_VGA 0
-#define COLOR_PALETTE_PRESETS 1
+#define COLOR_PALETTE_PRESET_CMD 1
+#define COLOR_PALETTE_PRESET_TERMINALAPP 2
+#define COLOR_PALETTE_PRESET_PUTTY 3
+#define COLOR_PALETTE_PRESET_MIRC 4
+#define COLOR_PALETTE_PRESET_XTERM 5
+#define COLOR_PALETTE_PRESET_HUMAN 6
+#define COLOR_PALETTE_PRESETS 7
 
 #define ESC_HIDE_CURSOR "\e[?25l"
 #define ESC_RESTORE_CURSOR "\e[?25h"
@@ -83,7 +89,13 @@ static const struct m_sub_options vo_shablo_conf = {
     .opts = (const m_option_t[]) {
         OPT_INT("vo-shablo-color-depth-per-channel", color_depth, 0),
         OPT_CHOICE("vo-shablo-color-palette-preset", color_palette_preset, 0,
-                   ({"vga", COLOR_PALETTE_PRESET_VGA})),
+                   ({"vga", COLOR_PALETTE_PRESET_VGA},
+                    {"cmd", COLOR_PALETTE_PRESET_CMD},
+                    {"termapp", COLOR_PALETTE_PRESET_TERMINALAPP},
+                    {"putty", COLOR_PALETTE_PRESET_PUTTY},
+                    {"mirc", COLOR_PALETTE_PRESET_MIRC},
+                    {"xterm", COLOR_PALETTE_PRESET_XTERM},
+                    {"human", COLOR_PALETTE_PRESET_HUMAN})),
         OPT_FLAG("vo-shablo-fg-ext", fg_ext, 0),
         OPT_FLAG("vo-shablo-bg-ext", bg_ext, 0),
         OPT_INT("vo-shablo-block-width", block_width, 0),
@@ -125,6 +137,36 @@ static uint32_t BASE_COLORS[COLOR_PALETTE_PRESETS][EXT_PALETTE_SIZE] =
     {
         0x000000, 0xaa0000, 0x00aa00, 0xaa5500, 0x0000aa, 0xaa00aa, 0x00aaaa, 0xaaaaaa,
         0x555555, 0xff5555, 0x55ff55, 0xffff55, 0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
+    },
+    /* CMD */
+    {
+        0x000000, 0x800000, 0x008000, 0x808000, 0x000080, 0x800080, 0x008080, 0xc0c0c0,
+        0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
+    },
+    /* Terminal.app */
+    {
+        0x000000, 0xc23621, 0x25bc26, 0xadad27, 0x492ee1, 0xd338d3, 0x33bbc8, 0xcbcccd,
+        0x818383, 0xfc391f, 0x31e722, 0xeaec23, 0x5833ff, 0xf935f8, 0x14f0f0, 0xe9ebeb
+    },
+    /* PuTTY */
+    {
+        0x000000, 0xbb0000, 0x00bb00, 0xbbbb00, 0x0000bb, 0xbb00bb, 0x00bbbb, 0xbbbbbb,
+        0x555555, 0xff5555, 0x55ff55, 0xffff55, 0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
+    },
+    /* mIRC */
+    {
+        0x000000, 0x7f0000, 0x009300, 0xfc7f00, 0x00007f, 0x9c009c, 0x009393, 0xd2d2d2,
+        0x7f7f7f, 0xff0000, 0x00fc00, 0xffff00, 0x0000fc, 0xff00ff, 0x00ffff, 0xffffff
+    },
+    /* xterm */
+    {
+        0x000000, 0xcd0000, 0x00cd00, 0xcdcd00, 0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5,
+        0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00, 0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff
+    },
+    /* human */
+    {
+        0x010101, 0xde382b, 0x39b54a, 0xffc706, 0x006fb8, 0x762671, 0x2cb5e9, 0xcccccc,
+        0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
     }
 };
 

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -275,7 +275,8 @@ static uint16_t lookup_r_g_b_2_shfgbg_map(
     size_t ir = (size_t) r;
     size_t ig = (size_t) g;
     size_t ib = (size_t) b;
-    return r_g_b_2_shfgbg_map[ib + COLOR_DEPTH_SIZE * (ig + COLOR_DEPTH_SIZE * (ir))];
+    return r_g_b_2_shfgbg_map[
+        ib + COLOR_DEPTH_SIZE * (ig + COLOR_DEPTH_SIZE * (ir))];
 }
 
 static void set_r_g_b_2_shfgbg(uint8_t r, uint8_t g, uint8_t b,
@@ -284,7 +285,8 @@ static void set_r_g_b_2_shfgbg(uint8_t r, uint8_t g, uint8_t b,
     size_t ir = (size_t) r;
     size_t ig = (size_t) g;
     size_t ib = (size_t) b;
-    r_g_b_2_shfgbg_map[ib + COLOR_DEPTH_SIZE * (ig + COLOR_DEPTH_SIZE * (ir))] = shfgbg;
+    r_g_b_2_shfgbg_map[
+        ib + COLOR_DEPTH_SIZE * (ig + COLOR_DEPTH_SIZE * (ir))] = shfgbg;
 }
 
 static void rgb_2_r_g_b(uint32_t rgb,
@@ -693,8 +695,8 @@ static void r_g_b_2_nearest_fg_bg_sh(uint8_t r, uint8_t g, uint8_t b,
 // the rgb color using nearest neighbour applied in CIELAB color space.
 static uint16_t* calc_lookup_table(bool lazy)
 {
-    uint16_t* result = calloc(COLOR_DEPTH_SIZE * COLOR_DEPTH_SIZE * COLOR_DEPTH_SIZE,
-        sizeof(uint16_t));
+    uint16_t* result = calloc(COLOR_DEPTH_SIZE * COLOR_DEPTH_SIZE *
+        COLOR_DEPTH_SIZE, sizeof(uint16_t));
     if (result == NULL) {
         return NULL;
     }
@@ -711,8 +713,10 @@ static uint16_t* calc_lookup_table(bool lazy)
                     uint8_t best_fg = 0;
                     uint8_t best_bg = 0;
                     uint8_t best_sh = 0;
-                    r_g_b_2_nearest_fg_bg_sh(r, g, b, &best_fg, &best_bg, &best_sh);
-                    *to_head++ = 0x8000 | fg_bg_sh_2_shfgbg(best_fg, best_bg, best_sh);
+                    r_g_b_2_nearest_fg_bg_sh(r, g, b,
+                        &best_fg, &best_bg, &best_sh);
+                    *to_head++ = 0x8000 |
+                        fg_bg_sh_2_shfgbg(best_fg, best_bg, best_sh);
                 }
             }
         }
@@ -863,7 +867,8 @@ static void dithering_pull_error(uint8_t* r, uint8_t* g, uint8_t* b)
 }
 
 static double dithering_calc_error(uint8_t origin, uint8_t effective) {
-    return exp_2_lin_color(c8_2_cexp(origin)) - exp_2_lin_color(c8_2_cexp(effective));
+    return exp_2_lin_color(c8_2_cexp(origin)) -
+        exp_2_lin_color(c8_2_cexp(effective));
 }
 
 // Little helper for Floyd&Steinberg dithering.

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -477,7 +477,7 @@ static void calc_reduced_emulated_color_palette(size_t* result_size, uint16_t** 
     *result_size = res_size;
 }
 
-// Calculates the main lookup table (rgb -> shfgbg) by approximating the rgb color using nearest neighbour applied in RGB color space.
+// Calculates the main lookup table (rgb -> shfgbg) by approximating the rgb color using nearest neighbour applied in CIELAB color space.
 static uint16_t* calc_lookup_table(void) {
     uint16_t* result = calloc(depth_size * depth_size * depth_size, sizeof(uint16_t));
     if (result == NULL) {

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -83,6 +83,8 @@
 #define COLOR_DEPTH_SIZE (1 << COLOR_DEPTH)
 #define COLOR_DEPTH_MASK (COLOR_DEPTH_SIZE - 1)
 
+#define ENTRY_EXISTS_FLAG 0x8000
+
 struct vo_shablo_opts {
     int fg_ext;
     int bg_ext;
@@ -715,7 +717,7 @@ static uint16_t* calc_lookup_table(bool lazy)
                     uint8_t best_sh = 0;
                     r_g_b_2_nearest_fg_bg_sh(r, g, b,
                         &best_fg, &best_bg, &best_sh);
-                    *to_head++ = 0x8000 |
+                    *to_head++ = ENTRY_EXISTS_FLAG |
                         fg_bg_sh_2_shfgbg(best_fg, best_bg, best_sh);
                 }
             }
@@ -728,10 +730,10 @@ static void r_g_b_2_fg_bg_sh(uint8_t r, uint8_t g, uint8_t b,
     uint8_t* fg, uint8_t* bg, uint8_t* sh)
 {
     uint16_t shfgbg = lookup_r_g_b_2_shfgbg_map(r, g, b);
-    if ((shfgbg & 0x8000) == 0) {
+    if ((shfgbg & ENTRY_EXISTS_FLAG) == 0) {
         // lazy lookup cell calculation
         r_g_b_2_nearest_fg_bg_sh(r, g, b, fg, bg, sh);
-        shfgbg = 0x8000 | fg_bg_sh_2_shfgbg(*fg, *bg, *sh);
+        shfgbg = ENTRY_EXISTS_FLAG | fg_bg_sh_2_shfgbg(*fg, *bg, *sh);
         set_r_g_b_2_shfgbg(r, g, b, shfgbg);
     }
     shfgbg_2_fg_bg_sh(shfgbg, fg, bg, sh);

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <config.h>
+#include <math.h>
 
 #if HAVE_POSIX
 #include <sys/ioctl.h>

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -211,10 +211,10 @@ static uint16_t fg_bg_sh_2_shfgbg(uint8_t fg, uint8_t bg, uint8_t sh) {
     return ((uint16_t) sh << 8) | ((uint16_t) fg << 4) | ((uint16_t) bg);
 }
 
-static void shfgbg_2_fg_bg_sh(uint16_t sh_fg_bg, uint8_t* fg, uint8_t* bg, uint8_t* sh) {
-    *bg = sh_fg_bg & 0xf;
-    *fg = (sh_fg_bg >> 4) & 0xf;
-    *sh = (sh_fg_bg >> 8) & 0x7;
+static void shfgbg_2_fg_bg_sh(uint16_t shfgbg, uint8_t* fg, uint8_t* bg, uint8_t* sh) {
+    *bg = shfgbg & 0xf;
+    *fg = (shfgbg >> 4) & 0xf;
+    *sh = (shfgbg >> 8) & 0x7;
 }
 
 static uint16_t lookup_r_g_b_2_shfgbg_map(uint8_t red, uint8_t green, uint8_t blue) {

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -143,45 +143,61 @@ struct priv {
 };
 
 /* shade characters */
-static char* SHADE_CHARS[SHADES] = {" ", "\xe2\x96\x91", "\xe2\x96\x92", "\xe2\x96\x93", "\xe2\x96\x88"};
+static char* SHADE_CHARS[SHADES] = {
+    " ", "\xe2\x96\x91", "\xe2\x96\x92", "\xe2\x96\x93", "\xe2\x96\x88"
+};
 
 /* predefined color palettes */
 static uint32_t BASE_COLORS[COLOR_PALETTE_PRESETS][EXT_PALETTE_SIZE] =
 {
     /* VGA */
     {
-        0x000000, 0xaa0000, 0x00aa00, 0xaa5500, 0x0000aa, 0xaa00aa, 0x00aaaa, 0xaaaaaa,
-        0x555555, 0xff5555, 0x55ff55, 0xffff55, 0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
+        0x000000, 0xaa0000, 0x00aa00, 0xaa5500,
+        0x0000aa, 0xaa00aa, 0x00aaaa, 0xaaaaaa,
+        0x555555, 0xff5555, 0x55ff55, 0xffff55,
+        0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
     },
     /* CMD */
     {
-        0x000000, 0x800000, 0x008000, 0x808000, 0x000080, 0x800080, 0x008080, 0xc0c0c0,
-        0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
+        0x000000, 0x800000, 0x008000, 0x808000,
+        0x000080, 0x800080, 0x008080, 0xc0c0c0,
+        0x808080, 0xff0000, 0x00ff00, 0xffff00,
+        0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
     },
     /* Terminal.app */
     {
-        0x000000, 0xc23621, 0x25bc26, 0xadad27, 0x492ee1, 0xd338d3, 0x33bbc8, 0xcbcccd,
-        0x818383, 0xfc391f, 0x31e722, 0xeaec23, 0x5833ff, 0xf935f8, 0x14f0f0, 0xe9ebeb
+        0x000000, 0xc23621, 0x25bc26, 0xadad27,
+        0x492ee1, 0xd338d3, 0x33bbc8, 0xcbcccd,
+        0x818383, 0xfc391f, 0x31e722, 0xeaec23,
+        0x5833ff, 0xf935f8, 0x14f0f0, 0xe9ebeb
     },
     /* PuTTY */
     {
-        0x000000, 0xbb0000, 0x00bb00, 0xbbbb00, 0x0000bb, 0xbb00bb, 0x00bbbb, 0xbbbbbb,
-        0x555555, 0xff5555, 0x55ff55, 0xffff55, 0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
+        0x000000, 0xbb0000, 0x00bb00, 0xbbbb00,
+        0x0000bb, 0xbb00bb, 0x00bbbb, 0xbbbbbb,
+        0x555555, 0xff5555, 0x55ff55, 0xffff55,
+        0x5555ff, 0xff55ff, 0x55ffff, 0xffffff
     },
     /* mIRC */
     {
-        0x000000, 0x7f0000, 0x009300, 0xfc7f00, 0x00007f, 0x9c009c, 0x009393, 0xd2d2d2,
-        0x7f7f7f, 0xff0000, 0x00fc00, 0xffff00, 0x0000fc, 0xff00ff, 0x00ffff, 0xffffff
+        0x000000, 0x7f0000, 0x009300, 0xfc7f00,
+        0x00007f, 0x9c009c, 0x009393, 0xd2d2d2,
+        0x7f7f7f, 0xff0000, 0x00fc00, 0xffff00,
+        0x0000fc, 0xff00ff, 0x00ffff, 0xffffff
     },
     /* xterm */
     {
-        0x000000, 0xcd0000, 0x00cd00, 0xcdcd00, 0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5,
-        0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00, 0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff
+        0x000000, 0xcd0000, 0x00cd00, 0xcdcd00,
+        0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5,
+        0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00,
+        0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff
     },
     /* human */
     {
-        0x010101, 0xde382b, 0x39b54a, 0xffc706, 0x006fb8, 0x762671, 0x2cb5e9, 0xcccccc,
-        0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
+        0x010101, 0xde382b, 0x39b54a, 0xffc706,
+        0x006fb8, 0x762671, 0x2cb5e9, 0xcccccc,
+        0x808080, 0xff0000, 0x00ff00, 0xffff00,
+        0x0000ff, 0xff00ff, 0x00ffff, 0xffffff
     }
 };
 
@@ -197,15 +213,28 @@ static size_t depth_shift;
 static uint8_t round_addend;
 
 /* maps between true colors and emulated colors */
-static uint8_t* fg_bg_sh_ch_2_intensity_map = NULL; // what emulated colors look like in RGB
-static size_t fg_bg_sh_ch_2_intensity_map_size; // the number of ((fg, bg, sh) -> *) entries in that map
 
-static uint16_t* r_g_b_2_shfgbg_map = NULL; // how RGB colors can be emulated via (fg, bg, sh)
+// what emulated colors look like in RGB
+static uint8_t* fg_bg_sh_ch_2_intensity_map = NULL;
+
+// the number of ((fg, bg, sh) -> *) entries in that map
+static size_t fg_bg_sh_ch_2_intensity_map_size;
+
+// how RGB colors can be emulated via (fg, bg, sh)
+static uint16_t* r_g_b_2_shfgbg_map = NULL;
 
 /* reduced palette for optimization */
-static uint16_t* reduced_fg_bg_sh_palette_indices = NULL; // (fg, bg, sh) entries that are sufficient to represent the whole fg_bg_sh_ch_2_intensity_map
-static size_t reduced_fg_bg_sh_palette_indices_size; // the number N of entries in that palette; 0 < N < fg_bg_sh_ch_2_intensity_map_size
-static double* reduced_fg_bg_sh_palette_lab = NULL; // the lab values (L*, a*, b*) of the reduced palette
+
+// (fg, bg, sh) entries that are sufficient
+// to represent the whole fg_bg_sh_ch_2_intensity_map
+static uint16_t* reduced_fg_bg_sh_palette_indices = NULL;
+
+// the number N of entries in that palette;
+// 0 < N < fg_bg_sh_ch_2_intensity_map_size
+static size_t reduced_fg_bg_sh_palette_indices_size;
+
+// the lab values (L*, a*, b*) of the reduced palette
+static double* reduced_fg_bg_sh_palette_lab = NULL;
 
 static int min_int(int a, int b) {
     return a < b ? a : b;
@@ -223,28 +252,40 @@ static double max_double(double a, double b) {
     return a > b ? a : b;
 }
 
-static uint8_t* lookup_fg_bg_sh_2_ch_intensity_map(uint8_t fg, uint8_t bg, uint8_t sh) {
-    return fg_bg_sh_ch_2_intensity_map + (COLOR_CHANNELS * (sh + SHADES * (bg + bg_colors * (fg))));
+static uint8_t* lookup_fg_bg_sh_2_ch_intensity_map(
+    uint8_t fg, uint8_t bg, uint8_t sh)
+{
+    return fg_bg_sh_ch_2_intensity_map + (COLOR_CHANNELS * (sh + SHADES *
+        (bg + bg_colors * (fg))));
 }
 
 static uint16_t fg_bg_sh_2_shfgbg(uint8_t fg, uint8_t bg, uint8_t sh) {
     return ((uint16_t) sh << 8) | ((uint16_t) fg << 4) | ((uint16_t) bg);
 }
 
-static void shfgbg_2_fg_bg_sh(uint16_t shfgbg, uint8_t* fg, uint8_t* bg, uint8_t* sh) {
+static void shfgbg_2_fg_bg_sh(uint16_t shfgbg,
+    uint8_t* fg, uint8_t* bg, uint8_t* sh)
+{
     *bg = shfgbg & 0xf;
     *fg = (shfgbg >> 4) & 0xf;
     *sh = (shfgbg >> 8) & 0x7;
 }
 
-static uint16_t lookup_r_g_b_2_shfgbg_map(uint8_t red, uint8_t green, uint8_t blue) {
-    int r = depth_mask & (min_int((int) red + round_addend, 0xff) >> depth_shift);
-    int g = depth_mask & (min_int((int) green + round_addend, 0xff) >> depth_shift);
-    int b = depth_mask & (min_int((int) blue + round_addend, 0xff) >> depth_shift);
+static uint16_t lookup_r_g_b_2_shfgbg_map(
+    uint8_t red, uint8_t green, uint8_t blue)
+{
+    int r = depth_mask & (min_int((int) red + round_addend, 0xff)
+        >> depth_shift);
+    int g = depth_mask & (min_int((int) green + round_addend, 0xff)
+        >> depth_shift);
+    int b = depth_mask & (min_int((int) blue + round_addend, 0xff)
+        >> depth_shift);
     return r_g_b_2_shfgbg_map[b + depth_size * (g + depth_size * (r))];
 }
 
-static void r_g_b_2_fg_bg_sh(uint8_t r, uint8_t g, uint8_t b, uint8_t* fg, uint8_t* bg, uint8_t* sh) {
+static void r_g_b_2_fg_bg_sh(uint8_t r, uint8_t g, uint8_t b,
+    uint8_t* fg, uint8_t* bg, uint8_t* sh)
+{
     uint16_t shfgbg = lookup_r_g_b_2_shfgbg_map(r, g, b);
     shfgbg_2_fg_bg_sh(shfgbg, fg, bg, sh);
 }
@@ -259,15 +300,19 @@ static uint32_t color_idx_2_rgb(uint8_t color_idx) {
     return BASE_COLORS[color_palette_preset][color_idx];
 }
 
-static void color_idx_2_r_g_b(uint8_t color_idx, uint8_t* r, uint8_t* g, uint8_t* b) {
+static void color_idx_2_r_g_b(uint8_t color_idx,
+    uint8_t* r, uint8_t* g, uint8_t* b)
+{
     rgb_2_r_g_b(color_idx_2_rgb(color_idx), r, g, b);
 }
 
 // Calculates the map ((fg, bg, sh, ch) -> intensity).
-// The question to answer here is: What does (fg, bg, sh) look like, expressed as an RGB color?
+// The question to answer here is: What does (fg, bg, sh) look like,
+//     expressed as an RGB color?
 // Precondition: fg_colors and bg_colors must be initialized
 static uint8_t* calc_fg_bg_sh_ch_2_intensity_map(void) {
-    uint8_t *result = calloc(fg_bg_sh_ch_2_intensity_map_size, COLOR_CHANNELS * sizeof(uint8_t));
+    uint8_t *result = calloc(fg_bg_sh_ch_2_intensity_map_size,
+        COLOR_CHANNELS * sizeof(uint8_t));
     if (result == NULL) {
         return NULL;
     }
@@ -277,15 +322,19 @@ static uint8_t* calc_fg_bg_sh_ch_2_intensity_map(void) {
 
     uint8_t* head = result;
     for (uint8_t fg_idx = 0; fg_idx < fg_colors; ++fg_idx) {
-        color_idx_2_r_g_b(fg_idx, &fg_rgb[CH_R], &fg_rgb[CH_G], &fg_rgb[CH_B]);
+        color_idx_2_r_g_b(fg_idx,
+            &fg_rgb[CH_R], &fg_rgb[CH_G], &fg_rgb[CH_B]);
         for (uint8_t bg_idx = 0; bg_idx < bg_colors; ++bg_idx) {
-            color_idx_2_r_g_b(bg_idx, &bg_rgb[CH_R], &bg_rgb[CH_G], &bg_rgb[CH_B]);
+            color_idx_2_r_g_b(bg_idx,
+                &bg_rgb[CH_R], &bg_rgb[CH_G], &bg_rgb[CH_B]);
             for (uint8_t sh_idx = 0; sh_idx < SHADES; ++sh_idx) {
                 for (uint8_t chan = 0; chan < COLOR_CHANNELS; ++chan) {
                     // add background color and foreground color parts
                     double fg_part = ((double) fg_rgb[chan] * sh_idx);
-                    double bg_part = ((double) bg_rgb[chan] * (MAX_SHADE_INDEX - sh_idx));
-                    double value = ((fg_part + bg_part + SHADE_ADDEND) / MAX_SHADE_INDEX);
+                    double bg_part = ((double) bg_rgb[chan] *
+                        (MAX_SHADE_INDEX - sh_idx));
+                    double value = ((fg_part + bg_part + SHADE_ADDEND) /
+                        MAX_SHADE_INDEX);
                     value = min_double(0xff, max_double(0x00, value));
                     *head++ = (uint8_t) value;
                 }
@@ -296,7 +345,9 @@ static uint8_t* calc_fg_bg_sh_ch_2_intensity_map(void) {
 }
 
 // Returns the squared Euclidean distance between (a1, b1, c1) and (a2, b2, c2).
-static double get_squared_distance(double a1, double b1, double c1, double a2, double b2, double c2) {
+static double get_squared_distance(double a1, double b1, double c1,
+    double a2, double b2, double c2)
+{
     double da = a2 - a1;
     double db = b2 - b1;
     double dc = c2 - c1;
@@ -304,7 +355,9 @@ static double get_squared_distance(double a1, double b1, double c1, double a2, d
 }
 
 // transforms RGB color to XYZ color
-static void r_g_b_2_x_y_z(uint8_t red, uint8_t green, uint8_t blue, double* x, double* y, double* z) {
+static void r_g_b_2_x_y_z(uint8_t red, uint8_t green, uint8_t blue,
+    double* x, double* y, double* z)
+{
     // RGB to sRGB
     double sr = (double) red * 100.0;
     double sg = (double) green * 100.0;
@@ -323,11 +376,16 @@ static void r_g_b_2_x_y_z(uint8_t red, uint8_t green, uint8_t blue, double* x, d
 // helper function to calculate cbrt(p/p_n) for CIELAB
 static double lab_cbrt(double p, double p_n) {
     double ppn = p / p_n;
-    return ppn < (216.0 / 24389.0) ? ((1.0 / 116.0) * (24389.0 / 27.0 * p / p_n + 16.0)) : cbrt(ppn);
+    return ppn < (216.0 / 24389.0) ?
+        ((1.0 / 116.0) * (24389.0 / 27.0 * p / p_n + 16.0)) :
+        cbrt(ppn);
 }
 
-// transforms color from CIEXYZ (CIE 1931 color space) to CIELAB, for (D65, 2 degrees)
-static void x_y_z_2_l_a_b(double x, double y, double z, double* l, double* a, double* b) {
+// transforms color from CIEXYZ (CIE 1931 color space) to CIELAB,
+// for (D65, 2 degrees)
+static void x_y_z_2_l_a_b(double x, double y, double z,
+    double* l, double* a, double* b)
+{
     double cbrt_x = lab_cbrt(x, X_N_D65_2DEG);
     double cbrt_y = lab_cbrt(y, Y_N_D65_2DEG);
     double cbrt_z = lab_cbrt(z, Z_N_D65_2DEG);
@@ -338,7 +396,9 @@ static void x_y_z_2_l_a_b(double x, double y, double z, double* l, double* a, do
 }
 
 // transforms color from sRGB to CIELAB, for (D65, 2 degrees)
-static void r_g_b_2_l_a_b(uint8_t r, uint8_t g, uint8_t b, double* ll, double* aa, double* bb) {
+static void r_g_b_2_l_a_b(uint8_t r, uint8_t g, uint8_t b,
+    double* ll, double* aa, double* bb)
+{
     double x, y, z;
     r_g_b_2_x_y_z(r, g, b, &x, &y, &z);
     x_y_z_2_l_a_b(x, y, z, ll, aa, bb);
@@ -352,7 +412,9 @@ static double r_g_b_2_y(uint8_t r, uint8_t g, uint8_t b) {
     return 0.299 * sr + 0.587 * sg + 0.114 * sb;
 }
 
-static double get_y_dist_between_index_colors(uint8_t color_idx1, uint8_t color_idx2) {
+static double get_y_dist_between_index_colors(
+    uint8_t color_idx1, uint8_t color_idx2)
+{
     uint8_t r1, g1, b1;
     color_idx_2_r_g_b(color_idx1, &r1, &g1, &b1);
     double y1 = r_g_b_2_y(r1, g1, b1);
@@ -368,12 +430,17 @@ static bool is_gray(uint8_t r, uint8_t g, uint8_t b) {
     return r == g && g == b;
 }
 
-// Evaluates which one of two color emulations (c1, c2) is nicer to emulate a given color c (true -> c1, false -> c2).
-// Roughly said, a color emulation is nicer if foreground color and background color are more near to c than the other color emulation.
+// Evaluates which one of two color emulations (c1, c2) is nicer to emulate
+//     a given color c (true -> c1, false -> c2).
+// Roughly said, a color emulation is nicer if foreground color and
+// background color are more near to c than the other color emulation.
 // Both colors c1, c2 must be given by their (fg, bg, sh) values.
 // c must be given in (r, g, b).
 // Precondition: c1 and c2 do both emulate c.
-static bool is_nicer_than(uint8_t r, uint8_t g, uint8_t b, uint8_t fg1, uint8_t bg1, uint8_t sh1, uint8_t fg2, uint8_t bg2, uint8_t sh2) {
+static bool is_nicer_than(uint8_t r, uint8_t g, uint8_t b,
+    uint8_t fg1, uint8_t bg1, uint8_t sh1,
+    uint8_t fg2, uint8_t bg2, uint8_t sh2)
+{
     // plain colors
     if (sh1 == 0 && sh2 != 0) {
         return true;
@@ -415,13 +482,21 @@ static bool is_nicer_than(uint8_t r, uint8_t g, uint8_t b, uint8_t fg1, uint8_t 
 
 // Helper function for calc_reduced_emulated_color_palette
 // Check
-//    - (1) if this color is in the reduced emulation color palette then take the nicer one and
+//    - (1) if this color is in the reduced emulation color palette then
+//          take the nicer one and
 //    - (2) if it is not in the reduced emulation color palette then add it.
-static void calc_reduced_emulated_color_palette_helper(uint8_t fg_idx, uint8_t bg_idx, uint8_t sh_idx, uint8_t from_r, uint8_t from_g, uint8_t from_b, size_t* current_palette_size, uint16_t* current_palette) {
+static void calc_reduced_emulated_color_palette_helper(
+    uint8_t fg_idx, uint8_t bg_idx, uint8_t sh_idx,
+    uint8_t from_r, uint8_t from_g, uint8_t from_b,
+    size_t* current_palette_size, uint16_t* current_palette)
+{
     bool not_yet_in_the_list = true;
 
     // go through all colors in the current palette
-    for (size_t to_idx = 0; to_idx < *current_palette_size; ++to_idx, ++current_palette) {
+    for (size_t to_idx = 0;
+        to_idx < *current_palette_size;
+        ++to_idx, ++current_palette)
+    {
         // get color
         uint16_t shfgbg = *current_palette;
 
@@ -434,7 +509,8 @@ static void calc_reduced_emulated_color_palette_helper(uint8_t fg_idx, uint8_t b
         uint8_t b = *rgb++;
 
         // check current color (r, g, b)<=>(fg, bg, sh)
-        // against given color (from_r, from_g, from_b)<=>(fg_idx, bg_idx, sh_idx)
+        // against given color (from_r, from_g, from_b)
+        //                  <=>(fg_idx, bg_idx, sh_idx)
         if (r == from_r && g == from_g && b == from_b) {
             // they match.
             // check if the given color (fg_idx, bg_idx, sh_idx)
@@ -460,17 +536,22 @@ static void calc_reduced_emulated_color_palette_helper(uint8_t fg_idx, uint8_t b
 
 // Calculates a reduced color emulation palette.
 // A color emulation is a combination of (fg, bg, sh) which emulates a color c.
-// A color emulation duplicate c' is a color emulation (fg', bg', sh') which emulates c, too.
-// Color emulation duplicates will be eliminated whereas the nicer one will be in the result.
+// A color emulation duplicate c' is a color emulation (fg', bg', sh') which
+//     emulates c, too.
+// Color emulation duplicates will be eliminated whereas the nicer one will be
+//     in the result.
 //
-// For example, the color emulation (fg=0, bg=1, sh=2) equals (fg=1, bg=0, sh=2) and thus, only one of them is needed.
+// For example, the color emulation (fg=0, bg=1, sh=2) equals (fg=1, bg=0, sh=2)
+//     and thus, only one of them is needed.
 //
 // Precondition:
 //    fg_bg_sh_ch_2_intensity_map_size,
 //    fg_bg_sh_ch_2_intensity_map,
 //    fg_colors and
 //    bg_colors must be initialized.
-static void calc_reduced_emulated_color_palette(size_t* result_size, uint16_t** result) {
+static void calc_reduced_emulated_color_palette(
+    size_t* result_size, uint16_t** result
+) {
     uint16_t* res = calloc(fg_bg_sh_ch_2_intensity_map_size, sizeof(uint16_t));
     if (res == NULL) {
         result = NULL;
@@ -489,7 +570,8 @@ static void calc_reduced_emulated_color_palette(size_t* result_size, uint16_t** 
                 uint8_t from_b = *from_head++;
 
                 // add color if new to the reduced palette
-                calc_reduced_emulated_color_palette_helper(fg, bg, sh, from_r, from_g, from_b, &res_size, res);
+                calc_reduced_emulated_color_palette_helper(fg, bg, sh,
+                    from_r, from_g, from_b, &res_size, res);
             }
         }
     }
@@ -499,7 +581,8 @@ static void calc_reduced_emulated_color_palette(size_t* result_size, uint16_t** 
 
 // Calculates the CIELAB color values of the emulated color palette.
 static double* reduced_emulated_color_palette_to_lab(void) {
-    double* res = calloc(reduced_fg_bg_sh_palette_indices_size, sizeof(double) * COLOR_CHANNELS);
+    double* res = calloc(reduced_fg_bg_sh_palette_indices_size,
+        sizeof(double) * COLOR_CHANNELS);
     if (res == NULL) {
         return NULL;
     }
@@ -524,9 +607,11 @@ static double* reduced_emulated_color_palette_to_lab(void) {
     return res;
 }
 
-// Calculates the main lookup table (rgb -> shfgbg) by approximating the rgb color using nearest neighbour applied in CIELAB color space.
+// Calculates the main lookup table (rgb -> shfgbg) by approximating
+// the rgb color using nearest neighbour applied in CIELAB color space.
 static uint16_t* calc_lookup_table(void) {
-    uint16_t* result = calloc(depth_size * depth_size * depth_size, sizeof(uint16_t));
+    uint16_t* result = calloc(depth_size * depth_size * depth_size,
+        sizeof(uint16_t));
     if (result == NULL) {
         return NULL;
     }
@@ -549,12 +634,16 @@ static uint16_t* calc_lookup_table(void) {
                 uint16_t* from = reduced_fg_bg_sh_palette_indices;
                 double* from_lab = reduced_fg_bg_sh_palette_lab;
                 // check all available colors for best match
-                for (size_t sh_fg_bg_idx = 0; sh_fg_bg_idx < reduced_fg_bg_sh_palette_indices_size; ++sh_fg_bg_idx) {
+                for (size_t sh_fg_bg_idx = 0;
+                    sh_fg_bg_idx < reduced_fg_bg_sh_palette_indices_size;
+                    ++sh_fg_bg_idx)
+                {
                     double ll2 = *from_lab++;
                     double aa2 = *from_lab++;
                     double bb2 = *from_lab++;
                     uint16_t sh_fg_bg = *from++;
-                    double dist = get_squared_distance(ll1, aa1, bb1, ll2, aa2, bb2);
+                    double dist = get_squared_distance(ll1, aa1, bb1,
+                        ll2, aa2, bb2);
                     // check if better color found
                     if (best_dist > dist || is_first) {
                         uint8_t fg_idx;
@@ -568,7 +657,8 @@ static uint16_t* calc_lookup_table(void) {
                         is_first = false;
                     }
                 }
-                *to_head++ = fg_bg_sh_2_shfgbg(best_fg_idx, best_bg_idx, best_sh_idx);
+                *to_head++ = fg_bg_sh_2_shfgbg(best_fg_idx, best_bg_idx,
+                    best_sh_idx);
             }
         }
     }
@@ -583,11 +673,13 @@ static bool init(int new_color_palette_preset, int depth_per_channel,
     }
 
     if (depth_per_channel < MIN_COLOR_DEPTH) {
-        fprintf(stderr, "[shablo]: --vo-shablo-color-depth-per-channel=%d: too low (min value: %d)", depth_per_channel, MIN_COLOR_DEPTH);
+        fprintf(stderr, "[shablo]: --vo-shablo-color-depth-per-channel=%d: "
+            "too low (min value: %d)", depth_per_channel, MIN_COLOR_DEPTH);
         return false;
     }
     if (depth_per_channel > MAX_COLOR_DEPTH) {
-        fprintf(stderr, "[shablo]: --vo-shablo-color-depth-per-channel=%d: too high (max value: %d)", depth_per_channel, MAX_COLOR_DEPTH);
+        fprintf(stderr, "[shablo]: --vo-shablo-color-depth-per-channel=%d: "
+            "too high (max value: %d)", depth_per_channel, MAX_COLOR_DEPTH);
         return false;
     }
 
@@ -645,12 +737,17 @@ static int* color_error_head = NULL;
 static size_t color_error_head_x = 0;
 static size_t color_error_head_y = 0;
 
-// Creates and/or resets the matrix containing the errors used in error diffusion dithering.
-static bool prepare_color_error_array(size_t width, size_t height, size_t width_ext, size_t height_ext) {
+// Creates and/or resets the matrix containing the errors
+//     used in error diffusion dithering.
+static bool prepare_color_error_array(size_t width, size_t height,
+    size_t width_ext, size_t height_ext)
+{
     size_t size = COLOR_CHANNELS * (width + width_ext) * (height + height_ext);
 
-    if (color_error != NULL && width == color_error_width && height == color_error_height
-            && color_error_width_ext == width_ext && color_error_height_ext == height_ext) {
+    if (color_error != NULL && width == color_error_width &&
+        height == color_error_height && color_error_width_ext == width_ext &&
+        color_error_height_ext == height_ext)
+    {
         memset(color_error, 0, size * sizeof(int));
         color_error_head = color_error;
         color_error_head_x = 0;
@@ -698,7 +795,8 @@ static void dithering_advance_head(void) {
     color_error_head = advanced_head;
 }
 
-// Accumulates the error diffusion dithering error onto call-by-reference RGB values.
+// Accumulates the error diffusion dithering error onto
+//     call-by-reference RGB values.
 static void dithering_pull_error(uint8_t* r, uint8_t* g, uint8_t* b) {
     *r = max_int(min_int((int) (*r) + color_error_head[CH_R], 0xff), 0);
     *g = max_int(min_int((int) (*g) + color_error_head[CH_G], 0xff), 0);
@@ -710,13 +808,22 @@ static int dithering_fs_helper(int e) {
     return ((e >> 3) + 1) >> 1;
 }
 
-// Calculates the error for Floyd&Steinberg dithering and stores it into the error matrix.
-static void dithering_fs_push_error(uint8_t r_origin, uint8_t g_origin, uint8_t b_origin, uint8_t r_effective, uint8_t g_effective, uint8_t b_effective) {
-    int error[3] = {(int) r_origin - (int) r_effective, (int) g_origin - (int) g_effective, (int) b_origin - (int) b_effective};
+// Calculates the error for Floyd&Steinberg dithering and stores it
+//     into the error matrix.
+static void dithering_fs_push_error(
+    uint8_t r_origin, uint8_t g_origin, uint8_t b_origin,
+    uint8_t r_effective, uint8_t g_effective, uint8_t b_effective)
+{
+    int error[3] = {
+        (int) r_origin - (int) r_effective,
+        (int) g_origin - (int) g_effective,
+        (int) b_origin - (int) b_effective
+    };
 
     int* next_head = color_error_head + COLOR_CHANNELS;
     // add error
-    size_t line_size = (color_error_width - DITHERING_FS_WIDTH_EXT) * COLOR_CHANNELS;
+    size_t line_size = (color_error_width - DITHERING_FS_WIDTH_EXT) *
+        COLOR_CHANNELS;
     for (int ch = 0; ch < COLOR_CHANNELS; ++ch) {
         int e1 = error[ch];
         int e2 = e1 << 1;
@@ -748,13 +855,22 @@ static int dithering_jjn_helper(int e) {
     return (e + 24) / 48;
 }
 
-// Calculates the error for Jarvis&Judice&Ninke dithering and stores it into the error matrix.
-static void dithering_jjn_push_error(uint8_t r_origin, uint8_t g_origin, uint8_t b_origin, uint8_t r_effective, uint8_t g_effective, uint8_t b_effective) {
-    int error[3] = {(int) r_origin - (int) r_effective, (int) g_origin - (int) g_effective, (int) b_origin - (int) b_effective};
+// Calculates the error for Jarvis&Judice&Ninke dithering and
+// stores it into the error matrix.
+static void dithering_jjn_push_error(
+    uint8_t r_origin, uint8_t g_origin, uint8_t b_origin,
+    uint8_t r_effective, uint8_t g_effective, uint8_t b_effective)
+{
+    int error[3] = {
+        (int) r_origin - (int) r_effective,
+        (int) g_origin - (int) g_effective,
+        (int) b_origin - (int) b_effective
+    };
 
     int* next_head = color_error_head + COLOR_CHANNELS;
     // add error
-    size_t line_size = (color_error_width - DITHERING_JJN_WIDTH_EXT) * COLOR_CHANNELS;
+    size_t line_size = (color_error_width - DITHERING_JJN_WIDTH_EXT) *
+        COLOR_CHANNELS;
     for (int ch = 0; ch < COLOR_CHANNELS; ++ch) {
         int e1 = error[ch];
         int e2 = e1 << 1;
@@ -813,10 +929,12 @@ static void write_shaded(
         ok = true;
         break;
     case DITHERING_FS:
-        ok = prepare_color_error_array(swidth, sheight, DITHERING_FS_WIDTH_EXT, DITHERING_FS_HEIGHT_EXT);
+        ok = prepare_color_error_array(swidth, sheight,
+            DITHERING_FS_WIDTH_EXT, DITHERING_FS_HEIGHT_EXT);
         break;
     case DITHERING_JJN:
-        ok = prepare_color_error_array(swidth, sheight, DITHERING_JJN_WIDTH_EXT, DITHERING_JJN_HEIGHT_EXT);
+        ok = prepare_color_error_array(swidth, sheight,
+            DITHERING_JJN_WIDTH_EXT, DITHERING_JJN_HEIGHT_EXT);
         break;
     }
     if (!ok) {
@@ -847,11 +965,13 @@ static void write_shaded(
             uint8_t fg_idx;
             uint8_t bg_idx;
             uint8_t sh_idx;
-            r_g_b_2_fg_bg_sh(r_effective, g_effective, b_effective, &fg_idx, &bg_idx, &sh_idx);
+            r_g_b_2_fg_bg_sh(r_effective, g_effective, b_effective,
+                &fg_idx, &bg_idx, &sh_idx);
 
             // dithering.write
             if (dithering != DITHERING_NONE) {
-                uint8_t* effective = lookup_fg_bg_sh_2_ch_intensity_map(fg_idx, bg_idx, sh_idx);
+                uint8_t* effective = lookup_fg_bg_sh_2_ch_intensity_map(
+                    fg_idx, bg_idx, sh_idx);
                 r_effective = *effective++;
                 g_effective = *effective++;
                 b_effective = *effective++;
@@ -859,10 +979,12 @@ static void write_shaded(
                 case DITHERING_NONE:
                     break;
                 case DITHERING_FS:
-                    dithering_fs_push_error(r, g, b, r_effective, g_effective, b_effective);
+                    dithering_fs_push_error(r, g, b,
+                        r_effective, g_effective, b_effective);
                     break;
                 case DITHERING_JJN:
-                    dithering_jjn_push_error(r, g, b, r_effective, g_effective, b_effective);
+                    dithering_jjn_push_error(r, g, b,
+                        r_effective, g_effective, b_effective);
                     break;
                 }
             }
@@ -994,7 +1116,8 @@ static int preinit(struct vo *vo)
 
     struct priv *p = vo->priv;
     p->opts = mp_get_config_group(vo, vo->global, &vo_shablo_conf);
-    vo->monitor_par = (double) ((double) (vo->opts->monitor_pixel_aspect) * (double) p->opts->block_height / (double) p->opts->block_width);
+    vo->monitor_par = (double) ((double) (vo->opts->monitor_pixel_aspect) *
+        (double) p->opts->block_height / (double) p->opts->block_width);
     p->sws = mp_sws_alloc(vo);
     return 0;
 }

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -113,6 +113,7 @@ static const struct m_sub_options vo_shablo_conf = {
     .defaults = &(const struct vo_shablo_opts) {
         .fg_ext = false,
         .bg_ext = false,
+        .dithering = DITHERING_NONE,
         .color_palette_preset = COLOR_PALETTE_PRESET_VGA,
         .color_depth = 6,
         .block_width = DEFAULT_BLOCK_WIDTH,
@@ -203,7 +204,7 @@ static int min_int(int a, int b) {
 }
 
 static int max_int(int a, int b) {
-    return a < b ? a : b;
+    return a > b ? a : b;
 }
 
 static double min_double(double a, double b) {

--- a/video/out/vo_shablo.c
+++ b/video/out/vo_shablo.c
@@ -44,7 +44,12 @@
 #define DEFAULT_WIDTH 80
 #define DEFAULT_HEIGHT 25
 
+#define DEFAULT_BLOCK_WIDTH 8
+#define DEFAULT_BLOCK_HEIGHT 16
+
 struct vo_shablo_opts {
+    int block_width;
+    int block_height;
     int width;   // 0 -> default
     int height;  // 0 -> default
 };
@@ -52,11 +57,15 @@ struct vo_shablo_opts {
 #define OPT_BASE_STRUCT struct vo_shablo_opts
 static const struct m_sub_options vo_shablo_conf = {
     .opts = (const m_option_t[]) {
+        OPT_INT("vo-shablo-block-width", block_width, 0),
+        OPT_INT("vo-shablo-block-height", block_height, 0),
         OPT_INT("vo-shablo-width", width, 0),
         OPT_INT("vo-shablo-height", height, 0),
         {0}
     },
     .defaults = &(const struct vo_shablo_opts) {
+        .block_width = DEFAULT_BLOCK_WIDTH,
+        .block_height = DEFAULT_BLOCK_HEIGHT,
     },
     .size = sizeof(struct vo_shablo_opts),
 };
@@ -203,12 +212,12 @@ static void uninit(struct vo *vo)
 
 static int preinit(struct vo *vo)
 {
-    // most terminal characters aren't 1:1, so we default to 2:1.
+    // most terminal characters aren't 1:1, so we default to 16:8.
     // if user passes their own value of choice, it'll be scaled accordingly.
 
     struct priv *p = vo->priv;
     p->opts = mp_get_config_group(vo, vo->global, &vo_shablo_conf);
-    vo->monitor_par = vo->opts->monitor_pixel_aspect * 2;
+    vo->monitor_par = (double) ((double) (vo->opts->monitor_pixel_aspect) * (double) p->opts->block_height / (double) p->opts->block_width);
     p->sws = mp_sws_alloc(vo);
     return 0;
 }

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -436,6 +436,7 @@ def build(ctx):
         ( "video/out/vo_opengl_cb.c",            "gl" ),
         ( "video/out/vo_sdl.c",                  "sdl2" ),
         ( "video/out/vo_tct.c" ),
+        ( "video/out/vo_shablo.c" ),
         ( "video/out/vo_vaapi.c",                "vaapi-x11 && gpl" ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),
         ( "video/out/vo_wayland.c",              "wayland" ),


### PR DESCRIPTION
VO "shablo" is a new video output driver that renders frames in a text terminal by combining the 8 or 16 ANSI foreground and background colors with shaded block characters (U+32, U+2591, U+2592, U+2593, U+2588). It's based on VO tct and perhaps it could be merged with tct in the future.

Please note:

- Consult the manual for interesting options.
- I'm unsure about my changes in the files "/wscript_build.py", "/video/out/vo.c", and "/Copyright".
- Some terminals, e.g. gnome-terminal, really merge the foreground and the background color when a shaded block comes up. Those results might appear nicer.
- Sometimes, when started in a terminal which does not merges the colors, blocks appear brighter than calculated (e.g. light gray 1/4 + black 3/4 = dark gray, but could appear lighter than dark gray). Maybe, it depends on the monitor. Maybe, I can find a solution for that problem.

I agree that my changes can be relicensed to LGPL 2.1 or later.
