### PR TITLE
cocoa-cb: remove pre-allocation

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -66,13 +66,7 @@ const struct m_sub_options macos_conf = {
 // running in libmpv mode, and cocoa_main() was never called.
 static bool application_instantiated;
 
-struct playback_thread_ctx {
-    int  *argc;
-    char ***argv;
-};
-
 static pthread_t playback_thread_id;
-static struct playback_thread_ctx thread_ctx = {0};
 
 @interface Application ()
 {
@@ -90,18 +84,6 @@ static void terminate_cocoa_application(void)
 {
     [NSApp hide:NSApp];
     [NSApp terminate:NSApp];
-}
-
-static void *playback_thread(void *ctx_obj)
-{
-    mpthread_set_name("playback core (OSX)");
-    @autoreleasepool {
-        struct playback_thread_ctx *ctx = (struct playback_thread_ctx*) ctx_obj;
-        int r = mpv_main(*ctx->argc, *ctx->argv);
-        terminate_cocoa_application();
-        // normally never reached - unless the cocoa mainloop hasn't started yet
-        exit(r);
-    }
 }
 
 @implementation Application
@@ -139,12 +121,6 @@ static void *playback_thread(void *ctx_obj)
     [em removeEventHandlerForEventClass:kCoreEventClass
                              andEventID:kAEQuitApplication];
     [super dealloc];
-}
-
-- (void)initMPVCore
-{
-    pthread_create(&playback_thread_id, NULL, playback_thread, &thread_ctx);
-    [[EventsResponder sharedInstance] waitForInputContext];
 }
 
 static const char macosx_icon[] =
@@ -187,9 +163,9 @@ static const char macosx_icon[] =
 
 - (void)setMpvHandle:(struct mpv_handle *)ctx
 {
-    if (_cocoa_cb) {
-        [_cocoa_cb setMpvHandle:ctx];
-    }
+#if HAVE_MACOS_COCOA_CB
+    [NSApp setCocoaCB:[[CocoaCB alloc] init:ctx]];
+#endif
 }
 
 - (void)queueCommand:(char *)cmd
@@ -255,11 +231,28 @@ static const char macosx_icon[] =
 }
 @end
 
+struct playback_thread_ctx {
+    int  *argc;
+    char ***argv;
+};
+
 static void cocoa_run_runloop(void)
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     [NSApp run];
     [pool drain];
+}
+
+static void *playback_thread(void *ctx_obj)
+{
+    mpthread_set_name("playback core (OSX)");
+    @autoreleasepool {
+        struct playback_thread_ctx *ctx = (struct playback_thread_ctx*) ctx_obj;
+        int r = mpv_main(*ctx->argc, *ctx->argv);
+        terminate_cocoa_application();
+        // normally never reached - unless the cocoa mainloop hasn't started yet
+        exit(r);
+    }
 }
 
 void cocoa_register_menu_item_action(MPMenuKey key, void* action)
@@ -273,10 +266,6 @@ static void init_cocoa_application(bool regular)
     NSApp = mpv_shared_app();
     [NSApp setDelegate:NSApp];
     [NSApp setMenuBar:[[MenuBar alloc] init]];
-
-#if HAVE_MACOS_COCOA_CB
-    [NSApp setCocoaCB:[[CocoaCB alloc] init]];
-#endif
 
     // Will be set to Regular from cocoa_common during UI creation so that we
     // don't create an icon when playing audio only files.
@@ -339,8 +328,9 @@ int cocoa_main(int argc, char *argv[])
         application_instantiated = true;
         [[EventsResponder sharedInstance] setIsApplication:YES];
 
-        thread_ctx.argc = &argc;
-        thread_ctx.argv = &argv;
+        struct playback_thread_ctx ctx = {0};
+        ctx.argc     = &argc;
+        ctx.argv     = &argv;
 
         if (bundle_started_from_finder(argv)) {
             setup_bundle(&argc, argv);
@@ -353,8 +343,8 @@ int cocoa_main(int argc, char *argv[])
             init_cocoa_application(false);
         }
 
-        if (![NSApp cocoaCB])
-            [NSApp initMPVCore];
+        pthread_create(&playback_thread_id, NULL, playback_thread, &ctx);
+        [[EventsResponder sharedInstance] waitForInputContext];
         cocoa_run_runloop();
 
         // This should never be reached: cocoa_run_runloop blocks until the

--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -31,7 +31,6 @@ struct mpv_handle;
 - (void)stopMPV:(char *)cmd;
 - (void)openFiles:(NSArray *)filenames;
 - (void)setMpvHandle:(struct mpv_handle *)ctx;
