### PR TITLE
ao_oss: Fallback to stereo when the device does not support >2 channels

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -336,19 +336,23 @@ static int reopen_device(struct ao *ao, bool allow_format_changes)
             mp_chmap_sel_add_map(&sel, &oss_layouts[n]);
         if (!ao_chmap_sel_adjust(ao, &sel, &channels))
             goto fail;
-        int reqchannels = channels.num;
+        int c, nchannels, reqchannels;
+        nchannels = reqchannels = channels.num;
         // We only use SNDCTL_DSP_CHANNELS for >2 channels, in case some drivers don't have it
         if (reqchannels > 2) {
-            int nchannels = reqchannels;
-            if (ioctl(p->audio_fd, SNDCTL_DSP_CHANNELS, &nchannels) == -1 ||
-                nchannels != reqchannels)
-            {
+            if (ioctl(p->audio_fd, SNDCTL_DSP_CHANNELS, &nchannels) == -1) {
                 MP_ERR(ao, "Failed to set audio device to %d channels.\n",
                        reqchannels);
                 goto fail;
             }
+            if (nchannels != reqchannels) {
+                // Fallback to stereo
+                nchannels = 2;
+                goto stereo;
+            }
         } else {
-            int c = reqchannels - 1;
+stereo:
+            c = nchannels - 1;
             if (ioctl(p->audio_fd, SNDCTL_DSP_STEREO, &c) == -1) {
                 MP_ERR(ao, "Failed to set audio device to %d channels.\n",
                        reqchannels);


### PR DESCRIPTION
ioctl(..., SNDCTL_DSP_CHANNELS, &nchannels) for not supported
nchannels does not return an error and instead set nchannels to
the default value.

Instead of failing with no audio, fallback to stereo.

Without this change file with >2 audio channels on devices that do
not support >2 channels ends up to not using any audio output.

I agree that my changes can be relicensed to LGPL 2.1 or later.