### PR TITLE
hwdec_surfacetexture for Android/MediaCodec

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4902,6 +4902,26 @@ The following video options are currently all specific to ``--vo=gpu`` and
     set anyway.
     OS X and cocoa-cb only
 
+``--android-surfacetexture-listener-class=(int64_t)(intptr_t)(jclass)io.mpv.NativeOnFrameAvailableListener``
+    Providers a reference to a SurfaceTexture.OnFrameAvailableListener java
+    subclass to the surfacetexture hwdec for help in mapping hardware
+    mediacodec frames to gpu textures.
+
+    To set this option, import the following code into your Java application::
+
+        package io.mpv
+        import android.graphics.SurfaceTexture
+        class NativeOnFrameAvailableListener: SurfaceTexture.OnFrameAvailableListener {
+            var nativePtr = 0L
+            override fun onFrameAvailable(texture: SurfaceTexture?) {
+                nativeOnFrameAvailable(nativePtr)
+            }
+            private external fun nativeOnFrameAvailable(nativePtr: Long)
+        }
+
+    Android with ``--gpu-context=android`` and
+    ``--gpu-hwdec-interop=surfacetexture`` only.
+
 ``--android-surface-size=<WxH>``
     Set dimensions of the rendering surface used by the Android gpu context.
     Needs to be set by the embedding application if the dimensions change during

