### PR TITLE
Gross workarounds to deal with x264 4:4:4 bugs

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1159,6 +1159,18 @@ Video
     on the machine and use that, up to the maximum of 16. You can set more than
     16 threads manually.
 
+``--vd-lavc-assume-old-x264=<yes|no>``
+    Assume the video was encoded by an old, buggy x264 version (default: no).
+    Normally, this is autodtected by libavcodec. But if the bitstream contains
+    no x264 version info (or it was somehow skipped), and the stream was in fact
+    encoded by an old x264 version (build 150 or earlier), and if the stream
+    uses ``4:4:4`` chroma, then libavcodec will by default show corrupted video.
+    This option sets the libavcodec ``x264_build`` option to ``150``, which
+    means that if the stream contains no version info, or was not encoded by
+    x264 at all, it assumes it was encoded by the old version. Enabling this
+    option is pretty safe if you want your broken files to work, but in theory
+    this can break on streams not encoded by x264, or if a stream encoded by a
+    newer x264 version contains no version info.
 
 
 Audio

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -254,6 +254,7 @@ const struct m_sub_options demux_mkv_conf = {
 
 static void probe_last_timestamp(struct demuxer *demuxer, int64_t start_pos);
 static void probe_first_timestamp(struct demuxer *demuxer);
+static int read_next_block_into_queue(demuxer_t *demuxer);
 static void free_block(struct block_info *block);
 
 #define AAC_SYNC_EXTENSION_TYPE 0x02b7
@@ -1878,6 +1879,59 @@ static int demux_mkv_open_sub(demuxer_t *demuxer, mkv_track_t *track)
     return 0;
 }
 
+static void probe_x264_garbage(demuxer_t *demuxer)
+{
+    mkv_demuxer_t *mkv_d = demuxer->priv;
+
+    for (int n = 0; n < mkv_d->num_tracks; n++) {
+        mkv_track_t *track = mkv_d->tracks[n];
+        struct sh_stream *sh = track->stream;
+
+        if (!sh || sh->type != STREAM_VIDEO)
+            continue;
+
+        if (sh->codec->codec && strcmp(sh->codec->codec, "h264") != 0)
+            continue;
+
+        struct block_info *block = NULL;
+
+        // Find first block for this track.
+        // Restrict reading number of total packets. (Arbitrary to avoid bloat.)
+        for (int i = 0; i < 100; i++) {
+            if (i >= mkv_d->num_blocks && read_next_block_into_queue(demuxer) < 1)
+                break;
+            if (mkv_d->blocks[i].track == track) {
+                block = &mkv_d->blocks[i];
+                break;
+            }
+        }
+
+        if (!block || block->num_laces < 1)
+            continue;
+
+        bstr data = {block->laces[0]->data, block->laces[0]->size};
+
+        assert(data.start[data.len + 1] == 0); // (we explicitly pad this)
+
+        // This is in SEI unregistered userdata - parsing that (well, skipping
+        // to there) is a big PITA. So wing it, which should be good enough,
+        // unless someone creates a manipulated file with the goal to break this
+        // on purpose. Parsing of the x264 version itself follows libavcodec.
+        int pos = bstr_find(data, bstr0("x264 - core "));
+        if (pos < 0)
+            continue;
+        char *version = &data.start[pos + 12];
+
+        unsigned int build = 0;
+        if (sscanf(version, "%u", &build) != 1)
+            continue;
+        if (build > 0)
+            sh->codec->x264_build = build;
+        if (build == 1 && strncmp(version, "0000", 4) == 0)
+            sh->codec->x264_build = 67;
+    }
+}
+
 static int read_ebml_header(demuxer_t *demuxer)
 {
     stream_t *s = demuxer->stream;
@@ -2077,6 +2131,7 @@ static int demux_mkv_open(demuxer_t *demuxer, enum demux_check check)
     probe_first_timestamp(demuxer);
     if (mkv_d->opts->probe_duration)
         probe_last_timestamp(demuxer, start_pos);
+    probe_x264_garbage(demuxer);
 
     return 0;
 }

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -207,7 +207,10 @@ typedef struct mkv_demuxer {
 
     bool eof_warning, keyframe_warning;
 
-    struct block_info tmp_block;
+    // Small queue of read but not yet returned packets. This is mostly
+    // temporary data, and not normally larger than 0 or 1 elements.
+    struct block_info *blocks;
+    int num_blocks;
 } mkv_demuxer_t;
 
 #define OPT_BASE_STRUCT struct demux_mkv_opts
