### PR TITLE
x11: always prefer EGL over GLX (may break vdpau)

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -22,6 +22,9 @@ Interface changes
  --- mpv 0.29.0 ---
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,
       --ad-spdif-dtshd, --softvol options
+    - always prefer EGL over GLX, which helps with AMD/vaapi, but will break
+      vdpau with --vo=gpu - use --gpu-context=x11 to be able to use vdpau. This
+      does not affect --vo=vdpau or --hwdec=vdpau-copy.
  --- mpv 0.28.0 ---
     - rename --hwdec=mediacodec option to mediacodec-copy, to reflect
       conventions followed by other hardware video decoding APIs

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4779,9 +4779,6 @@ The following video options are currently all specific to ``--vo=gpu`` and
         X11/GLX
     x11vk
         VK_KHR_xlib_surface
-    x11probe
-        For internal autoprobing, equivalent to ``x11`` otherwise. Don't use
-        directly, it could be removed without warning as autoprobing is changed.
     wayland
         Wayland/EGL
     waylandvk

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -35,7 +35,6 @@
 
 /* OpenGL */
 extern const struct ra_ctx_fns ra_ctx_glx;
-extern const struct ra_ctx_fns ra_ctx_glx_probe;
 extern const struct ra_ctx_fns ra_ctx_x11_egl;
 extern const struct ra_ctx_fns ra_ctx_drm_egl;
 extern const struct ra_ctx_fns ra_ctx_cocoa;
@@ -79,9 +78,6 @@ static const struct ra_ctx_fns *contexts[] = {
 #endif
 #if HAVE_GL_DXINTEROP
     &ra_ctx_dxgl,
-#endif
-#if HAVE_GL_X11
-    &ra_ctx_glx_probe,
 #endif
 #if HAVE_EGL_X11
     &ra_ctx_x11_egl,

--- a/video/out/opengl/context_glx.c
+++ b/video/out/opengl/context_glx.c
@@ -308,20 +308,6 @@ uninit:
     return false;
 }
 
-static bool glx_init_probe(struct ra_ctx *ctx)
-{
-    if (!glx_init(ctx))
-        return false;
-
-    struct priv *p = ctx->priv;
-    if (!(p->gl.mpgl_caps & MPGL_CAP_VDPAU)) {
-        MP_VERBOSE(ctx, "No vdpau support found - probing more things.\n");
-        glx_uninit(ctx);
-        return false;
-    }
-
-    return true;
-}
 
 static void resize(struct ra_ctx *ctx)
 {
@@ -361,16 +347,5 @@ const struct ra_ctx_fns ra_ctx_glx = {
     .wakeup         = glx_wakeup,
     .wait_events    = glx_wait_events,
     .init           = glx_init,
-    .uninit         = glx_uninit,
-};
-
-const struct ra_ctx_fns ra_ctx_glx_probe = {
-    .type           = "opengl",
-    .name           = "x11probe",
-    .reconfig       = glx_reconfig,
-    .control        = glx_control,
-    .wakeup         = glx_wakeup,
-    .wait_events    = glx_wait_events,
-    .init           = glx_init_probe,
     .uninit         = glx_uninit,
 };


### PR DESCRIPTION
VDPAU is pretty much on its way out. It's inadequate for new video
formats such as HEVC, and has been neglected by nvidia (unfixed bugs
like broken rendering even of 8 bit HEVC). VDPAU also doesn't work on
EGL, but fortunately nvdec does.

On the other hand, AMD has support for both vdpau and vaapi. AMD+Vaapi
with libva 2 and some extensions that were added after the 2.0 release
(probably still git-only) supports full EGL interop, making vdpau
unnecessary.

The problem is that we strictly prefer GLX if the vdpau GL extension is
present. This means on AMD we will always GLX over EGL, this preferring
vdpau over vaapi. This makes the hardware decoding situation worse for
AMD.

Decide that it's time to drop the GLX probing, and always use EGL.

---

I don't know if everyone would agree to this. Those who prefer vdpau for whatever reasons probably won't.

This does of course not affect vo=vdpau.