--- a/misc/jni.c
+++ b/misc/jni.c
@@ -1,0 +1,429 @@
+/*
+ * JNI utility functions
+ *
+ * Copyright (c) 2015-2016 Matthieu Bouron <matthieu.bouron stupeflix.com>
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libavcodec/jni.h>
+#include <libavutil/mem.h>
+#include <libavutil/bprint.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "jni.h"
+
+static JavaVM *java_vm;
+static pthread_key_t current_env;
+static pthread_once_t once = PTHREAD_ONCE_INIT;
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+
+static void jni_detach_env(void *data)
+{
+    if (java_vm) {
+        (*java_vm)->DetachCurrentThread(java_vm);
+    }
+}
+
+static void jni_create_pthread_key(void)
+{
+    pthread_key_create(&current_env, jni_detach_env);
+}
+
+JNIEnv *mp_jni_get_env(struct mp_log *log)
+{
+    int ret = 0;
+    JNIEnv *env = NULL;
+
+    pthread_mutex_lock(&lock);
+    if (java_vm == NULL) {
+        java_vm = av_jni_get_java_vm(NULL);
+    }
+
+    if (!java_vm) {
+        mp_err(log, "No Java virtual machine has been registered\n");
+        goto done;
+    }
+
+    pthread_once(&once, jni_create_pthread_key);
+
+    if ((env = pthread_getspecific(current_env)) != NULL) {
+        goto done;
+    }
+
+    ret = (*java_vm)->GetEnv(java_vm, (void **)&env, JNI_VERSION_1_6);
+    switch(ret) {
+    case JNI_EDETACHED:
+        if ((*java_vm)->AttachCurrentThread(java_vm, &env, NULL) != 0) {
+            mp_err(log, "Failed to attach the JNI environment to the current thread\n");
+            env = NULL;
+        } else {
+            pthread_setspecific(current_env, env);
+        }
+        break;
+    case JNI_OK:
+        break;
+    case JNI_EVERSION:
+        mp_err(log, "The specified JNI version is not supported\n");
+        break;
+    default:
+        mp_err(log, "Failed to get the JNI environment attached to this thread\n");
+        break;
+    }
+
+done:
+    pthread_mutex_unlock(&lock);
+    return env;
+}
+
+char *mp_jni_jstring_to_utf_chars(JNIEnv *env, jstring string, struct mp_log *log)
+{
+    char *ret = NULL;
+    const char *utf_chars = NULL;
+
+    jboolean copy = 0;
+
+    if (!string) {
+        return NULL;
+    }
+
+    utf_chars = (*env)->GetStringUTFChars(env, string, &copy);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "String.getStringUTFChars() threw an exception\n");
+        return NULL;
+    }
+
+    ret = av_strdup(utf_chars);
+
+    (*env)->ReleaseStringUTFChars(env, string, utf_chars);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "String.releaseStringUTFChars() threw an exception\n");
+        return NULL;
+    }
+
+    return ret;
+}
+
+jstring mp_jni_utf_chars_to_jstring(JNIEnv *env, const char *utf_chars, struct mp_log *log)
+{
+    jstring ret;
+
+    ret = (*env)->NewStringUTF(env, utf_chars);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "NewStringUTF() threw an exception\n");
+        return NULL;
+    }
+
+    return ret;
+}
+
+int mp_jni_exception_get_summary(JNIEnv *env, jthrowable exception, char **error, struct mp_log *log)
+{
+    int ret = 0;
+
+    AVBPrint bp;
+
+    char *name = NULL;
+    char *message = NULL;
+
+    jclass class_class = NULL;
+    jmethodID get_name_id = NULL;
+
+    jclass exception_class = NULL;
+    jmethodID get_message_id = NULL;
+
+    jstring string = NULL;
+
+    av_bprint_init(&bp, 0, AV_BPRINT_SIZE_AUTOMATIC);
+
+    exception_class = (*env)->GetObjectClass(env, exception);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Could not find Throwable class\n");
+        ret = -1;
+        goto done;
+    }
+
+    class_class = (*env)->GetObjectClass(env, exception_class);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Could not find Throwable class's class\n");
+        ret = -1;
+        goto done;
+    }
+
+    get_name_id = (*env)->GetMethodID(env, class_class, "getName", "()Ljava/lang/String;");
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Could not find method Class.getName()\n");
+        ret = -1;
+        goto done;
+    }
+
+    string = (*env)->CallObjectMethod(env, exception_class, get_name_id);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Class.getName() threw an exception\n");
+        ret = -1;
+        goto done;
+    }
+
+    if (string) {
+        name = mp_jni_jstring_to_utf_chars(env, string, log);
+        (*env)->DeleteLocalRef(env, string);
+        string = NULL;
+    }
+
+    get_message_id = (*env)->GetMethodID(env, exception_class, "getMessage", "()Ljava/lang/String;");
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Could not find method java/lang/Throwable.getMessage()\n");
+        ret = -1;
+        goto done;
+    }
+
+    string = (*env)->CallObjectMethod(env, exception, get_message_id);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        mp_err(log, "Throwable.getMessage() threw an exception\n");
+        ret = -1;
+        goto done;
+    }
+
+    if (string) {
+        message = mp_jni_jstring_to_utf_chars(env, string, log);
+        (*env)->DeleteLocalRef(env, string);
+        string = NULL;
+    }
+
+    if (name && message) {
+        av_bprintf(&bp, "%s: %s", name, message);
+    } else if (name && !message) {
+        av_bprintf(&bp, "%s occurred", name);
+    } else if (!name && message) {
+        av_bprintf(&bp, "Exception: %s", message);
+    } else {
+        mp_warn(log, "Could not retrieve exception name and message\n");
+        av_bprintf(&bp, "Exception occurred");
+    }
+
+    ret = av_bprint_finalize(&bp, error);
+done:
+
+    av_free(name);
+    av_free(message);
+
+    if (class_class) {
+        (*env)->DeleteLocalRef(env, class_class);
+    }
+
+    if (exception_class) {
+        (*env)->DeleteLocalRef(env, exception_class);
+    }
+
+    if (string) {
+        (*env)->DeleteLocalRef(env, string);
+    }
+
+    return ret;
+}
+
+int mp_jni_exception_check(JNIEnv *env, int logging, struct mp_log *log)
+{
+    int ret;
+
+    jthrowable exception;
+
+    char *message = NULL;
+
+    if (!(*(env))->ExceptionCheck((env))) {
+        return 0;
+    }
+
+    if (!logging) {
+        (*(env))->ExceptionClear((env));
+        return -1;
+    }
+
+    exception = (*env)->ExceptionOccurred(env);
+    (*(env))->ExceptionClear((env));
+
+    if ((ret = mp_jni_exception_get_summary(env, exception, &message, log)) < 0) {
+        (*env)->DeleteLocalRef(env, exception);
+        return ret;
+    }
+
+    (*env)->DeleteLocalRef(env, exception);
+
+    mp_err(log, "%s\n", message);
+    av_free(message);
+
+    return -1;
+}
+
+int mp_jni_init_jfields(JNIEnv *env, void *jfields, const struct MPJniField *jfields_mapping, int global, struct mp_log *log)
+{
+    int i, ret = 0;
+    jclass last_clazz = NULL;
+
+    for (i = 0; jfields_mapping[i].name; i++) {
+        int mandatory = jfields_mapping[i].mandatory;
+        enum MPJniFieldType type = jfields_mapping[i].type;
+
+        if (type == MP_JNI_CLASS) {
+            jclass clazz;
+
+            last_clazz = NULL;
+
+            clazz = (*env)->FindClass(env, jfields_mapping[i].name);
+            if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                goto done;
+            }
+
+            last_clazz = *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset) =
+                    global ? (*env)->NewGlobalRef(env, clazz) : clazz;
+
+            if (global) {
+                (*env)->DeleteLocalRef(env, clazz);
+            }
+
+        } else {
+
+            if (!last_clazz) {
+                ret = -1;
+                break;
+            }
+
+            switch(type) {
+            case MP_JNI_FIELD: {
+                jfieldID field_id = (*env)->GetFieldID(env, last_clazz, jfields_mapping[i].method, jfields_mapping[i].signature);
+                if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                    goto done;
+                }
+
+                *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = field_id;
+                break;
+            }
+            case MP_JNI_STATIC_FIELD_AS_INT:
+            case MP_JNI_STATIC_FIELD: {
+                jfieldID field_id = (*env)->GetStaticFieldID(env, last_clazz, jfields_mapping[i].method, jfields_mapping[i].signature);
+                if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                    goto done;
+                }
+
+                if (type == MP_JNI_STATIC_FIELD_AS_INT) {
+                    if (field_id) {
+                        jint value = (*env)->GetStaticIntField(env, last_clazz, field_id);
+                        if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                            goto done;
+                        }
+                        *(jint*)((uint8_t*)jfields + jfields_mapping[i].offset) = value;
+                    }
+                } else {
+                    *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = field_id;
+                }
+                break;
+            }
+            case MP_JNI_METHOD: {
+                jmethodID method_id = (*env)->GetMethodID(env, last_clazz, jfields_mapping[i].method, jfields_mapping[i].signature);
+                if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                    goto done;
+                }
+
+                *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = method_id;
+                break;
+            }
+            case MP_JNI_STATIC_METHOD: {
+                jmethodID method_id = (*env)->GetStaticMethodID(env, last_clazz, jfields_mapping[i].method, jfields_mapping[i].signature);
+                if ((ret = mp_jni_exception_check(env, mandatory, log)) < 0 && mandatory) {
+                    goto done;
+                }
+
+                *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = method_id;
+                break;
+            }
+            default:
+                mp_err(log, "Unknown JNI field type\n");
+                ret = -1;
+                goto done;
+            }
+
+            ret = 0;
+        }
+    }
+
+done:
+    if (ret < 0) {
+        /* reset jfields in case of failure so it does not leak references */
+        mp_jni_reset_jfields(env, jfields, jfields_mapping, global, log);
+    }
+
+    return ret;
+}
+
+int mp_jni_reset_jfields(JNIEnv *env, void *jfields, const struct MPJniField *jfields_mapping, int global, struct mp_log *log)
+{
+    int i;
+
+    for (i = 0; jfields_mapping[i].name; i++) {
+        enum MPJniFieldType type = jfields_mapping[i].type;
+
+        switch(type) {
+        case MP_JNI_CLASS: {
+            jclass clazz = *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset);
+            if (!clazz)
+                continue;
+
+            if (global) {
+                (*env)->DeleteGlobalRef(env, clazz);
+            } else {
+                (*env)->DeleteLocalRef(env, clazz);
+            }
+
+            *(jclass*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            break;
+        }
+        case MP_JNI_FIELD: {
+            *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            break;
+        }
+        case MP_JNI_STATIC_FIELD: {
+            *(jfieldID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            break;
+        }
+        case MP_JNI_STATIC_FIELD_AS_INT: {
+            *(jint*)((uint8_t*)jfields + jfields_mapping[i].offset) = 0;
+            break;
+        }
+        case MP_JNI_METHOD: {
+            *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            break;
+        }
+        case MP_JNI_STATIC_METHOD: {
+            *(jmethodID*)((uint8_t*)jfields + jfields_mapping[i].offset) = NULL;
+            break;
+        }
+        default:
+            mp_err(log, "Unknown JNI field type\n");
+        }
+    }
+
+    return 0;
+}

--- a/misc/jni.h
+++ b/misc/jni.h
@@ -1,0 +1,157 @@
+/*
+ * JNI utility functions
+ *
+ * Copyright (c) 2015-2016 Matthieu Bouron <matthieu.bouron stupeflix.com>
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MP_JNI_H
+#define MP_JNI_H
+
+#include <jni.h>
+#include "common/msg.h"
+
+/* Convenience macros */
+#define MP_JNI_GET_ENV(obj) mp_jni_get_env((obj)->log)
+#define MP_JNI_EXCEPTION_CHECK() mp_jni_exception_check(env, 0, NULL)
+#define MP_JNI_EXCEPTION_LOG(obj) mp_jni_exception_check(env, 1, (obj)->log)
+#define MP_JNI_DO(what, obj, method, ...) (*env)->what(env, obj, method, ##__VA_ARGS__)
+#define MP_JNI_NEW(clazz, method, ...) MP_JNI_DO(NewObject, clazz, method, ##__VA_ARGS__)
+#define MP_JNI_CALL_INT(obj, method, ...) MP_JNI_DO(CallIntMethod, obj, method, ##__VA_ARGS__)
+#define MP_JNI_CALL_BOOL(obj, method, ...) MP_JNI_DO(CallBooleanMethod, obj, method, ##__VA_ARGS__)
+#define MP_JNI_CALL_VOID(obj, method, ...) MP_JNI_DO(CallVoidMethod, obj, method, ##__VA_ARGS__)
+#define MP_JNI_CALL_STATIC_INT(clazz, method, ...) MP_JNI_DO(CallStaticIntMethod, clazz, method, ##__VA_ARGS__)
+
+/*
+ * Attach permanently a JNI environment to the current thread and retrieve it.
+ *
+ * If successfully attached, the JNI environment will automatically be detached
+ * at thread destruction.
+ *
+ * @param attached pointer to an integer that will be set to 1 if the
+ * environment has been attached to the current thread or 0 if it is
+ * already attached.
+ * @param log context used for logging
+ * @return the JNI environment on success, NULL otherwise
+ */
+JNIEnv *mp_jni_get_env(struct mp_log *log);
+
+/*
+ * Convert a jstring to its utf characters equivalent.
+ *
+ * @param env JNI environment
+ * @param string Java string to convert
+ * @param log context used for logging
+ * @return a pointer to an array of unicode characters on success, NULL
+ * otherwise
+ */
+char *mp_jni_jstring_to_utf_chars(JNIEnv *env, jstring string, struct mp_log *log);
+
+/*
+ * Convert utf chars to its jstring equivalent.
+ *
+ * @param env JNI environment
+ * @param utf_chars a pointer to an array of unicode characters
+ * @param log context used for logging
+ * @return a Java string object on success, NULL otherwise
+ */
+jstring mp_jni_utf_chars_to_jstring(JNIEnv *env, const char *utf_chars, struct mp_log *log);
+
+/*
+ * Extract the error summary from a jthrowable in the form of "className: errorMessage"
+ *
+ * @param env JNI environment
+ * @param exception exception to get the summary from
+ * @param error address pointing to the error, the value is updated if a
+ * summary can be extracted
+ * @param log context used for logging
+ * @return 0 on success, < 0 otherwise
+ */
+int mp_jni_exception_get_summary(JNIEnv *env, jthrowable exception, char **error, struct mp_log *log);
+
+/*
+ * Check if an exception has occurred,log it using av_log and clear it.
+ *
+ * @param env JNI environment
+ * @param value used to enable logging if an exception has occurred,
+ * 0 disables logging, != 0 enables logging
+ * @param log context used for logging
+ */
+int mp_jni_exception_check(JNIEnv *env, int logging, struct mp_log *log);
+
+/*
+ * Jni field type.
+ */
+enum MPJniFieldType {
+
+    MP_JNI_CLASS,
+    MP_JNI_FIELD,
+    MP_JNI_STATIC_FIELD,
+    MP_JNI_STATIC_FIELD_AS_INT,
+    MP_JNI_METHOD,
+    MP_JNI_STATIC_METHOD
+
+};
+
+/*
+ * Jni field describing a class, a field or a method to be retrieved using
+ * the mp_jni_init_jfields method.
+ */
+struct MPJniField {
+
+    const char *name;
+    const char *method;
+    const char *signature;
+    enum MPJniFieldType type;
+    int offset;
+    int mandatory;
+
+};
+
+/*
+ * Retrieve class references, field ids and method ids to an arbitrary structure.
+ *
+ * @param env JNI environment
+ * @param jfields a pointer to an arbitrary structure where the different
+ * fields are declared and where the MPJNIField mapping table offsets are
+ * pointing to
+ * @param jfields_mapping null terminated array of MPJNIFields describing
+ * the class/field/method to be retrieved
+ * @param global make the classes references global. It is the caller
+ * responsibility to properly release global references.
+ * @param log_ctx context used for logging, can be NULL
+ * @return 0 on success, < 0 otherwise
+ */
+int mp_jni_init_jfields(JNIEnv *env, void *jfields, const struct MPJniField *jfields_mapping, int global, struct mp_log *log);
+
+/*
+ * Delete class references, field ids and method ids of an arbitrary structure.
+ *
+ * @param env JNI environment
+ * @param jfields a pointer to an arbitrary structure where the different
+ * fields are declared and where the MPJNIField mapping table offsets are
+ * pointing to
+ * @param jfields_mapping null terminated array of MPJNIFields describing
+ * the class/field/method to be deleted
+ * @param global treat the classes references as global and delete them
+ * accordingly
+ * @param log_ctx context used for logging, can be NULL
+ * @return 0 on success, < 0 otherwise
+ */
+int mp_jni_reset_jfields(JNIEnv *env, void *jfields, const struct MPJniField *jfields_mapping, int global, struct mp_log *log);
+
+#endif

--- a/video/img_format.c
+++ b/video/img_format.c
@@ -318,6 +318,9 @@ enum mp_csp mp_imgfmt_get_forced_csp(int imgfmt)
     if (pixdesc && strncmp(pixdesc->name, "xyz", 3) == 0)
         return MP_CSP_XYZ;
 
+    if (imgfmt == IMGFMT_ADRENO)
+        return MP_CSP_AUTO;
+
     if (pixdesc && (pixdesc->flags & AV_PIX_FMT_FLAG_RGB))
         return MP_CSP_RGB;
 

--- a/video/img_format.h
+++ b/video/img_format.h
@@ -202,6 +202,7 @@ enum mp_imgfmt {
     IMGFMT_MEDIACODEC,      // AVMediaCodecBuffer
     IMGFMT_DRMPRIME,        // AVDRMFrameDescriptor
     IMGFMT_CUDA,            // CUDA Buffer
+    IMGFMT_ADRENO,          // Adreno GL_TEXTURE_EXTERNAL_OES
 
     // Generic pass-through of AV_PIX_FMT_*. Used for formats which don't have
     // a corresponding IMGFMT_ value.

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -166,6 +166,7 @@ struct ra_hwdec_mapper *ra_hwdec_mapper_create(struct ra_hwdec *hwdec,
         .priv = talloc_zero_size(mapper, hwdec->driver->mapper->priv_size),
         .src_params = *params,
         .dst_params = *params,
+        .transform = identity_trans,
     };
     if (mapper->driver->init(mapper) < 0)
         ra_hwdec_mapper_free(&mapper);

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -28,6 +28,7 @@
 extern const struct ra_hwdec_driver ra_hwdec_vaegl;
 extern const struct ra_hwdec_driver ra_hwdec_vaglx;
 extern const struct ra_hwdec_driver ra_hwdec_videotoolbox;
+extern const struct ra_hwdec_driver ra_hwdec_surfacetexture;
 extern const struct ra_hwdec_driver ra_hwdec_vdpau;
 extern const struct ra_hwdec_driver ra_hwdec_dxva2egl;
 extern const struct ra_hwdec_driver ra_hwdec_d3d11egl;
@@ -77,6 +78,9 @@ const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
 #endif
 #if HAVE_DRMPRIME && HAVE_DRM
     &ra_hwdec_drmprime_drm,
+#endif
+#if HAVE_ANDROID
+    &ra_hwdec_surfacetexture,
 #endif
 
     NULL

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -4,6 +4,7 @@
 #include "video/mp_image.h"
 #include "ra.h"
 #include "video/hwdec.h"
+#include "video/out/gpu/utils.h"
 
 struct ra_hwdec {
     const struct ra_hwdec_driver *driver;
@@ -44,6 +45,7 @@ struct ra_hwdec_mapper {
     // .init() callback.
     struct ra_tex *tex[4];
     bool vdpau_fields;
+    struct gl_transform transform;
 };
 
 // This can be used to map frames of a specific hw format as GL textures.

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -119,6 +119,7 @@ struct ra_tex_params {
     bool non_normalized;    // hack for GL_TEXTURE_RECTANGLE OSX idiocy
                             // always set to false, except in OSX code
     bool external_oes;      // hack for GL_TEXTURE_EXTERNAL_OES idiocy
+    bool external_oes_2d;   // more android-specific idiocy
     // If non-NULL, the texture will be created with these contents. Using
     // this does *not* require setting host_mutable. Otherwise, the initial
     // data is undefined.

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -70,6 +70,7 @@ struct texplane {
     struct ra_tex *tex;
     int w, h;
     bool flipped;
+    struct gl_transform transform;
 };
 
 struct video_image {
@@ -760,6 +761,10 @@ static void pass_get_images(struct gl_video *p, struct video_image *vimg,
 
         get_transform(t->w, t->h, p->image_params.rotate, t->flipped,
                       &img[n].transform);
+
+        if (!gl_transform_eq(t->transform, identity_trans))
+            gl_transform_trans(t->transform, &img[n].transform);
+
         if (p->image_params.rotate % 180 == 90)
             MPSWAP(int, img[n].w, img[n].h);
 
@@ -882,6 +887,7 @@ static void init_video(struct gl_video *p)
 
             plane->w = mp_image_plane_w(&layout, n);
             plane->h = mp_image_plane_h(&layout, n);
+            plane->transform = identity_trans;
 
             struct ra_tex_params params = {
                 .dimensions = 2,
@@ -3388,6 +3394,7 @@ static bool pass_upload_image(struct gl_video *p, struct mp_image *mpi, uint64_t
                     .w = mp_image_plane_w(&layout, n),
                     .h = mp_image_plane_h(&layout, n),
                     .tex = tex[n],
+                    .transform = p->hwdec_mapper->transform,
                 };
             }
         } else {

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1297,6 +1297,9 @@ static void copy_image(struct gl_video *p, int *offset, struct image img)
         img.multiplier *= 1.0 / (tex_max - 1);
     }
 
+    if (img.tex->params.external_oes_2d)
+        GLSLHF("#define texture texture2D\n");
+
     GLSLF("color.%s = %f * vec4(texture(texture%d, texcoord%d)).%s;\n",
           dst, img.multiplier, id, id, src);
 

--- a/video/out/opengl/context_android.c
+++ b/video/out/opengl/context_android.c
@@ -25,15 +25,13 @@
 #include "common/common.h"
 #include "options/m_config.h"
 #include "context.h"
-
-struct android_opts {
-    struct m_geometry surface_size;
-};
+#include "context_android.h"
 
 #define OPT_BASE_STRUCT struct android_opts
 const struct m_sub_options android_conf = {
     .opts = (const struct m_option[]) {
         OPT_SIZE_BOX("android-surface-size", surface_size, UPDATE_VO_RESIZE),
+        OPT_INT64("android-surfacetexture-listener-class", listener_class, 0),
         {0}
     },
     .size = sizeof(struct android_opts),

--- a/video/out/opengl/context_android.h
+++ b/video/out/opengl/context_android.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef MP_CONTEXT_ANDROID_H
+#define MP_CONTEXT_ANDROID_H
+
+#include "options/m_option.h"
+
+struct android_opts {
+    struct m_geometry surface_size;
+    int64_t listener_class;
+};
+
+#endif

--- a/video/out/opengl/hwdec_surfacetexture.c
+++ b/video/out/opengl/hwdec_surfacetexture.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2018 Aman Gupta <aman@tmm1.net>
+ *
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+
+#include <libavcodec/jni.h>
+#include <libavcodec/mediacodec.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_mediacodec.h>
+#include <pthread.h>
+
+#include "config.h"
+#include "context_android.h"
+#include "common/global.h"
+#include "misc/jni.h"
+#include "options/m_config.h"
+#include "osdep/timer.h"
+#include "video/out/gpu/hwdec.h"
+#include "video/mp_image_pool.h"
+#include "ra_gl.h"
+
+extern const struct m_sub_options android_conf;
+
+struct priv_owner {
+    struct mp_hwdec_ctx hwctx;
+    jobject surface;
+    jobject texture;
+    GLuint gl_texture;
+};
+
+struct priv {
+    struct mp_log *log;
+    const struct ra_format *tex_format;
+
+    jfloatArray matrix;
+    jfloat transform[16];
+
+    jclass listener_class;
+    jobject listener;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    int on_frame_available;
+};
+
+struct JNISurfaceTexture {
+    jclass clazz;
+    jmethodID ctor;
+    jmethodID release;
+    jmethodID attachToGLContext;
+    jmethodID detachFromGLContext;
+    jmethodID updateTexImage;
+    jmethodID releaseTexImage;
+    jmethodID getTransformMatrix;
+    jmethodID setOnFrameAvailableListener;
+    struct MPJniField mapping[];
+} SurfaceTexture = {.mapping = {
+    #define OFFSET(member) offsetof(struct JNISurfaceTexture, member)
+    {"android/graphics/SurfaceTexture", NULL, NULL, MP_JNI_CLASS, OFFSET(clazz), 1},
+    {"android/graphics/SurfaceTexture", "<init>", "(I)V", MP_JNI_METHOD, OFFSET(ctor), 1},
+    {"android/graphics/SurfaceTexture", "release", "()V", MP_JNI_METHOD, OFFSET(release), 1},
+    {"android/graphics/SurfaceTexture", "attachToGLContext", "(I)V", MP_JNI_METHOD, OFFSET(attachToGLContext), 1},
+    {"android/graphics/SurfaceTexture", "detachFromGLContext", "()V", MP_JNI_METHOD, OFFSET(detachFromGLContext), 1},
+    {"android/graphics/SurfaceTexture", "updateTexImage", "()V", MP_JNI_METHOD, OFFSET(updateTexImage), 1},
+    {"android/graphics/SurfaceTexture", "releaseTexImage", "()V", MP_JNI_METHOD, OFFSET(releaseTexImage), 1},
+    {"android/graphics/SurfaceTexture", "getTransformMatrix", "([F)V", MP_JNI_METHOD, OFFSET(getTransformMatrix), 1},
+    {"android/graphics/SurfaceTexture", "setOnFrameAvailableListener", "(Landroid/graphics/SurfaceTexture$OnFrameAvailableListener;)V", MP_JNI_METHOD, OFFSET(setOnFrameAvailableListener), 1},
+    {0}
+    #undef OFFSET
+}};
+
+struct JNISurface {
+    jclass clazz;
+    jmethodID ctor;
+    jmethodID release;
+    struct MPJniField mapping[];
+} Surface = {.mapping = {
+    #define OFFSET(member) offsetof(struct JNISurface, member)
+    {"android/view/Surface", NULL, NULL, MP_JNI_CLASS, OFFSET(clazz), 1},
+    {"android/view/Surface", "<init>", "(Landroid/graphics/SurfaceTexture;)V", MP_JNI_METHOD, OFFSET(ctor), 1},
+    {"android/view/Surface", "release", "()V", MP_JNI_METHOD, OFFSET(release), 1},
+    {0}
+    #undef OFFSET
+}};
+
+static void uninit_jni(struct ra_hwdec *hw)
+{
+    JNIEnv *env = MP_JNI_GET_ENV(hw);
+    mp_jni_reset_jfields(env, &Surface, Surface.mapping, 1, hw->log);
+    mp_jni_reset_jfields(env, &SurfaceTexture, SurfaceTexture.mapping, 1, hw->log);
+}
+
+static int init_jni(struct ra_hwdec *hw)
+{
+    JNIEnv *env = MP_JNI_GET_ENV(hw);
+    if (mp_jni_init_jfields(env, &Surface, Surface.mapping, 1, hw->log) < 0 ||
+        mp_jni_init_jfields(env, &SurfaceTexture, SurfaceTexture.mapping, 1, hw->log) < 0) {
+            uninit_jni(hw);
+            return -1;
+    }
+
+    return 0;
+}
+
+static AVBufferRef *create_mediacodec_device_ref(jobject surface)
+{
+    AVBufferRef *device_ref = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_MEDIACODEC);
+    if (!device_ref)
+        return NULL;
+
+    AVHWDeviceContext *ctx = (void *)device_ref->data;
+    AVMediaCodecDeviceContext *hwctx = ctx->hwctx;
+    hwctx->surface = surface;
+
+    if (av_hwdevice_ctx_init(device_ref) < 0)
+        av_buffer_unref(&device_ref);
+
+    return device_ref;
+}
+
+static int init(struct ra_hwdec *hw)
+{
+    struct priv_owner *p = hw->priv;
+    GL *gl = ra_gl_get(hw->ra);
+    if (gl->es == 0) {
+        MP_ERR(hw, "GLES required. Try --opengl-es=yes\n");
+        return -1;
+    }
+
+    static const char *es2_exts[] = {"GL_OES_EGL_image_external", 0};
+    static const char *es3_exts[] = {"GL_OES_EGL_image_external_essl3", 0};
+    if (strstr(gl->extensions, es3_exts[0]))
+        hw->glsl_extensions = es3_exts;
+    else
+        hw->glsl_extensions = es2_exts;
+
+    if (init_jni(hw) < 0)
+        return -1;
+
+    gl->GenTextures(1, &p->gl_texture);
+    gl->BindTexture(GL_TEXTURE_EXTERNAL_OES, p->gl_texture);
+    gl->TexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl->TexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    gl->TexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl->TexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl->BindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
+
+    JNIEnv *env = MP_JNI_GET_ENV(hw);
+    jobject texture = MP_JNI_NEW(SurfaceTexture.clazz, SurfaceTexture.ctor, p->gl_texture);
+    if (!texture || MP_JNI_EXCEPTION_LOG(hw) < 0) {
+        MP_ERR(hw, "SurfaceTexture Init failed\n");
+        return -1;
+    }
+    p->texture = (*env)->NewGlobalRef(env, texture);
+    (*env)->DeleteLocalRef(env, texture);
+
+    jobject surface = MP_JNI_NEW(Surface.clazz, Surface.ctor, p->texture);
+    if (!surface || MP_JNI_EXCEPTION_LOG(hw) < 0) {
+        MP_ERR(hw, "Surface Init failed\n");
+        (*env)->DeleteGlobalRef(env, p->texture);
+        return -1;
+    }
+    p->surface = (*env)->NewGlobalRef(env, surface);
+    (*env)->DeleteLocalRef(env, surface);
+
+    p->hwctx = (struct mp_hwdec_ctx){
+        .driver_name = hw->driver->name,
+        .av_device_ref = create_mediacodec_device_ref(p->surface),
+    };
+    hwdec_devices_add(hw->devs, &p->hwctx);
+
+    return 0;
+}
+
+static void uninit(struct ra_hwdec *hw)
+{
+    struct priv_owner *p = hw->priv;
+    JNIEnv *env = MP_JNI_GET_ENV(hw);
+
+    if (p->gl_texture) {
+        GL *gl = ra_gl_get(hw->ra);
+        MP_JNI_CALL_VOID(p->texture, SurfaceTexture.detachFromGLContext);
+        MP_JNI_EXCEPTION_LOG(hw);
+        gl->DeleteTextures(1, &p->gl_texture);
+    }
+
+    if (p->texture) {
+        MP_JNI_CALL_VOID(p->texture, SurfaceTexture.release);
+        MP_JNI_EXCEPTION_LOG(hw);
+        (*env)->DeleteGlobalRef(env, p->texture);
+        p->texture = NULL;
+    }
+
+    if (p->surface) {
+        MP_JNI_CALL_VOID(p->surface, Surface.release);
+        MP_JNI_EXCEPTION_LOG(hw);
+        (*env)->DeleteGlobalRef(env, p->surface);
+        p->surface = NULL;
+    }
+
+    hwdec_devices_remove(hw->devs, &p->hwctx);
+    av_buffer_unref(&p->hwctx.av_device_ref);
+}
+
+static void native_on_frame_available(JNIEnv *env, jobject object, jlong native_ptr)
+{
+    struct priv *p = (struct priv *)(intptr_t)native_ptr;
+    if (!p)
+        return;
+
+    pthread_mutex_lock(&p->lock);
+    p->on_frame_available = 1;
+    pthread_cond_signal(&p->cond);
+    pthread_mutex_unlock(&p->lock);
+}
+
+static jclass surface_listener_new(struct ra_hwdec_mapper *mapper, jclass listener_class, void *ctx)
+{
+    jobject listener = NULL;
+    JNIEnv *env = MP_JNI_GET_ENV(mapper);
+    if (!env)
+        return NULL;
+
+    static const JNINativeMethod methods[] = {
+        {"nativeOnFrameAvailable", "(J)V", (void *)&native_on_frame_available},
+    };
+    (*env)->RegisterNatives(env, listener_class, methods, 1);
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0)
+        goto done;
+
+    jmethodID init_id = (*env)->GetMethodID(env, listener_class, "<init>", "()V");
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0)
+        goto done;
+
+    jmethodID set_native_ptr_id = (*env)->GetMethodID(env, listener_class, "setNativePtr", "(J)V");
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0)
+        goto done;
+
+    listener = (*env)->NewObject(env, listener_class, init_id);
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0)
+        goto done;
+
+    (*env)->CallVoidMethod(env, listener, set_native_ptr_id, (jlong)(intptr_t)ctx);
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0)
+        goto done;
+
+done:
+    return listener;
+}
+
+static int mapper_init(struct ra_hwdec_mapper *mapper)
+{
+    struct priv *p = mapper->priv;
+    struct priv_owner *o = mapper->owner->priv;
+    GL *gl = ra_gl_get(mapper->ra);
+    JNIEnv *env = MP_JNI_GET_ENV(mapper);
+
+    p->log = mapper->log;
+    pthread_mutex_init(&p->lock, NULL);
+    pthread_cond_init(&p->cond, NULL);
+
+    void *tmp = talloc_new(NULL);
+    struct android_opts *opts = mp_get_config_group(tmp, mapper->owner->global, &android_conf);
+    p->listener_class = (jclass)(intptr_t)opts->listener_class;
+    talloc_free(tmp);
+
+    if (!p->listener_class) {
+        MP_ERR(mapper, "SurfaceTexture mapping may not work reliably without a Java Surface.OnFrameAvailableListener.\n");
+        MP_ERR(mapper, "Import the following class into your application and set `--android-surfacetexture-listener-class=(int64_t)(intptr_t)NewGlobalRef((jclass)io.mpv.NativeOnFrameAvailableListener)`:\n");
+        MP_ERR(mapper, "    package io.mpv\n");
+        MP_ERR(mapper, "    import android.graphics.SurfaceTexture\n");
+        MP_ERR(mapper, "    class NativeOnFrameAvailableListener: SurfaceTexture.OnFrameAvailableListener {\n");
+        MP_ERR(mapper, "        var nativePtr = 0L\n");
+        MP_ERR(mapper, "        override fun onFrameAvailable(texture: SurfaceTexture?) {\n");
+        MP_ERR(mapper, "            nativeOnFrameAvailable(nativePtr)\n");
+        MP_ERR(mapper, "        }\n");
+        MP_ERR(mapper, "        private external fun nativeOnFrameAvailable(nativePtr: Long)\n");
+        MP_ERR(mapper, "    }\n");
+    } else {
+        jobject listener = surface_listener_new(mapper, p->listener_class, p);
+        if (!listener) {
+            MP_FATAL(mapper, "NativeOnFrameAvailableListener could not be created from `--android-surfacetexture-listener-class=(jclass)%p`.\n", p->listener_class);
+            return -1;
+        }
+        p->listener = (*env)->NewGlobalRef(env, listener);
+        (*env)->DeleteLocalRef(env, listener);
+
+        MP_JNI_CALL_VOID(o->texture, SurfaceTexture.setOnFrameAvailableListener, p->listener);
+        if (MP_JNI_EXCEPTION_LOG(mapper) < 0) return -1;
+    }
+
+    jfloatArray matrix = (*env)->NewFloatArray(env, 16);
+    if (MP_JNI_EXCEPTION_LOG(mapper) < 0) return -1;
+    p->matrix = (*env)->NewGlobalRef(env, matrix);
+    (*env)->DeleteLocalRef(env, matrix);
+
+    mapper->dst_params = mapper->src_params;
+    mapper->dst_params.imgfmt = IMGFMT_RGB0;
+    mapper->dst_params.hw_subfmt = 0;
+
+    p->tex_format = ra_find_unorm_format(mapper->ra, 1, 4);
+
+    return 0;
+}
+
+static void mapper_uninit(struct ra_hwdec_mapper *mapper)
+{
+    struct priv *p = mapper->priv;
+    struct priv_owner *o = mapper->owner->priv;
+    JNIEnv *env = MP_JNI_GET_ENV(mapper);
+
+    if (p->listener) {
+        jmethodID set_native_ptr_id = (*env)->GetMethodID(env, p->listener_class, "setNativePtr", "(J)V");
+        MP_JNI_EXCEPTION_LOG(mapper);
+        (*env)->CallVoidMethod(env, p->listener, set_native_ptr_id, (jlong)0);
+        MP_JNI_EXCEPTION_LOG(mapper);
+
+        MP_JNI_CALL_VOID(o->texture, SurfaceTexture.setOnFrameAvailableListener, NULL);
+        MP_JNI_EXCEPTION_LOG(mapper);
+
+        (*env)->DeleteGlobalRef(env, p->listener);
+        p->listener = NULL;
+    }
+
+    (*env)->DeleteGlobalRef(env, p->matrix);
+
+    pthread_mutex_destroy(&p->lock);
+    pthread_cond_destroy(&p->cond);
+}
+
+static void mapper_unmap(struct ra_hwdec_mapper *mapper)
+{
+    ra_tex_free(mapper->ra, &mapper->tex[0]);
+}
+
+static int mapper_map(struct ra_hwdec_mapper *mapper)
+{
+    struct priv *p = mapper->priv;
+    struct priv_owner *o = mapper->owner->priv;
+    JNIEnv *env = MP_JNI_GET_ENV(mapper);
+
+    if (!o->gl_texture)
+        return -1;
+
+    AVMediaCodecBuffer *buffer = (AVMediaCodecBuffer *)mapper->src->planes[3];
+    int frame_available = 0;
+
+    pthread_mutex_lock(&p->lock);
+    p->on_frame_available = 0;
+    av_mediacodec_release_buffer(buffer, 1);
+    if (p->listener) {
+        struct timespec ts = mp_rel_time_to_timespec(0.030);
+        int ret = pthread_cond_timedwait(&p->cond, &p->lock, &ts);
+        if (ret < 0)
+            MP_WARN(mapper, "Failed to wait on signal: %s\n", mp_strerror(ret));
+        frame_available = p->on_frame_available;
+    } else {
+        frame_available = 1;
+    }
+    pthread_mutex_unlock(&p->lock);
+
+    if (!frame_available)
+        MP_WARN(mapper, "no frame!\n");
+
+    MP_JNI_CALL_VOID(o->texture, SurfaceTexture.updateTexImage);
+    if (MP_JNI_EXCEPTION_LOG(mapper->owner)) return -1;
+
+    MP_JNI_CALL_VOID(o->texture, SurfaceTexture.getTransformMatrix, p->matrix);
+    if (MP_JNI_EXCEPTION_LOG(mapper->owner)) return -1;
+
+    (*env)->GetFloatArrayRegion(env, p->matrix, 0, 16, p->transform);
+    if (MP_JNI_EXCEPTION_LOG(mapper->owner)) return -1;
+
+    mapper->transform = (struct gl_transform){
+        .m = {{p->transform[0],  p->transform[1]},
+              {p->transform[4], -p->transform[5]}},
+        .t = {1.0 - p->transform[13], p->transform[14]}
+    };
+
+    struct ra_tex_params params = {
+        .dimensions = 2,
+        .w = mapper->src_params.w,
+        .h = mapper->src_params.h,
+        .d = 1,
+        .format = p->tex_format,
+        .render_src = true,
+        .src_linear = true,
+        .external_oes = true,
+    };
+    if (!params.format)
+        return -1;
+
+    mapper->tex[0] = ra_create_wrapped_tex(mapper->ra, &params, o->gl_texture);
+    if (!mapper->tex[0])
+        return -1;
+
+    return 0;
+}
+
+const struct ra_hwdec_driver ra_hwdec_surfacetexture = {
+    .name = "surfacetexture",
+    .priv_size = sizeof(struct priv_owner),
+    .imgfmts = {IMGFMT_MEDIACODEC, 0},
+    .init = init,
+    .uninit = uninit,
+    .mapper = &(const struct ra_hwdec_mapper_driver){
+        .priv_size = sizeof(struct priv),
+        .init = mapper_init,
+        .uninit = mapper_uninit,
+        .map = mapper_map,
+        .unmap = mapper_unmap,
+    },
+};

