### PR TITLE
Fix HDR peak detection check in dumb mode

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3524,6 +3524,13 @@ static void check_gl_features(struct gl_video *p)
         MP_VERBOSE(p, "Disabling alpha checkerboard (no gl_FragCoord).\n");
     }
 
+    bool have_compute_peak = have_compute && have_ssbo && have_numgroups;
+    if (!have_compute_peak && p->opts.compute_hdr_peak >= 0) {
+        int msgl = p->opts.compute_hdr_peak == 1 ? MSGL_WARN : MSGL_V;
+        MP_MSG(p, msgl, "Disabling HDR peak computation (no compute shaders).\n");
+        p->opts.compute_hdr_peak = -1;
+    }
+
     p->forced_dumb_mode = p->opts.dumb_mode > 0 || !have_fbo || !have_texrg;
     bool voluntarily_dumb = check_dumb_mode(p);
     if (p->forced_dumb_mode || voluntarily_dumb) {
@@ -3543,6 +3550,7 @@ static void check_gl_features(struct gl_video *p)
             .alpha_mode = p->opts.alpha_mode,
             .use_rectangle = p->opts.use_rectangle,
             .background = p->opts.background,
+            .compute_hdr_peak = p->opts.compute_hdr_peak,
             .dither_algo = p->opts.dither_algo,
             .dither_depth = p->opts.dither_depth,
             .dither_size = p->opts.dither_size,
@@ -3607,13 +3615,6 @@ static void check_gl_features(struct gl_video *p)
     if (!have_mglsl && p->opts.deband) {
         p->opts.deband = 0;
         MP_WARN(p, "Disabling debanding (GLSL version too old).\n");
-    }
-
-    bool have_compute_peak = have_compute && have_ssbo && have_numgroups;
-    if (!have_compute_peak && p->opts.compute_hdr_peak >= 0) {
-        int msgl = p->opts.compute_hdr_peak == 1 ? MSGL_WARN : MSGL_V;
-        MP_MSG(p, msgl, "Disabling HDR peak computation (no compute shaders).\n");
-        p->opts.compute_hdr_peak = -1;
     }
 }
 

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3488,6 +3488,7 @@ static void check_gl_features(struct gl_video *p)
     bool have_texrg = rg_tex && !rg_tex->luminance_alpha;
     bool have_compute = ra->caps & RA_CAP_COMPUTE;
     bool have_ssbo = ra->caps & RA_CAP_BUF_RW;
+    bool have_fragcoord = ra->caps & RA_CAP_FRAGCOORD;
     bool have_numgroups = ra->caps & RA_CAP_NUM_GROUPS;
 
     const char *auto_fbo_fmts[] = {"rgba16", "rgba16f", "rgba16hf",
@@ -3510,15 +3511,13 @@ static void check_gl_features(struct gl_video *p)
         }
     }
 
-    if (!(ra->caps & RA_CAP_FRAGCOORD) && p->opts.dither_depth >= 0 &&
+    if (!have_fragcoord && p->opts.dither_depth >= 0 &&
         p->opts.dither_algo != DITHER_NONE)
     {
         p->opts.dither_algo = DITHER_NONE;
         MP_WARN(p, "Disabling dithering (no gl_FragCoord).\n");
     }
-    if (!(ra->caps & RA_CAP_FRAGCOORD) &&
-        p->opts.alpha_mode == ALPHA_BLEND_TILES)
-    {
+    if (!have_fragcoord && p->opts.alpha_mode == ALPHA_BLEND_TILES) {
         p->opts.alpha_mode = ALPHA_BLEND;
         // Verbose, since this is the default setting
         MP_VERBOSE(p, "Disabling alpha checkerboard (no gl_FragCoord).\n");


### PR DESCRIPTION
Similar in spirit to #5460. Includes a semi-related cosmetic change so the RA_CAP_FRAGCOORD check looks like all the others.