### PR TITLE
encode: fix expected streams when using --lavfi-complex

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1296,20 +1296,20 @@ static void play_current_file(struct MPContext *mpctx)
 
     update_demuxer_properties(mpctx);
 
-    if (mpctx->encode_lavc_ctx) {
-        if (mpctx->current_track[0][STREAM_VIDEO])
-            encode_lavc_expect_stream(mpctx->encode_lavc_ctx, STREAM_VIDEO);
-        if (mpctx->current_track[0][STREAM_AUDIO])
-            encode_lavc_expect_stream(mpctx->encode_lavc_ctx, STREAM_AUDIO);
-        encode_lavc_set_metadata(mpctx->encode_lavc_ctx,
-                                 mpctx->demuxer->metadata);
-    }
-
     update_playback_speed(mpctx);
 
     reinit_video_chain(mpctx);
     reinit_audio_chain(mpctx);
     reinit_sub_all(mpctx);
+
+    if (mpctx->encode_lavc_ctx) {
+        if (mpctx->vo_chain)
+            encode_lavc_expect_stream(mpctx->encode_lavc_ctx, STREAM_VIDEO);
+        if (mpctx->ao_chain)
+            encode_lavc_expect_stream(mpctx->encode_lavc_ctx, STREAM_AUDIO);
+        encode_lavc_set_metadata(mpctx->encode_lavc_ctx,
+                                 mpctx->demuxer->metadata);
+    }
 
     if (!mpctx->vo_chain && !mpctx->ao_chain && opts->stream_auto_sel) {
         MP_FATAL(mpctx, "No video or audio streams selected.\n");


### PR DESCRIPTION
```
mpctx->current_track[0][STREAM_VIDEO] (and STREAM_AUDIO) are empty when
using --lavfi-complex. Moving the muxer stream hinting after audio/video chain
initialization and checking if the chains exist fixes encoding with --lavfi-complex.

Previously, the output audio/video streams did not get prepared and the encode
would fail due to unexpected stream addition.
```

Example command using a null lavfi-complex:
`mpv video.mkv --lavfi-complex '[vid1] null [vo]; [aid1] anull [ao]' --o out.mkv`
This will fail without the PR's fix.

This doesn't seem to break anything and as far as I understand the encode mode prep work, it won't. Hopefully someone with more experience can confirm.
(commit name etc open for bikeshedding)

I agree that my changes can be relicensed to LGPL 2.1 or later.