-- (void)initMPVCore;
 
 @property(nonatomic, retain) MenuBar *menuBar;
 @property(nonatomic, assign) size_t openCount;

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -31,9 +31,9 @@ class EventsView: NSView {
     override var acceptsFirstResponder: Bool { return true }
 
 
-    init(frame frameRect: NSRect, cocoaCB ccb: CocoaCB) {
+    init(cocoaCB ccb: CocoaCB) {
         cocoaCB = ccb
-        super.init(frame: frameRect)
+        super.init(frame: NSMakeRect(0, 0, 960, 480))
         autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
         wantsBestResolutionOpenGLSurface = true
         register(forDraggedTypes: [NSFilenamesPboardType, NSURLPboardType])
@@ -249,6 +249,7 @@ class EventsView: NSView {
     }
 
     func canHideCursor() -> Bool {
+        if cocoaCB.window == nil { return false }
         return !hasMouseDown && containsMouseLocation() && window!.isKeyWindow
     }
 

--- a/video/out/cocoa-cb/video_layer.swift
+++ b/video/out/cocoa-cb/video_layer.swift
@@ -59,7 +59,15 @@ class VideoLayer: CAOpenGLLayer {
         super.init()
         autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         backgroundColor = NSColor.black.cgColor
-        contentsScale = cocoaCB.window.backingScaleFactor
+
+        CGLCreateContext(copyCGLPixelFormat(forDisplayMask: 0), nil, &cglContext)
+        var i: GLint = 1
+        CGLSetParameter(cglContext!, kCGLCPSwapInterval, &i)
+        CGLSetCurrentContext(cglContext!)
+
+        mpv.initRender()
+        mpv.setRenderUpdateCallback(updateCallback, context: self)
+        mpv.setRenderControlCallback(cocoaCB.controlCallback, context: cocoaCB)
     }
 
     override init(layer: Any) {
@@ -70,12 +78,6 @@ class VideoLayer: CAOpenGLLayer {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    func setUpRender() {
-        mpv.initRender()
-        mpv.setRenderUpdateCallback(updateCallback, context: self)
-        mpv.setRenderControlCallback(cocoaCB.controlCallback, context: cocoaCB)
     }
 
     override func canDraw(inCGLContext ctx: CGLContextObj,
@@ -181,16 +183,8 @@ class VideoLayer: CAOpenGLLayer {
     }
 
     override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj {
-        let ctx = super.copyCGLContext(forPixelFormat: pf)
-        var i: GLint = 1
-        CGLSetParameter(ctx, kCGLCPSwapInterval, &i)
-        CGLSetCurrentContext(ctx)
-        cglContext = ctx
-
-        if let app = NSApp as? Application {
-            app.initMPVCore()
-        }
-        return ctx
+        contentsScale = cocoaCB.window.backingScaleFactor
+        return cglContext!
     }
 
     let updateCallback: mpv_render_update_fn = { (ctx) in

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -78,28 +78,23 @@ class Window: NSWindow, NSWindowDelegate {
         }
     }
 
-    convenience init(cocoaCB ccb: CocoaCB) {
-        self.init(contentRect: NSMakeRect(0, 0, 960, 480),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
-            backing: .buffered, defer: false, screen: NSScreen.main())
-        cocoaCB = ccb
-        title = "mpv"
-    }
-
-    convenience init(contentRect: NSRect, styleMask style: NSWindowStyleMask,
-                     screen: NSScreen?, cocoaCB ccb: CocoaCB)
-    {
-        self.init(contentRect: contentRect, styleMask: style,
+    convenience init(contentRect: NSRect, screen: NSScreen?, view: NSView, cocoaCB ccb: CocoaCB) {
+        self.init(contentRect: contentRect,
+                  styleMask: [.titled, .closable, .miniaturizable, .resizable],
                   backing: .buffered, defer: false, screen: screen)
         cocoaCB = ccb
+        title = cocoaCB.title
         minSize = NSMakeSize(160, 90)
         collectionBehavior = .fullScreenPrimary
         delegate = self
+        contentView!.addSubview(view)
+        view.frame = contentView!.frame
 
         unfsContentFrame = convertToScreen(contentView!.frame)
         targetScreen = screen!
         currentScreen = screen!
         unfScreen = screen!
+        initTitleBar()
 
         if let app = NSApp as? Application {
             app.menuBar.register(#selector(setHalfWindowSize), for: MPM_H_SIZE)

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -30,6 +30,10 @@ class CocoaCB: NSObject {
     var cursorVisibilityWanted: Bool = true
     var isShuttingDown: Bool = false
 
+    var title: String = "mpv" {
+        didSet { if window != nil { window.title = title } }
+    }
+
     enum State {
         case uninit
         case needsInit
@@ -47,31 +51,22 @@ class CocoaCB: NSObject {
 
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue")
 
-    override init() {
-        super.init()
-        window = Window(cocoaCB: self)
-
-        view = EventsView(frame: window.contentView!.bounds, cocoaCB: self)
-        window.contentView!.addSubview(view)
-
+    convenience init(_ mpvHandle: OpaquePointer) {
+        self.init()
+        mpv = MPVHelper(mpvHandle)
         layer = VideoLayer(cocoaCB: self)
-        view.layer = layer
-        view.wantsLayer = true
-        view.layerContentsPlacement = .scaleProportionallyToFit
-    }
-
-    func setMpvHandle(_ ctx: OpaquePointer) {
-        mpv = MPVHelper(ctx)
-        layer.setUpRender()
     }
 
     func preinit() {
         if backendState == .uninit {
             backendState = .needsInit
-            DispatchQueue.main.async {
-                self.updateICCProfile()
-            }
+            view = EventsView(cocoaCB: self)
+            view.layer = layer
+            view.wantsLayer = true
+            view.layerContentsPlacement = .scaleProportionallyToFit
             startDisplayLink()
+            initLightSensor()
+            addDisplayReconfigureObserver()
         }
     }
 
@@ -92,25 +87,21 @@ class CocoaCB: NSObject {
 
     func initBackend() {
         NSApp.setActivationPolicy(.regular)
+        setAppIcon()
 
         let targetScreen = getTargetScreen(forFullscreen: false) ?? NSScreen.main()
         let wr = getWindowGeometry(forScreen: targetScreen!, videoOut: mpv.mpctx!.pointee.video_out)
-        let win = Window(contentRect: wr, styleMask: window.styleMask,
-                              screen: targetScreen, cocoaCB: self)
-        win.title = window.title
-        win.setOnTop(mpv.getBoolProperty("ontop"))
-        win.keepAspect = mpv.getBoolProperty("keepaspect-window")
-        window.close()
-        window = win
-        window.contentView!.addSubview(view)
-        view.frame = window.contentView!.frame
-        window.initTitleBar()
+        window = Window(contentRect: wr, screen: targetScreen, view: view, cocoaCB: self)
+        updateICCProfile()
+        window.setOnTop(mpv.getBoolProperty("ontop"))
+        window.keepAspect = mpv.getBoolProperty("keepaspect-window")
+        window.title = title
 
-        setAppIcon()
         window.isRestorable = false
         window.makeMain()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        updateDisplaylink()
         layer.setVideo(true)
 
         if mpv.getBoolProperty("fullscreen") {
@@ -121,8 +112,6 @@ class CocoaCB: NSObject {
             window.isMovableByWindowBackground = true
         }
 
-        initLightSensor()
-        addDisplayReconfigureObserver()
         backendState = .init
     }
 
@@ -155,7 +144,8 @@ class CocoaCB: NSObject {
     }
 
     func startDisplayLink() {
-        let displayId = UInt32(window.screen!.deviceDescription["NSScreenNumber"] as! Int)
+        let displayId = NSScreen.main()!.deviceDescription["NSScreenNumber"] as! UInt32
+
         CVDisplayLinkCreateWithActiveCGDisplays(&link)
         CVDisplayLinkSetCurrentCGDisplay(link!, displayId)
         if #available(macOS 10.12, *) {
@@ -323,8 +313,8 @@ class CocoaCB: NSObject {
     }
 
     func getTargetScreen(forFullscreen fs: Bool) -> NSScreen? {
-        let screenID = fs ? mpv.getStringProperty("fs-screen") ?? "current":
-                            mpv.getStringProperty("screen") ?? "current"
+        let screenType = fs ? "fs-screen" : "screen"
+        let screenID = mpv.getStringProperty(screenType) ?? "current"
 
         switch screenID {
         case "current", "default", "all":
@@ -431,21 +421,17 @@ class CocoaCB: NSObject {
             let titleData = data!.assumingMemoryBound(to: Int8.self)
             let title = String(cString: titleData)
             DispatchQueue.main.async {
-                ccb.window.title = String(cString: titleData)
+                ccb.title = String(cString: titleData)
             }
             return VO_TRUE
         case VOCTRL_PREINIT:
-            ccb.preinit()
+            DispatchQueue.main.sync { ccb.preinit() }
             return VO_TRUE
         case VOCTRL_UNINIT:
-            DispatchQueue.main.async {
-                ccb.uninit()
-            }
+            DispatchQueue.main.async { ccb.uninit() }
             return VO_TRUE
         case VOCTRL_RECONFIG:
-            DispatchQueue.main.async {
-                ccb.reconfig()
-            }
+            DispatchQueue.main.async { ccb.reconfig() }
             return VO_TRUE
         default:
             return VO_NOTIMPL
@@ -455,7 +441,7 @@ class CocoaCB: NSObject {
     func processEvent(_ event: UnsafePointer<mpv_event>) {
         switch event.pointee.event_id {
         case MPV_EVENT_SHUTDOWN:
-            if window.isAnimating {
+            if window != nil && window.isAnimating {
                 isShuttingDown = true
                 return
             }


### PR DESCRIPTION
some testing would be appreciated since it changes quite a bit of the init routine.

the second commit is left separate for now since it's probably a bit controversial and maybe there is a better way to do it. basically i need a way to retrieve some properties in the callback, but `mpv_get_property` will lock the core for that which will deadlock.