### PR TITLE
Various DRM Atomic improvements

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,11 +488,6 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
-    ``--drm-overlay=<number>``
-        Select the DRM overlay index to use.
-        Overlay index is zero based, and related to crtc.
-        (default: 0)
-
     ``--drm-format=<xrgb8888,xrgb2101010>``
         Select the DRM format to use (default: xrgb8888). This allows you to
         choose the bit depth of the DRM mode. xrgb8888 is your usual 24 bit per
@@ -505,6 +500,13 @@ Available video output drivers are:
 
         This currently only has an effect when used together with the ``drm``
         backend for the ``gpu`` VO. The ``drm`` VO always uses xrgb8888.
+
+    ``--drm-osd-size=<[WxH]>``
+        Sets the OSD OpenGL size to the specified size. OSD will then be upscaled
+        to the current screen resolution. This option can be useful when using
+        several layers in high resolutions with a GPU which cannot handle it.
+        Note : this option is only available with DRM atomic support.
+        (default: display resolution)
 
 ``mediacodec_embed`` (Android)
     Renders ``IMGFMT_MEDIACODEC`` frames directly to an ``android.view.Surface``.

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,6 +488,20 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
+    ``--drm-osd-plane-id=<number>``
+        Select the DRM planed index to use for OSD (or OSD and video).
+        Index is zero based, and related to crtc.
+        When using this option with drm_prime renderer, it will only affect
+        the OSD contents. Otherwise it will set OSD & video plane.
+        (default: primary plane)
+
+    ``--drm-video-plane-id=<number>``
+        Select the DRM planed index to use for video layer.
+        Index is zero based, and related to crtc.
+        This option only has effect when using the drm_prime renderer (which
+        supports several layers) together with ``vo=gpu`` and ``gpu-context=drm``.
+        (default: first overlay plane)
+
     ``--drm-format=<xrgb8888,xrgb2101010>``
         Select the DRM format to use (default: xrgb8888). This allows you to
         choose the bit depth of the DRM mode. xrgb8888 is your usual 24 bit per

--- a/libmpv/opengl_cb.h
+++ b/libmpv/opengl_cb.h
@@ -177,6 +177,9 @@ struct mpv_opengl_cb_drm_params {
     // currently used crtc id
     int crtc_id;
 
+    // currently used connector id
+    int connector_id;
+
     // pointer to the drmModeAtomicReq that is being used for the renderloop.
     // This atomic request pointer should be usually created at every renderloop.
     struct _drmModeAtomicReq *atomic_request;

--- a/libmpv/render.h
+++ b/libmpv/render.h
@@ -276,6 +276,18 @@ typedef enum mpv_render_param_type {
      * in the same way.
      */
     MPV_RENDER_PARAM_SKIP_RENDERING = 13,
+    /**
+     * DRM display, contains drm display handles.
+     * Valid for mpv_render_context_create().
+     * Type : struct mpv_opengl_drm_params*
+     */
+    MPV_RENDER_PARAM_DRM_DISPLAY = 14,
+    /**
+     * DRM osd size, contains osd dimensions.
+     * Valid for mpv_render_context_create().
+     * Type : struct mpv_opengl_drm_osd_size*
+     */
+    MPV_RENDER_PARAM_DRM_OSD_SIZE = 15,
 } mpv_render_param_type;
 
 /**

--- a/libmpv/render_gl.h
+++ b/libmpv/render_gl.h
@@ -147,6 +147,37 @@ typedef struct mpv_opengl_fbo {
     int internal_format;
 } mpv_opengl_fbo;
 
+typedef struct mpv_opengl_drm_params {
+    /**
+     * DRM fd (int). set this to -1 if invalid.
+     */
+    int fd;
+
+    /**
+     * Currently used crtc id
+     */
+    int crtc_id;
+
+    /**
+     * Currently used connector id
+     */
+    int connector_id;
+
+    /**
+     * Pointer to a drmModeAtomicReq pointer that is being used for the renderloop.
+     * This pointer should hold a pointer to the atomic request pointer
+     * The atomic request pointer is usually changed at every renderloop.
+     */
+    struct _drmModeAtomicReq **atomic_request_ptr;
+} mpv_opengl_drm_params;
+
+typedef struct mpv_opengl_drm_osd_size {
+    /**
+     * size of the OSD in pixels.
+     */
+    int width, height;
+} mpv_opengl_drm_osd_size;
+
 #ifdef __cplusplus
 }
 #endif

