### PR TITLE
vo_gpu: fix broken 10 bit via integer textures playback

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -862,9 +862,6 @@ static void init_video(struct gl_video *p)
     }
     p->color_swizzle[4] = '\0';
 
-    // Format-dependent checks.
-    check_gl_features(p);
-
     mp_image_params_guess_csp(&p->image_params);
 
     av_lfg_init(&p->lfg, 1);
@@ -908,6 +905,9 @@ static void init_video(struct gl_video *p)
     }
 
     debug_check_gl(p, "after video texture creation");
+
+    // Format-dependent checks.
+    check_gl_features(p);
 
     gl_video_setup_hooks(p);
 }


### PR DESCRIPTION
The check_gl_features(p) call here checks whether dumb mode can be used.
It uses the field use_integer_conversion, which is set _after_ the call
in the same function. Move check_gl_features() to the end of the
function, when use_integer_conversion is finally set.

Fixes that it tried to use bilinear filtering with integer textures. The
bug disabled the code that is supposed to convert it to non-integer
textures.
