### PR TITLE
vo_gpu: switch to optimization level performance

### DIFF
--- a/video/out/gpu/spirv_shaderc.c
+++ b/video/out/gpu/spirv_shaderc.c
@@ -32,7 +32,7 @@ static bool shaderc_init(struct ra_ctx *ctx)
         goto error;
 
     shaderc_compile_options_set_optimization_level(p->opts,
-                                            shaderc_optimization_level_size);
+                                    shaderc_optimization_level_performance);
     if (ctx->opts.debug)
         shaderc_compile_options_set_generate_debug_info(p->opts);
 


### PR DESCRIPTION
Upstream has this now. Didn't really make any different for me (except
making the polar compute shader 2%-3% faster), but maybe it does for
somebody else.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