--- a/video/out/drm_atomic.c
+++ b/video/out/drm_atomic.c
@@ -209,6 +209,9 @@ struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd,
                     mp_err(log, "Unable to retrieve type property from plane %d\n", j);
                     goto fail;
                 } else {
+                    if (value == DRM_PLANE_TYPE_CURSOR) // Skip cursor planes
+                        continue;
+
                     layercount++;
 
                     if ((!primary_id) && (value == DRM_PLANE_TYPE_PRIMARY))

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -25,6 +25,7 @@
 #include "common/msg.h"
 
 struct drm_object {
+    int fd;
     uint32_t id;
     uint32_t type;
     drmModeObjectProperties *props;
@@ -35,6 +36,7 @@ struct drm_atomic_context {
     int fd;
 
     struct drm_object *crtc;
+    struct drm_object *connector;
     struct drm_object *primary_plane;
     struct drm_object *overlay_plane;
 
@@ -46,10 +48,11 @@ int drm_object_create_properties(struct mp_log *log, int fd, struct drm_object *
 void drm_object_free_properties(struct drm_object *object);
 int drm_object_get_property(struct drm_object *object, char *name, uint64_t *value);
 int drm_object_set_property(drmModeAtomicReq *request, struct drm_object *object, char *name, uint64_t value);
+drmModePropertyBlobPtr drm_object_get_property_blob(struct drm_object *object, char *name);
 struct drm_object * drm_object_create(struct mp_log *log, int fd, uint32_t object_id, uint32_t type);
 void drm_object_free(struct drm_object *object);
 void drm_object_print_info(struct mp_log *log, struct drm_object *object);
-struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int overlay_id);
+struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int connector_id, int overlay_id);
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx);
 
 #endif // MP_DRMATOMIC_H

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -37,8 +37,8 @@ struct drm_atomic_context {
 
     struct drm_object *crtc;
     struct drm_object *connector;
-    struct drm_object *primary_plane;
-    struct drm_object *overlay_plane;
+    struct drm_object *osd_plane;
+    struct drm_object *video_plane;
 
     drmModeAtomicReq *request;
 };
@@ -52,7 +52,8 @@ drmModePropertyBlobPtr drm_object_get_property_blob(struct drm_object *object, c
 struct drm_object * drm_object_create(struct mp_log *log, int fd, uint32_t object_id, uint32_t type);
 void drm_object_free(struct drm_object *object);
 void drm_object_print_info(struct mp_log *log, struct drm_object *object);
-struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int connector_id, int overlay_id);
+struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int connector_id,
+													 int osd_plane_id, int video_plane_id);
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx);
 
 #endif // MP_DRMATOMIC_H

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -47,12 +47,17 @@ const struct m_sub_options drm_conf = {
         OPT_STRING_VALIDATE("drm-connector", drm_connector_spec,
                             0, drm_validate_connector_opt),
         OPT_INT("drm-mode", drm_mode_id, 0),
-        OPT_INT("drm-overlay", drm_overlay_id, 0),
+        OPT_INT("drm-osd-plane-id", drm_osd_plane_id, 0),
+        OPT_INT("drm-video-plane-id", drm_video_plane_id, 0),
         OPT_CHOICE("drm-format", drm_format, 0,
                    ({"xrgb8888",    DRM_OPTS_FORMAT_XRGB8888},
                     {"xrgb2101010", DRM_OPTS_FORMAT_XRGB2101010})),
         OPT_SIZE_BOX("drm-osd-size", drm_osd_size, 0),
         {0},
+    },
+    .defaults = &(const struct drm_opts) {
+        .drm_osd_plane_id = -1,
+        .drm_video_plane_id = -1,
     },
     .size = sizeof(struct drm_opts),
 };
