### PR TITLE
vo_gpu: opengl: fix segfault when gl->DeleteSync is unavailable

### DIFF
--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -542,7 +542,9 @@ static void gl_buf_destroy(struct ra *ra, struct ra_buf *buf)
     GL *gl = ra_gl_get(ra);
     struct ra_buf_gl *buf_gl = buf->priv;
 
-    gl->DeleteSync(buf_gl->fence);
+    if (buf_gl->fence)
+        gl->DeleteSync(buf_gl->fence);
+
     if (buf->data) {
         gl->BindBuffer(buf_gl->target, buf_gl->buffer);
         gl->UnmapBuffer(buf_gl->target);


### PR DESCRIPTION
This deinit code was never checked, so this line would always crash on
implementations without support for sync objects.

Fixes #6197.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
