### PR TITLE
Make sure the string is NULL-terminated after strncpy

### DIFF
--- a/stream/stream_smb.c
+++ b/stream/stream_smb.c
@@ -43,6 +43,7 @@ static void smb_auth_fn(const char *server, const char *share,
              char *password, int pwmaxlen)
 {
   strncpy(workgroup, "LAN", wgmaxlen - 1);
+  workgroup[wgmaxlen - 1] = '\0';
 }
 
 static int control(stream_t *s, int cmd, void *arg) {


### PR DESCRIPTION
strncpy does not guarantee that the string will be NULL-terminated.

I agree that my changes can be relicensed to LGPL 2.1 or later.
