### PR TITLE
filters: Add cuda/nvdec deinterlacing auto-filter using vf_yadif_cuda

### DIFF
--- a/filters/f_auto_filters.c
+++ b/filters/f_auto_filters.c
@@ -75,6 +75,10 @@ static void deint_process(struct mp_filter *f)
     } else if (img->imgfmt == IMGFMT_D3D11) {
         p->sub.filter =
             mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "d3d11vpp", NULL);
+    } else if (img->imgfmt == IMGFMT_CUDA) {
+        char *args[] = {"mode", "send_field", NULL};
+        p->sub.filter =
+            mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "yadif_cuda", args);
     } else if (mp_sws_supports_input(img->imgfmt)) {
         char *args[] = {"mode", "send_field", NULL};
         p->sub.filter =


### PR DESCRIPTION
Historically, there's been no way to offer deinterlacing with nvdec,
and for cuviddec, it required a command line flag, with no way to
toggle while playing.

Now that we have a cuda deinterlacing filter in ffmpeg, we can hook
it up hook it up as the cuda auto-deinterlacer. In practice, this
isn't going to be present very often, due to the licensing mess with
the cuda sdk, but we can support it when it is there.