### PR TITLE
ao/openal: Mute support, better surround and better sync

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -112,6 +112,12 @@ Available audio output drivers are:
 ``openal``
     Experimental OpenAL audio output driver
 
+    ``--openal-direct-channels=<yes|no>``
+        Enable OpenAL Soft's direct channel extension when available to avoid
+        tinting the sound with ambisonics or HRTF.
+        Channels are dropped when when they are not available as downmixing
+        will be disabled. Default: no.
+
     .. note:: This driver is not very useful. Playing multi-channel audio with
               it is slow.
 

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -112,6 +112,14 @@ Available audio output drivers are:
 ``openal``
     Experimental OpenAL audio output driver
 
+    ``--openal-num-buffer=<2-128>``
+        Specify the number of audio buffers to use. Lower values are better for
+        lower CPU usage. Default: 4.
+
+    ``--openal-num-samples=<256-32768>``
+        Specify the number of complete samples to use for each buffer. Higher
+        values are better for lower CPU usage. Default: 8192.
+
     ``--openal-direct-channels=<yes|no>``
         Enable OpenAL Soft's direct channel extension when available to avoid
         tinting the sound with ambisonics or HRTF.

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -110,7 +110,7 @@ Available audio output drivers are:
     exclusive mode (bypasses the sound server).
 
 ``openal``
-    Experimental OpenAL audio output driver
+    OpenAL audio output driver
 
     ``--openal-num-buffer=<2-128>``
         Specify the number of audio buffers to use. Lower values are better for
@@ -125,9 +125,6 @@ Available audio output drivers are:
         tinting the sound with ambisonics or HRTF.
         Channels are dropped when when they are not available as downmixing
         will be disabled. Default: no.
-
-    .. note:: This driver is not very useful. Playing multi-channel audio with
-              it is slow.
 
 ``pulse``
     PulseAudio audio output driver

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -70,6 +70,7 @@ static struct ao *ao_data;
 struct priv {
     ALenum al_format;
     int chunk_size;
+    int direct_channels;
 };
 
 static void reset(struct ao *ao);
@@ -308,6 +309,10 @@ static int init(struct ao *ao)
     alListenerfv(AL_ORIENTATION, direction);
 
     alGenSources(1, &source);
+    if (p->direct_channels && alGetEnumValue((ALchar*)"AL_DIRECT_CHANNELS_SOFT")) {
+        alSourcei(source, alGetEnumValue((ALchar*)"AL_DIRECT_CHANNELS_SOFT"), AL_TRUE);
+    }
+
     cur_buf = 0;
     unqueue_buf = 0;
     alGenBuffers(NUM_BUF, buffers);
@@ -449,4 +454,9 @@ const struct ao_driver audio_out_openal = {
     .reset     = reset,
     .drain     = drain,
     .priv_size = sizeof(struct priv),
+    .options = (const struct m_option[]) {
+        OPT_FLAG("direct-channels", direct_channels, 0),
+        {0}
+    },
+    .options_prefix = "openal",
 };

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -435,7 +435,22 @@ static double get_delay(struct ao *ao)
     ALint queued;
     unqueue_buffers();
     alGetSourcei(source, AL_BUFFERS_QUEUED, &queued);
-    return queued * CHUNK_SAMPLES / (double)ao->samplerate;
+
+    double soft_source_latency = 0;
+    if(alIsExtensionPresent("AL_SOFT_source_latency")) {
+        ALdouble offsets[2];
+        LPALGETSOURCEDVSOFT alGetSourcedvSOFT = alGetProcAddress("alGetSourcedvSOFT");
+        alGetSourcedvSOFT(source, AL_SEC_OFFSET_LATENCY_SOFT, offsets);
+        // Additional latency to the play buffer, the remaining seconds to be
+        // played minus the offset (seconds already played)
+        soft_source_latency = offsets[1] - offsets[0];
+    } else {
+        float offset = 0;
+        alGetSourcef(source, AL_SEC_OFFSET, &offset);
+        soft_source_latency = -offset;
+    }
+
+    return (queued * CHUNK_SAMPLES / (double)ao->samplerate) + soft_source_latency;
 }
 
 #define OPT_BASE_STRUCT struct priv

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -89,6 +89,18 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
         vol->left = vol->right = volume * 100;
         return CONTROL_TRUE;
     }
+    case AOCONTROL_GET_MUTE:
+    case AOCONTROL_SET_MUTE: {
+        bool mute = *(bool *)arg;
+        ALfloat al_mute = (ALfloat)(!mute);
+        if (cmd == AOCONTROL_SET_MUTE) {
+            alSourcef(source, AL_GAIN, al_mute);
+        }
+        alGetSourcef(source, AL_GAIN, &al_mute);
+        *(bool *)arg = !((bool)al_mute);
+        return CONTROL_TRUE;
+    }
+
     case AOCONTROL_HAS_SOFT_VOLUME:
         return CONTROL_TRUE;
     }


### PR DESCRIPTION
Hello everyone, I was having some problems with OpenAL on my Creative X-Fi so I decided to do some changes to see if I can make things better.

To ease synchronization between channels I changed the previous one-source-per-channel scheme to one that uses OpenAL multichannel extensions to emit surround sound, this also allows the use of OpenAL Soft's AL_DIRECT_CHANNELS_SOFT for a sound without any ambisonic tint. I also added 32-bit output support for Creative XFis.

Another functions that I added was mute support, even though MPV seems to not use it natively, and, most importantly, added support for OpenAL Soft's AL_SOFT_source_latency extension to help audio/video synchronization.

I also added support to manually setting the number of buffers and the buffer size, along with support for AOPLAY_FINAL_CHUNK. I kept the previous latency as the default, but it can be reduced.

I tested on Windows (Creative OpenAL and OpenAL Soft) and Kubuntu 17.10 (OpenAL Soft), everything is working as expected. I tested over the **release/0.27** branch on Linux, and on **release/0.27** and **master** on Windows.

Could not test on a Mac.

Any suggestion will be appreciated, and I hope I got the format right :)

I agree that my changes can be relicensed to LGPL 2.1 or later.
