### PR TITLE
Reintroduce vo_wayland as vo_wlshm

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -578,3 +578,9 @@ Available video output drivers are:
 
     To use hardware decoding with ``--vo=gpu`` instead, use
     ``--hwdec=mediacodec-copy`` along with ``--gpu-context=android``.
+
+``wlshm`` (Wayland only)
+    Shared memory video output driver without hardware acceleration that works
+    whenever Wayland is present.
+
+    .. note:: This is a fallback only, and should not be normally used.

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -60,6 +60,7 @@ extern const struct vo_driver video_out_drm;
 extern const struct vo_driver video_out_direct3d;
 extern const struct vo_driver video_out_sdl;
 extern const struct vo_driver video_out_vaapi;
+extern const struct vo_driver video_out_wlshm;
 extern const struct vo_driver video_out_rpi;
 extern const struct vo_driver video_out_tct;
 
@@ -75,6 +76,9 @@ const struct vo_driver *const video_out_drivers[] =
 #endif
 #if HAVE_DIRECT3D
     &video_out_direct3d,
+#endif
+#if HAVE_WAYLAND
+    &video_out_wlshm,
 #endif
 #if HAVE_XV
     &video_out_xv,

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -488,6 +488,7 @@ def build(ctx):
         ( "video/out/vo_tct.c" ),
         ( "video/out/vo_vaapi.c",                "vaapi-x11 && gpl" ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),
+        ( "video/out/vo_wlshm.c",                "wayland" ),
         ( "video/out/vo_x11.c" ,                 "x11" ),
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),


### PR DESCRIPTION
vo_wayland was removed during the wayland rewrite done in 0.28. However,
it is still useful for systems that do not have OpenGL.

The new wayland_common code makes vo_wayland much simpler, and
eliminates many of the issues the previous vo_wayland had.

I agree that my changes can be relicensed to LGPL 2.1 or later.