### PR TITLE
ao_alsa: Improve get_space

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -940,6 +940,11 @@ static int get_space(struct ao *ao)
 {
     struct priv *p = ao->priv;
 
+    // in case of pausing or the device still being configured,
+    // just return our buffer size.
+    if (p->paused || snd_pcm_state(p->alsa) == SND_PCM_STATE_SETUP)
+        return p->buffersize;
+
     snd_pcm_sframes_t space = snd_pcm_avail(p->alsa);
     if (space < 0) {
         MP_ERR(ao, "Error received from snd_pcm_avail (%ld, %s)!\n",

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -954,8 +954,10 @@ static int get_space(struct ao *ao)
             return p->buffersize;
         }
 
-        MP_ERR(ao, "Error received from snd_pcm_avail (%ld, %s)!\n",
-               space, snd_strerror(space));
+        MP_ERR(ao, "Error received from snd_pcm_avail "
+                   "(%ld, %s with ALSA state %s)!\n",
+               space, snd_strerror(space),
+               snd_pcm_state_name(snd_pcm_state(p->alsa)));
 
         // request a reload of the AO if device is not present,
         // then error out.


### PR DESCRIPTION
Fixes #5890 to no longer spam messages during pause, and removes spam from EOF.

1. Early exit from `get_space()` if paused or ALSA is not yet initialized. This lack of early exit was not noticed before because there was no logging of error states present in `get_space()`.
2. Special case XRUN errors and attempt to re-initialize the audio output in case one does happen. Warn the user about the (most likely) singular XRUN.
3. Log the ALSA state when we receive and error. This can help when debugging unexpected error cases.

Overall, this inconveniences the users less (no spam!) yet still reminds us that something is not exactly right with some logic somewhere (we get XRUNs right before EOF).