### PR TITLE
osc: improve look of seekranges

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -167,9 +167,14 @@ Configurable Options
 ``seekbarstyle``
     Default: bar
 
-    Sets the style of the seekbar, slider (diamond marker), knob (circle
-    marker with guide), or bar (fill).
-    Default pre-0.21.0 was 'slider'.
+    Sets the style of the playback position marker and overall shape
+    of the seekbar: ``bar``, ``diamond`` or ``knob``.
+
+``seekbarhandlesize``
+    Default: 0.6
+
+    Size ratio of the seek handle if ``seekbarstyle`` is set to ``dimaond``
+    or ``knob``. This is relative to the full height of the seekbar.
 
 ``seekbarkeyframes``
     Default: yes
@@ -179,6 +184,28 @@ Configurable Options
     will be used instead. Keyframes are preferred, but exact seeks may be
     useful in cases where keyframes cannot be found. Note that using exact
     seeks can potentially make mouse dragging much slower.
+
+``seekrangestyle``
+    Default: inverted
+
+    Display seekable ranges on the seekbar. ``bar`` shows them on the full
+    height of the bar, ``line`` as a thick line and ``inverted`` as a thin
+    line that is inverted over playback position markers. ``none`` will hide
+    them. Additionally, ``slider`` will show a permanent handle inside the seekbar
+    with cached ranges marked inside. Note that these will look differently
+    based on the seekbarstyle option. Also, ``slider`` does not work with
+    ``seekbarstyle`` set to ``bar``.
+
+``seekrangeseparate``
+    Default: yes
+
+    Controls whether to show line-style seekable ranges on top of the
+    seekbar or separately if ``seekbarstyle`` is set to ``bar``.
+
+``seekrangealpha``
+    Default: 200
+
+    Alpha of the seekable ranges, 0 (opaque) to 255 (fully transparent).
 
 ``deadzonesize``
     Default: 0.5
@@ -280,11 +307,6 @@ Configurable Options
     Default: no
 
     Display timecodes with milliseconds
-
-``seekranges``
-    Default: yes
-
-    Display seekable ranges on the seekbar
 
 ``visibility``
     Default: auto (auto hide/show on mouse move)

--- a/player/lua/assdraw.lua
+++ b/player/lua/assdraw.lua
@@ -1,5 +1,6 @@
 local ass_mt = {}
 ass_mt.__index = ass_mt
+local c = 0.551915024494 -- circle approximation
 
 local function ass_new()
     return setmetatable({ scale = 4, text = "" }, ass_mt)
@@ -75,24 +76,84 @@ function ass_mt.rect_cw(ass, x0, y0, x1, y1)
     ass:line_to(x0, y1)
 end
 
-function ass_mt.round_rect_cw(ass, x0, y0, x1, y1, r)
-    local c = 0.551915024494 * r -- circle approximation
-    ass:move_to(x0 + r, y0)
-    ass:line_to(x1 - r, y0) -- top line
-    if r > 0 then
-        ass:bezier_curve(x1 - r + c, y0, x1, y0 + r - c, x1, y0 + r) -- top right corner
+function ass_mt.hexagon_cw(ass, x0, y0, x1, y1, r1, r2)
+    if r2 == nil then
+        r2 = r1
     end
-    ass:line_to(x1, y1 - r) -- right line
-    if r > 0 then
-        ass:bezier_curve(x1, y1 - r + c, x1 - r + c, y1, x1 - r, y1) -- bottom right corner
+    ass:move_to(x0 + r1, y0)
+    if x0 ~= x1 then
+        ass:line_to(x1 - r2, y0)
     end
-    ass:line_to(x0 + r, y1) -- bottom line
-    if r > 0 then
-        ass:bezier_curve(x0 + r - c, y1, x0, y1 - r + c, x0, y1 - r) -- bottom left corner
+    ass:line_to(x1, y0 + r2)
+    if x0 ~= x1 then
+        ass:line_to(x1 - r2, y1)
     end
