### PR TITLE
Revert "ao_openal: enable building on OSX"

### DIFF
--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -24,19 +24,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-
-#ifdef __APPLE__
-#ifndef AL_FORMAT_MONO_FLOAT32
-#define AL_FORMAT_MONO_FLOAT32 0x10010
-#endif
-#ifndef AL_FORMAT_STEREO_FLOAT32
-#define AL_FORMAT_STEREO_FLOAT32 0x10011
-#endif
-#ifndef AL_FORMAT_MONO_DOUBLE_EXT
-#define AL_FORMAT_MONO_DOUBLE_EXT 0x10012
-#endif
-#include <OpenAL/MacOSX_OALExtensions.h>
-#else
 #ifdef OPENAL_AL_H
 #include <OpenAL/alc.h>
 #include <OpenAL/al.h>
@@ -46,7 +33,6 @@
 #include <AL/al.h>
 #include <AL/alext.h>
 #endif
-#endif // __APPLE__
 
 #include "common/msg.h"
 

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -4,7 +4,7 @@ from waflib import Utils
 import os
 
 __all__ = ["check_pthreads", "check_iconv", "check_lua",
-           "check_cocoa", "check_openal", "check_wl_protocols"]
+           "check_cocoa", "check_wl_protocols"]
 
 pthreads_program = load_fragment('pthreads.c')
 
@@ -111,14 +111,3 @@ def check_cocoa(ctx, dependency_identifier):
         ])
 
     return res
-
-def check_openal(ctx, dependency_identifier):
-    checks = [
-        check_pkg_config('openal', '>= 1.13'),
-        check_statement(['OpenAL/AL.h'], 'int i = AL_VERSION', framework='OpenAL')
-        ]
-
-    for fn in checks:
-        if fn(ctx, dependency_identifier):
-            return True
-    return False

--- a/wscript
+++ b/wscript
@@ -506,7 +506,7 @@ audio_output_features = [
     }, {
         'name': '--openal',
         'desc': 'OpenAL audio output',
-        'func': check_openal,
+        'func': check_pkg_config('openal', '>= 1.13'),
         'default': 'disable'
     }, {
         'name': '--opensles',


### PR DESCRIPTION
This reverts commit af6126adbe61fb2b6cc780025246d33df93072e6. Apple's
OpenAL support is ridiculously out of date, revert back to just using
OpenAL Soft on macOS (fixes #4645).