### PR TITLE
Font Detection Fixes

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -87,6 +87,10 @@ static const char *const font_mimetypes[] = {
     "application/vnd.ms-opentype",
     "application/x-font-ttf",
     "application/x-font", // probably incorrect
+    "font/collection",
+    "font/otf",
+    "font/sfnt",
+    "font/ttf",
     NULL
 };
 

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -94,7 +94,7 @@ static const char *const font_mimetypes[] = {
     NULL
 };
 
-static const char *const font_exts[] = {".ttf", ".ttc", ".otf", NULL};
+static const char *const font_exts[] = {".ttf", ".ttc", ".otf", ".otc", NULL};
 
 static bool attachment_is_font(struct mp_log *log, struct demux_attachment *f)
 {


### PR DESCRIPTION
Included are the new RFC8081 font media types, and the .otc file extension should now be recognized.

References:
- [RFC 8081](https://tools.ietf.org/html/rfc8081)
- [OpenType Font File Specification](https://www.microsoft.com/typography/otspec/otff.htm)

`font/woff` and `font/woff2` were deliberately not added because they were previously excluded as well.
