### PR TITLE
stats: remove superfluous line breaks

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -424,7 +424,7 @@ end
 
 
 local function add_file(s)
-    append(s, "", {prefix=o.nl .. o.nl .. "File:", nl="", indent=""})
+    append(s, "", {prefix="File:", nl="", indent=""})
     append_property(s, "filename", {prefix_sep="", nl="", indent=""})
     if not (mp.get_property_osd("filename") == mp.get_property_osd("media-title")) then
         append_property(s, "media-title", {prefix="Title:"})


### PR DESCRIPTION
Those accidentally slipped in with 9975835bdeec3f2b04b136ef40c70b02487bb0e6
due to bad copy & paste.

Libass didn't render these superfluous line breaks so I didn't notice. However, with PR https://github.com/libass/libass/pull/285 applied it suddenly does. So fix that before this PR hits libass master. Thanks to @Akemi who noticed it!