### PR TITLE
m_option: fix duplicate flag value

### DIFF
--- a/options/m_option.h
+++ b/options/m_option.h
@@ -410,8 +410,8 @@ char *format_file_size(int64_t size);
 
 // The following are also part of the M_OPT_* flags, and are used to update
 // certain groups of options.
-#define UPDATE_OPT_FIRST        (1 << 7)
-#define UPDATE_TERM             (1 << 7)  // terminal options
+#define UPDATE_OPT_FIRST        (1 << 8)
+#define UPDATE_TERM             (1 << 8)  // terminal options
 #define UPDATE_OSD              (1 << 10) // related to OSD rendering
 #define UPDATE_BUILTIN_SCRIPTS  (1 << 11) // osc/ytdl/stats
 #define UPDATE_IMGPAR           (1 << 12) // video image params overrides


### PR DESCRIPTION
bfc33da250e4fdb6bb57bdf051ad666570ae985f added a new m_option flag but didn't shift the ones after it.

Alternatively, we could bump to 9 and have room to add another flag without bumping.