### PR TITLE
x11: retrieve the icc profile from colord

### DIFF
--- a/wscript
+++ b/wscript
@@ -587,8 +587,12 @@ video_output_features = [
                                  'xscrnsaver',  '>= 1.0.0',
                                  'xext',        '>= 1.0.0',
                                  'xinerama',    '>= 1.0.0',
-                                 'xrandr',      '>= 1.2.0',
-                                 'colord',      '>= 1.0.2'),
+                                 'xrandr',      '>= 1.2.0'),
+    } , {
+        'name': '--colord',
+        'desc': 'colord',
+        'deps': 'x11',
+        'func': check_pkg_config('colord', '>= 1.0.2'),
     } , {
         'name': '--xv',
         'desc': 'Xv video output',

--- a/wscript
+++ b/wscript
@@ -587,7 +587,8 @@ video_output_features = [
                                  'xscrnsaver',  '>= 1.0.0',
                                  'xext',        '>= 1.0.0',
                                  'xinerama',    '>= 1.0.0',
-                                 'xrandr',      '>= 1.2.0'),
+                                 'xrandr',      '>= 1.2.0',
+                                 'colord',      '>= 1.0.2'),
     } , {
         'name': '--xv',
         'desc': 'Xv video output',


### PR DESCRIPTION
Most desktop environments do not support the _ICC_PROFILE Atom well,
especially if there are multiple displays. 

Retrieving and using the icc profile from the colord server, if
available.

I agree that my changes can be relicensed to LGPL 2.1 or later.