@@ -2285,7 +2288,9 @@ static void mkv_seek_reset(demuxer_t *demuxer)
         avcodec_free_context(&track->av_parser_codec);
     }
 
-    free_block(&mkv_d->tmp_block);
+    for (int n = 0; n < mkv_d->num_blocks; n++)
+        free_block(&mkv_d->blocks[n]);
+    mkv_d->num_blocks = 0;
 
     mkv_d->skip_to_timecode = INT64_MIN;
 }
@@ -2736,16 +2741,11 @@ error:
     return -1;
 }
 
-static int read_next_block(demuxer_t *demuxer, struct block_info *block)
+static int read_next_block_into_queue(demuxer_t *demuxer)
 {
     mkv_demuxer_t *mkv_d = (mkv_demuxer_t *) demuxer->priv;
     stream_t *s = demuxer->stream;
-
-    if (mkv_d->tmp_block.num_laces) {
-        *block = mkv_d->tmp_block;
-        mkv_d->tmp_block = (struct block_info){0};
-        return 1;
-    }
+    struct block_info block = {0};
 
     while (1) {
         while (stream_tell(s) < mkv_d->cluster_end) {
@@ -2764,21 +2764,21 @@ static int read_next_block(demuxer_t *demuxer, struct block_info *block)
                 end += stream_tell(s);
                 if (end > mkv_d->cluster_end)
                     goto find_next_cluster;
-                int res = read_block_group(demuxer, end, block);
+                int res = read_block_group(demuxer, end, &block);
                 if (res < 0)
                     goto find_next_cluster;
                 if (res > 0)
-                    return 1;
+                    goto add_block;
                 break;
             }
 
             case MATROSKA_ID_SIMPLEBLOCK: {
-                *block = (struct block_info){ .simple = true };
-                int res = read_block(demuxer, mkv_d->cluster_end, block);
+                block = (struct block_info){ .simple = true };
+                int res = read_block(demuxer, mkv_d->cluster_end, &block);
                 if (res < 0)
                     goto find_next_cluster;
                 if (res > 0)
-                    return 1;
+                    goto add_block;
                 break;
             }
 
@@ -2828,6 +2828,29 @@ static int read_next_block(demuxer_t *demuxer, struct block_info *block)
         if (mkv_d->cluster_end != EBML_UINT_INVALID)
             mkv_d->cluster_end += stream_tell(s);
     }
+    assert(0); // unreachable
+
+add_block:
+    index_block(demuxer, &block);
+    MP_TARRAY_APPEND(mkv_d, mkv_d->blocks, mkv_d->num_blocks, block);
+    return 1;
+}
+
+static int read_next_block(demuxer_t *demuxer, struct block_info *block)
+{
+    mkv_demuxer_t *mkv_d = demuxer->priv;
+
+    if (!mkv_d->num_blocks) {
+        int res = read_next_block_into_queue(demuxer);
+        if (res < 1)
+            return res;
+
+        assert(mkv_d->num_blocks);
+    }
+
+    *block = mkv_d->blocks[0];
+    MP_TARRAY_REMOVE_AT(mkv_d->blocks, mkv_d->num_blocks, 0);
+    return 1;
 }
 
 static int demux_mkv_fill_buffer(demuxer_t *demuxer)
