### PR TITLE
video: warn user against FFmpeg's lies

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -940,6 +940,19 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
             demuxer->duration = duration;
     }
 
+    // In some cases, libavformat will export bogus bullshit timestamps anyway,
+    // such as with mjpeg.
+    if (priv->avif_flags & AVFMT_NOTIMESTAMPS) {
+        MP_WARN(demuxer,
+                "This format is marked by FFmpeg as having no timestamps!\n"
+                "FFmpeg will likely make up its own broken timestamps. For\n"
+                "video streams you can correct this with:\n"
+                "    --no-correct-pts --fps=VALUE\n"
+                "with VALUE being the real framerate of the stream. You can\n"
+                "expect seeking and buffering estimation to be generally\n"
+                "broken as well.\n");
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
I found that at least for mjpeg streams, FFmpeg will set packet pts/dts
anyway. The mjpeg raw video demuxer (along with some other raw formats)
has a "framerate" demuxer option which defaults to 25, so all mjpeg
streams will be played at 25 FPS by default.

mpv doesn't like this much. If AVFMT_NOTIMESTAMPS is set, it prints a
warning, that might print a bogus FPS value for the assumed framerate.
The code was originally written with the assumption in mind FFmpeg would
not set pts/dts for such formats - but since it does, the printed
estimated framerate will never be used. --fps will also not be used by
default in this situation.

To make this hopefully less confusing, explicitly state the situation
when the AVFMT_NOTIMESTAMPS flag is set, and give instructions how to
work it around.

Also, remove the warning in dec_video.c. We don't know what FPS it's
going to assume anyway. If there are really no timestamps in the stream,
it will trigger our normal missing pts workaround. Add the assumed FPS
there.

In theory, we could just clear packet timestamps if AVFMT_NOTIMESTAMPS
is set, and make up our own timestamps. That is non-trivial for advanced
video codecs like h264, so I'm not going there. For seeking and
buffering estimation the situation thus remains half-broken.

This is a mitigation for #5419.

---

The possibly alternative described at the end (just clearing ffmpeg's timestamps and doing our own stuff) is well possible, but more work (to get buffering estimation and packet cache seeking back we have to make up our own dts values), and more risky (could possibly clear good timestamps). Maybe later.