### PR TITLE
Fix semantics of Windows POSIX 2008 locale stubs

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -799,4 +799,18 @@ int msync(void *addr, size_t length, int flags)
 }
 #endif
 
+locale_t newlocale(int category, const char *locale, locale_t base)
+{
+    return (locale_t)1;
+}
+
+locale_t uselocale(locale_t locobj)
+{
+    return (locale_t)1;
+}
+
+void freelocale(locale_t locobj)
+{
+}
+
 #endif // __MINGW32__

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -193,11 +193,12 @@ int msync(void *addr, size_t length, int flags);
 #define glob(...) mp_glob(__VA_ARGS__)
 #define globfree(...) mp_globfree(__VA_ARGS__)
 
-// There is not anything that helps with this on Windows.
+// These are stubs since there is not anything that helps with this on Windows.
 #define locale_t int
-#define newlocale(a, b, c) 1
-#define uselocale(a) 1
-#define freelocale(a)
+#define LC_ALL_MASK 0
+locale_t newlocale(int, const char *, locale_t);
+locale_t uselocale(locale_t);
+void freelocale(locale_t);
 
 #else /* __MINGW32__ */
 


### PR DESCRIPTION
The freelocale() fix is probably important, because otherwise mp_archive_free() won't work as expected. This also silences some warnings.