### PR TITLE
Fix unnecessary buffering stalls when eia_608 caption track is active

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -457,6 +457,7 @@ void demuxer_feed_caption(struct sh_stream *stream, demux_packet_t *dp)
             return;
         }
         sh->codec->codec = "eia_608";
+        sh->ignore_eof = true;
         stream->ds->cc = sh;
         demux_add_sh_stream(demuxer, sh);
     }
@@ -1659,6 +1660,8 @@ static int cached_demux_control(struct demux_internal *in, int cmd, void *arg)
         int num_packets = 0;
         for (int n = 0; n < in->num_streams; n++) {
             struct demux_stream *ds = in->streams[n]->ds;
+            if (in->streams[n]->ignore_eof)
+                continue;
             if (ds->active && !(!ds->head && ds->eof)) {
                 r->underrun |= !ds->head && !ds->eof;
                 r->ts_range[0] = MP_PTS_MAX(r->ts_range[0], ds->base_ts);

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -678,7 +678,7 @@ static bool read_packet(struct demux_internal *in)
                 if (in->wakeup_cb)
                     in->wakeup_cb(in->wakeup_cb_ctx);
                 pthread_cond_signal(&in->wakeup);
-                MP_VERBOSE(in, "EOF reached.\n");
+                MP_DBG(in, "EOF reached.\n");
             }
         }
         in->eof = in->last_eof = eof;

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -56,6 +56,7 @@ struct sh_stream {
 
     // Internal to demux.c
     struct demux_stream *ds;
+    bool ignore_eof;            // ignore stream in underrun detection
 };
 
 struct mp_codec_params {

--- a/player/video.c
+++ b/player/video.c
@@ -1327,7 +1327,7 @@ void write_video(struct MPContext *mpctx)
     osd_set_force_video_pts(mpctx->osd, MP_NOPTS_VALUE);
 
     if (!update_subtitles(mpctx, mpctx->next_frames[0]->pts)) {
-        MP_VERBOSE(mpctx, "Video frame delayed due waiting on subtitles.\n");
+        MP_DBG(mpctx, "Video frame delayed due to waiting on subtitles.\n");
         return;
     }
 


### PR DESCRIPTION
Fixes this behavior:

```
$ wget https://s3.amazonaws.com/tmm1/sample.mpg
$ mpv -v --cache=yes --demuxer-readahead-secs=30 sample.mpg
...
[statusline] AV: 00:00:04 / 00:00:15 (30%) A-V:  0.000 Cache: 10s+0KB
[cplayer] Video frame delayed due waiting on subtitles.
[lavf] EOF reached.
[cplayer] Enter buffering.
[statusline] (Buffering) AV: 00:00:04 / 00:00:15 (30%) A-V:  0.000 Cache: 10s+0KB
[cplayer] End buffering (waited 0.025408 secs).
[statusline] AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[lavf] EOF reached.
[statusline] AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[cplayer] Video frame delayed due waiting on subtitles.
[lavf] EOF reached.
[cplayer] Enter buffering.
[statusline] (Buffering) AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[cplayer] End buffering (waited 0.025300 secs).
[statusline] AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[lavf] EOF reached.
[cplayer] Enter buffering.
[statusline] (Buffering) AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[cplayer] End buffering (waited 0.025627 secs).
[statusline] AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[cplayer] Video frame delayed due waiting on subtitles.
[lavf] EOF reached.
[cplayer] Enter buffering.
[statusline] (Buffering) AV: 00:00:04 / 00:00:15 (31%) A-V:  0.000 Cache: 10s+0KB
[cplayer] End buffering (waited 0.031530 secs).
[statusline] AV: 00:00:04 / 00:00:15 (31%) A-V: -0.000 Cache: 10s+0KB
[lavf] EOF reached.
...
```