### PR TITLE
Add more-POSIXy versions of open() and fstat() on Windows

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -221,7 +221,7 @@ static int parse_txt(struct pl_parser *p)
 
 static bool same_st(struct stat *st1, struct stat *st2)
 {
-    return HAVE_POSIX && st1->st_dev == st2->st_dev && st1->st_ino == st2->st_ino;
+    return st1->st_dev == st2->st_dev && st1->st_ino == st2->st_ino;
 }
 
 // Return true if this was a readable directory.

--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -52,7 +52,7 @@ def __add_clang_flags__(ctx):
                        "-Wno-tautological-constant-out-of-range-compare" ]
 
 def __add_mswin_flags__(ctx):
-    ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x0601', '-DUNICODE', '-DCOBJMACROS',
+    ctx.env.CFLAGS += ['-D_WIN32_WINNT=0x0602', '-DUNICODE', '-DCOBJMACROS',
                        '-DINITGUID', '-U__STRICT_ANSI__']
     ctx.env.LAST_LINKFLAGS += ['-Wl,--major-os-version=6,--minor-os-version=0',
                  '-Wl,--major-subsystem-version=6,--minor-subsystem-version=0']


### PR DESCRIPTION
This should fix opening directories as playlists on Windows. It should also enable the filesystem loop checking in demux_playlist.c. There was an attempt to keep io.c UWP-compatible (see ``#if !HAVE_UWP``,) but it's untested.