### PR TITLE
Cosmetic changes for macOS and vo_opengl

### DIFF
--- a/DOCS/tech-overview.txt
+++ b/DOCS/tech-overview.txt
@@ -177,13 +177,13 @@ video/out/:
     Video output. They also create GUI windows and handle user input. In most
     cases, the windowing code is shared among VOs, like x11_common.c for X11 and
     w32_common.c for Windows. The VOs stand between frontend and windowing code.
-    vo_opengl can pick a windowing system at runtime, e.g. the same binary can
+    vo_gpu can pick a windowing system at runtime, e.g. the same binary can
     provide both X11 and Cocoa support on OSX.
 
     VOs can be reconfigured at runtime. A vo_reconfig() call can change the video
     resolution and format, without destroying the window.
 
-    vo_opengl should be taken as reference.
+    vo_gpu should be taken as reference.
 
 audio/:
     format.h/format.c define the uncompressed audio formats. (As well as some

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -61,7 +61,7 @@ static void terminate_cocoa_application(void)
 }
 
 @implementation Application
-@synthesize menuBar = _menu_Bar;
+@synthesize menuBar = _menu_bar;
 @synthesize openCount = _open_count;
 
 - (void)sendEvent:(NSEvent *)event

--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -29,6 +29,5 @@ struct mpv_event;
 - (void)openFiles:(NSArray *)filenames;
 
 @property(nonatomic, retain) MenuBar *menuBar;
-@property(nonatomic, retain) NSArray *files;
 @property(nonatomic, assign) size_t openCount;
 @end

--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -52,6 +52,12 @@ static const NSEventModifierFlags NSEventModifierFlagShift = NSShiftKeyMask;
 static const NSEventModifierFlags NSEventModifierFlagControl = NSControlKeyMask;
 static const NSEventModifierFlags NSEventModifierFlagCommand = NSCommandKeyMask;
 static const NSEventModifierFlags NSEventModifierFlagOption = NSAlternateKeyMask;
+
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9)
+typedef NSUInteger NSModalResponse;
+static const NSModalResponse NSModalResponseOK = NSFileHandlingPanelOKButton
+#endif
+
 #endif
 
 #endif /* MPV_MACOSX_COMPAT */

--- a/osdep/macosx_events.h
+++ b/osdep/macosx_events.h
@@ -26,7 +26,6 @@ struct mpv_handle;
 
 void cocoa_put_key(int keycode);
 void cocoa_put_key_with_modifiers(int keycode, int modifiers);
-void cocoa_put_key_event(void *event);
 
 void cocoa_init_apple_remote(void);
 void cocoa_uninit_apple_remote(void);

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -194,11 +194,6 @@ void cocoa_put_key(int keycode)
     [[EventsResponder sharedInstance] putKey:keycode];
 }
 
