### PR TITLE
Restore previous osd seek / pause behaviour and make it more configurable

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -35,6 +35,7 @@ Interface changes
       vf toggle commands and the filter enable/disable flag to customize it.
     - deprecate --af=lavrresample. Use the ``--audio-resample-...`` options to
       customize resampling, or the libavfilter ``--af=aresample`` filter.
+    - add --osd-on-seek
  --- mpv 0.28.0 ---
     - rename --hwdec=mediacodec option to mediacodec-copy, to reflect
       conventions followed by other hardware video decoding APIs

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3129,15 +3129,15 @@ OSD
     shown.
 
     This is also used for the ``show-progress`` command (by default mapped to
-    ``P``), when toggling pause, and when seeking.
+    ``P``), and when seeking.
 
     ``--osd-status-msg`` is a legacy equivalent (but with a minor difference).
 
 ``--osd-status-msg=<string>``
     Show a custom string during playback instead of the standard status text.
     This overrides the status text used for ``--osd-level=3``, when using the
-    ``show-progress`` command (by default mapped to ``P``), when toggling pause,
-    and when seeking. Expands properties. See `Property Expansion`_.
+    ``show-progress`` command (by default mapped to ``P``), and when
+    seeking. Expands properties. See `Property Expansion`_.
 
     This option has been replaced with ``--osd-msg3``. The only difference is
     that this option implicitly includes ``${osd-sym-cc}``. This option is

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3094,8 +3094,14 @@ OSD
     Disable display of the OSD bar.
 
     You can configure this on a per-command basis in input.conf using ``osd-``
-    prefixes, see ``Input command prefixes``. If you want to disable the OSD
+    prefixes, see ``Input Command Prefixes``. If you want to disable the OSD
     completely, use ``--osd-level=0``.
+
+``--osd-on-seek=<no,bar,msg,msg-bar>``
+    Set what is displayed on the OSD during seeks. The default is ``bar``.
+
+    You can configure this on a per-command basis in input.conf using ``osd-``
+    prefixes, see ``Input Command Prefixes``.
 
 ``--osd-duration=<time>``
     Set the duration of the OSD messages in ms (default: 1000).
@@ -3128,16 +3134,18 @@ OSD
     (default), then the playback time, duration, and some more information is
     shown.
 
-    This is also used for the ``show-progress`` command (by default mapped to
-    ``P``), and when seeking.
+    This is used for the ``show-progress`` command (by default mapped to ``P``),
+    and when seeking if enabled with ``--osd-on-seek`` or by ``osd-`` prefixes
+    in input.conf (see ``Input Command Prefixes``).
 
     ``--osd-status-msg`` is a legacy equivalent (but with a minor difference).
 
 ``--osd-status-msg=<string>``
     Show a custom string during playback instead of the standard status text.
     This overrides the status text used for ``--osd-level=3``, when using the
-    ``show-progress`` command (by default mapped to ``P``), and when
-    seeking. Expands properties. See `Property Expansion`_.
+    ``show-progress`` command (by default mapped to ``P``), and when seeking if
+    enabled with ``--osd-on-seek`` or ``osd-`` prefixes in input.conf (see
+    ``Input Command Prefixes``). Expands properties. See `Property Expansion`_.
 
     This option has been replaced with ``--osd-msg3``. The only difference is
     that this option implicitly includes ``${osd-sym-cc}``. This option is

--- a/options/options.c
+++ b/options/options.c
@@ -589,6 +589,11 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("use-filedir-conf", use_filedir_conf, 0),
     OPT_CHOICE("osd-level", osd_level, 0,
                ({"0", 0}, {"1", 1}, {"2", 2}, {"3", 3})),
+    OPT_CHOICE("osd-on-seek", osd_on_seek, 0,
+               ({"no", 0},
+                {"bar", 1},
+                {"msg", 2},
+                {"msg-bar", 3})),
     OPT_INTRANGE("osd-duration", osd_duration, 0, 0, 3600000),
     OPT_FLAG("osd-fractions", osd_fractions, 0),
 
@@ -878,6 +883,7 @@ const struct MPOpts mp_default_opts = {
     .cursor_autohide_delay = 1000,
     .video_osd = 1,
     .osd_level = 1,
+    .osd_on_seek = 1,
     .osd_duration = 1000,
 #if HAVE_LUA
     .lua_load_osc = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -183,6 +183,7 @@ typedef struct MPOpts {
     int osd_level;
     int osd_duration;
     int osd_fractions;
+    int osd_on_seek;
     int video_osd;
 
     int untimed;

--- a/player/command.c
+++ b/player/command.c
@@ -4342,9 +4342,7 @@ static const struct property_osd_display {
     {"ab-loop-b", .msg = "A-B loop: ${ab-loop-a} - ${ab-loop-b}"},
     {"audio-device", "Audio device"},
     // By default, don't display the following properties on OSD
-    {"pause",
-     .seek_msg = OSD_SEEK_INFO_TEXT,
-     .seek_bar = OSD_SEEK_INFO_BAR},
+    {"pause", NULL},
     {"fullscreen", NULL},
     {0}
 };

--- a/player/command.c
+++ b/player/command.c
@@ -4821,6 +4821,9 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
     bool auto_osd = on_osd == MP_ON_OSD_AUTO;
     bool msg_osd = auto_osd || (on_osd & MP_ON_OSD_MSG);
     bool bar_osd = auto_osd || (on_osd & MP_ON_OSD_BAR);
+    bool seek_msg_osd = auto_osd ? opts->osd_on_seek & 2 : msg_osd;
+    bool seek_bar_osd = auto_osd ? opts->osd_on_seek & 1 : bar_osd;
+
     int osdl = msg_osd ? 1 : OSD_LEVEL_INVISIBLE;
     bool async = cmd->flags & MP_ASYNC_CMD;
 
@@ -4884,9 +4887,9 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             set_osd_function(mpctx, v > 0 ? OSD_FFW : OSD_REW);
             break;
         }}
-        if (bar_osd)
+        if (seek_bar_osd)
             mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-        if (msg_osd)
+        if (seek_msg_osd)
             mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
         break;
     }
@@ -4905,9 +4908,9 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
             queue_seek(mpctx, MPSEEK_ABSOLUTE, oldpts, MPSEEK_EXACT,
                        MPSEEK_FLAG_DELAY);
             set_osd_function(mpctx, OSD_REW);
-            if (bar_osd)
+            if (seek_bar_osd)
                 mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-            if (msg_osd)
+            if (seek_msg_osd)
                 mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
         } else {
             return -1;
@@ -5104,9 +5107,9 @@ int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *re
                     queue_seek(mpctx, MPSEEK_ABSOLUTE, a[0], MPSEEK_EXACT,
                                MPSEEK_FLAG_DELAY);
                     set_osd_function(mpctx, (a[0] > refpts) ? OSD_FFW : OSD_REW);
-                    if (bar_osd)
+                    if (seek_bar_osd)
                         mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
-                    if (msg_osd)
+                    if (seek_msg_osd)
                         mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT;
                 }
             }


### PR DESCRIPTION
This basically undoes #5361. However, given the amount of complaining about how hard it is to change the default OSD settings by remapping every associated key led me to implement the `--osd-on-seek` option (which can still be overridden for individual key bindings in input.conf). The pause osd change is reverted outright.

You're all wrong BTW. Apologies to my comrade @eugenesvk in #3028.