### PR TITLE
Add a command to change the screenshot template

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -207,6 +207,10 @@ List of Input Commands
     The ``async`` flag has an effect on this command (see ``screenshot``
     command).
 
+``screenshot-template "<template>"``
+    Set a new screenshot file template (see ``--screenshot-template``
+    for valid values).
+
 ``playlist-next [weak|force]``
     Go to the next entry on the playlist.
 

--- a/player/command.c
+++ b/player/command.c
@@ -5507,6 +5507,13 @@ static void cmd_screenshot_to_file(void *p)
                        async);
 }
 
+static void cmd_screenshot_template(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+
+    set_screenshot_template(cmd->mpctx, cmd->args[0].v.s);
+}
+
 static void cmd_screenshot_raw(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -5932,6 +5939,9 @@ const struct mp_cmd_def mp_cmds[] = {
         OARG_CHOICE(2, ({"video", 0},
                         {"window", 1},
                         {"subtitles", 2})),
+    }},
+    { "screenshot-template", cmd_screenshot_template, {
+        ARG_STRING,
     }},
     { "loadfile", cmd_loadfile, {
         ARG_STRING,

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -467,6 +467,13 @@ end:
     ctx->osd = old_osd;
 }
 
+void set_screenshot_template(struct MPContext *mpctx, const char *template) {
+  screenshot_ctx *ctx = mpctx->screenshot_ctx;
+    
+  ctx->mpctx->opts->screenshot_template =
+    talloc_strdup(ctx->mpctx->opts, template);
+}
+
 void screenshot_request(struct MPContext *mpctx, int mode, bool each_frame,
                         bool osd, bool async)
 {

--- a/player/screenshot.h
+++ b/player/screenshot.h
@@ -45,4 +45,7 @@ struct mp_image *screenshot_get_rgb(struct MPContext *mpctx, int mode);
 // Called by the playback core code when a new frame is displayed.
 void screenshot_flip(struct MPContext *mpctx);
 
+// Change the screenshot template.
+void set_screenshot_template(struct MPContext *mpctx, const char *template);
+
 #endif /* MPLAYER_SCREENSHOT_H */


### PR DESCRIPTION
I find it useful to be able to change the screenshot template on the fly, especially when recording sequences of screenshot, so that they can be grouped together in a sensible manner.  So this patch just adds a screenshot-template command.

I agree that my changes can be relicensed to LGPL 2.1 or later.
