### PR TITLE
Reduce default buffer sizes for ALSA and Pulse

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -128,7 +128,7 @@ Available audio output drivers are:
         Set the audio buffer size in milliseconds. A higher value buffers
         more data, and has a lower probability of buffer underruns. A smaller
         value makes the audio stream react faster, e.g. to playback speed
-        changes. Default: 250.
+        changes.
 
     ``--pulse-latency-hacks=<yes|no>``
         Enable hacks to workaround PulseAudio timing bugs (default: no). If

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4133,6 +4133,20 @@ ALSA audio output options
     or it will work only for files which use the layout implicit to your
     ALSA device).
 
+``--alsa-buffer-time=<microseconds>``
+    Set the requested buffer time in microseconds. A value of 0 skips requesting
+    anything from the ALSA API. This and the period count option uses the ALSA
+    ``near`` functions to set the requested parameters. If doing so results in
+    an empty configuration set, setting these parameters is skipped.
+
+    Both options control the buffer size. A low buffer size can lead to higher
+    CPU usage and audio dropouts, while a high buffer size can lead to higher
+    latency in volume changes and other filtering.
+
+``--alsa-periods=<number>``
+    Number of periods requested from the ALSA API. See ``--alsa-buffer-time``
+    for further remarks.
+
 
 GPU renderer options
 -----------------------

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -82,8 +82,8 @@ static const struct m_sub_options ao_alsa_conf = {
         .mixer_name = "Master",
         .mixer_index = 0,
         .ni = 0,
-        .buffer_time = 250000,
-        .frags = 16,
+        .buffer_time = 25000,
+        .frags = 4,
     },
     .size = sizeof(struct ao_alsa_opts),
 };

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -30,6 +30,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 
@@ -59,6 +60,8 @@ struct ao_alsa_opts {
     int resample;
     int ni;
     int ignore_chmap;
+    int buffer_time;
+    int frags;
 };
 
 #define OPT_BASE_STRUCT struct ao_alsa_opts
@@ -70,6 +73,8 @@ static const struct m_sub_options ao_alsa_conf = {
         OPT_INTRANGE("alsa-mixer-index", mixer_index, 0, 0, 99),
         OPT_FLAG("alsa-non-interleaved", ni, 0),
         OPT_FLAG("alsa-ignore-chmap", ignore_chmap, 0),
+        OPT_INTRANGE("alsa-buffer-time", buffer_time, 0, 0, INT_MAX),
+        OPT_INTRANGE("alsa-periods", frags, 0, 0, INT_MAX),
         {0}
     },
     .defaults = &(const struct ao_alsa_opts) {
@@ -77,6 +82,8 @@ static const struct m_sub_options ao_alsa_conf = {
         .mixer_name = "Master",
         .mixer_index = 0,
         .ni = 0,
+        .buffer_time = 250000,
+        .frags = 16,
     },
     .size = sizeof(struct ao_alsa_opts),
 };
@@ -98,9 +105,6 @@ struct priv {
 
     struct ao_alsa_opts *opts;
 };
-
-#define BUFFER_TIME 250000  // 250ms
-#define FRAGCOUNT 16
 
 #define CHECK_ALSA_ERROR(message) \
     do { \
@@ -648,6 +652,7 @@ alsa_error: ;
 static int init_device(struct ao *ao, int mode)
 {
     struct priv *p = ao->priv;
+    struct ao_alsa_opts *opts = p->opts;
     int ret = INIT_DEVICE_ERR_GENERIC;
     char *tmp;
     size_t tmp_s;
@@ -790,12 +795,15 @@ static int init_device(struct ao *ao, int mode)
     snd_pcm_hw_params_copy(hwparams_backup, alsa_hwparams);
 
     // Cargo-culted buffer settings; might still be useful for PulseAudio.
-    err = snd_pcm_hw_params_set_buffer_time_near
-            (p->alsa, alsa_hwparams, &(unsigned int){BUFFER_TIME}, NULL);
-    CHECK_ALSA_WARN("Unable to set buffer time near");
-    if (err >= 0) {
+    err = 0;
+    if (opts->buffer_time) {
+        err = snd_pcm_hw_params_set_buffer_time_near
+                (p->alsa, alsa_hwparams, &(unsigned int){opts->buffer_time}, NULL);
+        CHECK_ALSA_WARN("Unable to set buffer time near");
+    }
+    if (err >= 0 && opts->frags) {
         err = snd_pcm_hw_params_set_periods_near
-                    (p->alsa, alsa_hwparams, &(unsigned int){FRAGCOUNT}, NULL);
+                    (p->alsa, alsa_hwparams, &(unsigned int){opts->frags}, NULL);
         CHECK_ALSA_WARN("Unable to set periods");
     }
     if (err < 0)

--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -831,7 +831,7 @@ const struct ao_driver audio_out_pulse = {
     .list_devs = list_devs,
     .priv_size = sizeof(struct priv),
     .priv_defaults = &(const struct priv) {
-        .cfg_buffer = 250,
+        .cfg_buffer = 25,
     },
     .options = (const struct m_option[]) {
         OPT_STRING("host", cfg_host, 0),


### PR DESCRIPTION
Targets about 25ms, although ALSA with dmix will usually be a bit higher.