### PR TITLE
stream: use native libavformat reconnection feature

### DIFF
--- a/stream/cache.c
+++ b/stream/cache.c
@@ -504,7 +504,6 @@ static bool control_needs_flush(int stream_ctrl)
     case STREAM_CTRL_AVSEEK:
     case STREAM_CTRL_SET_ANGLE:
     case STREAM_CTRL_SET_CURRENT_TITLE:
-    case STREAM_CTRL_RECONNECT:
     case STREAM_CTRL_DVB_SET_CHANNEL:
     case STREAM_CTRL_DVB_SET_CHANNEL_NAME:
     case STREAM_CTRL_DVB_STEP_CHANNEL:

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -64,7 +64,6 @@ enum stream_ctrl {
     STREAM_CTRL_GET_BASE_FILENAME,
 
     // Certain network protocols
-    STREAM_CTRL_RECONNECT,
     STREAM_CTRL_AVSEEK,
     STREAM_CTRL_HAS_AVSEEK,
     STREAM_CTRL_GET_METADATA,


### PR DESCRIPTION
Remove our own hacky reconnection code, and use libavformat's feature
for that. It's disabled by default, and until recently it did not work
too well. This has been fixed in recent git master, so there's no reason
to keep our own code.

We set "reconnect_delay_max" to 7, which limits the maximum time it
waits. Since libavformat doubles the wait time on each reconnect attempt
(starting with 1), and stops trying to reconnect once the wait time is
over the reconnect_delay_max value, this allows for 4 reconnection
attempts which should add to 11 seconds maximum wait time. The default
is 120, which seems too high for normal playback use.

(The user can still override these parameters with --stream-lavf-o.)

---

Yeah, this just wipes the recent changes to the reconnect code.