### PR TITLE
DVB v5 tuning fixes, VDR format extensions, ATSC cable / terrestrial fixes

### DIFF
--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -606,31 +606,119 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
     }
 
     /* Tune. */
-    struct dtv_property p[] = {
-        { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
-        { .cmd = DTV_FREQUENCY, .u.data = freq },
-        { .cmd = DTV_MODULATION, .u.data = modulation },
-        { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
-        { .cmd = DTV_INNER_FEC, .u.data = HP_CodeRate },
-        { .cmd = DTV_INVERSION, .u.data = specInv },
-        { .cmd = DTV_ROLLOFF, .u.data = ROLLOFF_AUTO },
-        { .cmd = DTV_BANDWIDTH_HZ, .u.data = bandwidth_hz },
-        { .cmd = DTV_PILOT, .u.data = PILOT_AUTO },
-        { .cmd = DTV_STREAM_ID, .u.data = stream_id },
-        { .cmd = DTV_TUNE },
-    };
-    struct dtv_properties cmdseq = {
-        .num = sizeof(p) / sizeof(p[0]),
-        .props = p
-    };
-    MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
-               get_dvb_delsys(delsys));
-    if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq) < 0) {
-        MP_ERR(priv, "ERROR tuning channel\n");
-        goto old_api;
+    switch (delsys) {
+    case SYS_DVBS:
+    case SYS_DVBS2:
+        {
+            struct dtv_property p[] = {
+                { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
+                { .cmd = DTV_FREQUENCY, .u.data = freq },
+                { .cmd = DTV_MODULATION, .u.data = modulation },
+                { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
+                { .cmd = DTV_INNER_FEC, .u.data = HP_CodeRate },
+                { .cmd = DTV_INVERSION, .u.data = specInv },
+                { .cmd = DTV_ROLLOFF, .u.data = ROLLOFF_AUTO },
+                { .cmd = DTV_PILOT, .u.data = PILOT_AUTO },
+                { .cmd = DTV_TUNE },
+            };
+            struct dtv_properties cmdseq = {
+                .num = sizeof(p) / sizeof(p[0]),
+                .props = p
+            };
+            MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
+                       get_dvb_delsys(delsys));
+            if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq) < 0) {
+                MP_ERR(priv, "ERROR tuning channel\n");
+                goto old_api;
+            }
+        }
+        break;
+    case SYS_DVBT:
+    case SYS_DVBT2:
+        {
+            struct dtv_property p[] = {
+                { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
+                { .cmd = DTV_FREQUENCY, .u.data = freq },
+                { .cmd = DTV_MODULATION, .u.data = modulation },
+                { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
+                { .cmd = DTV_CODE_RATE_HP, .u.data = HP_CodeRate },
+                { .cmd = DTV_CODE_RATE_LP, .u.data = LP_CodeRate },
+                { .cmd = DTV_INVERSION, .u.data = specInv },
+                { .cmd = DTV_BANDWIDTH_HZ, .u.data = bandwidth_hz },
+                { .cmd = DTV_TRANSMISSION_MODE, .u.data = TransmissionMode },
+                { .cmd = DTV_GUARD_INTERVAL, .u.data = guardInterval },
+                { .cmd = DTV_HIERARCHY, .u.data = hier },
+                { .cmd = DTV_STREAM_ID, .u.data = stream_id },
+                { .cmd = DTV_TUNE },
+            };
+            struct dtv_properties cmdseq = {
+                .num = sizeof(p) / sizeof(p[0]),
+                .props = p
+            };
+            MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
+                       get_dvb_delsys(delsys));
+            if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq) < 0) {
+                MP_ERR(priv, "ERROR tuning channel\n");
+                goto old_api;
+            }
+        }
+        break;
+    case SYS_DVBC_ANNEX_A:
+    case SYS_DVBC_ANNEX_C:
+        {
+            struct dtv_property p[] = {
+                { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
+                { .cmd = DTV_FREQUENCY, .u.data = freq },
+                { .cmd = DTV_MODULATION, .u.data = modulation },
+                { .cmd = DTV_SYMBOL_RATE, .u.data = srate },
+                { .cmd = DTV_INNER_FEC, .u.data = HP_CodeRate },
+                { .cmd = DTV_INVERSION, .u.data = specInv },
+                { .cmd = DTV_TUNE },
+            };
+            struct dtv_properties cmdseq = {
+                .num = sizeof(p) / sizeof(p[0]),
+                .props = p
+            };
+            MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
+                       get_dvb_delsys(delsys));
+            if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq) < 0) {
+                MP_ERR(priv, "ERROR tuning channel\n");
+                goto old_api;
+            }
+        }
+        break;
+#ifdef DVB_ATSC
+    case SYS_ATSC:
+        {
+            struct dtv_property p[] = {
+                { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
+                { .cmd = DTV_FREQUENCY, .u.data = freq },
+                { .cmd = DTV_INVERSION, .u.data = specInv },
+                { .cmd = DTV_MODULATION, .u.data = modulation },
+                { .cmd = DTV_TUNE },
+            };
+            struct dtv_properties cmdseq = {
+                .num = sizeof(p) / sizeof(p[0]),
+                .props = p
+            };
+            MP_VERBOSE(priv, "Tuning via S2API, channel is %s.\n",
+                       get_dvb_delsys(delsys));
+            if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq) < 0) {
+                MP_ERR(priv, "ERROR tuning channel\n");
+                goto old_api;
+            }
+        }
+        break;
+#endif
     }
 
