### PR TITLE
DVB: Add multiple frontends support: MAX_FRONTENDS now 8.

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -3292,14 +3292,14 @@ static int mp_property_dvb_channel(void *ctx, struct m_property *prop,
     case M_PROPERTY_SET:
         r = prop_stream_ctrl(mpctx, STREAM_CTRL_DVB_SET_CHANNEL, arg);
         if (r == M_PROPERTY_OK && !mpctx->stop_play)
-            mpctx->stop_play = PT_RELOAD_FILE;
+            mpctx->stop_play = PT_CURRENT_ENTRY;
         return r;
     case M_PROPERTY_SWITCH: {
         struct m_property_switch_arg *sa = arg;
         int dir = sa->inc >= 0 ? 1 : -1;
         r = prop_stream_ctrl(mpctx, STREAM_CTRL_DVB_STEP_CHANNEL, &dir);
         if (r == M_PROPERTY_OK && !mpctx->stop_play)
-            mpctx->stop_play = PT_RELOAD_FILE;
+            mpctx->stop_play = PT_CURRENT_ENTRY;
         return r;
     }
     case M_PROPERTY_GET_TYPE:
@@ -3318,14 +3318,14 @@ static int mp_property_dvb_channel_name(void *ctx, struct m_property *prop,
     case M_PROPERTY_SET:
         r = prop_stream_ctrl(mpctx, STREAM_CTRL_DVB_SET_CHANNEL_NAME, arg);
         if (r == M_PROPERTY_OK && !mpctx->stop_play)
-            mpctx->stop_play = PT_RELOAD_FILE;
+            mpctx->stop_play = PT_CURRENT_ENTRY;
         return r;
     case M_PROPERTY_SWITCH: {
         struct m_property_switch_arg *sa = arg;
         int dir = sa->inc >= 0 ? 1 : -1;
         r = prop_stream_ctrl(mpctx, STREAM_CTRL_DVB_STEP_CHANNEL, &dir);
         if (r == M_PROPERTY_OK && !mpctx->stop_play)
-            mpctx->stop_play = PT_RELOAD_FILE;
+            mpctx->stop_play = PT_CURRENT_ENTRY;
         return r;
     }
     case M_PROPERTY_GET: {

--- a/stream/dvb_tune.h
+++ b/stream/dvb_tune.h
@@ -26,7 +26,8 @@ struct mp_log;
 
 const char *get_dvb_delsys(unsigned int delsys);
 unsigned int dvb_get_tuner_delsys_mask(int fe_fd, struct mp_log *log);
-int dvb_open_devices(dvb_priv_t *priv, unsigned int n, unsigned int demux_cnt);
+int dvb_open_devices(dvb_priv_t *priv, unsigned int adapter,
+                     unsigned int frontend, unsigned int demux_cnt);
 int dvb_fix_demuxes(dvb_priv_t *priv, unsigned int cnt);
 int dvb_set_ts_filt(dvb_priv_t *priv, int fd, uint16_t pid, dmx_pes_type_t pestype);
 int dvb_get_pmt_pid(dvb_priv_t *priv, int card, int service_id);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -26,6 +26,9 @@
 #include <linux/dvb/audio.h>
 #include <linux/dvb/version.h>
 
+#define MAX_ADAPTERS 16
+#define MAX_FRONTENDS 8
+
 #undef DVB_ATSC
 #if defined(DVB_API_VERSION_MINOR)
 
@@ -69,7 +72,8 @@ typedef struct {
     unsigned int freq, srate, diseqc;
     char pol;
     unsigned int tpid, dpid1, dpid2, progid, ca, pids[DMX_FILTER_SIZE], pids_cnt;
-    bool is_dvb_x2;
+    bool is_dvb_x2; /* Used only in dvb_get_channels() and parse_vdr_par_string(), use delsys. */
+    unsigned int frontend;
     unsigned int delsys;
     unsigned int stream_id;
     unsigned int service_id;
@@ -90,7 +94,7 @@ typedef struct {
 
 typedef struct {
     int devno;
-    unsigned int delsys_mask;
+    unsigned int delsys_mask[MAX_FRONTENDS];
     dvb_channels_list_t *list;
 } dvb_adapter_config_t;
 
@@ -98,6 +102,7 @@ typedef struct {
     unsigned int adapters_count;
     dvb_adapter_config_t *adapters;
     unsigned int cur_adapter;
+    unsigned int cur_frontend;
 
     int fe_fd;
     int dvr_fd;


### PR DESCRIPTION
Now tuners with multiple frontends work.
I have Astrometa DVB-T2: https://www.linuxtv.org/wiki/index.php/Astrometa_DVB-T2
where:
frontend0 - DVB-T
frontend1 - DVB-T, DVB-T2 and DVB-C ANNEX A.
Our local broadcasting is DVB-T2, so without this path I cant watch TV.

On play list load mpv query all frontends and add channels with capable DVB type, also capable frontend num saved with channel props to future use while tuning.


There was bug: channels switched exponentially long time, I suspect this some how connected with play time:
[statusline] AV: 00:00:42 / 00:00:00 A-V: -0.000 Cache: ???+1MB
was not reset, so next channel not start play while ~40 seconds.
My fix is change:
mpctx->stop_play = PT_RELOAD_FILE;
to
mpctx->stop_play = PT_CURRENT_ENTRY;
in dvb commands handle function.
Probably PT_RELOAD_FILE does not properly handled for streams that have no seek capability.