### PR TITLE
Use default LC_CTYPE

### DIFF
--- a/stream/stream_libarchive.c
+++ b/stream/stream_libarchive.c
@@ -242,7 +242,7 @@ struct mp_archive *mp_archive_new(struct mp_log *log, struct stream *src,
 {
     struct mp_archive *mpa = talloc_zero(NULL, struct mp_archive);
     mpa->log = log;
-    mpa->locale = newlocale(LC_ALL_MASK, "C.UTF-8", (locale_t)0);
+    mpa->locale = newlocale(LC_ALL_MASK - LC_CTYPE_MASK, "C", (locale_t)0);
     if (!mpa->locale)
         goto err;
     mpa->arch = archive_read_new();


### PR DESCRIPTION
Suggested by @richfelker and ignored for a year.
Fixes problems with libarchive on systems with libcs which don't support the "C.UTF-8" locale.

I agree that my changes can be relicensed to LGPL 2.1 or later.
