### PR TITLE
os x: mavericks fullscreen fix

### DIFF
--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -418,6 +418,14 @@
         // needed to counter the 'snap to top' behaviour.
         nf.origin.y = (NSHeight(vf) - NSHeight(nf)) / 2;
 
+    // Mavericks fullscreen bug workaround
+    if ((NSAppKitVersionNumber >= 1244 && NSAppKitVersionNumber < 1334)
+            && [self.adapter isInFullScreenMode]
+            && !_is_animating
+            && nf.origin.y != vf.origin.y) {
+        nf.origin.y = vf.origin.y;
+    }
+
     return nf;
 }
 


### PR DESCRIPTION
description of the issue available [here](https://github.com/mpv-player/mpv/issues/4044#issuecomment-343160545).
tested on OS X Mavericks 10.9.4 (both native/non-native fullscreen).

I agree that my changes can be relicensed to LGPL 2.1 or later.
