### PR TITLE
vo_gpu: allow higher icc-contrast and improve logging

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5277,7 +5277,7 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Size of the 3D LUT generated from the ICC profile in each dimension.
     Default is 64x64x64. Sizes may range from 2 to 512.
 
-``--icc-contrast=<0-100000>``
+``--icc-contrast=<0-1000000>``
     Specifies an upper limit on the target device's contrast ratio. This is
     detected automatically from the profile if possible, but for some profiles
     it might be missing, causing the contrast to be assumed as infinite. As a

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -83,7 +83,7 @@ const struct m_sub_options mp_icc_conf = {
         OPT_FLAG("icc-profile-auto", profile_auto, 0),
         OPT_STRING("icc-cache-dir", cache_dir, M_OPT_FILE),
         OPT_INT("icc-intent", intent, 0),
-        OPT_INTRANGE("icc-contrast", contrast, 0, 0, 100000),
+        OPT_INTRANGE("icc-contrast", contrast, 0, 0, 1000000),
         OPT_STRING_VALIDATE("icc-3dlut-size", size_str, 0, validate_3dlut_size_opt),
 
         OPT_REPLACED("3dlut-size", "icc-3dlut-size"),
@@ -304,7 +304,8 @@ static cmsHPROFILE get_vid_profile(struct gl_lcms *p, cmsContext cms,
 
         // Built-in contrast failsafe
         double contrast = 3.0 / (src_black[0] + src_black[1] + src_black[2]);
-        if (contrast > 100000) {
+        MP_VERBOSE(p, "Detected ICC profile contrast: %f\n", contrast);
+        if (contrast > 100000 && !p->opts->contrast) {
             MP_WARN(p, "ICC profile detected contrast very high (>100000),"
                     " falling back to contrast 1000 for sanity. Set the"
                     " icc-contrast option to silence this warning.\n");


### PR DESCRIPTION
With the advent of actual HDR devices, my real measured ICC profile has
an "infinite" contrast, since the display is completely off on pure
black inputs. 100k:1 might not be enough, so let's just bump it up to
1m:1 to be safe.

Also, improve the logging in the case that the detected contrast is too
high by default.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
