### PR TITLE
player: add more logging around buffering state

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -676,11 +676,16 @@ static void handle_pause_on_low_cache(struct MPContext *mpctx)
     if (mpctx->cache_buffer != cache_buffer) {
         if ((mpctx->cache_buffer == 100) != (cache_buffer == 100)) {
             if (cache_buffer < 100) {
-                MP_VERBOSE(mpctx, "Enter buffering.\n");
+                MP_VERBOSE(mpctx, "Enter buffering (buffer went from %d%% -> %d%%) [%fs].\n",
+                           mpctx->cache_buffer, cache_buffer, s.ts_duration);
             } else {
                 double t = now - mpctx->cache_stop_time;
-                MP_VERBOSE(mpctx, "End buffering (waited %f secs).\n", t);
+                MP_VERBOSE(mpctx, "End buffering (waited %f secs) [%fs].\n",
+                           t, s.ts_duration);
             }
+        } else {
+            MP_VERBOSE(mpctx, "Still buffering (buffer went from %d%% -> %d%%) [%fs].\n",
+                       mpctx->cache_buffer, cache_buffer, s.ts_duration);
         }
         mpctx->cache_buffer = cache_buffer;
         force_update = true;


### PR DESCRIPTION
I've been using these patches for a few months to get more visibility into buffering behaviors. Pretty useful IMHO, so I think it's worth merging.

Here's an example where I was using `--cache-wait=1.25` and there was a momentary dip in the demuxer cache:

```
[cplayer] Enter buffering (buffer went from 100% -> 92%) [0.925889s].
[cplayer] Still buffering (buffer went from 92% -> 74%) [0.925889s].
[cplayer] Still buffering (buffer went from 74% -> 78%) [0.975944s].
[cplayer] Still buffering (buffer went from 78% -> 90%) [1.126089s].
[cplayer] End buffering (waited 0.425415 secs) [1.342978s].
```