### PR TITLE
hwdec_drmprime_drm : Fix a DRM buffer memory leakage

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -83,8 +83,6 @@ static void set_current_frame(struct ra_hwdec *hw, struct drm_frame *frame)
     } else {
         memset(&p->current_frame.fb, 0, sizeof(p->current_frame.fb));
         mp_image_setrefp(&p->current_frame.image, NULL);
-        mp_image_setrefp(&p->last_frame.image, NULL);
-        mp_image_setrefp(&p->old_frame.image, NULL);
     }
 }
 
@@ -180,6 +178,9 @@ static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
                 }
             }
         }
+    } else {
+        while (p->old_frame.fb.fb_id)
+          set_current_frame(hw, NULL);
     }
 
     set_current_frame(hw, &next_frame);


### PR DESCRIPTION
We use tripple buffering for this interop and we were only unreffing the
data structures, which doesn't destroy the drm buffers.
This patch allows to make sure that we release the drm buffers on playback
end.

I agree that my changes can be relicensed to LGPL 2.1 or later.
