### PR TITLE
osc: fix accidentally skipping files when seeking with slider

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1538,6 +1538,8 @@ function osc_init()
     end
     osc_param.playresx = osc_param.playresy * osc_param.display_aspect
 
+    -- stop seeking with the slider to prevent skipping files
+    state.active_element = nil
 
 
 


### PR DESCRIPTION
When seeking near the end of the file and the next file loads, seeking
continues on the next file at the same position and then immediately
the file after that. This patch stops slider seeking when a new file is
loaded, which is the standard behavior of many other players.

I agree that my changes can be relicensed to LGPL 2.1 or later.
