### PR TITLE
lavc_conv: make disable_styles faster

### DIFF
--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -57,12 +57,13 @@ static const char *get_lavc_format(const char *format)
 // We always want the user defined style instead.
 static void disable_styles(bstr header)
 {
+    bstr style = bstr0("\nStyle: ");
     while (header.len) {
-        int n = bstr_find(header, bstr0("\nStyle: "));
+        int n = bstr_find(header, style);
         if (n < 0)
             break;
         header.start[n + 1] = '#'; // turn into a comment
-        header = bstr_cut(header, 2);
+        header = bstr_cut(header, n + style.len);
     }
 }
 


### PR DESCRIPTION
The current invocation of bstr_cut is as good as no cutting at all. Almost the entire header is reread in every iteration of the loop. I don’t know how many styles libavcodec tends to generate, but if (now or in the future) it generates many, then this loop is slow for no good reason. If anything, the code would be more clear and have the same performance if it didn't call bstr_cut at all.

The intention here (and the sensible thing regardless) seems to be to skip the part of the string that bstr_find has already looked through and found nothing. This commit additionally skips the whole substring, because overlapping matches are impossible. **I have another version of the commit that only skips `n + 2` bytes if you prefer that.**

I agree that my changes can be relicensed to LGPL 2.1 or later, the ISC license or the MIT license.