### PR TITLE
x11: fix ICC profiling for multiple monitors

### DIFF
--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -44,6 +44,7 @@ struct xrandr_display {
     double fps;
     char *name;
     bool overlaps;
+    int atom_id;
 };
 
 struct vo_x11_state {


### PR DESCRIPTION
To find the correct ICC profile X atom, the screen number was calculated
directly from the xrandr order of the screens.
But if a primary screen is set, it should be the first Xinerama screen,
even if it is not the first xrandr screen.

Calculate the the proper atom id for each screen.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