@@ -238,7 +243,7 @@ static void parse_connector_spec(struct mp_log *log,
 
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int overlay_id)
+                       int mode_id, int osd_plane_id, int video_plane_id)
 {
     int card_no = -1;
     char *connector_name = NULL;
@@ -286,7 +291,7 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
     } else {
         mp_verbose(log, "DRM Atomic support found\n");
         kms->atomic_context = drm_atomic_create_context(kms->log, kms->fd, kms->crtc_id,
-                                                        kms->connector->connector_id, overlay_id);
+                                                        kms->connector->connector_id, osd_plane_id, video_plane_id);
         if (!kms->atomic_context) {
             mp_err(log, "Failed to create DRM atomic context\n");
             goto err;

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -285,7 +285,8 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
         mp_verbose(log, "No DRM Atomic support found\n");
     } else {
         mp_verbose(log, "DRM Atomic support found\n");
-        kms->atomic_context = drm_atomic_create_context(kms->log, kms->fd, kms->crtc_id, overlay_id);
+        kms->atomic_context = drm_atomic_create_context(kms->log, kms->fd, kms->crtc_id,
+                                                        kms->connector->connector_id, overlay_id);
         if (!kms->atomic_context) {
             mp_err(log, "Failed to create DRM atomic context\n");
             goto err;

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -51,6 +51,7 @@ const struct m_sub_options drm_conf = {
         OPT_CHOICE("drm-format", drm_format, 0,
                    ({"xrgb8888",    DRM_OPTS_FORMAT_XRGB8888},
                     {"xrgb2101010", DRM_OPTS_FORMAT_XRGB2101010})),
+        OPT_SIZE_BOX("drm-osd-size", drm_osd_size, 0),
         {0},
     },
     .size = sizeof(struct drm_opts),

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -48,7 +48,8 @@ struct vt_switcher {
 struct drm_opts {
     char *drm_connector_spec;
     int drm_mode_id;
-    int drm_overlay_id;
+    int drm_osd_plane_id;
+    int drm_video_plane_id;
     int drm_format;
     struct m_geometry drm_osd_size;
 };
@@ -64,7 +65,7 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
                          void *user_data);
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int overlay_id);
+                       int mode_id, int osd_plane_id, int video_plane_id);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -50,6 +50,7 @@ struct drm_opts {
     int drm_mode_id;
     int drm_overlay_id;
     int drm_format;
+    struct m_geometry drm_osd_size;
 };
 
 bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log);

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "hwdec.h"
 #include "libmpv_gpu.h"
+#include "libmpv/render_gl.h"
 #include "video.h"
 #include "video/out/libmpv.h"
 
@@ -30,6 +31,14 @@ static const struct native_resource_entry native_resource_map[] = {
     [MPV_RENDER_PARAM_WL_DISPLAY] = {
         .name = "wl",
         .size = 0,
+    },
+    [MPV_RENDER_PARAM_DRM_DISPLAY] = {
+        .name = "drm_params",
+        .size = sizeof (mpv_opengl_drm_params),
+    },
+    [MPV_RENDER_PARAM_DRM_OSD_SIZE] = {
+        .name = "drm_osd_size",
+        .size = sizeof (mpv_opengl_drm_osd_size),
     },
 };
 

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -352,9 +352,9 @@ static void drm_egl_swap_buffers(struct ra_ctx *ctx)
     update_framebuffer_from_bo(ctx, p->gbm.next_bo);
 
     if (atomic_ctx) {
-        drm_object_set_property(atomic_ctx->request, atomic_ctx->primary_plane, "FB_ID", p->fb->id);
-        drm_object_set_property(atomic_ctx->request, atomic_ctx->primary_plane, "CRTC_ID", atomic_ctx->crtc->id);
-        drm_object_set_property(atomic_ctx->request, atomic_ctx->primary_plane, "ZPOS", 1);
+        drm_object_set_property(atomic_ctx->request, atomic_ctx->osd_plane, "FB_ID", p->fb->id);
+        drm_object_set_property(atomic_ctx->request, atomic_ctx->osd_plane, "CRTC_ID", atomic_ctx->crtc->id);
+        drm_object_set_property(atomic_ctx->request, atomic_ctx->osd_plane, "ZPOS", 1);
 
         ret = drmModeAtomicCommit(p->kms->fd, atomic_ctx->request,
                                   DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_PAGE_FLIP_EVENT, NULL);
@@ -442,7 +442,7 @@ static bool probe_gbm_format(struct ra_ctx *ctx, uint32_t argb_format, uint32_t 
     }
 
     drmModePlane *drmplane =
-        drmModeGetPlane(p->kms->fd, p->kms->atomic_context->primary_plane->id);
+        drmModeGetPlane(p->kms->fd, p->kms->atomic_context->osd_plane->id);
     bool have_argb = false;
     bool have_xrgb = false;
     bool result = false;
@@ -490,7 +490,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     MP_VERBOSE(ctx, "Initializing KMS\n");
     p->kms = kms_create(ctx->log, ctx->vo->opts->drm_opts->drm_connector_spec,
                         ctx->vo->opts->drm_opts->drm_mode_id,
-                        ctx->vo->opts->drm_opts->drm_overlay_id);
+                        ctx->vo->opts->drm_opts->drm_osd_plane_id,
+                        ctx->vo->opts->drm_opts->drm_video_plane_id);
     if (!p->kms) {
         MP_ERR(ctx, "Failed to create KMS.\n");
         return false;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -247,17 +247,105 @@ static void update_framebuffer_from_bo(struct ra_ctx *ctx, struct gbm_bo *bo)
     p->fb = fb;
 }
 
