### PR TITLE
hwdec_ios: fix crash after mapper_init failure

### DIFF
--- a/video/out/opengl/hwdec_ios.m
+++ b/video/out/opengl/hwdec_ios.m
@@ -253,8 +253,10 @@ static void mapper_uninit(struct ra_hwdec_mapper *mapper)
     struct priv *p = mapper->priv;
 
     CVPixelBufferRelease(p->pbuf);
-    CFRelease(p->gl_texture_cache);
-    p->gl_texture_cache = NULL;
+    if (p->gl_texture_cache) {
+        CFRelease(p->gl_texture_cache);
+        p->gl_texture_cache = NULL;
+    }
 }
 
 const struct ra_hwdec_driver ra_hwdec_videotoolbox = {


### PR DESCRIPTION
NULL de-reference causes exception inside CFRelease