### PR TITLE
demux_mkv: add V_SNOW tag to mkv_video_tags

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1375,6 +1375,7 @@ static const char *const mkv_video_tags[][2] = {
     {"V_DIRAC",             "dirac"},
     {"V_PRORES",            "prores"},
     {"V_MPEGH/ISO/HEVC",    "hevc"},
+    {"V_SNOW",              "snow"},
     {0}
 };
 


### PR DESCRIPTION
Apparently, and to nobody's surprise, mkv can contain snow. It does so with the V_SNOW tag. We can now play back snow-inside-mkv in mpv.

I agree that my changes can be relicensed to LGPL 2.1 or later.