+static bool crtc_setup_atomic(struct ra_ctx *ctx, drmModeModeInfo mode)
+{
+    struct priv *p = ctx->priv;
+
+    struct drm_atomic_context *atomic_ctx = p->kms->atomic_context;
+    drmModeAtomicReqPtr request = drmModeAtomicAlloc();
+    if (request) {
+        drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->kms->crtc_id);
+
+        uint32_t blob_id;
+        if (drmModeCreatePropertyBlob(p->kms->fd, &mode, sizeof(drmModeModeInfo),
+                                      &blob_id) != 0) {
+            MP_ERR(ctx->vo, "Failed to DRM mode blob\n");
+            return 0;
+        }
+        drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id);
+        drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1);
+
+        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_X",   0);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_Y",   0);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_W",   p->osd_size.width << 16);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_H",   p->osd_size.height << 16);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_X",  0);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_Y",  0);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_W",  mode.hdisplay);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_H",  mode.vdisplay);
+
+        int ret = drmModeAtomicCommit(p->kms->fd, request,
+                                  DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_PAGE_FLIP_EVENT
+                                  | DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+
+        if (ret)
+           MP_WARN(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
+
+        drmModeAtomicFree(request);
+
+        return ret == 0;
+    } else {
+        MP_ERR(ctx->vo, "Failed to allocate drm atomic request\n");
+    }
+
+    return false;
+}
+
+static bool crtc_release_atomic(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+
+    struct drm_atomic_context *atomic_ctx = p->kms->atomic_context;
+    drmModeAtomicReqPtr request = drmModeAtomicAlloc();
+    if (request) {
+        drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->old_crtc->crtc_id);
+
+        uint32_t blob_id;
+        if (drmModeCreatePropertyBlob(p->kms->fd, &p->old_crtc->mode, sizeof(drmModeModeInfo),
+                                      &blob_id) != 0) {
+            MP_ERR(ctx->vo, "Failed to DRM mode blob\n");
+            return 0;
+        }
+        drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id);
+        drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1);
+        drm_object_set_property(request, atomic_ctx->osd_plane, "FB_ID",   p->old_crtc->buffer_id);
+
+        int ret = drmModeAtomicCommit(p->kms->fd, request,
+                                  DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_PAGE_FLIP_EVENT
+                                  | DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+
+        if (ret)
+           MP_WARN(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
+
+        drmModeAtomicFree(request);
+
+        return ret == 0;
+    } else {
+        MP_ERR(ctx->vo, "Failed to allocate drm atomic request\n");
+    }
+
+    return false;
+}
+
 static bool crtc_setup(struct ra_ctx *ctx)
 {
     struct priv *p = ctx->priv;
     if (p->active)
         return true;
     p->old_crtc = drmModeGetCrtc(p->kms->fd, p->kms->crtc_id);
-    int ret = drmModeSetCrtc(p->kms->fd, p->kms->crtc_id, p->fb->id,
-                             0, 0, &p->kms->connector->connector_id, 1,
-                             &p->kms->mode);
-    p->active = true;
-    return ret == 0;
+
+    if (p->kms->atomic_context) {
+        int ret = crtc_setup_atomic(ctx, p->kms->mode);
+        p->active = true;
+        return ret;
+
+    } else {
+        int ret = drmModeSetCrtc(p->kms->fd, p->kms->crtc_id, p->fb->id,
+                                 0, 0, &p->kms->connector->connector_id, 1,
+                                 &p->kms->mode);
+        p->active = true;
+        return ret == 0;
+    }
 }
 
 static void crtc_release(struct ra_ctx *ctx)
