### PR TITLE
[FEATURE] macOS 10.14 Dark Mode Support for Cocoa window and title bar

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -120,6 +120,13 @@ class Window: NSWindow, NSWindowDelegate {
 
         setTitleBarStyle(Int(mpv.macOpts!.macos_title_bar_style))
         contentView!.addSubview(titleBarEffect!, positioned: .above, relativeTo: nil)
+
+        if #available(OSX 10.14, *) {
+            // Handle run-time changes of the system theme (Dark Mode / Light Mode)
+            DistributedNotificationCenter.default().addObserver( forName: NSNotification.Name("AppleInterfaceThemeChangedNotification"), object: nil, queue: nil) { notification in
+                    self.setTitleBarStyle(Int(self.mpv.macOpts!.macos_title_bar_style))
+            }
+        }
     }
 
     func setTitleBarStyle(_ style: Any) {

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -144,8 +144,12 @@ class Window: NSWindow, NSWindowDelegate {
         }
 
         if effect == "auto" {
-            let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-            effect = systemStyle == nil ? "mediumlight" : "ultradark"
+            if #available(OSX 10.14, *) {
+                // Forward effect name "auto" as-is
+            } else {
+                let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+                effect = systemStyle == nil ? "mediumlight" : "ultradark"
+            }
         }
 
         switch effect {
@@ -161,6 +165,13 @@ class Window: NSWindow, NSWindowDelegate {
             appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
             titleBarEffect!.material = .titlebar
             titleBarEffect!.state = .followsWindowActiveState
+        case "auto":
+            // Apply NSApplications' appearance to this window
+            if #available(OSX 10.14, *) {
+                appearance = NSApp.effectiveAppearance
+                titleBarEffect!.material = .titlebar
+                titleBarEffect!.state = .followsWindowActiveState
+            }
         case "dark": fallthrough
         default:
             appearance = NSAppearance(named: NSAppearanceNameVibrantDark)


### PR DESCRIPTION
Dear mpv team
Dear @Akemi

This PR adapts mpv's Cocoa window to the new "Dark Mode" in macOS 10.14 Mojave.

### Issue
Currently - with `macos-title-bar-style=auto` - the appearance of the main title bar is determined by enumerating hard-coded NSVisualEffectView.Material names, a behavior which is [deprecated starting with macOS 10.14](https://developer.apple.com/documentation/appkit/supporting_dark_mode_in_your_interface). Also, the users' system-wide theme choice (Dark/Light) is ignored on Mojave

### Solution
This PR amends this behavior by applying the system-wide "Dark Mode" or "Light Mode" theme on the main window when `macos-title-bar-style=auto`, which is the default setting, meaning that the users' system-wide theme choice is respected in mpv (including dynamic response to run-time theme changes).

Additionally, the legacy styles (e.g. `macos-title-bar-style=dark`), are supported as well if the user  specifically enables these.

Tested on

 - macOS 10.14 Developer Beta 4 (18A336e)
 - macOS 10.13.6 (17G65)

Looking forward to your feedback,
S