-void cocoa_put_key_event(void *event)
-{
-    [[EventsResponder sharedInstance] handleKey:event];
-}
-
 void cocoa_put_key_with_modifiers(int keycode, int modifiers)
 {
     keycode |= [[EventsResponder sharedInstance] mapKeyModifiers:modifiers];

--- a/osdep/macosx_events_objc.h
+++ b/osdep/macosx_events_objc.h
@@ -26,24 +26,17 @@ struct input_ctx;
 @interface EventsResponder : NSObject <HIDRemoteDelegate>
 
 + (EventsResponder *)sharedInstance;
-
 - (void)setInputContext:(struct input_ctx *)ctx;
-
 - (void)setIsApplication:(BOOL)isApplication;
 
 /// Blocks until inputContext is present.
 - (void)waitForInputContext;
-
 - (void)wakeup;
-
-- (bool)queueCommand:(char *)cmd;
-
 - (void)putKey:(int)keycode;
-
 - (void)setHighestPriotityMediaKeysTap;
-
 - (void)handleFilesArray:(NSArray *)files;
 
+- (bool)queueCommand:(char *)cmd;
 - (bool)processKeyEvent:(NSEvent *)event;
 
 @end

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -660,7 +660,7 @@
     [panel setCanChooseDirectories:YES];
     [panel setAllowsMultipleSelection:YES];
 
-    if ([panel runModal] == NSFileHandlingPanelOKButton){
+    if ([panel runModal] == NSModalResponseOK){
         NSMutableArray *fileArray = [[NSMutableArray alloc] init];
         for (id url in [panel URLs])
             [fileArray addObject:[url path]];

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -64,7 +64,7 @@ static enum AVPixelFormat get_format_hwdec(struct AVCodecContext *avctx,
 
 // Maximum number of surfaces the player wants to buffer.
 // This number might require adjustment depending on whatever the player does;
-// for example, if vo_opengl increases the number of reference surfaces for
+// for example, if vo_gpu increases the number of reference surfaces for
 // interpolation, this value has to be increased too.
 #define HWDEC_EXTRA_SURFACES 6
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -65,7 +65,7 @@ static int mp_image_layout(int imgfmt, int w, int h, int stride_align,
 
     // Note: for non-mod-2 4:2:0 YUV frames, we have to allocate an additional
     //       top/right border. This is needed for correct handling of such
-    //       images in filter and VO code (e.g. vo_vdpau or vo_opengl).
+    //       images in filter and VO code (e.g. vo_vdpau or vo_gpu).
 
     for (int n = 0; n < MP_MAX_PLANES; n++) {
         int alloc_w = mp_chroma_div_up(w, desc.xs[n]);

--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -45,7 +45,8 @@
 @synthesize targetScreen = _target_screen;
 @synthesize previousScreen = _previous_screen;
 @synthesize currentScreen = _current_screen;
-@synthesize unfScreen = _unf_Screen;
+@synthesize unfScreen = _unf_screen;
+
 - (id)initWithContentRect:(NSRect)content_rect
                 styleMask:(NSWindowStyleMask)style_mask
                   backing:(NSBackingStoreType)buffering_type

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3344,7 +3344,7 @@ static bool test_fbo(struct gl_video *p, const struct ra_format *fmt)
 }
 
 // Return whether dumb-mode can be used without disabling any features.
-// Essentially, vo_opengl with mostly default settings will return true.
+// Essentially, vo_gpu with mostly default settings will return true.
 static bool check_dumb_mode(struct gl_video *p)
 {
     struct gl_video_opts *o = &p->opts;

--- a/video/out/opengl/context_cocoa.c
+++ b/video/out/opengl/context_cocoa.c
@@ -19,7 +19,6 @@
 #include <dlfcn.h>
 #include "options/m_config.h"
 #include "video/out/cocoa_common.h"
-#include "osdep/macosx_versions.h"
 #include "context.h"
 
 struct cocoa_opts {

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1190,7 +1190,7 @@ void vo_get_src_dst_rects(struct vo *vo, struct mp_rect *out_src,
 // flip_page[_timed] will be called offset_us microseconds too early.
 // (For vo_vdpau, which does its own timing.)
 // num_req_frames set the requested number of requested vo_frame.frames.
-// (For vo_opengl interpolation.)
+// (For vo_gpu interpolation.)
 void vo_set_queue_params(struct vo *vo, int64_t offset_us, int num_req_frames)
 {
     struct vo_internal *in = vo->in;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -65,7 +65,7 @@ enum mp_voctrl {
     VOCTRL_SET_EQUALIZER,               // struct voctrl_set_equalizer_args*
     VOCTRL_GET_EQUALIZER,               // struct voctrl_get_equalizer_args*
 
-    /* private to vo_opengl */
+    /* private to vo_gpu */
     VOCTRL_LOAD_HWDEC_API,
 
     // Redraw the image previously passed to draw_image() (basically, repeat

--- a/video/out/vo_vdpau.c
+++ b/video/out/vo_vdpau.c
@@ -1027,7 +1027,7 @@ static int preinit(struct vo *vo)
 
     if (mp_vdpau_guess_if_emulated(vc->mpvdp)) {
         MP_WARN(vo, "VDPAU is most likely emulated via VA-API.\n"
-                    "This is inefficient. Use --vo=opengl instead.\n");
+                    "This is inefficient. Use --vo=gpu instead.\n");
     }
 
     // Mark everything as invalid first so uninit() can tell what has been

--- a/video/out/win_state.c
+++ b/video/out/win_state.c
@@ -84,8 +84,8 @@ void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
     *out_geo = (struct vo_win_geometry){0};
 
     // The case of calling this function even though no video was configured
-    // yet (i.e. vo->params==NULL) happens when vo_opengl creates a hidden
-    // window in order to create an OpenGL context.
+    // yet (i.e. vo->params==NULL) happens when vo_gpu creates a hidden window
+    // in order to create a rendering context.
     struct mp_image_params params = { .w = 320, .h = 200 };
     if (vo->params)
         params = *vo->params;

--- a/wscript
+++ b/wscript
@@ -770,7 +770,7 @@ video_output_features = [
                      linkflags="-L/opt/vc/lib",
                      header_name="bcm_host.h",
                      lib=['mmal_core', 'mmal_util', 'mmal_vc_client', 'bcm_host']),
-            # We still need all OpenGL symbols, because the vo_opengl code is
+            # We still need all OpenGL symbols, because the vo_gpu code is
             # generic and supports anything from GLES2/OpenGL 2.1 to OpenGL 4 core.
             check_cc(lib="EGL", linkflags="-lGLESv2"),
             check_cc(lib="GLESv2"),


### PR DESCRIPTION
if wanted i can remove the last commit that changes some remaining vo_opengl mentions. i didn't find any more, but there still might be more. wasn't too sure how to prefix that commit message.

the macOS changes are just some cosmetics and a fix for a deprecation warning on macOS 10.13.