### PR TITLE
cocoa-cb: remove empty elements from dropped URLs

### DIFF
--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -75,7 +75,8 @@ class EventsView: NSView {
                 return true
             }
         } else if types.contains(NSURLPboardType) {
-            if let url = pb.propertyList(forType: NSURLPboardType) as? [Any] {
+            if var url = pb.propertyList(forType: NSURLPboardType) as? [String] {
+                url = url.filter{ !$0.isEmpty }
                 EventsResponder.sharedInstance().handleFilesArray(url)
                 return true
             }


### PR DESCRIPTION
the `propertyList` functions adds an empty element at the end of the array, even so the `NSURLPboardType` type only supports one dropped URL atm per docs. just remove all empty elements instead of using just the first element of the array since `handleFilesArray` expects an array. it's a bit more future proof in the case Apple ever decides to allow more than one URL to be dropped on a view.

Fixes #6241