### PR TITLE
vo_gpu: fix mobius tone mapping when sig_peak < 1.0

### DIFF
--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -689,6 +689,7 @@ static void pass_tone_map(struct gl_shader_cache *sc, bool detect_peak,
         break;
 
     case TONE_MAPPING_MOBIUS:
+        GLSLF("if (sig_peak > 1.0) {\n");
         GLSLF("const float j = %f;\n", isnan(param) ? 0.3 : param);
         // solve for M(j) = j; M(sig_peak) = 1.0; M'(j) = 1.0
         // where M(x) = scale * (x+a)/(x+b)
@@ -697,6 +698,7 @@ static void pass_tone_map(struct gl_shader_cache *sc, bool detect_peak,
               "max(1e-6, sig_peak - 1.0);\n");
         GLSLF("float scale = (b*b + 2.0*b*j + j*j) / (b-a);\n");
         GLSL(sig = sig > j ? scale * (sig + a) / (sig + b) : sig;)
+        GLSLF("}\n");
         break;
 
     case TONE_MAPPING_REINHARD: {


### PR DESCRIPTION
Mobius isn't well-defined for sig_peak < 1.0. We can solve this by just
soft-clamping sig_peak to 1.0. Although, in this case, we can just skip
tone mapping altogether since the limit mobius as of sig_peak -> 1.0 is
just a linear function.

---------------------------------------------------------------
Found this while testing soft HDR simulation with an actual HDR display. Apart from this bug, the results with `--target-peak` and `--tone-mapping=mobius` match the theory exactly - I get an image that overall looks perceptually the same as SDR, except with an extended dynamic range in both directions.

Still not sure what the big buzz is about. It doesn't really look any better than SDR, and the dynamic backlight shit is just as annoying as all other dynamic contrast methods that they've tried selling us for the past decade or two, but this at least confirms our algorithms are working as intended. But still, maybe an _actual_ HDR display (i.e. static contrast above 1000:1) would be better. Who knows.

cc #5521