### PR TITLE
Fix various typos in log messages

### DIFF
--- a/audio/aconverter.c
+++ b/audio/aconverter.c
@@ -325,7 +325,7 @@ static bool configure_lavrr(struct mp_aconverter *p, bool verbose)
     p->is_resampling = false;
 
     if (avresample_open(p->avrctx) < 0 || avresample_open(p->avrctx_out) < 0) {
-        MP_ERR(p, "Cannot open Libavresample Context. \n");
+        MP_ERR(p, "Cannot open Libavresample context.\n");
         goto error;
     }
     return true;

--- a/audio/filter/af_lavcac3enc.c
+++ b/audio/filter/af_lavcac3enc.c
@@ -400,7 +400,7 @@ static int af_open(struct af_instance* af){
             }
         }
         if (i >= 19) {
-            MP_WARN(af, "unable set unsupported bitrate %d, use default "
+            MP_WARN(af, "unable set unsupported bitrate %d, using default "
                     "bitrate (check manpage to see supported bitrates).\n",
                     s->cfg_bit_rate);
         }

--- a/audio/out/push.c
+++ b/audio/out/push.c
@@ -309,7 +309,7 @@ static void ao_play_data(struct ao *ao)
         r = ao->driver->play(ao, (void **)planes, samples, flags);
     MP_STATS(ao, "end ao fill");
     if (r > samples) {
-        MP_ERR(ao, "Audio device returned non-sense value.\n");
+        MP_ERR(ao, "Audio device returned nonsense value.\n");
         r = samples;
     } else if (r < 0) {
         MP_ERR(ao, "Error writing audio to device.\n");

--- a/common/recorder.c
+++ b/common/recorder.c
@@ -160,7 +160,7 @@ struct mp_recorder *mp_recorder_create(struct mpv_global *global,
     av_dict_set(&priv->mux->metadata, "encoding_tool", version, 0);
 
     if (avformat_write_header(priv->mux, NULL) < 0) {
-        MP_ERR(priv, "Write header failed.\n");
+        MP_ERR(priv, "Writing header failed.\n");
         goto error;
     }
 

--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -509,8 +509,8 @@ static void ebml_parse_element(struct ebml_parse_ctx *ctx, void *target,
         bool multiple = fd->multiple;
         int *countptr = (int *) (s + fd->count_offset);
         if (*countptr >= num_elems[field_idx]) {
-            // Shouldn't happen with on any sane file without bugs
-            MP_ERR(ctx, "Too many subelems?\n");
+            // Shouldn't happen on any sane file without bugs
+            MP_ERR(ctx, "Too many subelements.\n");
             ctx->has_errors = true;
             data += length;
             continue;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -895,7 +895,7 @@ static void open_demux_reentrant(struct MPContext *mpctx)
             if (done) {
                 MP_VERBOSE(mpctx, "Dropping finished prefetch of wrong URL.\n");
             } else {
-                MP_VERBOSE(mpctx, "Aborting onging prefetch of wrong URL.\n");
+                MP_VERBOSE(mpctx, "Aborting ongoing prefetch of wrong URL.\n");
             }
             cancel_open(mpctx);
         }
@@ -1060,7 +1060,7 @@ static int reinit_complex_filters(struct MPContext *mpctx, bool force_uninit)
     {
         if (mpctx->vo_chain) {
             if (mpctx->vo_chain->video_src) {
-                MP_ERR(mpctx, "Pad vo tries to connected to already used VO.\n");
+                MP_ERR(mpctx, "Pad vo tries to connect to already used VO.\n");
                 goto done;
             }
         } else {
@@ -1080,7 +1080,7 @@ static int reinit_complex_filters(struct MPContext *mpctx, bool force_uninit)
     {
         if (mpctx->ao_chain) {
             if (mpctx->ao_chain->audio_src) {
-                MP_ERR(mpctx, "Pad ao tries to connected to already used AO.\n");
+                MP_ERR(mpctx, "Pad ao tries to connect to already used AO.\n");
                 goto done;
             }
         } else {

--- a/player/video.c
+++ b/player/video.c
@@ -1328,7 +1328,7 @@ void write_video(struct MPContext *mpctx)
     osd_set_force_video_pts(mpctx->osd, MP_NOPTS_VALUE);
 
     if (!update_subtitles(mpctx, mpctx->next_frames[0]->pts)) {
-        MP_VERBOSE(mpctx, "Video frame delayed due waiting on subtitles.\n");
+        MP_VERBOSE(mpctx, "Video frame delayed due to waiting on subtitles.\n");
         return;
     }
 

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -236,7 +236,7 @@ static cmsHPROFILE get_vid_profile(struct gl_lcms *p, cmsContext cms,
         }
 
         // Otherwise, warn the user and generate the profile as usual
-        MP_WARN(p, "Video contained an invalid ICC profile! Ignoring..\n");
+        MP_WARN(p, "Video contained an invalid ICC profile! Ignoring...\n");
     }
 
     // The input profile for the transformation is dependent on the video

--- a/video/out/opengl/hwdec_vaegl.c
+++ b/video/out/opengl/hwdec_vaegl.c
@@ -497,7 +497,7 @@ static void determine_working_formats(struct ra_hwdec *hw)
     AVHWFramesConstraints *fc =
             av_hwdevice_get_hwframe_constraints(p->ctx->av_device_ref, NULL);
     if (!fc) {
-        MP_WARN(hw, "failed to retrieve libavutil frame constaints\n");
+        MP_WARN(hw, "failed to retrieve libavutil frame constraints\n");
         goto done;
     }
     for (int n = 0; fc->valid_sw_formats[n] != AV_PIX_FMT_NONE; n++) {


### PR DESCRIPTION
I tried to keep it strictly to things that are clearly a bit off, and not just odd style choices such as the RANDOM SHOUTING in the dvb code.

I agree that my changes can be relicensed to LGPL 2.1 or later.
