### PR TITLE
Vapourynth fixes

### DIFF
--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -369,8 +369,9 @@ static void vf_vapoursynth_process(struct mp_filter *f)
                 if (reinit_vs(p) < 0) {
                     MP_ERR(p, "could not init VS\n");
                     mp_frame_unref(&frame);
-                    goto done;
+                    return;
                 }
+                pthread_mutex_lock(&p->lock);
             }
             if (p->out_pts == MP_NOPTS_VALUE)
                 p->out_pts = mpi->pts;

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -327,7 +327,7 @@ static void vf_vapoursynth_process(struct mp_filter *f)
     }
 
     // Read input and pass it to the input queue VS reads.
-    if (p->num_buffered < MP_TALLOC_AVAIL(p->buffered) && !p->eof) {
+    while (p->num_buffered < MP_TALLOC_AVAIL(p->buffered) && !p->eof) {
         // Note: this requests new input frames even if no output was ever
         // requested. Normally this is not how mp_filter works, but since VS
         // works asynchronously, it's probably ok.
@@ -382,6 +382,8 @@ static void vf_vapoursynth_process(struct mp_filter *f)
             MP_ERR(p, "discarding unknown frame type\n");
             mp_frame_unref(&frame);
             goto done;
+        } else {
+            break; // no new data available
         }
     }
 


### PR DESCRIPTION
The first commit fixes the deadlock mentioned in #5470 due to broken mutex usage. The second one isn't strictly needed and merely makes it "cleaner".