### PR TITLE
build: disable dependencies if swift is too old and output swift version

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -115,6 +115,8 @@ def check_cocoa(ctx, dependency_identifier):
 def check_swift(ctx, dependency_identifier):
     if ctx.env.SWIFT_VERSION:
         major = int(ctx.env.SWIFT_VERSION.split('.')[0])
+        ctx.add_optional_message(dependency_identifier,
+                                 'version found: ' + ctx.env.SWIFT_VERSION)
         if major >= 3:
             return True
     return False

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -4,7 +4,7 @@ from waflib import Utils
 import os
 
 __all__ = ["check_pthreads", "check_iconv", "check_lua",
-           "check_cocoa", "check_openal", "check_wl_protocols"]
+           "check_cocoa", "check_openal", "check_wl_protocols", "check_swift"]
 
 pthreads_program = load_fragment('pthreads.c')
 
@@ -111,6 +111,13 @@ def check_cocoa(ctx, dependency_identifier):
         ])
 
     return res
+
+def check_swift(ctx, dependency_identifier):
+    if ctx.env.SWIFT_VERSION:
+        major = int(ctx.env.SWIFT_VERSION.split('.')[0])
+        if major >= 3:
+            return True
+    return False
 
 def check_openal(ctx, dependency_identifier):
     checks = [

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -11,8 +11,8 @@ def __add_swift_flags(ctx):
     ctx.env.SWIFT_FLAGS = ('-frontend -c -sdk %s -enable-objc-interop'
                            ' -emit-objc-header -parse-as-library'
                            ' -target x86_64-apple-macosx10.10') % (ctx.env.MACOS_SDK)
-    swift_version = __run([ctx.env.SWIFT, '-version']).split(' ')[3].split('.')[:2]
-    major, minor = [int(n) for n in swift_version]
+    ctx.env.SWIFT_VERSION = __run([ctx.env.SWIFT, '-version']).split(' ')[3]
+    major, minor = [int(n) for n in ctx.env.SWIFT_VERSION.split('.')[:2]]
 
     # the -swift-version parameter is only supported on swift 3.1 and newer
     if major >= 3 and minor >= 1 or major >= 4:

--- a/wscript
+++ b/wscript
@@ -911,7 +911,7 @@ standalone_features = [
         'name': '--macos-cocoa-cb',
         'desc': 'macOS opengl-cb backend',
         'deps': 'cocoa',
-        'func': check_true
+        'func': check_swift
     }
 ]
 

--- a/wscript
+++ b/wscript
@@ -167,6 +167,11 @@ main_dependencies = [
         'fmsg': 'Unable to find either POSIX or MinGW-w64 environment, ' \
                 'or compiler does not work.',
     }, {
+        'name': '--swift',
+        'desc': 'Swift environment',
+        'deps': 'os-darwin',
+        'func': check_swift,
+    }, {
         'name': '--uwp',
         'desc': 'Universal Windows Platform',
         'default': 'disable',
@@ -910,8 +915,8 @@ standalone_features = [
      }, {
         'name': '--macos-cocoa-cb',
         'desc': 'macOS opengl-cb backend',
-        'deps': 'cocoa',
-        'func': check_swift
+        'deps': 'cocoa  && swift',
+        'func': check_true
     }
 ]
 


### PR DESCRIPTION
i think it makes sense to automatically disable cocoa-cb (or anything in the future that depends on swift) if the swift version is too old and not supported.