### PR TITLE
manpage: Correct show-text duration default value

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -350,7 +350,7 @@ List of Input Commands
     Print text to stdout. The string can contain properties (see
     `Property Expansion`_).
 
-``show-text "<string>" [<duration>|- [<level>]]``
+``show-text "<string>" [<duration>|-1 [<level>]]``
     Show text on the OSD. The string can contain properties, which are expanded
     as described in `Property Expansion`_. This can be used to show playback
     time, filename, and so on.


### PR DESCRIPTION
duration is parsed as an integer, and the default value is used if ```-1``` is passed. Passing ```-``` as described here causes a parameter value error.

Please correct me if I'm totally missing something here.

I agree that my changes can be relicensed to LGPL 2.1 or later.
