### PR TITLE
cocoa-cb: change window styling

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4864,6 +4864,18 @@ The following video options are currently all specific to ``--vo=gpu`` and
     :auto:        Detects the system settings and sets the title bar styling
                   appropriately, either ultradark or mediumlight.
 
+``--macos-fs-animation-duration=<default|0-1000>``
+    Sets the fullscreen resize animation duration in ms (default: default).
+    The default value is slightly less than the system's animation duration
+    (500ms) to prevent some problems when the end of an async animation happens
+    at the same time as the end of the system wide fullscreen animation. Setting
+    anything higher than 500ms will only prematurely cancel the resize animation
+    after the system wide animation ended. The upper limit is still set at
+    1000ms since it's possible that Apple or the user changes the system
+    defaults. Anything higher than 1000ms though seems too long and shouldn't be
+    set anyway.
+    OS X and cocoa-cb only
+
 ``--android-surface-size=<WxH>``
     Set dimensions of the rendering surface used by the Android gpu context.
     Needs to be set by the embedding application if the dimensions change during

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4852,6 +4852,18 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     OS X only.
 
+``--macos-title-bar-style=<dark|ultradark|light|mediumlight|auto>``
+    Sets the styling of the title bar (default: dark).
+    OS X and cocoa-cb only
+
+    :dark:        Dark title bar with vibrancy, a subtle blurring effect that
+                  dynamically blends the background (Video) into the title bar.
+    :ultradark:   Darker title bar with vibrancy (like QuickTime Player).
+    :light:       Bright title bar with vibrancy.
+    :mediumlight: Less bright title bar with vibrancy.
+    :auto:        Detects the system settings and sets the title bar styling
+                  appropriately, either ultradark or mediumlight.
+
 ``--android-surface-size=<WxH>``
     Set dimensions of the rendering surface used by the Android gpu context.
     Needs to be set by the embedding application if the dimensions change during

--- a/options/options.c
+++ b/options/options.c
@@ -87,6 +87,7 @@ extern const struct m_sub_options d3d11_conf;
 extern const struct m_sub_options d3d11va_conf;
 extern const struct m_sub_options angle_conf;
 extern const struct m_sub_options cocoa_conf;
