### PR TITLE
vo_gpu: vulkan: fix strncpy truncation in spirv_compiler_init

### DIFF
--- a/video/out/gpu/spirv.c
+++ b/video/out/gpu/spirv.c
@@ -65,7 +65,7 @@ bool spirv_compiler_init(struct ra_ctx *ctx)
         ctx->spirv->fns = compilers[i];
 
         const char *name = m_opt_choice_str(compiler_choices, i);
-        strncpy(ctx->spirv->name, name, sizeof(ctx->spirv->name));
+        strncpy(ctx->spirv->name, name, sizeof(ctx->spirv->name) - 1);
         MP_VERBOSE(ctx, "Initializing SPIR-V compiler '%s'\n", name);
         if (ctx->spirv->fns->init(ctx))
             return true;


### PR DESCRIPTION
Fixes GCC8 warning
../video/out/gpu/spirv.c: In function 'spirv_compiler_init':
../video/out/gpu/spirv.c:68:9: warning: 'strncpy' specified bound 32 equals destination size [-Wstringop-truncation]