### PR TITLE
vo_gpu: rpi: defer gl_ctx_resize until after gl_ctx_init

### DIFF
--- a/video/out/opengl/context_rpi.c
+++ b/video/out/opengl/context_rpi.c
@@ -198,7 +198,8 @@ static bool recreate_dispmanx(struct ra_ctx *ctx)
 
     ctx->vo->dwidth = p->w;
     ctx->vo->dheight = p->h;
-    ra_gl_ctx_resize(ctx->swapchain, p->w, p->h, 0);
+    if (ctx->swapchain)
+        ra_gl_ctx_resize(ctx->swapchain, p->w, p->h, 0);
 
     ctx->vo->want_redraw = true;
 
@@ -247,6 +248,7 @@ static bool rpi_init(struct ra_ctx *ctx)
     if (!ra_gl_ctx_init(ctx, &p->gl, params))
         goto fail;
 
+    ra_gl_ctx_resize(ctx->swapchain, ctx->vo->dwidth, ctx->vo->dheight, 0);
     return true;
 
 fail:


### PR DESCRIPTION
This segfaults otherwise. The conditional is needed to break a circular
dependency (gl_init depends on mpgl_load_functions which depends on
recreate_dispmanx which calls gl_ctx_resize).

Fixes #5398

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
