### PR TITLE
ao_audiounit: rename pause function to reset

### DIFF
--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -192,7 +192,7 @@ const struct ao_driver audio_out_audiounit = {
     .name           = "audiounit",
     .uninit         = uninit,
     .init           = init,
-    .pause          = stop,
+    .reset          = stop,
     .resume         = start,
     .priv_size      = sizeof(struct priv),
 };


### PR DESCRIPTION
AudioUnit output driver uses the pull based api so it should have
a reset function instead of a pause function.

I agree that my changes can be relicensed to LGPL 2.1 or later.
