### PR TITLE
cocoa-cb: add support for 10bit opengl rendering

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -100,10 +100,11 @@ class MPVHelper: NSObject {
             mpv_render_context_report_swap(mpvRenderContext)
     }
 
-    func drawRender(_ surface: NSSize) {
+    func drawRender(_ surface: NSSize, _ depth: GLint) {
         if mpvRenderContext != nil {
             var i: GLint = 0
             var flip: CInt = 1
+            var ditherDepth = depth
             glGetIntegerv(GLenum(GL_DRAW_FRAMEBUFFER_BINDING), &i)
             // CAOpenGLLayer has ownership of FBO zero yet can return it to us,
             // so only utilize a newly received FBO ID if it is nonzero.
@@ -116,6 +117,7 @@ class MPVHelper: NSObject {
             var params: [mpv_render_param] = [
                 mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: &data),
                 mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: &flip),
+                mpv_render_param(type: MPV_RENDER_PARAM_DEPTH, data: &ditherDepth),
                 mpv_render_param()
             ]
             mpv_render_context_render(mpvRenderContext, &params);


### PR DESCRIPTION
this is supposed to add 10bit rendering support to cocoa-cb and is not meant to be merged as is for now. i would like to start a discussion how this should be handled. i left a debug output in for testing, it prints the detected displays and their bit depth. 10bit rendering will only be activated if a 10bit setup is detected. the test itself might be a bit controversial because it doesn't use a proper API but instead the xml output of a system tool.

there are some theoretical shortcomings. macOS doesn't support any 10bit per component opengl context integer framebuffer formats, only 8bit. 10bit is only supported via 16bit float formats (references: official Apple [example](https://developer.apple.com/library/content/samplecode/DeepImageDisplayWithOpenGL/Introduction/Intro.html#//apple_ref/doc/uid/TP40016622-Intro-DontLinkElementID_2), [docs](https://developer.apple.com/library/content/releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_11_2.html#//apple_ref/doc/uid/TP40016630-SW1), [third party program](https://github.com/Psychtoolbox-3/Psychtoolbox-3/blob/master/PsychSourceGL/Source/OSX/Screen/PsychWindowGlue.c#L358)). according do Apple its display's framebuffer is either 8bit or 10bit, depending on the device. i tested the 16bit float opengl framebuffer on my purely 8bit setup and in my opinion their dithering is worse than what mpv produce when just using the 8bit opengl framebuffer. so i kinda want to only activate this when the system (or rather on of the connected displays) actually supports it. otherwise we have a slightly worse result and it might impact performance(?). since i don't have any 10bit hardware i couldn't visually test this.

another problem is/was that there seems to be no official API to check for 10bit support to selectively activate 16bit float framebuffers. the `NSScreen.depth` properties `bitsPerPixel` and `bitsPerSample` always report 24bit and 8bit respectively even on official 10bit supported Macs. a stackoverflow [post](https://stackoverflow.com/questions/36902312/detecting-if-a-display-supports-30-bit-color) suggested that checking for wide gamut or P3 profile support is the official way to test for this. this is kinda only 'reliable' on macs that ship with a display and might not work for external displays, especially if only a generic color profile is set. i tested this on my display when choosing the P3 color profile and this would check positive even though the displays framebuffer is only 8bit.
there is also a private struct that contains that info but i don't really want to use that, neither should we. the best way i could find is using the system tool `system_profiler` and its xml/plist output. since it outputs a xml/plist string it can be fairly easily parsed and used (Arrays and Dicts). through this tool i was able to get the display's frame buffer depth.

i am also not sure about the technicalities and restrictions that this 16bit float format has. like having a theoretically precision of 11bits(?). maybe that can be clarified.

if a 16 bit format is used it can be seen in the verbose log. it will print `[libmpv_render] Dither to 16.` instead of `8`. this should also probably be used with `fbo-format=rgba16` or `fbo-format=rgba16f`.

for testing i also created a small [swift script](https://gist.github.com/Akemi/0e8d68d5b7996f74c0af05b4e1948dd5) that tests your setup for 10bit support. usage `swift -swift-version 3 display_test.swift`. it would probably be helpful if people with a 10bit capable system could run this script and report the output here. just to check if my findings and code are correct.

this will fix issue #3613, or at least the original request was only for macOS support.