### PR TITLE
x11_common: replace atoi with strtoul

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -588,7 +588,8 @@ int vo_x11_init(struct vo *vo)
         dispName += 4;
     else if (strncmp(dispName, "localhost:", 10) == 0)
         dispName += 9;
-    x11->display_is_local = dispName[0] == ':' && atoi(dispName + 1) < 10;
+    x11->display_is_local = dispName[0] == ':' &&
+                            strtoul(dispName + 1, NULL, 10) < 10;
     MP_VERBOSE(x11, "X11 running at %dx%d (\"%s\" => %s display)\n",
                x11->ws_width, x11->ws_height, dispName,
                x11->display_is_local ? "local" : "remote");


### PR DESCRIPTION
Using strtol and strtoul is allegedly better practice, and I'm going for strtoul here because I'm pretty sure X11 displays cannot be in the negative.

I agree that my changes can be relicensed to LGPL 2.1 or later.
