### PR TITLE
build: fix linking libmpv when swift features are build

### DIFF
--- a/waftools/waf_customizations.py
+++ b/waftools/waf_customizations.py
@@ -28,18 +28,25 @@ def m_hook(self, node):
     """
     return self.create_compiled_task('c', node)
 
+def try_last_linkflags(cls):
+    try:
+        return cls.orig_run_str + ' ${LAST_LINKFLAGS}'
+    except AttributeError:
+        try:
+            return cls.hcode + ' ${LAST_LINKFLAGS}'
+        except TypeError:
+            return cls.hcode.decode('iso8859-1') + ' ${LAST_LINKFLAGS}'
+
 def build(ctx):
     from waflib import Task
 
     cls = Task.classes['cprogram']
     class cprogram(cls):
-        try:
-            run_str = cls.orig_run_str + ' ${LAST_LINKFLAGS}'
-        except AttributeError:
-            try:
-                run_str = cls.hcode + ' ${LAST_LINKFLAGS}'
-            except TypeError:
-                run_str = cls.hcode.decode('iso8859-1') + ' ${LAST_LINKFLAGS}'
+        run_str = try_last_linkflags(cls)
+
+    cls = Task.classes['cshlib']
+    class cshlib(cls):
+        run_str = try_last_linkflags(cls)
 
     cls = Task.classes['macplist']
     class macplist(cls):


### PR DESCRIPTION
i was under the impression that `LAST_LINKFLAGS` was part of waf, but it's actually something we add manually to our linking process. `LAST_LINKFLAGS` weren't added to libmpv linking. i am not sure if this is an oversight or intentional? if it's intentional i will fix this differently. at least on [windows](https://github.com/mpv-player/mpv/blob/257a2b9646e845ef801588e871b9859d30ebf99a/waftools/detections/compiler.py#L54) `LAST_LINKFLAGS` is used and could cause problems in the case of linking libmpv, if leaving the last link flags out intentionally.