### PR TITLE
drm: better names for  plane options/variables etc.

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -31,6 +31,9 @@ API changes
 ===========
 
 ::
+ --- mpv 0.30.0 ---
+ 1.102  - rename struct mpv_opengl_drm_osd_size to mpv_opengl_drm_draw_surface_size
+        - rename MPV_RENDER_PARAM_DRM_OSD_SIZE to MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE
 
  --- mpv 0.29.0 ---
  1.101  - add MPV_RENDER_PARAM_ADVANCED_CONTROL and related API

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,9 +20,16 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
-    - the `--drm-osd-plane-id` and `--drm-video-plane-id`
+    - rename `--drm-osd-plane-id` to `--drm-draw-plane`, `--drm-video-plane-id` to
+      `--drm-drmprime-video-plane` and `--drm-osd-size` to `--drm-draw-surface-size`
+      to better reflect what the options actually control, that the values they
+      accept aren't actually internal DRM ID's (like with similar options in
+      ffmpeg's KMS support), and that the video plane is only used when the drmprime
+      overlay hwdec interop is active, with the video being drawn to the draw plane
+      otherwise.
+    - in addition to the above, the `--drm-draw-plane` and `--drm-drmprime-video-plane`
       options now accept either an integer index, or the values primary or overlay.
-      `--drm-osd-plane-id` now defaults to primary and `--drm-video-plane-id`
+      `--drm-draw-plane` now defaults to primary and `--drm-drmprime-video-plane`
       defaults to overlay. This should be similar to previous behavior on most drivers
       due to how planes are usually sorted.
     - rename --opensles-frames-per-buffer to --opensles-frames-per-enqueue to

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,11 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
+    - the `--drm-osd-plane-id` and `--drm-video-plane-id`
+      options now accept either an integer index, or the values primary or overlay.
+      `--drm-osd-plane-id` now defaults to primary and `--drm-video-plane-id`
+      defaults to overlay. This should be similar to previous behavior on most drivers
+      due to how planes are usually sorted.
     - rename --opensles-frames-per-buffer to --opensles-frames-per-enqueue to
       better reflect its purpose. In the past it overrides the buffer size the AO
       requests (but not the default/value of the generic --audio-buffer option).

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,19 +488,21 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
-    ``--drm-osd-plane-id=<number>``
-        Select the DRM plane index to use for OSD (or OSD and video).
-        Index is zero based, and related to crtc.
-        When using this option with the drm_prime renderer, it will only affect
-        the OSD contents. Otherwise it will set OSD & video plane.
-        (default: primary plane)
+    ``--drm-osd-plane-id=<primary|overlay|N>``
+        Select the DRM plane to use for OSD (or OSD and video). The plane can be
+        specified as ``primary``, which will pick the first applicable primary
+        plane; ``overlay``, which will pick the first applicable overlay plane;
+        or by index. The index is zero based, and related to the CRTC. When using
+        this option with the drm_prime renderer, it will only affect the OSD
+        contents. Otherwise it will set OSD & video plane.
+        (default: primary)
 
-    ``--drm-video-plane-id=<number>``
-        Select the DRM plane index to use for video layer.
-        Index is zero based, and related to crtc.
-        This option only has effect when using the drm_prime renderer (which
-        supports several layers) together with ``vo=gpu`` and ``gpu-context=drm``.
-        (default: first overlay plane)
+    ``--drm-video-plane-id=<primary|overlay|N>``
+        Select the DRM plane index to use for video layer. This option accepts
+        the same values as ``--drm-osd-plane-id``. This option has an effect
+        only when using the drm_prime renderer (which supports several layers)
+        together with ``vo=gpu`` and ``gpu-context=drm``.
+        (default: overlay)
 
     ``--drm-format=<xrgb8888|xrgb2101010>``
         Select the DRM format to use (default: xrgb8888). This allows you to

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,21 +488,28 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
-    ``--drm-osd-plane-id=<primary|overlay|N>``
-        Select the DRM plane to use for OSD (or OSD and video). The plane can be
-        specified as ``primary``, which will pick the first applicable primary
-        plane; ``overlay``, which will pick the first applicable overlay plane;
-        or by index. The index is zero based, and related to the CRTC. When using
-        this option with the drm_prime renderer, it will only affect the OSD
-        contents. Otherwise it will set OSD & video plane.
+    ``--drm-draw-plane=<primary|overlay|N>``
+        Select the DRM plane to which video and OSD is drawn to, under normal
+        circumstances. The plane can be specified as ``primary``, which will
+        pick the first applicable primary plane; ``overlay``, which will pick
+        the first applicable overlay plane; or by index. The index is zero
+        based, and related to the CRTC.
         (default: primary)
 
-    ``--drm-video-plane-id=<primary|overlay|N>``
-        Select the DRM plane index to use for video layer. This option accepts
-        the same values as ``--drm-osd-plane-id``. This option has an effect
-        only when using the drm_prime renderer (which supports several layers)
-        together with ``vo=gpu`` and ``gpu-context=drm``.
-        (default: overlay)
+        When using this option with the drmprime-drm hwdec interop, only the OSD
+        is rendered to this plane.
+
+    ``--drm-drmprime-video-plane=<primary|overlay|N>``
+        Select the DRM plane to use for video with the drmprime-drm hwdec
+        interop (used by e.g. the rkmpp hwdec on RockChip SoCs, and v4l2 hwdec:s
+        on various other SoC:s). The plane is unused otherwise. This option
+        accepts the same values as ``--drm-draw-plane``. (default: overlay)
+
+        To be able to successfully play 4K video on various SoCs you might need
+        to set ``--drm-draw-plane=overlay --drm-drmprime-video-plane=primary``
+        and setting ``--drm-draw-surface-size=1920x1080``, to render the OSD at a
+        lower resolution (the video when handled by the hwdec will be on the
+        drmprime-video plane and at full 4K resolution)
 
     ``--drm-format=<xrgb8888|xrgb2101010>``
         Select the DRM format to use (default: xrgb8888). This allows you to
@@ -517,11 +524,18 @@ Available video output drivers are:
         This currently only has an effect when used together with the ``drm``
         backend for the ``gpu`` VO. The ``drm`` VO always uses xrgb8888.
 
-    ``--drm-osd-size=<[WxH]>``
-        Sets the OSD OpenGL size to the specified size. OSD will then be upscaled
-        to the current screen resolution. This option can be useful when using
-        several layers in high resolutions with a GPU which cannot handle it.
-        Note : this option is only available with DRM atomic support.
+    ``--drm-draw-surface-size=<[WxH]>``
+        Sets the size of the surface used on the draw plane. The surface will
+        then be upscaled to the current screen resolution. This option can be
+        useful when used together with the drmprime-drm hwdec interop at high
+        resolutions, as it allows scaling the draw plane (which in this case
+        only handles the OSD) down to a size the GPU can handle.
+
+        When used without the drmprime-drm hwdec interop this option will just
+        cause the video to get rendered at a different resolution and then
+        scaled to screen size.
+
+        Note: this option is only available with DRM atomic support.
         (default: display resolution)
 
 ``mediacodec_embed`` (Android)

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -210,7 +210,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 101)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 102)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before

