### PR TITLE
input: make command argument list a dynamic array

### DIFF
--- a/input/cmd_list.c
+++ b/input/cmd_list.c
@@ -39,7 +39,8 @@
  * (ARG_INT, ARG_FLOAT, ARG_STRING) if any, then optional arguments
  * (OARG_INT(default), etc) if any. The command will be given the default
  * argument value if the user didn't give enough arguments to specify it.
- * A command can take a maximum of MP_CMD_MAX_ARGS arguments.
+ * A command can take a maximum of MP_CMD_DEF_MAX_ARGS arguments, or more
+ * if the command uses varargs.
  */
 
 #define ARG_INT                 OPT_INT(ARG(i), 0)
@@ -363,7 +364,7 @@ void mp_print_cmd_list(struct mp_log *out)
     for (int i = 0; mp_cmds[i].name; i++) {
         const struct mp_cmd_def *def = &mp_cmds[i];
         mp_info(out, "%-20.20s", def->name);
-        for (int j = 0; j < MP_CMD_MAX_ARGS && def->args[j].type; j++) {
+        for (int j = 0; j < MP_CMD_DEF_MAX_ARGS && def->args[j].type; j++) {
             const char *type = def->args[j].type->name;
             if (def->args[j].defval)
                 mp_info(out, " [%s]", type);

--- a/input/cmd_list.h
+++ b/input/cmd_list.h
@@ -21,14 +21,14 @@
 #include <stdbool.h>
 #include "options/m_option.h"
 
-#define MP_CMD_MAX_ARGS 10
+#define MP_CMD_DEF_MAX_ARGS 9
 
 #define MP_CMD_OPT_ARG 0x1000
 
 struct mp_cmd_def {
     int id;             // one of MP_CMD_...
     const char *name;   // user-visible name (as used in input.conf)
-    const struct m_option args[MP_CMD_MAX_ARGS];
+    const struct m_option args[MP_CMD_DEF_MAX_ARGS];
     bool allow_auto_repeat; // react to repeated key events
     bool on_updown;     // always emit it on both up and down key events
     bool vararg;        // last argument can be given 0 to multiple times

--- a/input/input.h
+++ b/input/input.h
@@ -56,6 +56,9 @@ enum mp_input_section_flags {
 struct input_ctx;
 struct mp_log;
 
+// Arbitrary upper bound for sanity.
+#define MP_CMD_MAX_ARGS 100
+
 struct mp_cmd_arg {
     const struct m_option *type;
     union {
@@ -71,7 +74,7 @@ struct mp_cmd_arg {
 typedef struct mp_cmd {
     int id;
     char *name;
-    struct mp_cmd_arg args[MP_CMD_MAX_ARGS];
+    struct mp_cmd_arg *args;
     int nargs;
     int flags; // mp_cmd_flags bitfield
     bstr original;

--- a/player/command.c
+++ b/player/command.c
@@ -4991,7 +4991,7 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     }
 
     case MP_CMD_CYCLE_VALUES: {
-        char *args[MP_CMD_MAX_ARGS + 1] = {0};
+        char **args = talloc_zero_array(NULL, char *, cmd->nargs + 1);
         for (int n = 0; n < cmd->nargs; n++)
             args[n] = cmd->args[n].v.s;
         int first = 1, dir = 1;
@@ -5015,14 +5015,17 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             } else if (r == M_PROPERTY_UNKNOWN) {
                 set_osd_msg(mpctx, osdl, osd_duration,
                             "Unknown property: '%s'", property);
+                talloc_free(args);
                 return -1;
             } else if (r <= 0) {
                 set_osd_msg(mpctx, osdl, osd_duration,
                             "Failed to set property '%s' to '%s'",
                             property, value);
+                talloc_free(args);
                 return -1;
             }
         }
+        talloc_free(args);
         break;
     }
 
@@ -5390,10 +5393,11 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     }
 
     case MP_CMD_RUN: {
-        char *args[MP_CMD_MAX_ARGS + 1] = {0};
+        char **args = talloc_zero_array(NULL, char *, cmd->nargs + 1);
         for (int n = 0; n < cmd->nargs; n++)
             args[n] = cmd->args[n].v.s;
         mp_subprocess_detached(mpctx->log, args);
+        talloc_free(args);
         break;
     }
 
@@ -5510,11 +5514,12 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
         break;
     }
     case MP_CMD_SCRIPT_MESSAGE: {
-        const char *args[MP_CMD_MAX_ARGS];
+        const char **args = talloc_array(NULL, const char *, cmd->nargs);
         mpv_event_client_message event = {.args = args};
         for (int n = 0; n < cmd->nargs; n++)
             event.args[event.num_args++] = cmd->args[n].v.s;
         mp_client_broadcast_event(mpctx, MPV_EVENT_CLIENT_MESSAGE, &event);
+        talloc_free(args);
         break;
     }
 


### PR DESCRIPTION
Replace the static array with dynamic memory allocation. This also
requires some code to honor mp_cmd.nargs more strictly. Generally
allocates more stuff.

Fixes #5375 (although we could also just raise the static limit).

---

Well, not sure if this is better, or if the static limit should simply be raised.