### PR TITLE
Implement cuda/nvdev hwdec for vulkan backend

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -750,7 +750,7 @@ Video
     likely works with Intel GPUs only. It also requires the opengl EGL backend.
 
     The ``cuda`` and ``cuda-copy`` modes provides deinterlacing in the decoder
-    which is useful as there is no other deinterlacing mechanism in the opengl
+    which is useful as there is no other deinterlacing mechanism in the gpu
     output path. To use this deinterlacing you must pass the option:
     ``vd-lavc-o=deint=[weave|bob|adaptive]``.
     Pass ``weave`` (or leave the option unset) to not attempt any
@@ -778,6 +778,11 @@ Video
         When using this switch, hardware decoding is still only done for some
         codecs. See ``--hwdec-codecs`` to enable hardware decoding for more
         codecs.
+
+    .. note::
+
+       Most non-copy methods only work with the OpenGL GPU backend. Currently,
+       only the ``nvdec`` and ``cuda`` methods work with Vulkan.
 
     .. admonition:: Quality reduction with hardware decoding
 
@@ -888,14 +893,18 @@ Video
     format, with likely no advantages.
 
 ``--cuda-decode-device=<auto|0..>``
-    Choose the GPU device used for decoding when using the ``cuda`` hwdec.
+    Choose the GPU device used for decoding when using the ``cuda`` or
+    ``nvdec`` hwdecs with the OpenGL GPU backend.
 
-    By default, the device that is being used to provide OpenGL output will
+    By default, the device that is being used to provide ``gpu`` output will
     also be used for decoding (and in the vast majority of cases, only one
     GPU will be present).
 
