### PR TITLE
m_option: add print callback to start/end/length

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2431,10 +2431,28 @@ out:
     return 1;
 }
 
+static char *print_rel_time(const m_option_t *opt, const void *val)
+{
+    const struct m_rel_time *t = val;
+    switch(t->type) {
+    case REL_TIME_ABSOLUTE:
+        return talloc_asprintf(NULL, "%g", t->pos);
+    case REL_TIME_RELATIVE:
+        return talloc_asprintf(NULL, "%s%g",
+            (t->pos >= 0) ? "+" : "-", fabs(t->pos));
+    case REL_TIME_CHAPTER:
+        return talloc_asprintf(NULL, "#%g", t->pos);
+    case REL_TIME_PERCENT:
+        return talloc_asprintf(NULL, "%g%%", t->pos);
+    }
+    return talloc_strdup(NULL, "none");
+}
+
 const m_option_type_t m_option_type_rel_time = {
     .name  = "Relative time or percent position",
     .size  = sizeof(struct m_rel_time),
     .parse = parse_rel_time,
+    .print = print_rel_time,
     .copy  = copy_opt,
 };
 


### PR DESCRIPTION
Any suggestions on improving the repeated talloc_asprintf would be welcome.