### PR TITLE
stream_file: enable cache for FUSE filesystems on OpenBSD and FreeBSD

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -193,7 +193,7 @@ static bool check_stream_network(int fd)
 {
     struct statfs fs;
     const char *stypes[] = { "afpfs", "nfs", "smbfs", "webdav", "osxfusefs",
-                             NULL };
+                             "fuse", "fusefs.sshfs", NULL };
     if (fstatfs(fd, &fs) == 0)
         for (int i=0; stypes[i]; i++)
             if (strcmp(stypes[i], fs.f_fstypename) == 0)


### PR DESCRIPTION
Obviously "osxfusefs" works only on Mac. On OpenBSD it's just "fuse" while on FreeBSD (for the scenario described in #634) it would be "fusefs.sshfs"

I agree that my changes can be relicensed to LGPL 2.1 or later.