### PR TITLE
vf_convert: default to limited range when converting RGB to YUV

### DIFF
--- a/video/filter/vf_convert.c
+++ b/video/filter/vf_convert.c
@@ -71,6 +71,11 @@ static int reconfig(struct vf_instance *vf, struct mp_image_params *in,
     *out = *in;
     out->imgfmt = best;
 
+    // If we convert from RGB to YUV, default to limited range.
+    if (mp_imgfmt_get_forced_csp(in->imgfmt) == MP_CSP_RGB &&
+        mp_imgfmt_get_forced_csp(out->imgfmt) == MP_CSP_AUTO)
+        out->color.levels = MP_CSP_LEVELS_TV;
+
     mp_image_params_guess_csp(out);
 
     mp_sws_set_from_cmdline(vf->priv->sws, vf->chain->opts->vo->sws_opts);


### PR DESCRIPTION
Full range YUV causes problems everywhere. For example it's usually the
wrong choice when using encoding mode, and libswscale sometimes messes
up when converting to full range too. (In this partricular case, we
found that converting rgba->yuv420p16 full range actually seems to
output limited range.)

This actually restores a similar heueristic from the late vf_scale.c.
