### PR TITLE
Cache pausing improvements

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3856,6 +3856,15 @@ Cache
     data and stalls decoding/playback (default: yes). If enabled, it will
     pause and unpause once more data is available, aka "buffering".
 
+``--cache-pause-wait=<seconds>``
+    Number of seconds the packet cache should have buffered before starting
+    playback again if "buffering" was entered (default: 1). This can be used
+    to control how long the player rebuffers if ``--cache-pause`` is enabled,
+    and the demuxer underruns. If the given time is higher than the maximum
+    set with ``--cache-secs`` or  ``--demuxer-readahead-secs``, or prefetching
+    ends before that for some other reason (like file end), playback resumes
+    earlier.
+
 
 Network
 -------

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3851,9 +3851,10 @@ Cache
     very high, so the actually achieved readahead will usually be limited by
     the value of the ``--demuxer-max-bytes`` option.
 
-``--cache-pause``, ``--no-cache-pause``
-    Whether the player should automatically pause when the cache runs low,
-    and unpause once more data is available ("buffering").
+``--cache-pause=<yes|no>``
+    Whether the player should automatically pause when the cache runs out of
+    data and stalls decoding/playback (default: yes). If enabled, it will
+    pause and unpause once more data is available, aka "buffering".
 
 
 Network

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3865,6 +3865,20 @@ Cache
     ends before that for some other reason (like file end), playback resumes
     earlier.
 
+``--cache-pause-initial=<yes|no>``
+    Enter "buffering" mode before starting playback (default: no). This can be
+    used to ensure playback starts smoothly, in exchange for waiting some time
+    to prefetch network data (as controlled by ``--cache-pause-wait``). For
+    example, some common behavior is that playback starts, but network caches
+    immediately underrun when trying to decode more data as playback progresses.
+
+    Another thing that can happen is that the network prefetching is so CPU
+    demanding (due to demuxing in the background) that playback drops frames
+    at first. In these cases, it helps enabling this option, and setting
+    ``--cache-secs`` and ``--cache-pause-wait`` to roughly the same value.
+
+    This option also triggers when playback is restarted after seeking.
+
 
 Network
 -------

