### PR TITLE
 osd: treat user provided term-status-msg the same as the default

### DIFF
--- a/player/osd.c
+++ b/player/osd.c
@@ -197,9 +197,9 @@ static void term_osd_print_status_lazy(struct MPContext *mpctx)
     saddf(&line, ": ");
 
     // Playback position
-    sadd_hhmmssff(&line, get_playback_time(mpctx), mpctx->opts->osd_fractions);
+    sadd_hhmmssff(&line, get_playback_time(mpctx), opts->osd_fractions);
     saddf(&line, " / ");
-    sadd_hhmmssff(&line, get_time_length(mpctx), mpctx->opts->osd_fractions);
+    sadd_hhmmssff(&line, get_time_length(mpctx), opts->osd_fractions);
 
     sadd_percentage(&line, get_percent_pos(mpctx));
 

--- a/player/osd.c
+++ b/player/osd.c
@@ -156,28 +156,12 @@ static bool is_busy(struct MPContext *mpctx)
     return !mpctx->restart_complete && mp_time_sec() - mpctx->start_timestamp > 0.3;
 }
 
-static void term_osd_print_status_lazy(struct MPContext *mpctx)
+static char *get_term_status_msg(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
 
-    update_window_title(mpctx, false);
-    update_vo_playback_state(mpctx);
-
-    if (!opts->use_terminal)
-        return;
-
-    if (opts->quiet || !mpctx->playback_initialized || !mpctx->playing_msg_shown)
-    {
-        term_osd_set_status_lazy(mpctx, "");
-        return;
-    }
-
-    if (opts->status_msg) {
-        char *r = mp_property_expand_escaped_string(mpctx, opts->status_msg);
-        term_osd_set_status_lazy(mpctx, r);
-        talloc_free(r);
-        return;
-    }
+    if (opts->status_msg)
+        return mp_property_expand_escaped_string(mpctx, opts->status_msg);
 
     char *line = NULL;
 
@@ -271,6 +255,27 @@ static void term_osd_print_status_lazy(struct MPContext *mpctx)
             }
         }
     }
+
+    return line;
+}
+
+static void term_osd_print_status_lazy(struct MPContext *mpctx)
+{
+    struct MPOpts *opts = mpctx->opts;
+
+    update_window_title(mpctx, false);
+    update_vo_playback_state(mpctx);
+
+    if (!opts->use_terminal)
+        return;
+
+    if (opts->quiet || !mpctx->playback_initialized || !mpctx->playing_msg_shown)
+    {
+        term_osd_set_status_lazy(mpctx, "");
+        return;
+    }
+
+    char *line = get_term_status_msg(mpctx);
 
     if (opts->term_osd_bar) {
         saddf(&line, "\n");


### PR DESCRIPTION
This is achieved by adding the new function get_term_status_msg that
returns the status message specified by the user, or the mpv default.

Previously, term_osd_print_status_lazy would exit early as soon as a
user status message had been set, which potentially skipped adding the
term_osd_bar if the user also requested that.

fixes #3280
