### PR TITLE
wayland_common: fix idle_inhibitor protocol segfault

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1198,6 +1198,7 @@ static int set_screensaver_inhibitor(struct vo_wayland_state *wl, int state)
     } else {
         MP_VERBOSE(wl, "Disabling the idle inhibitor\n");
         zwp_idle_inhibitor_v1_destroy(wl->idle_inhibitor);
+        wl->idle_inhibitor = NULL;
     }
     return VO_TRUE;
 }


### PR DESCRIPTION
The pointer is used as a state and wasn't zeroed after seeks