+extern const struct m_sub_options macos_conf;
 extern const struct m_sub_options android_conf;
 
 static const struct m_sub_options screenshot_conf = {
@@ -733,6 +734,10 @@ const m_option_t mp_opts[] = {
 
 #if HAVE_GL_COCOA
     OPT_SUBSTRUCT("", cocoa_opts, cocoa_conf, 0),
+#endif
+
+#if HAVE_MACOS_COCOA_CB
+    OPT_SUBSTRUCT("", macos_opts, macos_conf, 0),
 #endif
 
 #if HAVE_ANDROID

--- a/options/options.h
+++ b/options/options.h
@@ -341,6 +341,7 @@ typedef struct MPOpts {
     struct d3d11_opts *d3d11_opts;
     struct d3d11va_opts *d3d11va_opts;
     struct cocoa_opts *cocoa_opts;
+    struct macos_opts *macos_opts;
     struct android_opts *android_opts;
     struct dvd_opts *dvd_opts;
 

--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -39,6 +39,7 @@ class MPVHelper: NSObject {
         mpv_observe_property(mpvHandle, 0, "ontop", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "border", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "keepaspect-window", MPV_FORMAT_FLAG)
+        mpv_observe_property(mpvHandle, 0, "macos-title-bar-style", MPV_FORMAT_STRING)
     }
 
     func setGLCB() {

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -42,6 +42,7 @@
 
 struct macos_opts {
     int macos_title_bar_style;
+    int macos_fs_animation_duration;
 };
 
 #define OPT_BASE_STRUCT struct macos_opts
@@ -50,9 +51,15 @@ const struct m_sub_options macos_conf = {
         OPT_CHOICE("macos-title-bar-style", macos_title_bar_style, 0,
                    ({"dark", 0}, {"ultradark", 1}, {"light", 2},
                     {"mediumlight", 3}, {"auto", 4})),
+        OPT_CHOICE_OR_INT("macos-fs-animation-duration",
+                          macos_fs_animation_duration, 0, 0, 1000,
+                          ({"default", -1})),
         {0}
     },
     .size = sizeof(struct macos_opts),
+    .defaults = &(const struct macos_opts){
+        .macos_fs_animation_duration = -1,
+    },
 };
 
 // Whether the NSApplication singleton was created. If this is false, we are

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -23,6 +23,7 @@
 #include "common/msg.h"
 #include "input/input.h"
 #include "player/client.h"
+#include "options/m_config.h"
 
 #import "osdep/macosx_application_objc.h"
 #include "osdep/macosx_compat.h"
@@ -38,6 +39,21 @@
 #endif
 
 #define MPV_PROTOCOL @"mpv://"
+
+struct macos_opts {
+    int macos_title_bar_style;
+};
+
+#define OPT_BASE_STRUCT struct macos_opts
+const struct m_sub_options macos_conf = {
+    .opts = (const struct m_option[]) {
+        OPT_CHOICE("macos-title-bar-style", macos_title_bar_style, 0,
+                   ({"dark", 0}, {"ultradark", 1}, {"light", 2},
+                    {"mediumlight", 3}, {"auto", 4})),
+        {0}
+    },
+    .size = sizeof(struct macos_opts),
+};
 
 // Whether the NSApplication singleton was created. If this is false, we are
 // running in libmpv mode, and cocoa_main() was never called.

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -110,12 +110,14 @@ class EventsView: NSView {
         if mpv.getBoolProperty("input-cursor") {
             cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_LEAVE, 0)
         }
+        cocoaCB.window.hideTitleBar()
     }
 
     override func mouseMoved(with event: NSEvent) {
         if mpv != nil && mpv.getBoolProperty("input-cursor") {
             signalMouseMovement(event)
         }
+        cocoaCB.window.showTitleBar()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -233,8 +235,7 @@ class EventsView: NSView {
         let menuBarHeight = NSApp.mainMenu!.menuBarHeight
 
         if cocoaCB.window.isInFullscreen && (menuBarHeight > 0) {
-            let titleBar = NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled)
-            topMargin = titleBar.size.height + 1 + menuBarHeight
+            topMargin = cocoaCB.window.titleBarHeight + 1 + menuBarHeight
         }
 
         var vF = window!.screen!.frame
@@ -244,7 +245,11 @@ class EventsView: NSView {
         let vFV = convert(vFW, from: nil)
         let pt = convert(window!.mouseLocationOutsideOfEventStream, from: nil)
 
-        let clippedBounds = bounds.intersection(vFV)
+        var clippedBounds = bounds.intersection(vFV)
+        if !cocoaCB.window.isInFullscreen {
+            clippedBounds.origin.y += cocoaCB.window.titleBarHeight
+            clippedBounds.size.height -= cocoaCB.window.titleBarHeight
+        }
         return clippedBounds.contains(pt)
     }
 

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -376,7 +376,22 @@ class Window: NSWindow, NSWindowDelegate {
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
         let newFrame = !isAnimating && isInFullscreen ? targetScreen!.frame :
                                                         frameRect
+        let aspectRatioDiff = fabs( (newFrame.width/newFrame.height) -
+                                    (frame.width/frame.height) )
+
+        let isNotUserLiveResize = isAnimating || !(!isAnimating && inLiveResize)
+        if aspectRatioDiff > 0.005 && isNotUserLiveResize {
+            cocoaCB.layer.drawLock.lock()
+            cocoaCB.layer.atomicDrawingStart()
+        }
+
         super.setFrame(newFrame, display: flag)
+        cocoaCB.layer.neededFlips += 1
+
+        if aspectRatioDiff > 0.005 && isNotUserLiveResize {
+            Swift.print("drawUnLock")
+            cocoaCB.layer.drawLock.unlock()
+        }
 
         if keepAspect {
             contentAspectRatio = unfsContentFrame!.size

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -252,7 +252,7 @@ class Window: NSWindow, NSWindowDelegate {
         hideTitleBar()
 
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
-            context.duration = duration - 0.05
+            context.duration = getFsAnimationDuration(duration - 0.05)
             window.animator().setFrame(intermediateFrame, display: true)
         }, completionHandler: { })
     }
@@ -264,7 +264,7 @@ class Window: NSWindow, NSWindowDelegate {
         setFrame(intermediateFrame, display: true)
 
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
-            context.duration = duration - 0.05
+            context.duration = getFsAnimationDuration(duration - 0.05)
             window.animator().setFrame(newFrame, display: true)
         }, completionHandler: { })
     }
@@ -326,6 +326,15 @@ class Window: NSWindow, NSWindowDelegate {
         isInFullscreen = false
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
         cocoaCB.layer.neededFlips += 1
+    }
+
+    func getFsAnimationDuration(_ def: Double) -> Double{
+        let duration = mpv.getStringProperty("macos-fs-animation-duration") ?? "default"
+        if duration == "default" {
+            return def
+        } else {
+            return Double(duration)!/1000
+        }
     }
 
     func setOnTop(_ state: Bool) {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -99,12 +99,12 @@ class CocoaCB: NSObject {
                               screen: targetScreen, cocoaCB: self)
         win.title = window.title
         win.setOnTop(mpv.getBoolProperty("ontop"))
-        win.setBorder(mpv.getBoolProperty("border"))
         win.keepAspect = mpv.getBoolProperty("keepaspect-window")
         window.close()
         window = win
         window.contentView!.addSubview(view)
         view.frame = window.contentView!.frame
+        window.initTitleBar()
 
         setAppIcon()
         window.isRestorable = false
@@ -486,7 +486,7 @@ class CocoaCB: NSObject {
         switch String(cString: property.name) {
         case "border":
             if let data = MPVHelper.mpvFlagToBool(property.data) {
-                window.setBorder(data)
+                window.border = data
             }
         case "ontop":
             if let data = MPVHelper.mpvFlagToBool(property.data) {
@@ -495,6 +495,10 @@ class CocoaCB: NSObject {
         case "keepaspect-window":
             if let data = MPVHelper.mpvFlagToBool(property.data) {
                 window.keepAspect = data
+            }
+        case "macos-title-bar-style":
+            if let data = MPVHelper.mpvStringArrayToString(property.data) {
+                window.setTitleBarStyle(data)
             }
         default:
             break

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -8,8 +8,9 @@ def __run(cmd):
         return ""
 
 def __add_swift_flags(ctx):
-    ctx.env.SWIFT_FLAGS = ('-frontend -c -sdk %s -enable-objc-interop -emit-objc-header'
-                           ' -emit-module -parse-as-library') % (ctx.env.MACOS_SDK)
+    ctx.env.SWIFT_FLAGS = ('-frontend -c -sdk %s -enable-objc-interop'
+                           ' -emit-objc-header -parse-as-library'
+                           ' -target x86_64-apple-macosx10.10') % (ctx.env.MACOS_SDK)
     swift_version = __run([ctx.env.SWIFT, '-version']).split(' ')[3].split('.')[:2]
     major, minor = [int(n) for n in swift_version]
 
@@ -31,7 +32,6 @@ def __find_swift_library(ctx):
         'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static/macosx',
         'usr/lib/swift_static/macosx'
     ]
-    dev_path = __run('xcode-select -p')[1:]
     dev_path = __run(['xcode-select', '-p'])[1:]
 
     ctx.start_msg('Checking for Swift Library')


### PR DESCRIPTION
ignore the `build: fix swift detection with python2` commit, it is part of another PR but was needed to fix the build.

this drastically changes the window styling. it moves the title bar inside of the window frame and it automatically hides. it's similar to QuickTime Player now. it supports 4 different styling and auto select based on your system settings. for now `dark` is the default styling. some screenshots how it looks like, active and inactive window. feel free to voice your opinion (that's why i opened that PR before being completely done with that change) or report any issues since i didn't test it too much yet.

this also seems to have the nice side effect of fixing #3944 and the black flicker and makes the animation appear smoother, because of less abrupt resizing.

**current:**
![current](https://user-images.githubusercontent.com/680386/36119729-1eb66c88-1041-11e8-89f0-7c1c526e7163.png)
![current-inactive](https://user-images.githubusercontent.com/680386/36119728-1e90c0c8-1041-11e8-9974-0447a9bfd6c8.png)

**dark:**
![dark](https://user-images.githubusercontent.com/680386/36119237-a30d3432-103f-11e8-8fa4-624c10c8a4ef.png)
![dark-inactive](https://user-images.githubusercontent.com/680386/36306827-bd9787d0-1319-11e8-89b9-b4e31d8c6a6d.png)

**ultradark:**
![ultradark](https://user-images.githubusercontent.com/680386/36119273-c08e92c6-103f-11e8-9f6f-458170524f4e.png)
![ultradark-inactive](https://user-images.githubusercontent.com/680386/36119274-c0ae70b4-103f-11e8-9ca6-b24456ee6060.png)

**light:**
![light](https://user-images.githubusercontent.com/680386/36119289-c990cdda-103f-11e8-9f31-70ab2e57e77d.png)
![light-inactive](https://user-images.githubusercontent.com/680386/36306836-c35484de-1319-11e8-8d2a-4de8da6a4ebb.png)

**mediumlight:**
![mediumlight](https://user-images.githubusercontent.com/680386/36119321-dd04d33e-103f-11e8-9650-6bf516af695a.png)
![mediumlight-inactive](https://user-images.githubusercontent.com/680386/36119320-dce5061c-103f-11e8-89be-585a1d190a9d.png)