-    Note that when using the ``cuda-copy`` hwdec, a different option must be
-    passed: ``--vd-lavc-o=gpu=<0..>``.
+    Note that when using the ``cuda-copy`` or ``nvdec-copy`` hwdec, a
+    different option must be passed: ``--vd-lavc-o=gpu=<0..>``.
+
+    Note that this option is not available with the Vulkan GPU backend. With
+    Vulkan, decoding must always happen on the display device.
 
 ``--vaapi-device=<device file>``
     Choose the DRM device for ``vaapi-copy``. This should be the path to a

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -188,6 +188,7 @@ enum ra_buf_type {
     RA_BUF_TYPE_SHADER_STORAGE, // shader buffer (SSBO), for RA_VARTYPE_BUF_RW
     RA_BUF_TYPE_UNIFORM,        // uniform buffer (UBO), for RA_VARTYPE_BUF_RO
     RA_BUF_TYPE_VERTEX,         // not publicly usable (RA-internal usage)
+    RA_BUF_TYPE_SHARED_MEMORY,  // device memory for sharing with external API
 };
 
 struct ra_buf_params {

--- a/video/out/opengl/hwdec_cuda.c
+++ b/video/out/opengl/hwdec_cuda.c
@@ -19,13 +19,13 @@
 
 /*
  * This hwdec implements an optimized output path using CUDA->OpenGL
- * interop for frame data that is stored in CUDA device memory.
- * Although it is not explicit in the code here, the only practical way
- * to get data in this form is from the 'cuvid' decoder (aka NvDecode).
- *
- * For now, cuvid/NvDecode will always return images in NV12 format, even
- * when decoding 10bit streams (there is some hardware dithering going on).
+ * or CUDA->Vulkan interop for frame data that is stored in CUDA
+ * device memory. Although it is not explicit in the code here, the
+ * only practical way to get data in this form is from the
+ * nvdec/cuvid decoder.
  */
+
+#include <unistd.h>
 
 #include <ffnvcodec/dynlink_loader.h>
 #include <libavutil/hwcontext.h>
@@ -35,12 +35,32 @@
 #include "formats.h"
 #include "options/m_config.h"
 #include "ra_gl.h"
+#include "video/out/vulkan/formats.h"
+#include "video/out/vulkan/ra_vk.h"
+#include "video/out/vulkan/utils.h"
+
+#if HAVE_WIN32_DESKTOP
+#include <versionhelpers.h>
+#endif
 
 struct priv_owner {
     struct mp_hwdec_ctx hwctx;
     CudaFunctions *cu;
     CUcontext display_ctx;
     CUcontext decode_ctx;
+
+    bool is_gl;
+    bool is_vk;
+};
+
+struct ext_buf {
+#if HAVE_WIN32_DESKTOP
+    HANDLE handle;
+#else
+    int fd;
+#endif
+    CUexternalMemory mem;
+    CUdeviceptr buf;
 };
 
 struct priv {
@@ -49,6 +69,9 @@ struct priv {
     CUarray cu_array[4];
 
     CUcontext display_ctx;
+
+    struct ra_buf_params buf_params[4];
+    struct ra_buf_pool buf_pool[4];
 };
 
 static int check_cu(struct ra_hwdec *hw, CUresult err, const char *func)
@@ -81,19 +104,31 @@ static int cuda_init(struct ra_hwdec *hw)
     CUdevice display_dev;
     AVBufferRef *hw_device_ctx = NULL;
     CUcontext dummy;
-    unsigned int device_count;
     int ret = 0;
     struct priv_owner *p = hw->priv;
     CudaFunctions *cu;
 
-    if (!ra_is_gl(hw->ra))
-        return -1;
-
-    GL *gl = ra_gl_get(hw->ra);
-    if (gl->version < 210 && gl->es < 300) {
-        MP_VERBOSE(hw, "need OpenGL >= 2.1 or OpenGL-ES >= 3.0\n");
-        return -1;
+#if HAVE_GL
+    p->is_gl = ra_is_gl(hw->ra);
+    if (p->is_gl) {
+        GL *gl = ra_gl_get(hw->ra);
+        if (gl->version < 210 && gl->es < 300) {
+            MP_VERBOSE(hw, "need OpenGL >= 2.1 or OpenGL-ES >= 3.0\n");
+            return -1;
+        }
     }
+#endif
+
+#if HAVE_VULKAN
+    p->is_vk = ra_vk_get(hw->ra) != NULL;
+    if (p->is_vk) {
+        if (!ra_vk_get(hw->ra)->has_ext_external_memory_export) {
+            MP_ERR(hw, "CUDA hwdec with Vulkan requires the %s extension\n",
+                   MP_VK_EXTERNAL_MEMORY_EXPORT_EXTENSION_NAME);
+            return -1;
+        }
+    }
+#endif
 
     ret = cuda_load_functions(&p->cu, NULL);
     if (ret != 0) {
@@ -102,46 +137,96 @@ static int cuda_init(struct ra_hwdec *hw)
     }
     cu = p->cu;
 
+    if (p->is_vk && !cu->cuImportExternalMemory) {
+        MP_ERR(hw, "CUDA hwdec with Vulkan requires driver version 410.48 or newer.\n");
+        return -1;
+    }
+
     ret = CHECK_CU(cu->cuInit(0));
     if (ret < 0)
         goto error;
 
     // Allocate display context
-    ret = CHECK_CU(cu->cuGLGetDevices(&device_count, &display_dev, 1,
-                                      CU_GL_DEVICE_LIST_ALL));
-    if (ret < 0)
-        goto error;
-
-    ret = CHECK_CU(cu->cuCtxCreate(&p->display_ctx, CU_CTX_SCHED_BLOCKING_SYNC,
-                                   display_dev));
-    if (ret < 0)
-        goto error;
-
-    p->decode_ctx = p->display_ctx;
-
-    int decode_dev_idx = -1;
-    mp_read_option_raw(hw->global, "cuda-decode-device", &m_option_type_choice,
-                       &decode_dev_idx);
-
-    if (decode_dev_idx > -1) {
-        CUdevice decode_dev;
-        ret = CHECK_CU(cu->cuDeviceGet(&decode_dev, decode_dev_idx));
+    if (p->is_gl) {
+        unsigned int device_count;
+        ret = CHECK_CU(cu->cuGLGetDevices(&device_count, &display_dev, 1,
+                                          CU_GL_DEVICE_LIST_ALL));
         if (ret < 0)
             goto error;
 
-        if (decode_dev != display_dev) {
-            MP_INFO(hw, "Using separate decoder and display devices\n");
+        ret = CHECK_CU(cu->cuCtxCreate(&p->display_ctx, CU_CTX_SCHED_BLOCKING_SYNC,
+                                       display_dev));
+        if (ret < 0)
+            goto error;
 
-            // Pop the display context. We won't use it again during init()
-            ret = CHECK_CU(cu->cuCtxPopCurrent(&dummy));
+        p->decode_ctx = p->display_ctx;
+
+        int decode_dev_idx = -1;
+        mp_read_option_raw(hw->global, "cuda-decode-device", &m_option_type_choice,
+                           &decode_dev_idx);
+
+        if (decode_dev_idx > -1) {
+            CUdevice decode_dev;
+            ret = CHECK_CU(cu->cuDeviceGet(&decode_dev, decode_dev_idx));
             if (ret < 0)
                 goto error;
 
-            ret = CHECK_CU(cu->cuCtxCreate(&p->decode_ctx, CU_CTX_SCHED_BLOCKING_SYNC,
-                                           decode_dev));
-            if (ret < 0)
-                goto error;
+            if (decode_dev != display_dev) {
+                MP_INFO(hw, "Using separate decoder and display devices\n");
+
+                // Pop the display context. We won't use it again during init()
+                ret = CHECK_CU(cu->cuCtxPopCurrent(&dummy));
+                if (ret < 0)
+                    goto error;
+
+                ret = CHECK_CU(cu->cuCtxCreate(&p->decode_ctx, CU_CTX_SCHED_BLOCKING_SYNC,
+                                               decode_dev));
+                if (ret < 0)
+                    goto error;
+            }
         }
+    } else if (p->is_vk) {
+#if HAVE_VULKAN
+        uint8_t vk_uuid[VK_UUID_SIZE];
+        struct mpvk_ctx *vk = ra_vk_get(hw->ra);
+
+        mpvk_get_phys_device_uuid(vk, vk_uuid);
+
+        int count;
+        ret = CHECK_CU(cu->cuDeviceGetCount(&count));
+        if (ret < 0)
+            goto error;
+
+        display_dev = -1;
+        for (int i = 0; i < count; i++) {
+            CUdevice dev;
+            ret = CHECK_CU(cu->cuDeviceGet(&dev, i));
+            if (ret < 0)
+                continue;
+
+            CUuuid uuid;
+            ret = CHECK_CU(cu->cuDeviceGetUuid(&uuid, dev));
+            if (ret < 0)
+                continue;
+
+            if (memcmp(vk_uuid, uuid.bytes, VK_UUID_SIZE) == 0) {
+                display_dev = dev;
+                break;
+            }
+        }
+
+        if (display_dev == -1) {
+            MP_ERR(hw, "Could not match Vulkan display device in CUDA.\n");
+            goto error;
+        }
+
+        ret = CHECK_CU(cu->cuCtxCreate(&p->display_ctx, CU_CTX_SCHED_BLOCKING_SYNC,
+                                       display_dev));
+        if (ret < 0)
+            goto error;
+
+        p->decode_ctx = p->display_ctx;
+#endif
     }
 
     hw_device_ctx = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_CUDA);
@@ -197,6 +282,106 @@ static void cuda_uninit(struct ra_hwdec *hw)
 #undef CHECK_CU
 #define CHECK_CU(x) check_cu((mapper)->owner, (x), #x)
 
+#if HAVE_VULKAN
+static struct ra_buf *cuda_buf_pool_get(struct ra_hwdec_mapper *mapper, int n)
+{
+    struct priv_owner *p_owner = mapper->owner->priv;
+    struct priv *p = mapper->priv;
+    CudaFunctions *cu = p_owner->cu;
+    int ret = 0;
+
+    struct ra_buf_pool *pool = &p->buf_pool[n];
+    struct ra_buf *buf = ra_buf_pool_get(mapper->ra, pool, &p->buf_params[n]);
+    if (!buf) {
+        goto error;
+    }
+
+    if (!ra_vk_buf_get_user_data(buf)) {
+        struct ext_buf *ebuf = talloc_zero(NULL, struct ext_buf);
+        struct vk_external_mem mem_info;
+
+        bool success = ra_vk_buf_get_external_info(mapper->ra, buf, &mem_info);
+        if (!success) {
+            ret = -1;
+            goto error;
+        }
+
+#if HAVE_WIN32_DESKTOP
+        ebuf->handle = mem_info.mem_handle;
+        MP_DBG(mapper, "vk_external_info[%d][%d]: %p %zu %zu\n", n, pool->index, ebuf->handle, mem_info.size, mem_info.offset);
+#else
+        ebuf->fd = mem_info.mem_fd;
+        MP_DBG(mapper, "vk_external_info[%d][%d]: %d %zu %zu\n", n, pool->index, ebuf->fd, mem_info.size, mem_info.offset);
+#endif
+
+        CUDA_EXTERNAL_MEMORY_HANDLE_DESC ext_desc = {
+#if HAVE_WIN32_DESKTOP
+            .type = IsWindows8OrGreater()
+                ? CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32
+                : CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT,
+            .handle.win32.handle = ebuf->handle,
+#else
+            .type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD,
+            .handle.fd = ebuf->fd,
+#endif
+            .size = mem_info.mem_size,
+            .flags = 0,
+        };
+        ret = CHECK_CU(cu->cuImportExternalMemory(&ebuf->mem, &ext_desc));
+        if (ret < 0)
+            goto error;
+
+        CUDA_EXTERNAL_MEMORY_BUFFER_DESC buf_desc = {
+            .offset = mem_info.offset,
+            .size = mem_info.size,
+            .flags = 0,
+        };
+        ret = CHECK_CU(cu->cuExternalMemoryGetMappedBuffer(&ebuf->buf, ebuf->mem, &buf_desc));
+        if (ret < 0)
+            goto error;
+
+        ra_vk_buf_set_user_data(buf, ebuf);
+    }
+    return buf;
+
+error:
+    MP_ERR(mapper, "cuda_buf_pool_get failed\n");
+    return NULL;
+}
+
+static void cuda_buf_pool_uninit(struct ra_hwdec_mapper *mapper, int n)
+{
+    struct priv_owner *p_owner = mapper->owner->priv;
+    struct priv *p = mapper->priv;
+    CudaFunctions *cu = p_owner->cu;
+
+    struct ra_buf_pool *pool = &p->buf_pool[n];
+    for (int i = 0; i < pool->num_buffers; i++) {
+        struct ra_buf *buf = pool->buffers[i];
+        struct ext_buf *ebuf = ra_vk_buf_get_user_data(buf);
+        if (ebuf) {
+            if (ebuf->mem > 0) {
+                CHECK_CU(cu->cuDestroyExternalMemory(ebuf->mem));
+#if HAVE_WIN32_DESKTOP
+            }
+            if (ebuf->handle) {
+                // Handle must always be closed by us.
+                CloseHandle(ebuf->handle);
+            }
+#else
+            } else if (ebuf->fd > -1) {
+                // fd should only be closed if external memory was not imported
+                close(ebuf->fd);
+            }
+#endif
+        }
+        talloc_free(ebuf);
+        ra_vk_buf_set_user_data(buf, NULL);
+    }
+    ra_buf_pool_uninit(mapper->ra, pool);
+}
+#endif // HAVE_VULKAN
+
 static int mapper_init(struct ra_hwdec_mapper *mapper)
 {
     struct priv_owner *p_owner = mapper->owner->priv;
@@ -243,27 +428,39 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
             goto error;
         }
 
-        GLuint texture;
-        GLenum target;
-        ra_gl_get_raw_tex(mapper->ra, mapper->tex[n], &texture, &target);
+        if (p_owner->is_gl) {
+#if HAVE_GL
+            GLuint texture;
+            GLenum target;
+            ra_gl_get_raw_tex(mapper->ra, mapper->tex[n], &texture, &target);
 
-        ret = CHECK_CU(cu->cuGraphicsGLRegisterImage(&p->cu_res[n], texture, target,
-                                                     CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD));
-        if (ret < 0)
-            goto error;
+            ret = CHECK_CU(cu->cuGraphicsGLRegisterImage(&p->cu_res[n], texture, target,
+                                                         CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD));
+            if (ret < 0)
+                goto error;
 
-        ret = CHECK_CU(cu->cuGraphicsMapResources(1, &p->cu_res[n], 0));
-        if (ret < 0)
-            goto error;
+            ret = CHECK_CU(cu->cuGraphicsMapResources(1, &p->cu_res[n], 0));
+            if (ret < 0)
+                goto error;
 
-        ret = CHECK_CU(cu->cuGraphicsSubResourceGetMappedArray(&p->cu_array[n], p->cu_res[n],
-                                                               0, 0));
-        if (ret < 0)
-            goto error;
+            ret = CHECK_CU(cu->cuGraphicsSubResourceGetMappedArray(&p->cu_array[n], p->cu_res[n],
+                                                                   0, 0));
+            if (ret < 0)
+                goto error;
 
-        ret = CHECK_CU(cu->cuGraphicsUnmapResources(1, &p->cu_res[n], 0));
-        if (ret < 0)
-            goto error;
+            ret = CHECK_CU(cu->cuGraphicsUnmapResources(1, &p->cu_res[n], 0));
+            if (ret < 0)
+                goto error;
+#endif
+        } else if (p_owner->is_vk) {
+            struct ra_buf_params buf_params = {
+                .type = RA_BUF_TYPE_SHARED_MEMORY,
+                .size = mp_image_plane_h(&p->layout, n) *
+                        mp_image_plane_w(&p->layout, n) *
+                        mapper->tex[n]->params.format->pixel_size,
+            };
+            p->buf_params[n] = buf_params;
+        }
     }
 
  error:
@@ -288,6 +485,10 @@ static void mapper_uninit(struct ra_hwdec_mapper *mapper)
             CHECK_CU(cu->cuGraphicsUnregisterResource(p->cu_res[n]));
         p->cu_res[n] = 0;
         ra_tex_free(mapper->ra, &mapper->tex[n]);
+
+#if HAVE_VULKAN
+        cuda_buf_pool_uninit(mapper, n);
+#endif
     }
     CHECK_CU(cu->cuCtxPopCurrent(&dummy));
 }
