### PR TITLE
demux_mkv: fix x264 hack if video track uses header compression

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1909,8 +1909,14 @@ static void probe_x264_garbage(demuxer_t *demuxer)
         if (!block || block->num_laces < 1)
             continue;
 
-        sh->codec->first_packet = new_demux_packet_from_buf(block->laces[0]);
+        bstr sblock = {block->laces[0]->data, block->laces[0]->size};
+        bstr nblock = demux_mkv_decode(demuxer->log, track, sblock, 1);
+
+        sh->codec->first_packet = new_demux_packet_from(nblock.start, nblock.len);
         talloc_steal(mkv_d, sh->codec->first_packet);
+
+        if (nblock.start != sblock.start)
+            talloc_free(nblock.start);
     }
 }
 


### PR DESCRIPTION
The x264 hack requires reading the first video packet, which in turn we
handle with a hack in demux_mkv.c to get the packet without having to
add special crap to demux.c. Another useless MKV feature (which they
enabled by default at one point and which caused many demuxers to break
completely, only to disable it again when it was too late) conflicts
with this, because we actually pass a block as packet contents, instead
of after "decompression".

Fix this by calling demux_mkv_decode().
