### PR TITLE
build: add a version requirement for vulkan pkg-config check

### DIFF
--- a/wscript
+++ b/wscript
@@ -807,7 +807,8 @@ video_output_features = [
     }, {
         'name': '--vulkan',
         'desc':  'Vulkan context support',
-        'func': check_pkg_config('vulkan'),
+        # Lowest version tested, Ubuntu 16.04's
+        'func': check_pkg_config('vulkan >= 1.0.61'),
     }, {
         'name': 'egl-helpers',
         'desc': 'EGL helper functions',


### PR DESCRIPTION
`vkGetPhysicalDeviceProperties2KHR` was added in Vulkan 1.0.39,
but 1.0.61 from Ubuntu Xenial (16.04) was the lowest anyone tried
to build mpv with as of late, so we are marking that as the minimum
required version.

This fixes issues arising during build time from having too old
version of vulkan available on a system, instead of causing a failure
to build.