### PR TITLE
options: drop some previously deprecated options

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,7 +32,7 @@ API changes
 
 ::
 
- --- mpv 0.29.0 ---
+ --- mpv 0.28.0 ---
  1.26   - remove glMPGetNativeDisplay("drm") support
         - add mpv_opengl_cb_window_pos and mpv_opengl_cb_drm_params and
           support via glMPGetNativeDisplay() for using it

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -19,6 +19,9 @@ Interface changes
 
 ::
 
+ --- mpv 0.29.0 ---
+    - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,
+      --ad-spdif-dtshd, --softvol options
  --- mpv 0.28.0 ---
     - rename --hwdec=mediacodec option to mediacodec-copy, to reflect
       conventions followed by other hardware video decoding APIs

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -84,7 +84,6 @@ static int init(struct dec_audio *da, const char *decoder)
     struct spdifContext *spdif_ctx = talloc_zero(NULL, struct spdifContext);
     da->priv = spdif_ctx;
     spdif_ctx->log = da->log;
-    spdif_ctx->use_dts_hd = da->opts->dtshd;
     spdif_ctx->pool = mp_aframe_pool_create(spdif_ctx);
 
     if (strcmp(decoder, "spdif_dts_hd") == 0)

--- a/options/options.c
+++ b/options/options.c
@@ -323,12 +323,6 @@ const m_option_t mp_opts[] = {
     OPT_TRACKCHOICE("vid", stream_id[0][STREAM_VIDEO]),
     OPT_TRACKCHOICE("sid", stream_id[0][STREAM_SUB]),
     OPT_TRACKCHOICE("secondary-sid", stream_id[1][STREAM_SUB]),
-    OPT_TRACKCHOICE("ff-aid", stream_id_ff[STREAM_AUDIO],
-                    .deprecation_message = "no replacement"),
-    OPT_TRACKCHOICE("ff-vid", stream_id_ff[STREAM_VIDEO],
-                    .deprecation_message = "no replacement"),
-    OPT_TRACKCHOICE("ff-sid", stream_id_ff[STREAM_SUB],
-                    .deprecation_message = "no replacement"),
     OPT_ALIAS("sub", "sid"),
     OPT_ALIAS("video", "vid"),
     OPT_ALIAS("audio", "aid"),
@@ -406,16 +400,9 @@ const m_option_t mp_opts[] = {
 
     OPT_STRING("audio-spdif", audio_spdif, 0),
 
-    OPT_FLAG("ad-spdif-dtshd", dtshd, 0,
-             .deprecation_message = "use --audio-spdif instead"),
-
     OPT_STRING_VALIDATE("hwdec", hwdec_api, M_OPT_OPTIONAL_PARAM,
                         hwdec_validate_opt),
     OPT_STRING("hwdec-codecs", hwdec_codecs, 0),
-#if HAVE_VIDEOTOOLBOX_HWACCEL
-    OPT_IMAGEFORMAT("videotoolbox-format", videotoolbox_format, 0, .min = -1,
-                    .deprecation_message = "use --hwdec-image-format instead"),
-#endif
     OPT_IMAGEFORMAT("hwdec-image-format", hwdec_image_format, 0, .min = -1),
 
     // -1 means auto aspect (prefer container size until aspect change)
@@ -502,12 +489,6 @@ const m_option_t mp_opts[] = {
     OPT_CHOICE("force-window", force_vo, 0,
                ({"no", 0}, {"yes", 1}, {"immediate", 2})),
 
-    OPT_CHOICE("softvol", softvol, 0,
-               ({"no", SOFTVOL_NO},
-                {"yes", SOFTVOL_YES},
-                {"auto", SOFTVOL_AUTO}),
-               .deprecation_message = "softvol is always active, and behaves "
-                                      "as if --softvol=yes is always set"),
     OPT_FLOATRANGE("volume-max", softvol_max, 0, 100, 1000),
     // values <0 for volume and mute are legacy and ignored
     OPT_FLOATRANGE("volume", softvol_volume, UPDATE_VOL, -1, 1000),
@@ -774,7 +755,6 @@ const m_option_t mp_opts[] = {
     OPT_REMOVED("volstep", "edit input.conf directly instead"),
     OPT_REMOVED("fixed-vo", "--fixed-vo=yes is now the default"),
     OPT_REPLACED("mkv-subtitle-preroll", "demuxer-mkv-subtitle-preroll"),
-    OPT_REPLACED("dtshd", "ad-spdif-dtshd"),
     OPT_REPLACED("ass-use-margins", "sub-use-margins"),
     OPT_REPLACED("media-title", "force-media-title"),
     OPT_REPLACED("input-unix-socket", "input-ipc-server"),
@@ -822,7 +802,6 @@ const struct MPOpts mp_default_opts = {
     .audio_driver_list = NULL,
     .audio_decoders = NULL,
     .video_decoders = NULL,
-    .softvol = SOFTVOL_AUTO,
     .softvol_max = 130,
     .softvol_volume = 100,
     .softvol_mute = 0,
@@ -891,9 +870,6 @@ const struct MPOpts mp_default_opts = {
                    { [STREAM_AUDIO] = -2,
                      [STREAM_VIDEO] = -2,
                      [STREAM_SUB] = -2, }, },
-    .stream_id_ff = { [STREAM_AUDIO] = -1,
-                      [STREAM_VIDEO] = -1,
-                      [STREAM_SUB] = -1, },
     .stream_auto_sel = 1,
     .audio_display = 1,
     .sub_visibility = 1,
@@ -921,7 +897,6 @@ const struct MPOpts mp_default_opts = {
 
     .hwdec_api = HAVE_RPI ? "mmal" : "no",
     .hwdec_codecs = "h264,vc1,wmv3,hevc,mpeg2video,vp9",
-    .videotoolbox_format = IMGFMT_NV12,
 
     .audio_output_channels = {
         .set = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -99,7 +99,6 @@ typedef struct MPOpts {
     int audio_stream_silence;
     float audio_wait_open;
     int force_vo;
-    int softvol;
     float softvol_volume;
     int rgain_mode;
     float rgain_preamp;         // Set replaygain pre-amplification
@@ -199,7 +198,6 @@ typedef struct MPOpts {
     double image_display_duration;
     char *lavfi_complex;
     int stream_id[2][STREAM_TYPE_COUNT];
-    int stream_id_ff[STREAM_TYPE_COUNT];
     char **stream_lang[STREAM_TYPE_COUNT];
     int stream_auto_sel;
     int audio_display;
@@ -236,7 +234,6 @@ typedef struct MPOpts {
     int audio_output_format;
     int audio_normalize;
     int force_srate;
-    int dtshd;
     double playback_speed;
     int pitch_correction;
     struct m_obj_settings *vf_settings, *vf_defs;
@@ -287,7 +284,6 @@ typedef struct MPOpts {
 
     char *hwdec_api;
     char *hwdec_codecs;
-    int videotoolbox_format;
     int hwdec_image_format;
 
     int w32_priority;

--- a/player/audio.c
+++ b/player/audio.c
@@ -140,9 +140,6 @@ static int recreate_audio_filters(struct MPContext *mpctx)
     if (afs->initialized < 1 && af_init(afs) < 0)
         goto fail;
 
-    if (mpctx->opts->softvol == SOFTVOL_NO)
-        MP_ERR(mpctx, "--softvol=no is not supported anymore.\n");
-
     mp_notify(mpctx, MPV_EVENT_AUDIO_RECONFIG, NULL);
 
     return 0;

--- a/player/command.c
+++ b/player/command.c
@@ -2180,44 +2180,6 @@ static int property_switch_track(struct m_property *prop, int action, void *arg,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
-// Similar, less featured, for selecting by ff-index.
-static int property_switch_track_ff(void *ctx, struct m_property *prop,
-                                    int action, void *arg)
-{
-    MPContext *mpctx = ctx;
-    enum stream_type type = (intptr_t)prop->priv;
-    struct track *track = mpctx->current_track[0][type];
-
-    switch (action) {
-    case M_PROPERTY_GET:
-        *(int *) arg = track ? track->ff_index : -2;
-        return M_PROPERTY_OK;
-    case M_PROPERTY_SET: {
-        MP_WARN(mpctx, "Warning: property '%s' is deprecated and "
-                "will be removed in the future.\n", prop->name);
-        int id = *(int *)arg;
-        if (mpctx->playback_initialized) {
-            track = NULL;
-            for (int n = 0; n < mpctx->num_tracks; n++) {
-                struct track *cur = mpctx->tracks[n];
-                if (cur->type == type && cur->ff_index == id) {
-                    track = cur;
-                    break;
-                }
-            }
-            if (!track && id >= 0)
-                return M_PROPERTY_ERROR;
-            mp_switch_track_n(mpctx, 0, type, track, 0);
-            print_track_list(mpctx, "Track switched:");
-        } else {
-            mpctx->opts->stream_id_ff[type] = *(int *)arg;
-        }
-        return M_PROPERTY_OK;
-    }
-    }
-    return mp_property_generic_option(mpctx, prop, action, arg);
-}
-
 static int track_channels(struct track *track)
 {
     return track->stream ? track->stream->codec->channels.num : 0;
@@ -4050,12 +4012,6 @@ static const struct m_property mp_properties_base[] = {
     {"dvb-channel-name", mp_property_dvb_channel_name},
 
     {"cursor-autohide", mp_property_cursor_autohide},
-
-#define TRACK_FF(name, type) \
-    {name, property_switch_track_ff, (void *)(intptr_t)type}
-    TRACK_FF("ff-vid", STREAM_VIDEO),
-    TRACK_FF("ff-aid", STREAM_AUDIO),
-    TRACK_FF("ff-sid", STREAM_SUB),
 
     {"window-minimized", mp_property_win_minimized},
     {"display-names", mp_property_display_names},

--- a/player/core.h
+++ b/player/core.h
@@ -632,11 +632,4 @@ double calc_average_frame_duration(struct MPContext *mpctx);
 int init_video_decoder(struct MPContext *mpctx, struct track *track);
 void recreate_auto_filters(struct MPContext *mpctx);
 
-// Values of MPOpts.softvol
-enum {
-    SOFTVOL_NO = 0,
-    SOFTVOL_YES = 1,
-    SOFTVOL_AUTO = 2,
-};
-
 #endif /* MPLAYER_MP_CORE_H */

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -360,11 +360,8 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
 {
     struct MPOpts *opts = mpctx->opts;
     int tid = opts->stream_id[order][type];
-    int ffid = order == 0 ? opts->stream_id_ff[type] : -1;
     char **langs = order == 0 ? opts->stream_lang[type] : NULL;
-    if (ffid != -1)
-        tid = -1; // prefer selecting ffid
-    if (tid == -2 || ffid == -2)
+    if (tid == -2)
         return NULL;
     bool select_fallback = type == STREAM_VIDEO || type == STREAM_AUDIO;
     struct track *pick = NULL;
@@ -373,8 +370,6 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
         if (track->type != type)
             continue;
         if (track->user_tid == tid)
-            return track;
-        if (track->ff_index == ffid)
             return track;
         if (!pick || compare_track(track, pick, langs, mpctx->opts))
             pick = track;

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -738,10 +738,6 @@ static int init_generic_hwaccel(struct dec_video *vd, enum AVPixelFormat hw_fmt)
 
     AVHWFramesContext *new_fctx = (void *)new_frames_ctx->data;
 
-#if LIBAVCODEC_VERSION_MICRO >= 100
-    if (ctx->hwdec.pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
-        new_fctx->sw_format = imgfmt2pixfmt(vd->opts->videotoolbox_format);
-#endif
     if (vd->opts->hwdec_image_format)
         new_fctx->sw_format = imgfmt2pixfmt(vd->opts->hwdec_image_format);
 


### PR DESCRIPTION
A release has been made, so drop options deprecated for that release.
Also drop some options which have been deprecated a much longer time
before.

Also fix a typo in client-api-changes.rst.
