### PR TITLE
video: minor fixes and improvements to recent hwdec changes

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -470,6 +470,10 @@ static void select_and_set_hwdec(struct dec_video *vd)
                     }
                     MP_WARN(vd, "Using emulated hardware decoding API.\n");
                 }
+            } else if (!hwdec->copying) {
+                // Most likely METHOD_INTERNAL, which often use delay-loaded
+                // VO support as well.
+                hwdec_devices_request_all(vd->hwdec_devs);
             }
 
             ctx->use_hwdec = true;

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -117,6 +117,7 @@ int ra_hwdec_validate_opt(struct mp_log *log, const m_option_t *opt,
     }
     if (help) {
         mp_info(log, "    auto (behavior depends on context)\n"
+                     "    all (load all hwdecs)\n"
                      "    no (do not load any and block loading on demand)\n");
         return M_OPT_EXIT;
     }

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -317,6 +317,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .tone_mapping_param = NAN,
     .tone_mapping_desat = 1.0,
     .early_flush = -1,
+    .hwdec_interop = "auto",
 };
 
 static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
@@ -3433,6 +3434,7 @@ static void check_gl_features(struct gl_video *p)
             .tone_mapping_desat = p->opts.tone_mapping_desat,
             .early_flush = p->opts.early_flush,
             .icc_opts = p->opts.icc_opts,
+            .hwdec_interop = p->opts.hwdec_interop,
         };
         for (int n = 0; n < SCALER_COUNT; n++)
             p->opts.scaler[n] = gl_video_opts_def.scaler[n];
@@ -3884,8 +3886,7 @@ void gl_video_load_hwdecs(struct gl_video *p, struct mp_hwdec_devices *devs,
     if (strcmp(type, "no") == 0) {
         // do nothing, just block further loading
     } else if (strcmp(type, "all") == 0) {
-        for (int n = 0; ra_hwdec_drivers[n]; n++)
-            load_add_hwdec(p, devs, ra_hwdec_drivers[n], true);
+        gl_video_load_hwdecs_all(p, devs);
     } else {
         for (int n = 0; ra_hwdec_drivers[n]; n++) {
             const struct ra_hwdec_driver *drv = ra_hwdec_drivers[n];


### PR DESCRIPTION
Don't reset --gpu-hwdec-interop if vo_gpu uses dumb mode.

For METHOD_INTERNAL hwdecs (non-copy cases), make sure the VO interops
are always loaded, because those decoders will output hardware pixel
formats, which will need special support in vo_gpu. Otherwise,
initialization will fail, complaining that it can't convert the output
format to something the VO supports.

Make gl_video_load_hwdecs() call gl_video_load_hwdecs_all() to remove
some minor code duplication. Add the "all" value to the
--gpu-hwdec-interop help output.
