### PR TITLE
cli: more flexibility with date reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.d
 *.exe
 *.pyc
+*.orig
 .depend
 
 /config.h

--- a/common/common.h
+++ b/common/common.h
@@ -60,6 +60,7 @@ enum stream_type {
 
 extern const char mpv_version[];
 extern const char mpv_builddate[];
+extern const char mpv_gitdate[];
 extern const char mpv_copyright[];
 
 char *mp_format_time(double time, bool fractions);

--- a/common/version.c
+++ b/common/version.c
@@ -23,8 +23,14 @@
 #else
 #define BUILDDATE_FULL "\n binary built on " BUILDDATE
 #endif
+#ifdef NO_BUILD_GITTIMESTAMPS
+#undef GITDATE
+#define GITDATE_FULL ""
+#else
+#define GITDATE_FULL "\n last updated on " GITDATE
+#endif
 
 const char mpv_version[]  = "mpv " VERSION;
 const char mpv_builddate[] = BUILDDATE_FULL;
-const char mpv_gitdate[] = GITDATE;
+const char mpv_gitdate[] = GITDATE_FULL;
 const char mpv_copyright[] = MPVCOPYRIGHT;

--- a/common/version.c
+++ b/common/version.c
@@ -26,4 +26,5 @@
 
 const char mpv_version[]  = "mpv " VERSION;
 const char mpv_builddate[] = BUILDDATE_FULL;
+const char mpv_gitdate[] = GITDATE;
 const char mpv_copyright[] = MPVCOPYRIGHT;

--- a/common/version.c
+++ b/common/version.c
@@ -19,9 +19,11 @@
 #include "version.h"
 #ifdef NO_BUILD_TIMESTAMPS
 #undef BUILDDATE
-#define BUILDDATE "UNKNOWN"
+#define BUILDDATE_FULL ""
+#else
+#define BUILDDATE_FULL "\n built on " BUILDDATE
 #endif
 
 const char mpv_version[]  = "mpv " VERSION;
-const char mpv_builddate[] = BUILDDATE;
+const char mpv_builddate[] = BUILDDATE_FULL;
 const char mpv_copyright[] = MPVCOPYRIGHT;

--- a/common/version.c
+++ b/common/version.c
@@ -21,7 +21,7 @@
 #undef BUILDDATE
 #define BUILDDATE_FULL ""
 #else
-#define BUILDDATE_FULL "\n built on " BUILDDATE
+#define BUILDDATE_FULL "\n binary built on " BUILDDATE
 #endif
 
 const char mpv_version[]  = "mpv " VERSION;

--- a/player/main.c
+++ b/player/main.c
@@ -141,7 +141,7 @@ void mp_update_logging(struct MPContext *mpctx, bool preinit)
 void mp_print_version(struct mp_log *log, int always)
 {
     int v = always ? MSGL_INFO : MSGL_V;
-    mp_msg(log, v, "%s %s\n built on %s\n",
+    mp_msg(log, v, "%s %s %s\n",
            mpv_version, mpv_copyright, mpv_builddate);
     print_libav_versions(log, v);
     mp_msg(log, v, "\n");

--- a/player/main.c
+++ b/player/main.c
@@ -141,8 +141,8 @@ void mp_update_logging(struct MPContext *mpctx, bool preinit)
 void mp_print_version(struct mp_log *log, int always)
 {
     int v = always ? MSGL_INFO : MSGL_V;
-    mp_msg(log, v, "%s %s %s\n",
-           mpv_version, mpv_copyright, mpv_builddate);
+    mp_msg(log, v, "%s %s %s\n last updated on %s\n",
+           mpv_version, mpv_copyright, mpv_builddate, mpv_gitdate);
     print_libav_versions(log, v);
     mp_msg(log, v, "\n");
     // Only in verbose mode.

--- a/player/main.c
+++ b/player/main.c
@@ -141,7 +141,7 @@ void mp_update_logging(struct MPContext *mpctx, bool preinit)
 void mp_print_version(struct mp_log *log, int always)
 {
     int v = always ? MSGL_INFO : MSGL_V;
-    mp_msg(log, v, "%s %s %s\n last updated on %s\n",
+    mp_msg(log, v, "%s %s %s %s\n",
            mpv_version, mpv_copyright, mpv_builddate, mpv_gitdate);
     print_libav_versions(log, v);
     mp_msg(log, v, "\n");

--- a/version.sh
+++ b/version.sh
@@ -43,12 +43,11 @@ fi
 git_revision=$(cat snapshot_version 2> /dev/null)
 test "$git_revision" || test ! -e .git || git_revision="$(git describe \
     --match "v[0-9]*" --always --tags --dirty | sed 's/^v//')"
-version="$git_revision\n"
 git_revision_master="$(git rev-parse --short master)"
 git_revision_head="$(git rev-parse --short HEAD)"
 git_hashes="master-$git_revision_master HEAD-$git_revision_head"
 branches_included="contains: $(git branch --merged | grep -v master | sed 's/^..//g' | tr '\n' ' ')"
-version="$git_revision ($git_hashes)\n$branches_included\n"
+version="$git_revision ($git_hashes)\n$branches_included"
 
 # other tarballs extract the version number from the VERSION file
 if test ! "$version"; then

--- a/version.sh
+++ b/version.sh
@@ -54,6 +54,7 @@ fi
 NEW_REVISION="#define VERSION \"${VERSION}\""
 OLD_REVISION=$(head -n 1 "$version_h" 2> /dev/null)
 BUILDDATE="#define BUILDDATE \"$(date)\""
+GITDATE="#define GITDATE \"$(git show -s --format=%cd)\""
 MPVCOPYRIGHT="#define MPVCOPYRIGHT \"Copyright © 2000-2019 mpv/MPlayer/mplayer2 projects\""
 
 # Update version.h only on revision changes to avoid spurious rebuilds
@@ -61,6 +62,7 @@ if test "$NEW_REVISION" != "$OLD_REVISION"; then
     cat <<EOF > "$version_h"
 $NEW_REVISION
 $BUILDDATE
+$GITDATE
 $MPVCOPYRIGHT
 EOF
 fi

--- a/version.sh
+++ b/version.sh
@@ -53,7 +53,7 @@ fi
 
 NEW_REVISION="#define VERSION \"${VERSION}\""
 OLD_REVISION=$(head -n 1 "$version_h" 2> /dev/null)
-BUILDDATE="#define BUILDDATE \"$(date)\""
+BUILDDATE="#define BUILDDATE \"$(date +"%a %b %-e %T %Y %z")\""
 GITDATE="#define GITDATE \"$(git show -s --format=%cd)\""
 MPVCOPYRIGHT="#define MPVCOPYRIGHT \"Copyright © 2000-2019 mpv/MPlayer/mplayer2 projects\""
 

--- a/version.sh
+++ b/version.sh
@@ -47,7 +47,8 @@ version="$git_revision\n"
 git_revision_master="$(git rev-parse --short master)"
 git_revision_head="$(git rev-parse --short HEAD)"
 git_hashes="master-$git_revision_master HEAD-$git_revision_head"
-version="$git_revision ($git_hashes)\n"
+branches_included="contains: $(git branch --merged | grep -v master | sed 's/^..//g' | tr '\n' ' ')"
+version="$git_revision ($git_hashes)\n$branches_included\n"
 
 # other tarballs extract the version number from the VERSION file
 if test ! "$version"; then

--- a/version.sh
+++ b/version.sh
@@ -44,6 +44,10 @@ git_revision=$(cat snapshot_version 2> /dev/null)
 test "$git_revision" || test ! -e .git || git_revision="$(git describe \
     --match "v[0-9]*" --always --tags --dirty | sed 's/^v//')"
 version="$git_revision\n"
+git_revision_master="$(git rev-parse --short master)"
+git_revision_head="$(git rev-parse --short HEAD)"
+git_hashes="master-$git_revision_master HEAD-$git_revision_head"
+version="$git_revision ($git_hashes)\n"
 
 # other tarballs extract the version number from the VERSION file
 if test ! "$version"; then

--- a/version.sh
+++ b/version.sh
@@ -43,7 +43,7 @@ fi
 git_revision=$(cat snapshot_version 2> /dev/null)
 test "$git_revision" || test ! -e .git || git_revision="$(git describe \
     --match "v[0-9]*" --always --tags --dirty | sed 's/^v//')"
-version="$git_revision"
+version="$git_revision\n"
 
 # other tarballs extract the version number from the VERSION file
 if test ! "$version"; then

--- a/wscript
+++ b/wscript
@@ -71,6 +71,11 @@ build_options = [
         'default': 'enable',
         'func': check_true
     }, {
+        'name': '--commit-date',
+        'desc': 'whether to include most recent commit timestamp',
+        'default': 'enable',
+        'func': check_true
+    }, {
         'name': '--rfc-date',
         'desc': 'use RFC 3339 format for build/commit dates',
         'default': 'disable',
@@ -1111,6 +1116,9 @@ def configure(ctx):
 
     if not ctx.dependency_satisfied('build-date'):
         ctx.env.CFLAGS += ['-DNO_BUILD_TIMESTAMPS']
+
+    if not ctx.dependency_satisfied('commit-date'):
+        ctx.env.CFLAGS += ['-DNO_BUILD_GITTIMESTAMPS']
 
     if ctx.dependency_satisfied('clang-database'):
         ctx.load('clang_compilation_database')

--- a/wscript
+++ b/wscript
@@ -71,6 +71,16 @@ build_options = [
         'default': 'enable',
         'func': check_true
     }, {
+        'name': '--rfc-date',
+        'desc': 'use RFC 3339 format for build/commit dates',
+        'default': 'disable',
+        'func': check_true
+    }, {
+        'name': '--utc-date',
+        'desc': 'use UTC without timezone offset for build/commit dates',
+        'default': 'disable',
+        'func': check_true
+    }, {
         'name': '--optimize',
         'desc': 'whether to optimize',
         'default': 'enable',
@@ -1105,6 +1115,12 @@ def configure(ctx):
     if ctx.dependency_satisfied('clang-database'):
         ctx.load('clang_compilation_database')
 
+    if ctx.dependency_satisfied('rfc-date'):
+        ctx.env.RFCDATE = '--rfc=yes'
+
+    if ctx.dependency_satisfied('utc-date'):
+        ctx.env.UTCDATE = '--utc=yes'
+
     if ctx.dependency_satisfied('cplugins'):
         # We need to export the libmpv symbols, since the mpv binary itself is
         # not linked against libmpv. The C plugin needs to be able to pick
@@ -1122,7 +1138,7 @@ def __write_version__(ctx):
     ctx(
         source = 'version.sh',
         target = 'version.h',
-        rule   = 'sh ${SRC} ${CWD_ST:VERSIONSH_CWD} ${VERSIONH_ST:TGT}',
+        rule   = 'sh ${SRC} ${RFCDATE} ${UTCDATE} ${CWD_ST:VERSIONSH_CWD} ${VERSIONH_ST:TGT}',
         always = True,
         update_outputs = True)
 


### PR DESCRIPTION
This allows for users to completely disable the 'built on' line if `--disable-build-date` is used (superseding #6046), and adds a few new options and information:

* The date of the most recent change to git HEAD is now printed underneath the binary build date.  This way, comparing the build date and the git commit date can easily show whether it's just a new build of an old commit or not.
* Adds an option to use date's RFC 3339 formatting (purely cosmetic).  Still reports in local time with timezone offset.  I actually debated whether to use date's ISO 8601 option or not, but I prefer the spacing in RFC 3339.
* Adds an option to format as the non-offset UTC date.  This means that the git commit date will be completely reproducible, for users that need that.
* Adds an option to disable the git commit date line completely, like the corresponding one for omitting the build date.
* Adds *.orig to the list in .gitignore, mostly just because fixing up these patches made me realize that it wasn't included there already.

RFC and UTC options can be used together.  I can't say I'm entirely happy with the wording for the commit date (I just tried to make it concise; the first version was 'most recent change commited on' which made aligning the build date with it look ridiculous), so I'm open to suggestions there.