--- a/options/options.c
+++ b/options/options.c
@@ -450,7 +450,7 @@ const m_option_t mp_opts[] = {
     OPT_STRING("sub-demuxer", sub_demuxer_name, 0),
     OPT_FLAG("demuxer-thread", demuxer_thread, 0),
     OPT_FLAG("prefetch-playlist", prefetch_open, 0),
-    OPT_FLAG("cache-pause", cache_pausing, 0),
+    OPT_FLAG("cache-pause", cache_pause, 0),
     OPT_FLAG("cache-pause-initial", cache_pause_initial, 0),
     OPT_FLOAT("cache-pause-wait", cache_pause_wait, M_OPT_MIN, .min = 0),
 
@@ -895,7 +895,7 @@ const struct MPOpts mp_default_opts = {
     .autoload_files = 1,
     .demuxer_thread = 1,
     .hls_bitrate = INT_MAX,
-    .cache_pausing = 1,
+    .cache_pause = 1,
     .cache_pause_wait = 1.0,
     .chapterrange = {-1, -1},
     .ab_loop = {MP_NOPTS_VALUE, MP_NOPTS_VALUE},

--- a/options/options.c
+++ b/options/options.c
@@ -451,6 +451,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("demuxer-thread", demuxer_thread, 0),
     OPT_FLAG("prefetch-playlist", prefetch_open, 0),
     OPT_FLAG("cache-pause", cache_pausing, 0),
+    OPT_FLAG("cache-pause-initial", cache_pause_initial, 0),
     OPT_FLOAT("cache-pause-wait", cache_pause_wait, M_OPT_MIN, .min = 0),
 
     OPT_DOUBLE("mf-fps", mf_fps, 0),

--- a/options/options.c
+++ b/options/options.c
@@ -451,6 +451,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("demuxer-thread", demuxer_thread, 0),
     OPT_FLAG("prefetch-playlist", prefetch_open, 0),
     OPT_FLAG("cache-pause", cache_pausing, 0),
+    OPT_FLOAT("cache-pause-wait", cache_pause_wait, M_OPT_MIN, .min = 0),
 
     OPT_DOUBLE("mf-fps", mf_fps, 0),
     OPT_STRING("mf-type", mf_type, 0),
@@ -894,6 +895,7 @@ const struct MPOpts mp_default_opts = {
     .demuxer_thread = 1,
     .hls_bitrate = INT_MAX,
     .cache_pausing = 1,
+    .cache_pause_wait = 1.0,
     .chapterrange = {-1, -1},
     .ab_loop = {MP_NOPTS_VALUE, MP_NOPTS_VALUE},
     .edition_id = -1,

--- a/options/options.h
+++ b/options/options.h
@@ -263,6 +263,7 @@ typedef struct MPOpts {
     char *sub_demuxer_name;
 
     int cache_pausing;
+    int cache_pause_initial;
     float cache_pause_wait;
 
     struct image_writer_opts *screenshot_image_opts;

--- a/options/options.h
+++ b/options/options.h
@@ -263,6 +263,7 @@ typedef struct MPOpts {
     char *sub_demuxer_name;
 
     int cache_pausing;
+    float cache_pause_wait;
 
     struct image_writer_opts *screenshot_image_opts;
     char *screenshot_template;

--- a/options/options.h
+++ b/options/options.h
@@ -262,7 +262,7 @@ typedef struct MPOpts {
     char *audio_demuxer_name;
     char *sub_demuxer_name;
 
-    int cache_pausing;
+    int cache_pause;
     int cache_pause_initial;
     float cache_pause_wait;
 

--- a/player/core.h
+++ b/player/core.h
@@ -432,7 +432,7 @@ typedef struct MPContext {
     bool playing_msg_shown;
 
     bool paused_for_cache;
-    double cache_stop_time, cache_wait_time;
+    double cache_stop_time;
     int cache_buffer;
 
     // Set after showing warning about decoding being too slow for realtime

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -618,7 +618,7 @@ static void handle_pause_on_low_cache(struct MPContext *mpctx)
 
     if (mpctx->restart_complete && use_pause_on_low_cache) {
         if (mpctx->paused && mpctx->paused_for_cache) {
-            if (!s.underrun && (!opts->cache_pausing || s.idle ||
+            if (!s.underrun && (!opts->cache_pause || s.idle ||
                                 s.ts_duration >= opts->cache_pause_wait))
             {
                 mpctx->paused_for_cache = false;
@@ -627,7 +627,7 @@ static void handle_pause_on_low_cache(struct MPContext *mpctx)
             }
             mp_set_timeout(mpctx, 0.2);
         } else {
-            if (opts->cache_pausing && s.underrun) {
+            if (opts->cache_pause && s.underrun) {
                 mpctx->paused_for_cache = true;
                 update_internal_pause_state(mpctx);
                 mpctx->cache_stop_time = now;

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -950,6 +950,17 @@ static void handle_playback_restart(struct MPContext *mpctx)
         mpctx->video_status < STATUS_READY)
         return;
 
+    if (opts->cache_pause_initial && (mpctx->video_status == STATUS_READY ||
+                                      mpctx->audio_status == STATUS_READY))
+    {
+        // Audio or video is restarting, and initial buffering is enabled. Make
+        // sure we actually restart them in paused mode, so no audio gets
+        // dropped and video technically doesn't start yet.
+        mpctx->paused_for_cache = true;
+        mpctx->cache_buffer = 0;
+        update_internal_pause_state(mpctx);
+    }
+
     if (mpctx->video_status == STATUS_READY) {
         mpctx->video_status = STATUS_PLAYING;
         get_relative_time(mpctx);


### PR DESCRIPTION
Two things of interested:
- the 2nd commit changes the "adaptive" buffering/pausing mechanism to a fixed wait, because the "adaptive" behavior was probably more like "bullshit" behavior
- the 3rd commit adds an option to enter the buffering state on playback start

CC @LongChair because he pretty much requested a way to wait until buffering is done; see https://github.com/mpv-player/mpv/commit/57c0c6ab3dbca28249f4ef199fcf41ff4a8eb0ea#diff-1d6a5494d6e6ca1cadd10688a1e233bdR3875

CC @tmm1 because he often seems to do streaming stuff (also maybe @sfan5 ?)