### PR TITLE
[WIP] vo: Add support for vsync feedback

### DIFF
--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -83,6 +83,15 @@ struct ra_swapchain_fns {
     // Performs a buffer swap. This blocks for as long as necessary to meet
     // params.swapchain_depth, or until the next vblank (for vsynced contexts)
     void (*swap_buffers)(struct ra_swapchain *sw);
+
+    // Return the latency at which swap_buffers() is performed. This is in
+    // seconds and always >= 0. Essentially, it's the predicted time the last
+    // shown frame will take until it is actually displayed on the physical
+    // screen. (A reasonable implementation is returning the duration the
+    // last actually displayed frame took after its swap_buffers() was called.)
+    // Should return -1 on error (e.g. discontinuities).
+    // Can be NULL 0 or always return -1 if unsupported.
+    double (*get_latency)(struct ra_swapchain *sw);
 };
 
 // Create and destroy a ra_ctx. This also takes care of creating and destroying

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -84,14 +84,8 @@ struct ra_swapchain_fns {
     // params.swapchain_depth, or until the next vblank (for vsynced contexts)
     void (*swap_buffers)(struct ra_swapchain *sw);
 
-    // Return the latency at which swap_buffers() is performed. This is in
-    // seconds and always >= 0. Essentially, it's the predicted time the last
-    // shown frame will take until it is actually displayed on the physical
-    // screen. (A reasonable implementation is returning the duration the
-    // last actually displayed frame took after its swap_buffers() was called.)
-    // Should return -1 on error (e.g. discontinuities).
-    // Can be NULL 0 or always return -1 if unsupported.
-    double (*get_latency)(struct ra_swapchain *sw);
+    // See vo. Usually called after swap_buffers().
+    void (*get_vsync)(struct ra_swapchain *sw, struct vo_vsync_info *info);
 };
 
 // Create and destroy a ra_ctx. This also takes care of creating and destroying

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -262,6 +262,7 @@ static const struct gl_functions gl_functions[] = {
     },
     {
         .ver_core = 320,
+        .ver_es_core = 300,
         .extension = "GL_ARB_sync",
         .functions = (const struct gl_function[]) {
             DEF_FN(FenceSync),

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -313,9 +313,16 @@ void ra_gl_ctx_swap_buffers(struct ra_swapchain *sw)
     }
 }
 
+static double ra_gl_ctx_get_latency(struct ra_swapchain *sw)
+{
+    struct priv *p = sw->priv;
+    return p->params.get_latency ? p->params.get_latency(sw->ctx) : -1;
+}
+
 static const struct ra_swapchain_fns ra_gl_swapchain_fns = {
     .color_depth   = ra_gl_ctx_color_depth,
     .start_frame   = ra_gl_ctx_start_frame,
     .submit_frame  = ra_gl_ctx_submit_frame,
     .swap_buffers  = ra_gl_ctx_swap_buffers,
+    .get_latency   = ra_gl_ctx_get_latency,
 };

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -313,10 +313,12 @@ void ra_gl_ctx_swap_buffers(struct ra_swapchain *sw)
     }
 }
 
