### PR TITLE
input: minor additions to default key bindings

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -58,6 +58,10 @@ Ctrl+LEFT and Ctrl+RIGHT
     Seek to the previous/next subtitle. Subject to some restrictions and
     might not always work; see ``sub-seek`` command.
 
+Ctrl+Shift+Left and Ctrl+Shift+Right
+    Adjust subtitle delay so that the next or previous subtitle is displayed
+    now. This is especially useful to sync subtitles to audio.
+
 [ and ]
     Decrease/increase current playback speed by 10%.
 
@@ -66,6 +70,17 @@ Ctrl+LEFT and Ctrl+RIGHT
 
 BACKSPACE
     Reset playback speed to normal.
+
+Shift+BACKSPACE
+    Undo the last seek. This works only if the playlist entry was not changed.
+    Hitting it a second time will go back to the original position.
+    See ``revert-seek`` command for details.
+
+Shift+Ctrl+BACKSPACE
+    Mark the current position. This will then be used by ``Shift+BACKSPACE``
+    as revert position (once you seek back, the marker will be reset). You can
+    use this to seek around in the file and then return to the exact position
+    where you left off.
 
 < and >
     Go backward/forward in the playlist.
@@ -115,8 +130,9 @@ ESC
 T
     Toggle stay-on-top (see also ``--ontop``).
 
-w and e
-    Decrease/increase pan-and-scan range.
+w and W
+    Decrease/increase pan-and-scan range. The ``e`` key does the same as
+    ``W`` currently, but use is discouraged.
 
 o (also P)
     Show progression bar, elapsed time and total duration on the OSD.
@@ -130,8 +146,9 @@ v
 j and J
     Cycle through the available subtitles.
 
-x and z
-    Adjust subtitle delay by +/- 0.1 seconds.
+z and Z
+    Adjust subtitle delay by +/- 0.1 seconds. The ``x`` key does the same as
+    ``Z`` currently, but use is discouraged.
 
 l
     Set/clear A-B loop points. See ``ab-loop`` command for details.
@@ -151,8 +168,9 @@ V
     Toggle subtitle VSFilter aspect compatibility mode. See
     ``--sub-ass-vsfilter-aspect-compat`` for more info.
 
-r and t
-    Move subtitles up/down.
+r and R
+    Move subtitles up/down. The ``t`` key does the same as ``R`` currently, but
+    use is discouraged.
 
 s
     Take a screenshot.
@@ -182,6 +200,23 @@ A
 
 Ctrl h
     Toggle hardware video decoding on/off.
+
+Alt+LEFT, Alt+RIGHT, Alt+UP, Alt+DOWN
+    Move the video rectangle (panning).
+
+Alt + and Alt -
+    Combining ``Alt`` with the ``+`` or ``-`` keys changes video zoom.
+
+Alt+BACKSPACE
+    Reset the pan/zoom settings.
+
+F9
+    Show the playlist and the current position in it (useful only if a UI window
+    is used, broken on the terminal).
+
+F10
+    Show the list of audio and subtitle streams (useful only if a UI window  is
+    used, broken on the terminal).
 
 (The following keys are valid only when using a video output that supports the
 corresponding adjustment.)

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -54,6 +54,19 @@
 # Skip to previous/next subtitle (subject to some restrictions; see manpage)
 #Ctrl+LEFT   no-osd sub-seek -1
 #Ctrl+RIGHT  no-osd sub-seek  1
+# Adjust timing to previous/next subtitle
+#Ctrl+Shift+LEFT sub-step -1
+#Ctrl+Shift+RIGHT sub-step 1
+# Move video rectangle
+#Alt+left  add video-pan-x  0.1
+#Alt+right add video-pan-x -0.1
+#Alt+up    add video-pan-y  0.1
+#Alt+down  add video-pan-y -0.1
+# Zoom/unzoom video
+#Alt++     add video-zoom   0.1
+#Alt+-     add video-zoom  -0.1
+# Reset video zoom/pan settings
+#Alt+BS set video-zoom 0 ; set video-pan-x 0 ; set video-pan-y 0
 #PGUP add chapter 1                     # skip to next chapter
 #PGDWN add chapter -1                   # skip to previous chapter
 #Shift+PGUP seek 600
@@ -63,6 +76,8 @@
 #{ multiply speed 0.5
 #} multiply speed 2.0
 #BS set speed 1.0                       # reset speed to normal
+#Shift+BS revert-seek                   # undo previous (or marked) seek
+#Shift+Ctrl+BS revert-seek mark         # mark position for revert-seek
 #q quit
 #Q quit-watch-later
 #q {encode} quit 4
@@ -81,7 +96,8 @@
 #i script-binding stats/display-stats
 #I script-binding stats/display-stats-toggle
 #z add sub-delay -0.1                   # subtract 100 ms delay from subs
-#x add sub-delay +0.1                   # add
+#Z add sub-delay +0.1                   # add
+#x add sub-delay +0.1                   # same as previous binding (discouraged)
 #ctrl++ add audio-delay 0.100           # this changes audio/video sync
 #ctrl+- add audio-delay -0.100
 #9 add volume -2
@@ -103,7 +119,8 @@
 # toggle deinterlacer (automatically inserts or removes required filter)
 #d cycle deinterlace
 #r add sub-pos -1                       # move subtitles up
-#t add sub-pos +1                       #                down
+#R add sub-pos +1                       #                down
+#t add sub-pos +1                       # same as previous binding (discouraged)
 #v cycle sub-visibility
 # stretch SSA/ASS subtitles with anamorphic videos to match historical
 #V cycle sub-ass-vsfilter-aspect-compat
@@ -121,7 +138,8 @@
 #Ctrl+s async screenshot window         # ...with subtitles and OSD, and scaled
 #Alt+s screenshot each-frame            # automatically screenshot every frame
 #w add panscan -0.1                     # zoom out with -panscan 0 -fs
-#e add panscan +0.1                     #      in
+#W add panscan +0.1                     #      in
+#e add panscan +0.1                     # same as previous binding (discouraged)
 # cycle video aspect ratios; "-1" is the container aspect
 #A cycle-values video-aspect "16:9" "4:3" "2.35:1" "-1"
 #POWER quit
@@ -144,6 +162,8 @@
 #ctrl+c quit 4
 #DEL script-binding osc/visibility      # cycle OSC display
 #ctrl+h cycle-values hwdec "auto" "no"  # cycle hardware decoding
+#F8 show_text ${playlist}               # show playlist
+#F9 show_text ${track-list}             # show list of audio/sub streams
 
 # Apple Remote section
 #AR_PLAY cycle pause
@@ -174,11 +194,7 @@
 
 # ? add sub-scale +0.1                  # increase subtitle font size
 # ? add sub-scale -0.1                  # decrease subtitle font size
-# ? sub-step -1                         # immediately display next subtitle
-# ? sub-step +1                         #                     previous
 # ? cycle angle                         # switch DVD/Bluray angle
-# ? add balance -0.1                    # adjust audio balance in favor of left
-# ? add balance 0.1                     #                                  right
 # ? cycle sub-forced-only               # toggle DVD forced subs
 # ? cycle program                       # cycle transport stream programs
 # ? stop                                # stop playback (quit or enter idle mode)


### PR DESCRIPTION
This adds key bindings for some semi-popular features. It also tries to
cleanup some old bindings. For example w/e for panscan is now changed to
w/W. In all cases, the old bindings are still kept and work, though.

---

Comments and suggestions welcome. Bikeshed away, I guess.