@@ -303,28 +504,54 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     CudaFunctions *cu = p_owner->cu;
     CUcontext dummy;
     int ret = 0, eret = 0;
+    bool is_gl = p_owner->is_gl;
+    bool is_vk = p_owner->is_vk;
 
     ret = CHECK_CU(cu->cuCtxPushCurrent(p->display_ctx));
     if (ret < 0)
         return ret;
 
     for (int n = 0; n < p->layout.num_planes; n++) {
+        struct ra_buf *buf = NULL;
+
         CUDA_MEMCPY2D cpy = {
             .srcMemoryType = CU_MEMORYTYPE_DEVICE,
-            .dstMemoryType = CU_MEMORYTYPE_ARRAY,
             .srcDevice     = (CUdeviceptr)mapper->src->planes[n],
             .srcPitch      = mapper->src->stride[n],
             .srcY          = 0,
-            .dstArray      = p->cu_array[n],
             .WidthInBytes  = mp_image_plane_w(&p->layout, n) *
                              mapper->tex[n]->params.format->pixel_size,
             .Height        = mp_image_plane_h(&p->layout, n),
         };
+
+        if (is_gl) {
+            cpy.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+            cpy.dstArray = p->cu_array[n];
+        } else if (is_vk) {
+#if HAVE_VULKAN
+            buf = cuda_buf_pool_get(mapper, n);
+            struct ext_buf *ebuf = ra_vk_buf_get_user_data(buf);
+
+            cpy.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+            cpy.dstDevice = ebuf->buf;
+            cpy.dstPitch  = mp_image_plane_w(&p->layout, n) *
+                            mapper->tex[n]->params.format->pixel_size;
+#endif
+        }
+
         ret = CHECK_CU(cu->cuMemcpy2D(&cpy));
         if (ret < 0)
             goto error;
-    }
 
