### PR TITLE
lua+js: Implement and document utils.stat()

### DIFF
--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -168,6 +168,8 @@ Otherwise, where the Lua APIs return ``nil`` on error, JS returns ``undefined``.
 
 ``mp.utils.readdir(path [, filter])`` (LE)
 
+``mp.utils.stat(path)`` (LE)
+
 ``mp.utils.split_path(path)``
 
 ``mp.utils.join_path(p1, p2)``

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -168,7 +168,7 @@ Otherwise, where the Lua APIs return ``nil`` on error, JS returns ``undefined``.
 
 ``mp.utils.readdir(path [, filter])`` (LE)
 
-``mp.utils.stat(path)`` (LE)
+``mp.utils.file_info(path)`` (LE)
 
 ``mp.utils.split_path(path)``
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -591,22 +591,13 @@ strictly part of the guaranteed API.
 
     On error, ``nil, error`` is returned.
 
-``utils.stat(path)``
-    Stats the given path and returns a table with the following entries:
+``utils.file_info(path)``
+    Stats the given path for information and returns a table with the
+    following entries:
 
-        ``dev``
-            device id (may be unavailable on Windows)
-        ``ino``
-            inode number (may be unavailable on Windows)
         ``mode``
-            protection bits (on Windows, always 755 for directories and 644
-            for files)
-        ``nlink``
-            number of hard links
-        ``uid``
-            owner user id (unavailable on Windows)
-        ``gid``
-            owner group id (unavailable on Windows)
+            protection bits (on Windows, always 755 (octal) for directories
+            and 644 (octal) for files)
         ``size``
             size in bytes
         ``atime``
@@ -620,13 +611,13 @@ strictly part of the guaranteed API.
         ``is_dir``
             Whether ``path`` is a directory (boolean)
 
-    All values (if not otherwise specified) are integers.
-    Timestamps (``atime``, ``mtime`` and ``ctime``) are in seconds since the
-    Unix epoch (Unix time).
-    ``is_file`` and ``is_dir`` are provided as a convenience; they are and can
-    be derived from ``mode``.
+    ``mode`` and ``size`` are integers.
+    Timestamps (``atime``, ``mtime`` and ``ctime``) are integer seconds since
+    the Unix epoch (Unix time).
+    The booleans ``is_file`` and ``is_dir`` are provided as a convenience;
+    they can be and are derived from ``mode``.
 
-    On error, ``nil, error`` is returned.
+    On error (eg. path does not exist), ``nil, error`` is returned.
 
 ``utils.split_path(path)``
     Split a path into directory component and filename component, and return

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -591,6 +591,43 @@ strictly part of the guaranteed API.
 
     On error, ``nil, error`` is returned.
 
+``utils.stat(path)``
+    Stats the given path and returns a table with the following entries:
+
+        ``dev``
+            device id (may be unavailable on Windows)
+        ``ino``
+            inode number (may be unavailable on Windows)
+        ``mode``
+            protection bits (on Windows, always 755 for directories and 644
+            for files)
+        ``nlink``
+            number of hard links
+        ``uid``
+            owner user id (unavailable on Windows)
+        ``gid``
+            owner group id (unavailable on Windows)
+        ``size``
+            size in bytes
+        ``atime``
+            time of last access
+        ``mtime``
+            time of last modification
+        ``ctime``
+            time of last metadata change (Linux) / time of creation (Windows)
+        ``is_file``
+            Whether ``path`` is a regular file (boolean)
+        ``is_dir``
+            Whether ``path`` is a directory (boolean)
+
+    All values (if not otherwise specified) are integers.
+    Timestamps (``atime``, ``mtime`` and ``ctime``) are in seconds since the
+    Unix epoch (Unix time).
+    ``is_file`` and ``is_dir`` are provided as a convenience; they are and can
+    be derived from ``mode``.
+
+    On error, ``nil, error`` is returned.
+
 ``utils.split_path(path)``
     Split a path into directory component and filename component, and return
     them. The first return value is always the directory. The second return

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -836,7 +836,7 @@ static void script_readdir(js_State *J, void *af)
     }
 }
 
