### PR TITLE
demux: mark eia608 packets as keyframes

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -933,6 +933,7 @@ void demuxer_feed_caption(struct sh_stream *stream, demux_packet_t *dp)
         return;
     }
 
+    dp->keyframe = true;
     dp->pts = MP_ADD_PTS(dp->pts, -in->ts_offset);
     dp->dts = MP_ADD_PTS(dp->dts, -in->ts_offset);
     pthread_mutex_unlock(&in->lock);


### PR DESCRIPTION
This fixes an issue where captions stop rendering after an
in-demuxer-cache seek, because the demuxer keeps waiting to find
a keyframe (ds->skip_to_keyframe set to true in execute_cache_seek).