### PR TITLE
audio: improve behavior if filters output nothing during probing

### DIFF
--- a/filters/f_output_chain.c
+++ b/filters/f_output_chain.c
@@ -351,7 +351,10 @@ static void process_format_change(struct mp_filter *f)
                 p->format_change_phase = 2;
                 mp_pin_out_request_data(p->filters_out);
             } else if (!p->public.failed_output_conversion) {
-                MP_ERR(p, "we didn't get an output frame? (broken filter?)\n");
+                MP_ERR(p, "No output format - empty file or broken filter?\n");
+                p->ao = NULL;
+                p->public.ao_needs_update = true;
+                p->format_change_phase = 5;
             }
             mp_filter_internal_mark_progress(f);
             return;

--- a/player/audio.c
+++ b/player/audio.c
@@ -272,6 +272,11 @@ static void reinit_audio_filters_and_output(struct MPContext *mpctx)
     if (!out_fmt)
         abort();
 
+    if (!mp_aframe_config_is_valid(out_fmt)) {
+        talloc_free(out_fmt);
+        goto init_error;
+    }
+
     if (af_fmt_is_pcm(mp_aframe_get_format(out_fmt))) {
         if (opts->force_srate)
             mp_aframe_set_rate(out_fmt, opts->force_srate);


### PR DESCRIPTION
Just bail out immediately (and disable audio) if format probing has no
result, instead of doing nothing and then apparently freezing.

This can happen with bogus filters, cases where the first audio frame is
essentially dropped by filters (can happen with large resampling
factors), and if the audio track contains no packets at all, or all
packets fail to decode.
