### PR TITLE
[WIP] build: upgrade to waf 2.0.8

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -5,10 +5,10 @@
 from __future__ import print_function
 import os, sys, stat, hashlib, subprocess
 
-WAFRELEASE = "waf-1.9.8"
+WAFRELEASE = "waf-2.0.8"
 WAFURLS    = ["https://waf.io/" + WAFRELEASE,
               "http://www.freehackers.org/~tnagy/release/" + WAFRELEASE]
-SHA256HASH = "167dc42bab6d5bd823b798af195420319cb5c9b571e00db7d83df2a0fe1f4dbf"
+SHA256HASH = "5404fc1ab93813942f9c7b3d1d3470e05e52161deefcb7fdb807da95e90940cc"
 
 if os.path.exists("waf"):
     wafver = subprocess.check_output([sys.executable, './waf', '--version']).decode()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -5,10 +5,10 @@
 from __future__ import print_function
 import os, sys, stat, hashlib, subprocess
 
-WAFRELEASE = "waf-2.0.8"
+WAFRELEASE = "waf-2.0.9"
 WAFURLS    = ["https://waf.io/" + WAFRELEASE,
               "http://www.freehackers.org/~tnagy/release/" + WAFRELEASE]
-SHA256HASH = "5404fc1ab93813942f9c7b3d1d3470e05e52161deefcb7fdb807da95e90940cc"
+SHA256HASH = "2a8e0816f023995e557f79ea8940d322bec18f286917c8f9a6fa2dc3875dfa48"
 
 if os.path.exists("waf"):
     wafver = subprocess.check_output([sys.executable, './waf', '--version']).decode()

--- a/waftools/generators/sources.py
+++ b/waftools/generators/sources.py
@@ -94,6 +94,7 @@ def __wayland_protocol_header__(ctx, **kwargs):
 @TaskGen.feature('cshlib')
 @TaskGen.feature('cstlib')
 @TaskGen.feature('apply_link')
+@TaskGen.after_method('do_the_symbol_stuff')
 def handle_add_object(tgen):
     if getattr(tgen, 'add_object', None):
         for input in Utils.to_list(tgen.add_object):

--- a/wscript
+++ b/wscript
@@ -916,18 +916,8 @@ standalone_features = [
 ]
 
 _INSTALL_DIRS_LIST = [
-    ('bindir',  '${PREFIX}/bin',      'binary files'),
-    ('libdir',  '${PREFIX}/lib',      'library files'),
-    ('confdir', '${PREFIX}/etc/mpv',  'configuration files'),
-
-    ('incdir',  '${PREFIX}/include',  'include files'),
-
-    ('datadir', '${PREFIX}/share',    'data files'),
-    ('mandir',  '${DATADIR}/man',     'man pages '),
-    ('docdir',  '${DATADIR}/doc/mpv', 'documentation files'),
-    ('htmldir', '${DOCDIR}',          'html documentation files'),
+    ('confdir', '${SYSCONFDIR}/mpv',  'configuration files'),
     ('zshdir',  '${DATADIR}/zsh/site-functions', 'zsh completion functions'),
-
     ('confloaddir', '${CONFDIR}', 'configuration files load directory'),
 ]
 
@@ -937,17 +927,16 @@ def options(opt):
     opt.load('features')
     opt.load('gnu_dirs')
 
-    group = opt.get_option_group("build and install options")
-    """
+    group = opt.get_option_group("Installation directories")
     for ident, default, desc in _INSTALL_DIRS_LIST:
         group.add_option('--{0}'.format(ident),
             type    = 'string',
             dest    = ident,
             default = default,
             help    = 'directory for installing {0} [{1}]' \
-                      .format(desc, default))
-    """
+                      .format(desc, default.replace('${','').replace('}','')))
 
+    group = opt.get_option_group("build and install options")
     group.add_option('--variant',
         default = '',
         help    = 'variant name for saving configuration and build results')
@@ -1008,9 +997,8 @@ def configure(ctx):
     ctx.load('detections.compiler_swift')
     ctx.load('detections.compiler')
     ctx.load('detections.devices')
-
     ctx.load('gnu_dirs')
