### PR TITLE
demux, player: mark dependent tracks

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -724,6 +724,8 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
             sh->title = talloc_asprintf(sh, "visual impaired");
         if (!sh->title && st->disposition & AV_DISPOSITION_HEARING_IMPAIRED)
             sh->title = talloc_asprintf(sh, "hearing impaired");
+        if (st->disposition & AV_DISPOSITION_DEPENDENT)
+            sh->dependent_track = true;
         AVDictionaryEntry *lang = av_dict_get(st->metadata, "language", NULL, 0);
         if (lang && lang->value)
             sh->lang = talloc_strdup(sh, lang->value);

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -45,6 +45,7 @@ struct sh_stream {
     char *lang;                 // language code
     bool default_track;         // container default track flag
     bool forced_track;          // container forced track flag
+    bool dependent_track;       // container dependent track flag
     int hls_bitrate;
 
     struct mp_tags *tags;

--- a/player/command.c
+++ b/player/command.c
@@ -2242,6 +2242,7 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
         {"albumart",    SUB_PROP_FLAG(track->attached_picture)},
         {"default",     SUB_PROP_FLAG(track->default_track)},
         {"forced",      SUB_PROP_FLAG(track->forced_track)},
+        {"dependent",   SUB_PROP_FLAG(track->dependent_track)},
         {"external",    SUB_PROP_FLAG(track->is_external)},
         {"selected",    SUB_PROP_FLAG(track->selected)},
         {"external-filename", SUB_PROP_STR(track->external_filename),

--- a/player/core.h
+++ b/player/core.h
@@ -134,7 +134,7 @@ struct track {
     int ff_index; // same as stream->ff_index, or 0.
 
     char *title;
-    bool default_track, forced_track;
+    bool default_track, forced_track, dependent_track;
     bool attached_picture;
     char *lang;
 


### PR DESCRIPTION
ffmpeg marks audio tracks which are not meant to be played standalone
as DEPENDENT. these are typically used in DVB broadcasts for audio
descriptions, and are meant to be mixed into the main audio track during
playback.