### PR TITLE
video: in context_drm_egl only use ARGB8888 format for framebuffer if hardware supports this on the primary plane + various bugfixes

### DIFF
--- a/video/out/drm_atomic.c
+++ b/video/out/drm_atomic.c
@@ -203,6 +203,7 @@ struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd,
             }
         }
         drmModeFreePlane(drmplane);
+        drmplane = NULL;
     }
 
     if (!ctx->primary_plane) {
@@ -232,7 +233,7 @@ fail:
         drmModeFreePlane(drmplane);
     if (plane)
         drm_object_free(plane);
-    return false;
+    return NULL;
 }
 
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx)

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -395,7 +395,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
 
     p->drm_params.fd = p->kms->fd;
     p->drm_params.crtc_id = p->kms->crtc_id;
-    p->drm_params.atomic_request = p->kms->atomic_context->request;
+    if (p->kms->atomic_context)
+        p->drm_params.atomic_request = p->kms->atomic_context->request;
     struct ra_gl_ctx_params params = {
         .swap_buffers = drm_egl_swap_buffers,
         .native_display_type = "opengl-cb-drm-params",

--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -48,7 +48,7 @@ struct priv {
     struct mp_log *log;
 
     struct mp_image_params params;
-  
+
     struct drm_atomic_context *ctx;
     struct drm_frame current_frame, old_frame;
 
@@ -182,7 +182,7 @@ static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
 
     set_current_frame(hw, &next_frame);
     return 0;
-    
+
  fail:
     drm_prime_destroy_framebuffer(p->log, p->ctx->fd, &next_frame.fb);
     return ret;


### PR DESCRIPTION
The change to always use ARGB8888 format used with the DRM primary
plane (commit: 762b8cc30007480f06d338ac77d6e91cc04cd320) causes --gpu-context=drm to break on drivers which do not
support this, e.g. intel sandy bridge.

Instead we probe to see if the driver supports ARGB8888, falling back
on XRGB8888 if this is not available. If neither is available it is treated as an error.

When the driver does not support DRM atomic, we always use XRGB8888.
The reason being that the change to use ARGB8888 is primarily
motivated by the need to have the primary plane (with OSD only in this
case) above the overlay plane (the video) when using --hwdec=rkmpp
(hwdec_drmprime_drm), which also needs DRM atomic. Without DRM atomic
we cannot use that hwdec anyway, and without the hwdec everything will
always be rendered to the primary plane, only

If XRGB8888 gets selected, you could potentially end up with either no OSD or OSD only (depending
on whether the driver supports ZPOS or not) when using --hwdec=rkmpp.
However, I think all rockchips should support both atomic, ARGB8888 on
the primary plane, and ZPOS (more testing across different rockhip
SoC:s needed?) so it will not be a problem in practice

Edit: I changed this comment when I updated the PR to include my DRM primary plane format probing code

Old comment:
Passing in an invalid DRM overlay id with the --drm-overlay option would
cause drmplane to be freed twice: once in the for-loop and once at the
error-handler label fail.

Solve by setting drmpanel to NULL after freeing it.

I agree that my changes can be relicensed to LGPL 2.1 or later.
