### PR TITLE
ipc: avoid dereferencing NULL

### DIFF
--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -216,16 +216,22 @@ done:
 
 static void ipc_start_client(struct mp_ipc_ctx *ctx, struct client_arg *client)
 {
-    client->client = mp_new_client(ctx->client_api, client->client_name),
-    client->log    = mp_client_get_log(client->client);
+    client->client = mp_new_client(ctx->client_api, client->client_name);
+    if (!client->client)
+        goto err;
+    client->log = mp_client_get_log(client->client);
 
     pthread_t client_thr;
-    if (pthread_create(&client_thr, NULL, client_thread, client)) {
+    if (pthread_create(&client_thr, NULL, client_thread, client))
+        goto err;
+
+    return;
+err:
+    if (client->client)
         mpv_detach_destroy(client->client);
-        if (client->close_client_fd)
-            close(client->client_fd);
-        talloc_free(client);
-    }
+    if (client->close_client_fd)
+        close(client->client_fd);
+    talloc_free(client);
 }
 
 static void ipc_start_client_json(struct mp_ipc_ctx *ctx, int id, int fd)


### PR DESCRIPTION
This can happen when ctx->client_api->shutting_down is set to true,
or when there are over 1000 clients with the same name passed to mp_new_client().

I agree that my changes can be relicensed to LGPL 2.1 or later.
