### PR TITLE
subprocess-win: don't change the mouse cursor in CreateProcess

### DIFF
--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -251,7 +251,7 @@ int mp_subprocess(char **args, struct mp_cancel *cancel, void *ctx,
     STARTUPINFOEXW si = {
         .StartupInfo = {
             .cb = sizeof(si),
-            .dwFlags = STARTF_USESTDHANDLES,
+            .dwFlags = STARTF_USESTDHANDLES | STARTF_FORCEOFFFEEDBACK,
             .hStdInput = NULL,
             .hStdOutput = pipes[0].write,
             .hStdError = pipes[1].write,


### PR DESCRIPTION
By default the CreateProcess changes the mouse cursor to IDC_APPSTARTING (or whatever it is called):
![cursor](https://i.imgur.com/NKgoH1t.png)

This is very noticeable when using the [mpv_thumbnail_script](https://github.com/TheAMM/mpv_thumbnail_script) script.
The cursor won't change to default arrow until the script finishes generating thumbnails.

The new flag added to `STARTUPINFOEXW` prevents changing the cursor from default arrow on creating a new process.