### PR TITLE
context_drm_egl: Improve performance by moving the page-flip wait to the beginning of swap_buffers

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -262,6 +262,7 @@ static const struct gl_functions gl_functions[] = {
     },
     {
         .ver_core = 320,
+        .ver_es_core = 300,
         .extension = "GL_ARB_sync",
         .functions = (const struct gl_function[]) {
             DEF_FN(FenceSync),


### PR DESCRIPTION
By not waiting on the page flip directly after calling drmModePageFlip/drmModeAtomicCommit, and instead waiting on the previous page flip at the beginning of swap_buffers we can improve performance by quite a bit. Works especially well for more uneven workloads, such as playing a 24 FPS movie on a 60 Hz screen (with display-sync, when swap_buffers is called for every vsync).

Since I found that the fences in `video/out/opengl/context.c` was quite important to synchronize things, this also includes a few fixes to make sure we can have them when:
  * OpenGL ES 3.0+ is being used (supports fencing, but the code for it was missing)
  * DRM Atomic is used (do not use an external_swapchain, which disables the fences)

I agree that my changes can be relicensed to LGPL 2.1 or later.
