### PR TITLE
Fix vo_mediacodec_embed using latest ffmpeg

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2540,7 +2540,6 @@ Window
     value cast to ``intptr_t``. Use with ``--vo=mediacodec_embed`` and
     ``--hwdec=mediacodec`` for direct rendering using MediaCodec, or with
     ``--vo=gpu --gpu-context=android`` (with or without ``--hwdec=mediacodec-copy``).
-    This is currently broken.
 
 ``--no-window-dragging``
     Don't move the window when clicking on it and moving the mouse pointer.

--- a/wscript
+++ b/wscript
@@ -412,7 +412,7 @@ iconv support use --disable-iconv.",
 ]
 
 ffmpeg_pkg_config_checks = [
-    'libavutil',     '>= 56.0.100',
+    'libavutil',     '>= 56.6.100',
     'libavcodec',    '>= 58.7.100',
     'libavformat',   '>= 58.0.102',
     'libswscale',    '>= 5.0.101',


### PR DESCRIPTION
Fixes vo_mediacodec_embed, which was broken in 80359c6615658f2784

Confirmed working with ffmpeg-master in mpv-android by @sfan5