### PR TITLE
vo_libmpv: support render performance data

### DIFF
--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -207,6 +207,14 @@ static void screenshot(struct render_backend *ctx, struct vo_frame *frame,
     gl_video_screenshot(p->renderer, frame, args);
 }
 
+static void perfdata(struct render_backend *ctx,
+                     struct voctrl_performance_data *out)
+{
+    struct priv *p = ctx->priv;
+
+    gl_video_perfdata(p->renderer, out);
+}
+
 static void destroy(struct render_backend *ctx)
 {
     struct priv *p = ctx->priv;
@@ -235,5 +243,6 @@ const struct render_backend_fns render_backend_gpu = {
     .render = render,
     .get_image = get_image,
     .screenshot = screenshot,
+    .perfdata = perfdata,
     .destroy = destroy,
 };

--- a/video/out/libmpv.h
+++ b/video/out/libmpv.h
@@ -54,6 +54,8 @@ struct render_backend_fns {
     void (*reset)(struct render_backend *ctx);
     void (*screenshot)(struct render_backend *ctx, struct vo_frame *frame,
                        struct voctrl_screenshot *args);
+    void (*perfdata)(struct render_backend *ctx,
+                     struct voctrl_performance_data *out);
     // Like vo_driver.get_image().
     struct mp_image *(*get_image)(struct render_backend *ctx, int imgfmt,
                                   int w, int h, int stride_align);


### PR DESCRIPTION
similar to commit 0be3a94e0b81d553849f9520f7ee9f2b6e34c6b4. #5322 could still be related, but the issue might be gone by now with the rewrite of opengl-cb and the new libmpv API.