### PR TITLE
client API: change --stop-playback-on-init-failure default

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,9 +32,12 @@ API changes
 
 ::
 
+ --- mpv 0.28.0 ---
  1.26   - remove glMPGetNativeDisplay("drm") support
         - add mpv_opengl_cb_window_pos and mpv_opengl_cb_drm_params and
           support via glMPGetNativeDisplay() for using it
+        - make --stop-playback-on-init-failure=no the default in libmpv (just
+          like in mpv CLI)
  --- mpv 0.27.0 ---
  1.25   - remove setting "no-" options via mpv_set_option*(). (See corresponding
           deprecation in 0.23.0.)

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -365,11 +365,10 @@ Playback Control
         Without ``--hr-seek``, skipping will snap to keyframes.
 
 ``--stop-playback-on-init-failure=<yes|no>``
-    Stop playback if either audio or video fails to initialize. Currently,
-    the default behavior is ``no`` for the command line player, but ``yes``
-    for libmpv. With ``no``, playback will continue in video-only or audio-only
-    mode if one of them fails. This doesn't affect playback of audio-only or
-    video-only files.
+    Stop playback if either audio or video fails to initialize (default: no).
+    With ``no``, playback will continue in video-only or audio-only mode if one
+    of them fails. This doesn't affect playback of audio-only or video-only
+    files.
 
 Program Behavior
 ----------------

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -20,7 +20,6 @@ osc=no
 ytdl=no
 input-default-bindings=no
 input-vo-keyboard=no
-stop-playback-on-init-failure=yes
 # OSX/Cocoa global input hooks
 input-appleremote=no
 input-media-keys=no


### PR DESCRIPTION
This was off for mpv CLI, but on for libmpv. The motivation behind this
was that it would be confusing for applications if libmpv continued
playback in a severely "degraded" way (without either audio or video),
and that it would be better to fail early.

In reality the behavior was just a confusing difference to mpv CLI, and
has confused actual users as well. Get rid of it.

Not bothering with a version bump, since this is so minor, and it's easy
to ensure compatibility in affected applications by just setting the
option explicitly.

(Also adding the missing next-release-marker in client-api-changes.rst.)
