### PR TITLE
strip ytdl:// from direct links in ytdl_hook.lua

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -383,8 +383,9 @@ mp.add_hook("on_load", 10, function ()
 
         -- what did we get?
         if not (json["direct"] == nil) and (json["direct"] == true) then
-            -- direct URL, nothing to do
+            -- direct URL, nothing else to do
             msg.verbose("Got direct URL")
+            mp.set_property("stream-open-filename", url)                            
             return
         elseif not (json["_type"] == nil)
             and ((json["_type"] == "playlist")


### PR DESCRIPTION
When youtube-dl returns a playlist of links that are not youtube videos, all links in the playlist file are prepended with ytdl:// by ytdl_hook.lua

When each of these links is passed off individually to ytdl_hook.lua during on_load and a direct link is detected, the ytdl:// is not appropriately stripped off, which results in a link beginning with 'ytdl://http://', ending in an unsupported protocol error back on the player side for each item in the playlist.

One example of this issue in action is `mpv http://shoutengine.com/NyaniShortPhilosophicalStoriesinTamil.xml`.

To resolve this, if a direct link is detected, save it back to the player after the ytdl:// has been stripped off.

I agree that my changes can be relicensed to LGPL 2.1 or later.
