### PR TITLE
ytdl_hook cleanups and playlist index support

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -560,6 +560,10 @@ Program Behavior
     which mpv should not use with youtube-dl. The patterns are matched after
     the ``http(s)://`` part of the URL.
 
+    The `use_manifests` script option makes mpv use the master manifest URL for
+    formats like HLS and DASH, if available, allowing for video/audio selection
+    in runtime. It's disabled ("no") by default for performance reasons.
+
     ``^`` matches the beginning of the URL, ``$`` matches its end, and you
     should use ``%`` before any of the characters ``^$()%|,.[]*+-?`` to match
     that character.

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -320,7 +320,8 @@ local function add_single_video(json)
 
             if not (sub_info.data == nil) then
                 sub = "memory://"..sub_info.data
-            elseif not (sub_info.url == nil) then
+            elseif not (sub_info.url == nil) and
+                url_is_safe(sub_info.url) then
                 sub = sub_info.url
             end
 
@@ -543,7 +544,8 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
                         local subfile = "edl://"
                         for i, entry in pairs(json.entries) do
                             if not (entry.requested_subtitles == nil) and
-                                not (entry.requested_subtitles[j] == nil) then
+                                not (entry.requested_subtitles[j] == nil) and
+                                url_is_safe(entry.requested_subtitles[j].url) then
                                 subfile = subfile..edl_escape(entry.requested_subtitles[j].url)
                             else
                                 subfile = subfile..edl_escape("memory://WEBVTT")

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -215,8 +215,8 @@ local function edl_track_joined(fragments, protocol, is_live, base)
 end
 
 local function has_native_dash_demuxer()
-    local demuxers = mp.get_property_native("demuxer-lavf-list")
-    for _,v in ipairs(demuxers) do
+    local demuxers = mp.get_property_native("demuxer-lavf-list", {})
+    for _, v in ipairs(demuxers) do
         if v == "dash" then
             return true
         end
@@ -230,7 +230,7 @@ local function valid_manifest(json)
         return false
     end
     local proto = reqfmt["protocol"] or json["protocol"] or ""
-    return (has_native_dash_demuxer() and proto == "http_dash_segments") or
+    return (proto == "http_dash_segments" and has_native_dash_demuxer()) or
         proto:find("^m3u8")
 end
 

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -4,7 +4,8 @@ local options = require 'mp.options'
 
 local o = {
     exclude = "",
-    try_ytdl_first = false
+    try_ytdl_first = false,
+    use_manifests = false
 }
 options.read_options(o)
 
@@ -279,7 +280,7 @@ local function add_single_video(json)
     local reqfmts = json["requested_formats"]
 
     -- prefer manifest_url if present
-    if valid_manifest(json) then
+    if o.use_manifests and valid_manifest(json) then
         local mpd_url = reqfmts and reqfmts[1]["manifest_url"] or
             json["manifest_url"]
         if not mpd_url then

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -626,9 +626,13 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
                     site = entry["webpage_url"]
                 end
 
-                -- links with only youtube id as returned by --flat-playlist
+                -- links without protocol as returned by --flat-playlist
                 if not site:find("://") then
-                    table.insert(playlist, "https://youtu.be/" .. site)
+                    -- youtube extractor provides only IDs,
+                    -- others come prefixed with the extractor name and ":"
+                    local prefix = site:find(":") and "ytdl://" or
+                        "https://youtu.be/"
+                    table.insert(playlist, prefix .. site)
                 elseif url_is_safe(site) then
                     table.insert(playlist, site)
                 end

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -381,7 +381,6 @@ local function add_single_video(json)
             "rtmp_app", json.app)
     end
 
-    -- ffmpeg ignores proxy if https is used and doesn't support SOCKS
     if json.proxy and json.proxy ~= "" then
         stream_opts = append_libav_opt(stream_opts,
             "http_proxy", json.proxy)
@@ -391,7 +390,7 @@ local function add_single_video(json)
 end
 
 mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
-    local url = mp.get_property("stream-open-filename")
+    local url = mp.get_property("stream-open-filename", "")
     local start_time = os.clock()
     if (url:find("ytdl://") == 1) or
         ((url:find("https?://") == 1) and not is_blacklisted(url)) then
@@ -484,13 +483,12 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
         json["proxy"] = json["proxy"] or proxy
 
         -- what did we get?
-        if not (json["direct"] == nil) and (json["direct"] == true) then
+        if json["direct"] then
             -- direct URL, nothing to do
             msg.verbose("Got direct URL")
             return
