### PR TITLE
options: don't report errors on help value for OPT_FLAG and OPT_COLOR

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1962,6 +1962,10 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
 static int parse_geometry(struct mp_log *log, const m_option_t *opt,
                           struct bstr name, struct bstr param, void *dst)
 {
+    bool is_help = bstr_equals0(param, "help");
+    if (is_help)
+        goto error;
+
     struct m_geometry gm;
     if (!parse_geometry_str(&gm, param))
         goto error;
@@ -1972,10 +1976,13 @@ static int parse_geometry(struct mp_log *log, const m_option_t *opt,
     return 1;
 
 error:
-    mp_err(log, "Option %.*s: invalid geometry: '%.*s'\n",
-           BSTR_P(name), BSTR_P(param));
-    mp_err(log, "Valid format: [W[%%][xH[%%]]][{+-}X[%%]{+-}Y[%%]] | [X[%%]:Y[%%]]\n");
-    return M_OPT_INVALID;
+    if (!is_help) {
+        mp_err(log, "Option %.*s: invalid geometry: '%.*s'\n",
+               BSTR_P(name), BSTR_P(param));
+    }
+    mp_info(log,
+         "Valid format: [W[%%][xH[%%]]][{+-}X[%%]{+-}Y[%%]] | [X[%%]:Y[%%]]\n");
+    return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
 const m_option_type_t m_option_type_geometry = {

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -135,13 +135,18 @@ static int parse_flag(struct mp_log *log, const m_option_t *opt,
             VAL(dst) = 0;
         return 1;
     }
-    mp_fatal(log, "Invalid parameter for %.*s flag: %.*s\n",
-                BSTR_P(name), BSTR_P(param));
-    mp_info(log, "Valid values are:\n");
+    bool is_help = bstr_equals0(param, "help");
+    if (is_help) {
+        mp_info(log, "Valid values for %.*s flag are:\n", BSTR_P(name));
+    } else {
+        mp_fatal(log, "Invalid parameter for %.*s flag: %.*s\n",
+                 BSTR_P(name), BSTR_P(param));
+        mp_info(log, "Valid values are:\n");
+    }
     mp_info(log, "    yes\n");
     mp_info(log, "    no\n");
     mp_info(log, "    (passing nothing)\n");
-    return M_OPT_INVALID;
+    return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
 static char *print_flag(const m_option_t *opt, const void *val)

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1746,6 +1746,10 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
     if (param.len == 0)
         return M_OPT_MISSING_PARAM;
 
+    bool is_help = bstr_equals0(param, "help");
+    if (is_help)
+        goto error;
+
     bstr val = param;
     struct m_color color = {0};
 
@@ -1790,12 +1794,14 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
     return 1;
 
 error:
-    mp_err(log, "Option %.*s: invalid color: '%.*s'\n",
-           BSTR_P(name), BSTR_P(param));
-    mp_err(log, "Valid colors must be in the form #RRGGBB or #AARRGGBB (in hex)\n"
-                "Or in the form 'r/g/b/a', where each component is a value in the\n"
-                "range 0.0-1.0. (Also allowed: 'gray', 'gray/a', 'r/g/b'.\n");
-    return M_OPT_INVALID;
+    if (!is_help) {
+        mp_err(log, "Option %.*s: invalid color: '%.*s'\n",
+               BSTR_P(name), BSTR_P(param));
+    }
+    mp_info(log, "Valid colors must be in the form #RRGGBB or #AARRGGBB (in hex)\n"
+            "or in the form 'r/g/b/a', where each component is a value in the\n"
+            "range 0.0-1.0. (Also allowed: 'gray', 'gray/a', 'r/g/b').\n");
+    return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
 const m_option_type_t m_option_type_color = {


### PR DESCRIPTION
The same idea as in 3723e61 but for OPT_FLAG now.

Before the change:
-----
````
mpv --border=help
Invalid parameter for border flag: help
Valid values are:
    yes
    no
    (passing nothing)
Error parsing option border (option parameter could not be parsed)
Setting commandline option --border=help failed.

Exiting... (Fatal error)
````

````
mpv --border=sdjfkhlsdfh
Invalid parameter for border flag: sdjfkhlsdfh
Valid values are:
    yes
    no
    (passing nothing)
Error parsing option border (option parameter could not be parsed)
Setting commandline option --border=sdjfkhlsdfh failed.

Exiting... (Fatal error)
````

After the change:
-----
````
mpv --border=help
Valid values for border flag are:
    yes
    no
    (passing nothing)
````

````
mpv --border=sdjfkhlsdfh
Invalid parameter for border flag: sdjfkhlsdfh
Valid values are:
    yes
    no
    (passing nothing)
Error parsing option border (option parameter could not be parsed)
Setting commandline option --border=sdjfkhlsdfh failed.

Exiting... (Fatal error)
````