### PR TITLE
TOOLS/autoload: Fixed broken "disabled" option

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -92,6 +92,7 @@ function find_and_add_entries()
     msg.trace(("dir: %s, filename: %s"):format(dir, filename))
     if o.disabled then
         msg.verbose("stopping: autoload disabled")
+        return
     elseif #dir == 0 then
         msg.verbose("stopping: not a local path")
         return


### PR DESCRIPTION
`--script-opts=autoload-disabled=yes` now properly stops the script from running.

I agree that my changes can be relicensed to LGPL 2.1 or later.
