### PR TITLE
player: make track language matching case insensitive

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -176,7 +176,7 @@ static void append_dir_subtitles(struct mpv_global *global,
         if (bstr_startswith(tmp_fname_trim, f_fname_trim))
             lang = guess_lang_from_filename(tmp_fname_trim);
         for (int n = 0; langs && langs[n]; n++) {
-            if (lang.len && bstr_startswith0(lang, langs[n])) {
+            if (lang.len && bstr_case_startswith(lang, bstr0(langs[n]))) {
                 prio = 4; // matches the movie name + lang extension
                 break;
             }

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -296,7 +296,7 @@ void add_demuxer_tracks(struct MPContext *mpctx, struct demuxer *demuxer)
 static int match_lang(char **langs, char *lang)
 {
     for (int idx = 0; langs && langs[idx]; idx++) {
-        if (lang && strcmp(langs[idx], lang) == 0)
+        if (lang && strcasecmp(langs[idx], lang) == 0)
             return INT_MAX - idx;
     }
     return 0;


### PR DESCRIPTION
There is no reason not to do this, and probably saves the user some
trouble.

Mostly untested.

Closes #5272.