### PR TITLE
demux_mkv: add A_MLP to mkv_audio_tags

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1588,6 +1588,7 @@ static const char *const mkv_audio_tags[][2] = {
     { "A_FLAC",                 "flac" },
     { "A_ALAC",                 "alac" },
     { "A_TTA1",                 "tta" },
+    { "A_MLP",                  "mlp" },
     { NULL },
 };
 


### PR DESCRIPTION
Fixes #5923 

I agree that my changes can be relicensed to LGPL 2.1 or later.