--- a/video/out/opengl/hwdec_surfacetexture.c
+++ b/video/out/opengl/hwdec_surfacetexture.c
@@ -47,6 +47,7 @@ struct priv_owner {
 struct priv {
     struct mp_log *log;
     const struct ra_format *tex_format;
+    bool external_oes_2d;
 
     jfloatArray matrix;
     jfloat transform[16];
@@ -351,6 +352,12 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
         p->tex_format = fmt;
         mapper->dst_params.imgfmt = IMGFMT_ADRENO;
     }
+    if (strncmp(renderer, "PowerVR Rogue GX6250", 20) == 0) {
+        // Some Android devices that support GLES3 still only support
+        // texture2D() on external textures.
+        //  - Amazon FireTV gen2 [API22]
+        p->external_oes_2d = true;
+    }
 
     return 0;
 }
@@ -438,6 +445,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
         .render_src = true,
         .src_linear = true,
         .external_oes = true,
+        .external_oes_2d = p->external_oes_2d,
     };
     if (!params.format)
         return -1;

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -472,6 +472,7 @@ def build(ctx):
         ( "video/out/opengl/hwdec_ios.m",        "ios-gl" ),
         ( "video/out/opengl/hwdec_osx.c",        "videotoolbox-gl" ),
         ( "video/out/opengl/hwdec_rpi.c",        "rpi" ),
