### PR TITLE
ao_alsa: replace snd_pcm_status() with snd_pcm_avail() on get_space()

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -939,17 +939,16 @@ static void drain(struct ao *ao)
 static int get_space(struct ao *ao)
 {
     struct priv *p = ao->priv;
-    snd_pcm_status_t *status;
     int err;
 
-    snd_pcm_status_alloca(&status);
+    unsigned space = err = snd_pcm_avail(p->alsa);
+    if (err == -EPIPE) // EOF
+        return p->buffersize;
 
-    err = snd_pcm_status(p->alsa, status);
     if (!check_device_present(ao, err))
         goto alsa_error;
-    CHECK_ALSA_ERROR("cannot get pcm status");
+    CHECK_ALSA_ERROR("cannot get pcm avail");
 
-    unsigned space = snd_pcm_status_get_avail(status);
     if (space > p->buffersize) // Buffer underrun?
         space = p->buffersize;
     return space / p->outburst * p->outburst;


### PR DESCRIPTION
Fix bug with alsa dmix on Fedora 29. After several minutes,
audio suddenly becomes bad and muted.

I agree that my changes can be relicensed to LGPL 2.1 or later.
