### PR TITLE
vo_gpu: port HDR tone mapping algorithm from libplacebo

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5063,7 +5063,7 @@ The following video options are currently all specific to ``--vo=gpu`` and
         for in-range material as much as possible. Use this when you care about
         color accuracy more than detail preservation. This is somewhere in
         between ``clip`` and ``reinhard``, depending on the value of
-        ``--tone-mapping-param``. (default)
+        ``--tone-mapping-param``.
     reinhard
         Reinhard tone mapping algorithm. Very simple continuous curve.
         Preserves overall image brightness but uses nonlinear contrast, which
@@ -5074,7 +5074,9 @@ The following video options are currently all specific to ``--vo=gpu`` and
         desaturating everything. Developed by John Hable for use in video
         games. Use this when you care about detail preservation more than
         color/brightness accuracy. This is roughly equivalent to
-        ``--hdr-tone-mapping=reinhard --tone-mapping-param=0.24``.
+        ``--hdr-tone-mapping=reinhard --tone-mapping-param=0.24``. If possible,
+        you should also enable ``--hdr-compute-peak`` for the best results.
+        (Default)
     gamma
         Fits a logarithmic transfer between the tone curves.
     linear
@@ -5103,13 +5105,15 @@ The following video options are currently all specific to ``--vo=gpu`` and
     linear
         Specifies the scale factor to use while stretching. Defaults to 1.0.
 
-``--hdr-compute-peak``
-    Compute the HDR peak per-frame of relying on tagged metadata. These values
-    are averaged over local regions as well as over several frames to prevent
-    the value from jittering around too much. This option basically gives you
-    dynamic, per-scene tone mapping. Requires compute shaders, which is a
-    fairly recent OpenGL feature, and will probably also perform horribly on
-    some drivers, so enable at your own risk.
+``--hdr-compute-peak=<auto|yes|no>``
+    Compute the HDR peak and frame average brightness per-frame instead of
+    relying on tagged metadata. These values are averaged over local regions as
+    well as over several frames to prevent the value from jittering around too
+    much. This option basically gives you dynamic, per-scene tone mapping.
+    Requires compute shaders, which is a fairly recent OpenGL feature, and will
+    probably also perform horribly on some drivers, so enable at your own risk.
+    The special value ``auto`` (default) will enable HDR peak computation
+    automatically if compute shaders and SSBOs are supported.
 
 ``--tone-mapping-desaturate=<value>``
     Apply desaturation for highlights. The parameter essentially controls the
@@ -5119,8 +5123,9 @@ The following video options are currently all specific to ``--vo=gpu`` and
     into white instead. This makes images feel more natural, at the cost of
     reducing information about out-of-range colors.
 
-    The default of 1.0 provides a good balance that roughly matches the look
-    and feel of the ACES ODT curves. A setting of 0.0 disables this option.
+    The default of 0.5 provides a good balance. This value is weaker than the
+    ACES ODT curves' recommendation, but works better for most content in
+    practice. A setting of 0.0 disables this option.
 
 ``--gamut-warning``
     If enabled, mpv will mark all clipped/out-of-gamut pixels that exceed a

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -54,6 +54,7 @@ enum {
     RA_CAP_GATHER         = 1 << 9, // supports textureGather in GLSL
     RA_CAP_FRAGCOORD      = 1 << 10, // supports reading from gl_FragCoord
     RA_CAP_PARALLEL_COMPUTE  = 1 << 11, // supports parallel compute shaders
+    RA_CAP_NUM_GROUPS     = 1 << 12, // supports gl_NumWorkGroups
 };
 
 enum ra_ctype {

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -96,7 +96,7 @@ enum tone_mapping {
 };
 
 // How many frames to average over for HDR peak detection
-#define PEAK_DETECT_FRAMES 100
+#define PEAK_DETECT_FRAMES 20
 
 struct gl_video_opts {
     int dumb_mode;

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -101,6 +101,7 @@ static int ra_init_gl(struct ra *ra, GL *gl)
         {RA_CAP_TEX_1D,             MPGL_CAP_1D_TEX},
         {RA_CAP_TEX_3D,             MPGL_CAP_3D_TEX},
         {RA_CAP_COMPUTE,            MPGL_CAP_COMPUTE_SHADER},
+        {RA_CAP_NUM_GROUPS,         MPGL_CAP_COMPUTE_SHADER},
         {RA_CAP_NESTED_ARRAY,       MPGL_CAP_NESTED_ARRAY},
     };
 

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -209,7 +209,7 @@ struct ra *ra_create_vk(struct mpvk_ctx *vk, struct mp_log *log)
     ra->max_pushc_size = vk->limits.maxPushConstantsSize;
 
     if (vk->pool_compute) {
-        ra->caps |= RA_CAP_COMPUTE;
+        ra->caps |= RA_CAP_COMPUTE | RA_CAP_NUM_GROUPS;
         // If we have more compute queues than graphics queues, we probably
         // want to be using them. (This seems mostly relevant for AMD)
         if (vk->pool_compute->num_queues > vk->pool_graphics->num_queues)


### PR DESCRIPTION
The current peak detection algorithm was very bugged (which contributed
to the excessive cross-flame flicker without long normalization) and
also didn't take into account the frame average brightness level.

The new algorithm both takes into account frame average brightness (in
addition to peak brightness), and also computes the values in a more
stable/correct way. (The old path was basically undefined behavior)

In addition to improving the algorithm, we also switch to hable tone
mapping by default, and try to enable peak computation automatically
whever possible (compute shaders + SSBOs supported). We also make the
desaturation milder, after extensive testing during libplacebo
development.

I also had to compensate a bit for the representational differences
between mpv and libplacebo (libplacebo treats 1.0 as the reference peak,
but mpv treats it as the nominal peak), but it shouldn't have caused any
problems.

This is still not quite the same as libplacebo, since libplacebo also
allows tagging the desired scene average brightness on the output, and
it also supports reading the scene average brightness from static
metadata (MaxFALL) where available. But those changes are a bit more
involved. It's possible we could also read this from metadata in the
future, but we have problems communicating with AVFrames as it is and I
don't want to touch the mpv colorimetry structs for the time being.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
