### PR TITLE
tv: Recognise v4l2 'JPEG' fourcc

### DIFF
--- a/demux/demux_tv.c
+++ b/demux/demux_tv.c
@@ -85,7 +85,7 @@ static int demux_open_tv(demuxer_t *demuxer, enum demux_check check)
     /* get IMAGE FORMAT */
     int fourcc;
     funcs->control(tvh->priv, TVI_CONTROL_VID_GET_FORMAT, &fourcc);
-    if (fourcc == MP_FOURCC_MJPEG) {
+    if (fourcc == MP_FOURCC_MJPEG || fourcc == MP_FOURCC_JPEG) {
         sh_v->codec->codec = "mjpeg";
     } else {
         sh_v->codec->codec = "rawvideo";

--- a/stream/tv.h
+++ b/stream/tv.h
@@ -280,5 +280,6 @@ extern const struct m_sub_options tv_params_conf;
 #define MP_FOURCC_YUY2  MP_FOURCC('Y', 'U', 'Y', '2')
 
 #define MP_FOURCC_MJPEG MP_FOURCC('M', 'J', 'P', 'G')
+#define MP_FOURCC_JPEG  MP_FOURCC('J', 'P', 'E', 'G')
 
 #endif /* MPLAYER_TV_H */

--- a/stream/tvi_def.h
+++ b/stream/tvi_def.h
@@ -79,6 +79,7 @@ static inline void fill_blank_frame(char* buffer,int len,int fmt){
         }
         break;
     case MP_FOURCC_MJPEG:
+    case MP_FOURCC_JPEG:
         /*
         This is compressed format. I don't know yet how to fill such frame with blue color.
         Keeping frame unchanged.

--- a/stream/tvi_v4l2.c
+++ b/stream/tvi_v4l2.c
@@ -235,7 +235,8 @@ static int fcc_mp2vl(int fcc)
     case MP_FOURCC_YUY2:   return V4L2_PIX_FMT_YUYV;
     case MP_FOURCC_YV12:   return V4L2_PIX_FMT_YVU420;
     case MP_FOURCC_UYVY:   return V4L2_PIX_FMT_UYVY;
-    case MP_FOURCC_MJPEG:   return V4L2_PIX_FMT_MJPEG;
+    case MP_FOURCC_MJPEG:  return V4L2_PIX_FMT_MJPEG;
+    case MP_FOURCC_JPEG:   return V4L2_PIX_FMT_JPEG;
     }
     return fcc;
 }
@@ -259,7 +260,8 @@ static int fcc_vl2mp(int fcc)
     case V4L2_PIX_FMT_YVU420:   return MP_FOURCC_YV12;
     case V4L2_PIX_FMT_YUYV:     return MP_FOURCC_YUY2;
     case V4L2_PIX_FMT_UYVY:     return MP_FOURCC_UYVY;
-    case V4L2_PIX_FMT_MJPEG:     return MP_FOURCC_MJPEG;
+    case V4L2_PIX_FMT_MJPEG:    return MP_FOURCC_MJPEG;
+    case V4L2_PIX_FMT_JPEG:     return MP_FOURCC_JPEG;
     }
     return fcc;
 }
@@ -298,6 +300,7 @@ static const char *pixfmt2name(char *buf, int pixfmt)
     case V4L2_PIX_FMT_HI240:        return "HI240";
     case V4L2_PIX_FMT_WNVA:         return "WNVA";
     case V4L2_PIX_FMT_MJPEG:        return "MJPEG";
+    case V4L2_PIX_FMT_JPEG:         return "JPEG";
     }
     sprintf(buf, "unknown (0x%x)", pixfmt);
     return buf;


### PR DESCRIPTION
Naturally, there's more than one fourcc that indicates an mjpeg
stream.