### PR TITLE
cocoa-cb: add logging for CGL pixel format attributes

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -128,6 +128,7 @@ class MPVHelper: NSObject {
     }
 
     func drawRender(_ surface: NSSize, skip: Bool = false) {
+        deinitLock.lock()
         if mpvRenderContext != nil {
             var i: GLint = 0
             var flip: CInt = 1
@@ -152,6 +153,7 @@ class MPVHelper: NSObject {
             glClearColor(0, 0, 0, 1)
             glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
         }
+        deinitLock.unlock()
     }
 
     func setRenderICCProfile(_ profile: NSColorSpace) {

--- a/video/out/cocoa-cb/video_layer.swift
+++ b/video/out/cocoa-cb/video_layer.swift
@@ -148,6 +148,18 @@ class VideoLayer: CAOpenGLLayer {
     override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj {
         if cglPixelFormat != nil { return cglPixelFormat! }
 
+        let attributeLookUp: [UInt32:String] = [
+            kCGLOGLPVersion_3_2_Core.rawValue:     "kCGLOGLPVersion_3_2_Core",
+            kCGLOGLPVersion_Legacy.rawValue:       "kCGLOGLPVersion_Legacy",
+            kCGLPFAOpenGLProfile.rawValue:         "kCGLPFAOpenGLProfile",
+            kCGLPFAAccelerated.rawValue:           "kCGLPFAAccelerated",
+            kCGLPFADoubleBuffer.rawValue:          "kCGLPFADoubleBuffer",
+            kCGLPFABackingStore.rawValue:          "kCGLPFABackingStore",
+            kCGLPFAAllowOfflineRenderers.rawValue: "kCGLPFAAllowOfflineRenderers",
+            kCGLPFASupportsAutomaticGraphicsSwitching.rawValue: "kCGLPFASupportsAutomaticGraphicsSwitching",
+            0: ""
+        ]
+
         let glVersions: [CGLOpenGLProfile] = [
             kCGLOGLPVersion_3_2_Core,
             kCGLOGLPVersion_Legacy
@@ -175,6 +187,13 @@ class VideoLayer: CAOpenGLLayer {
                 if err == kCGLBadAttribute || err == kCGLBadPixelFormat || pix == nil {
                     glAttributes.remove(at: index)
                 } else {
+                    var attArray = glAttributes.map({ (value: _CGLPixelFormatAttribute) -> String in
+                        return attributeLookUp[value.rawValue]!
+                    })
+                    attArray.removeLast()
+
+                    mpv.sendVerbose("Created CGL pixel format with attributes: " +
+                                    "\(attArray.joined(separator: ", "))")
                     break verLoop
                 }
             }

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -613,6 +613,12 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.updateCusorVisibility()
     }
 
+    func windowDidChangeOcclusionState(_ notification: Notification) {
+        if occlusionState.contains(.visible) {
+            cocoaCB.layer.update(force: true)
+        }
+    }
+
     func windowWillMove(_ notification: Notification) {
         isMoving = true
     }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -72,7 +72,6 @@ class CocoaCB: NSObject {
     }
 
     func uninit() {
-        layer.setVideo(false)
         window.orderOut(nil)
     }
 
@@ -81,7 +80,6 @@ class CocoaCB: NSObject {
             DispatchQueue.main.sync { self.initBackend(vo) }
         } else {
             DispatchQueue.main.async {
-                self.layer.setVideo(true)
                 self.updateWindowSize(vo)
                 self.layer.update()
             }
@@ -106,7 +104,6 @@ class CocoaCB: NSObject {
         window.makeMain()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        layer.setVideo(true)
 
         if Bool(opts.fullscreen) {
             DispatchQueue.main.async {
@@ -449,7 +446,6 @@ class CocoaCB: NSObject {
 
     func shutdown(_ destroy: Bool = false) {
         setCursorVisiblility(true)
-        layer.setVideo(false)
         stopDisplaylink()
         uninitLightSensor()
         removeDisplayReconfigureObserver()


### PR DESCRIPTION
this PR depends on ~~#5753 and~~ #5786. only relevant commit for this PR is  `cocoa-cb: add logging for CGL pixel format attributes`.

some time ago i had a problem debugging some problems of someone else. it all boiled down to his system forcing a legacy context but i couldn't see it at first glance. so i thought i would be helpful to know what kind of context is created in the end.