### PR TITLE
wscript_build: apply project-wide CFLAGS/LDFLAGS to mpv.com

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -611,8 +611,8 @@ def build(ctx):
 
             wrapctx.env.cprogram_PATTERN = "%s.com"
             wrapflags = ['-municode', '-mconsole']
-            wrapctx.env.CFLAGS = wrapflags
-            wrapctx.env.LAST_LINKFLAGS = wrapflags
+            wrapctx.env.CFLAGS = ctx.env.CFLAGS + wrapflags
+            wrapctx.env.LAST_LINKFLAGS = ctx.env.LAST_LINKFLAGS + wrapflags
 
     if ctx.dependency_satisfied('test'):
         for test in ctx.path.ant_glob("test/*.c"):


### PR DESCRIPTION
mpv.com fails to build when cross-compiling with a multilib version
of GCC, because the -m32 flags aren't getting passed to the build
process for osdep/win32-console-wrapper.c or the link phase for
mpv.com itself.

Fixes #5991