--- a/libmpv/render.h
+++ b/libmpv/render.h
@@ -283,12 +283,18 @@ typedef enum mpv_render_param_type {
      */
     MPV_RENDER_PARAM_DRM_DISPLAY = 14,
     /**
-     * DRM osd size, contains osd dimensions.
+     * DRM draw surface size, contains draw surface dimensions.
      * Valid for mpv_render_context_create().
-     * Type : struct mpv_opengl_drm_osd_size*
+     * Type : struct mpv_opengl_drm_draw_surface_size*
      */
-    MPV_RENDER_PARAM_DRM_OSD_SIZE = 15,
+    MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE = 15,
 } mpv_render_param_type;
+
+/**
+ * For backwards compatibility with the old naming of
+ * MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE
+ */
+#define MPV_RENDER_PARAM_DRM_OSD_SIZE MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE
 
 /**
  * Used to pass arbitrary parameters to some mpv_render_* functions. The

--- a/libmpv/render_gl.h
+++ b/libmpv/render_gl.h
@@ -177,12 +177,17 @@ typedef struct mpv_opengl_drm_params {
     int render_fd;
 } mpv_opengl_drm_params;
 
-typedef struct mpv_opengl_drm_osd_size {
+typedef struct mpv_opengl_drm_draw_surface_size {
     /**
-     * size of the OSD in pixels.
+     * size of the draw plane surface in pixels.
      */
     int width, height;
-} mpv_opengl_drm_osd_size;
+} mpv_opengl_drm_draw_surface_size;
+
+/**
+ * For backwards compatibility with the old naming of mpv_opengl_drm_draw_surface_size
+ */
+#define mpv_opengl_drm_osd_size mpv_opengl_drm_draw_surface_size
 
 #ifdef __cplusplus
 }

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -25,6 +25,9 @@
 
 #include "common/msg.h"
 
