### PR TITLE
Make osd-msg-bar default for seeking and pausing.

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3097,8 +3097,7 @@ OSD
     Whether to load the on-screen-controller (default: yes).
 
 ``--no-osd-bar``, ``--osd-bar``
-    Disable display of the OSD bar. This will make some things (like seeking)
-    use OSD text messages instead of the bar.
+    Disable display of the OSD bar.
 
     You can configure this on a per-command basis in input.conf using ``osd-``
     prefixes, see ``Input command prefixes``. If you want to disable the OSD
@@ -3136,16 +3135,15 @@ OSD
     shown.
 
     This is also used for the ``show-progress`` command (by default mapped to
-    ``P``), or in some non-default cases when seeking.
+    ``P``), and when seeking.
 
     ``--osd-status-msg`` is a legacy equivalent (but with a minor difference).
 
 ``--osd-status-msg=<string>``
     Show a custom string during playback instead of the standard status text.
     This overrides the status text used for ``--osd-level=3``, when using the
-    ``show-progress`` command (by default mapped to ``P``), or in some
-    non-default cases when seeking. Expands properties. See
-    `Property Expansion`_.
+    ``show-progress`` command (by default mapped to ``P``), and when
+    seeking. Expands properties. See `Property Expansion`_.
 
     This option has been replaced with ``--osd-msg3``. The only difference is
     that this option implicitly includes ``${osd-sym-cc}``. This option is

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3122,16 +3122,16 @@ OSD
 
 ``--osd-msg1=<string>``
     Show this string as message on OSD with OSD level 1 (visible by default).
-    The message will be visible by default, and as long no other message
+    The message will be visible by default, and as long as no other message
     covers it, and the OSD level isn't changed (see ``--osd-level``).
     Expands properties; see `Property Expansion`_.
 
 ``--osd-msg2=<string>``
-    Similar as ``--osd-msg1``, but for OSD level 2. If this is an empty string
+    Similar to ``--osd-msg1``, but for OSD level 2. If this is an empty string
     (default), then the playback time is shown.
 
 ``--osd-msg3=<string>``
-    Similar as ``--osd-msg1``, but for OSD level 3. If this is an empty string
+    Similar to ``--osd-msg1``, but for OSD level 3. If this is an empty string
     (default), then the playback time, duration, and some more information is
     shown.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3135,15 +3135,15 @@ OSD
     shown.
 
     This is also used for the ``show-progress`` command (by default mapped to
-    ``P``), and when seeking.
+    ``P``), when toggling pause, and when seeking.
 
     ``--osd-status-msg`` is a legacy equivalent (but with a minor difference).
 
 ``--osd-status-msg=<string>``
     Show a custom string during playback instead of the standard status text.
     This overrides the status text used for ``--osd-level=3``, when using the
-    ``show-progress`` command (by default mapped to ``P``), and when
-    seeking. Expands properties. See `Property Expansion`_.
+    ``show-progress`` command (by default mapped to ``P``), when toggling pause,
+    and when seeking. Expands properties. See `Property Expansion`_.
 
     This option has been replaced with ``--osd-msg3``. The only difference is
     that this option implicitly includes ``${osd-sym-cc}``. This option is

--- a/player/command.c
+++ b/player/command.c
@@ -4821,7 +4821,6 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     bool auto_osd = on_osd == MP_ON_OSD_AUTO;
     bool msg_osd = auto_osd || (on_osd & MP_ON_OSD_MSG);
     bool bar_osd = auto_osd || (on_osd & MP_ON_OSD_BAR);
-    bool msg_or_nobar_osd = msg_osd && !(auto_osd && opts->osd_bar_visible);
     int osdl = msg_osd ? 1 : OSD_LEVEL_INVISIBLE;
     bool async = cmd->flags & MP_ASYNC_CMD;
 
@@ -4887,7 +4886,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
         }}
         if (bar_osd)
             mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-        if (msg_or_nobar_osd)
