### PR TITLE
options: don't report errors on help value for OPT_SIZE_BOX

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1996,6 +1996,10 @@ const m_option_type_t m_option_type_geometry = {
 static int parse_size_box(struct mp_log *log, const m_option_t *opt,
                           struct bstr name, struct bstr param, void *dst)
 {
+    bool is_help = bstr_equals0(param, "help");
+    if (is_help)
+        goto error;
+
     struct m_geometry gm;
     if (!parse_geometry_str(&gm, param))
         goto error;
@@ -2009,10 +2013,12 @@ static int parse_size_box(struct mp_log *log, const m_option_t *opt,
     return 1;
 
 error:
-    mp_err(log, "Option %.*s: invalid size: '%.*s'\n",
-           BSTR_P(name), BSTR_P(param));
-    mp_err(log, "Valid format: W[%%][xH[%%]] or empty string\n");
-    return M_OPT_INVALID;
+    if (!is_help) {
+        mp_err(log, "Option %.*s: invalid size: '%.*s'\n",
+               BSTR_P(name), BSTR_P(param));
+    }
+    mp_info(log, "Valid format: W[%%][xH[%%]] or empty string\n");
+    return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
 const m_option_type_t m_option_type_size_box = {

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1748,7 +1748,7 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
 
     bool is_help = bstr_equals0(param, "help");
     if (is_help)
-        goto error;
+        goto exit;
 
     bstr val = param;
     struct m_color color = {0};
@@ -1756,11 +1756,11 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
     if (bstr_eatstart0(&val, "#")) {
         // #[AA]RRGGBB
         if (val.len != 6 && val.len != 8)
-            goto error;
+            goto exit;
         bool has_alpha = val.len == 8;
         uint32_t c = bstrtoll(val, &val, 16);
         if (val.len)
-            goto error;
+            goto exit;
         color = (struct m_color) {
             (c >> 16) & 0xFF,
             (c >> 8) & 0xFF,
@@ -1771,13 +1771,13 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
         bstr comp_str[5];
         int num = split_char(param, '/', 5, comp_str);
         if (num < 1 || num > 4)
-            goto error;
+            goto exit;
         double comp[4] = {0, 0, 0, 1};
         for (int n = 0; n < num; n++) {
             bstr rest;
             double d = bstrtod(comp_str[n], &rest);
             if (rest.len || !comp_str[n].len || d < 0 || d > 1 || !isfinite(d))
-                goto error;
+                goto exit;
             comp[n] = d;
         }
         if (num == 2)
@@ -1793,7 +1793,7 @@ static int parse_color(struct mp_log *log, const m_option_t *opt,
 
     return 1;
 
-error:
+exit:
     if (!is_help) {
         mp_err(log, "Option %.*s: invalid color: '%.*s'\n",
                BSTR_P(name), BSTR_P(param));
@@ -1964,18 +1964,18 @@ static int parse_geometry(struct mp_log *log, const m_option_t *opt,
 {
     bool is_help = bstr_equals0(param, "help");
     if (is_help)
-        goto error;
+        goto exit;
 
     struct m_geometry gm;
     if (!parse_geometry_str(&gm, param))
-        goto error;
+        goto exit;
 
     if (dst)
         *((struct m_geometry *)dst) = gm;
 
     return 1;
 
-error:
+exit:
     if (!is_help) {
         mp_err(log, "Option %.*s: invalid geometry: '%.*s'\n",
                BSTR_P(name), BSTR_P(param));
@@ -1998,21 +1998,21 @@ static int parse_size_box(struct mp_log *log, const m_option_t *opt,
 {
     bool is_help = bstr_equals0(param, "help");
     if (is_help)
-        goto error;
+        goto exit;
 
     struct m_geometry gm;
     if (!parse_geometry_str(&gm, param))
-        goto error;
+        goto exit;
 
     if (gm.xy_valid)
-        goto error;
+        goto exit;
 
     if (dst)
         *((struct m_geometry *)dst) = gm;
 
     return 1;
 
-error:
+exit:
     if (!is_help) {
         mp_err(log, "Option %.*s: invalid size: '%.*s'\n",
                BSTR_P(name), BSTR_P(param));


### PR DESCRIPTION
The same idea as in 3723e61 but for `OPT_SIZE_BOX` now.

Affects options `autofit`, `autofit-larger` and `autofit-smaller`.

Before the change:
-----
````
mpv --autofit=help
Option autofit: invalid size: 'help'
Valid format: W[%][xH[%]] or empty string
Error parsing option autofit (option parameter could not be parsed)
Setting commandline option --autofit=help failed.

Exiting... (Fatal error)
````

After the change:
-----
````
mpv --autofit=help
Valid format: W[%][xH[%]] or empty string
````