### PR TITLE
vd_lavc: fix crash with RPI hwdec

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -453,7 +453,8 @@ static void select_and_set_hwdec(struct dec_video *vd)
             } else if (!hwdec->copying) {
                 // Most likely METHOD_INTERNAL, which often use delay-loaded
                 // VO support as well.
-                hwdec_devices_request_all(vd->hwdec_devs);
+                if (vd->hwdec_devs)
+                    hwdec_devices_request_all(vd->hwdec_devs);
             }
 
             ctx->use_hwdec = true;


### PR DESCRIPTION
If you use vo_rpi, this could crash, because hwdec_devs is NULL.

Untested. Fixes #5301.
