### PR TITLE
osd: allow sub-text to work even if sub-visibility is disabled

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1674,9 +1674,9 @@ Property list
     card is performed. Can also be used for channel switching.
 
 ``sub-text``
-    Return the current subtitle text. Formatting is stripped. If a subtitle
-    is selected, but no text is currently visible, or the subtitle is not
-    text-based (i.e. DVD/BD subtitles), an empty string is returned.
+    Return the current subtitle text regardless of sub visibility.
+    Formatting is stripped. If the subtitle is not text-based
+    (i.e. DVD/BD subtitles), an empty string is returned.
 
     This property is experimental and might be removed in the future.
 

--- a/player/osd.c
+++ b/player/osd.c
@@ -98,7 +98,7 @@ static void term_osd_update(struct MPContext *mpctx)
 
 void term_osd_set_subs(struct MPContext *mpctx, const char *text)
 {
-    if (mpctx->video_out || !text)
+    if (mpctx->video_out || !text || !mpctx->opts->subs_rend->sub_visibility)
         text = ""; // disable
     if (strcmp(mpctx->term_osd_subs ? mpctx->term_osd_subs : "", text) == 0)
         return;

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -345,7 +345,7 @@ char *sub_get_text(struct dec_sub *sub, double pts)
     sub->last_vo_pts = pts;
     update_segment(sub);
 
-    if (opts->sub_visibility && sub->sd->driver->get_text)
+    if (sub->sd->driver->get_text)
         text = sub->sd->driver->get_text(sub->sd, pts);
     pthread_mutex_unlock(&sub->lock);
     return text;


### PR DESCRIPTION
Currently, the `sub-text` property is explicitly disabled if subtitles are not visible. This just lets `sub-text` work regardless of sub visibility and preserves the behavior of subtitles in the terminal.

I agree that my changes can be relicensed to LGPL 2.1 or later.
