### PR TITLE
cocoa: change deprecation warning from opengl-cb to libmpv

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -75,10 +75,10 @@ Interface changes
       pad must be connected either to another filter, or to a video/audio track
       or video/audio output). If they are disconnected at runtime, the stream
       will probably stall.
-    - deprecate the OpenGL cocoa backend, option choice --gpu-context=cocoa
-      when used with --gpu-api=opengl (use --vo=opengl-cb)
     - rename --vo=opengl-cb to --vo=libmpv (goes in hand with the opengl-cb
       API deprecation, see client-api-changes.rst)
+    - deprecate the OpenGL cocoa backend, option choice --gpu-context=cocoa
+      when used with --gpu-api=opengl (use --vo=libmpv)
     - make --deinterlace=yes always deinterlace, instead of trying to check
       certain unreliable video metadata. Also flip the defaults of all builtin
       HW deinterlace filters to always deinterlace.

--- a/video/out/opengl/context_cocoa.c
+++ b/video/out/opengl/context_cocoa.c
@@ -171,7 +171,7 @@ static bool cocoa_init(struct ra_ctx *ctx)
     p->opts = mp_get_config_group(ctx, ctx->global, &cocoa_conf);
     vo_cocoa_init(ctx->vo);
 
-    MP_WARN(ctx->vo, "opengl cocoa backend is deprecated, use opengl-cb instead\n");
+    MP_WARN(ctx->vo, "opengl cocoa backend is deprecated, use vo=libmpv instead\n");
 
     if (!create_gl_context(ctx))
         goto fail;


### PR DESCRIPTION
this was missed when when opengl-cb was deprecated and i moved cocoa-cb to the new API. i also moved the the entry for cocoa-cb in `interface-changes.rst` underneath the `opengl-cb to libmpv` one and changed it to reference `vo=libmpv` instead. i think this way it makes more sense since we reference the proper `vo` directly instead of suggestion to use a `vo` that was deprecated a few changes later but in the same release.