### PR TITLE
wscript: remove redundant libraries check for shaderc-static

### DIFF
--- a/wscript
+++ b/wscript
@@ -740,8 +740,7 @@ video_output_features = [
         'deps': '!shaderc-shared',
         'groups': ['shaderc'],
         'func': check_cc(header_name='shaderc/shaderc.h',
-                         lib=['shaderc_combined', 'glslang', 'SPIRV-Tools',
-                              'SPIRV-Tools-opt', 'stdc++']),
+                         lib=['shaderc_combined', 'stdc++']),
     }, {
         'name': '--shaderc',
         'desc': 'libshaderc SPIR-V compiler',


### PR DESCRIPTION
`libshaderc_combined.a` already bundled every libs it depends on

References: https://github.com/google/shaderc/tree/master/libshaderc#build-artifacts
