### PR TITLE
drm: user-friendlyness improvements to some options

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -479,13 +479,14 @@ Available video output drivers are:
     ``--drm-connector=[<gpu_number>.]<name>``
         Select the connector to use (usually this is a monitor.) If ``<name>``
         is empty or ``auto``, mpv renders the output on the first available
-        connector. Use ``--drm-connector=help`` to get list of available
+        connector. Use ``--drm-connector=help`` to get a list of available
         connectors. When using multiple graphic cards, use the ``<gpu_number>``
         argument to disambiguate.
         (default: empty)
 
     ``--drm-mode=<number>``
-        Mode ID to use (resolution and frame rate).
+        Mode ID to use (resolution and frame rate). Use ``--drm-mode=help`` to
+        get a list of available modes for all active connectors.
         (default: 0)
 
     ``--drm-atomic=<no|auto>``

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,6 +488,16 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
+    ``--drm-atomic=<no|auto>``
+        Toggle use of atomic modesetting. Mostly useful for debugging.
+
+        :no:    Use legacy modesetting.
+        :auto:  Use atomic modesetting, falling back to legacy modesetting if
+                not available. (default)
+
+        Note: Only affects ``gpu-context=drm``. ``vo=drm`` supports legacy
+        modesetting only.
+
     ``--drm-draw-plane=<primary|overlay|N>``
         Select the DRM plane to which video and OSD is drawn to, under normal
         circumstances. The plane can be specified as ``primary``, which will

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -484,10 +484,21 @@ Available video output drivers are:
         argument to disambiguate.
         (default: empty)
 
-    ``--drm-mode=<number>``
-        Mode ID to use (resolution and frame rate). Use ``--drm-mode=help`` to
-        get a list of available modes for all active connectors.
-        (default: 0)
+    ``--drm-mode=<preferred|highest|N|WxH[@R]>``
+        Mode to use (resolution and frame rate).
+        Possible values:
+
+        :preferred: Use the preferred mode for the screen on the selected
+                    connector. (default)
+        :highest:   Use the mode with the highest resolution available on the
+                    selected connector.
+        :N:         Select mode by index.
+        :WxH[@R]:   Specify mode by width, height, and optionally refresh rate.
+                    In case several modes match, selects the mode that comes
+                    first in the EDID list of modes.
+
+        Use ``--drm-mode=help`` to get a list of available modes for all active
+        connectors.
 
     ``--drm-atomic=<no|auto>``
         Toggle use of atomic modesetting. Mostly useful for debugging.

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -43,6 +43,19 @@
 
 static int vt_switcher_pipe[2];
 
