### PR TITLE
ao_pulse: fix tlength calculation

### DIFF
--- a/audio/format.c
+++ b/audio/format.c
@@ -135,17 +135,6 @@ const char *af_fmt_to_str(int format)
     return "??";
 }
 
-int af_fmt_seconds_to_bytes(int format, float seconds, int channels, int samplerate)
-{
-    assert(!af_fmt_is_planar(format));
-    int bps      = af_fmt_to_bytes(format);
-    int framelen = channels * bps;
-    int bytes    = seconds  * bps * samplerate;
-    if (bytes % framelen)
-        bytes += framelen - (bytes % framelen);
-    return bytes;
-}
-
 void af_fill_silence(void *dst, size_t bytes, int format)
 {
     memset(dst, af_fmt_is_unsigned(format) ? 0x80 : 0, bytes);

--- a/audio/format.h
+++ b/audio/format.h
@@ -64,9 +64,6 @@ bool af_fmt_is_pcm(int format);
 int af_fmt_to_planar(int format);
 int af_fmt_from_planar(int format);
 
-// Amount of bytes that contain audio of the given duration, aligned to frames.
-int af_fmt_seconds_to_bytes(int format, float seconds, int channels, int samplerate);
-
 void af_fill_silence(void *dst, size_t bytes, int format);
 
 void af_get_best_sample_formats(int src_format, int *out_formats);

--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -454,11 +454,11 @@ static int init(struct ao *ao)
     pa_stream_set_write_callback(priv->stream, stream_request_cb, ao);
     pa_stream_set_latency_update_callback(priv->stream,
                                           stream_latency_update_cb, ao);
-    int buf_size = af_fmt_seconds_to_bytes(ao->format, priv->cfg_buffer / 1000.0,
-                                           ao->channels.num, ao->samplerate);
+    uint32_t buf_size = ao->samplerate * (priv->cfg_buffer / 1000.0) *
+        af_fmt_to_bytes(ao->format) * ao->channels.num;
     pa_buffer_attr bufattr = {
         .maxlength = -1,
-        .tlength = buf_size > 0 ? buf_size : (uint32_t)-1,
+        .tlength = buf_size > 0 ? buf_size : -1,
         .prebuf = -1,
         .minreq = -1,
         .fragsize = -1,


### PR DESCRIPTION
also remove the now unused non-sensical af_fmt_seconds_to_bytes.

Alternative to #6047. @sfan5 @jeeb 