### PR TITLE
ytdl_hook: try to set video track first if available

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -311,14 +311,14 @@ local function add_single_video(json)
             if not edl_track and not url_is_safe(track.url) then
                 return
             end
-            if track.acodec and track.acodec ~= "none" then
+            if track.vcodec and track.vcodec ~= "none" then
+                -- video track
+                streamurl = edl_track or track.url
+            elseif track.acodec and track.acodec ~= "none" and track.vcodec == "none" then
                 -- audio track
                 mp.commandv("audio-add",
                     edl_track or track.url, "auto",
                     track.format_note or "")
-            elseif track.vcodec and track.vcodec ~= "none" then
-                -- video track
-                streamurl = edl_track or track.url
             end
         end
 


### PR DESCRIPTION
Fixes `--ytdl-format="dash-fastly_skyfire-video-363357330+dash-fastly_skyfire_sep-audio-363357330" https://vimeo.com/108650530`

This happened because the video track also had audio available and after
adding it expecting an audio-only track, there were no more tracks with video.