### PR TITLE
cocoa-cb: fix crash on macOS 10.10

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -241,7 +241,9 @@ class CocoaCB: NSObject {
 
     func updateICCProfile() {
         mpv.setRenderICCProfile(window.screen!.colorSpace!)
-        layer.colorspace = window.screen!.colorSpace!.cgColorSpace!
+        if #available(macOS 10.11, *) {
+            layer.colorspace = window.screen!.colorSpace!.cgColorSpace!
+        }
     }
 
     func lmuToLux(_ v: UInt64) -> Int {


### PR DESCRIPTION
apparently the [colorspace](https://developer.apple.com/documentation/quartzcore/caopengllayer/1521873-colorspace#declarations) of the layer is only available on 10.11 but the compiler didn't throw an error, which it usually does.

this is untested since cocoa-cb can only be build on 10.11 (10.10 only has swift 2.x availabe) and i can't be bothered to build all dependencies for a lower target OS version.