### PR TITLE
screenshot: create directories from template

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -364,6 +364,11 @@ static char *gen_fname(screenshot_ctx *ctx, const char *file_ext)
             talloc_free(t);
         }
 
+        char *full_dir = bstrto0(fname, mp_dirname(fname));
+        if (!mp_path_exists(full_dir)) {
+            mp_mkdirp(full_dir);
+        }
+
         if (!mp_path_exists(fname))
             return fname;
 


### PR DESCRIPTION
screenshot-template could be set to e.g. "%F/%04n", so we want to make sure that the path generated from the template actually exists.

Please let me know if I fucked up the memory allocation, I am not good with C.

I agree that my changes can be relicensed to LGPL 2.1 or later.
