### PR TITLE
ao_opensles: set numBuffers to 8

### DIFF
--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -119,7 +119,7 @@ static int init(struct ao *ao)
     CHK((*p->output_mix)->Realize(p->output_mix, SL_BOOLEAN_FALSE));
 
     locator_buffer_queue.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
-    locator_buffer_queue.numBuffers = 1;
+    locator_buffer_queue.numBuffers = 8;
 
     if (af_fmt_is_int(ao->format)) {
         // Be future-proof


### PR DESCRIPTION
Apparently some Android builds/forks require this for Bluetooth
audio to work as they unexpectedly accept fast flag for it.

Shouldn't cause any side-effect (e.g. buffer requirement increased
when on wired audio). It's a hardcoded default in the upstream
AAudio implementation anyway.

Ref.:
https://android.googlesource.com/platform/frameworks/av/+/android-8.0.0_r1/media/libaaudio/src/legacy/AudioStreamTrack.cpp#109
https://android.googlesource.com/platform/frameworks/wilhelm/+/android-8.0.0_r1/src/android/AudioPlayer_to_android.cpp#1680
https://android.googlesource.com/platform/frameworks/av/+/android-8.0.0_r1/media/libaudioclient/AudioTrack.cpp#488

Also see https://github.com/termux/termux-packages/issues/2703.