### PR TITLE
cocoa-cb: use new libmpv API instead of opengl-cb

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -19,6 +19,8 @@ import Cocoa
 import OpenGL.GL
 import OpenGL.GL3
 
+let glDummy: @convention(c) () -> Void = {}
+
 class MPVHelper: NSObject {
 
     var mpvHandle: OpaquePointer?
@@ -72,7 +74,7 @@ class MPVHelper: NSObject {
         let addr = CFBundleGetFunctionPointerForName(indentifier, symbol)
 
         if symbol as String == "glFlush" {
-            return glDummyPtr()
+            return unsafeBitCast(glDummy, to: UnsafeMutableRawPointer.self)
         }
 
         return addr

--- a/osdep/macOS_swift_bridge.h
+++ b/osdep/macOS_swift_bridge.h
@@ -20,7 +20,8 @@
 #import <IOKit/pwr_mgt/IOPMLib.h>
 
 #include "player/client.h"
-#include "libmpv/opengl_cb.h"
+#include "video/out/libmpv.h"
+#include "libmpv/render_gl.h"
 
 #include "player/core.h"
 #include "input/input.h"

--- a/osdep/macOS_swift_bridge.h
+++ b/osdep/macOS_swift_bridge.h
@@ -47,8 +47,3 @@ static int SWIFT_KEY_MOUSE_LEAVE = MP_KEY_MOUSE_LEAVE;
 static int SWIFT_KEY_MOUSE_ENTER = MP_KEY_MOUSE_ENTER;
 static int SWIFT_KEY_STATE_DOWN  = MP_KEY_STATE_DOWN;
 static int SWIFT_KEY_STATE_UP    = MP_KEY_STATE_UP;
-
-// dummy function to override glFlush()
-static void glDummy() {}
-static void *glDummyPtr(void) __attribute__((unused));
-static void *glDummyPtr() { return &glDummy; }

--- a/player/client.c
+++ b/player/client.c
@@ -1836,39 +1836,12 @@ int mpv_opengl_cb_uninit_gl(mpv_opengl_cb_context *ctx)
     return 0;
 }
 
-void mp_client_set_control_callback(struct mpv_opengl_cb_context *ctx,
-                                           mpv_opengl_cb_control_fn callback,
-                                           void *callback_ctx)
-{
-    if (ctx->client_api->render_context) {
-        mp_render_context_set_control_callback(ctx->client_api->render_context,
-                                               callback, callback_ctx);
-    }
-}
-
-void mp_client_set_icc_profile(struct mpv_opengl_cb_context *ctx, bstr icc_data)
-{
-    if (!ctx->client_api->render_context)
-        return;
-    mpv_render_param param = {MPV_RENDER_PARAM_ICC_PROFILE,
-            &(mpv_byte_array){icc_data.start, icc_data.len}};
-    mpv_render_context_set_parameter(ctx->client_api->render_context, param);
-}
-
-void mp_client_set_ambient_lux(struct mpv_opengl_cb_context *ctx, int lux)
-{
-    if (!ctx->client_api->render_context)
-        return;
-    mpv_render_param param = {MPV_RENDER_PARAM_AMBIENT_LIGHT, &(int){lux}};
-    mpv_render_context_set_parameter(ctx->client_api->render_context, param);
-}
-
 int mpv_opengl_cb_render(mpv_opengl_cb_context *ctx, int fbo, int vp[4])
 {
     return mpv_opengl_cb_draw(ctx, fbo, vp[2], vp[3]);
 }
 
-void *mp_get_sub_api2(mpv_handle *ctx, mpv_sub_api sub_api, bool lock)
+void *mpv_get_sub_api(mpv_handle *ctx, mpv_sub_api sub_api)
 {
     if (!ctx->mpctx->initialized)
         return NULL;
@@ -1880,11 +1853,6 @@ void *mp_get_sub_api2(mpv_handle *ctx, mpv_sub_api sub_api, bool lock)
     default:;
     }
     return res;
-}
-
-void *mpv_get_sub_api(mpv_handle *ctx, mpv_sub_api sub_api)
-{
-    return mp_get_sub_api2(ctx, sub_api, true);
 }
 
 // stream_cb

--- a/player/client.h
+++ b/player/client.h
@@ -37,7 +37,6 @@ struct mp_log *mp_client_get_log(struct mpv_handle *ctx);
 struct mpv_global *mp_client_get_global(struct mpv_handle *ctx);
 struct MPContext *mp_client_get_core(struct mpv_handle *ctx);
 struct MPContext *mp_client_api_get_core(struct mp_client_api *api);
-void *mp_get_sub_api2(mpv_handle *ctx, mpv_sub_api sub_api, bool lock);
 
 // m_option.c
 void *node_get_alloc(struct mpv_node *node);
@@ -53,15 +52,5 @@ void kill_video(struct mp_client_api *client_api);
 
 bool mp_streamcb_lookup(struct mpv_global *g, const char *protocol,
                         void **out_user_data, mpv_stream_cb_open_ro_fn *out_fn);
