### PR TITLE
10.14 crashes

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -125,7 +125,7 @@ static const char macosx_icon[] =
 - (NSImage *)getMPVIcon
 {
     NSData *icon_data = [NSData dataWithBytesNoCopy:(void *)macosx_icon
-                                             length:sizeof(macosx_icon)
+                                             length:sizeof(macosx_icon) - 1
                                        freeWhenDone:NO];
     return [[NSImage alloc] initWithData:icon_data];
 }

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -375,7 +375,8 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
 
 - (void)restartMediaKeys
 {
-    CGEventTapEnable(self->_mk_tap_port, true);
+    if (self->_mk_tap_port)
+        CGEventTapEnable(self->_mk_tap_port, true);
 }
 
 - (void)setHighestPriotityMediaKeysTap
@@ -410,10 +411,10 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
             tap_event_callback,
             self);
 
-        assert(self->_mk_tap_port != nil);
-
-        NSMachPort *port = (NSMachPort *)self->_mk_tap_port;
-        [[NSRunLoop mainRunLoop] addPort:port forMode:NSRunLoopCommonModes];
+        if(self->_mk_tap_port) {
+            NSMachPort *port = (NSMachPort *)self->_mk_tap_port;
+            [[NSRunLoop mainRunLoop] addPort:port forMode:NSRunLoopCommonModes];
+        }
     });
 }
 
@@ -421,10 +422,12 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSMachPort *port = (NSMachPort *)self->_mk_tap_port;
-        CGEventTapEnable(self->_mk_tap_port, false);
-        [[NSRunLoop mainRunLoop] removePort:port forMode:NSRunLoopCommonModes];
-        CFRelease(self->_mk_tap_port);
-        self->_mk_tap_port = nil;
+        if (port) {
+            CGEventTapEnable(self->_mk_tap_port, false);
+            [[NSRunLoop mainRunLoop] removePort:port forMode:NSRunLoopCommonModes];
+            CFRelease(self->_mk_tap_port);
+            self->_mk_tap_port = nil;
+        }
     });
 }
 


### PR DESCRIPTION
cc: @Akemi 
Apple apparently doesn't recommend using ICNS for icons anymore, and instead recommends PNG.
I think the event tap now fails to create if the application doesn't have assistive-device permissions.