+        if (msg_osd)
             mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
         break;
     }
@@ -4908,7 +4907,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             set_osd_function(mpctx, OSD_REW);
             if (bar_osd)
                 mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-            if (msg_or_nobar_osd)
+            if (msg_osd)
                 mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
         } else {
             return -1;
@@ -5104,7 +5103,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
                     set_osd_function(mpctx, (a[0] > refpts) ? OSD_FFW : OSD_REW);
                     if (bar_osd)
                         mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-                    if (msg_or_nobar_osd)
+                    if (msg_osd)
                         mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
                 }
             }

--- a/player/command.c
+++ b/player/command.c
@@ -4342,7 +4342,9 @@ static const struct property_osd_display {
     {"ab-loop-b", .msg = "A-B loop: ${ab-loop-a} - ${ab-loop-b}"},
     {"audio-device", "Audio device"},
     // By default, don't display the following properties on OSD
-    {"pause", NULL},
+    {"pause",
+     .seek_msg = OSD_SEEK_INFO_TEXT,
+     .seek_bar = OSD_SEEK_INFO_BAR},
     {"fullscreen", NULL},
     {0}
 };

--- a/player/command.c
+++ b/player/command.c
@@ -3378,7 +3378,7 @@ static int mp_property_playlist(void *ctx, struct m_property *prop,
         return M_PROPERTY_OK;
     }
 
-    struct get_playlist_ctx p = { .mpctx = mpctx };
+    struct get_playlist_ctx p = {.mpctx = mpctx};
     return m_property_read_list(action, arg, playlist_entry_count(mpctx->playlist),
                                 get_playlist_entry, &p);
 }
