### PR TITLE
cocoa-cb: fall back to software renderer when everything fails

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4882,6 +4882,15 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     OS X only.
 
+``--cocoa-cb-sw-renderer=<yes|no|auto>``
+    Use the Apple Software Renderer when using cocoa-cb (default: auto). If set
+    to ``no`` the software renderer is never used and instead fails when a the
+    usual pixel format could not be created, ``yes`` will always only use the
+    software renderer, and ``auto`` only falls back to the software renderer
+    when the usual pixel format couldn't be created.
+
+    OS X only.
+
 ``--macos-title-bar-style=<dark|ultradark|light|mediumlight|auto>``
     Sets the styling of the title bar (default: dark).
     OS X and cocoa-cb only

--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -45,6 +45,12 @@ class MPVHelper: NSObject {
         mpctx = UnsafeMutablePointer<MPContext>(mp_client_get_core(mpvHandle))
         inputContext = mpctx!.pointee.input
 
+        if let app = NSApp as? Application {
+            let ptr = mp_get_config_group(mpctx!, mp_client_get_global(mpvHandle),
+                                          app.getMacOSConf())
+            macOpts = UnsafeMutablePointer<macos_opts>(OpaquePointer(ptr))!.pointee
+        }
+
         mpv_observe_property(mpvHandle, 0, "ontop", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "border", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "keepaspect-window", MPV_FORMAT_FLAG)

--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -23,6 +23,7 @@
 struct macos_opts {
     int macos_title_bar_style;
     int macos_fs_animation_duration;
+    int cocoa_cb_sw_renderer;
 };
 
 // multithreaded wrapper for mpv_main

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -49,11 +49,14 @@ const struct m_sub_options macos_conf = {
         OPT_CHOICE_OR_INT("macos-fs-animation-duration",
                           macos_fs_animation_duration, 0, 0, 1000,
                           ({"default", -1})),
+        OPT_CHOICE("cocoa-cb-sw-renderer", cocoa_cb_sw_renderer, 0,
+                   ({"auto", -1}, {"no", 0}, {"yes", 1})),
         {0}
     },
     .size = sizeof(struct macos_opts),
     .defaults = &(const struct macos_opts){
         .macos_fs_animation_duration = -1,
+        .cocoa_cb_sw_renderer = -1,
     },
 };
 

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -61,12 +61,6 @@ class CocoaCB: NSObject {
         if backendState == .uninitialized {
             backendState = .needsInit
 
-            if let app = NSApp as? Application {
-                let ptr = mp_get_config_group(mpv.mpctx!, vo.pointee.global,
-                                              app.getMacOSConf())
-                mpv.macOpts = UnsafeMutablePointer<macos_opts>(OpaquePointer(ptr))!.pointee
-            }
-
             view = EventsView(cocoaCB: self)
             view.layer = layer
             view.wantsLayer = true

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -42,7 +42,8 @@ static bool is_software_gl(GL *gl)
            strcmp(renderer, "Software Rasterizer") == 0 ||
            strstr(renderer, "llvmpipe") ||
            strcmp(vendor, "Microsoft Corporation") == 0 ||
-           strcmp(renderer, "Mesa X11") == 0;
+           strcmp(renderer, "Mesa X11") == 0 ||
+           strcmp(renderer, "Apple Software Renderer") == 0;
 }
 
 static void GLAPIENTRY dummy_glBindFramebuffer(GLenum target, GLuint framebuffer)


### PR DESCRIPTION
~~i would have liked to add an options for this, but since we need to pre-allocate the opengl context before any options access is available to us this is sadly not possible.~~

besides making mpv usable in VMs, this should also fix a problem with homebrews automatic jenkins testing (https://github.com/Homebrew/homebrew-core/pull/30369). @ilovezfs do you think you can test and confirm that this fixes the testing problem with homebrew?