### PR TITLE
manpage: vaapi-copy is not limited to Intel GPUs 

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -679,7 +679,7 @@ Video
     :vdpau:     requires ``--vo=gpu`` or ``--vo=vdpau`` (Linux only)
     :vdpau-copy: copies video back into system RAM (Linux with some GPUs only)
     :vaapi:     requires ``--vo=gpu`` or ``--vo=vaapi`` (Linux only)
-    :vaapi-copy: copies video back into system RAM (Linux with Intel GPUs only)
+    :vaapi-copy: copies video back into system RAM (Linux with some GPUs only)
     :videotoolbox: requires ``--vo=gpu`` (OS X 10.8 and up),
                    or ``--vo=opengl-cb`` (iOS 9.0 and up)
     :videotoolbox-copy: copies video back into system RAM (OS X 10.8 or iOS 9.0 and up)


### PR DESCRIPTION
vaapi-copy works with some AMD cards (only tested with RX 470)

I agree that my changes can be relicensed to LGPL 2.1 or later.
