### PR TITLE
av_log: stop accessing private ffmpeg fields

### DIFF
--- a/common/av_log.c
+++ b/common/av_log.c
@@ -93,10 +93,10 @@ static struct mp_log *get_av_log(void *ptr)
         AVCodecContext *s = ptr;
         if (s->codec) {
             if (s->codec->type == AVMEDIA_TYPE_AUDIO) {
-                if (s->codec->decode)
+                if (av_codec_is_decoder(s->codec))
                     return log_decaudio;
             } else if (s->codec->type == AVMEDIA_TYPE_VIDEO) {
-                if (s->codec->decode)
+                if (av_codec_is_decoder(s->codec))
                     return log_decvideo;
             }
         }


### PR DESCRIPTION
MPlayer legacy added in 3c49701490aecb.
