### PR TITLE
cocoa-cb: render on a dedicated dispatch queue

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -305,7 +305,7 @@ class Window: NSWindow, NSWindowDelegate {
         }
 
         isAnimating = false
-        cocoaCB.layer.neededFlips += 1
+        cocoaCB.layer.update()
         cocoaCB.checkShutdown()
     }
 
@@ -316,7 +316,7 @@ class Window: NSWindow, NSWindowDelegate {
         endAnimation()
         isInFullscreen = true
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
-        cocoaCB.layer.neededFlips += 1
+        cocoaCB.layer.update()
     }
 
     func setToWindow() {
@@ -327,7 +327,7 @@ class Window: NSWindow, NSWindowDelegate {
         endAnimation()
         isInFullscreen = false
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
-        cocoaCB.layer.neededFlips += 1
+        cocoaCB.layer.update()
     }
 
     func getFsAnimationDuration(_ def: Double) -> Double{

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -86,7 +86,7 @@ class CocoaCB: NSObject {
         } else {
             layer.setVideo(true)
             updateWindowSize()
-            layer.neededFlips += 1
+            layer.update()
         }
     }
 
@@ -150,7 +150,7 @@ class CocoaCB: NSObject {
                         flagsOut: UnsafeMutablePointer<CVOptionFlags>,
               displayLinkContext: UnsafeMutableRawPointer?) -> CVReturn in
         let ccb: CocoaCB = MPVHelper.bridge(ptr: displayLinkContext!)
-        ccb.layer.reportFlip()
+        ccb.mpv.reportRenderFlip()
         return kCVReturnSuccess
     }
 
@@ -160,7 +160,7 @@ class CocoaCB: NSObject {
         CVDisplayLinkSetCurrentCGDisplay(link!, displayId)
         if #available(macOS 10.12, *) {
             CVDisplayLinkSetOutputHandler(link!) { link, now, out, inFlags, outFlags -> CVReturn in
-                self.layer.reportFlip()
+                self.mpv.reportRenderFlip()
                 return kCVReturnSuccess
             }
         } else {
@@ -454,6 +454,7 @@ class CocoaCB: NSObject {
 
     func shutdown(_ destroy: Bool = false) {
         setCursorVisiblility(true)
+        layer.setVideo(false)
         stopDisplaylink()
         uninitLightSensor()
         removeDisplayReconfigureObserver()


### PR DESCRIPTION
tested this watching a 16min long video while doing some other heavy stuff. it's quite an extreme example, on normal playback one probably won't notice it most of the time. though it's still an improvement.

```
before:
    Dropped: 0 Output: 38 Mistimed: 80 Delayed: 71
after: 
    Dropped: 0 Output: 2  Mistimed: 5  Delayed: 2
```

```
Dropped:  decoder-frame-drop-count
Output:   frame-drop-count
Mistimed: mistimed-frame-count
Delayed:  vo-delayed-frame-count
```