@@ -278,12 +366,17 @@ static void crtc_release(struct ra_ctx *ctx)
     }
 
     if (p->old_crtc) {
-        drmModeSetCrtc(p->kms->fd,
-                       p->old_crtc->crtc_id, p->old_crtc->buffer_id,
-                       p->old_crtc->x, p->old_crtc->y,
-                       &p->kms->connector->connector_id, 1,
-                       &p->old_crtc->mode);
-        drmModeFreeCrtc(p->old_crtc);
+        if (p->kms->atomic_context) {
+            if (!crtc_release_atomic(ctx))
+                MP_ERR(ctx->vo, "Failed to restore previous mode\n");
+        } else {
+            drmModeSetCrtc(p->kms->fd,
+                           p->old_crtc->crtc_id, p->old_crtc->buffer_id,
+                           p->old_crtc->x, p->old_crtc->y,
+                           &p->kms->connector->connector_id, 1,
+                           &p->old_crtc->mode);
+        }
+        drmModeFreeCrtc(p->old_crtc);       
         p->old_crtc = NULL;
     }
 }

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -526,18 +526,18 @@ static void drm_egl_uninit(struct ra_ctx *ctx)
     }
 }
 
-// If primary plane supports ARGB we want to use that, but if it doesn't we fall
+// If the OSD plane supports ARGB we want to use that, but if it doesn't we fall
 // back on XRGB. If the driver does not support atomic there is no particular
 // reason to be using ARGB (drmprime hwdec will not work without atomic,
 // anyway), so we fall back to XRGB (another reason is that we do not have the
