### PR TITLE
build: manually add library search paths for linking

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -100,7 +100,17 @@ def check_cocoa(ctx, dependency_identifier):
         includes         = ctx.srcnode.abspath(),
         linkflags        = '-fobjc-arc')
 
-    return fn(ctx, dependency_identifier)
+    res = fn(ctx, dependency_identifier)
+    if res and ctx.env.MACOS_SDK:
+        # on macOS we explicitly need to set the SDK path, otherwise it can lead
+        # to linking warnings or errors
+        ctx.env.append_value('LAST_LINKFLAGS', [
+            '-isysroot', ctx.env.MACOS_SDK,
+            '-L/usr/lib',
+            '-L/usr/local/lib'
+        ])
+
+    return res
 
 def check_openal(ctx, dependency_identifier):
     checks = [

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -154,13 +154,6 @@ def build(ctx):
                               bridge, header, tgt, src)
         return task.exec_command(cmd)
 
-    if ctx.dependency_satisfied('cocoa') and ctx.env.MACOS_SDK:
-        # on macOS we explicitly need to set the SDK path, otherwise it can lead to
-        # linking warnings or errors
-        ctx.env.append_value('LINKFLAGS', [
-            '-isysroot', ctx.env.MACOS_SDK
-        ])
-
     if ctx.dependency_satisfied('macos-cocoa-cb'):
         swift_source = [
             ( "osdep/macOS_mpv_helper.swift" ),


### PR DESCRIPTION
#5528 is confirmed to be still fixed, though i have no idea why the fix (https://github.com/mpv-player/mpv/commit/a17456608c0eb8dce61951b1beb0cd64e29a0f0a) worked in the first place. it should have always failed like in issue #5791. #5791 is fixed by manually adding the library search path now. maybe @AirPort can also confirm that the libjpeg problem is still fixed.

i am open for suggestions if there is a better way to handle this.