### PR TITLE
Undo --loop-file interaction with --start

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -781,19 +781,11 @@ static void handle_loop_file(struct MPContext *mpctx)
 
     // Do not attempt to loop-file if --ab-loop is active.
     else if (opts->loop_file && mpctx->stop_play == AT_END_OF_FILE) {
-        double play_start_pts = get_play_start_pts(mpctx);
-        if (play_start_pts == MP_NOPTS_VALUE)
-            play_start_pts = 0;
-        double play_end_pts = get_play_end_pts(mpctx);
-        if (play_end_pts == MP_NOPTS_VALUE || play_start_pts < play_end_pts){
-            mpctx->stop_play = KEEP_PLAYING;
-            set_osd_function(mpctx, OSD_FFW);
-            queue_seek(mpctx, MPSEEK_ABSOLUTE, play_start_pts, MPSEEK_EXACT,
-                        MPSEEK_FLAG_NOFLUSH);
-            if (opts->loop_file > 0)
-                opts->loop_file--;
-        }
-
+        mpctx->stop_play = KEEP_PLAYING;
+        set_osd_function(mpctx, OSD_FFW);
+        queue_seek(mpctx, MPSEEK_ABSOLUTE, 0, MPSEEK_DEFAULT, MPSEEK_FLAG_NOFLUSH);
+        if (opts->loop_file > 0)
+            opts->loop_file--;
     }
 }
 


### PR DESCRIPTION
I had changed `--loop-file` to interact with `--start` to work the same way that `--loop-playlist` does. (That is, `--loop-file` seeks to the `--start` time upon looping, not the beginning of the file.) However, the consensus (at least from hanna and wm4) is that the old behavior is preferred, and if anything, then `--loop-playlist` should also ignore the `--start` option.

I've reverted the two commits that change this behavior with standard commit revert messages to make it very clear what was reverted. If these should be rebased with different commit messages or squashed into one with this information in the extended message, I can do that too, but I left it as is just in case. 
