### PR TITLE
command: add expand-path to expand mpv paths

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -529,6 +529,18 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     used only through the client API or from a script using
     ``mp.command_native``. (see `Property Expansion`_).
 
+``expand-path "<string>"``
+    Expand a path's double-tilde placeholders into a platform-specific path.
+    As ``expand-text``, this can only be used through the client API or from
+    a script using ``mp.command_native``.
+
+    .. admonition:: Example
+
+        ``mp.osd_message(mp.command_native({"expand-path", "~~home/"}))``
+
+        This line of Lua would show the location of the user's mpv
+        configuration directory on the OSD.
+
 ``show-progress``
     Show the progress bar, the elapsed time and the total duration of the file
     on the OSD.

--- a/player/command.c
+++ b/player/command.c
@@ -4967,6 +4967,17 @@ static void cmd_expand_text(void *p)
     };
 }
 
+static void cmd_expand_path(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    cmd->result = (mpv_node){
+        .format = MPV_FORMAT_STRING,
+        .u.string = mp_get_user_path(NULL, mpctx->global, cmd->args[0].v.s)
+    };
+}
+
 static void cmd_loadfile(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -5811,6 +5822,7 @@ const struct mp_cmd_def mp_cmds[] = {
                                     OPT_INT("level", v.i, MP_CMD_OPT_ARG), },
         .allow_auto_repeat = true},
     { "expand-text", cmd_expand_text, { OPT_STRING("text", v.s, 0) } },
+    { "expand-path", cmd_expand_path, { OPT_STRING("text", v.s, 0) } },
     { "show-progress", cmd_show_progress, .allow_auto_repeat = true},
 
     { "sub-add", cmd_track_add,


### PR DESCRIPTION
The question came up on how a client would figure out where screenshot-directory saved its screenshots if it contained mpv-specific expansions. This command should remedy the situation by providing a way for the client to ask mpv to do an expansion.
