### PR TITLE
osx: Fix compilation due to NSApp having type id

### DIFF
--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -602,7 +602,7 @@
 - (NSMenu *)mainMenu
 {
     NSMenu *mainMenu = [[NSMenu alloc] initWithTitle:@"MainMenu"];
-    NSApp.servicesMenu = [NSMenu alloc];
+    [NSApp setServicesMenu:[[NSMenu alloc] init]];
 
     for(id mMenu in menuTree) {
         NSMenu *menu = [[NSMenu alloc] initWithTitle:mMenu[@"name"]];
@@ -633,7 +633,7 @@
                 }
 
                 if ([subMenu[@"name"] isEqual:@"Services"]) {
-                    iItem.submenu = NSApp.servicesMenu;
+                    iItem.submenu = [NSApp servicesMenu];
                 }
             }
         }


### PR DESCRIPTION
Replace dot syntax with accessor syntax so that clang no longer errors out due to not finding the property servicesMenu on NSApp.

I agree that my changes can be relicensed to LGPL 2.1 or later.

cc @Akemi 