### PR TITLE
hwdec_drmprime_drm: Missing NULL-check on drm_atomic_context video_plane

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -114,6 +114,9 @@ static void disable_video_plane(struct ra_hwdec *hw)
     if (!p->ctx)
         return;
 
+    if (!p->ctx->video_plane)
+        return;
+
     // Disabling video plane is needed on some devices when using the
     // primary plane for video. Primary buffer can't be active with no
     // framebuffer associated. So we need this function to commit it


### PR DESCRIPTION
Since 810acf32d6cf0dfbad66c602689ef1218fc0a6e3 video_plane can be NULL
under some circumstances. While there is a check in init, init treats
this as an error condition and would call uninit, which in turn calls
disable_video_plane, which would then segfault. Fix this by including
a NULL check inside disable_video_plane, so that it doesn't try to
disable what isnt' there.

I agree that my changes can be relicensed to LGPL 2.1 or later.
