### PR TITLE
vo_gpu: hwdec_drmprime_drm: don't crash for non-GL contexts

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -205,6 +205,9 @@ static int init(struct ra_hwdec *hw)
     struct priv *p = hw->priv;
     int drm_overlay;
 
+    if (!ra_is_gl(hw->ra))
+        return -1;
+
     p->log = hw->log;
 
     void *tmp = talloc_new(NULL);


### PR DESCRIPTION
Using vulkan with --hwdec crashed because of this.