### PR TITLE
vo_gpu: hwdec_drmprime_drm: silence error on failed autoprobing

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -217,7 +217,7 @@ static int init(struct ra_hwdec *hw)
             gl ? (struct mpv_opengl_cb_drm_params *)
             mpgl_get_native_display(gl, "opengl-cb-drm-params") : NULL;
     if (!params) {
-        MP_ERR(hw, "Could not get drm interop info.\n");
+        MP_VERBOSE(hw, "Could not get drm interop info.\n");
         goto err;
     }
 


### PR DESCRIPTION
When autoprobing the hwdec interops (which now happens to all compiled
interops if hardware decoding is used), failure to load an interop
should not print an error in the normal case. So hide it.

(We could make the log level conditional on whether autoprobing is used,
but directly loading it without autoprobing is obscure, and most other
interops don't do this either.)
