### PR TITLE
dec_video: drain pending frames from decoder before waiting on new packets

### DIFF
--- a/video/decode/dec_video.c
+++ b/video/decode/dec_video.c
@@ -405,6 +405,17 @@ void video_work(struct dec_video *d_video)
     if (d_video->current_mpi || !d_video->vd_driver)
         return;
 
+    if (!d_video->packet && !d_video->new_segment) {
+        bool progress = receive_frame(d_video, &d_video->current_mpi);
+        if (!progress) {
+            d_video->current_state = DATA_EOF;
+            return;
+        } else if (d_video->current_mpi) {
+            d_video->current_state = DATA_OK;
+            return;
+        }
+    }
+
     if (!d_video->packet && !d_video->new_segment &&
         demux_read_packet_async(d_video->header, &d_video->packet) == 0)
     {


### PR DESCRIPTION
This fixes a playback issue on some Android devices, where the mediacodec
mpeg2 decoder has a built-in de-interlacer and returns a frame per field.

On these devices, playing a live mpeg2 stream causes constant demuxer
underruns, because video_work() only calls receive_frame() once for every
send_packet(). Even though two frames are generated per packet, the second
frame is not received or displayed until another packet is enqueued. On
file-based streams, the demuxer can race ahead and there's no issue; but on
live streams, the demuxer is constantly waiting for a new packet and so
by the time the second frame is received its usually too late to display it.

After this commit, video_work() will first try to drain any pending frames
from the decoder before attempting to receive more packets (which may
block on network i/o).

cc @wm4 wdyt of this approach?