-        elseif not (json["_type"] == nil)
-            and ((json["_type"] == "playlist")
-            or (json["_type"] == "multi_video")) then
+        elseif (json["_type"] == "playlist")
+            or (json["_type"] == "multi_video") then
             -- a playlist
 
             if (#json.entries == 0) then
@@ -519,9 +517,7 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
                 end
 
                 -- can't change the http headers for each entry, so use the 1st
-                if json.entries[1] then
-                    set_http_headers(json.entries[1].http_headers)
-                end
+                set_http_headers(json.entries[1].http_headers)
 
                 mp.set_property("stream-open-filename", playlist)
                 if not (json.title == nil) then

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -142,6 +142,45 @@ local function is_blacklisted(url)
     return false
 end
 
+local function parse_yt_playlist(url, json)
+    -- return 0-based index to use with --playlist-start
+
+    if not json.extractor or json.extractor ~= "youtube:playlist" then
+        return nil
+    end
+
+    local query = url:match("%?.+")
+    if not query then return nil end
+
+    local args = {}
+    for arg, param in query:gmatch("(%a+)=([^&?]+)") do
+        if arg and param then
+            args[arg] = param
+        end
+    end
+
+    local maybe_idx = tonumber(args["index"])
+
+    -- if index matches v param it's probably the requested item
+    if maybe_idx and #json.entries >= maybe_idx and
+        json.entries[maybe_idx].id == args["v"] then
+        msg.debug("index matches requested video")
+        return maybe_idx - 1
+    end
+
+    -- if there's no index or it doesn't match, look for video
+    for i = 1, #json.entries do
+        if json.entries[i] == args["v"] then
+            msg.debug("found requested video in index " .. (i - 1))
+            return i - 1
+        end
+    end
+
+    msg.debug("requested video not found in playlist")
+    -- if item isn't on the playlist, give up
+    return nil
+end
+
 local function make_absolute_url(base_url, url)
     if url:find("https?://") == 1 then return url end
 
@@ -417,10 +456,11 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
     local raw_options = mp.get_property_native("options/ytdl-raw-options")
     local allsubs = true
     local proxy = nil
+    local use_playlist = false
 
     local command = {
         ytdl.path, "--no-warnings", "-J", "--flat-playlist",
-        "--sub-format", "ass/srt/best", "--no-playlist"
+        "--sub-format", "ass/srt/best"
     }
 
     -- Checks if video option is "no", change format accordingly,
@@ -445,14 +485,18 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
         end
         if (param == "sub-lang") and (arg ~= "") then
             allsubs = false
-        end
-        if (param == "proxy") and (arg ~= "") then
+        elseif (param == "proxy") and (arg ~= "") then
             proxy = arg
+        elseif (param == "yes-playlist") then
+            use_playlist = true
         end
     end
 
     if (allsubs == true) then
         table.insert(command, "--all-subs")
+    end
+    if not use_playlist then
+        table.insert(command, "--no-playlist")
     end
     table.insert(command, "--")
     table.insert(command, url)
@@ -559,6 +603,7 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
             msg.verbose("Playlist with single entry detected.")
             add_single_video(json.entries[1])
         else
+            local playlist_index = parse_yt_playlist(url, json)
             local playlist = {"#EXTM3U"}
             for i, entry in pairs(json.entries) do
                 local site = entry.url
@@ -589,9 +634,12 @@ mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function ()
 
             end
 
-            if #playlist > 0 then
-                mp.set_property("stream-open-filename", "memory://" .. table.concat(playlist, "\n"))
+            if use_playlist and
+                not option_was_set("playlist-start") and playlist_index then
+                mp.set_property_number("playlist-start", playlist_index)
             end
+
+            mp.set_property("stream-open-filename", "memory://" .. table.concat(playlist, "\n"))
         end
 
     else -- probably a video


### PR DESCRIPTION
Also another off by default script opt to avoid reverting support for manifest_url usage. Can be changed to on or removed when hls/dash demuxing of master playlists is improved in FFmpeg.

The first commit is due to seeing maintainers simply grabbing ytdl_hook for their backporting needs. If the [commit adding demuxer-lavf-list](https://github.com/mpv-player/mpv/commit/828bd2963cd10a851e0a977809687aed4d377dc3) isn't backported too using it will break the script.

Concerning on_load_fail, there's no way to probe for that afaik, so if you're backporting this by simply grabbing the latest version of the script, remove that too or backport 89f81da481c81cda1abd7c971b36f00ea80d80fe too.