### PR TITLE
client: Allow "C.UTF-8" as LC_NUMERIC locale (for Android)

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -479,7 +479,7 @@ static void *core_thread(void *tag)
 static bool check_locale(void)
 {
     char *name = setlocale(LC_NUMERIC, NULL);
-    return !name || strcmp(name, "C") == 0;
+    return !name || strcmp(name, "C") == 0 || strcmp(name, "C.UTF-8") == 0;
 }
 
 mpv_handle *mpv_create(void)


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.