-
-// Legacy.
-typedef int (*mpv_opengl_cb_control_fn)(void *cb_ctx, int *events,
-                                        uint32_t request, void *data);
-struct mpv_opengl_cb_context;
-void mp_client_set_control_callback(struct mpv_opengl_cb_context *ctx,
-                                    mpv_opengl_cb_control_fn callback,
-                                    void *callback_ctx);
-void mp_client_set_icc_profile(struct mpv_opengl_cb_context *ctx, bstr icc_data);
-void mp_client_set_ambient_lux(struct mpv_opengl_cb_context *ctx, int lux);
 
 #endif

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -52,7 +52,7 @@ class EventsView: NSView {
             return
         }
 
-        tracker = NSTrackingArea(rect: self.bounds,
+        tracker = NSTrackingArea(rect: bounds,
             options: [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .enabledDuringMouseDrag],
             owner: self, userInfo: nil)
         addTrackingArea(tracker!)

--- a/video/out/cocoa-cb/video_layer.swift
+++ b/video/out/cocoa-cb/video_layer.swift
@@ -76,10 +76,10 @@ class VideoLayer: CAOpenGLLayer {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setUpGLCB() {
-        self.mpv.initGLCB()
-        self.mpv.setGLCBUpdateCallback(self.updateCallback, context: self)
-        self.mpv.setGLCBControlCallback(self.cocoaCB.controlCallback, context: self.cocoaCB)
+    func setUpRender() {
+        mpv.initRender()
+        mpv.setRenderUpdateCallback(updateCallback, context: self)
+        mpv.setRenderControlCallback(cocoaCB.controlCallback, context: cocoaCB)
     }
 
     override func canDraw(inCGLContext ctx: CGLContextObj,
@@ -114,7 +114,7 @@ class VideoLayer: CAOpenGLLayer {
              }
         }
 
-        mpv.drawGLCB(surfaceSize!)
+        mpv.drawRender(surfaceSize!)
         CGLFlushDrawable(ctx)
         drawLock.unlock()
 
@@ -200,7 +200,7 @@ class VideoLayer: CAOpenGLLayer {
         return ctx
     }
 
-    let updateCallback: mpv_opengl_cb_update_fn = { (ctx) in
+    let updateCallback: mpv_render_update_fn = { (ctx) in
         let layer: VideoLayer = MPVHelper.bridge(ptr: ctx!)
         layer.neededFlips += 1
     }
@@ -218,7 +218,7 @@ class VideoLayer: CAOpenGLLayer {
     }
 
     func reportFlip() {
-        mpv.reportGLCBFlip()
+        mpv.reportRenderFlip()
         videoLock.lock()
         if !isAsynchronous && neededFlips > 0 && hasVideo {
             if !cocoaCB.window.occlusionState.contains(.visible) &&

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -398,7 +398,6 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.layer.neededFlips += 1
 
         if aspectRatioDiff > 0.005 && isNotUserLiveResize {
-            Swift.print("drawUnLock")
             cocoaCB.layer.drawLock.unlock()
         }
 

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -61,7 +61,7 @@ class CocoaCB: NSObject {
 
     func setMpvHandle(_ ctx: OpaquePointer) {
         mpv = MPVHelper(ctx)
-        layer.setUpGLCB()
+        layer.setUpRender()
     }
 
     func preinit() {
@@ -113,7 +113,7 @@ class CocoaCB: NSObject {
         NSApp.activate(ignoringOtherApps: true)
         layer.setVideo(true)
 
-        if self.mpv.getBoolProperty("fullscreen") {
+        if mpv.getBoolProperty("fullscreen") {
             DispatchQueue.main.async {
                 self.window.toggleFullScreen(nil)
             }
@@ -239,7 +239,7 @@ class CocoaCB: NSObject {
 
     func updateICCProfile() {
         if mpv.getBoolProperty("icc-profile-auto") {
-            mpv.setGLCBICCProfile(window.screen!.colorSpace!)
+            mpv.setRenderICCProfile(window.screen!.colorSpace!)
         }
         layer.colorspace = window.screen!.colorSpace!.cgColorSpace!
     }
@@ -273,7 +273,7 @@ class CocoaCB: NSObject {
             var mean = (values[0] + values[1]) / 2
             if ccb.lastLmu != mean {
                 ccb.lastLmu = mean
-                ccb.mpv.setGLCBLux(ccb.lmuToLux(ccb.lastLmu))
+                ccb.mpv.setRenderLux(ccb.lmuToLux(ccb.lastLmu))
             }
         }
     }
@@ -383,7 +383,7 @@ class CocoaCB: NSObject {
         return ev
     }
 
-    var controlCallback: mpv_opengl_cb_control_fn = { ( ctx, events, request, data ) -> Int32 in
+    var controlCallback: mp_render_cb_control_fn = { ( ctx, events, request, data ) -> Int32 in
         let ccb: CocoaCB = MPVHelper.bridge(ptr: ctx!)
 
         switch mp_voctrl(request) {
@@ -466,7 +466,7 @@ class CocoaCB: NSObject {
             stopDisplaylink()
             uninitLightSensor()
             removeDisplayReconfigureObserver()
-            mpv.deinitGLCB()
+            mpv.deinitRender()
             mpv.deinitMPV()
         case MPV_EVENT_PROPERTY_CHANGE:
             if backendState == .init {


### PR DESCRIPTION
did i catch all the legacy stuff with `client: remove legacy API that is unused now`? also should i leave it as a separate commit or merge it with `cocoa-cb: use new libmpv API instead of opengl-cb`?

yeah somehow i failed at rebasing and a `print` made it in one of my merged PRs.