### PR TITLE
osc: hide cache if not forced for local files

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1839,30 +1839,24 @@ function osc_init()
 
     ne.content = function ()
         local dmx_cache = mp.get_property_number("demuxer-cache-duration")
-        local cache_used = mp.get_property_number("cache-used", 0)
+        local cache_used = mp.get_property_number("cache-used", 0) * 1024
         local dmx_cache_state = mp.get_property_native("demuxer-cache-state", {})
         local is_network = mp.get_property_native("demuxer-via-network")
+        local show_cache = cache_used > 0
         if dmx_cache then
             dmx_cache = string.format("%3.0fs", dmx_cache)
         end
         if dmx_cache_state["fw-bytes"] then
-            cache_used = cache_used + dmx_cache_state["fw-bytes"] / 1024
+            cache_used = cache_used + dmx_cache_state["fw-bytes"]
         end
-        if cache_used > 0 then
-            local suffix = " KiB"
-            if (cache_used >= 1024) then
-                cache_used = cache_used/1024
-                suffix = " MiB"
-            end
-            cache_used = string.format("%5.1f%s", cache_used, suffix)
-        end
-        if (is_network and dmx_cache) or cache_used then
+        if (is_network and dmx_cache) or show_cache then
             -- Only show dmx-cache-duration by itself if it's a network file.
             -- Cache can be forced even for local files, so always show that.
             return string.format("Cache: %s%s%s",
                 (dmx_cache and dmx_cache or ""),
-                ((dmx_cache and cache_used) and " + " or ""),
-                (cache_used or ""))
+                ((dmx_cache and show_cache) and " | " or ""),
+                (show_cache and
+                    utils.format_bytes_humanized(cache_used) or ""))
         else
             return ""
         end


### PR DESCRIPTION
Also hide cache if 'cache-used' is 0 (usually means video fits
entirely within demuxer-cache-duration or stream cache is disabled).