### PR TITLE
osc: add seekbarkeyframes as a user option

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -171,6 +171,15 @@ Configurable Options
     marker with guide), or bar (fill).
     Default pre-0.21.0 was 'slider'.
 
+``seekbarkeyframes``
+    Default: yes
+
+    Controls the mode used to seek when dragging the seekbar. By default,
+    keyframes are used. If set to false, exact seeking on mouse drags
+    will be used instead. Keyframes are preferred, but exact seeks may be
+    useful in cases where keyframes cannot be found. Note that using exact
+    seeks can potentially make mouse dragging much slower.
+
 ``deadzonesize``
     Default: 0.5
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -34,6 +34,7 @@ local user_opts = {
     layout = "bottombar",
     seekbarstyle = "bar",       -- slider (diamond marker), knob (circle
                                 -- marker with guide), or bar (fill)
+    seekbarkeyframes = true,    -- use keyframes when dragging the seekbar
     title = "${media-title}",   -- string compatible with property-expansion
                                 -- to be shown as OSC title
     tooltipborder = 1,          -- border of tooltip in bottom/topbar
@@ -1784,8 +1785,8 @@ function osc_init()
             local seekto = get_slider_value(element)
             if (element.state.lastseek == nil) or
                 (not (element.state.lastseek == seekto)) then
-                    mp.commandv("seek", seekto,
-                        "absolute-percent", "keyframes")
+                    mp.commandv("seek", seekto, "absolute-percent",
+                        user_opts.seekbarkeyframes and "keyframes" or "exact")
                     element.state.lastseek = seekto
             end
 


### PR DESCRIPTION
mpv doesn't provide a simple way to change what seeking mode the osc seekbar uses on click. In videos with broken PTS, the seekbar will generate some very obnoxious artifacts since it defaults to `absolute-percent+keyframes`. This adds `seekbarmode` as a setting that can be changed in osc.conf similar to input.conf

I agree that my changes can be relicensed to LGPL 2.1 or later.
