### PR TITLE
cocoa-cb: several size related fixes

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -367,8 +367,8 @@ class Window: NSWindow, NSWindowDelegate {
     func updateFrame(_ rect: NSRect) {
         if rect != frame {
             let cRect = frameRect(forContentRect: rect)
-            setFrame(cRect, display: true)
             unfsContentFrame = rect
+            setFrame(cRect, display: true)
         }
     }
 

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -57,6 +57,7 @@ class CocoaCB: NSObject {
         layer = VideoLayer(cocoaCB: self)
         view.layer = layer
         view.wantsLayer = true
+        view.layerContentsPlacement = .scaleProportionallyToFit
     }
 
     func setMpvHandle(_ ctx: OpaquePointer) {
@@ -133,6 +134,7 @@ class CocoaCB: NSObject {
             if !window.isVisible {
                 window.makeKeyAndOrderFront(nil)
             }
+            layer.atomicDrawingStart()
             window.updateSize(wr.size)
         }
     }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -72,8 +72,6 @@ class CocoaCB: NSObject {
                 self.updateICCProfile()
             }
             startDisplayLink()
-        } else {
-            layer.setVideo(true)
         }
     }
 
@@ -86,6 +84,7 @@ class CocoaCB: NSObject {
         if backendState == .needsInit {
             initBackend()
         } else {
+            layer.setVideo(true)
             updateWindowSize()
             layer.neededFlips += 1
         }
@@ -128,15 +127,13 @@ class CocoaCB: NSObject {
     }
 
     func updateWindowSize() {
-        if layer.hasVideo {
-            let targetScreen = getTargetScreen(forFullscreen: false) ?? NSScreen.main()
-            let wr = getWindowGeometry(forScreen: targetScreen!, videoOut: mpv.mpctx!.pointee.video_out)
-            if !window.isVisible {
-                window.makeKeyAndOrderFront(nil)
-            }
-            layer.atomicDrawingStart()
-            window.updateSize(wr.size)
+        let targetScreen = getTargetScreen(forFullscreen: false) ?? NSScreen.main()
+        let wr = getWindowGeometry(forScreen: targetScreen!, videoOut: mpv.mpctx!.pointee.video_out)
+        if !window.isVisible {
+            window.makeKeyAndOrderFront(nil)
         }
+        layer.atomicDrawingStart()
+        window.updateSize(wr.size)
     }
 
     func setAppIcon() {


### PR DESCRIPTION
why easy if you can do it the complicated way. anyway i could removed quite a lot of special cases now, all the aspect ratio checks. the atomic drawing, which caused some problems is now only ever used when the vo is reconfigured, eg file switch.

this also fixes an issue @avih mentioned on irc when deactivating the fs resize animation still kept the sliding animation visible on videos with an aspect ratio different from the display aspect ratio. the rounded corners are still there till it actually enters fullscreen though.

this also removes the atomic drawing that @sCreami had some problems with on #5520.