### PR TITLE
video, audio: always read all frames before getting next packet

### DIFF
--- a/video/decode/dec_video.h
+++ b/video/decode/dec_video.h
@@ -77,6 +77,7 @@ struct dec_video {
     struct demux_packet *new_segment;
     struct demux_packet *packet;
     bool framedrop_enabled;
+    bool may_decoder_framedrop;
     struct mp_image *current_mpi;
     int current_state;
 };


### PR DESCRIPTION
The old code tried to make sure at all times to try to read a new
packet. Only once that was read, it tried to retrieve new video or audio
frames the decoder might already have decoded.

Change this to strictly read frames from the decoder until it signals
that it wants a new packet, and only then read and feed a new packet.
This is in theory nicer, follows the libavcodec recommended data flow,
and and reduces the minimum latency by 1 frame.

This merely requires switching the order in which those calls are done.
Normally, the decoder will return only 1 frame until a new packet is
required. If we would just feed it 1 packet, return DATA_AGAIN, and wait
until the next frame is decoded, we would run the playloop 1 time too
often for no reason (which is fine but might have some overhead). To
avoid this, try to read a frame again after possibly feeding a packet.
For this reason, move the feed/read code to its own functions each,
instead of merely moving the code.

The audio and video code for this particular thing is basically
duplicated. The idea is to unify them one day, so make the change to
both. (Doing this for video is the real motivation for this change, see
below.)

The video code change is slightly more complicated, because we have to
care about the framedrop counting (which is just a heuristic, but for
now considered better than nothing, and possibly considered required to
warn the user of framedrops happening - maybe).

Apparently this change helps with stalling streams on Android with the
mediacodec wrapper and mpeg2 decoder implementations which interlace on
decoding (and return 2 frames per packet).

Based on an idea and observations by tmm1.

---

CC @tmm1, replaces #5309