### PR TITLE
Restore libav support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 env:
   matrix:
     - LIBAV=ffmpeg-git
+    - LIBAV=libav-git
   global:
     # Coverity token
     - secure: "H21mSRlMhk4BKS0xHZvCFGJxteCP0hRVUxTuNfM2Z9HBsyutuLEYMtViLO86VtM+Tqla3xXPzUdS4ozLwI72Ax/5ZUDXACROj73yW6QhFB5D6rLut12+FjqC7M33Qv2hl0xwgNBmR5dsm1ToP37+Wn+ecJQNvN8fkTXF+HVzOEw="

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1273,6 +1273,9 @@ Property list
     buffering amount, while the seek ranges represent the buffered data that
     can actually be used for cached seeking.
 
+    ``fw-bytes`` is the number of bytes of packets buffered in the range
+    starting from the current decoding position.
+
     When querying the property with the client API using ``MPV_FORMAT_NODE``,
     or with Lua ``mp.get_property_native``, this will return a mpv_node with
     the following contents:
@@ -1284,6 +1287,7 @@ Property list
                 MPV_FORMAT_NODE_MAP
                     "start"             MPV_FORMAT_DOUBLE
                     "end"               MPV_FORMAT_DOUBLE
+            "fw-bytes"          MPV_FORMAT_INT64
 
     Other fields (might be changed or removed in the future):
 

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -683,8 +683,10 @@ listed.
   (``drop-frame-count`` property.)
 - Cache state, e.g. ``Cache:  2s+134KB``. Visible if the stream cache is enabled.
   The first value shows the amount of video buffered in the demuxer in seconds,
-  the second value shows *additional* data buffered in the stream cache in
-  kilobytes. (``demuxer-cache-duration`` and ``cache-used`` properties.)
+  the second value shows the sum of the demuxer forward cache size and the
+  *additional* data buffered in the stream cache in kilobytes.
+  (``demuxer-cache-duration``, ``demuxer-cache-state``, ``cache-used``
+  properties.)
 
 
 PROTOCOLS

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2874,6 +2874,12 @@ Demuxer
 
     See ``--list-options`` for defaults and value range.
 
+``--demuxer-max-spill-bytes=<value>``
+    Maximum bytes which the demuxer is allowed to buffer in addition to
+    ``--demuxer-max-bytes`` if a decoder is in immediate need of new data. This
+    option is mostly for debugging, and you probably never need to rouch it. It
+    might change arbitrarily or get removed in the future.
+
 ``--demuxer-max-back-bytes=<value>``
     This controls how much past data the demuxer is allowed to preserve. This
     is useful only if the ``--demuxer-seekable-cache`` option is enabled.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3841,7 +3841,9 @@ Cache
 ``--cache-secs=<seconds>``
     How many seconds of audio/video to prefetch if the cache is active. This
     overrides the ``--demuxer-readahead-secs`` option if and only if the cache
-    is enabled and the value is larger. (Default: 120.)
+    is enabled and the value is larger. The default value is set to something
+    very high, so the actually achieved readahead will usually be limited by
+    the value of the ``--demuxer-max-bytes`` option.
 
 ``--cache-pause``, ``--no-cache-pause``
     Whether the player should automatically pause when the cache runs low,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3762,7 +3762,7 @@ Cache
     between readahead and backbuffer sizes.
 
 ``--cache-default=<kBytes|no>``
-    Set the size of the cache in kilobytes (default: 75000 KB). Using ``no``
+    Set the size of the cache in kilobytes (default: 10000 KB). Using ``no``
     will not automatically enable the cache e.g. when playing from a network
     stream. Note that using ``--cache`` will always override this option.
 
@@ -3783,7 +3783,7 @@ Cache
     This option allows control over this.
 
 ``--cache-backbuffer=<kBytes>``
-    Size of the cache back buffer (default: 75000 KB). This will add to the total
+    Size of the cache back buffer (default: 10000 KB). This will add to the total
     cache size, and reserved the amount for seeking back. The reserved amount
     will not be used for readahead, and instead preserves already read data to
     enable fast seeking back.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2874,12 +2874,6 @@ Demuxer
 
     See ``--list-options`` for defaults and value range.
 
