### PR TITLE
ad_spdif.c: fix dts-hd hra bitstream

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -207,14 +207,14 @@ static int init_filter(struct mp_filter *da, AVPacket *pkt)
         num_channels                    = 2;
         break;
     case AV_CODEC_ID_DTS: {
-        bool is_hd = profile == FF_PROFILE_DTS_HD_HRA ||
-                     profile == FF_PROFILE_DTS_HD_MA ||
-                     profile == FF_PROFILE_UNKNOWN;
-        if (spdif_ctx->use_dts_hd && is_hd) {
-            av_dict_set(&format_opts, "dtshd_rate", "768000", 0); // 4*192000
+        bool is_hd_ma = profile == FF_PROFILE_DTS_HD_MA ||
+                        profile == FF_PROFILE_UNKNOWN;
+		bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;				
+        if (spdif_ctx->use_dts_hd && (is_hd_ma || is_hd_hr)) { // 4*192000 = MA 1*192000 = HRA       
+            av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0); 
             sample_format               = AF_FORMAT_S_DTSHD;
             samplerate                  = 192000;
-            num_channels                = 2*4;
+            num_channels                = is_hd_hr ? 2 : 2*4;
         } else {
             sample_format               = AF_FORMAT_S_DTS;
             samplerate                  = 48000;

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -209,7 +209,7 @@ static int init_filter(struct mp_filter *da, AVPacket *pkt)
     case AV_CODEC_ID_DTS: {
         bool is_hd_ma = profile == FF_PROFILE_DTS_HD_MA ||
                         profile == FF_PROFILE_UNKNOWN;
-	bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;
+	  bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;
         if (spdif_ctx->use_dts_hd && (is_hd_ma || is_hd_hr)) { // 4*192000 = MA 1*192000 = HRA       
             av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0);
             sample_format               = AF_FORMAT_S_DTSHD;

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -209,7 +209,7 @@ static int init_filter(struct mp_filter *da, AVPacket *pkt)
     case AV_CODEC_ID_DTS: {
         bool is_hd_ma = profile == FF_PROFILE_DTS_HD_MA ||
                         profile == FF_PROFILE_UNKNOWN;
-	  bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;
+	    bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;
         if (spdif_ctx->use_dts_hd && (is_hd_ma || is_hd_hr)) { // 4*192000 = MA 1*192000 = HRA       
             av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0);
             sample_format               = AF_FORMAT_S_DTSHD;

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -209,7 +209,7 @@ static int init_filter(struct mp_filter *da, AVPacket *pkt)
     case AV_CODEC_ID_DTS: {
         bool is_hd_ma = profile == FF_PROFILE_DTS_HD_MA ||
                         profile == FF_PROFILE_UNKNOWN;
-		bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;				
+	bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;				
         if (spdif_ctx->use_dts_hd && (is_hd_ma || is_hd_hr)) { // 4*192000 = MA 1*192000 = HRA       
             av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0); 
             sample_format               = AF_FORMAT_S_DTSHD;

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -209,9 +209,9 @@ static int init_filter(struct mp_filter *da, AVPacket *pkt)
     case AV_CODEC_ID_DTS: {
         bool is_hd_ma = profile == FF_PROFILE_DTS_HD_MA ||
                         profile == FF_PROFILE_UNKNOWN;
-	bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;				
+	bool is_hd_hr = profile == FF_PROFILE_DTS_HD_HRA;
         if (spdif_ctx->use_dts_hd && (is_hd_ma || is_hd_hr)) { // 4*192000 = MA 1*192000 = HRA       
-            av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0); 
+            av_dict_set(&format_opts, "dtshd_rate", is_hd_hr ? "192000" : "768000", 0);
             sample_format               = AF_FORMAT_S_DTSHD;
             samplerate                  = 192000;
             num_channels                = is_hd_hr ? 2 : 2*4;


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.

###  Why?
DTS-HD High-Resolution Audio was not correctly bitstreamed to the AVR.
It was streamed with the parameters -> 8ch@192kHz and "dtshd_rate" = 768000
In the future, DTS-HD HRA could become popular because DTS:X can be on top of it.
(Like Dolby Digital Plus and ATMOS)

Issue: https://github.com/mpv-player/mpv/issues/6148 

### State before patch
mpv with parameter `--audio-spdif=dts-hd` on a DTS-HD HRA movie/file would stream 
the file with the parameters _8ch@192kHz and "dtshd_rate" = 768000_. 
**Result:** The receiver displayed that it's getting dts
(not dts hd hra!) and plays nothing or crackling.
mpv with parameter` --audio-spdif=dts` would stream only the lossy core
**Result:** The receiver displayed that it's getting dts. (as it should), 
The audio was working.

### State after patch
mpv with parameter `--audio-spdif=dts-hd` on a DTS-HD HRA movie/file is streamed 
with the parametrs correctly set _2ch@192kHz and "dtshd_rate" = 192000_. 
**Result:** The receiver displays that it's getting DTS-HD HRA.
AVR is playing back the audio as it should.

mpv with parameter` --audio-spdif=dts` on a DTS-HD HRA file stream
will stream the lossy core
**Result:** The receiver displayed that it's getting dts. (as it should), audio is working.

mpv with parameter `--audio-spdif=dts-hd` on a DTS-HD **MA** movie/file is streamed 
with the parametrs set _8ch@192kHz and "dtshd_rate" = 768000_. (as before the patch)
**Result:** The receiver displays that it's getting DTS-HD MA.
AVR plays the audio just fine.

### Testing
Plattform: Windows 10 1809 
Hardware: AMD WX 3100 (AMD 18.Q3)
AVR: Pioneer VSX-932

+Tested format options:
DTS 5.1 - 24Bit/48kHz
DTS-HD HRA 5.1 - 24Bit/48kHz
DTS-HD HRA 7.1 - 24Bit/48kHz
DTS-HD HRA 7.1 - 24Bit/96kHz
DTS-HD MA 5.1 - 24Bit/48kHz
DTS-HD MA 6.1 - 24Bit/48kHz
DTS-HD MA 7.1 - 16Bit/48kHz
DTS-HD MA 7.1 - 24Bit/48kHz
DTS-HD MA 7.1 - 24Bit/96kHz
DTS-HD MA 7.1 - DTS-X - 24Bit/48 kHz
**-> every format option worked**

+Not tested format option:
DTS-HD HRA 7.1 - DTS:X - 24Bit/48kHz 
I had no sample for that variant. (should work)

### Code
formatting is not correct as it's not breaking the line after 80/85 columns.
I think the readability is better, as it is right now. Could be changed, of cause


### Sources - credit
https://github.com/Nevcairiel -> 
LAVfilters - https://github.com/Nevcairiel/LAVFilters/issues/167
https://github.com/Nevcairiel/LAVFilters/blob/master/decoder/LAVAudio/Bitstream.cpp
Bitstream.cpp is under GNU General Public License 2 later
(I looked at the code, how they achieved it  
adopted/changed it so that it fits in the mpv environment.) 