### PR TITLE
cocoa-cb: fix fs animation and wrong drawing size

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -114,7 +114,9 @@ class CocoaCB: NSObject {
         layer.setVideo(true)
 
         if self.mpv.getBoolProperty("fullscreen") {
-            window.toggleFullScreen(nil)
+            DispatchQueue.main.async {
+                self.window.toggleFullScreen(nil)
+            }
         } else {
             window.isMovableByWindowBackground = true
         }


### PR DESCRIPTION
fixes two size issues. this makes the fullscreen animation appear a lot smoother, especially with a border.

there are still two other issues, black flicker and a stretched surface on window spect ration change, that need to be fixed. this will be done after #5520 was completed and merged because one fix loosely depends on it.