@@ -2839,7 +2862,6 @@ static int demux_mkv_fill_buffer(demuxer_t *demuxer)
         if (res < 0)
             return 0;
         if (res > 0) {
-            index_block(demuxer, &block);
             res = handle_block(demuxer, &block);
             free_block(&block);
             if (res > 0)
@@ -2887,7 +2909,6 @@ static int create_index_until(struct demuxer *demuxer, int64_t timecode)
             if (res < 0)
                 break;
             if (res > 0) {
-                index_block(demuxer, &block);
                 free_block(&block);
             }
             index = get_highest_index_entry(demuxer);
@@ -3113,7 +3134,7 @@ static void probe_last_timestamp(struct demuxer *demuxer, int64_t start_pos)
         }
     }
 
-    free_block(&mkv_d->tmp_block);
+    mkv_seek_reset(demuxer);
 
     int64_t last_ts[STREAM_TYPE_COUNT] = {0};
     while (1) {
@@ -3151,11 +3172,7 @@ static void probe_first_timestamp(struct demuxer *demuxer)
     if (!mkv_d->opts->probe_start_time)
         return;
 
-    struct block_info block;
-    if (read_next_block(demuxer, &block) > 0) {
-        index_block(demuxer, &block);
-        mkv_d->tmp_block = block;
-    }
+    read_next_block_into_queue(demuxer);
 
     demuxer->start_time = mkv_d->cluster_tc / 1e9;
 

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -76,6 +76,11 @@ struct mp_codec_params {
     // Timestamp granularity for converting double<->rational timestamps.
     int native_tb_num, native_tb_den;
 
+    // Used by an obscure bug workaround mechanism. As an exception to the usual
+    // rules, demuxers are allowed to set this after adding the sh_stream, but
+    // only before the demuxer open call returns.
+    int x264_build;
+
     // STREAM_AUDIO
     int samplerate;
     struct mp_chmap channels;

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -648,8 +648,12 @@ static void init_avctx(struct dec_video *vd)
     avctx->skip_idct = lavc_param->skip_idct;
     avctx->skip_frame = lavc_param->skip_frame;
 
-    if (lavc_codec->id == AV_CODEC_ID_H264 && lavc_param->old_x264)
-        av_opt_set(avctx, "x264_build", "150", AV_OPT_SEARCH_CHILDREN);
+    if (lavc_codec->id == AV_CODEC_ID_H264 &&
+        (c->x264_build || lavc_param->old_x264))
+    {
+        int ver = c->x264_build ? c->x264_build : 150;
+        av_opt_set_int(avctx, "x264_build", ver, AV_OPT_SEARCH_CHILDREN);
+    }
 
     mp_set_avopts(vd->log, avctx, lavc_param->avopts);
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -80,6 +80,7 @@ struct vd_lavc_params {
     int framedrop;
     int threads;
     int bitexact;
+    int old_x264;
     int check_hw_profile;
     int software_fallback;
     char **avopts;
@@ -109,6 +110,7 @@ const struct m_sub_options vd_lavc_conf = {
         OPT_DISCARD("framedrop", framedrop, 0),
         OPT_INT("threads", threads, M_OPT_MIN, .min = 0),
         OPT_FLAG("bitexact", bitexact, 0),
+        OPT_FLAG("assume-old-x264", old_x264, 0),
         OPT_FLAG("check-hw-profile", check_hw_profile, 0),
         OPT_CHOICE_OR_INT("software-fallback", software_fallback, 0, 1, INT_MAX,
                           ({"no", INT_MAX}, {"yes", 1})),
@@ -645,6 +647,9 @@ static void init_avctx(struct dec_video *vd)
     avctx->skip_loop_filter = lavc_param->skip_loop_filter;
     avctx->skip_idct = lavc_param->skip_idct;
     avctx->skip_frame = lavc_param->skip_frame;
+
+    if (lavc_codec->id == AV_CODEC_ID_H264 && lavc_param->old_x264)
+        av_opt_set(avctx, "x264_build", "150", AV_OPT_SEARCH_CHILDREN);
 
     mp_set_avopts(vd->log, avctx, lavc_param->avopts);
 


### PR DESCRIPTION
The first commit is just a minor demux_mkv refactor as preparation.

The second commit adds an option to explicitly enable workaround for this x264 bug (requires latest ffmpeg git).

The third commit is a pretty gross attempt at fixing resuming for broken files that play normally if you play them from the start. Not sure if we want this.