### PR TITLE
build: add --no-download option to bootstrap.py

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -16,6 +16,10 @@ if os.path.exists("waf"):
         print("Found 'waf', skipping download.")
         sys.exit(0)
 
+if "--no-download" in sys.argv[1:]:
+    print("Did not find {} and no download was requested.".format(WAFRELEASE))
+    sys.exit(1)
+
 try:
     from urllib.request import urlopen, URLError
 except:


### PR DESCRIPTION
A user of the [mpv-git AUR package](https://aur.archlinux.org/packages/mpv-git/) requested that waf be downloaded by the packaging system instead of at compile-time. This has several advantages (building without network access, caching the waf download by the packaging system) so I'd like to do it, but I want to avoid building with the wrong version of waf and getting cryptic problems.

This change adds a flag to `bootstrap.py` that will not download waf, but will just perform the version check and error out (failing the build) if it's wrong. This will indicate that the package build script needs to be updated.

This was a 5-minute job and I'm not attached to this patch in particular. If anyone has a better solution to my use case, I'd welcome suggestions.