### PR TITLE
man: mention stats in interactive control

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -218,6 +218,11 @@ F9
     Show the list of audio and subtitle streams (useful only if a UI window  is
     used, broken on the terminal).
 
+i and I
+    Show/toggle an overlay displaying statistics about the currently playing
+    file such as codec, framerate, number of dropped frames and so on. See
+    `STATS`_ for more information.
+
 (The following keys are valid only when using a video output that supports the
 corresponding adjustment.)
 


### PR DESCRIPTION
Someone on IRC pointed out that the default stats bindings weren't documented in the interactive control section of the manual, so let's add them with a short mention and a reference to the STATS section of the manual.

I agree that my changes can be relicensed to LGPL 2.1 or later.
