### PR TITLE
Sort filenames naturally when playing a directory / archive

### DIFF
--- a/demux/demux_libarchive.c
+++ b/demux/demux_libarchive.c
@@ -21,13 +21,14 @@
 #include "common/common.h"
 #include "common/playlist.h"
 #include "stream/stream.h"
+#include "misc/natural_sort.h"
 #include "demux.h"
 
 #include "stream/stream_libarchive.h"
 
 static int cmp_filename(const void *a, const void *b)
 {
-    return strcmp(*(char **)a, *(char **)b);
+    return mp_natural_sort_cmp(*(char **)a, *(char **)b);
 }
 
 static int open_file(struct demuxer *demuxer, enum demux_check check)

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -29,6 +29,7 @@
 #include "options/path.h"
 #include "stream/stream.h"
 #include "osdep/io.h"
+#include "misc/natural_sort.h"
 #include "demux.h"
 
 #define PROBE_SIZE (8 * 1024)
@@ -284,7 +285,7 @@ static bool scan_dir(struct pl_parser *p, char *path,
 
 static int cmp_filename(const void *a, const void *b)
 {
-    return strcmp(*(char **)a, *(char **)b);
+    return mp_natural_sort_cmp(*(char **)a, *(char **)b);
 }
 
 static int parse_dir(struct pl_parser *p)

--- a/misc/natural_sort.c
+++ b/misc/natural_sort.c
@@ -1,0 +1,67 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "misc/ctype.h"
+
+#include "natural_sort.h"
+
+// Comparison function for an ASCII-only "natural" sort. Case is ignored and
+// numbers are ordered by value regardless of padding. Two filenames that differ
+// only in the padding of numbers will be considered equal and end up in
+// arbitrary order. Bytes outside of A-Z/a-z/0-9 will by sorted by byte value.
+int mp_natural_sort_cmp(const char *name1, const char *name2)
+{
+    while (name1[0] && name2[0]) {
+        if (mp_isdigit(name1[0]) && mp_isdigit(name2[0])) {
+            while (name1[0] == '0')
+                name1++;
+            while (name2[0] == '0')
+                name2++;
+            const char *end1 = name1, *end2 = name2;
+            while (mp_isdigit(*end1))
+                end1++;
+            while (mp_isdigit(*end2))
+                end2++;
+            // With padding stripped, a number with more digits is bigger.
+            if ((end1 - name1) < (end2 - name2))
+                return -1;
+            if ((end1 - name1) > (end2 - name2))
+                return 1;
+            // Same length, lexicographical works.
+            while (name1 < end1) {
+                if (name1[0] < name2[0])
+                    return -1;
+                if (name1[0] > name2[0])
+                    return 1;
+                name1++;
+                name2++;
+            }
+        } else {
+            if (mp_tolower(name1[0]) < mp_tolower(name2[0]))
+                return -1;
+            if (mp_tolower(name1[0]) > mp_tolower(name2[0]))
+                return 1;
+            name1++;
+            name2++;
+        }
+    }
+    if (name2[0])
+        return -1;
+    if (name1[0])
+        return 1;
+    return 0;
+}

--- a/misc/natural_sort.h
+++ b/misc/natural_sort.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MP_NATURAL_SORT_H
+#define MP_NATURAL_SORT_H
+
+int mp_natural_sort_cmp(const char *name1, const char *name2);
+
+#endif

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -317,6 +317,7 @@ def build(ctx):
         ( "misc/charset_conv.c" ),
         ( "misc/dispatch.c" ),
         ( "misc/json.c" ),
+        ( "misc/natural_sort.c" ),
         ( "misc/node.c" ),
         ( "misc/rendezvous.c" ),
         ( "misc/ring.c" ),


### PR DESCRIPTION
Based on discussion in #6016 with some feedback from @avih.

I have two versions of this. This one doesn't actually parse numbers; it just counts non-padding digits and falls back to lexicographical if they're the same order of magnitude. This might be too "clever". I've done an equivalent implementation using `strtoull` in 9479ba41aa1668808ad36926afd6268553ffe23d, which is much clearer code but will consider any numbers over ULLONG_MAX equal.