+        if (is_vk) {
+            struct ra_tex_upload_params params = {
+                .tex = mapper->tex[n],
+                .invalidate = true,
+                .buf = buf,
+            };
+            mapper->ra->fns->tex_upload(mapper->ra, &params);
+        }
+    }
 
  error:
    eret = CHECK_CU(cu->cuCtxPopCurrent(&dummy));

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -73,4 +73,8 @@ struct mpvk_ctx {
     // Cached capabilities
     VkPhysicalDeviceLimits limits;
     VkPhysicalDeviceFeatures features;
+
+    // Extension availability
+    bool has_ext_external_memory;
+    bool has_ext_external_memory_export;
 };

--- a/video/out/vulkan/malloc.h
+++ b/video/out/vulkan/malloc.h
@@ -11,6 +11,7 @@ struct vk_memslice {
     VkDeviceMemory vkmem;
     size_t offset;
     size_t size;
+    size_t slab_size;
     void *priv;
 };
 
@@ -32,4 +33,5 @@ struct vk_bufslice {
 // creating/destroying lots of (little) VkBuffers.
 bool vk_malloc_buffer(struct mpvk_ctx *vk, VkBufferUsageFlags bufFlags,
                       VkMemoryPropertyFlags memFlags, VkDeviceSize size,
-                      VkDeviceSize alignment, struct vk_bufslice *out);
+                      VkDeviceSize alignment, bool exportable,
+                      struct vk_bufslice *out);

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -693,7 +693,19 @@ struct ra_buf_vk {
     // "current" metadata, can change during course of execution
     VkPipelineStageFlags current_stage;
     VkAccessFlags current_access;
+    // Arbitrary user data for the creator of a buffer
+    void *user_data;
 };
