### PR TITLE
 ta: introduce talloc_dup() and use it in some places 

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -1802,7 +1802,7 @@ static struct replaygain_data *decode_rgain(struct mp_log *log,
             rg.album_gain = rg.track_gain;
             rg.album_peak = rg.track_peak;
         }
-        return talloc_memdup(NULL, &rg, sizeof(rg));
+        return talloc_dup(NULL, &rg);
     }
 
     if (decode_gain(log, tags, "REPLAYGAIN_GAIN", &rg.track_gain) >= 0 &&
@@ -1810,7 +1810,7 @@ static struct replaygain_data *decode_rgain(struct mp_log *log,
     {
         rg.album_gain = rg.track_gain;
         rg.album_peak = rg.track_peak;
-        return talloc_memdup(NULL, &rg, sizeof(rg));
+        return talloc_dup(NULL, &rg);
     }
 
     return NULL;

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1076,7 +1076,7 @@ static int demux_mkv_read_tags(demuxer_t *demuxer)
     if (ebml_read_element(s, &parse_ctx, &tags, &ebml_tags_desc) < 0)
         return -1;
 
-    mkv_d->tags = talloc_memdup(mkv_d, &tags, sizeof(tags));
+    mkv_d->tags = talloc_dup(mkv_d, &tags);
     talloc_steal(mkv_d->tags, parse_ctx.talloc_ctx);
     return 0;
 }
@@ -2758,8 +2758,7 @@ static int read_block_group(demuxer_t *demuxer, int64_t end,
                                   &ebml_block_additions_desc) < 0)
                 return -1;
             if (additions.n_block_more > 0) {
-                block->additions =
-                    talloc_memdup(NULL, &additions, sizeof(additions));
+                block->additions = talloc_dup(NULL, &additions);
                 talloc_steal(block->additions, parse_ctx.talloc_ctx);
                 parse_ctx.talloc_ctx = NULL;
             }

--- a/input/cmd_parse.c
+++ b/input/cmd_parse.c
@@ -400,17 +400,14 @@ void mp_cmd_free(mp_cmd_t *cmd)
 
 mp_cmd_t *mp_cmd_clone(mp_cmd_t *cmd)
 {
-    mp_cmd_t *ret;
-    int i;
-
     if (!cmd)
         return NULL;
 
-    ret = talloc_dup(NULL, cmd);
+    mp_cmd_t *ret = talloc_dup(NULL, cmd);
     talloc_set_destructor(ret, destroy_cmd);
     ret->name = talloc_strdup(ret, cmd->name);
     ret->args = talloc_zero_array(ret, struct mp_cmd_arg, ret->nargs);
-    for (i = 0; i < ret->nargs; i++) {
+    for (int i = 0; i < ret->nargs; i++) {
         ret->args[i].type = cmd->args[i].type;
         m_option_copy(ret->args[i].type, &ret->args[i].v, &cmd->args[i].v);
     }

--- a/input/cmd_parse.c
+++ b/input/cmd_parse.c
@@ -356,7 +356,7 @@ mp_cmd_t *mp_input_parse_cmd_(struct mp_log *log, bstr str, const char *loc)
             talloc_steal(list, cmd);
             struct mp_cmd_arg arg = {0};
             arg.v.p = cmd;
-            list->args = talloc_memdup(list, &arg, sizeof(arg));
+            list->args = talloc_dup(list, &arg);
             p_prev = &cmd->queue_next;
             cmd = list;
         }
@@ -406,7 +406,7 @@ mp_cmd_t *mp_cmd_clone(mp_cmd_t *cmd)
     if (!cmd)
         return NULL;
 
-    ret = talloc_memdup(NULL, cmd, sizeof(mp_cmd_t));
+    ret = talloc_dup(NULL, cmd);
     talloc_set_destructor(ret, destroy_cmd);
     ret->name = talloc_strdup(ret, cmd->name);
     ret->args = talloc_zero_array(ret, struct mp_cmd_arg, ret->nargs);
@@ -427,7 +427,7 @@ mp_cmd_t *mp_cmd_clone(mp_cmd_t *cmd)
             } else {
                 struct mp_cmd_arg arg = {0};
                 arg.v.p = sub;
-                ret->args = talloc_memdup(ret, &arg, sizeof(arg));
+                ret->args = talloc_dup(ret, &arg);
             }
             prev = sub;
         }

--- a/ta/ta.h
+++ b/ta/ta.h
@@ -96,7 +96,7 @@ bool ta_vasprintf_append_buffer(char **str, const char *fmt, va_list ap) TA_PRF(
 
 #define ta_steal(ta_parent, ptr) (TA_TYPEOF(ptr))ta_steal_(ta_parent, ptr)
 
-#define ta_dup_ptrtype(ta_parent, ptr) \
+#define ta_dup(ta_parent, ptr) \
     (TA_TYPEOF(ptr))ta_memdup(ta_parent, ptr, sizeof(*(ptr)))
 
 // Ugly macros that crash on OOM.
@@ -126,7 +126,7 @@ bool ta_vasprintf_append_buffer(char **str, const char *fmt, va_list ap) TA_PRF(
 #define ta_xnew_array_size(...)         ta_oom_p(ta_new_array_size(__VA_ARGS__))
 #define ta_xnew_ptrtype(...)            ta_oom_g(ta_new_ptrtype(__VA_ARGS__))
 #define ta_xnew_array_ptrtype(...)      ta_oom_g(ta_new_array_ptrtype(__VA_ARGS__))
-#define ta_xdup_ptrtype(...)            ta_oom_g(ta_dup_ptrtype(__VA_ARGS__))
+#define ta_xdup(...)                    ta_oom_g(ta_dup(__VA_ARGS__))
 
 #define ta_xsteal(ta_parent, ptr) (TA_TYPEOF(ptr))ta_xsteal_(ta_parent, ptr)
 #define ta_xrealloc(ta_parent, ptr, type, count) \

--- a/ta/ta_talloc.h
+++ b/ta/ta_talloc.h
@@ -45,6 +45,7 @@
 #define talloc_get_size                 ta_get_size
 #define talloc_free_children            ta_free_children
 #define talloc_free                     ta_free
+#define talloc_dup                      ta_xdup
 #define talloc_memdup                   ta_xmemdup
 #define talloc_strdup                   ta_xstrdup
 #define talloc_strndup                  ta_xstrndup

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -574,7 +574,7 @@ static void run_reconfig(void *p)
     mp_image_params_get_dsize(params, &vo->dwidth, &vo->dheight);
 
     talloc_free(vo->params);
-    vo->params = talloc_memdup(vo, params, sizeof(*params));
+    vo->params = talloc_dup(vo, params);
 
     *ret = vo->driver->reconfig(vo, vo->params);
     vo->config_ok = *ret >= 0;
@@ -632,7 +632,7 @@ void vo_control_async(struct vo *vo, int request, void *data)
 
     switch (request) {
     case VOCTRL_UPDATE_PLAYBACK_STATE:
-        d[2] = ta_xdup_ptrtype(d, (struct voctrl_playback_state *)data);
+        d[2] = talloc_dup(d, (struct voctrl_playback_state *)data);
         break;
     case VOCTRL_KILL_SCREENSAVER:
     case VOCTRL_RESTORE_SCREENSAVER:


### PR DESCRIPTION
It was actually already implemented as ta_dup_ptrtype(), but that seems
like a clunky name. Also we still use the talloc_ names throughout the
source, and I'd rather use an old name instead of a mixing inconsistent
naming conventions.

---

The second commit is strictly speaking unrelated, but just a tiny change.