### PR TITLE
manpage: kill reference to removed option "--heartbeat-cmd"

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2547,7 +2547,7 @@ Window
 
     This is not supported on all video outputs or platforms. Sometimes it is
     implemented, but does not work (known to happen with GNOME). You might be
-    able to work around this using ``--heartbeat-cmd`` instead.
+    able to work around this using a script instead.
 
 ``--wid=<ID>``
     This tells mpv to attach to an existing window. If a VO is selected that


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
