### PR TITLE
af_rubberband: add af-command to multiply current pitch

### DIFF
--- a/DOCS/man/af.rst
+++ b/DOCS/man/af.rst
@@ -219,6 +219,12 @@ Available filters are:
         change the playback pitch at runtime. Note that speed is controlled
         using the standard ``speed`` property, not ``af-command``.
 
+    ``multiply-pitch <factor>``
+        Multiply the current value of ``<pitch-scale>`` dynamically.  For
+        example: 0.5 to go down by an octave, 1.5 to go up by a perfect fifth.
+        If you want to go up or down by semi-tones, use 1.059463094352953 and
+        0.9438743126816935
+
 ``lavfi=graph``
     Filter audio using FFmpeg's libavfilter.
 


### PR DESCRIPTION
This commit introduces the multiply-pitch af-command. Users may bind
keys to this command in order to incrementally adjust the pitch of a
track. This will probably mostly be useful for musicians trying to
transpose up and down by semi tones without having to calculate
the correct ratio beforehand.

As an example, here is an input.conf to test this feature:

    # Lower pitch by one semi-tone
    { af-command all multiply-pitch 0.9438743126816935
    # Raise pitch by one semi-tone
    } af-command all multiply-pitch 1.059463094352953

I agree that my changes can be relicensed to LGPL 2.1 or later.