### PR TITLE
wscript_build: fixup swift include parameter to point to source root

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -150,8 +150,8 @@ def build(ctx):
 
         cmd = ('%s %s -module-name macOS_swift -emit-module-path %s '
                '-import-objc-header %s -emit-objc-header-path %s -o %s %s '
-               '-I. -I..') % (ctx.env.SWIFT, ctx.env.SWIFT_FLAGS, module,
-                              bridge, header, tgt, src)
+               '-I. -I%s') % (ctx.env.SWIFT, ctx.env.SWIFT_FLAGS, module,
+                              bridge, header, tgt, src, ctx.srcnode.abspath())
         return task.exec_command(cmd)
 
     if ctx.dependency_satisfied('macos-cocoa-cb'):


### PR DESCRIPTION
Fixes compilation of the swift components with
`--variant="random_string"`, in which case "." is not the source
directory.
