### PR TITLE
cli: Make --disable-build-date display no 'built on' line at all

### DIFF
--- a/common/version.c
+++ b/common/version.c
@@ -19,9 +19,11 @@
 #include "version.h"
 #ifdef NO_BUILD_TIMESTAMPS
 #undef BUILDDATE
-#define BUILDDATE "UNKNOWN"
+#define BUILDDATE_FULL ""
+#else
+#define BUILDDATE_FULL "\n built on " BUILDDATE
 #endif
 
 const char mpv_version[]  = "mpv " VERSION;
-const char mpv_builddate[] = BUILDDATE;
+const char mpv_builddate[] = BUILDDATE_FULL;
 const char mpv_copyright[] = MPVCOPYRIGHT;


### PR DESCRIPTION
The behavior of `--disable-build-date` spitting back 'built on UNKNOWN' was mentioned in another bug report recently, and as I still had this patch floating around from the previous time it was mentioned, I figured I might as well finally open a PR for it.

As before, I don't particularly care whether this patch gets merged, since I prefer to see the build date and thus never disable it, but for those that want/need to use `--disable-build-date`, this will make the output a bit less jarring.