### PR TITLE
cocoa-cb: some minor fixes

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -109,10 +109,10 @@ class MPVHelper: NSObject {
             // so only utilize a newly received FBO ID if it is nonzero.
             fbo = i != 0 ? i : fbo
 
-            var data = mpv_opengl_fbo(fbo: Int32(i),
-                                         w: Int32(surface.width),
-                                         h: Int32(surface.height),
-                                         internal_format: 0)
+            var data = mpv_opengl_fbo(fbo: Int32(fbo),
+                                        w: Int32(surface.width),
+                                        h: Int32(surface.height),
+                          internal_format: 0)
             var params: [mpv_render_param] = [
                 mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: &data),
                 mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: &flip),

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -48,10 +48,6 @@ class EventsView: NSView {
             removeTrackingArea(tracker!)
         }
 
-        if mpv != nil && !mpv.getBoolProperty("input-cursor") {
-            return
-        }
-
         tracker = NSTrackingArea(rect: bounds,
             options: [.activeAlways, .mouseEnteredAndExited, .mouseMoved, .enabledDuringMouseDrag],
             owner: self, userInfo: nil)
@@ -88,12 +84,11 @@ class EventsView: NSView {
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        return mpv.getBoolProperty("input-cursor")
+        return true
     }
 
     override func becomeFirstResponder() -> Bool {
-        return mpv.getBoolProperty("input-cursor") ||
-               mpv.getBoolProperty("input-vo-keyboard")
+        return true
     }
 
     override func resignFirstResponder() -> Bool {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -237,9 +237,7 @@ class CocoaCB: NSObject {
     }
 
     func updateICCProfile() {
-        if mpv.getBoolProperty("icc-profile-auto") {
-            mpv.setRenderICCProfile(window.screen!.colorSpace!)
-        }
+        mpv.setRenderICCProfile(window.screen!.colorSpace!)
         layer.colorspace = window.screen!.colorSpace!.cgColorSpace!
     }
 

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -38,8 +38,8 @@ def __find_swift_library(ctx):
     for path in swift_library_paths:
         swift_library = ctx.root.find_dir([dev_path, path])
         if swift_library is not None:
-            ctx.end_msg(swift_library)
-            __add_swift_library_linking_flags(ctx, swift_library)
+            ctx.end_msg(swift_library.abspath())
+            __add_swift_library_linking_flags(ctx, swift_library.abspath())
             return
     ctx.end_msg(False)
 

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -141,7 +141,7 @@ def build(ctx):
 
     def swift(task):
         src = ' '.join([x.abspath() for x in task.inputs])
-        bridge = ctx.path.find_node("osdep/macOS_swift_bridge.h")
+        bridge = ctx.path.find_node("osdep/macOS_swift_bridge.h").abspath()
         tgt = task.outputs[0].abspath()
         header = task.outputs[1].abspath()
         module = task.outputs[2].abspath()
@@ -179,7 +179,7 @@ def build(ctx):
 
         ctx.env.append_value('LINKFLAGS', [
             '-Xlinker', '-add_ast_path',
-            '-Xlinker', '%s' % ctx.path.find_resource("osdep/macOS_swift.swiftmodule")
+            '-Xlinker', '%s' % ctx.path.find_or_declare("osdep/macOS_swift.swiftmodule").abspath()
         ])
 
     if ctx.dependency_satisfied('cplayer'):


### PR DESCRIPTION
i only tested the oldest supported waf version and there one has to explicitly request an absolute path in comparison to 1.9.8 for example.

for the icc profile change the API [mentioned](https://github.com/mpv-player/mpv/blob/7ee01860d9c16f2d9d9ea3f5ae5c2a699c7cf1f9/libmpv/render.h#L145) that it handles the option itself now.