### PR TITLE
demux_lavf: return AVERROR_EOF on file end

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -242,7 +242,10 @@ static int mp_read(void *opaque, uint8_t *buf, int size)
 
     MP_TRACE(demuxer, "%d=mp_read(%p, %p, %d), pos: %"PRId64", eof:%d\n",
              ret, stream, buf, size, stream_tell(stream), stream->eof);
-    return ret;
+    if (stream->eof)
+        return AVERROR_EOF;
+    else
+        return ret;
 }
 
 static int64_t mp_seek(void *opaque, int64_t pos, int whence)


### PR DESCRIPTION
libavformat fixed bug when 0 was considered as EOF. Now we need to return proper EOF using AVERROR_EOF

Signed-off-by: Daniel Kucera <daniel.kucera@gmail.com>

