### PR TITLE
Minor --external-files fixes

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -22,6 +22,8 @@ Interface changes
  --- mpv 0.29.0 ---
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,
       --ad-spdif-dtshd, --softvol options
+    - fix --external-files: strictly never select any tracks from them, unless
+      explicitly selected (this may or may not be expected)
  --- mpv 0.28.0 ---
     - rename --hwdec=mediacodec option to mediacodec-copy, to reflect
       conventions followed by other hardware video decoding APIs

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5376,7 +5376,8 @@ Miscellaneous
 
     Unlike ``--sub-files`` and ``--audio-files``, this includes all tracks, and
     does not cause default stream selection over the "proper" file. This makes
-    it slightly less intrusive.
+    it slightly less intrusive. (In mpv 0.28.0 and before, this was not quite
+    strictly enforced.)
 
     This is a list option. See `List Options`_ for details.
 

--- a/demux/demux_null.c
+++ b/demux/demux_null.c
@@ -24,6 +24,7 @@ static int try_open_file(struct demuxer *demux, enum demux_check check)
     if (!bstr_startswith0(bstr0(demux->filename), "null://") &&
         check != DEMUX_CHECK_REQUEST)
         return -1;
+    demux->seekable = true;
     return 0;
 }
 

--- a/player/core.h
+++ b/player/core.h
@@ -141,6 +141,7 @@ struct track {
     // If this track is from an external file (e.g. subtitle file).
     bool is_external;
     bool no_default;            // pretend it's not external for auto-selection
+    bool no_auto_select;
     char *external_filename;
     bool auto_loaded;
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -310,6 +310,7 @@ static int match_lang(char **langs, char *lang)
  * Sort tracks based on the following criteria, and pick the first:
  * 0a) track matches ff-index (always wins)
  * 0b) track matches tid (almost always wins)
+ * 0c) track is not from --external-file
  * 1) track is external (no_default cancels this)
  * 1b) track was passed explicitly (is not an auto-loaded subtitle)
  * 2) earlier match in lang list
@@ -371,6 +372,8 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
             continue;
         if (track->user_tid == tid)
             return track;
+        if (track->no_auto_select)
+            continue;
         if (!pick || compare_track(track, pick, langs, mpctx->opts))
             pick = track;
     }
@@ -624,6 +627,7 @@ struct track *mp_add_external_file(struct MPContext *mpctx, char *filename,
         t->title = talloc_strdup(t, mp_basename(disp_filename));
         t->external_filename = talloc_strdup(t, filename);
         t->no_default = sh->type != filter;
+        t->no_auto_select = filter == STREAM_TYPE_COUNT;
         if (!first && (filter == STREAM_TYPE_COUNT || sh->type == filter))
             first = t;
     }


### PR DESCRIPTION
Not sure about the first one, but I really don't appreciate it autoselecting any tracks with --external-files (not to do this was the reason why I added this in the first place). I think a recent commit for allowing subtitle tracks in --audio-files broke this.

Also, demux_null is sometimes used to get a "blank" state, and then adding files to it via --external-files. Allowing seeking seems to be fine in these cases. (Although the behavior is still not ideal.)