### PR TITLE
Prefer system mixer for muting / volume changes if possible

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1375,11 +1375,30 @@ Property list
     is loadedThis is because the same underlying code is used for seeking and
     resyncing.)
 
+``dynamic-volume`` (RW)
+    Current volume. This property combines ``ao-volume`` and ``volume``
+    (if the former is available), otherwise it's equivalent ``volume``.
+
+    Reading this property returns the effective volume mpv is playing at,
+    taking into account both the system and internal volume.
+
+    When writing this property, adjusting system volume (``ao-volume``)
+    will be preferred. The internal volume will only be adjusted if unavoidable,
+    e.g. when setting volumes greater than 100%.
+
+``dynamic-mute`` (RW)
+    Current mute status. This property combines ``ao-mute`` and ``mute``
+    (if the former is available), otherwise it's equivalent ``mute``.
+
+    When setting this property, changing system mute state (``ao-mute``) will
+    be preferred and ``mute`` only used as fallback.
+
 ``mixer-active``
     Return ``yes`` if the audio mixer is active, ``no`` otherwise.
 
     This option is relatively useless. Before mpv 0.18.1, it could be used to
-    infer behavior of the ``volume`` property.
+    infer behavior of the ``volume`` property. This option **can't** be used
+    to infer the behaviour of ``dynamic-volume`` or ``dynamic-mute`` either.
 
 ``ao-volume`` (RW)
     System volume. This property is available only if mpv audio output is

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -37,8 +37,8 @@
 # numeric value accordingly
 #WHEEL_UP      seek 10
 #WHEEL_DOWN    seek -10
-#WHEEL_LEFT    add volume -2
-#WHEEL_RIGHT   add volume 2
+#WHEEL_LEFT    add dynamic-volume -2
+#WHEEL_RIGHT   add dynamic-volume 2
 
 ## Seek units are in seconds, but note that these are limited by keyframes
 #RIGHT seek  5
@@ -100,11 +100,11 @@
 #x add sub-delay +0.1                   # same as previous binding (discouraged)
 #ctrl++ add audio-delay 0.100           # this changes audio/video sync
 #ctrl+- add audio-delay -0.100
-#9 add volume -2
-#/ add volume -2
-#0 add volume 2
-#* add volume 2
-#m cycle mute
+#9 add dynamic-volume -2
+#/ add dynamic-volume -2
+#0 add dynamic-volume 2
+#* add dynamic-volume 2
+#m cycle dynamic-mute
 #1 add contrast -1
 #2 add contrast 1
 #3 add brightness -1
@@ -151,9 +151,9 @@
 #REWIND seek -60
 #NEXT playlist-next
 #PREV playlist-prev
-#VOLUME_UP add volume 2
-#VOLUME_DOWN add volume -2
-#MUTE cycle mute
+#VOLUME_UP add dynamic-volume 2
+#VOLUME_DOWN add dynamic-volume -2
+#MUTE cycle dynamic-mute
 #CLOSE_WIN quit
 #CLOSE_WIN {encode} quit 4
 #E cycle edition                        # next edition
@@ -175,10 +175,10 @@
 #AR_PREV seek -10
 #AR_PREV_HOLD seek -120
 #AR_MENU show-progress
-#AR_MENU_HOLD cycle mute
-#AR_VUP add volume 2
+#AR_MENU_HOLD cycle dynamic-mute
+#AR_VUP add dynamic-volume 2
 #AR_VUP_HOLD add chapter 1
-#AR_VDOWN add volume -2
+#AR_VDOWN add dynamic-volume -2
 #AR_VDOWN_HOLD add chapter -1
 
 #


### PR DESCRIPTION
This essentially readds `softvol=no` in a very limited fashion.
volume adjustments:
* if unsupported by AO: softvol
* `0 <= vol <= 100`: use system mixer
* `vol > 100`: use softvol

muting:
* if supported by AO: system mixer
* otherwise: softvol


opinions? @wm4 @atomnuker 
also would be nice if someone could test this with replaygain