### PR TITLE
vo_gpu: EGL: provide SwapInterval to generic code

### DIFF
--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -199,6 +199,14 @@ bool mpegl_create_context_cb(struct ra_ctx *ctx, EGLDisplay display,
     return false;
 }
 
+static int GLAPIENTRY swap_interval(int interval)
+{
+    EGLDisplay display = eglGetCurrentDisplay();
+    if (!display)
+        return 1;
+    return !eglSwapInterval(display, interval);
+}
+
 static void *mpegl_get_proc_address(void *ctx, const char *name)
 {
     void *p = eglGetProcAddress(name);
@@ -223,4 +231,6 @@ void mpegl_load_functions(struct GL *gl, struct mp_log *log)
         egl_exts = eglQueryString(display, EGL_EXTENSIONS);
 
     mpgl_load_functions2(gl, mpegl_get_proc_address, NULL, egl_exts, log);
+    if (!gl->SwapInterval)
+        gl->SwapInterval = swap_interval;
 }


### PR DESCRIPTION
This means that we now explicitly set an interval of 1. Although that
should be the EGL default, some drivers could possibly ignore this
(unconfirmed, also unconfirmed whether setting it explicitly helps in
those cases). In any case, this commit also allows disabling vsync, for
users who want it.
