### PR TITLE
ao_alsa: use snd_pcm_avail_update on get_space

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -940,9 +940,9 @@ static int get_space(struct ao *ao)
 {
     struct priv *p = ao->priv;
 
-    snd_pcm_sframes_t space = snd_pcm_avail(p->alsa);
+    snd_pcm_sframes_t space = snd_pcm_avail_update(p->alsa);
     if (space < 0) {
-        MP_ERR(ao, "Error received from snd_pcm_avail (%ld, %s)!\n",
+        MP_ERR(ao, "Error received from snd_pcm_avail_update (%ld, %s)!\n",
                space, snd_strerror(space));
         if (space == -EPIPE) // EOF
             return p->buffersize;

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -942,10 +942,11 @@ static int get_space(struct ao *ao)
 
     snd_pcm_sframes_t space = snd_pcm_avail_update(p->alsa);
     if (space < 0) {
-        MP_ERR(ao, "Error received from snd_pcm_avail_update (%ld, %s)!\n",
-               space, snd_strerror(space));
         if (space == -EPIPE) // EOF
             return p->buffersize;
+
+        MP_ERR(ao, "Error received from snd_pcm_avail_update (%ld, %s)!\n",
+               space, snd_strerror(space));
 
         // request a reload of the AO if device is not present,
         // then error out.


### PR DESCRIPTION
Fix #5890

The difference between snd_pcm_avail and
snd_pcm_avail_update is:
snd_pcm_avail = snd_pcm_hwsync + snd_pcm_avail_update

Actually, snd_pcm_avail_update is less accurate than
snd_pcm_avail. But I guess, because it doesn't call
snd_pcm_hwsync, it won't return error when paused.

