### PR TITLE
vo_gpu: vulkan: suppress bogus error message on --vulkan-device

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -54,16 +54,16 @@ static int vk_validate_dev(struct mp_log *log, const struct m_option *opt,
 
     res = vkCreateInstance(&info, MPVK_ALLOCATOR, &inst);
     if (res != VK_SUCCESS)
-        goto error;
+        goto done;
 
     res = vkEnumeratePhysicalDevices(inst, &num, NULL);
     if (res != VK_SUCCESS)
-        goto error;
+        goto done;
 
     devices = talloc_array(NULL, VkPhysicalDevice, num);
     vkEnumeratePhysicalDevices(inst, &num, devices);
     if (res != VK_SUCCESS)
-        goto error;
+        goto done;
 
     bool help = bstr_equals0(param, "help");
     if (help) {
@@ -80,14 +80,14 @@ static int vk_validate_dev(struct mp_log *log, const struct m_option *opt,
                     (unsigned)prop.vendorID, (unsigned)prop.deviceID);
         } else if (bstr_equals0(param, prop.deviceName)) {
             ret = 0;
-            break;
+            goto done;
         }
     }
 
     if (!help)
         mp_err(log, "No device with name '%.*s'!\n", BSTR_P(param));
 
-error:
+done:
     talloc_free(devices);
     return ret;
 }


### PR DESCRIPTION
Since the code just broke out of the loop on a match rather than jumping
straight to the end of the function body, it ended up hitting the code
path for when the end of the list was reached.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
