### PR TITLE
context_drm_egl: Bug fixes (Fix Atomic DRM CRTC release and VAAPI EGL interop)

### DIFF
--- a/libmpv/render_gl.h
+++ b/libmpv/render_gl.h
@@ -149,7 +149,7 @@ typedef struct mpv_opengl_fbo {
 
 typedef struct mpv_opengl_drm_params {
     /**
-     * DRM fd (int). set this to -1 if invalid.
+     * DRM fd (int). Set to a negative number if invalid.
      */
     int fd;
 
@@ -169,6 +169,12 @@ typedef struct mpv_opengl_drm_params {
      * The atomic request pointer is usually changed at every renderloop.
      */
     struct _drmModeAtomicReq **atomic_request_ptr;
+
+    /**
+     * DRM render node. Used for VAAPI interop.
+     * Set to a negative number if invalid.
+     */
+    int render_fd;
 } mpv_opengl_drm_params;
 
 typedef struct mpv_opengl_drm_osd_size {

--- a/video/out/drm_atomic.c
+++ b/video/out/drm_atomic.c
@@ -290,9 +290,153 @@ fail:
 
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx)
 {
+    drm_mode_destroy_blob(ctx->fd, &ctx->old_state.crtc.mode);
     drm_object_free(ctx->crtc);
     drm_object_free(ctx->connector);
     drm_object_free(ctx->osd_plane);
     drm_object_free(ctx->video_plane);
     talloc_free(ctx);
+}
+
+static bool drm_atomic_save_plane_state(struct drm_object *plane,
+                                        struct drm_atomic_plane_state *plane_state)
+{
+    bool ret = true;
+
+    if (0 > drm_object_get_property(plane, "FB_ID", &plane_state->fb_id))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "CRTC_ID", &plane_state->crtc_id))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "SRC_X", &plane_state->src_x))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "SRC_Y", &plane_state->src_y))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "SRC_W", &plane_state->src_w))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "SRC_H", &plane_state->src_h))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "CRTC_X", &plane_state->crtc_x))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "CRTC_Y", &plane_state->crtc_y))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "CRTC_W", &plane_state->crtc_w))
+        ret = false;
+    if (0 > drm_object_get_property(plane, "CRTC_H", &plane_state->crtc_h))
+        ret = false;
+    // ZPOS might not exist, so ignore whether or not this succeeds
+    drm_object_get_property(plane, "ZPOS", &plane_state->zpos);
+
+    return ret;
+}
+
+static bool drm_atomic_restore_plane_state(drmModeAtomicReq *request,
+                                           struct drm_object *plane,
+                                           const struct drm_atomic_plane_state *plane_state)
+{
+    bool ret = true;
+
+    if (0 > drm_object_set_property(request, plane, "FB_ID", plane_state->fb_id))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "CRTC_ID", plane_state->crtc_id))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "SRC_X", plane_state->src_x))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "SRC_Y", plane_state->src_y))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "SRC_W", plane_state->src_w))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "SRC_H", plane_state->src_h))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "CRTC_X", plane_state->crtc_x))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "CRTC_Y", plane_state->crtc_y))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "CRTC_W", plane_state->crtc_w))
+        ret = false;
+    if (0 > drm_object_set_property(request, plane, "CRTC_H", plane_state->crtc_h))
+        ret = false;
+    // ZPOS might not exist, so ignore whether or not this succeeds
+    drm_object_set_property(request, plane, "ZPOS", plane_state->zpos);
+
+    return ret;
+}
+
+bool drm_atomic_save_old_state(struct drm_atomic_context *ctx)
+{
+    if (ctx->old_state.saved)
+        return false;
+
+    bool ret = true;
+
+    drmModeCrtc *crtc = drmModeGetCrtc(ctx->fd, ctx->crtc->id);
+    if (crtc == NULL)
+        return false;
+    ctx->old_state.crtc.mode.mode = crtc->mode;
+    drmModeFreeCrtc(crtc);
+
+    if (0 > drm_object_get_property(ctx->crtc, "ACTIVE", &ctx->old_state.crtc.active))
+        ret = false;
+
+    if (0 > drm_object_get_property(ctx->connector, "CRTC_ID", &ctx->old_state.connector.crtc_id))
+        ret = false;
+
+    if (!drm_atomic_save_plane_state(ctx->osd_plane, &ctx->old_state.osd_plane))
+        ret = false;
+    if (!drm_atomic_save_plane_state(ctx->video_plane, &ctx->old_state.video_plane))
+        ret = false;
+
+    ctx->old_state.saved = true;
+
+    return ret;
+}
+
+bool drm_atomic_restore_old_state(drmModeAtomicReqPtr request, struct drm_atomic_context *ctx)
+{
+    if (!ctx->old_state.saved)
+        return false;
+
+    bool ret = true;
+
+    if (0 > drm_object_set_property(request, ctx->connector, "CRTC_ID", ctx->old_state.connector.crtc_id))
+        ret = false;
+
+    if (!drm_mode_ensure_blob(ctx->fd, &ctx->old_state.crtc.mode))
+        ret = false;
+    if (0 > drm_object_set_property(request, ctx->crtc, "MODE_ID", ctx->old_state.crtc.mode.blob_id))
+        ret = false;
+    if (0 > drm_object_set_property(request, ctx->crtc, "ACTIVE", ctx->old_state.crtc.active))
+        ret = false;
+
+    if (!drm_atomic_restore_plane_state(request, ctx->osd_plane, &ctx->old_state.osd_plane))
+        ret = false;
+    if (!drm_atomic_restore_plane_state(request, ctx->video_plane, &ctx->old_state.video_plane))
+        ret = false;
+
+    ctx->old_state.saved = false;
+
+    return ret;
+}
+
+bool drm_mode_ensure_blob(int fd, struct drm_mode *mode)
+{
+    int ret = 0;
+
+    if (!mode->blob_id) {
+        ret = drmModeCreatePropertyBlob(fd, &mode->mode, sizeof(drmModeModeInfo),
+                                        &mode->blob_id);
+    }
+
+    return (ret == 0);
+}
+
+bool drm_mode_destroy_blob(int fd, struct drm_mode *mode)
+{
+    int ret = 0;
+
+    if (mode->blob_id) {
+        ret = drmModeDestroyPropertyBlob(fd, mode->blob_id);
+        mode->blob_id = 0;
+    }
+
+    return (ret == 0);
 }

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -237,7 +237,7 @@ static bool setup_mode(struct kms *kms, int mode_id)
         return false;
     }
 
