### PR TITLE
audio/format: decouple af_fmt_is_planar from af_fmt_to_planar

### DIFF
--- a/audio/format.c
+++ b/audio/format.c
@@ -55,12 +55,6 @@ bool af_fmt_is_int(int format)
     return format && !af_fmt_is_spdif(format) && !af_fmt_is_float(format);
 }
 
-// false for interleaved and AF_FORMAT_UNKNOWN
-bool af_fmt_is_planar(int format)
-{
-    return format && af_fmt_to_planar(format) == format;
-}
-
 bool af_fmt_is_spdif(int format)
 {
     return af_format_sample_alignment(format) > 1;
@@ -79,32 +73,37 @@ static const int planar_formats[][2] = {
     {AF_FORMAT_DOUBLEP, AF_FORMAT_DOUBLE},
 };
 
+bool af_fmt_is_planar(int format)
+{
+    for (int n = 0; n < MP_ARRAY_SIZE(planar_formats); n++) {
+        if (planar_formats[n][0] == format)
+            return true;
+    }
+    return false;
+}
+
 // Return the planar format corresponding to the given format.
-// If the format is already planar, return it.
-// Return 0 if there's no equivalent.
+// If the format is already planar or if there's no equivalent,
+// return it.
 int af_fmt_to_planar(int format)
 {
     for (int n = 0; n < MP_ARRAY_SIZE(planar_formats); n++) {
         if (planar_formats[n][1] == format)
             return planar_formats[n][0];
-        if (planar_formats[n][0] == format)
-            return format;
     }
-    return 0;
+    return format;
 }
 
 // Return the interleaved format corresponding to the given format.
-// If the format is already interleaved, return it.
-// Return 0 if there's no equivalent.
+// If the format is already interleaved or if there's no equivalent,
+// return it.
 int af_fmt_from_planar(int format)
 {
     for (int n = 0; n < MP_ARRAY_SIZE(planar_formats); n++) {
         if (planar_formats[n][0] == format)
             return planar_formats[n][1];
-        if (planar_formats[n][1] == format)
-            return format;
     }
-    return 0;
+    return format;
 }
 
 bool af_fmt_is_valid(int format)


### PR DESCRIPTION
so that af_fmt_to_planar (and hence af_fmt_from_planar) can just
return the input when it is not an interleaved (planar) format.