### PR TITLE
build: fixup vendored wayland protocols with variants

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -129,12 +129,14 @@ def build(ctx):
         ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
             protocol  = "unstable/idle-inhibit/idle-inhibit-unstable-v1",
             target    = "video/out/wayland/idle-inhibit-v1.h")
-        ctx.wayland_protocol_code(proto_dir = "../video/out/wayland",
-            protocol = "server-decoration",
-            target   = "video/out/wayland/srv-decor.c")
-        ctx.wayland_protocol_header(proto_dir = "../video/out/wayland",
-            protocol = "server-decoration",
-            target   = "video/out/wayland/srv-decor.h")
+        ctx.wayland_protocol_code(proto_dir = "video/out/wayland",
+            protocol          = "server-decoration",
+            vendored_protocol = True,
+            target            = "video/out/wayland/srv-decor.c")
+        ctx.wayland_protocol_header(proto_dir = "video/out/wayland",
+            protocol          = "server-decoration",
+            vendored_protocol = True,
+            target            = "video/out/wayland/srv-decor.h")
 
     ctx(features = "ebml_header", target = "ebml_types.h")
     ctx(features = "ebml_definitions", target = "ebml_defs.c")


### PR DESCRIPTION
Utilize the SRC variable for this to get a built-in relative path.
Can be tested by adding `--variant="random_string"` to configure and
build.