### PR TITLE
vo_gpu: mali-fbdev: fix build error

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -45,7 +45,7 @@ extern const struct ra_ctx_fns ra_ctx_angle;
 extern const struct ra_ctx_fns ra_ctx_dxgl;
 extern const struct ra_ctx_fns ra_ctx_rpi;
 extern const struct ra_ctx_fns ra_ctx_android;
-extern const struct ra_ctx_fns ra_ctx_mali;
+extern const struct ra_ctx_fns ra_ctx_mali_fbdev;
 extern const struct ra_ctx_fns ra_ctx_vdpauglx;
 
 /* Vulkan */
@@ -89,7 +89,7 @@ static const struct ra_ctx_fns *contexts[] = {
     &ra_ctx_drm_egl,
 #endif
 #if HAVE_MALI_FBDEV
-    &ra_ctx_mali,
+    &ra_ctx_mali_fbdev,
 #endif
 #if HAVE_VDPAU_GL_X11
     &ra_ctx_vdpauglx,


### PR DESCRIPTION
Apparantly the context was renamed.

I agree that my changes can be relicensed to LGPL 2.1 or later.