-    return check_status(priv, fd_frontend, timeout);
+    int tune_status = check_status(priv, fd_frontend, timeout);
+    if (tune_status != 0) {
+         MP_ERR(priv, "ERROR locking to channel when tuning with S2API, falling back to DVBv3-tuning.\n");
+         goto old_api;
+    } else {
+        return tune_status;
+    }
 
 old_api:
 #endif

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -152,11 +152,9 @@ old_api:
         if ((FE_CAN_8VSB | FE_CAN_16VSB) & fe_info.caps) {
             DELSYS_SET(ret_mask, SYS_ATSC);
         }
-#if 0 /* Not used now. */
         if ((FE_CAN_QAM_64 | FE_CAN_QAM_256 | FE_CAN_QAM_AUTO) & fe_info.caps) {
             DELSYS_SET(ret_mask, SYS_DVBC_ANNEX_B);
         }
-#endif
         break;
 #endif
     default:
@@ -598,6 +596,7 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
         break;
 #ifdef DVB_ATSC
     case SYS_ATSC:
+    case SYS_DVBC_ANNEX_B:
         MP_VERBOSE(priv, "tuning %s to %d, modulation=%d\n",
                    get_dvb_delsys(delsys), freq, modulation);
         break;
@@ -700,6 +699,7 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
         break;
 #ifdef DVB_ATSC
     case SYS_ATSC:
