### PR TITLE
cocoa-cb: fix building with SDK 10.12 and earlier

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -61,7 +61,7 @@ class Window: NSWindow, NSWindowDelegate {
         get { return NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled).size.height }
     }
     var titleButtons: [NSButton] {
-        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindow.ButtonType]).flatMap { standardWindowButton($0) } }
+        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindowButton]).flatMap { standardWindowButton($0) } }
     }
 
     override var canBecomeKey: Bool { return true }


### PR DESCRIPTION
sometimes i have the feeling i am too dumb to code for Apple platforms.

[here](https://developer.apple.com/documentation/appkit/nswindow.buttontype) the doc for this enum. top right corner say no changes to that API (`API Changes: None`) and available since SDK 10.2. so i just assumed it works.