### PR TITLE
options.c: display additional metadata tags during video playback

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -970,8 +970,9 @@ const struct MPOpts mp_default_opts = {
     .mf_fps = 1.0,
 
     .display_tags = (char **)(const char*[]){
-        "Artist", "Album", "Album_Artist", "Comment", "Composer", "Genre",
-        "Performer", "Title", "Track", "icy-title", "service_name",
+        "Artist", "Album", "Album_Artist", "Comment", "Composer",
+        "Date", "Description", "Genre", "Performer", "Rating",
+        "Series", "Title", "Track", "icy-title", "service_name",
         NULL
     },
 


### PR DESCRIPTION
This adds the 'Date', 'Description', 'Rating', and 'Series' tags to the
list of metadata displayed during playback.

The currently-displayed tags make sense for music files, but similar
information for video is more commonly - or at least should be - put
under other tags, while the audio-related tags are often used for
other information on video files (particularly with youtube-dl's
output).

I agree that my changes can be relicensed to LGPL 2.1 or later.
