### PR TITLE
ci: do bootstrap outside the docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
 before_install:
   - docker pull $CONTAINER
 script:
+  - ./bootstrap.py
   - docker run --env CC --env TARGET -v $TRAVIS_BUILD_DIR:/build $CONTAINER /bin/sh -c "cd /build && $CI_SCRIPT"
 after_failure: cat ./build/config.log
 after_script: TOOLS/travis-rebuild-website

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -16,7 +16,6 @@ export RANLIB=$TARGET-ranlib
 export CFLAGS="-O2 -mtune=intel -g -ggdb -pipe -Wall --param=ssp-buffer-size=4 -mms-bitfields -fmessage-length=0 -D_FORTIFY_SOURCE=2 -fexceptions -fasynchronous-unwind-tables -fstack-protector-strong -fno-ident"
 export LDFLAGS="-Wl,--no-keep-memory -fstack-protector-strong"
 
-./bootstrap.py
 ./waf configure \
     --enable-static-build \
     --enable-libmpv-shared \

--- a/ci/build-tumbleweed.sh
+++ b/ci/build-tumbleweed.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-./bootstrap.py
 ./waf configure \
   --enable-cdda          \
   --enable-dvbin         \


### PR DESCRIPTION
This way the docker container in itself does no networking.

It seems like travis disabled network access from the actual docker
containers.
