### PR TITLE
build: use a list instead of a string for rpi cflags

### DIFF
--- a/wscript
+++ b/wscript
@@ -749,10 +749,10 @@ video_output_features = [
         'name': '--rpi',
         'desc': 'Raspberry Pi support',
         'func': compose_checks(
-            check_cc(cflags="-isystem/opt/vc/include/ "+
-                            "-isystem/opt/vc/include/interface/vcos/pthreads " +
-                            "-isystem/opt/vc/include/interface/vmcs_host/linux " +
-                            "-fgnu89-inline",
+            check_cc(cflags=["-isystem/opt/vc/include",
+                             "-isystem/opt/vc/include/interface/vcos/pthreads",
+                             "-isystem/opt/vc/include/interface/vmcs_host/linux",
+                             "-fgnu89-inline"],
                      linkflags="-L/opt/vc/lib",
                      header_name="bcm_host.h",
                      lib=['mmal_core', 'mmal_util', 'mmal_vc_client', 'bcm_host']),


### PR DESCRIPTION
Using a string caused all 4 flags to be passed as one argument, causing
the build to fail when trying to include bcm_host.h.

I agree that my changes can be relicensed to LGPL 2.1 or later.
