### PR TITLE
vo_gpu: remove CAP_NESTED_ARRAY

### DIFF
--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -49,9 +49,8 @@ enum {
     RA_CAP_DIRECT_UPLOAD  = 1 << 4, // supports tex_upload without ra_buf
     RA_CAP_BUF_RO         = 1 << 5, // supports RA_VARTYPE_BUF_RO
     RA_CAP_BUF_RW         = 1 << 6, // supports RA_VARTYPE_BUF_RW
-    RA_CAP_NESTED_ARRAY   = 1 << 7, // supports nested arrays
-    RA_CAP_SHARED_BINDING = 1 << 8, // sampler/image/buffer namespaces are disjoint
-    RA_CAP_GLOBAL_UNIFORM = 1 << 9, // supports using "naked" uniforms (not UBO)
+    RA_CAP_SHARED_BINDING = 1 << 7, // sampler/image/buffer namespaces are disjoint
+    RA_CAP_GLOBAL_UNIFORM = 1 << 8, // supports using "naked" uniforms (not UBO)
 };
 
 enum ra_ctype {

--- a/video/out/gpu/spirv.h
+++ b/video/out/gpu/spirv.h
@@ -21,7 +21,6 @@ struct spirv_compiler {
     const char *required_ext; // or NULL
     int glsl_version;         // GLSL version supported
     int compiler_version;     // for cache invalidation, may be left as 0
-    int ra_caps;              // RA_CAP_* provided by this implementation, if any
 };
 
 struct spirv_compiler_fns {

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -362,11 +362,6 @@ static const struct gl_functions gl_functions[] = {
             {0},
         },
     },
-    {
-        .ver_core = 430,
-        .extension = "GL_ARB_arrays_of_arrays",
-        .provides = MPGL_CAP_NESTED_ARRAY,
-    },
     // Swap control, always an OS specific extension
     // The OSX code loads this manually.
     {

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -57,7 +57,6 @@ enum {
     MPGL_CAP_UBO                = (1 << 21),    // GL_ARB_uniform_buffer_object
     MPGL_CAP_SSBO               = (1 << 22),    // GL_ARB_shader_storage_buffer_object
     MPGL_CAP_COMPUTE_SHADER     = (1 << 23),    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
-    MPGL_CAP_NESTED_ARRAY       = (1 << 24),    // GL_ARB_arrays_of_arrays
 
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -101,7 +101,6 @@ static int ra_init_gl(struct ra *ra, GL *gl)
         {RA_CAP_TEX_1D,             MPGL_CAP_1D_TEX},
         {RA_CAP_TEX_3D,             MPGL_CAP_3D_TEX},
         {RA_CAP_COMPUTE,            MPGL_CAP_COMPUTE_SHADER},
-        {RA_CAP_NESTED_ARRAY,       MPGL_CAP_NESTED_ARRAY},
         {RA_CAP_BUF_RO,             MPGL_CAP_UBO},
         {RA_CAP_BUF_RW,             MPGL_CAP_SSBO},
     };

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -187,7 +187,6 @@ struct ra *ra_create_vk(struct mpvk_ctx *vk, struct mp_log *log)
     struct ra_vk *p = ra->priv = talloc_zero(ra, struct ra_vk);
     p->vk = vk;
 
-    ra->caps |= vk->spirv->ra_caps;
     ra->glsl_version = vk->spirv->glsl_version;
     ra->glsl_vulkan = true;
     ra->max_shmem = vk->limits.maxComputeSharedMemorySize;

--- a/video/out/vulkan/spirv_nvidia.c
+++ b/video/out/vulkan/spirv_nvidia.c
@@ -22,7 +22,6 @@ static bool nv_glsl_init(struct ra_ctx *ctx)
     struct spirv_compiler *spv = ctx->spirv;
     spv->required_ext = VK_NV_GLSL_SHADER_EXTENSION_NAME;
     spv->glsl_version = 450; // impossible to query, so hard-code it..
-    spv->ra_caps = RA_CAP_NESTED_ARRAY;
 
     // Make sure the extension is actually available, and fail gracefully
     // if it isn't


### PR DESCRIPTION
This capability was added to enable "ARB_arrays_of_arrays" extension
explicitly on certain GL implementation. This is no longer needed
after commit b9406917.

Also removes ra_caps from spirv_compiler, it's added to cover this
weird corner case that particular SPIRV compiler could provide new
capability to RA.

@haasn 
