### PR TITLE
hwdec_drmprime_drm: Do not show error message during probing

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -258,7 +258,7 @@ static int init(struct ra_hwdec *hw)
             goto err;
         }
     } else {
-        mp_err(p->log, "Failed to retrieve DRM fd from native display.\n");
+        mp_verbose(p->log, "Failed to retrieve DRM fd from native display.\n");
         goto err;
     }
 


### PR DESCRIPTION
Change the log-level of an error message that would sometimes show up
during hwdec probing, and could be misleading.

This should fix Issue #5857.

I agree that my changes can be relicensed to LGPL 2.1 or later.
