### PR TITLE
encode: allow specifying output metadata (--ometadata)

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -64,6 +64,7 @@ Interface changes
     - deprecate the --ff-aid, --ff-vid, -ff-sid options and properties (there is
       no replacement, but you can manually query the track property and use the
       "ff-index" field to find the mpv track ID to imitate this behavior)
+    - rename --no-ometadata to --no-ocopymetadata
  --- mpv 0.27.0 ---
     - drop previously deprecated --field-dominance option
     - drop previously deprecated "osd" command

--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -150,6 +150,6 @@ You can encode files from one format/codec to another using this facility.
     and all pts are passed through as-is. Never seek backwards or use multiple
     input files in this mode!
 
-``--no-ometadata``
+``--no-ocopymetadata``
     Turns off copying of metadata from input files to output files when
     encoding (which is enabled by default).

--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -153,3 +153,18 @@ You can encode files from one format/codec to another using this facility.
 ``--no-ocopymetadata``
     Turns off copying of metadata from input files to output files when
     encoding (which is enabled by default).
+
+``--ometadata=<metadata-tag[,metadata-tag,...]>``
+    Specifies metadata to include in the output file.
+    Supported keys vary between output formats. For example, Matroska (MKV) and
+    FLAC allow almost arbitary keys, while support in MP4 and MP3 is more limited.
+    You may use an empty value ala ``key=""`` to clear the value (eg. when copying
+    original metadata with ``--ocopymetadata``.)
+
+    .. admonition:: Example
+
+        "``--ometadata=title="Output title",comment="Another tag"``"
+            adds a title and a comment to the output file.
+
+        "``--ometadata=title=""``"
+            remvoes the ``title`` tag from the copied metadata.

--- a/common/encode.h
+++ b/common/encode.h
@@ -49,7 +49,7 @@ struct encode_opts {
     int neverdrop;
     int video_first;
     int audio_first;
-    int metadata;
+    int copymetadata;
 };
 
 // interface for mplayer.c

--- a/common/encode.h
+++ b/common/encode.h
@@ -50,6 +50,7 @@ struct encode_opts {
     int video_first;
     int audio_first;
     int copymetadata;
+    char **metadata;
 };
 
 // interface for mplayer.c

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -55,12 +55,12 @@ const struct m_sub_options encode_config = {
         OPT_FLAG("oneverdrop", neverdrop, M_OPT_FIXED),
         OPT_FLAG("ovfirst", video_first, M_OPT_FIXED),
         OPT_FLAG("oafirst", audio_first, M_OPT_FIXED),
-        OPT_FLAG("ometadata", metadata, M_OPT_FIXED),
+        OPT_FLAG("ocopymetadata", copymetadata, M_OPT_FIXED),
         {0}
     },
     .size = sizeof(struct encode_opts),
     .defaults = &(const struct encode_opts){
-        .metadata = 1,
+        .copymetadata = 1,
     },
 };
 