-    """
+
     for ident, _, _ in _INSTALL_DIRS_LIST:
         varname = ident.upper()
         ctx.env[varname] = getattr(ctx.options, ident)
@@ -1018,7 +1006,6 @@ def configure(ctx):
         # keep substituting vars, until the paths are fully expanded
         while re.match('\$\{([^}]+)\}', ctx.env[varname]):
             ctx.env[varname] = Utils.subst_vars(ctx.env[varname], ctx.env)
-    """
 
     ctx.parse_dependencies(build_options)
     ctx.parse_dependencies(main_dependencies)

--- a/wscript
+++ b/wscript
@@ -935,8 +935,10 @@ def options(opt):
     opt.load('compiler_c')
     opt.load('waf_customizations')
     opt.load('features')
+    opt.load('gnu_dirs')
 
     group = opt.get_option_group("build and install options")
+    """
     for ident, default, desc in _INSTALL_DIRS_LIST:
         group.add_option('--{0}'.format(ident),
             type    = 'string',
@@ -944,6 +946,7 @@ def options(opt):
             default = default,
             help    = 'directory for installing {0} [{1}]' \
                       .format(desc, default))
+    """
 
     group.add_option('--variant',
         default = '',

--- a/wscript
+++ b/wscript
@@ -12,6 +12,8 @@ from waftools.checks.custom import *
 c_preproc.go_absolute=True # enable system folders
 c_preproc.standard_includes.append('/usr/local/include')
 
+APPNAME = 'mpv'
+
 """
 Dependency identifiers (for win32 vs. Unix):
     wscript / C source                  meaning

--- a/wscript
+++ b/wscript
@@ -927,6 +927,18 @@ def options(opt):
     opt.load('features')
     opt.load('gnu_dirs')
 
+    #remove unused options from gnu_dirs
+    opt.parser.remove_option("--sbindir")
+    opt.parser.remove_option("--libexecdir")
+    opt.parser.remove_option("--sharedstatedir")
+    opt.parser.remove_option("--localstatedir")
+    opt.parser.remove_option("--oldincludedir")
+    opt.parser.remove_option("--infodir")
+    opt.parser.remove_option("--localedir")
+    opt.parser.remove_option("--dvidir")
+    opt.parser.remove_option("--pdfdir")
+    opt.parser.remove_option("--psdir")
+
     group = opt.get_option_group("Installation directories")
     for ident, default, desc in _INSTALL_DIRS_LIST:
         group.add_option('--{0}'.format(ident),

--- a/wscript
+++ b/wscript
@@ -1006,6 +1006,8 @@ def configure(ctx):
     ctx.load('detections.compiler')
     ctx.load('detections.devices')
 
+    ctx.load('gnu_dirs')
+    """
     for ident, _, _ in _INSTALL_DIRS_LIST:
         varname = ident.upper()
         ctx.env[varname] = getattr(ctx.options, ident)
@@ -1013,6 +1015,7 @@ def configure(ctx):
         # keep substituting vars, until the paths are fully expanded
         while re.match('\$\{([^}]+)\}', ctx.env[varname]):
             ctx.env[varname] = Utils.subst_vars(ctx.env[varname], ctx.env)
+    """
 
     ctx.parse_dependencies(build_options)
     ctx.parse_dependencies(main_dependencies)

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -722,7 +722,7 @@ def build(ctx):
             ctx.env.DATADIR + '/applications',
             ['etc/mpv.desktop'] )
 
-        ctx.install_files(os.path.join(ctx.env.SYSCONFDIR, "mpv"), ['etc/encoding-profiles.conf'] )
+        ctx.install_files(ctx.env.CONFDIR, ['etc/encoding-profiles.conf'] )
 
         for size in '16x16 32x32 64x64'.split():
             ctx.install_as(

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -689,7 +689,7 @@ def build(ctx):
             features     = 'subst',
             PREFIX       = ctx.env.PREFIX,
             LIBDIR       = ctx.env.LIBDIR,
-            INCDIR       = ctx.env.INCDIR,
+            INCDIR       = ctx.env.INCLUDEDIR,
             VERSION      = libversion,
             PRIV_LIBS    = get_deps(),
         )
@@ -697,7 +697,7 @@ def build(ctx):
         headers = ["client.h", "qthelper.hpp", "opengl_cb.h", "render.h",
                    "render_gl.h", "stream_cb.h"]
         for f in headers:
-            ctx.install_as(ctx.env.INCDIR + '/mpv/' + f, 'libmpv/' + f)
+            ctx.install_as(ctx.env.INCLUDEDIR + '/mpv/' + f, 'libmpv/' + f)
 
         ctx.install_as(ctx.env.LIBDIR + '/pkgconfig/mpv.pc', 'libmpv/mpv.pc')
 
@@ -722,7 +722,7 @@ def build(ctx):
             ctx.env.DATADIR + '/applications',
             ['etc/mpv.desktop'] )
 
-        ctx.install_files(ctx.env.CONFDIR, ['etc/encoding-profiles.conf'] )
+        ctx.install_files(os.path.join(ctx.env.SYSCONFDIR, "mpv"), ['etc/encoding-profiles.conf'] )
 
         for size in '16x16 32x32 64x64'.split():
             ctx.install_as(


### PR DESCRIPTION
manly to fix bugs with python 3.7, see the waf [changelog](https://gitlab.com/ita1024/waf/blob/master/ChangeLog).

i hope we can test this changes on various platforms and gradually add the needed fixes to this PR.

i tested this on macOS only and added one fix were needed. with the old waf version the `do_the_symbol_stuff`, where the `link_task` is defined/created, was always called before the `handle_add_object` task that adds the swift .o file to linking. with the new waf version this was always the other way around and the `handle_add_object` task always tried to modified the not yet existing `link_task` task.

thx to @jeeb, instead of using our custom way of setting various standard variables we use waf's "gnu_dirs". this was done because of some changes in waf the env variables weren't expanded properly and the mpv binary was installed relative to the current dir and not in our PREFIX.

gnu_dirs is already quite similar to what we had before, though some variables are not used at all and some others are unique to our build system. hence some options have been removed, but others were kept. following an overview what has been changes.

options that were nearly identical and could be removed from our custom code:
```
--prefix=PREFIX [default: '/usr/local/']    > --prefix=PREFIX [default: '/usr/local/']
--destdir=DESTDIR [default: '']             > --destdir=DESTDIR [default: '']
--bindir=BINDIR [${PREFIX}/bin]             > --bindir=BINDIR [EXEC_PREFIX/bin]
--libdir=LIBDIR [${PREFIX}/lib]             > --libdir=LIBDIR [EXEC_PREFIX/lib]
--incdir=INCDIR [${PREFIX}/include]         > --includedir=INCLUDEDIR [PREFIX/include]
--datadir=DATADIR [${PREFIX}/share]         > --datadir=DATADIR [DATAROOTDIR]
--mandir=MANDIR [${DATADIR}/man]            > --mandir=MANDIR [DATAROOTDIR/man]
--docdir=DOCDIR [${DATADIR}/doc/mpv]        > --docdir=DOCDIR [DATAROOTDIR/doc/PACKAGE]
--htmldir=HTMLDIR [${DOCDIR}]               > --htmldir=HTMLDIR [DOCDIR]
```

options and variables that gnu_dirs didn't have a replacement for, that were kept and slightly changed:
```
--confdir=CONFDIR [${PREFIX}/etc/mpv]           > --confdir=CONFDIR [SYSCONFDIR/mpv]   
--confloaddir=CONFLOADDIR [${CONFDIR}]          > --confloaddir=CONFLOADDIR [CONFDIR]  
--zshdir=ZSHDIR [${DATADIR}/zsh/site-functions] > --zshdir=ZSHDIR [DATADIR/zsh/site-functions]
```

options and variables that are new and being kept since other variables depend on them:
```
--sysconfdir=SYSCONFDIR [PREFIX/etc]
--exec-prefix=EXEC_PREFIX [PREFIX]
--datarootdir=DATAROOTDIR [PREFIX/share]
```

options that were removed because they are unused:
```
--sbindir=SBINDIR [EXEC_PREFIX/sbin]
--libexecdir=LIBEXECDIR [EXEC_PREFIX/libexec]
--sharedstatedir=SHAREDSTATEDIR [PREFIX/com]
--localstatedir=LOCALSTATEDIR [PREFIX/var]
--oldincludedir=OLDINCLUDEDIR [/usr/include]
--infodir=INFODIR [DATAROOTDIR/info]
--localedir=LOCALEDIR [DATAROOTDIR/locale]
--dvidir=DVIDIR [DOCDIR]
--pdfdir=PDFDIR [DOCDIR]
--psdir=PSDIR [DOCDIR]
```

the --help output for the kept variables and options was slightly changed to be consistent with gnu_dirs, eg `${` and `}` was removed.