### PR TITLE
cocoa-cb: fix shutdown when fullscreen animation is running

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -245,7 +245,10 @@ class MPVHelper: NSObject {
         mpvRenderContext = nil
     }
 
-    func deinitMPV() {
+    func deinitMPV(_ destroy: Bool = false) {
+        if destroy {
+            mpv_destroy(mpvHandle)
+        }
         mpvHandle = nil
         mpvLog = nil
         inputContext = nil

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -306,7 +306,7 @@ class Window: NSWindow, NSWindowDelegate {
 
         isAnimating = false
         cocoaCB.layer.neededFlips += 1
-        cocoaCB.isShuttingDown = false
+        cocoaCB.checkShutdown()
     }
 
     func setToFullScreen() {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -452,6 +452,21 @@ class CocoaCB: NSObject {
         }
     }
 
+    func shutdown(_ destroy: Bool = false) {
+        setCursorVisiblility(true)
+        stopDisplaylink()
+        uninitLightSensor()
+        removeDisplayReconfigureObserver()
+        mpv.deinitRender()
+        mpv.deinitMPV(destroy)
+    }
+
+    func checkShutdown() {
+        if isShuttingDown {
+            shutdown(true)
+        }
+    }
+
     func processEvent(_ event: UnsafePointer<mpv_event>) {
         switch event.pointee.event_id {
         case MPV_EVENT_SHUTDOWN:
@@ -459,12 +474,7 @@ class CocoaCB: NSObject {
                 isShuttingDown = true
                 return
             }
-            setCursorVisiblility(true)
-            stopDisplaylink()
-            uninitLightSensor()
-            removeDisplayReconfigureObserver()
-            mpv.deinitRender()
-            mpv.deinitMPV()
+            shutdown()
         case MPV_EVENT_PROPERTY_CHANGE:
             if backendState == .init {
                 handlePropertyChange(event)


### PR DESCRIPTION
commit 2edf00fb94ba18dc2d476e0354036043ce4f714d changed the MPV_EVENT_SHUTDOWN behaviour slightly. cocoa-cb relied on it being called continuously till all mpv_handles were destroyed.