### PR TITLE
Revert "build: require our own ffmpeg repo"

### DIFF
--- a/wscript
+++ b/wscript
@@ -458,18 +458,11 @@ libav_dependencies = [
         'req': True,
         'fmsg': "FFmpeg/Libav development files not found.",
     }, {
-        'name': 'ffmpeg_mpv',
-        'desc': 'libav* is FFmpeg mpv modified version',
-        'func': check_statement('libavcodec/version.h',
-                                'int x[LIBAVCODEC_MPV ? 1 : -1]',
-                                use='libavcodec')
-    }, {
-        'name': 'ffmpeg_garbage',
-        'deps': '!ffmpeg_mpv',
-        'desc': 'libav* is upstream FFmpeg (unsupported)',
+        'name': 'is_ffmpeg',
+        'desc': 'libav* is FFmpeg',
         # FFmpeg <=> LIBAVUTIL_VERSION_MICRO>=100
         'func': check_statement('libavcodec/version.h',
-                                'int x[LIBAVCODEC_VERSION_MICRO >= 100 ? 1 : -1]',
+                                'int x[LIBAVCODEC_MPV ? 1 : -1]',
                                 use='libavcodec')
     }, {
         # This check should always result in the opposite of is_ffmpeg.
@@ -488,9 +481,7 @@ libav_dependencies = [
         'func': check_ffmpeg_or_libav_versions(),
         'req': True,
         'fmsg': "Unable to find development files for some of the required \
-FFmpeg/Libav libraries. You need git master. For FFmpeg, the mpv fork, that \
-might contain additional fixes and features is required. It is available on \
-https://github.com/mpv-player/ffmpeg-mpv Aborting."
+FFmpeg/Libav libraries. You need at least {0}. Aborting.".format(libav_versions_string)
     }, {
         'name': '--libavdevice',
         'desc': 'libavdevice',


### PR DESCRIPTION
This reverts commit 83d44aca7dc7f46b8d3b64d441f5a8317a40e080.

Lets try this again...

"This was a really terrible idea and essentially a "F*** you" to any and all distros that support mpv. I get that ffmpeg can be frustrating, but only mpv and its users are hurt by this commit, not ffmpeg. Lets please revert it and come up with a proper solution."

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