@@ -4276,79 +4276,81 @@ static const struct property_osd_display {
     const char *msg;
 } property_osd_display[] = {
     // general
-    { "loop-playlist", "Loop" },
-    { "loop-file", "Loop current file" },
-    { "chapter", .seek_msg = OSD_SEEK_INFO_CHAPTER_TEXT,
-                 .seek_bar = OSD_SEEK_INFO_BAR },
-    { "hr-seek", "hr-seek" },
-    { "speed", "Speed" },
-    { "clock", "Clock" },
+    {"loop-playlist", "Loop"},
+    {"loop-file", "Loop current file"},
+    {"chapter",
+     .seek_msg = OSD_SEEK_INFO_CHAPTER_TEXT,
+     .seek_bar = OSD_SEEK_INFO_BAR},
+    {"hr-seek", "hr-seek"},
+    {"speed", "Speed"},
+    {"clock", "Clock"},
     // audio
-    { "volume", "Volume",
-      .msg = "Volume: ${?volume:${volume}% ${?mute==yes:(Muted)}}${!volume:${volume}}",
-      .osd_progbar = OSD_VOLUME, .marker = 100 },
-    { "ao-volume", "AO Volume",
-      .msg = "AO Volume: ${?ao-volume:${ao-volume}% ${?ao-mute==yes:(Muted)}}${!ao-volume:${ao-volume}}",
-      .osd_progbar = OSD_VOLUME, .marker = 100 },
-    { "mute", "Mute" },
-    { "ao-mute", "AO Mute" },
-    { "audio-delay", "A-V delay" },
-    { "audio", "Audio" },
+    {"volume", "Volume",
+     .msg = "Volume: ${?volume:${volume}% ${?mute==yes:(Muted)}}${!volume:${volume}}",
+     .osd_progbar = OSD_VOLUME, .marker = 100},
+    {"ao-volume", "AO Volume",
+     .msg = "AO Volume: ${?ao-volume:${ao-volume}% ${?ao-mute==yes:(Muted)}}${!ao-volume:${ao-volume}}",
+     .osd_progbar = OSD_VOLUME, .marker = 100},
+    {"mute", "Mute"},
+    {"ao-mute", "AO Mute"},
+    {"audio-delay", "A-V delay"},
+    {"audio", "Audio"},
     // video
-    { "panscan", "Panscan", .osd_progbar = OSD_PANSCAN },
-    { "taskbar-progress", "Progress in taskbar" },
-    { "snap-window", "Snap to screen edges" },
-    { "ontop", "Stay on top" },
-    { "border", "Border" },
-    { "framedrop", "Framedrop" },
-    { "deinterlace", "Deinterlace" },
-    { "colormatrix",
-       .msg = "YUV colormatrix:\n${colormatrix}" },
-    { "colormatrix-input-range",
-       .msg = "YUV input range:\n${colormatrix-input-range}" },
-    { "colormatrix-output-range",
-       .msg = "RGB output range:\n${colormatrix-output-range}" },
-    { "colormatrix-primaries",
-       .msg = "Colorspace primaries:\n${colormatrix-primaries}", },
-    { "colormatrix-gamma",
-       .msg = "Colorspace gamma:\n${colormatrix-gamma}", },
-    { "gamma", "Gamma", .osd_progbar = OSD_BRIGHTNESS },
-    { "brightness", "Brightness", .osd_progbar = OSD_BRIGHTNESS },
-    { "contrast", "Contrast", .osd_progbar = OSD_CONTRAST },
-    { "saturation", "Saturation", .osd_progbar = OSD_SATURATION },
-    { "hue", "Hue", .osd_progbar = OSD_HUE },
-    { "angle", "Angle" },
+    {"panscan", "Panscan", .osd_progbar = OSD_PANSCAN},
+    {"taskbar-progress", "Progress in taskbar"},
+    {"snap-window", "Snap to screen edges"},
+    {"ontop", "Stay on top"},
+    {"border", "Border"},
+    {"framedrop", "Framedrop"},
+    {"deinterlace", "Deinterlace"},
+    {"colormatrix",
+     .msg = "YUV colormatrix:\n${colormatrix}"},
+    {"colormatrix-input-range",
+     .msg = "YUV input range:\n${colormatrix-input-range}"},
+    {"colormatrix-output-range",
+     .msg = "RGB output range:\n${colormatrix-output-range}"},
+    {"colormatrix-primaries",
+     .msg = "Colorspace primaries:\n${colormatrix-primaries}"},
+    {"colormatrix-gamma",
+     .msg = "Colorspace gamma:\n${colormatrix-gamma}"},
+    {"gamma", "Gamma", .osd_progbar = OSD_BRIGHTNESS },
+    {"brightness", "Brightness", .osd_progbar = OSD_BRIGHTNESS},
+    {"contrast", "Contrast", .osd_progbar = OSD_CONTRAST},
+    {"saturation", "Saturation", .osd_progbar = OSD_SATURATION},
+    {"hue", "Hue", .osd_progbar = OSD_HUE},
+    {"angle", "Angle"},
     // subs
-    { "sub", "Subtitles" },
-    { "secondary-sid", "Secondary subtitles" },
-    { "sub-pos", "Sub position" },
-    { "sub-delay", "Sub delay" },
-    { "sub-speed", "Sub speed" },
-    { "sub-visibility", .msg = "Subtitles ${!sub-visibility==yes:hidden}"
-        "${?sub-visibility==yes:visible${?sub==no: (but no subtitles selected)}}" },
-    { "sub-forced-only", "Forced sub only" },
-    { "sub-scale", "Sub Scale"},
-    { "sub-ass-vsfilter-aspect-compat", "Subtitle VSFilter aspect compat"},
-    { "sub-ass-override", "ASS subtitle style override"},
-    { "vf", "Video filters", .msg = "Video filters:\n${vf}"},
-    { "af", "Audio filters", .msg = "Audio filters:\n${af}"},
-    { "tv-brightness", "Brightness", .osd_progbar = OSD_BRIGHTNESS },
-    { "tv-hue", "Hue", .osd_progbar = OSD_HUE},
-    { "tv-saturation", "Saturation", .osd_progbar = OSD_SATURATION },
-    { "tv-contrast", "Contrast", .osd_progbar = OSD_CONTRAST },
-    { "ab-loop-a", "A-B loop start"},
-    { "ab-loop-b", .msg = "A-B loop: ${ab-loop-a} - ${ab-loop-b}"},
-    { "audio-device", "Audio device"},
+    {"sub", "Subtitles"},
+    {"secondary-sid", "Secondary subtitles"},
+    {"sub-pos", "Sub position"},
+    {"sub-delay", "Sub delay"},
+    {"sub-speed", "Sub speed"},
+    {"sub-visibility",
+     .msg = "Subtitles ${!sub-visibility==yes:hidden}"
+      "${?sub-visibility==yes:visible${?sub==no: (but no subtitles selected)}}"},
+    {"sub-forced-only", "Forced sub only"},
+    {"sub-scale", "Sub Scale"},
+    {"sub-ass-vsfilter-aspect-compat", "Subtitle VSFilter aspect compat"},
+    {"sub-ass-override", "ASS subtitle style override"},
+    {"vf", "Video filters", .msg = "Video filters:\n${vf}"},
+    {"af", "Audio filters", .msg = "Audio filters:\n${af}"},
+    {"tv-brightness", "Brightness", .osd_progbar = OSD_BRIGHTNESS},
+    {"tv-hue", "Hue", .osd_progbar = OSD_HUE},
+    {"tv-saturation", "Saturation", .osd_progbar = OSD_SATURATION},
+    {"tv-contrast", "Contrast", .osd_progbar = OSD_CONTRAST},
+    {"ab-loop-a", "A-B loop start"},
+    {"ab-loop-b", .msg = "A-B loop: ${ab-loop-a} - ${ab-loop-b}"},
+    {"audio-device", "Audio device"},
     // By default, don't display the following properties on OSD
-    { "pause", NULL },
-    { "fullscreen", NULL },
+    {"pause", NULL},
+    {"fullscreen", NULL},
     {0}
 };
 
 static void show_property_osd(MPContext *mpctx, const char *name, int osd_mode)
 {
     struct MPOpts *opts = mpctx->opts;
-    struct property_osd_display disp = { .name = name, .osd_name = name };
+    struct property_osd_display disp = {.name = name, .osd_name = name};
 
     if (!osd_mode)
         return;
@@ -4805,10 +4807,10 @@ static struct mpv_node *add_map_entry(struct mpv_node *dst, const char *key)
 }
 
 #define ADD_MAP_INT(dst, name, i) (*add_map_entry(dst, name) = \
