### PR TITLE
Add rgba16hf to the list of FBO formats

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4707,9 +4707,9 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Selects the internal format of textures used for FBOs. The format can
     influence performance and quality of the video output. ``fmt`` can be one
     of: rgb8, rgb10, rgb10_a2, rgb16, rgb16f, rgb32f, rgba12, rgba16, rgba16f,
-    rgba32f. Default: ``auto``, which maps to rgba16 on desktop GL, and rgba16f
-    or rgb10_a2 on GLES (e.g. ANGLE), unless GL_EXT_texture_norm16 is
-    available.
+    rgba16hf, rgba32f. Default: ``auto``, which maps to rgba16 on desktop GL,
+    and rgba16f or rgb10_a2 on GLES (e.g. ANGLE), unless GL_EXT_texture_norm16
+    is available.
 
 ``--gamma-factor=<0.1..2.0>``
     Set an additional raw gamma factor (default: 1.0). If gamma is adjusted in

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3364,7 +3364,8 @@ static void check_gl_features(struct gl_video *p)
     bool have_compute = ra->caps & RA_CAP_COMPUTE;
     bool have_ssbo = ra->caps & RA_CAP_BUF_RW;
 
-    const char *auto_fbo_fmts[] = {"rgba16", "rgba16f", "rgb10_a2", "rgba8", 0};
+    const char *auto_fbo_fmts[] = {"rgba16", "rgba16f", "rgba16hf",
+                                   "rgb10_a2", "rgba8", 0};
     const char *user_fbo_fmts[] = {p->opts.fbo_format, 0};
     const char **fbo_fmts = user_fbo_fmts[0] && strcmp(user_fbo_fmts[0], "auto")
                           ? user_fbo_fmts : auto_fbo_fmts;


### PR DESCRIPTION
This change is from my ra-d3d branch, but it doesn't seem particularly Direct3D specific. Maybe it could be useful if there are Vulkan implementations out there that don't support rgba16?