### PR TITLE
vo_opengl: hwdec_vaegl: Reenable vaExportSurfaceHandle()

### DIFF
--- a/video/out/opengl/hwdec_vaegl.c
+++ b/video/out/opengl/hwdec_vaegl.c
@@ -128,7 +128,7 @@ struct priv {
     EGLImageKHR images[4];
     VAImage current_image;
     bool buffer_acquired;
-#if 0
+#if VA_CHECK_VERSION(1, 1, 0)
     bool esh_not_implemented;
     VADRMPRIMESurfaceDescriptor desc;
     bool surface_acquired;
@@ -215,7 +215,7 @@ static void mapper_unmap(struct ra_hwdec_mapper *mapper)
         p->images[n] = 0;
     }
 
-#if 0
+#if VA_CHECK_VERSION(1, 1, 0)
     if (p->surface_acquired) {
         for (int n = 0; n < p->desc.num_objects; n++)
             close(p->desc.objects[n].fd);
@@ -344,7 +344,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     VAImage *va_image = &p->current_image;
     VADisplay *display = p_owner->display;
 
-#if 0
+#if VA_CHECK_VERSION(1, 1, 0)
     if (p->esh_not_implemented)
         goto esh_failed;
 


### PR DESCRIPTION
Now actually in upstream libva and the Intel driver, to be released in 2.1 (VAAPI 1.1.0 or later).

https://github.com/01org/libva/commit/fcb9cc881596d7ff809adf5f6ff631c708d407e3
https://github.com/01org/intel-vaapi-driver/commit/106d1eb730210b498c1f9fca9f4f5c3df82d056d

I'll reenable it in Mesa as well soon.