### PR TITLE
player: update duration based on highest timestamp demuxed

### DIFF
--- a/demux/demux.h
+++ b/demux/demux.h
@@ -90,6 +90,7 @@ enum demux_event {
     DEMUX_EVENT_INIT = 1 << 0,      // complete (re-)initialization
     DEMUX_EVENT_STREAMS = 1 << 1,   // a stream was added
     DEMUX_EVENT_METADATA = 1 << 2,  // metadata or stream_metadata changed
+    DEMUX_EVENT_DURATION = 1 << 3,  // duration updated
     DEMUX_EVENT_ALL = 0xFFFF,
 };
 

--- a/player/command.c
+++ b/player/command.c
@@ -4117,6 +4117,7 @@ static const char *const *const mp_event_property_change[] = {
       "estimated-display-fps", "vsync-jitter", "sub-text", "audio-bitrate",
       "video-bitrate", "sub-bitrate", "decoder-frame-drop-count",
       "frame-drop-count", "video-frame-info"),
+    E(MP_EVENT_DURATION_UPDATE, "duration"),
     E(MPV_EVENT_VIDEO_RECONFIG, "video-out-params", "video-params",
       "video-format", "video-codec", "video-bitrate", "dwidth", "dheight",
       "width", "height", "fps", "aspect", "vo-configured", "current-vo",

--- a/player/command.h
+++ b/player/command.h
@@ -57,6 +57,7 @@ enum {
     MP_EVENT_WIN_STATE,
     MP_EVENT_CHANGE_PLAYLIST,
     MP_EVENT_CORE_IDLE,
+    MP_EVENT_DURATION_UPDATE,
 };
 
 bool mp_hook_test_completion(struct MPContext *mpctx, char *type);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -212,6 +212,8 @@ void update_demuxer_properties(struct MPContext *mpctx)
         mpctx->filtered_tags = info;
         mp_notify(mpctx, MPV_EVENT_METADATA_UPDATE, NULL);
     }
+    if (events & DEMUX_EVENT_DURATION)
+        mp_notify(mpctx, MP_EVENT_DURATION_UPDATE, NULL);
     demuxer->events = 0;
 }
 


### PR DESCRIPTION
This will help with things like livestreams.

As a minor detail, subtitles are excluded, because they sometimes have
"unused" events after video and audio ends. To avoid this annoying
corner case, just ignore them.

---

Looks a bit silly when the OSC updates, and the current position seemingly jumps around because the duration is getting higher as the stream buffers. But still better than not having a seek bar at all.

In theory, the OSC could do this manually, and use the reported cache state for this. Not sure what's better. This solution would benefit all potential users, and showing the highest known time on OSD or the terminal status line might be better than "unknown".