### PR TITLE
libva2 support

### DIFF
--- a/video/vaapi.c
+++ b/video/vaapi.c
@@ -40,9 +40,27 @@ int va_get_colorspace_flag(enum mp_csp csp)
     return 0;
 }
 
-// VA message callbacks are global and do not have a context parameter, so it's
-// impossible to know from which VADisplay they originate. Try to route them
-// to existing mpv/libmpv instances within this process.
+#if VA_CHECK_VERSION(1, 0, 0)
+static void va_message_callback(void *context, const char *msg, int mp_level)
+{
+    struct mp_vaapi_ctx *res = context;
+    mp_msg(res->log, mp_level, "libva: %s", msg);
+}
+
+static void va_error_callback(void *context, const char *msg)
+{
+    va_message_callback(context, msg, MSGL_ERR);
+}
+
+static void va_info_callback(void *context, const char *msg)
+{
+    va_message_callback(context, msg, MSGL_V);
+}
+#else
+// Pre-libva2 VA message callbacks are global and do not have a context
+// parameter, so it's impossible to know from which VADisplay they
+// originate.  Try to route them to existing mpv/libmpv instances within
+// this process.
 static pthread_mutex_t va_log_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct mp_vaapi_ctx **va_mpv_clients;
 static int num_va_mpv_clients;
@@ -77,6 +95,7 @@ static void va_info_callback(const char *msg)
 {
     va_message_callback(msg, MSGL_V);
 }
+#endif
 
 static void open_lavu_vaapi_device(struct mp_vaapi_ctx *ctx)
 {
@@ -108,6 +127,10 @@ struct mp_vaapi_ctx *va_initialize(VADisplay *display, struct mp_log *plog,
         },
     };
 
+#if VA_CHECK_VERSION(1, 0, 0)
+    vaSetErrorCallback(display, va_error_callback, res);
+    vaSetInfoCallback(display,  va_info_callback,  res);
+#else
     pthread_mutex_lock(&va_log_mutex);
     MP_TARRAY_APPEND(NULL, va_mpv_clients, num_va_mpv_clients, res);
     pthread_mutex_unlock(&va_log_mutex);
@@ -117,6 +140,7 @@ struct mp_vaapi_ctx *va_initialize(VADisplay *display, struct mp_log *plog,
 #ifdef VA_FOURCC_I010
     vaSetErrorCallback(va_error_callback);
     vaSetInfoCallback(va_info_callback);
+#endif
 #endif
 
     int major, minor;
@@ -154,6 +178,7 @@ void va_destroy(struct mp_vaapi_ctx *ctx)
         if (ctx->destroy_native_ctx)
             ctx->destroy_native_ctx(ctx->native_ctx);
 
+#if !VA_CHECK_VERSION(1, 0, 0)
         pthread_mutex_lock(&va_log_mutex);
         for (int n = 0; n < num_va_mpv_clients; n++) {
             if (va_mpv_clients[n] == ctx) {
@@ -164,6 +189,7 @@ void va_destroy(struct mp_vaapi_ctx *ctx)
         if (num_va_mpv_clients == 0)
             TA_FREEP(&va_mpv_clients); // avoid triggering leak detectors
         pthread_mutex_unlock(&va_log_mutex);
+#endif
 
         talloc_free(ctx);
     }


### PR DESCRIPTION
Patch 1 switches to using the safe message callbacks in libva2.  Support for the old unsafe callbacks in some late versions if libva1 is abandoned.

Patch 2 adds support for vaExportSurfaceHandle(), which allows sensible playback with Mesa on AMD cards (Mesa support already available for 8-bit, 10-bit still pending: <https://cgit.freedesktop.org/mesa/mesa/commit/?id=c4ed39f85b1ebd062eaa51880fcc79cfbcb4e5c3>).  This falls back to the old interface if vaExportSurfaceHandle() is not implemented or when using libva1.