-static void script_stat(js_State *J)
+static void script_file_info(js_State *J)
 {
     const char *path = js_tostring(J, 1);
 
@@ -849,16 +849,11 @@ static void script_stat(js_State *J)
     set_last_error(jctx(J), 0, NULL);
 
     const char * stat_names[] = {
-        "dev", "ino", "mode", "nlink", "uid", "gid",
-        "size", "atime", "mtime", "ctime", NULL
+        "mode", "size",
+        "atime", "mtime", "ctime", NULL
     };
     const double stat_values[] = {
-        statbuf.st_dev,
-        statbuf.st_ino,
         statbuf.st_mode,
-        statbuf.st_nlink,
-        statbuf.st_uid,
-        statbuf.st_gid,
         statbuf.st_size,
         statbuf.st_atime,
         statbuf.st_mtime,
@@ -1295,7 +1290,7 @@ static const struct fn_entry main_fns[] = {
 
 static const struct fn_entry utils_fns[] = {
     AF_ENTRY(readdir, 2),
-    FN_ENTRY(stat, 1),
+    FN_ENTRY(file_info, 1),
     FN_ENTRY(split_path, 1),
     AF_ENTRY(join_path, 2),
     AF_ENTRY(get_user_path, 1),

--- a/player/lua.c
+++ b/player/lua.c
@@ -1085,7 +1085,7 @@ static int script_readdir(lua_State *L)
     return 1;
 }
 
-static int script_stat(lua_State *L)
+static int script_file_info(lua_State *L)
 {
     const char *path = luaL_checkstring(L, 1);
 
@@ -1099,16 +1099,11 @@ static int script_stat(lua_State *L)
     lua_newtable(L); // Result stat table
 
     const char * stat_names[] = {
-        "dev", "ino", "mode", "nlink", "uid", "gid",
-        "size", "atime", "mtime", "ctime", NULL
+        "mode", "size",
+        "atime", "mtime", "ctime", NULL
     };
     const unsigned int stat_values[] = {
-        statbuf.st_dev,
-        statbuf.st_ino,
         statbuf.st_mode,
-        statbuf.st_nlink,
-        statbuf.st_uid,
-        statbuf.st_gid,
         statbuf.st_size,
         statbuf.st_atime,
         statbuf.st_mtime,
@@ -1338,7 +1333,7 @@ static const struct fn_entry main_fns[] = {
 
 static const struct fn_entry utils_fns[] = {
     FN_ENTRY(readdir),
-    FN_ENTRY(stat),
+    FN_ENTRY(file_info),
     FN_ENTRY(split_path),
     FN_ENTRY(join_path),
     FN_ENTRY(subprocess),

--- a/player/lua.c
+++ b/player/lua.c
@@ -1085,6 +1085,53 @@ static int script_readdir(lua_State *L)
     return 1;
 }
 
+static int script_stat(lua_State *L)
+{
+    const char *path = luaL_checkstring(L, 1);
+
+    struct stat statbuf;
+    if (stat(path, &statbuf) != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, "error");
+        return 2;
+    }
+
+    lua_newtable(L); // Result stat table
+
+    const char * stat_names[] = {
+        "dev", "ino", "mode", "nlink", "uid", "gid",
+        "size", "atime", "mtime", "ctime", NULL
+    };
+    const unsigned int stat_values[] = {
+        statbuf.st_dev,
+        statbuf.st_ino,
+        statbuf.st_mode,
+        statbuf.st_nlink,
+        statbuf.st_uid,
+        statbuf.st_gid,
+        statbuf.st_size,
+        statbuf.st_atime,
+        statbuf.st_mtime,
+        statbuf.st_ctime
+    };
+
+    // Add all fields
+    for (int i = 0; stat_names[i]; i++) {
+        lua_pushinteger(L, stat_values[i]);
+        lua_setfield(L, -2, stat_names[i]);
+    }
+
+    // Convenience booleans
+    lua_pushboolean(L, S_ISREG(statbuf.st_mode));
+    lua_setfield(L, -2, "is_file");
+
+    lua_pushboolean(L, S_ISDIR(statbuf.st_mode));
+    lua_setfield(L, -2, "is_dir");
+
+    // Return table
+    return 1;
+}
+
 static int script_split_path(lua_State *L)
 {
     const char *p = luaL_checkstring(L, 1);
@@ -1291,6 +1338,7 @@ static const struct fn_entry main_fns[] = {
 
 static const struct fn_entry utils_fns[] = {
     FN_ENTRY(readdir),
+    FN_ENTRY(stat),
     FN_ENTRY(split_path),
     FN_ENTRY(join_path),
     FN_ENTRY(subprocess),


### PR DESCRIPTION
I saw mention on the IRC that a `stat()` would be nice to have for the Lua and Javascript scripts, so I had a go at it. Sadly, no issue exists.
Thanks to `mp_stat()` being provided for Windows, this was pretty easy!

This *has* been tested on Linux (Ubuntu) for both Lua and Javascript. Works fine!
This has *not* been tested on Windows, but as it doesn't try to do anything cross-platform by itself and relies on the already-used `mp_stat()` being defined as `stat()` in `osdep/io.h`, it *should* work on Windows as well.

I agree that my changes can be relicensed to LGPL 2.1 or later.
