### PR TITLE
Avoid buffering frames in the VO when using vo_mediacodec_embed

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -408,6 +408,9 @@ static int get_req_frames(struct MPContext *mpctx, bool eof)
     if (eof)
         return 1;
 
+    if (mpctx->video_out->driver->caps & VO_CAP_NORETAIN)
+        return 1;
+
     // On the first frame, output a new frame as quickly as possible.
     // But display-sync likes to have a correct frame duration always.
     if (mpctx->video_pts == MP_NOPTS_VALUE)

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -891,7 +891,7 @@ bool vo_render_frame_external(struct vo *vo)
         update_vsync_timing_after_swap(vo);
     }
 
-    if (vo->driver->caps & VO_CAP_NOREDRAW) {
+    if (vo->driver->caps & VO_CAP_NORETAIN) {
         talloc_free(in->current_frame);
         in->current_frame = NULL;
     }
@@ -919,7 +919,7 @@ static void do_redraw(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
 
-    if (!vo->config_ok || (vo->driver->caps & VO_CAP_NOREDRAW))
+    if (!vo->config_ok || (vo->driver->caps & VO_CAP_NORETAIN))
         return;
 
     pthread_mutex_lock(&in->lock);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -190,8 +190,8 @@ enum {
     VO_CAP_ROTATE90     = 1 << 0,
     // VO does framedrop itself (vo_vdpau). Untimed/encoding VOs never drop.
     VO_CAP_FRAMEDROP    = 1 << 1,
-    // VO does not support redraws (vo_mediacodec_embed).
-    VO_CAP_NOREDRAW     = 1 << 2,
+    // VO does not allow frames to be retained (vo_mediacodec_embed).
+    VO_CAP_NORETAIN     = 1 << 2,
 };
 
 #define VO_MAX_REQ_FRAMES 10


### PR DESCRIPTION
Fixes playback issues on some mediacodec hardware.