### PR TITLE
osd: fix a compiler warning by adding parentheses in if condition

### DIFF
--- a/player/osd.c
+++ b/player/osd.c
@@ -358,7 +358,9 @@ void set_osd_bar_chapters(struct MPContext *mpctx, int type)
     if (len > 0) {
         double ab_loop_start_time = get_ab_loop_start_time(mpctx);
         if (opts->ab_loop[0] != MP_NOPTS_VALUE ||
-            ab_loop_start_time != MP_NOPTS_VALUE && opts->ab_loop[1] != MP_NOPTS_VALUE) {
+            (ab_loop_start_time != MP_NOPTS_VALUE &&
+               opts->ab_loop[1] != MP_NOPTS_VALUE))
+        {
             MP_TARRAY_APPEND(mpctx, mpctx->osd_progbar.stops,
                         mpctx->osd_progbar.num_stops, ab_loop_start_time / len);
         }


### PR DESCRIPTION
There was a compilation warning after the commit 0433162

````
../player/osd.c: In function 'set_osd_bar_chapters':
../player/osd.c:361:50: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
             ab_loop_start_time != MP_NOPTS_VALUE && opts->ab_loop[1] != MP_NOPTS_VALUE) {
````

Fixed it by adding suggested parentheses, also split the line to fit in 80-char length.
Moved a curly bracket to a new line, as suggested in contribute.md for complex conditional statements.