-// convenient atomic_ctx and its convenient primary_plane field).
+// convenient atomic_ctx and its convenient plane fields).
 static bool probe_gbm_format(struct ra_ctx *ctx, uint32_t argb_format, uint32_t xrgb_format)
 {
     struct priv *p = ctx->priv;
 
     if (!p->kms->atomic_context) {
         p->gbm_format = xrgb_format;
-        MP_VERBOSE(ctx->vo, "Not using DRM Atomic: Use %s for primary plane.\n",
+        MP_VERBOSE(ctx->vo, "Not using DRM Atomic: Use %s for OSD plane.\n",
                    gbm_format_to_string(xrgb_format));
         return true;
     }
@@ -557,11 +557,11 @@ static bool probe_gbm_format(struct ra_ctx *ctx, uint32_t argb_format, uint32_t 
 
     if (have_argb) {
         p->gbm_format = argb_format;
-        MP_VERBOSE(ctx->vo, "%s supported by primary plane.\n", gbm_format_to_string(argb_format));
+        MP_VERBOSE(ctx->vo, "%s supported by OSD plane.\n", gbm_format_to_string(argb_format));
         result = true;
     } else if (have_xrgb) {
         p->gbm_format = xrgb_format;
-        MP_VERBOSE(ctx->vo, "%s not supported by primary plane: Falling back to %s.\n",
+        MP_VERBOSE(ctx->vo, "%s not supported by OSD plane: Falling back to %s.\n",
                    gbm_format_to_string(argb_format), gbm_format_to_string(xrgb_format));
         result = true;
     }
@@ -667,7 +667,6 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     }
 
     p->drm_params.fd = p->kms->fd;
-    p->drm_params.connector_id = p->kms->connector->connector_id;
     p->drm_params.crtc_id = p->kms->crtc_id;
     p->drm_params.connector_id = p->kms->connector->connector_id;
     if (p->kms->atomic_context)

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -567,6 +567,7 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     p->drm_params.fd = p->kms->fd;
     p->drm_params.connector_id = p->kms->connector->connector_id;
     p->drm_params.crtc_id = p->kms->crtc_id;
+    p->drm_params.connector_id = p->kms->connector->connector_id;
     if (p->kms->atomic_context)
         p->drm_params.atomic_request_ptr = &p->kms->atomic_context->request;
     struct ra_gl_ctx_params params = {

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -28,7 +28,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
-#include "libmpv/opengl_cb.h"
+#include "libmpv/render_gl.h"
 #include "video/out/drm_common.h"
 #include "common/common.h"
 #include "osdep/timer.h"
@@ -80,7 +80,8 @@ struct priv {
     bool vt_switcher_active;
     struct vt_switcher vt_switcher;
 
-    struct mpv_opengl_cb_drm_params drm_params;
+    struct mpv_opengl_drm_params drm_params;
+    struct mpv_opengl_drm_osd_size osd_size;
 };
 
 // Not general. Limited to only the formats being used in this module
@@ -194,11 +195,11 @@ static bool init_gbm(struct ra_ctx *ctx)
     }
 
     MP_VERBOSE(ctx->vo, "Initializing GBM surface (%d x %d)\n",
-        p->kms->mode.hdisplay, p->kms->mode.vdisplay);
+        p->osd_size.width, p->osd_size.height);
     p->gbm.surface = gbm_surface_create(
         p->gbm.device,
-        p->kms->mode.hdisplay,
-        p->kms->mode.vdisplay,
+        p->osd_size.width,
+        p->osd_size.height,
         p->gbm_format,
         GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
     if (!p->gbm.surface) {
@@ -325,7 +326,7 @@ static bool drm_atomic_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *o
     if (p->kms->atomic_context) {
         if (!p->kms->atomic_context->request) {
             p->kms->atomic_context->request = drmModeAtomicAlloc();
-            p->drm_params.atomic_request = p->kms->atomic_context->request;
+            p->drm_params.atomic_request_ptr = &p->kms->atomic_context->request;
         }
         return ra_gl_ctx_start_frame(sw, out_fbo);
     }
@@ -383,7 +384,7 @@ static void drm_egl_swap_buffers(struct ra_ctx *ctx)
 
     if (atomic_ctx) {
         drmModeAtomicFree(atomic_ctx->request);
-        p->drm_params.atomic_request = atomic_ctx->request = drmModeAtomicAlloc();
+        atomic_ctx->request = drmModeAtomicAlloc();
     }
 
     gbm_surface_release_buffer(p->gbm.surface, p->gbm.bo);
@@ -495,6 +496,20 @@ static bool drm_egl_init(struct ra_ctx *ctx)
         return false;
     }
 
+    if (ctx->vo->opts->drm_opts->drm_osd_size.wh_valid) {
+        if (p->kms->atomic_context) {
+            p->osd_size.width = ctx->vo->opts->drm_opts->drm_osd_size.w;
+            p->osd_size.height = ctx->vo->opts->drm_opts->drm_osd_size.h;
+        } else {
+            p->osd_size.width = p->kms->mode.hdisplay;
+            p->osd_size.height = p->kms->mode.vdisplay;
+            MP_WARN(ctx, "Setting OSD size is only available with DRM atomic, defaulting to screen resolution\n");
+        }
+    } else {
+        p->osd_size.width = p->kms->mode.hdisplay;
+        p->osd_size.height = p->kms->mode.vdisplay;
+    }
+
     uint32_t argb_format;
     uint32_t xrgb_format;
     if (DRM_OPTS_FORMAT_XRGB2101010 == ctx->vo->opts->drm_opts->drm_format) {
@@ -550,9 +565,10 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     }
 
     p->drm_params.fd = p->kms->fd;
+    p->drm_params.connector_id = p->kms->connector->connector_id;
     p->drm_params.crtc_id = p->kms->crtc_id;
     if (p->kms->atomic_context)
-        p->drm_params.atomic_request = p->kms->atomic_context->request;
+        p->drm_params.atomic_request_ptr = &p->kms->atomic_context->request;
     struct ra_gl_ctx_params params = {
         .swap_buffers = drm_egl_swap_buffers,
         .external_swapchain = p->kms->atomic_context ? &drm_atomic_swapchain :
@@ -561,7 +577,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     if (!ra_gl_ctx_init(ctx, &p->gl, params))
         return false;
 
-    ra_add_native_resource(ctx->ra, "opengl-cb-drm-params", &p->drm_params);
+    ra_add_native_resource(ctx->ra, "drm_params", &p->drm_params);
+    ra_add_native_resource(ctx->ra, "drm_osd_size", &p->osd_size);
 
     return true;
 }

--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -224,7 +224,7 @@ static int init(struct ra_hwdec *hw)
     drm_params = ra_get_native_resource(hw->ra, "drm_params");
     if (drm_params) {
         p->ctx = drm_atomic_create_context(p->log, drm_params->fd, drm_params->crtc_id,
-                                           drm_overlay);
+                                           drm_params->connector_id, drm_overlay);
         if (!p->ctx) {
             mp_err(p->log, "Failed to retrieve DRM atomic context.\n");
             goto err;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -420,7 +420,8 @@ static int preinit(struct vo *vo)
     p->kms = kms_create(
         vo->log, vo->opts->drm_opts->drm_connector_spec,
                  vo->opts->drm_opts->drm_mode_id,
-                 vo->opts->drm_opts->drm_overlay_id);
+                 vo->opts->drm_opts->drm_osd_plane_id,
+                 vo->opts->drm_opts->drm_video_plane_id);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");
         goto err;


### PR DESCRIPTION
Here are a few commits that intend to improve drm atomic support.
The main topic there are taking care of are :
- switch the the new API for the drm prime interop.
- use atomic modesetting in atomic path.
- Add the ability to select planes for video & osd
- Add the ability to use a specified osd size that can be different than videomode.

cc @wm4  @xantoz

I agree that my changes can be relicensed to LGPL 2.1 or later.
