### PR TITLE
Random small cherry-picks from das big PR

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -186,8 +186,6 @@ static const struct format_hack format_hacks[] = {
     BLACKLIST("bin"),
     // Useless, does not work with custom streams.
     BLACKLIST("image2"),
-    // Probably a security risk.
-    BLACKLIST("ffm"),
     // Image demuxers ("<name>_pipe" is detected explicitly)
     {"image2pipe", .image_format = true},
     {0}

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -57,19 +57,6 @@ enum mp_cmd_flags {
                       MP_ON_OSD_BAR | MP_ON_OSD_MSG,
 };
 
-enum mp_input_section_flags {
-    // If a key binding is not defined in the current section, do not search the
-    // other sections for it (like the default section). Instead, an unbound
-    // key warning will be printed.
-    MP_INPUT_EXCLUSIVE = 1,
-    // Prefer it to other sections.
-    MP_INPUT_ON_TOP = 2,
-    // Let mp_input_test_dragging() return true, even if inside the mouse area.
-    MP_INPUT_ALLOW_VO_DRAGGING = 4,
-    // Don't force mouse pointer visible, even if inside the mouse area.
-    MP_INPUT_ALLOW_HIDE_CURSOR = 8,
-};
-
 // Arbitrary upper bound for sanity.
 #define MP_CMD_MAX_ARGS 100
 

--- a/input/input.h
+++ b/input/input.h
@@ -47,6 +47,19 @@ struct mp_input_src {
     void *priv;
 };
 
+enum mp_input_section_flags {
+    // If a key binding is not defined in the current section, do not search the
+    // other sections for it (like the default section). Instead, an unbound
+    // key warning will be printed.
+    MP_INPUT_EXCLUSIVE = 1,
+    // Prefer it to other sections.
+    MP_INPUT_ON_TOP = 2,
+    // Let mp_input_test_dragging() return true, even if inside the mouse area.
+    MP_INPUT_ALLOW_VO_DRAGGING = 4,
+    // Don't force mouse pointer visible, even if inside the mouse area.
+    MP_INPUT_ALLOW_HIDE_CURSOR = 8,
+};
+
 // Add an input source that runs on a thread. The source is automatically
 // removed if the thread loop exits.
 //  ctx: this is passed to loop_fn.

--- a/input/keycodes.h
+++ b/input/keycodes.h
@@ -135,6 +135,8 @@
 #define MP_KEY_IS_MOUSE_BTN_DBL(code) \
     ((code) >= MP_MBTN_DBL_BASE && (code) < MP_MBTN_DBL_END)
 
+#define MP_KEY_MOUSE_BTN_COUNT (MP_MBTN_END - MP_MBTN_BASE)
+
 // Apple Remote input module
 #define MP_AR_BASE        (MP_KEY_BASE+0xE0)
 #define MP_AR_PLAY        (MP_AR_BASE + 0)

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -395,8 +395,10 @@ static void *terminal_thread(void *ptr)
         polldev(fds, stdin_ok ? 2 : 1, -1);
         if (fds[0].revents)
             break;
-        if (fds[1].revents)
-            getch2(input_ctx);
+        if (fds[1].revents) {
+            if (!getch2(input_ctx))
+                break;
+        }
     }
     char c;
     bool quit = read(death_pipe[0], &c, 1) == 1 && c == 1;

--- a/player/command.c
+++ b/player/command.c
@@ -5757,7 +5757,7 @@ static void cmd_mouse(void *p)
         mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
         return;
     }
-    if (button < 0 || button >= 20) {// invalid button
+    if (button < 0 || button >= MP_KEY_MOUSE_BTN_COUNT) {// invalid button
         MP_ERR(mpctx, "%d is not a valid mouse button number.\n", button);
         cmd->success = false;
         return;

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -818,13 +818,7 @@ static enum AVPixelFormat get_format_hwdec(struct AVCodecContext *avctx,
 
     if (select == AV_PIX_FMT_NONE) {
         ctx->hwdec_failed = true;
-        for (int i = 0; fmt[i] != AV_PIX_FMT_NONE; i++) {
-            const AVPixFmtDescriptor *d = av_pix_fmt_desc_get(fmt[i]);
-            if (d && !(d->flags & AV_PIX_FMT_FLAG_HWACCEL)) {
-                select = fmt[i];
-                break;
-            }
-        }
+        select = avcodec_default_get_format(avctx, fmt);
     }
 
     const char *name = av_get_pix_fmt_name(select);

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1133,6 +1133,8 @@ void vo_x11_check_events(struct vo *vo)
             mp_input_put_key(x11->input_ctx, MP_KEY_MOUSE_ENTER);
             break;
         case ButtonPress:
+            if (Event.xbutton.button - 1 >= MP_KEY_MOUSE_BTN_COUNT)
+                break;
             if (Event.xbutton.button == 1)
                 x11->win_drag_button1_down = true;
             mp_input_put_key(x11->input_ctx,
@@ -1142,6 +1144,8 @@ void vo_x11_check_events(struct vo *vo)
             vo_x11_xembed_send_message(x11, msg);
             break;
         case ButtonRelease:
+            if (Event.xbutton.button - 1 >= MP_KEY_MOUSE_BTN_COUNT)
+                break;
             if (Event.xbutton.button == 1)
                 x11->win_drag_button1_down = false;
             mp_input_put_key(x11->input_ctx,


### PR DESCRIPTION
Some misc. fixes, before I fall asleep.

* Improvements to missing terminal and too many mouse buttons being available.
* Simplify `vd_lavc` 's `get_format` by utilizing an FFmpeg function that has been around since at least 2015.
* Stop black-listing no longer available ffm format that was in ye olden versions of FFmpeg pre-ffserver removal.
* Move `mp_input_section_flags` back to `input/input.h`.

Worked for mingw-w64 with both hwdec and swdec, and most likely will for Android since I have a feeling the last time I tested things I had all these things in the tree.