### PR TITLE
cocoa-cb: fix crash when no screen is available

### DIFF
--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -233,7 +233,7 @@ class EventsView: NSView {
             topMargin = cocoaCB.window.titleBarHeight + 1 + menuBarHeight
         }
 
-        var vF = window!.screen!.frame
+        guard var vF = window?.screen?.frame else { return false }
         vF.size.height -= topMargin
 
         let vFW = window!.convertFromScreen(vF)


### PR DESCRIPTION
there are probably more forced unwrapping cases that should be changed, though i would like to leave that for a future refactor PR.