### PR TITLE
vo_gpu: vulkan: fix the buffer size on partial upload

### DIFF
--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -886,6 +886,7 @@ static bool vk_tex_upload(struct ra *ra,
             struct mp_rect *rc = params->rc;
             region.imageOffset = (VkOffset3D){rc->x0, rc->y0, 0};
             region.imageExtent = (VkExtent3D){mp_rect_w(*rc), mp_rect_h(*rc), 1};
+            region.bufferImageHeight = region.imageExtent.height;
         }
     }
 


### PR DESCRIPTION
This was pased on the texture height, which was a mistake. In some cases
it could exceed the actual size of the buffer, leading to a vulkan API
error. This didn't seem to cause any problems in practice, since a
too-large synchronization is just bad for performance and shouldn't do
any harm internally, but either way, it was still undefined behavior to
submit a barrier outside of the buffer size.

Fix the calculation, thus fixing this issue.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
