### PR TITLE
build: fix adding of object files to linking with cplugins disabled

### DIFF
--- a/waftools/generators/sources.py
+++ b/waftools/generators/sources.py
@@ -94,7 +94,7 @@ def __wayland_protocol_header__(ctx, **kwargs):
 @TaskGen.feature('cshlib')
 @TaskGen.feature('cstlib')
 @TaskGen.feature('apply_link')
-@TaskGen.after_method('do_the_symbol_stuff')
+@TaskGen.after_method('process_source', 'process_use', 'apply_link', 'process_uselib_local', 'propagate_uselib_vars', 'do_the_symbol_stuff')
 def handle_add_object(tgen):
     if getattr(tgen, 'add_object', None):
         for input in Utils.to_list(tgen.add_object):


### PR DESCRIPTION
i wasn't aware that disabling the cplugins, disables `syms` and because of that `do_the_symbol_stuff` is never called. because of that `handle_add_object` is again called before the link_task is created.

now `handle_add_object` is called after the same [tasks](https://github.com/mpv-player/mpv/blob/master/waftools/syms.py#L36) as `do_the_symbol_stuff` is called after.