### PR TITLE
build: add quotes to all Swift build related paths

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -97,7 +97,7 @@ def check_cocoa(ctx, dependency_identifier):
         fragment         = load_fragment('cocoa.m'),
         compile_filename = 'test.m',
         framework_name   = ['Cocoa', 'IOKit', 'OpenGL', 'QuartzCore'],
-        includes         = ctx.srcnode.abspath(),
+        includes         = [ctx.srcnode.abspath()],
         linkflags        = '-fobjc-arc')
 
     res = fn(ctx, dependency_identifier)

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -9,9 +9,11 @@ def __run(cmd):
         return ""
 
 def __add_swift_flags(ctx):
-    ctx.env.SWIFT_FLAGS = ('-frontend -c -sdk %s -enable-objc-interop'
-                           ' -emit-objc-header -parse-as-library'
-                           ' -target x86_64-apple-macosx10.10') % (ctx.env.MACOS_SDK)
+    ctx.env.SWIFT_FLAGS = [
+        "-frontend", "-c", "-sdk", ctx.env.MACOS_SDK,
+        "-enable-objc-interop", "-emit-objc-header", "-parse-as-library",
+        "-target", "x86_64-apple-macosx10.10"
+    ]
 
     ver = re.compile("(?i)version\s?([\d.]+)")
     ctx.env.SWIFT_VERSION = ver.search(__run([ctx.env.SWIFT, '-version'])).group(1)
@@ -19,10 +21,10 @@ def __add_swift_flags(ctx):
 
     # the -swift-version parameter is only supported on swift 3.1 and newer
     if major >= 3 and minor >= 1 or major >= 4:
-        ctx.env.SWIFT_FLAGS += ' -swift-version 3'
+        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "3" ])
 
     if ctx.is_optimization():
-        ctx.env.SWIFT_FLAGS += ' -O'
+        ctx.env.SWIFT_FLAGS.append("-O")
 
 def __add_swift_library_linking_flags(ctx, swift_library):
     ctx.env.append_value('LINKFLAGS', [

--- a/wscript
+++ b/wscript
@@ -3,6 +3,7 @@
 import sys, os, re
 sys.path.insert(0, os.path.join(os.getcwd(), 'waftools'))
 sys.path.insert(0, os.getcwd())
+from shlex import split
 from waflib.Configure import conf
 from waflib.Tools import c_preproc
 from waflib import Utils
@@ -1053,7 +1054,7 @@ def configure(ctx):
         ctx.options.enable_lua = True
 
     if ctx.options.SWIFT_FLAGS:
-        ctx.env.SWIFT_FLAGS += ' ' + ctx.options.SWIFT_FLAGS
+        ctx.env.SWIFT_FLAGS.extend(split(ctx.options.SWIFT_FLAGS))
 
     ctx.parse_dependencies(standalone_features)
 

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -147,11 +147,12 @@ def build(ctx):
         tgt = task.outputs[0].abspath()
         header = task.outputs[1].abspath()
         module = task.outputs[2].abspath()
+        module_name = os.path.basename(module).rsplit(".", 1)[0]
 
         cmd = [ ctx.env.SWIFT ]
         cmd.extend(ctx.env.SWIFT_FLAGS)
         cmd.extend([
-            "-module-name", "macOS_swift",
+            "-module-name", module_name,
             "-emit-module-path", module,
             "-import-objc-header", bridge,
             "-emit-objc-header-path", header,


### PR DESCRIPTION
this doesn't seem very nice. i suppose using an argument list would probably better than quoting everything in a string?

Fixes #6220