### PR TITLE
Tweak --cache-pause-* options for more control over buffering behavior

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,8 @@ Interface changes
 ::
 
  --- mpv 0.29.0 ---
+    - change --cache-pause-initial from yes/no flag to number of seconds for
+      initial buffer
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,
       --ad-spdif-dtshd, --softvol options

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,8 @@ Interface changes
 ::
 
  --- mpv 0.29.0 ---
+    - add --cache-pause-fill to control when the packet cache is considered
+      full after --cache-pause-wait triggers buffering
     - change --cache-pause-initial from yes/no flag to number of seconds for
       initial buffer
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3943,17 +3943,17 @@ Cache
     ends before that for some other reason (like file end), playback resumes
     earlier.
 
-``--cache-pause-initial=<yes|no>``
-    Enter "buffering" mode before starting playback (default: no). This can be
-    used to ensure playback starts smoothly, in exchange for waiting some time
-    to prefetch network data (as controlled by ``--cache-pause-wait``). For
+``--cache-pause-initial=<seconds>``
+    Number of seconds the packet cache should have buffered before starting
+    initial playback (default: 0). This can be used to ensure playback starts
+    smoothly, in exchange for waiting some time to prefetch network data. For
     example, some common behavior is that playback starts, but network caches
     immediately underrun when trying to decode more data as playback progresses.
 
     Another thing that can happen is that the network prefetching is so CPU
     demanding (due to demuxing in the background) that playback drops frames
     at first. In these cases, it helps enabling this option, and setting
-    ``--cache-secs`` and ``--cache-pause-wait`` to roughly the same value.
+    ``--cache-secs`` and ``--cache-pause-initial`` to roughly the same value.
 
     This option also triggers when playback is restarted after seeking.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3935,13 +3935,22 @@ Cache
     pause and unpause once more data is available, aka "buffering".
 
 ``--cache-pause-wait=<seconds>``
+    Minimum number of seconds the packet cache needs to contain to avoid
+    triggering "buffering" (default: 1). If the packet cache gets below this
+    value, the demuxer is considered to be underrun and the player will start
+    rebuffering if ``--cache-pause`` is enabled. This will also control when
+    the player leaves the buffering state, unless ``--cache-pause-fill`` is
+    set. If the given time is higher than the maximum set with ``--cache-secs``
+    or  ``--demuxer-readahead-secs``, or prefetching ends before that for some
+    other reason (like file end), playback resumes earlier.
+
+``--cache-pause-fill=<seconds>``
     Number of seconds the packet cache should have buffered before starting
-    playback again if "buffering" was entered (default: 1). This can be used
-    to control how long the player rebuffers if ``--cache-pause`` is enabled,
-    and the demuxer underruns. If the given time is higher than the maximum
-    set with ``--cache-secs`` or  ``--demuxer-readahead-secs``, or prefetching
-    ends before that for some other reason (like file end), playback resumes
-    earlier.
+    playback again once "buffering" was entered. By default, the value of
+    ``--cache-pause-wait`` is used, so the same threshold is used for both
+    starting and stopping buffering. This can be used to control how long
+    the player rebuffers if ``--cache-pause`` is enabled, and the demuxer
+    underruns.
 
 ``--cache-pause-initial=<seconds>``
     Number of seconds the packet cache should have buffered before starting

--- a/options/options.c
+++ b/options/options.c
@@ -465,6 +465,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("cache-pause", cache_pause, 0),
     OPT_FLOAT("cache-pause-initial", cache_pause_initial, M_OPT_MIN, .min = 0),
     OPT_FLOAT("cache-pause-wait", cache_pause_wait, M_OPT_MIN, .min = 0),
+    OPT_FLOAT("cache-pause-fill", cache_pause_fill, M_OPT_MIN, .min = 0),
 
     OPT_DOUBLE("mf-fps", mf_fps, 0),
     OPT_STRING("mf-type", mf_type, 0),

--- a/options/options.c
+++ b/options/options.c
@@ -463,7 +463,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("demuxer-thread", demuxer_thread, 0),
     OPT_FLAG("prefetch-playlist", prefetch_open, 0),
     OPT_FLAG("cache-pause", cache_pause, 0),
-    OPT_FLAG("cache-pause-initial", cache_pause_initial, 0),
+    OPT_FLOAT("cache-pause-initial", cache_pause_initial, M_OPT_MIN, .min = 0),
     OPT_FLOAT("cache-pause-wait", cache_pause_wait, M_OPT_MIN, .min = 0),
 
     OPT_DOUBLE("mf-fps", mf_fps, 0),

--- a/options/options.h
+++ b/options/options.h
@@ -266,7 +266,7 @@ typedef struct MPOpts {
     char *sub_demuxer_name;
 
     int cache_pause;
-    int cache_pause_initial;
+    float cache_pause_initial;
     float cache_pause_wait;
 
     struct image_writer_opts *screenshot_image_opts;

--- a/options/options.h
+++ b/options/options.h
@@ -268,6 +268,7 @@ typedef struct MPOpts {
     int cache_pause;
     float cache_pause_initial;
     float cache_pause_wait;
+    float cache_pause_fill;
 
     struct image_writer_opts *screenshot_image_opts;
     char *screenshot_template;

--- a/player/core.h
+++ b/player/core.h
@@ -415,6 +415,7 @@ typedef struct MPContext {
     bool playing_msg_shown;
 
     bool paused_for_cache;
+    bool paused_for_initial_cache;
     double cache_stop_time;
     int cache_buffer;
 


### PR DESCRIPTION
`--cache-pause-initial` is now number of seconds, so it can be controlled separately from buffering that happens during regular playback.

New `--cache-pause-fill` can be used along with `--cache-pause-wait` to control buffering start and stop thresholds separately. For example, you can tell the player to start buffering when the packet cache is less than 0.5s, but fill up the buffer until 1s. Previously there were cases where the player would keep entering buffering over and over, because the packet cache would dip slightly below the threshold and then fill up quickly and resume right away.