### PR TITLE
vo_gpu: fix anamorphic video screenshots (second try)

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3181,16 +3181,17 @@ void gl_video_screenshot(struct gl_video *p, struct vo_frame *frame,
 
     if (!args->scaled) {
         int w, h;
-        mp_image_params_get_dsize(&p->real_image_params, &w, &h);
+        mp_image_params_get_dsize(&p->image_params, &w, &h);
         if (w < 1 || h < 1)
             return;
 
         if (p->image_params.rotate % 180 == 90)
             MPSWAP(int, w, h);
 
-        struct mp_rect rc = {0, 0, w, h};
+        struct mp_rect src = {0, 0, p->image_params.w, p->image_params.h};
+        struct mp_rect dst = {0, 0, w, h};
         struct mp_osd_res osd = {.w = w, .h = h, .display_par = 1.0};
-        gl_video_resize(p, &rc, &rc, &osd);
+        gl_video_resize(p, &src, &dst, &osd);
     }
 
     gl_video_reset_surfaces(p);


### PR DESCRIPTION
This passed the display size as source size to the renderer, which is of
course nonsense. I don't know what I was doing in 569383bc54.

Yet another fix for those damn anamorphic videos.

As a somewhat redundant/cosmetic change, use image_params instead of
image_params in the code above. They should have the same, dimensions
(but possibly different formats when doing hw decdoing), and mixing them
is confusing. p->image_params wins because it's shorter.

Actually fixes #5619.