+
+void ra_vk_buf_set_user_data(struct ra_buf *buf, void *user_data) {
+    struct ra_buf_vk *vk_priv = buf->priv;
+    vk_priv->user_data = user_data;
+}
+
+void *ra_vk_buf_get_user_data(struct ra_buf *buf) {
+    struct ra_buf_vk *vk_priv = buf->priv;
+    return vk_priv->user_data;
+}
 
 static void vk_buf_deref(struct ra *ra, struct ra_buf *buf)
 {

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -4,6 +4,10 @@
 #include "ra_vk.h"
 #include "malloc.h"
 
+#if HAVE_WIN32_DESKTOP
+#include <versionhelpers.h>
+#endif
+
 static struct ra_fns ra_fns_vk;
 
 enum queue_type {
@@ -787,6 +791,7 @@ static struct ra_buf *vk_buf_create(struct ra *ra,
     VkBufferUsageFlags bufFlags = 0;
     VkMemoryPropertyFlags memFlags = 0;
     VkDeviceSize align = 4; // alignment 4 is needed for buf_update
+    bool exportable = false;
 
     switch (params->type) {
     case RA_BUF_TYPE_TEX_UPLOAD:
@@ -811,6 +816,11 @@ static struct ra_buf *vk_buf_create(struct ra *ra,
         bufFlags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
         memFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         break;
+    case RA_BUF_TYPE_SHARED_MEMORY:
+        bufFlags |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        memFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        exportable = true;
+        break;
     default: abort();
     }
 
@@ -826,7 +836,7 @@ static struct ra_buf *vk_buf_create(struct ra *ra,
     }
 
     if (!vk_malloc_buffer(vk, bufFlags, memFlags, params->size, align,
-                          &buf_vk->slice))
+                          exportable, &buf_vk->slice))
     {
         goto error;
     }
@@ -914,6 +924,64 @@ static bool vk_tex_upload(struct ra *ra,
 
 error:
     return false;
+}
+
+static bool ra_vk_mem_get_external_info(struct ra *ra, struct vk_memslice *mem, struct vk_external_mem *ret)
+{
+    struct mpvk_ctx *vk = ra_vk_get(ra);
+
+#if HAVE_WIN32_DESKTOP
+    HANDLE mem_handle;
+
+    VkMemoryGetWin32HandleInfoKHR info = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR,
+        .pNext = NULL,
+        .memory = mem->vkmem,
+        .handleType = IsWindows8OrGreater()
+            ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR
+            : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT,
+    };
+
+    VK_LOAD_PFN(vkGetMemoryWin32HandleKHR);
+    VK(pfn_vkGetMemoryWin32HandleKHR(vk->dev, &info, &mem_handle));
+
+    ret->mem_handle = mem_handle;
+#else
+    int mem_fd;
+
+    VkMemoryGetFdInfoKHR info = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR,
+        .pNext = NULL,
+        .memory = mem->vkmem,
+        .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR,
+    };
+
+    VK_LOAD_PFN(vkGetMemoryFdKHR);
+    VK(pfn_vkGetMemoryFdKHR(vk->dev, &info, &mem_fd));
+
+    ret->mem_fd = mem_fd;
+#endif
+    ret->size = mem->size;
+    ret->offset = mem->offset;
+    ret->mem_size = mem->slab_size;
+
+    return true;
+
+error:
+    return false;
+}
+
+bool ra_vk_buf_get_external_info(struct ra *ra, struct ra_buf *buf, struct vk_external_mem *ret)
+{
+    if (buf->params.type != RA_BUF_TYPE_SHARED_MEMORY) {
+        MP_ERR(ra, "Buffer must be of TYPE_SHARED_MEMORY to be able to export it...");
+        return false;
+    }
+
+    struct ra_buf_vk *buf_vk = buf->priv;
+    struct vk_memslice *mem = &buf_vk->slice.mem;
+
+    return ra_vk_mem_get_external_info(ra, mem, ret);
 }
 
 #define MPVK_NUM_DS MPVK_MAX_STREAMING_DEPTH

