### PR TITLE
manpage: fix --vf exclamation mark description

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -16,7 +16,7 @@ The exact syntax is:
     name is an arbitrary user-given name, which identifies the filter. This
     is only needed if you want to toggle the filter at runtime.
 
-    A ``!`` before the filter name means the filter is enabled by default. It
+    A ``!`` before the filter name means the filter is disabled by default. It
     will be skipped on filter creation. This is also useful for runtime filter
     toggling.
 


### PR DESCRIPTION
An exclamation mark disables the filter by default instead of
enabling it.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