-    kms->mode = kms->connector->modes[mode_id];
+    kms->mode.mode = kms->connector->modes[mode_id];
     return true;
 }
 
@@ -281,7 +281,7 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
         .fd = open_card(card_no),
         .connector = NULL,
         .encoder = NULL,
-        .mode = { 0 },
+        .mode = {{0}},
         .crtc_id = -1,
         .card_no = card_no,
     };
@@ -324,7 +324,6 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
         }
     }
 
-
     drmModeFreeResources(res);
     return kms;
 
@@ -341,6 +340,7 @@ void kms_destroy(struct kms *kms)
 {
     if (!kms)
         return;
+    drm_mode_destroy_blob(kms->fd, &kms->mode);
     if (kms->connector) {
         drmModeFreeConnector(kms->connector);
         kms->connector = NULL;
@@ -425,7 +425,7 @@ void kms_show_available_cards_and_connectors(struct mp_log *log)
 
 double kms_get_display_fps(const struct kms *kms)
 {
-    return mode_get_Hz(&kms->mode);
+    return mode_get_Hz(&kms->mode.mode);
 }
 
 int drm_validate_connector_opt(struct mp_log *log, const struct m_option *opt,

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -32,7 +32,7 @@ struct kms {
     int fd;
     drmModeConnector *connector;
     drmModeEncoder *encoder;
-    drmModeModeInfo mode;
+    struct drm_mode mode;
     uint32_t crtc_id;
     int card_no;
     struct drm_atomic_context *atomic_context;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -253,52 +253,54 @@ static bool crtc_setup_atomic(struct ra_ctx *ctx)
     struct drm_atomic_context *atomic_ctx = p->kms->atomic_context;
 
     drmModeAtomicReqPtr request = drmModeAtomicAlloc();
-    if (request) {
-        if (drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->kms->crtc_id) < 0) {
-            MP_ERR(ctx->vo, "Could not set CRTC_ID on connector\n");
-            return false;
-        }
-
-        uint32_t blob_id;
-        if (drmModeCreatePropertyBlob(p->kms->fd, &p->kms->mode, sizeof(drmModeModeInfo),
-                                      &blob_id) != 0) {
-            MP_ERR(ctx->vo, "Failed to create DRM mode blob\n");
-            return false;
-        }
-        if (drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id) < 0) {
-            MP_ERR(ctx->vo, "Could not set MODE_ID on crtc\n");
-            return false;
-        }
-        if (drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1) < 0) {
-            MP_ERR(ctx->vo, "Could not set ACTIVE on crtc\n");
-            return false;
-        }
-
-        drm_object_set_property(request, atomic_ctx->osd_plane, "FB_ID", p->fb->id);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_ID", p->kms->crtc_id);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_X",   0);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_Y",   0);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_W",   p->osd_size.width << 16);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_H",   p->osd_size.height << 16);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_X",  0);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_Y",  0);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_W",  p->kms->mode.hdisplay);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_H",  p->kms->mode.vdisplay);
-
-        int ret = drmModeAtomicCommit(p->kms->fd, request, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
-        if (ret) {
-           MP_ERR(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
-           drmModeAtomicFree(request);
-           return false;
-        }
-
-        drmModeAtomicFree(request);
-
-        return ret == 0;
-    } else {
+    if (!request) {
         MP_ERR(ctx->vo, "Failed to allocate drm atomic request\n");
+        return false;
     }
 
+    if (drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->kms->crtc_id) < 0) {
+        MP_ERR(ctx->vo, "Could not set CRTC_ID on connector\n");
+        return false;
+    }
+
+    uint32_t blob_id = 0;
+    if (drmModeCreatePropertyBlob(p->kms->fd, &p->kms->mode, sizeof(drmModeModeInfo),
+                                  &blob_id) != 0) {
+        MP_ERR(ctx->vo, "Failed to create DRM mode blob\n");
+        blob_id = 0;
+        goto err;
+    }
+    if (drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id) < 0) {
+        MP_ERR(ctx->vo, "Could not set MODE_ID on crtc\n");
+        goto err;
+    }
+    if (drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1) < 0) {
+        MP_ERR(ctx->vo, "Could not set ACTIVE on crtc\n");
+        goto err;
+    }
+
+    drm_object_set_property(request, atomic_ctx->osd_plane, "FB_ID", p->fb->id);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_ID", p->kms->crtc_id);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_X",   0);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_Y",   0);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_W",   p->osd_size.width << 16);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "SRC_H",   p->osd_size.height << 16);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_X",  0);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_Y",  0);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_W",  p->kms->mode.hdisplay);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "CRTC_H",  p->kms->mode.vdisplay);
+
+    int ret = drmModeAtomicCommit(p->kms->fd, request, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+    if (ret)
+        MP_ERR(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
+
+    drmModeAtomicFree(request);
+    return ret == 0;
+
+  err:
+    if (blob_id)
+        drmModeDestroyPropertyBlob(p->kms->fd, blob_id);
+    drmModeAtomicFree(request);
     return false;
 }
 
@@ -308,31 +310,32 @@ static bool crtc_release_atomic(struct ra_ctx *ctx)
 
     struct drm_atomic_context *atomic_ctx = p->kms->atomic_context;
     drmModeAtomicReqPtr request = drmModeAtomicAlloc();
-    if (request) {
-        drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->old_crtc->crtc_id);
-
-        uint32_t blob_id;
-        if (drmModeCreatePropertyBlob(p->kms->fd, &p->old_crtc->mode, sizeof(drmModeModeInfo),
-                                      &blob_id) != 0) {
-            MP_ERR(ctx->vo, "Failed to create DRM mode blob\n");
-            return false;
-        }
-        drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id);
-        drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1);
-        drm_object_set_property(request, atomic_ctx->osd_plane, "FB_ID", p->old_crtc->buffer_id);
-
-        int ret = drmModeAtomicCommit(p->kms->fd, request, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
-
-        if (ret)
-           MP_WARN(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
-
-        drmModeAtomicFree(request);
-
-        return ret == 0;
-    } else {
+    if (!request) {
         MP_ERR(ctx->vo, "Failed to allocate drm atomic request\n");
+        return false;
     }
+    drm_object_set_property(request, atomic_ctx->connector, "CRTC_ID", p->old_crtc->crtc_id);
 
+    uint32_t blob_id;
+    if (drmModeCreatePropertyBlob(p->kms->fd, &p->old_crtc->mode, sizeof(drmModeModeInfo),
+                                  &blob_id) != 0) {
+        MP_ERR(ctx->vo, "Failed to create DRM mode blob\n");
+        goto err;
+    }
+    drm_object_set_property(request, atomic_ctx->crtc, "MODE_ID", blob_id);
+    drm_object_set_property(request, atomic_ctx->crtc, "ACTIVE", 1);
+    drm_object_set_property(request, atomic_ctx->osd_plane, "FB_ID", p->old_crtc->buffer_id);
+
+    int ret = drmModeAtomicCommit(p->kms->fd, request, DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+
+    if (ret)
+        MP_WARN(ctx->vo, "Failed to commit ModeSetting atomic request (%d)\n", ret);
+
+    drmModeAtomicFree(request);
+    return ret == 0;
+
+  err:
+    drmModeAtomicFree(request);
     return false;
 }
 

--- a/video/out/opengl/hwdec_vaegl.c
+++ b/video/out/opengl/hwdec_vaegl.c
@@ -36,6 +36,7 @@
 #include "video/vaapi.h"
 #include "common.h"
 #include "ra_gl.h"
+#include "libmpv/render_gl.h"
 
 #ifndef GL_OES_EGL_image
 typedef void* GLeglImageOES;
@@ -77,11 +78,11 @@ static VADisplay *create_wayland_va_display(struct ra *ra)
 
 static VADisplay *create_drm_va_display(struct ra *ra)
 {
-    int drm_fd = (intptr_t)ra_get_native_resource(ra, "drm");
-    // Note: yes, drm_fd==0 could be valid - but it's rare and doesn't fit with
-    //       our slightly crappy way of passing it through, so consider 0 not
-    //       valid.
-    return drm_fd ? vaGetDisplayDRM(drm_fd) : NULL;
+    mpv_opengl_drm_params *params = (mpv_opengl_drm_params*)ra_get_native_resource(ra, "drm_params");
+    if (!params || params->render_fd < 0)
+        return NULL;
+
+    return vaGetDisplayDRM(params->render_fd);
 }
 #endif
 

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -153,8 +153,8 @@ static bool fb_setup_double_buffering(struct vo *vo)
 
     p->front_buf = 0;
     for (unsigned int i = 0; i < 2; i++) {
-        p->bufs[i].width = p->kms->mode.hdisplay;
-        p->bufs[i].height = p->kms->mode.vdisplay;
+        p->bufs[i].width = p->kms->mode.mode.hdisplay;
+        p->bufs[i].height = p->kms->mode.mode.vdisplay;
     }
 
     for (unsigned int i = 0; i < BUF_COUNT; i++) {
@@ -186,7 +186,7 @@ static bool crtc_setup(struct vo *vo)
     int ret = drmModeSetCrtc(p->kms->fd, p->kms->crtc_id,
                              p->bufs[MOD(p->front_buf - 1, BUF_COUNT)].fb,
                              0, 0, &p->kms->connector->connector_id, 1,
-                             &p->kms->mode);
+                             &p->kms->mode.mode);
     p->active = true;
     return ret == 0;
 }


### PR DESCRIPTION
The previous code did not save enough, and was using only the legacy call drmModeGetCrtc to save information about the old state. If running with --drm-osd-plane-id=overlay, it could cause the fbcon framebuffer to become associated with the overlay plane when shutting down mpv, for instance.

The new code tries to use atomic calls exclusively when saving the restore state (with the exception of one little drmModeGetCrtc call to get the drmModeModeInfo out, as drmModeGetPropertyBlob was not working reliably for whatever reason).

I agree that my changes can be relicensed to LGPL 2.1 or later.
