### PR TITLE
stream_lavf: minor fixes to HTTP reconnection support

### DIFF
--- a/stream/stream.c
+++ b/stream/stream.c
@@ -341,7 +341,6 @@ static bool stream_reconnect(stream_t *s)
     if (!s->streaming || s->caching || !s->seekable || !s->cancel)
         return false;
 
-    int64_t pos = s->pos;
     double sleep_secs = 0;
     for (int retry = 0; retry < 6; retry++) {
         if (mp_cancel_wait(s->cancel, sleep_secs))
@@ -350,7 +349,7 @@ static bool stream_reconnect(stream_t *s)
         int r = stream_control(s, STREAM_CTRL_RECONNECT, NULL);
         if (r == STREAM_UNSUPPORTED)
             break;
-        if (r == STREAM_OK && stream_seek_unbuffered(s, pos) && s->pos == pos) {
+        if (r == STREAM_OK) {
             MP_WARN(s, "Reconnected successfully.\n");
             return true;
         }


### PR DESCRIPTION
Don't drop the stream buffers, because the read call (that must have
been failing) might try to extend an existing read buffer in the first
place. Just move the messy seek logic to stream_lavf.c. (In theory,
stream_lavf should probably make libavformat connect at the correct
offset instead of using a seek to reconnect it again. This patch doesn't
fix it, but at least it's a good argument to have the messing with the
position not in the generic code.)

Also update the comment about avio not supporting reconnecting. It has
that feature now. Maybe we should use it, but only after it gets fixed.
