### PR TITLE
Reorder gpu contexts to use Wayland when needed

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -73,6 +73,9 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_GL_DXINTEROP
     &ra_ctx_dxgl,
 #endif
+#if HAVE_GL_WAYLAND
+    &ra_ctx_wayland_egl,
+#endif
 #if HAVE_GL_X11
     &ra_ctx_glx_probe,
 #endif
@@ -81,9 +84,6 @@ static const struct ra_ctx_fns *contexts[] = {
 #endif
 #if HAVE_GL_X11
     &ra_ctx_glx,
-#endif
-#if HAVE_GL_WAYLAND
-    &ra_ctx_wayland_egl,
 #endif
 #if HAVE_EGL_DRM
     &ra_ctx_drm_egl,


### PR DESCRIPTION
Most Wayland environments will have XWayland available and active,
meaning there's X11, causing X11 context to be used.

If we reorder the entries in contexts so that HAVE_GL_WAYLAND comes
before HAVE_GL_X11, the resulting mpv binary will use Wayland when we're
under Wayland and use X11 when we're under X11.

Tested with 0.27.0-270-g0358cca39e