### PR TITLE
ipc-unix: don't blow up on readonly fd://

### DIFF
--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -73,7 +73,7 @@ static int ipc_write_str(struct client_arg *client, const char *buf)
             if (rc == 0)
                 return -1;
 
-            if (errno == EBADF) {
+            if (errno == EBADF || errno == ENOTSOCK) {
                 client->writable = false;
                 return 0;
             }


### PR DESCRIPTION
On my system, when trying to use mpv with a read-only fd created by
python 3.7, `send` triggers ENOTSOCK, not EBADF. Extend the logic to
detect non-writable fds by this `errno`.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