+        ( "video/out/opengl/hwdec_surfacetexture.c","android" ),
         ( "video/out/opengl/hwdec_vaegl.c",      "vaapi-egl" ),
         ( "video/out/opengl/hwdec_vdpau.c",      "vdpau-gl-x11" ),
         ( "video/out/opengl/libmpv_gl.c",        "gl" ),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -317,6 +317,7 @@ def build(ctx):
         ( "misc/bstr.c" ),
         ( "misc/charset_conv.c" ),
         ( "misc/dispatch.c" ),
+        ( "misc/jni.c",                          "android" ),
         ( "misc/json.c" ),
         ( "misc/node.c" ),
         ( "misc/rendezvous.c" ),


### PR DESCRIPTION
Implements a rw_hwdec driver for IMGFMT_MEDIACODEC on Android, as suggested by @wang-bin in https://github.com/mpv-player/mpv/pull/4580#issuecomment-358844146

This make `--vo=gpu --hwdec=mediacodec` work (as opposed to `--hwdec=mediacodec-copy`), by downloading the video frame from the MediaCodec decoder into an RGB GLES texture (via GL_TEXTURE_EXTERNAL_OES).

SurfaceTexture has a weird transform matrix requirement that is described in https://developer.android.com/reference/android/graphics/SurfaceTexture.html:

