### PR TITLE
options: add --start=none to reset previously set start time

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -107,6 +107,8 @@ Playback Control
 
     ``#c`` seeks to chapter number c. (Chapters start from 1.)
 
+    ``none`` resets any previously set option (useful for libmpv).
+
     .. admonition:: Examples
 
         ``--start=+56``, ``--start=+00:56``

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2324,6 +2324,11 @@ static int parse_rel_time(struct mp_log *log, const m_option_t *opt,
     if (param.len == 0)
         return M_OPT_MISSING_PARAM;
 
+    if (bstr_equals0(param, "none")) {
+        t.type = REL_TIME_NONE;
+        goto out;
+    }
+
     // Percent pos
     if (bstr_endswith0(param, "%")) {
         double percent = bstrtod(bstr_splice(param, 0, -1), &param);


### PR DESCRIPTION
Previously when using a libmpv instance to play multiple videos,
once --start was set there was no clear way to unset it. You could
use --start=0, but 0 does not always mean the beginning of the file
(especially when using --rebase-start-time=no). Looking up the start
timestamp and passing that in also does not always work, particularly
when the first timestamp is negative (since negative values to --start
have a special meaning).

This commit adds a new "none" value which maps to the internal
REL_TIME_NONE, matching the default value of the play_start option.

cc @thebombzen @jeeb #5175 