### PR TITLE
TOOLS/autoload.lua: update extensions

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -22,7 +22,7 @@ end
 
 EXTENSIONS = Set {
     'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp',
-    'mp3', 'wav', 'ogv', 'flac', 'm4a', 'wma',
+    'mp3', 'wav', 'ogm', 'flac', 'm4a', 'wma',
 }
 
 mputils = require 'mp.utils'

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -22,7 +22,7 @@ end
 
 EXTENSIONS = Set {
     'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp',
-    'mp3', 'wav', 'ogm', 'flac', 'm4a', 'wma',
+    'mp3', 'wav', 'ogm', 'flac', 'm4a', 'wma', 'ogg', 'opus',
 }
 
 mputils = require 'mp.utils'


### PR DESCRIPTION
I've noticed the double mention of 'ogv' for a while here and it just so happens I also run into 'ogm' files not being picked up due to this, so I switched the second mention of 'ogv' with 'ogm'. 

I agree that my changes can be relicensed to LGPL 2.1 or later.