+    case SYS_DVBC_ANNEX_B:
         {
             struct dtv_property p[] = {
                 { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },
@@ -768,6 +768,7 @@ old_api:
         break;
 #ifdef DVB_ATSC
     case SYS_ATSC:
+    case SYS_DVBC_ANNEX_B:
         feparams.u.vsb.modulation = modulation;
         break;
 #endif

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -714,8 +714,18 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
 
     int tune_status = check_status(priv, fd_frontend, timeout);
     if (tune_status != 0) {
-         MP_ERR(priv, "ERROR locking to channel when tuning with S2API, falling back to DVBv3-tuning.\n");
-         goto old_api;
+        MP_ERR(priv, "ERROR locking to channel when tuning with S2API, clearing and falling back to DVBv3-tuning.\n");
+        struct dtv_property p_clear[] = {
+            { .cmd = DTV_CLEAR },
+        };
+        struct dtv_properties cmdseq_clear = {
+            .num = 1,
+            .props = p_clear
+        };
+        if (ioctl(fd_frontend, FE_SET_PROPERTY, &cmdseq_clear) < 0) {
+            MP_ERR(priv, "FE_SET_PROPERTY DTV_CLEAR failed\n");
+        }
+        goto old_api;
     } else {
         return tune_status;
     }

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -124,6 +124,7 @@ typedef struct {
 /* Keep in sync with enum fe_delivery_system. */
 #ifndef DVB_USE_S2API
 #    define SYS_DVBC_ANNEX_A        1
+#    define SYS_DVBC_ANNEX_B        1
 #    define SYS_DVBT                3
 #    define SYS_DVBS                5
 #    define SYS_DVBS2               6
@@ -151,6 +152,7 @@ typedef struct {
         DELSYS_BIT(SYS_DVBS) |                                          \
         DELSYS_BIT(SYS_DVBS2) |                                         \
         DELSYS_BIT(SYS_ATSC) |                                          \
+        DELSYS_BIT(SYS_DVBC_ANNEX_B) |                                  \
         DELSYS_BIT(SYS_DVBT2) |                                         \
         DELSYS_BIT(SYS_DVBC_ANNEX_C)                                    \
     )

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -301,7 +301,9 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
         if (num_chars == strlen(&line[k])) {
             // It's a VDR-style config line.
             parse_vdr_par_string(vdr_par_str, ptr);
-            // We still need the special SAT-handling here.
+            // Units in VDR-style config files are divided by 1000.
+            ptr->freq *=  1000UL;
+            ptr->srate *=  1000UL;
             switch (delsys) {
             case SYS_DVBT:
             case SYS_DVBT2:
@@ -333,9 +335,6 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                 }
                 if (!DELSYS_IS_SET(delsys_mask, delsys))
                     continue; /* Skip channel. */
-
-                ptr->freq *=  1000UL;
-                ptr->srate *=  1000UL;
 
                 if (vdr_loc_str[0]) {
                     // In older vdr config format, this field contained the DISEQc information.

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -603,7 +603,9 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
             } else {
                 delsys = SYS_DVBC_ANNEX_B;
             }
-            mp_verbose(log, "Defined delivery system for ATSC as %s from modulation.\n",
+            if (!DELSYS_IS_SET(delsys_mask, delsys))
+                continue; /* Skip channel. */
+            mp_verbose(log, "Switched to delivery system for ATSC: %s (guessed from modulation).\n",
                        get_dvb_delsys(delsys));
         }
 #endif

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -319,6 +319,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
             case SYS_DVBC_ANNEX_A:
             case SYS_DVBC_ANNEX_C:
             case SYS_ATSC:
+            case SYS_DVBC_ANNEX_B:
                 mp_verbose(log, "VDR, %s, NUM: %d, NUM_FIELDS: %d, NAME: %s, "
                            "FREQ: %d, SRATE: %d",
                            get_dvb_delsys(delsys),
@@ -390,6 +391,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                 break;
 #ifdef DVB_ATSC
             case SYS_ATSC:
+            case SYS_DVBC_ANNEX_B:
                 fields = sscanf(&line[k], atsc_conf,
                                 &ptr->freq, mod, vpid_str, apid_str);
                 mp_verbose(log, "%s, NUM: %d, NUM_FIELDS: %d, NAME: %s, FREQ: %d\n",
@@ -523,6 +525,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
         case SYS_DVBC_ANNEX_A:
         case SYS_DVBC_ANNEX_C:
         case SYS_ATSC:
+        case SYS_DVBC_ANNEX_B:
             if (!strcmp(mod, "QAM_128")) {
                 ptr->mod = QAM_128;
             } else if (!strcmp(mod, "QAM_256")) {
@@ -541,6 +544,19 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
 #endif
             }
         }
+#ifdef DVB_ATSC
+        /* Modulation defines real delsys for ATSC:
+           Terrestrial (VSB) is SYS_ATSC, Cable (QAM) is SYS_DVBC_ANNEX_B. */
+        if (delsys == SYS_ATSC || delsys == SYS_DVBC_ANNEX_B) {
+            if (ptr->mod == VSB_8 || ptr->mod == VSB_16) {
+                delsys = SYS_ATSC;
+            } else {
+                delsys = SYS_DVBC_ANNEX_B;
+            }
+            mp_verbose(log, "Defined delivery system for ATSC as %s from modulation.\n",
+                       get_dvb_delsys(delsys));
+        }
+#endif
 
         switch (delsys) {
         case SYS_DVBT:

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -86,6 +86,50 @@ const struct m_sub_options stream_dvb_conf = {
 
 void dvbin_close(stream_t *stream);
 
+static fe_modulation_t parse_vdr_modulation(const char** modstring) {
+    if (!strncmp(*modstring, "16", 2)) {
+        (*modstring)+=2;
+        return QAM_16;
+    } else if (!strncmp(*modstring, "32", 2)) {
+        (*modstring)+=2;
+        return QAM_32;
+    } else if (!strncmp(*modstring, "64", 2)) {
+        (*modstring)+=2;
+        return QAM_64;
+    } else if (!strncmp(*modstring, "128", 3)) {
+        (*modstring)+=3;
+        return QAM_128;
+    } else if (!strncmp(*modstring, "256", 3)) {
+        (*modstring)+=3;
+        return QAM_256;
+    } else if (!strncmp(*modstring, "998", 3)) {
+        (*modstring)+=3;
+        return QAM_AUTO;
+    } else if (!strncmp(*modstring, "2", 1)) {
+        (*modstring)++;
+        return QPSK;
+    } else if (!strncmp(*modstring, "5", 1)) {
+        (*modstring)++;
+        return PSK_8;
+    } else if (!strncmp(*modstring, "6", 1)) {
+        (*modstring)++;
+        return APSK_16;
+    } else if (!strncmp(*modstring, "7", 1)) {
+        (*modstring)++;
+        return APSK_32;
+    } else if (!strncmp(*modstring, "10", 2)) {
+        (*modstring)+=2;
+        return VSB_8;
+    } else if (!strncmp(*modstring, "11", 2)) {
+        (*modstring)+=2;
+        return VSB_16;
+    } else if (!strncmp(*modstring, "12", 2)) {
+        (*modstring)+=2;
+        return DQPSK;
+    } else {
+        return QAM_AUTO;
+    }
+}
 
 static void parse_vdr_par_string(const char *vdr_par_str, dvb_channel_t *ptr)
 {
@@ -130,6 +174,10 @@ static void parse_vdr_par_string(const char *vdr_par_str, dvb_channel_t *ptr)
                     ptr->inv = INVERSION_OFF;
                 }
                 vdr_par++;
+                break;
+            case 'M':
+                vdr_par++;
+                ptr->mod = parse_vdr_modulation(&vdr_par);
                 break;
             default:
                 vdr_par++;
@@ -299,6 +347,8 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                         &num_chars);
 
         if (num_chars == strlen(&line[k])) {
+            // Modulation parsed here, not via old xine-parsing path.
+            mod[0] = '\0';
             // It's a VDR-style config line.
             parse_vdr_par_string(vdr_par_str, ptr);
             // Units in VDR-style config files are divided by 1000.


### PR DESCRIPTION
This changeset implements support for ATSC terrestrial / cable widespread in North America, which is a mix of ATSC and DVBC_ANNEX_B delivery systems actually, differentiation done by the modulation parameter. 
It also adds some more verbosity to the tuning part (if requested), a fallback to DVBv3 tuning if things go wrong, and parsing of the modulation parameter from VDR config files for any delivery system. 

Tested with DVB-S/S2 by me (which now also profits from parsed modulation) and ATSC terrestrial and cable by @bpaterni . 
This fixes the #4922 regression. 

I agree that my changes can be relicensed to LGPL 2.1 or later.
