### PR TITLE
lua+js: Implement and document utils.getpid()

### DIFF
--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -166,6 +166,8 @@ Otherwise, where the Lua APIs return ``nil`` on error, JS returns ``undefined``.
 
 ``mp.utils.getcwd()`` (LE)
 
+``mp.utils.getpid()``
+
 ``mp.utils.readdir(path [, filter])`` (LE)
 
 ``mp.utils.split_path(path)``

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -564,6 +564,9 @@ strictly part of the guaranteed API.
     Returns the directory that mpv was launched from. On error, ``nil, error``
     is returned.
 
+``utils.getpid()``
+    Returns the PID of the currently running mpv process.
+
 ``utils.readdir(path [, filter])``
     Enumerate all entries at the given path on the filesystem, and return them
     as array. Each entry is a directory entry (without the path).

--- a/osdep/getpid.h
+++ b/osdep/getpid.h
@@ -1,0 +1,37 @@
+/*
+ * getpid()/GetCurrentProcessId() wrapper for Windows
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MPLAYER_OSDEP_GETPID
+#define MPLAYER_OSDEP_GETPID
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+// The POSIX getpid() is available on Linux and OSX, but not on Windows.
+// So, on Windows, make getpid() actually call GetCurrentProcessId()
+
+#undef getpid
+#define getpid GetCurrentProcessId
+// GetCurrentProcessId returns a DWORD aka an unsigned int, which
+// should be compatible with pid_t.
+
+#endif
+
+#endif

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -28,6 +28,7 @@
 #include <mujs.h>
 
 #include "osdep/io.h"
+#include "osdep/getpid.h"
 #include "mpv_talloc.h"
 #include "common/common.h"
 #include "options/m_property.h"
@@ -858,6 +859,11 @@ static void script_get_user_path(js_State *J, void *af)
     js_pushstring(J, mp_get_user_path(af, jctx(J)->mpctx->global, path));
 }
 
+static void script_getpid(js_State *J)
+{
+    js_pushnumber(J, getpid());
+}
+
 struct subprocess_cb_ctx {
     struct mp_log *log;
     void *talloc_ctx;
@@ -1258,6 +1264,7 @@ static const struct fn_entry utils_fns[] = {
     FN_ENTRY(split_path, 1),
     AF_ENTRY(join_path, 2),
     AF_ENTRY(get_user_path, 1),
+    FN_ENTRY(getpid, 0),
     AF_ENTRY(subprocess, 1),
     AF_ENTRY(subprocess_detached, 1),
 

--- a/player/lua.c
+++ b/player/lua.c
@@ -29,6 +29,7 @@
 #include <lauxlib.h>
 
 #include "osdep/io.h"
+#include "osdep/getpid.h"
 
 #include "mpv_talloc.h"
 
@@ -1104,6 +1105,12 @@ static int script_join_path(lua_State *L)
     return 1;
 }
 
+static int script_getpid(lua_State *L)
+{
+    lua_pushinteger(L, getpid());
+    return 1;
+}
+
 struct subprocess_cb_ctx {
     struct mp_log *log;
     void* talloc_ctx;
@@ -1293,6 +1300,7 @@ static const struct fn_entry utils_fns[] = {
     FN_ENTRY(readdir),
     FN_ENTRY(split_path),
     FN_ENTRY(join_path),
+    FN_ENTRY(getpid),
     FN_ENTRY(subprocess),
     FN_ENTRY(subprocess_detached),
     FN_ENTRY(parse_json),


### PR DESCRIPTION
PIDs for the script kids.

This *has* been tested on Linux (Ubuntu) for both Lua and Javascript. Works, as should OSX.
This has *not* been tested on Windows, not yet. I'm working on getting builds on Windows happening, because this really needs to be tested on Windows - the script bindings are trivial, the real kicker is in replacing getpid() while on Windows. By what theory I've seen, it *should* work but I can't be certain, as I don't really do C.

Closes #5208.