### PR TITLE
ao_opensles: clear buffer queue in reset()

### DIFF
--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -198,6 +198,7 @@ static int init(struct ao *ao)
         (void*)&p->buffer_queue));
     CHK((*p->buffer_queue)->RegisterCallback(p->buffer_queue,
         buffer_callback, ao));
+    CHK((*p->play)->SetPlayState(p->play, SL_PLAYSTATE_PLAYING));
 
     return 1;
 error:
@@ -206,14 +207,6 @@ error:
 }
 
 #undef CHK
-
-static void set_play_state(struct ao *ao, SLuint32 state)
-{
-    struct priv *p = ao->priv;
-    SLresult res = (*p->play)->SetPlayState(p->play, state);
-    if (res != SL_RESULT_SUCCESS)
-        MP_ERR(ao, "Failed to SetPlayState(%d): %d\n", state, res);
-}
 
 static void reset(struct ao *ao)
 {
@@ -224,8 +217,6 @@ static void reset(struct ao *ao)
 static void resume(struct ao *ao)
 {
     struct priv *p = ao->priv;
-    set_play_state(ao, SL_PLAYSTATE_PLAYING);
-
     // enqueue two buffers
     buffer_callback(p->buffer_queue, ao);
     buffer_callback(p->buffer_queue, ao);

--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -101,7 +101,7 @@ static void buffer_callback(SLBufferQueueItf buffer_queue, void *context)
     pthread_mutex_unlock(&p->buffer_lock);
 }
 
-#define DEFAULT_BUFFER_SIZE_MS 50
+#define DEFAULT_BUFFER_SIZE_MS 200
 
 #define CHK(stmt) \
     { \

--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -217,7 +217,8 @@ static void set_play_state(struct ao *ao, SLuint32 state)
 
 static void reset(struct ao *ao)
 {
-    set_play_state(ao, SL_PLAYSTATE_STOPPED);
+    struct priv *p = ao->priv;
+    (*p->buffer_queue)->Clear(p->buffer_queue);
 }
 
 static void resume(struct ao *ao)


### PR DESCRIPTION
Avoid resume() from causing SL_RESULT_BUFFER_INSUFFICIENT ("Failed to Enqueue: 7" when seek or resume from pause).

I agree that my changes can be relicensed to LGPL 2.1 or later.