### PR TITLE
Fix surface resizes for android_context completely

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -732,7 +732,7 @@ Input Commands that are Possibly Subject to Change
     Load a script, similar to the ``--script`` option.
 
 Undocumented commands: ``tv-last-channel`` (TV/DVB only),
-``ao-reload`` (experimental/internal).
+``ao-reload``, ``vo-resize`` (experimental/internal).
 
 Hooks
 ~~~~~

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4744,7 +4744,8 @@ The following video options are currently all specific to ``--vo=gpu`` and
 ``--android-surface-width=<number>``
 ``--android-surface-height=<number>``
     Set dimensions of the rendering surface used by the Android gpu context.
-    Needs to be set by the embedding application.
+    Needs to be set by the embedding application. Setting these does not re-
+    configure the vo, thus ``vo-resize`` should be called afterwards.
 
     Android with ``--gpu-context=android`` only.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4741,6 +4741,13 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     OS X only.
 
+``--android-surface-width=<number>``
+``--android-surface-height=<number>``
+    Set dimensions of the rendering surface used by the Android gpu context.
+    Needs to be set by the embedding application.
+
+    Android with ``--gpu-context=android`` only.
+
 ``--swapchain-depth=<N>``
     Allow up to N in-flight frames. This essentially controls the frame
     latency. Increasing the swapchain depth can improve pipelining and prevent

--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -191,6 +191,7 @@ const struct mp_cmd_def mp_cmds[] = {
 
   { MP_CMD_VF, "vf", { ARG_STRING, ARG_STRING } },
   { MP_CMD_VF_COMMAND, "vf-command", { ARG_STRING, ARG_STRING, ARG_STRING } },
+  { MP_CMD_VO_RESIZE, "vo-resize", },
 
   { MP_CMD_SCRIPT_BINDING, "script-binding", { ARG_STRING },
     .allow_auto_repeat = true, .on_updown = true},

--- a/input/cmd_list.h
+++ b/input/cmd_list.h
@@ -99,6 +99,7 @@ enum mp_command_type {
     /// Video filter commands
     MP_CMD_VF,
     MP_CMD_VF_COMMAND,
+    MP_CMD_VO_RESIZE,
 
     /// Internal for Lua scripts
     MP_CMD_SCRIPT_BINDING,

--- a/options/options.c
+++ b/options/options.c
@@ -92,6 +92,7 @@ extern const struct m_sub_options d3d11_conf;
 extern const struct m_sub_options d3d11va_conf;
 extern const struct m_sub_options angle_conf;
 extern const struct m_sub_options cocoa_conf;
+extern const struct m_sub_options android_conf;
 
 static const struct m_sub_options screenshot_conf = {
     .opts = image_writer_opts,
@@ -685,6 +686,10 @@ const m_option_t mp_opts[] = {
 
 #if HAVE_GL_COCOA
     OPT_SUBSTRUCT("", cocoa_opts, cocoa_conf, 0),
+#endif
+
+#if HAVE_ANDROID
+    OPT_SUBSTRUCT("", android_opts, android_conf, 0),
 #endif
 
 #if HAVE_GL_WIN32

--- a/options/options.h
+++ b/options/options.h
@@ -332,6 +332,7 @@ typedef struct MPOpts {
     struct d3d11_opts *d3d11_opts;
     struct d3d11va_opts *d3d11va_opts;
     struct cocoa_opts *cocoa_opts;
+    struct android_opts *android_opts;
     struct dvd_opts *dvd_opts;
 
     int cuda_device;

--- a/player/command.c
+++ b/player/command.c
@@ -5463,6 +5463,13 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
         reload_audio_output(mpctx);
         break;
 
+    case MP_CMD_VO_RESIZE: {
+        if (!mpctx->video_out)
+            return -1;
+        vo_control(mpctx->video_out, VOCTRL_EXTERNAL_RESIZE, NULL);
+        break;
+    }
+
     case MP_CMD_AF:
         return edit_filters_osd(mpctx, STREAM_AUDIO, cmd->args[0].v.s,
                                 cmd->args[1].v.s, msg_osd);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -111,6 +111,9 @@ enum mp_voctrl {
     VOCTRL_GET_DISPLAY_FPS,             // double*
 
     VOCTRL_GET_PREF_DEINT,              // int*
+
+    /* private to vo_gpu */
+    VOCTRL_EXTERNAL_RESIZE,
 };
 
 // VOCTRL_SET_EQUALIZER

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -207,6 +207,10 @@ static int control(struct vo *vo, uint32_t request, void *data)
     case VOCTRL_PERFORMANCE_DATA:
         gl_video_perfdata(p->renderer, (struct voctrl_performance_data *)data);
         return true;
+    case VOCTRL_EXTERNAL_RESIZE:
+        p->ctx->fns->reconfig(p->ctx);
+        resize(vo);
+        return true;
     }
 
     int events = 0;


### PR DESCRIPTION
Android fucking sucks

tl;dr
\- we need to be able to tell mpv when the surface resized
\- querying these from EGL does not work, it reports outdated values
\- thus we need additionally need those properties to pass the correct dimensions


I agree that my changes can be relicensed to LGPL 2.1 or later.
