### PR TITLE
demux_mkv: fix off by one error

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2506,14 +2506,12 @@ static int read_block(demuxer_t *demuxer, int64_t end, struct block_info *block)
         goto exit;
 
     /* time (relative to cluster time) */
-    if (stream_tell(s) + 3 >= endpos)
+    if (stream_tell(s) + 3 > endpos)
         goto exit;
     uint8_t c1 = stream_read_char(s);
     uint8_t c2 = stream_read_char(s);
     time = c1 << 8 | c2;
 
-    if (stream_tell(s) + 2 > endpos)
-        goto exit;
     uint8_t header_flags = stream_read_char(s);
 
     block->filepos = stream_tell(s);


### PR DESCRIPTION
Caused by the relatively recent change to packet parsing. This time it
was probably triggered by lace type 0, which reduces the byte length of
a 0 sized to 3 (timestamp + flag) instead of 4 (lace count for other
lace types). The thing about laces is just my guess why it worked for
other 0 sized packets, though.

Also remove the redundant and incorrect check below.

Fixes #5271.