### PR TITLE
ao_jack: only auto-connect to audio ports

### DIFF
--- a/audio/out/ao_jack.c
+++ b/audio/out/ao_jack.c
@@ -143,7 +143,8 @@ connect_to_outports(struct ao *ao)
     if (!port_name)
         port_flags |= JackPortIsPhysical;
 
-    matching_ports = jack_get_ports(p->client, port_name, NULL, port_flags);
+    const char *port_type = JACK_DEFAULT_AUDIO_TYPE; // exclude MIDI ports
+    matching_ports = jack_get_ports(p->client, port_name, port_type, port_flags);
 
     if (!matching_ports || !matching_ports[0]) {
         MP_FATAL(ao, "no ports to connect to\n");


### PR DESCRIPTION
This prevents ao_jack from auto-connecting to MIDI ports (or other,
hypothetical future port types).

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