-    ass:line_to(x0, y0 + r) -- left line
-    if r > 0 then
-        ass:bezier_curve(x0, y0 + r - c, x0 + r - c, y0, x0 + r, y0) -- top left corner
+    ass:line_to(x0 + r1, y1)
+    ass:line_to(x0, y0 + r1)
+end
+
+function ass_mt.hexagon_ccw(ass, x0, y0, x1, y1, r1, r2)
+    if r2 == nil then
+        r2 = r1
+    end
+    ass:move_to(x0 + r1, y0)
+    ass:line_to(x0, y0 + r1)
+    ass:line_to(x0 + r1, y1)
+    if x0 ~= x1 then
+        ass:line_to(x1 - r2, y1)
+    end
+    ass:line_to(x1, y0 + r2)
+    if x0 ~= x1 then
+        ass:line_to(x1 - r2, y0)
+    end
+end
+
+function ass_mt.round_rect_cw(ass, x0, y0, x1, y1, r1, r2)
+    if r2 == nil then
+        r2 = r1
+    end
+    local c1 = c * r1 -- circle approximation
+    local c2 = c * r2 -- circle approximation
+    ass:move_to(x0 + r1, y0)
+    ass:line_to(x1 - r2, y0) -- top line
+    if r2 > 0 then
+        ass:bezier_curve(x1 - r2 + c2, y0, x1, y0 + r2 - c2, x1, y0 + r2) -- top right corner
+    end
+    ass:line_to(x1, y1 - r2) -- right line
+    if r2 > 0 then
+        ass:bezier_curve(x1, y1 - r2 + c2, x1 - r2 + c2, y1, x1 - r2, y1) -- bottom right corner
+    end
+    ass:line_to(x0 + r1, y1) -- bottom line
+    if r1 > 0 then
+        ass:bezier_curve(x0 + r1 - c1, y1, x0, y1 - r1 + c1, x0, y1 - r1) -- bottom left corner
+    end
+    ass:line_to(x0, y0 + r1) -- left line
+    if r1 > 0 then
+        ass:bezier_curve(x0, y0 + r1 - c1, x0 + r1 - c1, y0, x0 + r1, y0) -- top left corner
+    end
+end
+
+function ass_mt.round_rect_ccw(ass, x0, y0, x1, y1, r1, r2)
+    if r2 == nil then
+        r2 = r1
+    end
+    local c1 = c * r1 -- circle approximation
+    local c2 = c * r2 -- circle approximation
+    ass:move_to(x0 + r1, y0)
+    if r1 > 0 then
+        ass:bezier_curve(x0 + r1 - c1, y0, x0, y0 + r1 - c1, x0, y0 + r1) -- top left corner
+    end
+    ass:line_to(x0, y1 - r1) -- left line
+    if r1 > 0 then
+        ass:bezier_curve(x0, y1 - r1 + c1, x0 + r1 - c1, y1, x0 + r1, y1) -- bottom left corner
+    end
+    ass:line_to(x1 - r2, y1) -- bottom line
+    if r2 > 0 then
+        ass:bezier_curve(x1 - r2 + c2, y1, x1, y1 - r2 + c2, x1, y1 - r2) -- bottom right corner
+    end
+    ass:line_to(x1, y0 + r2) -- right line
+    if r2 > 0 then
+        ass:bezier_curve(x1, y0 + r2 - c2, x1 - r2 + c2, y0, x1 - r2, y0) -- top right corner
     end
 end
 


### PR DESCRIPTION
This looks much better imho. In case of the bar style we won't see seek ranges in the past, but that is of little use. If desired I can also make this change into a seekbarstyle option for users to chose from.

See the screenshot for comparison. Top 3 is before and bottom 3 are after. Note that slider style wasn't changed at all since that looks fine (and doesn't really work with the way the seek ranges are rendered now).
![seekranges](https://user-images.githubusercontent.com/7892635/35038395-ffe25a18-fb7a-11e7-914d-f332a679c46b.jpeg)