@@ -278,7 +278,7 @@ struct encode_lavc_context *encode_lavc_init(struct encode_opts *options,
 void encode_lavc_set_metadata(struct encode_lavc_context *ctx,
                               struct mp_tags *metadata)
 {
-    if (ctx->options->metadata)
+    if (ctx->options->copymetadata)
         ctx->metadata = metadata;
 }
 

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -56,6 +56,7 @@ const struct m_sub_options encode_config = {
         OPT_FLAG("ovfirst", video_first, M_OPT_FIXED),
         OPT_FLAG("oafirst", audio_first, M_OPT_FIXED),
         OPT_FLAG("ocopymetadata", copymetadata, M_OPT_FIXED),
+        OPT_KEYVALUELIST("ometadata", metadata, M_OPT_FIXED),
         {0}
     },
     .size = sizeof(struct encode_opts),
@@ -275,11 +276,48 @@ struct encode_lavc_context *encode_lavc_init(struct encode_opts *options,
     return ctx;
 }
 
+static void set_metadata_value(struct encode_lavc_context *ctx,
+                        const char *metadata_key, const char *metadata_value)
+{
+    // Add the key-value pair or remove the key if the value is empty
+    if (metadata_value[0]) {
+        MP_VERBOSE(ctx, "setting metadata value '%s' for key '%s'\n", metadata_value, metadata_key);
+        mp_tags_set_str(ctx->metadata, metadata_key, metadata_value);
+    } else {
+        MP_VERBOSE(ctx, "removing metadata key '%s'\n", metadata_key);
+        struct bstr key = bstr0(metadata_key);
+
+        for (int n = 0; n < ctx->metadata->num_keys; n++) {
+            if (bstrcasecmp0(key, ctx->metadata->keys[n]) == 0) {
+                talloc_free(ctx->metadata->keys[n]);
+                talloc_free(ctx->metadata->values[n]);
+
+                MP_TARRAY_REMOVE_AT(ctx->metadata->keys, ctx->metadata->num_keys, n);
+                ctx->metadata->num_keys++; // Increment again for second removal
+                MP_TARRAY_REMOVE_AT(ctx->metadata->values, ctx->metadata->num_keys, n);
+
+                break;
+            }
+        }
+    }
+}
+
 void encode_lavc_set_metadata(struct encode_lavc_context *ctx,
                               struct mp_tags *metadata)
 {
-    if (ctx->options->copymetadata)
+    if (ctx->options->copymetadata) {
         ctx->metadata = metadata;
+    } else {
+        ctx->metadata = talloc_zero(ctx, struct mp_tags);
+    }
+
+    if (ctx->options->metadata) {
+        char **kv = ctx->options->metadata;
+        // Set all user-provided metadata tags
+        for (int n = 0; kv && kv[n * 2]; n++) {
+            set_metadata_value(ctx, kv[n*2 + 0], kv[n*2 + 1]);
+        }
+    }
 }
 
 int encode_lavc_start(struct encode_lavc_context *ctx)

--- a/options/options.c
+++ b/options/options.c
@@ -812,6 +812,7 @@ const m_option_t mp_opts[] = {
     OPT_REMOVED("fs-black-out-screens", NULL),
     OPT_REPLACED("sub-paths", "sub-file-paths"),
     OPT_REMOVED("heartbeat-cmd", "use Lua scripting instead"),
+    OPT_REMOVED("no-ometadata", "use --no-ocopymetadata"),
 
     {0}
 };


### PR DESCRIPTION
This PR renames the old `--ometadata` (`--no-ometadata`, used to enable/disable copying file metadata from the source file to the output file) to a better fitting `--ocopymetadata` in 5974738.

d20c6af introduces a string-list option by the old name of `--ometadata`. It allows users, when encoding, to set their own metadata (with the string-list helpers such as `-add`, `-pre`, `-clr`).
Empty values (eg. `--ometadata=foo=`) can be used to clear copied metadata keys (assuming `--ocopymetadata` is used).

For example: `--ometadata title="Hello world"`, `--ometadata artist="Music McMusicface"`.

I'm all ears regarding the option rename. As far as I understand, `--no-ometadata` rarely used, so there *should* not be breakage or conflict in users.
Otherwise, the new `--ometadata` *should* work and does work for me, but I'm not an expert or even proficient with memory allocations and such, so I'll appreciate a knowledgeable look at `set_metadata_value()` and pals.

----

(Squash message for convenience?)
```
* encode_lavc+manpage: rename option --ometadata to --ocopymetadata
  --copymetadata describers the result of the option better, (copying
  metadata from the source file to the output file) and gives space
  for the following --ometadata option which allows the user to specify
  their own output metadata.
  Marks the old --no-ometadata OPT_REMOVED with a suggestion for the
  new --no-ocopymetadata.

* encode_lavc+manpage: implement custom output metadata (--ometadata)
  This commit introduces a new --ometadata key-value-list option,
  allowing the user to specify output metadata when encoding.
  Eg. --ometadata title="Hello",comment="World"
  The option can also be used to exclude existing metadata from
  the output file (assuming --ocopymetadata is enabled) with an
  empty value such as 'foo=""' or 'title=""'.
```