### PR TITLE
please compiler: fix warnings like `missing braces around initializer'

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -393,7 +393,7 @@ static int demux_mkv_read_info(demuxer_t *demuxer)
     mkv_d->tc_scale = 1000000;
     mkv_d->duration = 0;
 
-    struct ebml_info info = {0};
+    struct ebml_info info = {{0}};
     struct ebml_parse_ctx parse_ctx = {demuxer->log};
     if (ebml_read_element(s, &parse_ctx, &info, &ebml_info_desc) < 0)
         return -1;

--- a/player/command.c
+++ b/player/command.c
@@ -4827,7 +4827,7 @@ static void cmd_cycle_values(void *p)
 
 int run_command(struct MPContext *mpctx, struct mp_cmd *cmd, struct mpv_node *res)
 {
-    struct mpv_node dummy_node = {0};
+    struct mpv_node dummy_node = {{0}};
     struct mp_cmd_ctx *ctx = &(struct mp_cmd_ctx){
         .mpctx = mpctx,
         .cmd = cmd,

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -711,7 +711,7 @@ static void uninit_avctx(struct mp_filter *vd)
     ctx->hwdec_fail_count = 0;
     ctx->max_delay_queue = 0;
     ctx->hw_probing = false;
-    ctx->hwdec = (struct hwdec_info){0};
+    ctx->hwdec = (struct hwdec_info){{0}};
     ctx->use_hwdec = false;
 }
 

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -450,14 +450,14 @@ static void vt_switcher_sighandler(int sig)
 
 static bool has_signal_installed(int signo)
 {
-    struct sigaction act = { 0 };
+    struct sigaction act = {{0}};
     sigaction(signo, 0, &act);
     return act.sa_handler != 0;
 }
 
 static int install_signal(int signo, void (*handler)(int))
 {
-    struct sigaction act = { 0 };
+    struct sigaction act = {{0}};
     act.sa_handler = handler;
     sigemptyset(&act.sa_mask);
     act.sa_flags = SA_RESTART;

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -921,7 +921,7 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
         }
 
         for (int n = 0; n < sc->num_uniforms; n++) {
-            struct sc_cached_uniform u = {0};
+            struct sc_cached_uniform u = {{{0}}};
             if (sc->uniforms[n].type == SC_UNIFORM_TYPE_GLOBAL) {
                 // global uniforms need to be made visible to the ra_renderpass
                 u.index = sc->params.num_inputs;

--- a/video/out/gpu/utils.c
+++ b/video/out/gpu/utils.c
@@ -45,7 +45,7 @@ void ra_buf_pool_uninit(struct ra *ra, struct ra_buf_pool *pool)
         ra_buf_free(ra, &pool->buffers[i]);
 
     talloc_free(pool->buffers);
-    *pool = (struct ra_buf_pool){0};
+    *pool = (struct ra_buf_pool){{0}};
 }
 
 static bool ra_buf_params_compatible(const struct ra_buf_params *new,

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -994,7 +994,7 @@ static void uninit_video(struct gl_video *p)
         struct texplane *plane = &vimg->planes[n];
         ra_tex_free(p->ra, &plane->tex);
     }
-    *vimg = (struct video_image){0};
+    *vimg = (struct video_image){{{0}}};
 
     // Invalidate image_params to ensure that gl_video_config() will call
     // init_video() on uninitialized gl_video.
@@ -3313,7 +3313,7 @@ static void frame_perf_data(struct pass_info pass[], struct mp_frame_perf *out)
 
 void gl_video_perfdata(struct gl_video *p, struct voctrl_performance_data *out)
 {
-    *out = (struct voctrl_performance_data){0};
+    *out = (struct voctrl_performance_data){{0}};
     frame_perf_data(p->pass_fresh,  &out->fresh);
     frame_perf_data(p->pass_redraw, &out->redraw);
 }


### PR DESCRIPTION
though it's not a problem of mpv, just to make compiler happy.

see:
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39589
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64709

I agree that my changes can be relicensed to LGPL 2.1 or later.
