### PR TITLE
video: add rkmpp to the hwdec_wrappers array.

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -213,6 +213,7 @@ static const char *const hwdec_wrappers[] = {
     "crystalhd",
     "v4l2m2m",
     "cuvid",
+    "rkmpp",
     NULL
 };
 


### PR DESCRIPTION
Allows to get the hwdec picked up properly by mpv on rockchip devices

I agree that my changes can be relicensed to LGPL 2.1 or later.