+static int drm_validate_connector_opt(
+    struct mp_log *log, const struct m_option *opt, struct bstr name,
+    struct bstr param);
+
+static int drm_validate_mode_opt(
+    struct mp_log *log, const struct m_option *opt, struct bstr name,
+    struct bstr param);
+
+static void kms_show_available_modes(
+    struct mp_log *log, const drmModeConnector *connector);
+
+static void kms_show_available_connectors(struct mp_log *log, int card_no);
+
 #define OPT_BASE_STRUCT struct drm_opts
 const struct m_sub_options drm_conf = {
     .opts = (const struct m_option[]) {
@@ -384,7 +397,7 @@ static double mode_get_Hz(const drmModeModeInfo *mode)
     return mode->clock * 1000.0 / mode->htotal / mode->vtotal;
 }
 
-void kms_show_available_modes(
+static void kms_show_available_modes(
     struct mp_log *log, const drmModeConnector *connector)
 {
     for (unsigned int i = 0; i < connector->count_modes; i++) {
@@ -438,7 +451,7 @@ static void kms_show_connector_name_and_state_callback(
     mp_info(log, "  %s (%s)\n", other_connector_name, connection_str);
 }
 
-void kms_show_available_connectors(struct mp_log *log, int card_no)
+static void kms_show_available_connectors(struct mp_log *log, int card_no)
 {
     mp_info(log, "Available connectors for card %d:\n", card_no);
     kms_show_foreach_connector(
@@ -460,7 +473,7 @@ static void kms_show_connector_modes_callback(struct mp_log *log, int card_no,
     mp_info(log, "\n");
 }
 
-void kms_show_available_connectors_and_modes(struct mp_log *log, int card_no)
+static void kms_show_available_connectors_and_modes(struct mp_log *log, int card_no)
 {
     kms_show_foreach_connector(log, card_no, kms_show_connector_modes_callback);
 }
@@ -477,12 +490,12 @@ static void kms_show_foreach_card(
     }
 }
 
-void kms_show_available_cards_and_connectors(struct mp_log *log)
+static void kms_show_available_cards_and_connectors(struct mp_log *log)
 {
     kms_show_foreach_card(log, kms_show_available_connectors);
 }
 
-void kms_show_available_cards_connectors_and_modes(struct mp_log *log)
+static void kms_show_available_cards_connectors_and_modes(struct mp_log *log)
 {
     kms_show_foreach_card(log, kms_show_available_connectors_and_modes);
 }
@@ -492,8 +505,8 @@ double kms_get_display_fps(const struct kms *kms)
     return mode_get_Hz(&kms->mode.mode);
 }
 
-int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
-                               struct bstr name, struct bstr param)
+static int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
+                                      struct bstr name, struct bstr param)
 {
     if (bstr_equals0(param, "help")) {
         kms_show_available_cards_and_connectors(log);
@@ -502,8 +515,8 @@ int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
     return 1;
 }
 
-int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
-                          struct bstr name, struct bstr param)
+static int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
+                                 struct bstr name, struct bstr param)
 {
     if (bstr_equals0(param, "help")) {
         kms_show_available_cards_connectors_and_modes(log);

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -48,6 +48,7 @@ struct vt_switcher {
 struct drm_opts {
     char *drm_connector_spec;
     int drm_mode_id;
+    int drm_atomic;
     int drm_draw_plane;
     int drm_drmprime_video_plane;
     int drm_format;
@@ -65,7 +66,8 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
                          void *user_data);
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int draw_plane, int drmprime_video_plane);
+                       int mode_id, int draw_plane, int drmprime_video_plane,
+                       bool use_atomic);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -47,7 +47,7 @@ struct vt_switcher {
 
 struct drm_opts {
     char *drm_connector_spec;
-    int drm_mode_id;
+    char *drm_mode_spec;
     int drm_atomic;
     int drm_draw_plane;
     int drm_drmprime_video_plane;
@@ -66,7 +66,8 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
                          void *user_data);
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int draw_plane, int drmprime_video_plane,
+                       const char *mode_spec,
+                       int draw_plane, int drmprime_video_plane,
                        bool use_atomic);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
@@ -74,9 +75,14 @@ double kms_get_display_fps(const struct kms *kms);
 void kms_show_available_connectors(struct mp_log *log, int card_no);
 void kms_show_available_modes(struct mp_log *log,
                               const drmModeConnector *connector);
+void kms_show_available_connectors_and_modes(struct mp_log *log, int card_no);
 void kms_show_available_cards_and_connectors(struct mp_log *log);
+void kms_show_available_cards_connectors_and_modes(struct mp_log *log);
 
 int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
                                struct bstr name, struct bstr param);
+
+int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
+                          struct bstr name, struct bstr param);
 
 #endif

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -72,17 +72,4 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 
-void kms_show_available_connectors(struct mp_log *log, int card_no);
-void kms_show_available_modes(struct mp_log *log,
-                              const drmModeConnector *connector);
-void kms_show_available_connectors_and_modes(struct mp_log *log, int card_no);
-void kms_show_available_cards_and_connectors(struct mp_log *log);
-void kms_show_available_cards_connectors_and_modes(struct mp_log *log);
-
-int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,
-                               struct bstr name, struct bstr param);
-
-int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
-                          struct bstr name, struct bstr param);
-
 #endif

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -766,7 +766,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     p->kms = kms_create(ctx->log, ctx->vo->opts->drm_opts->drm_connector_spec,
                         ctx->vo->opts->drm_opts->drm_mode_id,
                         ctx->vo->opts->drm_opts->drm_draw_plane,
-                        ctx->vo->opts->drm_opts->drm_drmprime_video_plane);
+                        ctx->vo->opts->drm_opts->drm_drmprime_video_plane,
+                        ctx->vo->opts->drm_opts->drm_atomic);
     if (!p->kms) {
         MP_ERR(ctx, "Failed to create KMS.\n");
         return false;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -764,7 +764,7 @@ static bool drm_egl_init(struct ra_ctx *ctx)
 
     MP_VERBOSE(ctx, "Initializing KMS\n");
     p->kms = kms_create(ctx->log, ctx->vo->opts->drm_opts->drm_connector_spec,
-                        ctx->vo->opts->drm_opts->drm_mode_id,
+                        ctx->vo->opts->drm_opts->drm_mode_spec,
                         ctx->vo->opts->drm_opts->drm_draw_plane,
                         ctx->vo->opts->drm_opts->drm_drmprime_video_plane,
                         ctx->vo->opts->drm_opts->drm_atomic);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -417,11 +417,10 @@ static int preinit(struct vo *vo)
         MP_WARN(vo, "Failed to set up VT switcher. Terminal switching will be unavailable.\n");
     }
 
-    p->kms = kms_create(
-        vo->log, vo->opts->drm_opts->drm_connector_spec,
-                 vo->opts->drm_opts->drm_mode_id,
-                 vo->opts->drm_opts->drm_draw_plane,
-                 vo->opts->drm_opts->drm_drmprime_video_plane);
+    p->kms = kms_create(vo->log,
+                        vo->opts->drm_opts->drm_connector_spec,
+                        vo->opts->drm_opts->drm_mode_id,
+                        0, 0, false);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");
         goto err;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -419,7 +419,7 @@ static int preinit(struct vo *vo)
 
     p->kms = kms_create(vo->log,
                         vo->opts->drm_opts->drm_connector_spec,
-                        vo->opts->drm_opts->drm_mode_id,
+                        vo->opts->drm_opts->drm_mode_spec,
                         0, 0, false);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");


### PR DESCRIPTION
--drm-mode now has a proper help option (you no longer have to say --drm-mode=-1 and supply a file to mpv) which lists the available modes of all active connectors. This is also a stepping stone to even nicer ways of specifying the mode for --drm-mode.

<strike>--drm-osd-plane-id and --drm-video-plane-id now take the options "primary" and "overlay" allowing you to select planes by this property, rather than by index.</strike> already merged in another PR.

<strike>I've ordered the commits to facilitate partial merging, should we want just the bug fixes for 0.29.</strike>

I agree that my changes can be relicensed to LGPL 2.1 or later.
