### PR TITLE
player: properly set track information when auto-loading external files

### DIFF
--- a/player/core.h
+++ b/player/core.h
@@ -144,6 +144,7 @@ struct track {
     bool no_auto_select;
     char *external_filename;
     bool auto_loaded;
+    int num_tracks;
 
     struct demuxer *demuxer;
     // Invariant: !stream || stream->demuxer == demuxer


### PR DESCRIPTION
Before this commit, auto_loaded and lang were only set for the first
track in auto-loaded external files.

Fixes #5432

I agree that my changes can be relicensed to LGPL 2.1 or later.