-static double ra_gl_ctx_get_latency(struct ra_swapchain *sw)
+static void ra_gl_ctx_get_vsync(struct ra_swapchain *sw,
+                                struct vo_vsync_info *info)
 {
     struct priv *p = sw->priv;
-    return p->params.get_latency ? p->params.get_latency(sw->ctx) : -1;
+    if (p->params.get_vsync)
+        p->params.get_vsync(sw->ctx, info);
 }
 
 static const struct ra_swapchain_fns ra_gl_swapchain_fns = {
@@ -324,5 +326,5 @@ static const struct ra_swapchain_fns ra_gl_swapchain_fns = {
     .start_frame   = ra_gl_ctx_start_frame,
     .submit_frame  = ra_gl_ctx_submit_frame,
     .swap_buffers  = ra_gl_ctx_swap_buffers,
-    .get_latency   = ra_gl_ctx_get_latency,
+    .get_vsync     = ra_gl_ctx_get_vsync,
 };

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -23,8 +23,8 @@ struct ra_gl_ctx_params {
     // function or if you override it yourself.
     void (*swap_buffers)(struct ra_ctx *ctx);
 
-    // See ra_swapchain_fns.get_latency.
-    double (*get_latency)(struct ra_ctx *ctx);
+    // See ra_swapchain_fns.get_vsync.
+    void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
 
     // Set to false if the implementation follows normal GL semantics, which is
     // upside down. Set to true if it does *not*, i.e. if rendering is right

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -23,6 +23,9 @@ struct ra_gl_ctx_params {
     // function or if you override it yourself.
     void (*swap_buffers)(struct ra_ctx *ctx);
 
+    // See ra_swapchain_fns.get_latency.
+    double (*get_latency)(struct ra_ctx *ctx);
+
     // Set to false if the implementation follows normal GL semantics, which is
     // upside down. Set to true if it does *not*, i.e. if rendering is right
     // side up

--- a/video/out/opengl/context_glx.c
+++ b/video/out/opengl/context_glx.c
@@ -305,10 +305,10 @@ static void glx_swap_buffers(struct ra_ctx *ctx)
         p->latency = update_latency_oml(ctx);
 }
 
-static double glx_get_latency(struct ra_ctx *ctx)
+static void glx_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct priv *p = ctx->priv;
-    return p->latency;
+    info->latency = p->latency;
 }
 
 static bool glx_init(struct ra_ctx *ctx)
@@ -394,7 +394,7 @@ static bool glx_init(struct ra_ctx *ctx)
 
     struct ra_gl_ctx_params params = {
         .swap_buffers = glx_swap_buffers,
-        .get_latency  = glx_get_latency,
+        .get_vsync    = glx_get_vsync,
     };
 
     if (!ra_gl_ctx_init(ctx, gl, params))

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -141,7 +141,6 @@ struct vo_internal {
     double estimated_vsync_jitter;
     bool expecting_vsync;
     int64_t num_successive_vsyncs;
-    double last_vo_latency;
 
     int64_t flip_queue_offset; // queue flip events at most this much in advance
     int64_t timing_offset;     // same (but from options; not VO configured)
@@ -473,18 +472,14 @@ static void vsync_skip_detection(struct vo *vo)
 }
 
 // Always called locked.
-static void update_vsync_timing_after_swap(struct vo *vo)
+static void update_vsync_timing_after_swap(struct vo *vo,
+                                           struct vo_vsync_info *vsync)
 {
     struct vo_internal *in = vo->in;
 
-    int64_t now = mp_time_us();
+    int64_t vsync_time = vsync->last_queue_time;
     int64_t prev_vsync = in->prev_vsync;
-
-    // If we can, use a "made up" expected display time.
-    if (in->last_vo_latency >= 0)
-        now += in->last_vo_latency * (1000.0 * 1000.0);
-
-    in->prev_vsync = now;
+    in->prev_vsync = vsync_time;
 
     if (!in->expecting_vsync) {
         reset_vsync_timings(vo);
@@ -498,13 +493,13 @@ static void update_vsync_timing_after_swap(struct vo *vo)
     if (in->num_vsync_samples >= MAX_VSYNC_SAMPLES)
         in->num_vsync_samples -= 1;
     MP_TARRAY_INSERT_AT(in, in->vsync_samples, in->num_vsync_samples, 0,
-                        now - prev_vsync);
+                        vsync_time - prev_vsync);
     in->drop_point = MPMIN(in->drop_point + 1, in->num_vsync_samples);
     in->num_total_vsync_samples += 1;
     if (in->base_vsync) {
         in->base_vsync += in->vsync_interval;
     } else {
-        in->base_vsync = now;
+        in->base_vsync = vsync_time;
     }
 
     double avg = 0;
@@ -913,17 +908,24 @@ bool vo_render_frame_external(struct vo *vo)
 
         vo->driver->flip_page(vo);
 
-        double latency =
-            vo->driver->get_latency ? vo->driver->get_latency(vo) : -1;
+        struct vo_vsync_info vsync = {
+            .last_queue_time = mp_time_us(),
+            .latency = -1,
+        };
+        if (vo->driver->get_vsync)
+            vo->driver->get_vsync(vo, &vsync);
+
+        // If we can, use a "made up" expected display time.
+        if (vsync.latency >= 0)
+            vsync.last_queue_time += vsync.latency * (1000.0 * 1000.0);
 
         MP_STATS(vo, "end video-flip");
 
         pthread_mutex_lock(&in->lock);
         in->dropped_frame = prev_drop_count < vo->in->drop_count;
         in->rendering = false;
-        in->last_vo_latency = latency;
 
-        update_vsync_timing_after_swap(vo);
+        update_vsync_timing_after_swap(vo, &vsync);
     }
 
     if (vo->driver->caps & VO_CAP_NORETAIN) {

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -374,6 +374,11 @@ struct vo_driver {
      */
     void (*flip_page)(struct vo *vo);
 
+    /*
+     * See struct ra_swapchain. Optional.
+     */
+    double (*get_latency)(struct vo *vo);
+
     /* These optional callbacks can be provided if the GUI framework used by
      * the VO requires entering a message loop for receiving events and does
      * not call vo_wakeup() from a separate thread when there are new events.

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -98,6 +98,13 @@ static void flip_page(struct vo *vo)
     sw->fns->swap_buffers(sw);
 }
 
+static double get_latency(struct vo *vo)
+{
+    struct gpu_priv *p = vo->priv;
+    struct ra_swapchain *sw = p->ctx->swapchain;
+    return sw->fns->get_latency ? sw->fns->get_latency(sw) : -1;
+}
+
 static int query_format(struct vo *vo, int format)
 {
     struct gpu_priv *p = vo->priv;
@@ -326,6 +333,7 @@ const struct vo_driver video_out_gpu = {
     .get_image = get_image,
     .draw_frame = draw_frame,
     .flip_page = flip_page,
+    .get_latency = get_latency,
     .wait_events = wait_events,
     .wakeup = wakeup,
     .uninit = uninit,

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -98,11 +98,12 @@ static void flip_page(struct vo *vo)
     sw->fns->swap_buffers(sw);
 }
 
-static double get_latency(struct vo *vo)
+static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 {
     struct gpu_priv *p = vo->priv;
     struct ra_swapchain *sw = p->ctx->swapchain;
-    return sw->fns->get_latency ? sw->fns->get_latency(sw) : -1;
+    if (sw->fns->get_vsync)
+        sw->fns->get_vsync(sw, info);
 }
 
 static int query_format(struct vo *vo, int format)
@@ -333,7 +334,7 @@ const struct vo_driver video_out_gpu = {
     .get_image = get_image,
     .draw_frame = draw_frame,
     .flip_page = flip_page,
-    .get_latency = get_latency,
+    .get_vsync = get_vsync,
     .wait_events = wait_events,
     .wakeup = wakeup,
     .uninit = uninit,


### PR DESCRIPTION
Since the general problem area was brought up in Issue https://github.com/mpv-player/mpv/issues/6236 I thought I should share my progress of implementing the same for DRM.

This is based on, and includes, a few patches for adding vsync feedback to context_glx using GLX_OML_sync_control from wm4:s branch.

This patchset also includes my patches for moving the pageflip wait in context_drm_egl (#6244), as these changes are based upon those, but shouldn't be considered part of this PR.

TODO: 

- [X] Implement vsync reporting for context_glx (currently lacks support for reporting missed vsyncs)
- [X] Implement vsync reporting for context_drm_egl
- [ ] Change the interface to not use a get_vsync callback, but instead make `update_vsync_timing_after_swap()` public so vo:s can call it at the time which fits them the best. Toggleable in a manner similar to `vo_enable_external_renderloop()` (suggested by @atomnuker)
- [ ] Use the last_skipped_vsyncs field when available (wm4:s patches includes the field, but doesn't do anything with it)
- [ ] Generalize the DRM vsync reporting so parts can be reused between context_drm_egl and vo_drm
- [ ] Generalize the GLX_OML_sync_control code so parts can be reused with eglGetSyncValuesCHROMIUM for EGL (this extension shares the same problems as GLX_OML_sync_control, however)
- [ ] context_glx: Maybe replace GLX_OML_sync_control usage with GLX_INTEL_swap_event?(kind of makes above point pointless, though)
- [ ] Wayland presentation-time protocol (@emersion ?)

I agree that my changes can be relicensed to LGPL 2.1 or later.
