### PR TITLE
cocoa-cb: add support for VOCTRL_GET_DISPLAY_NAMES

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1630,7 +1630,9 @@ Property list
     are the xrandr names (LVDS1, HDMI1, DP1, VGA1, etc.). On Windows, these
     are the GDI names (\\.\DISPLAY1, \\.\DISPLAY2, etc.) and the first display
     in the list will be the one that Windows considers associated with the
-    window (as determined by the MonitorFromWindow API.)
+    window (as determined by the MonitorFromWindow API.) On macOS these are the
+    Display Product Names as used in the System Information and only one display
+    name is returned since a window can only be on one screen.
 
 ``display-fps`` (RW)
     The refresh rate of the current display. Currently, this is the lowest FPS

--- a/osdep/macOS_swift_bridge.h
+++ b/osdep/macOS_swift_bridge.h
@@ -49,3 +49,11 @@ static int SWIFT_KEY_MOUSE_LEAVE = MP_KEY_MOUSE_LEAVE;
 static int SWIFT_KEY_MOUSE_ENTER = MP_KEY_MOUSE_ENTER;
 static int SWIFT_KEY_STATE_DOWN  = MP_KEY_STATE_DOWN;
 static int SWIFT_KEY_STATE_UP    = MP_KEY_STATE_UP;
+
+// only used from Swift files and therefore seen as unused by the c compiler
+static void SWIFT_TARRAY_STRING_APPEND(void *t, char ***a, int *i, char *s) __attribute__ ((unused));
+
+static void SWIFT_TARRAY_STRING_APPEND(void *t, char ***a, int *i, char *s)
+{
+    MP_TARRAY_APPEND(t, *a, *i, s);
+}

--- a/osdep/macOS_swift_extensions.swift
+++ b/osdep/macOS_swift_extensions.swift
@@ -1,0 +1,28 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+extension NSScreen {
+
+    public var displayID: CGDirectDisplayID {
+        get {
+            return deviceDescription["NSScreenNumber"] as! CGDirectDisplayID
+        }
+    }
+
+}

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -157,10 +157,9 @@ class CocoaCB: NSObject {
     func startDisplayLink(_ vo: UnsafeMutablePointer<vo>) {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
         let screen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main()
-        let displayId = screen!.deviceDescription["NSScreenNumber"] as! UInt32
 
         CVDisplayLinkCreateWithActiveCGDisplays(&link)
-        CVDisplayLinkSetCurrentCGDisplay(link!, displayId)
+        CVDisplayLinkSetCurrentCGDisplay(link!, screen!.displayID)
         if #available(macOS 10.12, *) {
             CVDisplayLinkSetOutputHandler(link!) { link, now, out, inFlags, outFlags -> CVReturn in
                 self.mpv.reportRenderFlip()
@@ -179,8 +178,7 @@ class CocoaCB: NSObject {
     }
 
     func updateDisplaylink() {
-        let displayId = UInt32(window.screen!.deviceDescription["NSScreenNumber"] as! Int)
-        CVDisplayLinkSetCurrentCGDisplay(link!, displayId)
+        CVDisplayLinkSetCurrentCGDisplay(link!, window.screen!.displayID)
 
         queue.asyncAfter(deadline: DispatchTime.now() + 0.1) {
             self.flagEvents(VO_EVENT_WIN_STATE)
@@ -309,9 +307,8 @@ class CocoaCB: NSObject {
     var reconfigureCallback: CGDisplayReconfigurationCallBack = { (display, flags, userInfo) in
         if flags.contains(.setModeFlag) {
             let ccb: CocoaCB = MPVHelper.bridge(ptr: userInfo!)
-            let displayID = (ccb.window.screen!.deviceDescription["NSScreenNumber"] as! NSNumber).intValue
-            if UInt32(displayID) == display {
-                ccb.mpv.sendVerbose("Detected display mode change, updating screen refresh rate\n");
+            if ccb.window.screen!.displayID == display {
+                ccb.mpv.sendVerbose("Detected display mode change, updating screen refresh rate");
                 ccb.flagEvents(VO_EVENT_WIN_STATE)
             }
         }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -427,6 +427,20 @@ class CocoaCB: NSObject {
             let minimized = data!.assumingMemoryBound(to: Int32.self)
             minimized.pointee = ccb.window.isMiniaturized ? VO_WIN_STATE_MINIMIZED : Int32(0)
             return VO_TRUE
+        case VOCTRL_GET_DISPLAY_NAMES:
+            let opts: mp_vo_opts = vo!.pointee.opts!.pointee
+            let dnames = data!.assumingMemoryBound(to: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?.self)
+            var array: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>? = nil
+            var count: Int32 = 0
+            let screen = ccb.window != nil ? ccb.window.screen :
+                                             ccb.getScreenBy(id: Int(opts.screen_id)) ??
+                                             NSScreen.main()
+            let displayName = screen?.displayName ?? "Unknown"
+
+            SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
+            SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, nil)
+            dnames.pointee = array
+            return VO_TRUE
         case VOCTRL_UPDATE_WINDOW_TITLE:
             let titleData = data!.assumingMemoryBound(to: Int8.self)
             let title = String(cString: titleData)

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -157,6 +157,7 @@ def build(ctx):
     if ctx.dependency_satisfied('macos-cocoa-cb'):
         swift_source = [
             ( "osdep/macOS_mpv_helper.swift" ),
+            ( "osdep/macOS_swift_extensions.swift" ),
             ( "video/out/cocoa-cb/events_view.swift" ),
             ( "video/out/cocoa-cb/video_layer.swift" ),
             ( "video/out/cocoa-cb/window.swift" ),


### PR DESCRIPTION
i decided to use swift extensions to make it look less messy and for convenience. if we have those feature they should be used. i could clean up the type casting for the displayID a bit. if really wanted i could leave it as is and use a normal function for the `displayName`.

otherwise `displayName` is an optional because retrieval of the name could theoretically fail. in that case `Unknown` will be returned as name.

[edit]
since the display info dict isn't so well documented [this](https://0x0.st/sYAJ.txt) is how it could look like. `kDisplaySerialNumber` can be an optional, this is the case for my TV for example.

the display name itself is what is used in the System Information, eg. `DELL X` or `LG TV`