### PR TITLE
vo_gpu/android: fallback to EGL_WIDTH/HEIGHT

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4755,8 +4755,10 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
 ``--android-surface-width=<number>``, ``--android-surface-height=<number>``
     Set dimensions of the rendering surface used by the Android gpu context.
-    Needs to be set by the embedding application. Setting these does not re-
-    configure the vo, thus ``vo-resize`` should be called afterwards.
+    Needs to be set by the embedding application if the dimensions change during
+    runtime (i.e. if the device is rotated), via the surfaceChanged callback.
+    Setting these does not re-configure the vo, thus ``vo-resize`` should be
+    called afterwards.
 
     Android with ``--gpu-context=android`` only.
 

--- a/video/out/opengl/context_android.c
+++ b/video/out/opengl/context_android.c
@@ -136,12 +136,24 @@ fail:
 
 static bool android_reconfig(struct ra_ctx *ctx)
 {
+    struct priv *p = ctx->priv;
     void *tmp = talloc_new(NULL);
     struct android_opts *opts = mp_get_config_group(tmp, ctx->global, &android_conf);
+    int w = opts->w, h = opts->h;
 
-    ctx->vo->dwidth = opts->w;
-    ctx->vo->dheight = opts->h;
-    ra_gl_ctx_resize(ctx->swapchain, opts->w, opts->h, 0);
+    if (!w)
+        eglQuerySurface(p->egl_display, p->egl_surface, EGL_WIDTH, &w);
+    if (!h)
+        eglQuerySurface(p->egl_display, p->egl_surface, EGL_HEIGHT, &h);
+
+    if (!w || !h) {
+        MP_FATAL(ctx, "Failed to get height and width!\n");
+        return false;
+    }
+
+    ctx->vo->dwidth = w;
+    ctx->vo->dheight = h;
+    ra_gl_ctx_resize(ctx->swapchain, w, h, 0);
 
     talloc_free(tmp);
     return true;


### PR DESCRIPTION
Uses the EGL width/height by default when the user fails to set
the android-surface-width/android-surface-height options.

This means the vo-resize command is optional, and does not need to
be implemented on android devices which do not support rotation.

cc @sfan5 #5287