### PR TITLE
mp_image: strip all HDR peak information from SDR clips

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -812,6 +812,12 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
         }
     }
 
+    if (!mp_trc_is_hdr(params->color.gamma)) {
+        // Some clips have leftover HDR metadata after conversion to SDR, so to
+        // avoid blowing up the tone mapping code, strip/sanitize it
+        params->color.sig_peak = 1.0;
+    }
+
     if (params->chroma_location == MP_CHROMA_AUTO) {
         if (params->color.levels == MP_CSP_LEVELS_TV)
             params->chroma_location = MP_CHROMA_LEFT;


### PR DESCRIPTION
By overriding it with 1.0 (aka SDR). This prevents blowing up on
mistagged clips.

Fixes #6111

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
