### PR TITLE
cocoa-cb: use libmpv's advanced rendering control and timing 

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -128,6 +128,7 @@ class MPVHelper: NSObject {
     }
 
     func drawRender(_ surface: NSSize, skip: Bool = false) {
+        deinitLock.lock()
         if mpvRenderContext != nil {
             var i: GLint = 0
             var flip: CInt = 1
@@ -152,6 +153,7 @@ class MPVHelper: NSObject {
             glClearColor(0, 0, 0, 1)
             glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
         }
+        deinitLock.unlock()
     }
 
     func setRenderICCProfile(_ profile: NSColorSpace) {

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -613,6 +613,12 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.updateCusorVisibility()
     }
 
+    func windowDidChangeOcclusionState(_ notification: Notification) {
+        if occlusionState.contains(.visible) {
+            cocoaCB.layer.update(force: true)
+        }
+    }
+
     func windowWillMove(_ notification: Notification) {
         isMoving = true
     }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -72,7 +72,6 @@ class CocoaCB: NSObject {
     }
 
     func uninit() {
-        layer.setVideo(false)
         window.orderOut(nil)
     }
 
@@ -81,7 +80,6 @@ class CocoaCB: NSObject {
             DispatchQueue.main.sync { self.initBackend(vo) }
         } else {
             DispatchQueue.main.async {
-                self.layer.setVideo(true)
                 self.updateWindowSize(vo)
                 self.layer.update()
             }
@@ -106,7 +104,6 @@ class CocoaCB: NSObject {
         window.makeMain()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        layer.setVideo(true)
 
         if Bool(opts.fullscreen) {
             DispatchQueue.main.async {
@@ -449,7 +446,6 @@ class CocoaCB: NSObject {
 
     func shutdown(_ destroy: Bool = false) {
         setCursorVisiblility(true)
-        layer.setVideo(false)
         stopDisplaylink()
         uninitLightSensor()
         removeDisplayReconfigureObserver()


### PR DESCRIPTION
~~this incorporates PR #5753 (first 2 commits) since it makes a few things a bit easier. only the commit 
`cocoa-cb: use libmpv's advanced rendering control and timing` is relevant.~~

i simplified the function call of `mpv_render_context_update` in the helper a bit to only check for `MPV_RENDER_UPDATE_FRAME`, since we don't need anything else yet in cocoa-cb. if anything else is needed in the future we can change the semantic.

otherwise the rendering loop could be simplified quite a bit.