+#define DRM_OPTS_PRIMARY_PLANE -1
+#define DRM_OPTS_OVERLAY_PLANE -2
+
 struct drm_mode {
     drmModeModeInfo mode;
     uint32_t blob_id;
@@ -89,7 +92,7 @@ struct drm_object * drm_object_create(struct mp_log *log, int fd, uint32_t objec
 void drm_object_free(struct drm_object *object);
 void drm_object_print_info(struct mp_log *log, struct drm_object *object);
 struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int connector_id,
-													 int osd_plane_id, int video_plane_id);
+                                                     int osd_plane_idx, int video_plane_idx);
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx);
 
 bool drm_atomic_save_old_state(struct drm_atomic_context *ctx);

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -57,8 +57,8 @@ struct drm_atomic_state {
         struct drm_mode mode;
         uint64_t active;
     } crtc;
-    struct drm_atomic_plane_state osd_plane;
-    struct drm_atomic_plane_state video_plane;
+    struct drm_atomic_plane_state draw_plane;
+    struct drm_atomic_plane_state drmprime_video_plane;
 };
 
 struct drm_object {
@@ -74,8 +74,8 @@ struct drm_atomic_context {
 
     struct drm_object *crtc;
     struct drm_object *connector;
-    struct drm_object *osd_plane;
-    struct drm_object *video_plane;
+    struct drm_object *draw_plane;
+    struct drm_object *drmprime_video_plane;
 
     drmModeAtomicReq *request;
 
@@ -92,7 +92,7 @@ struct drm_object * drm_object_create(struct mp_log *log, int fd, uint32_t objec
 void drm_object_free(struct drm_object *object);
 void drm_object_print_info(struct mp_log *log, struct drm_object *object);
 struct drm_atomic_context *drm_atomic_create_context(struct mp_log *log, int fd, int crtc_id, int connector_id,
-                                                     int osd_plane_idx, int video_plane_idx);
+                                                     int draw_plane_idx, int drmprime_video_plane_idx);
 void drm_atomic_destroy_context(struct drm_atomic_context *ctx);
 
 bool drm_atomic_save_old_state(struct drm_atomic_context *ctx);

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <sys/vt.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include "drm_common.h"
 
@@ -47,8 +48,12 @@ const struct m_sub_options drm_conf = {
         OPT_STRING_VALIDATE("drm-connector", drm_connector_spec,
                             0, drm_validate_connector_opt),
         OPT_INT("drm-mode", drm_mode_id, 0),
-        OPT_INT("drm-osd-plane-id", drm_osd_plane_id, 0),
-        OPT_INT("drm-video-plane-id", drm_video_plane_id, 0),
+        OPT_CHOICE_OR_INT("drm-osd-plane-id", drm_osd_plane_id, 0, 0, INT_MAX,
+                          ({"primary", DRM_OPTS_PRIMARY_PLANE},
+                           {"overlay", DRM_OPTS_OVERLAY_PLANE})),
+        OPT_CHOICE_OR_INT("drm-video-plane-id", drm_video_plane_id, 0, 0, INT_MAX,
+                          ({"primary", DRM_OPTS_PRIMARY_PLANE},
+                           {"overlay", DRM_OPTS_OVERLAY_PLANE})),
         OPT_CHOICE("drm-format", drm_format, 0,
                    ({"xrgb8888",    DRM_OPTS_FORMAT_XRGB8888},
                     {"xrgb2101010", DRM_OPTS_FORMAT_XRGB2101010})),
@@ -56,8 +61,8 @@ const struct m_sub_options drm_conf = {
         {0},
     },
     .defaults = &(const struct drm_opts) {
-        .drm_osd_plane_id = -1,
-        .drm_video_plane_id = -1,
+        .drm_osd_plane_id = DRM_OPTS_PRIMARY_PLANE,
+        .drm_video_plane_id = DRM_OPTS_OVERLAY_PLANE,
     },
     .size = sizeof(struct drm_opts),
 };

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -48,10 +48,10 @@ struct vt_switcher {
 struct drm_opts {
     char *drm_connector_spec;
     int drm_mode_id;
-    int drm_osd_plane_id;
-    int drm_video_plane_id;
+    int drm_draw_plane;
+    int drm_drmprime_video_plane;
     int drm_format;
-    struct m_geometry drm_osd_size;
+    struct m_geometry drm_draw_surface_size;
 };
 
 bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log);
@@ -65,7 +65,7 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
                          void *user_data);
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int osd_plane_id, int video_plane_id);
+                       int mode_id, int draw_plane, int drmprime_video_plane);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -36,9 +36,9 @@ static const struct native_resource_entry native_resource_map[] = {
         .name = "drm_params",
         .size = sizeof (mpv_opengl_drm_params),
     },
