### PR TITLE
Fixed README Markdown formatting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ might be broken at times.
 
 _If_ you force upstream FFmpeg, and it doesn't work, please contact upstream
 FFmpeg for help, instead of mpv. See
-[FFmpeg contact][http://ffmpeg.org/contact.html#MailingLists] how to contact
+[FFmpeg contact](http://ffmpeg.org/contact.html#MailingLists) on how to contact
 FFmpeg upstream.
 
 ## FFmpeg ABI compatibility


### PR DESCRIPTION
README: Fix incorrect markdown formatting of link to ffmpeg's contact page

This change makes the previously unclickable link clickable in Github's HTML rendering of Markdown.

I agree that my changes can be relicensed to LGPL 2.1 or later.
