### PR TITLE
Don't attempt to use a BGRA-format swapchain with D3D11

### DIFF
--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -315,29 +315,18 @@ bool mp_d3d11_create_swapchain(ID3D11Device *dev, struct mp_log *log,
     if (FAILED(hr))
         factory2 = NULL;
 
-    // Try B8G8R8A8_UNORM first, since at least in Windows 8, it's always the
-    // format of the desktop image
-    static const DXGI_FORMAT formats[] = {
-        DXGI_FORMAT_B8G8R8A8_UNORM,
-        DXGI_FORMAT_R8G8B8A8_UNORM,
-    };
-    static const int formats_len = MP_ARRAY_SIZE(formats);
     bool flip = factory2 && opts->flip;
 
     // Return here to retry creating the swapchain
     do {
-        for (int i = 0; i < formats_len; i++) {
-            if (factory2) {
-                // Create a DXGI 1.2+ (Windows 8+) swap chain if possible
-                hr = create_swapchain_1_2(dev, factory2, log, opts, flip,
-                                          formats[i], &swapchain);
-            } else {
-                // Fall back to DXGI 1.1 (Windows 7)
-                hr = create_swapchain_1_1(dev, factory, log, opts, formats[i],
-                                          &swapchain);
-            }
-            if (SUCCEEDED(hr))
-                break;
+        if (factory2) {
+            // Create a DXGI 1.2+ (Windows 8+) swap chain if possible
+            hr = create_swapchain_1_2(dev, factory2, log, opts, flip,
+                                      DXGI_FORMAT_R8G8B8A8_UNORM, &swapchain);
+        } else {
+            // Fall back to DXGI 1.1 (Windows 7)
+            hr = create_swapchain_1_1(dev, factory, log, opts,
+                                      DXGI_FORMAT_R8G8B8A8_UNORM, &swapchain);
         }
         if (SUCCEEDED(hr))
             break;


### PR DESCRIPTION
BGRA swapchains don't work well with a42b8b1142fd, which attempts to use the swapchain format for intermediate FBOs, even though BGRA swapchains don't support typed UAV stores. This results in error spam with Intel graphics (but surprisingly, no errors with Nvidia):
```
[vo/gpu/d3d11] Failed to create Texture2D: The parameter is incorrect. (0x80070057)
[vo/gpu] Error: texture could not be created.
[vo/gpu/d3d11] after rendering:
[vo/gpu/d3d11] 92: ID3D11Device::CreateTexture2D: The format (0x57, B8G8R8A8_UNORM) cannot be bound as an UnorderedAccessView, or cast to a format that could be bound as an UnorderedAccessView.  Therefore this format does not support D3D11_BIND_UNORDERED_ACCESS.
[vo/gpu/d3d11] 104: ID3D11Device::CreateTexture2D: Returning E_INVALIDARG, meaning invalid parameters were passed.
```

Since BGRA swapchains don't seem to have a performance benefit, and a42b8b1142fd seems to improve performance on Intel, the simplest solution is to get rid of BGRA swapchains and always use RGBA.