### PR TITLE
build: more reliable way of getting the Swift version from a string

### DIFF
--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -1,3 +1,4 @@
+import re
 from waflib import Utils
 
 def __run(cmd):
@@ -11,7 +12,9 @@ def __add_swift_flags(ctx):
     ctx.env.SWIFT_FLAGS = ('-frontend -c -sdk %s -enable-objc-interop'
                            ' -emit-objc-header -parse-as-library'
                            ' -target x86_64-apple-macosx10.10') % (ctx.env.MACOS_SDK)
-    ctx.env.SWIFT_VERSION = __run([ctx.env.SWIFT, '-version']).split(' ')[3]
+
+    ver = re.compile("(?i)version\s?([\d.]+)")
+    ctx.env.SWIFT_VERSION = ver.search(__run([ctx.env.SWIFT, '-version'])).group(1)
     major, minor = [int(n) for n in ctx.env.SWIFT_VERSION.split('.')[:2]]
 
     # the -swift-version parameter is only supported on swift 3.1 and newer


### PR DESCRIPTION
seems like swift 1.x returns a version string like `Swift version 1.1 (swift-600.0.57.4)` whereas swift 2.x and newer return something like`Apple Swift version 4.0.3 (swiftlang-900.0.74.1 clang-900.0.39.2) `.

before it just dumbly always took the fourth element after a split by space. obviously that didn't work with the first swift version. i made the swift version extraction a bit more reliable with a regex and hopefully it will prevent errors for future changes in the version string.

Fixes #6212