>When sampling from the texture one should first transform the texture coordinates using the matrix queried via getTransformMatrix(float[]). The transform matrix may change each time updateTexImage() is called, so it should be re-queried each time the texture image is updated. This matrix transforms traditional 2D OpenGL ES texture coordinate column vectors of the form (s, t, 0, 1) where s and t are on the inclusive interval [0, 1] to the proper sampling location in the streamed texture. This transform compensates for any properties of the image stream source that cause it to appear different from a traditional OpenGL ES texture. For example, sampling from the bottom left corner of the image can be accomplished by transforming the column vector (0, 0, 0, 1) using the queried matrix, while sampling from the top right corner of the image can be done by transforming (1, 1, 0, 1).

The transform matrix has to be passed into the vertex shader, which I got working but it's hacked in pretty badly. I could use some advice on how to integrate it more cleanly, so it doesn't affect other gpu renderers.

There are some remaining issues:

- [x] transform matrix multiplication needs to be conditional in the vertex shader
- [x] video is flipped for some reason
- [x] playback stalls after pause/play
- [x] integrate `setOnFrameAvailableListener`
- [x] on some devices, video stalls after first few frames with "could not consume packet" errors
- [x] visual artifacts on some devices
- [ ] need `VO_CAP_NORETAIN` equivalent on vo_gpu
- [ ] pthread destructor is SEGVing on @sfan5's device

cc @haasn @sfan5 @xyzz @jeeb @wm4 @wang-bin 