-    [MPV_RENDER_PARAM_DRM_OSD_SIZE] = {
-        .name = "drm_osd_size",
-        .size = sizeof (mpv_opengl_drm_osd_size),
+    [MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE] = {
+        .name = "drm_draw_surface_size",
+        .size = sizeof (mpv_opengl_drm_draw_surface_size),
     },
 };
 

--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -114,17 +114,17 @@ static void disable_video_plane(struct ra_hwdec *hw)
     if (!p->ctx)
         return;
 
-    if (!p->ctx->video_plane)
+    if (!p->ctx->drmprime_video_plane)
         return;
 
-    // Disabling video plane is needed on some devices when using the
-    // primary plane for video. Primary buffer can't be active with no
-    // framebuffer associated. So we need this function to commit it
-    // right away as mpv will free all framebuffers on playback end.
+    // Disabling the drmprime video plane is needed on some devices when using
+    // the primary plane for video. Primary buffer can't be active with no
+    // framebuffer associated. So we need this function to commit it right away
+    // as mpv will free all framebuffers on playback end.
     drmModeAtomicReqPtr request = drmModeAtomicAlloc();
     if (request) {
-        drm_object_set_property(request, p->ctx->video_plane, "FB_ID", 0);
-        drm_object_set_property(request, p->ctx->video_plane, "CRTC_ID", 0);
+        drm_object_set_property(request, p->ctx->drmprime_video_plane, "FB_ID", 0);
+        drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_ID", 0);
 
         int ret = drmModeAtomicCommit(p->ctx->fd, request,
                                   DRM_MODE_ATOMIC_NONBLOCK, NULL);
@@ -162,11 +162,11 @@ static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
 
     if (hw_image) {
 
-        // grab osd windowing info to eventually upscale the overlay
-        // as egl windows could be upscaled to osd plane.
-        struct mpv_opengl_drm_osd_size *osd_size = ra_get_native_resource(hw->ra, "drm_osd_size");
-        if (osd_size) {
-            scale_dst_rect(hw, osd_size->width, osd_size->height, dst, &p->dst);
+        // grab draw plane windowing info to eventually upscale the overlay
+        // as egl windows could be upscaled to draw plane.
+        struct mpv_opengl_drm_draw_surface_size *draw_surface_size = ra_get_native_resource(hw->ra, "drm_draw_surface_size");
+        if (draw_surface_size) {
+            scale_dst_rect(hw, draw_surface_size->width, draw_surface_size->height, dst, &p->dst);
         } else {
             p->dst = *dst;
         }
@@ -187,24 +187,24 @@ static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
             }
 
             if (request) {
-                drm_object_set_property(request, p->ctx->video_plane, "FB_ID", next_frame.fb.fb_id);
-                drm_object_set_property(request,  p->ctx->video_plane, "CRTC_ID", p->ctx->crtc->id);
-                drm_object_set_property(request,  p->ctx->video_plane, "SRC_X",   p->src.x0 << 16);
-                drm_object_set_property(request,  p->ctx->video_plane, "SRC_Y",   p->src.y0 << 16);
-                drm_object_set_property(request,  p->ctx->video_plane, "SRC_W",   srcw << 16);
-                drm_object_set_property(request,  p->ctx->video_plane, "SRC_H",   srch << 16);
-                drm_object_set_property(request,  p->ctx->video_plane, "CRTC_X",  MP_ALIGN_DOWN(p->dst.x0, 2));
-                drm_object_set_property(request,  p->ctx->video_plane, "CRTC_Y",  MP_ALIGN_DOWN(p->dst.y0, 2));
-                drm_object_set_property(request,  p->ctx->video_plane, "CRTC_W",  dstw);
-                drm_object_set_property(request,  p->ctx->video_plane, "CRTC_H",  dsth);
-                drm_object_set_property(request,  p->ctx->video_plane, "ZPOS",    0);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "FB_ID", next_frame.fb.fb_id);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_ID", p->ctx->crtc->id);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "SRC_X",   p->src.x0 << 16);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "SRC_Y",   p->src.y0 << 16);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "SRC_W",   srcw << 16);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "SRC_H",   srch << 16);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_X",  MP_ALIGN_DOWN(p->dst.x0, 2));
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_Y",  MP_ALIGN_DOWN(p->dst.y0, 2));
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_W",  dstw);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_H",  dsth);
+                drm_object_set_property(request, p->ctx->drmprime_video_plane, "ZPOS",    0);
             } else {
-                ret = drmModeSetPlane(p->ctx->fd, p->ctx->video_plane->id, p->ctx->crtc->id, next_frame.fb.fb_id, 0,
+                ret = drmModeSetPlane(p->ctx->fd, p->ctx->drmprime_video_plane->id, p->ctx->crtc->id, next_frame.fb.fb_id, 0,
                                       MP_ALIGN_DOWN(p->dst.x0, 2), MP_ALIGN_DOWN(p->dst.y0, 2), dstw, dsth,
                                       p->src.x0 << 16, p->src.y0 << 16 , srcw << 16, srch << 16);
                 if (ret < 0) {
-                    MP_ERR(hw, "Failed to set the plane %d (buffer %d).\n", p->ctx->video_plane->id,
-                                next_frame.fb.fb_id);
+                    MP_ERR(hw, "Failed to set the drmprime video plane %d (buffer %d).\n",
+                           p->ctx->drmprime_video_plane->id, next_frame.fb.fb_id);
                     goto fail;
                 }
             }
@@ -240,14 +240,14 @@ static void uninit(struct ra_hwdec *hw)
 static int init(struct ra_hwdec *hw)
 {
     struct priv *p = hw->priv;
-    int osd_plane_id, video_plane_id;
+    int draw_plane, drmprime_video_plane;
 
     p->log = hw->log;
 
     void *tmp = talloc_new(NULL);
     struct drm_opts *opts = mp_get_config_group(tmp, hw->global, &drm_conf);
-    osd_plane_id = opts->drm_osd_plane_id;
-    video_plane_id = opts->drm_video_plane_id;
+    draw_plane = opts->drm_draw_plane;
+    drmprime_video_plane = opts->drm_drmprime_video_plane;
     talloc_free(tmp);
 
     struct mpv_opengl_drm_params *drm_params;
@@ -255,13 +255,13 @@ static int init(struct ra_hwdec *hw)
     drm_params = ra_get_native_resource(hw->ra, "drm_params");
     if (drm_params) {
         p->ctx = drm_atomic_create_context(p->log, drm_params->fd, drm_params->crtc_id,
-                                           drm_params->connector_id, osd_plane_id, video_plane_id);
+                                           drm_params->connector_id, draw_plane, drmprime_video_plane);
         if (!p->ctx) {
             mp_err(p->log, "Failed to retrieve DRM atomic context.\n");
             goto err;
         }
-        if (!p->ctx->video_plane) {
-            mp_warn(p->log, "No video plane. You might need to specify it manually using --drm-video-plane-id\n");
+        if (!p->ctx->drmprime_video_plane) {
+            mp_warn(p->log, "No drmprime video plane. You might need to specify it manually using --drm-drmprime-video-plane\n");
             goto err;
         }
     } else {

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -420,8 +420,8 @@ static int preinit(struct vo *vo)
     p->kms = kms_create(
         vo->log, vo->opts->drm_opts->drm_connector_spec,
                  vo->opts->drm_opts->drm_mode_id,
-                 vo->opts->drm_opts->drm_osd_plane_id,
-                 vo->opts->drm_opts->drm_video_plane_id);
+                 vo->opts->drm_opts->drm_draw_plane,
+                 vo->opts->drm_opts->drm_drmprime_video_plane);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");
         goto err;


### PR DESCRIPTION
The names `drm-osd-plane-id` and `drm-video-plane-id` have been nothing but a source of confusion. One being that the "OSD plane" is actually used for both video and OSD whenever the drmprime-drm hwdec interop is not being used. The -id part is also confusing, since the options in fact accept an index into the list of applicable planes for the currently selected CRTC, and not the DRM object identifier as one might be lead to think (this problem is especially grave when it comes to the variable names used internally in the code).

Instead I propose we name the same options `drm-draw-plane` and `drm-drmprime-video`. `drm-osd-size` follows and becomes `drm-draw-surface-size`.

I also make the options accept the generic parameters "overlay" and "primary", so that a user can specify simply whether a primary or overlay plane is wanted (which fits the usual use case for these options better, rather than having to specify a specific plane using a number)

This PR bumps libmpv version to 1.102, for renaming `MPV_RENDER_PARAM_DRM_OSD_SIZE` to `MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE` and renaming the struct `mpv_opengl_drm_osd_size` to `mpv_opengl_drm_draw_surface_size`

I agree that my changes can be relicensed to LGPL 2.1 or later.
