### PR TITLE
Fix playback of "music choice" cable channels in USA (video frames every 6s)

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -715,6 +715,8 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
             sh->default_track = true;
         if (st->disposition & AV_DISPOSITION_FORCED)
             sh->forced_track = true;
+        if (st->disposition & AV_DISPOSITION_DEPENDENT)
+            sh->dependent_track = true;
         if (priv->format_hack.use_stream_ids)
             sh->demuxer_id = st->id;
         AVDictionaryEntry *title = av_dict_get(st->metadata, "title", NULL, 0);
@@ -724,8 +726,6 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
             sh->title = talloc_asprintf(sh, "visual impaired");
         if (!sh->title && st->disposition & AV_DISPOSITION_HEARING_IMPAIRED)
             sh->title = talloc_asprintf(sh, "hearing impaired");
-        if (st->disposition & AV_DISPOSITION_DEPENDENT)
-            sh->dependent_track = true;
         AVDictionaryEntry *lang = av_dict_get(st->metadata, "language", NULL, 0);
         if (lang && lang->value && strcmp(lang->value, "und") != 0)
             sh->lang = talloc_strdup(sh, lang->value);

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -53,6 +53,9 @@
 #ifndef AV_DISPOSITION_TIMED_THUMBNAILS
 #define AV_DISPOSITION_TIMED_THUMBNAILS 0
 #endif
+#ifndef AV_DISPOSITION_STILL_IMAGE
+#define AV_DISPOSITION_STILL_IMAGE 0
+#endif
 
 #define INITIAL_PROBE_SIZE STREAM_BUFFER_SIZE
 #define PROBE_BUF_SIZE FFMIN(STREAM_MAX_BUFFER_SIZE, 2 * 1024 * 1024)
@@ -717,6 +720,8 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
             sh->forced_track = true;
         if (st->disposition & AV_DISPOSITION_DEPENDENT)
             sh->dependent_track = true;
+        if (st->disposition & AV_DISPOSITION_STILL_IMAGE)
+            sh->still_image = true;
         if (priv->format_hack.use_stream_ids)
             sh->demuxer_id = st->id;
         AVDictionaryEntry *title = av_dict_get(st->metadata, "title", NULL, 0);

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -46,6 +46,7 @@ struct sh_stream {
     bool default_track;         // container default track flag
     bool forced_track;          // container forced track flag
     bool dependent_track;       // container dependent track flag
+    bool still_image;           // video stream contains still images
     int hls_bitrate;
 
     struct mp_tags *tags;

--- a/player/core.h
+++ b/player/core.h
@@ -180,6 +180,8 @@ struct vo_chain {
     // - video consists of a single picture, which should be shown only once
     // - do not sync audio to video in any way
     bool is_coverart;
+    // - video consists of sparse still images
+    bool is_sparse;
 };
 
 // Like vo_chain, for audio.

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -950,7 +950,9 @@ static void handle_dummy_ticks(struct MPContext *mpctx)
 // Update current playback time.
 static void handle_playback_time(struct MPContext *mpctx)
 {
-    if (mpctx->vo_chain && !mpctx->vo_chain->is_coverart &&
+    if (mpctx->vo_chain &&
+        !mpctx->vo_chain->is_coverart &&
+        !mpctx->vo_chain->is_sparse &&
         mpctx->video_status >= STATUS_PLAYING &&
         mpctx->video_status < STATUS_EOF)
     {
@@ -986,6 +988,13 @@ static void handle_playback_restart(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
 
+    // Do not wait for video stream if it only has sparse frames.
+    if (mpctx->vo_chain &&
+        mpctx->vo_chain->is_sparse &&
+        mpctx->video_status < STATUS_READY) {
+        mpctx->video_status = STATUS_READY;
+    }
+
     if (mpctx->audio_status < STATUS_READY ||
         mpctx->video_status < STATUS_READY)
         return;
@@ -1008,7 +1017,9 @@ static void handle_playback_restart(struct MPContext *mpctx)
         }
 
         // Video needed, but not started yet -> wait.
-        if (mpctx->vo_chain && !mpctx->vo_chain->is_coverart &&
+        if (mpctx->vo_chain &&
+            !mpctx->vo_chain->is_coverart &&
+            !mpctx->vo_chain->is_sparse &&
             mpctx->video_status <= STATUS_READY)
             return;
 


### PR DESCRIPTION
Playing back https://s3.amazonaws.com/tmm1/music.ts (and especially when playing that channel live from my network TV tuner), there are a ton of issues:

- [x] "Invalid video timestamp" warnings shown
- [x] player does not start until first video frame, introducing up to 6s delay in playback
- [x] "Audio/Video desynchronisation detected" warning is shown
- [x] player tries to correct for A/V sync and delays video frames incorrectly
- [x] demuxer underrun triggers after each video frame is shown causing repeated "buffering" (when streaming live)
- [x] playback-time is only incremented every 6s