### PR TITLE
af_rubberband: reset delay to 0 on reset

### DIFF
--- a/audio/filter/af_rubberband.c
+++ b/audio/filter/af_rubberband.c
@@ -167,6 +167,7 @@ static void process(struct mp_filter *f)
             if (eof) {
                 mp_pin_in_write(f->ppins[1], MP_EOF_FRAME);
                 rubberband_reset(p->rubber);
+                p->rubber_delay = 0;
                 TA_FREEP(&p->pending);
                 p->sent_final = false;
                 return;
@@ -263,6 +264,7 @@ static void reset(struct mp_filter *f)
 
     if (p->rubber)
         rubberband_reset(p->rubber);
+    p->rubber_delay = 0;
     p->sent_final = false;
     TA_FREEP(&p->pending);
 }


### PR DESCRIPTION
This fixes A-V drift on seeking

I agree that my changes can be relicensed to LGPL 2.1 or later.
