### PR TITLE
demux_mkv: copy attachments (fonts) from ordered chapter sources

### DIFF
--- a/demux/demux_mkv_timeline.c
+++ b/demux/demux_mkv_timeline.c
@@ -305,6 +305,16 @@ static void find_ordered_chapter_sources(struct tl_ctx *ctx)
         ctx->num_sources = j;
     }
 
+    // Copy attachments from referenced sources so fonts are loaded for sub
+    // rendering.
+    for (int i = 1; i < ctx->num_sources; i++) {
+        for (int j = 0; j < ctx->sources[i]->num_attachments; j++) {
+            struct demux_attachment *att = &ctx->sources[i]->attachments[j];
+            demuxer_add_attachment(ctx->demuxer, att->name, att->type,
+                                   att->data, att->data_size);
+        }
+    }
+
     talloc_free(tmp);
 }
 


### PR DESCRIPTION
Fixes #6009.

This is pretty simplistic. The only questionable case I can see is multiple segments containing fonts with the same name. If they're actually the same font, it seems to work fine -- I tested that. It's just a bit of a waste, I guess. If they aren't the same, well, that'd pretty much have to be an intentionally messed up file and isn't worth worrying about IMO. The "correct" way might be to reinit libass when switching tracks with only the fonts from that segment, but I really don't think that's worth the added complexity.

We could skip the copy for attachments that already appear to be loaded (by name and mime type). Is that worth it?

This is copying more than it has to, because the additional demuxers stay alive and we could just point to their attachments instead of copying all the data. But `demuxer_add_attachment` is the only API we have for manipulating the attachment list and it copies unconditionally, so some bit of refactoring there would be needed. I don't want to go around the API and stick stuff directly into the attachment list, and if you look at the buffer-growing logic in `demuxer_add_attachment` you'll see why. So I guess another question of "Is this worth it". Fonts *can* be pretty big. I'm happy to make those changes if others think they're desirable, but I can't decide.