--- a/video/out/vulkan/ra_vk.h
+++ b/video/out/vulkan/ra_vk.h
@@ -43,3 +43,9 @@ struct vk_external_mem {
 
 // Export an ra_buf for importing by another api.
 bool ra_vk_buf_get_external_info(struct ra *ra, struct ra_buf *buf, struct vk_external_mem *ret);
+
+// Set the buffer user data
+void ra_vk_buf_set_user_data(struct ra_buf *buf, void *priv);
+
+// Get the buffer user data
+void *ra_vk_buf_get_user_data(struct ra_buf *buf);

--- a/video/out/vulkan/ra_vk.h
+++ b/video/out/vulkan/ra_vk.h
@@ -29,3 +29,17 @@ struct vk_cmd *ra_vk_submit(struct ra *ra, struct ra_tex *tex);
 // May be called on a struct ra of any type. Returns NULL if the ra is not
 // a vulkan ra.
 struct mpvk_ctx *ra_vk_get(struct ra *ra);
+
+struct vk_external_mem {
+#if HAVE_WIN32_DESKTOP
+    HANDLE mem_handle;
+#else
+    int mem_fd;
+#endif
+    size_t mem_size;
+    size_t size;
+    size_t offset;
+};
+
+// Export an ra_buf for importing by another api.
+bool ra_vk_buf_get_external_info(struct ra *ra, struct ra_buf *buf, struct vk_external_mem *ret);

--- a/video/out/vulkan/utils.h
+++ b/video/out/vulkan/utils.h
@@ -10,6 +10,12 @@
 #define VK_LOAD_PFN(name) PFN_##name pfn_##name = (PFN_##name) \
                             vkGetInstanceProcAddr(vk->inst, #name);
 
+#if HAVE_WIN32_DESKTOP
+    #define MP_VK_EXTERNAL_MEMORY_EXPORT_EXTENSION_NAME VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME
+#else
+    #define MP_VK_EXTERNAL_MEMORY_EXPORT_EXTENSION_NAME VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME
+#endif
+
 // Return a human-readable name for various struct mpvk_ctx enums
 const char* vk_err(VkResult res);
 

--- a/video/out/vulkan/utils.h
+++ b/video/out/vulkan/utils.h
@@ -56,6 +56,9 @@ bool mpvk_surface_init(struct vo *vo, struct mpvk_ctx *vk);
 // sw: also allow software/virtual devices
 bool mpvk_find_phys_device(struct mpvk_ctx *vk, const char *name, bool sw);
 
+// Get the UUID for the selected physical device
+bool mpvk_get_phys_device_uuid(struct mpvk_ctx *vk, uint8_t uuid_out[VK_UUID_SIZE]);
+
 // Pick a suitable surface format that's supported by this physical device.
 bool mpvk_pick_surface_format(struct mpvk_ctx *vk);
 

--- a/wscript
+++ b/wscript
@@ -846,11 +846,11 @@ hwaccel_features = [
     }, {
         'name': 'ffnvcodec',
         'desc': 'CUDA Headers and dynamic loader',
-        'func': check_pkg_config('ffnvcodec >= 8.1.24.1'),
+        'func': check_pkg_config('ffnvcodec >= 8.2.15.3'),
     }, {
         'name': '--cuda-hwaccel',
         'desc': 'CUDA hwaccel',
-        'deps': 'gl && ffnvcodec',
+        'deps': '(gl || vulkan) && ffnvcodec',
         'func': check_true,
     }
 ]


### PR DESCRIPTION
This is a working implementation of nvdec acceleration with the vulkan backend using the new CUDA 10 vulkan interop API. Due to bad documentation, I haven't yet worked out how to work with a VkImage directly in CUDA, and have needed to use an intermediate VkBuffer as the target for the copy from CUDA, which is then copied to the VkImage texture.

The implementation only works on Linux as the windows memory export mechanism is slightly different and I can't test it.

Finally, I did not attempt to do any semaphore based synchronisation between cuda and vulkan. The interop API supports exporting a vulkan semaphore and using it from CUDA. One can imagine this would be necessary to ensure the CUDA copy is correctly synchronised. I can believe that the existing barrier logic on the buffer -> image copy on the vulkan side is sufficient; certainly there is no visual indication of a synchronisation problem.