-``--demuxer-max-spill-bytes=<value>``
-    Maximum bytes which the demuxer is allowed to buffer in addition to
-    ``--demuxer-max-bytes`` if a decoder is in immediate need of new data. This
-    option is mostly for debugging, and you probably never need to rouch it. It
-    might change arbitrarily or get removed in the future.
-
 ``--demuxer-max-back-bytes=<value>``
     This controls how much past data the demuxer is allowed to preserve. This
     is useful only if the ``--demuxer-seekable-cache`` option is enabled.

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -117,7 +117,7 @@ const struct m_sub_options demux_conf = {
         .max_bytes_bw = 400 * 1024 * 1024,
         .max_spill_bytes = 1 * 1024 * 1024,
         .min_secs = 1.0,
-        .min_secs_cache = 120.0,
+        .min_secs_cache = 10.0 * 60 * 60,
         .seekable_cache = -1,
         .access_references = 1,
     },

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -86,7 +86,6 @@ const demuxer_desc_t *const demuxer_list[] = {
 struct demux_opts {
     int max_bytes;
     int max_bytes_bw;
-    int max_spill_bytes;
     double min_secs;
     int force_seekable;
     double min_secs_cache;
@@ -102,7 +101,6 @@ const struct m_sub_options demux_conf = {
         OPT_DOUBLE("demuxer-readahead-secs", min_secs, M_OPT_MIN, .min = 0),
         OPT_INTRANGE("demuxer-max-bytes", max_bytes, 0, 0, INT_MAX),
         OPT_INTRANGE("demuxer-max-back-bytes", max_bytes_bw, 0, 0, INT_MAX),
-        OPT_INTRANGE("demuxer-max-spill-bytes", max_spill_bytes, 0, 0, INT_MAX),
         OPT_FLAG("force-seekable", force_seekable, 0),
         OPT_DOUBLE("cache-secs", min_secs_cache, M_OPT_MIN, .min = 0),
         OPT_FLAG("access-references", access_references, 0),
@@ -115,7 +113,6 @@ const struct m_sub_options demux_conf = {
     .defaults = &(const struct demux_opts){
         .max_bytes = 400 * 1024 * 1024,
         .max_bytes_bw = 400 * 1024 * 1024,
-        .max_spill_bytes = 1 * 1024 * 1024,
         .min_secs = 1.0,
         .min_secs_cache = 10.0 * 60 * 60,
         .seekable_cache = -1,
@@ -159,7 +156,6 @@ struct demux_internal {
     bool autoselect;
     double min_secs;
     int max_bytes;
-    int max_bytes_with_spill;
     int max_bytes_bw;
     bool seekable_cache;
 
@@ -262,7 +258,8 @@ struct demux_stream {
     bool eager;             // try to keep at least 1 packet queued
                             // if false, this stream is disabled, or passively
                             // read (like subtitles)
-    bool refreshing;
+    bool refreshing;        // finding old position after track switches
+    bool eof;               // end of demuxed stream? (true if no more packets)
 
     bool global_correct_dts;// all observed so far
     bool global_correct_pos;
@@ -278,10 +275,13 @@ struct demux_stream {
     double bitrate;
     size_t fw_packs;        // number of packets in buffer (forward)
     size_t fw_bytes;        // total bytes of packets in buffer (forward)
-    bool eof;               // end of demuxed stream? (true if no more packets)
     struct demux_packet *reader_head;   // points at current decoder position
     bool skip_to_keyframe;
     bool attached_picture_added;
+
+    // for refresh seeks: pos/dts of last packet returned to reader
+    int64_t last_ret_pos;
+    double last_ret_dts;
 
     // for closed captions (demuxer_feed_caption)
     struct sh_stream *cc;
@@ -541,19 +541,26 @@ static void free_empty_cached_ranges(struct demux_internal *in)
     }
 }
 
-static void ds_clear_reader_state(struct demux_stream *ds)
+static void ds_clear_reader_queue_state(struct demux_stream *ds)
 {
     ds->in->fw_bytes -= ds->fw_bytes;
-
     ds->reader_head = NULL;
+    ds->fw_bytes = 0;
+    ds->fw_packs = 0;
     ds->eof = false;
+}
+
+static void ds_clear_reader_state(struct demux_stream *ds)
+{
+    ds_clear_reader_queue_state(ds);
+
     ds->base_ts = ds->last_br_ts = MP_NOPTS_VALUE;
     ds->last_br_bytes = 0;
     ds->bitrate = -1;
     ds->skip_to_keyframe = false;
     ds->attached_picture_added = false;
-    ds->fw_bytes = 0;
-    ds->fw_packs = 0;
+    ds->last_ret_pos = -1;
+    ds->last_ret_dts = MP_NOPTS_VALUE;
 }
 
 static void update_stream_selection_state(struct demux_internal *in,
@@ -1222,9 +1229,7 @@ static bool read_packet(struct demux_internal *in)
     }
     MP_TRACE(in, "bytes=%zd, read_more=%d prefetch_more=%d, refresh_more=%d\n",
              in->fw_bytes, read_more, prefetch_more, refresh_more);
-    if (in->fw_bytes >= in->max_bytes &&
-        !(read_more && refresh_more && in->fw_bytes < in->max_bytes_with_spill))
-    {
+    if (in->fw_bytes >= in->max_bytes) {
         // if we hit the limit just by prefetching, simply stop prefetching
         if (!read_more)
             return false;
@@ -1479,6 +1484,9 @@ static struct demux_packet *dequeue_packet(struct demux_stream *ds)
     size_t bytes = demux_packet_estimate_total_size(pkt);
     ds->fw_bytes -= bytes;
     ds->in->fw_bytes -= bytes;
+
+    ds->last_ret_pos = pkt->pos;
+    ds->last_ret_dts = pkt->dts;
 
     // The returned packet is mutated etc. and will be owned by the user.
     pkt = demux_copy_packet(pkt);
@@ -1958,8 +1966,6 @@ static struct demuxer *open_given_type(struct mpv_global *global,
         .d_user = demuxer,
         .min_secs = opts->min_secs,
         .max_bytes = opts->max_bytes,
-        .max_bytes_with_spill =
-            MPMIN(INT_MAX, (int64_t)opts->max_bytes + opts->max_spill_bytes),
         .max_bytes_bw = opts->max_bytes_bw,
         .initial_state = true,
     };
@@ -2457,10 +2463,31 @@ static void initiate_refresh_seek(struct demux_internal *in,
 
         for (int n = 0; n < in->num_streams; n++) {
             struct demux_stream *ds = in->streams[n]->ds;
+
+            bool correct_pos = ds->queue->correct_pos;
+            bool correct_dts = ds->queue->correct_dts;
+
+            // We need to re-read all packets anyway, so discard the buffered
+            // data. (In theory, we could keep the packets, and be able to use
+            // it for seeking if partially read streams are deselected again,
+            // but this causes other problems like queue overflows when
+            // selecting a new stream.)
+            ds_clear_reader_queue_state(ds);
+            clear_queue(ds->queue);
+
             // Streams which didn't have any packets yet will return all packets,
             // other streams return packets only starting from the last position.
-            if (ds->queue->last_pos != -1 || ds->queue->last_dts != MP_NOPTS_VALUE)
-                ds->refreshing |= ds->selected;
+            if (ds->selected && (ds->last_ret_pos != -1 ||
+                                 ds->last_ret_dts != MP_NOPTS_VALUE))
+            {
+                ds->refreshing = true;
+                ds->queue->correct_dts = correct_dts;
+                ds->queue->correct_pos = correct_pos;
+                ds->queue->last_pos = ds->last_ret_pos;
+                ds->queue->last_dts = ds->last_ret_dts;
+            }
+
+            update_seek_ranges(in->current_range);
         }
 
         start_ts -= 1.0; // small offset to get correct overlap

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1835,12 +1835,16 @@ function osc_init()
 
     ne.content = function ()
         local dmx_cache = mp.get_property_number("demuxer-cache-duration")
-        local cache_used = mp.get_property_number("cache-used")
+        local cache_used = mp.get_property_number("cache-used", 0)
+        local dmx_cache_state = mp.get_property_native("demuxer-cache-state", {})
         local is_network = mp.get_property_native("demuxer-via-network")
         if dmx_cache then
             dmx_cache = string.format("%3.0fs", dmx_cache)
         end
-        if cache_used then
+        if dmx_cache_state["fw-bytes"] then
+            cache_used = cache_used + dmx_cache_state["fw-bytes"] / 1024
+        end
+        if cache_used > 0 then
             local suffix = " KiB"
             if (cache_used >= 1024) then
                 cache_used = cache_used/1024

--- a/player/osd.c
+++ b/player/osd.c
@@ -261,11 +261,12 @@ static void term_osd_print_status_lazy(struct MPContext *mpctx)
             } else {
                 saddf(&line, "%2ds", (int)s.ts_duration);
             }
-            if (info.size > 0) {
-                if (info.fill >= 1024 * 1024) {
-                    saddf(&line, "+%lldMB", (long long)(info.fill / 1024 / 1024));
+            int64_t cache_size = s.fw_bytes + info.fill;
+            if (cache_size > 0) {
+                if (cache_size >= 1024 * 1024) {
+                    saddf(&line, "+%lldMB", (long long)(cache_size / 1024 / 1024));
                 } else {
-                    saddf(&line, "+%lldKB", (long long)(info.fill / 1024));
+                    saddf(&line, "+%lldKB", (long long)(cache_size / 1024));
                 }
             }
         }

--- a/stream/cache.c
+++ b/stream/cache.c
@@ -79,10 +79,10 @@ const struct m_sub_options stream_cache_conf = {
     .size = sizeof(struct mp_cache_opts),
     .defaults = &(const struct mp_cache_opts){
         .size = -1,
-        .def_size = 75000,
+        .def_size = 10000,
         .initial = 0,
         .seek_min = 500,
-        .back_buffer = 75000,
+        .back_buffer = 10000,
         .file_max = 1024 * 1024,
     },
 };

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -738,8 +738,10 @@ static int init_generic_hwaccel(struct dec_video *vd, enum AVPixelFormat hw_fmt)
 
     AVHWFramesContext *new_fctx = (void *)new_frames_ctx->data;
 
+#if LIBAVCODEC_VERSION_MICRO >= 100
     if (ctx->hwdec.pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
         new_fctx->sw_format = imgfmt2pixfmt(vd->opts->videotoolbox_format);
+#endif
     if (vd->opts->hwdec_image_format)
         new_fctx->sw_format = imgfmt2pixfmt(vd->opts->hwdec_image_format);
 

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -15,12 +15,6 @@ struct mp_hwdec_ctx {
 
     // List of IMGFMT_s, terminated with 0. NULL if N/A.
     int *supported_formats;
-
-    // Hint to generic code: it's using a wrapper API
-    bool emulated;
-
-    // Optional. Do not set for VO-bound devices.
-    void (*destroy)(struct mp_hwdec_ctx *ctx);
 };
 
 // Used to communicate hardware decoder device handles from VO to video decoder.

--- a/video/vaapi.c
+++ b/video/vaapi.c
@@ -176,8 +176,6 @@ struct mp_vaapi_ctx *va_initialize(VADisplay *display, struct mp_log *plog,
     if (av_hwdevice_ctx_init(res->av_device_ref) < 0)
         goto error;
 
-    res->hwctx.emulated = va_guess_if_emulated(res);
-
     return res;
 
 error:

--- a/video/vdpau.c
+++ b/video/vdpau.c
@@ -563,7 +563,6 @@ static struct AVBufferRef *vdpau_create_standalone(struct mpv_global *global,
         return NULL;
     }
 
-    vdp->hwctx.emulated = mp_vdpau_guess_if_emulated(vdp);
     vdp->close_display = true;
     return vdp->hwctx.av_device_ref;
 }

--- a/wscript
+++ b/wscript
@@ -421,7 +421,7 @@ ffmpeg_pkg_config_checks = [
 ]
 libav_pkg_config_checks = [
     'libavutil',     '>= 56.6.0',
-    'libavcodec',    '>= 58.5.0',
+    'libavcodec',    '>= 58.8.0',
     'libavformat',   '>= 58.1.0',
     'libswscale',    '>= 5.0.0',
     'libavfilter',   '>= 7.0.0',


### PR DESCRIPTION
Libav has been broken due to the hwdec changes. This was always a
temporary situation (depended on pending patches to be merged), although
it took a bit longer. This also restores the travis config.

One code change is needed in vd_lavc.c, because it checks the AV_PIX_FMT
for videotoolbox (as opposed to the mpv format identifier), which is not
available in Libav. Add an ifdef; the affected code is for a deprecated
option anyway.

**Note: only the top commit is part of the PR. Github shows other unmerged commits for dumb technical reasons.**