-    (struct mpv_node){ .format = MPV_FORMAT_INT64, .u.int64 = (i) });
+    (struct mpv_node){.format = MPV_FORMAT_INT64, .u.int64 = (i)});
 
 #define ADD_MAP_CSTR(dst, name, s) (*add_map_entry(dst, name) = \
-    (struct mpv_node){ .format = MPV_FORMAT_STRING, .u.string = (s) });
+    (struct mpv_node){.format = MPV_FORMAT_STRING, .u.string = (s)});
 
 int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *res)
 {
@@ -5371,7 +5373,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             return -1;
         struct mpv_node_list *info = talloc_zero(NULL, struct mpv_node_list);
         talloc_steal(info, img);
-        *res = (mpv_node){ .format = MPV_FORMAT_NODE_MAP, .u.list = info };
+        *res = (mpv_node){.format = MPV_FORMAT_NODE_MAP, .u.list = info};
         ADD_MAP_INT(res, "w", img->w);
         ADD_MAP_INT(res, "h", img->h);
         ADD_MAP_INT(res, "stride", img->stride[0]);


### PR DESCRIPTION
Fixes  #3028 (OSD not shown on user interaction). Some white-space cleanup to command.c as well.

I agree that my changes can be relicensed to LGPL 2.1 or later.
