### PR TITLE
Include debug info in shaderc generated SPIR-V when --gpu-debug is set

### DIFF
--- a/video/out/gpu/spirv_shaderc.c
+++ b/video/out/gpu/spirv_shaderc.c
@@ -33,6 +33,8 @@ static bool shaderc_init(struct ra_ctx *ctx)
 
     shaderc_compile_options_set_optimization_level(p->opts,
                                             shaderc_optimization_level_size);
+    if (ctx->opts.debug)
+        shaderc_compile_options_set_generate_debug_info(p->opts);
 
     int ver, rev;
     shaderc_get_spv_version(&ver, &rev);


### PR DESCRIPTION
Ping @haasn. This is useful for debugging issues with SPIRV-Cross, since it adds symbol information to the output.