### PR TITLE
cocoa-cb: title bar refactor

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -76,6 +76,8 @@ Interface changes
       network streams should not freeze the player core (only playback in
       uncached regions), and differing behavior should be reported as a bug.
       If --demuxer-thread=no is used, there are no guarantees.
+    - remove `--macos-title-bar-style`, replaced by `--macos-title-bar-material`
+      and `--macos-title-bar-appearance`.
  --- mpv 0.29.0 ---
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4905,6 +4905,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
     :ultraDark:             The standard macOS ultraDark material.
                             (macOS 10.11+ deprecated in macOS 10.14+)
 
+``--macos-title-bar-color=<color>``
+    Sets the color of the title bar (default: completely transparent). Is
+    influenced by ``--macos-title-bar-appearance`` and
+    ``--macos-title-bar-material``.
+    See ``--sub-color`` for color syntax.
+
 ``--macos-fs-animation-duration=<default|0-1000>``
     Sets the fullscreen resize animation duration in ms (default: default).
     The default value is slightly less than the system's animation duration

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4842,17 +4842,68 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     OS X only.
 
-``--macos-title-bar-style=<dark|ultradark|light|mediumlight|auto>``
-    Sets the styling of the title bar (default: dark).
-    OS X and cocoa-cb only
+``--macos-title-bar-appearance=<appearance>``
+    Sets the appearance of the title bar (default: auto). Not all combinations
+    of appearances and ``--macos-title-bar-material`` materials make sense or
+    are unique. Appearances that are not supported by you current macOS version
+    fall back to the default value.
+    macOS and cocoa-cb only
 
-    :dark:        Dark title bar with vibrancy, a subtle blurring effect that
-                  dynamically blends the background (Video) into the title bar.
-    :ultradark:   Darker title bar with vibrancy (like QuickTime Player).
-    :light:       Bright title bar with vibrancy.
-    :mediumlight: Less bright title bar with vibrancy.
-    :auto:        Detects the system settings and sets the title bar styling
-                  appropriately, either ultradark or mediumlight.
+    ``<appearance>`` can be one of the following:
+
+    :auto:                     Detects the system settings and sets the title
+                               bar appearance appropriately. On macOS 10.14 it
+                               also detects run time changes.
+    :aqua:                     The standard macOS Light appearance.
+    :darkAqua:                 The standard macOS Dark appearance. (macOS 10.14+)
+    :vibrantLight:             Light vibrancy appearance with.
+    :vibrantDark:              Dark vibrancy appearance with.
+    :aquaHighContrast:         Light Accessibility appearance. (macOS 10.14+)
+    :darkAquaHighContrast:     Dark Accessibility appearance. (macOS 10.14+)
+    :vibrantLightHighContrast: Light vibrancy Accessibility appearance.
+                               (macOS 10.14+)
+    :vibrantDarkHighContrast:  Dark vibrancy Accessibility appearance.
+                               (macOS 10.14+)
+
+``--macos-title-bar-material=<material>``
+    Sets the material of the title bar (default: titlebar). All deprecated
+    materials should not be used on macOS 10.14+ because their functionality
+    is not guaranteed. Not all combinations of materials and
+    ``--macos-title-bar-appearance`` appearances make sense or are unique.
+    Materials that are not supported by you current macOS version fall back to
+    the default value.
+    macOS and cocoa-cb only
+
+    ``<material>`` can be one of the following:
+
+    :titlebar:              The standard macOS titel bar material.
+    :selection:             The standard macOS selection material.
+    :menu:                  The standard macOS menu material. (macOS 10.11+)
+    :popover:               The standard macOS popover material. (macOS 10.11+)
+    :sidebar:               The standard macOS sidebar material. (macOS 10.11+)
+    :headerView:            The standard macOS header view material.
+                            (macOS 10.14+)
+    :sheet:                 The standard macOS sheet material. (macOS 10.14+)
+    :windowBackground:      The standard macOS window background material.
+                            (macOS 10.14+)
+    :hudWindow:             The standard macOS hudWindow material. (macOS 10.14+)
+    :fullScreen:            The standard macOS full screen material.
+                            (macOS 10.14+)
+    :toolTip:               The standard macOS tool tip material. (macOS 10.14+)
+    :contentBackground:     The standard macOS content background material.
+                            (macOS 10.14+)
+    :underWindowBackground: The standard macOS under window background material.
+                            (macOS 10.14+)
+    :underPageBackground:   The standard macOS under page background material.
+                            (deprecated in macOS 10.14+)
+    :dark:                  The standard macOS dark material.
+                            (deprecated in macOS 10.14+)
+    :light:                 The standard macOS light material.
+                            (macOS 10.14+)
+    :mediumLight:           The standard macOS mediumLight material.
+                            (macOS 10.11+, deprecated in macOS 10.14+)
+    :ultraDark:             The standard macOS ultraDark material.
+                            (macOS 10.11+ deprecated in macOS 10.14+)
 
 ``--macos-fs-animation-duration=<default|0-1000>``
     Sets the fullscreen resize animation duration in ms (default: default).

--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -56,6 +56,8 @@ class MPVHelper: NSObject {
         mpv_observe_property(mpvHandle, 0, "border", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "keepaspect-window", MPV_FORMAT_FLAG)
         mpv_observe_property(mpvHandle, 0, "macos-title-bar-style", MPV_FORMAT_STRING)
+        mpv_observe_property(mpvHandle, 0, "macos-title-bar-appearance", MPV_FORMAT_STRING)
+        mpv_observe_property(mpvHandle, 0, "macos-title-bar-material", MPV_FORMAT_STRING)
     }
 
     func initRender() {

--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -58,6 +58,7 @@ class MPVHelper: NSObject {
         mpv_observe_property(mpvHandle, 0, "macos-title-bar-style", MPV_FORMAT_STRING)
         mpv_observe_property(mpvHandle, 0, "macos-title-bar-appearance", MPV_FORMAT_STRING)
         mpv_observe_property(mpvHandle, 0, "macos-title-bar-material", MPV_FORMAT_STRING)
+        mpv_observe_property(mpvHandle, 0, "macos-title-bar-color", MPV_FORMAT_STRING)
     }
 
     func initRender() {

--- a/osdep/macOS_swift_extensions.swift
+++ b/osdep/macOS_swift_extensions.swift
@@ -56,3 +56,16 @@ extension NSScreen {
         }
     }
 }
+
+extension NSColor {
+
+    convenience init(hex: String) {
+        let int = Int(hex.dropFirst(), radix: 16)
+        let alpha = CGFloat((int! >> 24) & 0x000000FF)/255
+        let red   = CGFloat((int! >> 16) & 0x000000FF)/255
+        let green = CGFloat((int! >> 8)  & 0x000000FF)/255
+        let blue  = CGFloat((int!)       & 0x000000FF)/255
+
+        self.init(calibratedRed: red, green: green, blue: blue, alpha: alpha)
+    }
+}

--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -22,6 +22,8 @@
 
 struct macos_opts {
     int macos_title_bar_style;
+    int macos_title_bar_appearance;
+    int macos_title_bar_material;
     int macos_fs_animation_duration;
     int cocoa_cb_sw_renderer;
 };

--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -19,11 +19,13 @@
 #define MPV_MACOSX_APPLICATION
 
 #include "osdep/macosx_menubar.h"
+#include "options/m_option.h"
 
 struct macos_opts {
     int macos_title_bar_style;
     int macos_title_bar_appearance;
     int macos_title_bar_material;
+    struct m_color macos_title_bar_color;
     int macos_fs_animation_duration;
     int cocoa_cb_sw_renderer;
 };

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -57,6 +57,7 @@ const struct m_sub_options macos_conf = {
                     {"underWindowBackground", 12}, {"underPageBackground", 13},
                     {"dark", 14}, {"light", 15}, {"mediumLight", 16},
                     {"ultraDark", 17})),
+        OPT_COLOR("macos-title-bar-color", macos_title_bar_color, 0),
         OPT_CHOICE_OR_INT("macos-fs-animation-duration",
                           macos_fs_animation_duration, 0, 0, 1000,
                           ({"default", -1})),
@@ -68,6 +69,7 @@ const struct m_sub_options macos_conf = {
     },
     .size = sizeof(struct macos_opts),
     .defaults = &(const struct macos_opts){
+        .macos_title_bar_color = {0, 0, 0, 0},
         .macos_fs_animation_duration = -1,
         .cocoa_cb_sw_renderer = -1,
     },

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -43,14 +43,27 @@
 #define OPT_BASE_STRUCT struct macos_opts
 const struct m_sub_options macos_conf = {
     .opts = (const struct m_option[]) {
-        OPT_CHOICE("macos-title-bar-style", macos_title_bar_style, 0,
-                   ({"dark", 0}, {"ultradark", 1}, {"light", 2},
-                    {"mediumlight", 3}, {"auto", 4})),
+        OPT_CHOICE("macos-title-bar-appearance", macos_title_bar_appearance, 0,
+                   ({"auto", 0}, {"aqua", 1}, {"darkAqua", 2},
+                    {"vibrantLight", 3}, {"vibrantDark", 4},
+                    {"aquaHighContrast", 5}, {"darkAquaHighContrast", 6},
+                    {"vibrantLightHighContrast", 7},
+                    {"vibrantDarkHighContrast", 8})),
+        OPT_CHOICE("macos-title-bar-material", macos_title_bar_material, 0,
+                   ({"titlebar", 0}, {"selection", 1}, {"menu", 2},
+                    {"popover", 3}, {"sidebar", 4}, {"headerView", 5},
+                    {"sheet", 6}, {"windowBackground", 7}, {"hudWindow", 8},
+                    {"fullScreen", 9}, {"toolTip", 10}, {"contentBackground", 11},
+                    {"underWindowBackground", 12}, {"underPageBackground", 13},
+                    {"dark", 14}, {"light", 15}, {"mediumLight", 16},
+                    {"ultraDark", 17})),
         OPT_CHOICE_OR_INT("macos-fs-animation-duration",
                           macos_fs_animation_duration, 0, 0, 1000,
                           ({"default", -1})),
         OPT_CHOICE("cocoa-cb-sw-renderer", cocoa_cb_sw_renderer, 0,
                    ({"auto", -1}, {"no", 0}, {"yes", 1})),
+        OPT_REMOVED("macos-title-bar-style", "Split into --macos-title-bar-appearance "
+                     "and --macos-title-bar-material"),
         {0}
     },
     .size = sizeof(struct macos_opts),

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -106,14 +106,14 @@ class EventsView: NSView {
         if mpv.getBoolProperty("input-cursor") {
             cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_LEAVE, 0)
         }
-        cocoaCB.window.hideTitleBar()
+        cocoaCB.titleBar.hide()
     }
 
     override func mouseMoved(with event: NSEvent) {
         if mpv != nil && mpv.getBoolProperty("input-cursor") {
             signalMouseMovement(event)
         }
-        cocoaCB.window.showTitleBar()
+        cocoaCB.titleBar.show()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -231,7 +231,7 @@ class EventsView: NSView {
         let menuBarHeight = NSApp.mainMenu!.menuBarHeight
 
         if cocoaCB.window.isInFullscreen && (menuBarHeight > 0) {
-            topMargin = cocoaCB.window.titleBarHeight + 1 + menuBarHeight
+            topMargin = TitleBar.height + 1 + menuBarHeight
         }
 
         guard var vF = window?.screen?.frame else { return false }
@@ -243,8 +243,8 @@ class EventsView: NSView {
 
         var clippedBounds = bounds.intersection(vFV)
         if !cocoaCB.window.isInFullscreen {
-            clippedBounds.origin.y += cocoaCB.window.titleBarHeight
-            clippedBounds.size.height -= cocoaCB.window.titleBarHeight
+            clippedBounds.origin.y += TitleBar.height
+            clippedBounds.size.height -= TitleBar.height
         }
         return clippedBounds.contains(pt)
     }

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -93,12 +93,17 @@ class TitleBar: NSVisualEffectView {
             effect = style as! String
         }
 
-        if effect == "auto" {
-            let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-            effect = systemStyle == nil ? "mediumlight" : "ultradark"
-        }
-
         switch effect {
+        case "auto":
+             if #available(macOS 10.14, *) {
+                 cocoaCB.window.appearance = nil
+                 material = .titlebar
+                 state = .followsWindowActiveState
+             } else {
+                 let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+                 effect = systemStyle == nil ? "mediumlight" : "ultradark"
+                 setStyle(effect)
+             }
         case "mediumlight":
             cocoaCB.window.appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
             material = .titlebar

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -62,12 +62,14 @@ class TitleBar: NSVisualEffectView {
         autoresizingMask = [.viewWidthSizable, .viewMinYMargin]
         systemBar.alphaValue = 0
         state = .followsWindowActiveState
+        wantsLayer = true
 
         window.contentView!.addSubview(self, positioned: .above, relativeTo: nil)
         window.titlebarAppearsTransparent = true
         window.styleMask.insert(.fullSizeContentView)
         set(appearance: Int(mpv.macOpts!.macos_title_bar_appearance))
         set(material: Int(mpv.macOpts!.macos_title_bar_material))
+        set(color: mpv.macOpts!.macos_title_bar_color)
     }
 
     // catch these events so they are not propagated to the underlying view
@@ -105,6 +107,20 @@ class TitleBar: NSVisualEffectView {
             self.material = materialFrom(string: String(material as! Int))
         } else {
             self.material = materialFrom(string: material as! String)
+        }
+    }
+
+    func set(color: Any) {
+        if color is String {
+            layer?.backgroundColor = NSColor(hex: color as! String).cgColor
+        } else {
+            let col = color as! m_color
+            let red   = CGFloat(col.r)/255
+            let green = CGFloat(col.g)/255
+            let blue  = CGFloat(col.b)/255
+            let alpha = CGFloat(col.a)/255
+            layer?.backgroundColor = NSColor(calibratedRed: red, green: green,
+                                             blue: blue, alpha: alpha).cgColor
         }
     }
 

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -1,0 +1,165 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+class TitleBar: NSVisualEffectView {
+
+    weak var cocoaCB: CocoaCB! = nil
+    var mpv: MPVHelper! {
+        get { return cocoaCB == nil ? nil : cocoaCB.mpv }
+    }
+
+    var systemBar: NSView {
+        get { return (cocoaCB.window.standardWindowButton(.closeButton)?.superview)! }
+    }
+    static var height: CGFloat {
+        get { return NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled).size.height }
+    }
+    var buttons: [NSButton] {
+        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindowButton]).flatMap { cocoaCB.window.standardWindowButton($0) } }
+    }
+
+    convenience init(frame: NSRect, window: NSWindow, cocoaCB ccb: CocoaCB) {
+        let f = NSMakeRect(0, frame.size.height - TitleBar.height,
+                           frame.size.width, TitleBar.height)
+        self.init(frame: f)
+        cocoaCB = ccb
+        alphaValue = 0
+        blendingMode = .withinWindow
+        autoresizingMask = [.viewWidthSizable, .viewMinYMargin]
+        systemBar.alphaValue = 0
+
+        window.contentView!.addSubview(self, positioned: .above, relativeTo: nil)
+        window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
+        setStyle(Int(mpv.macOpts!.macos_title_bar_style))
+    }
+
+    // catch these events so they are not propagated to the underlying view
+    override func mouseDown(with event: NSEvent) { }
+
+    override func mouseUp(with event: NSEvent) {
+        if event.clickCount > 1 {
+            let def = UserDefaults.standard
+            var action = def.string(forKey: "AppleActionOnDoubleClick")
+
+            // macOS 10.10 and earlier
+            if action == nil {
+                action = def.bool(forKey: "AppleMiniaturizeOnDoubleClick") == true ?
+                    "Minimize" : "Maximize"
+            }
+
+            if action == "Minimize" {
+                cocoaCB.window.miniaturize(self)
+            } else if action == "Maximize" {
+                cocoaCB.window.zoom(self)
+            }
+        }
+    }
+
+    func setStyle(_ style: Any) {
+        var effect: String
+
+        if style is Int {
+            switch style as! Int {
+            case 4:
+                effect = "auto"
+            case 3:
+                effect = "mediumlight"
+            case 2:
+                effect = "light"
+            case 1:
+                effect = "ultradark"
+            case 0: fallthrough
+            default:
+                effect = "dark"
+            }
+        } else {
+            effect = style as! String
+        }
+
+        if effect == "auto" {
+            let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+            effect = systemStyle == nil ? "mediumlight" : "ultradark"
+        }
+
+        switch effect {
+        case "mediumlight":
+            cocoaCB.window.appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
+            material = .titlebar
+            state = .followsWindowActiveState
+        case "light":
+            cocoaCB.window.appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
+            material = .light
+            state = .active
+        case "ultradark":
+            cocoaCB.window.appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
+            material = .titlebar
+            state = .followsWindowActiveState
+        case "dark": fallthrough
+        default:
+            cocoaCB.window.appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
+            material = .dark
+            state = .active
+        }
+    }
+
+    func show() {
+        if (!cocoaCB.window.border && !cocoaCB.window.isInFullscreen) { return }
+        let loc = cocoaCB.view.convert(cocoaCB.window.mouseLocationOutsideOfEventStream, from: nil)
+
+        buttons.forEach { $0.isHidden = false }
+        NSAnimationContext.runAnimationGroup({ (context) -> Void in
+            context.duration = 0.20
+            systemBar.animator().alphaValue = 1
+            if !cocoaCB.window.isInFullscreen && !cocoaCB.window.isAnimating {
+                animator().alphaValue = 1
+                isHidden = false
+            }
+        }, completionHandler: nil )
+
+        if loc.y > TitleBar.height {
+            hideDelayed()
+        } else {
+            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(hide), object: nil)
+        }
+    }
+
+    func hide() {
+        if cocoaCB.window.isInFullscreen && !cocoaCB.window.isAnimating {
+            alphaValue = 0
+            isHidden = true
+            return
+        }
+        NSAnimationContext.runAnimationGroup({ (context) -> Void in
+            context.duration = 0.20
+            systemBar.animator().alphaValue = 0
+            animator().alphaValue = 0
+        }, completionHandler: {
+            self.buttons.forEach { $0.isHidden = true }
+            self.isHidden = true
+        })
+    }
+
+    func hideDelayed() {
+        NSObject.cancelPreviousPerformRequests(withTarget: self,
+                                                 selector: #selector(hide),
+                                                   object: nil)
+        perform(#selector(hide), with: nil, afterDelay: 0.5)
+    }
+}

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -17,31 +17,6 @@
 
 import Cocoa
 
-class CustomTtitleBar: NSVisualEffectView {
-
-    // catch these events so they are not propagated to the underlying view
-    override func mouseDown(with event: NSEvent) { }
-
-    override func mouseUp(with event: NSEvent) {
-        if event.clickCount > 1 {
-            let def = UserDefaults.standard
-            var action = def.string(forKey: "AppleActionOnDoubleClick")
-
-            // macOS 10.10 and earlier
-            if action == nil {
-                action = def.bool(forKey: "AppleMiniaturizeOnDoubleClick") == true ?
-                    "Minimize" : "Maximize"
-            }
-
-            if action == "Minimize" {
-                window!.miniaturize(self)
-            } else if action == "Maximize" {
-                window!.zoom(self)
-            }
-        }
-    }
-}
-
 class Window: NSWindow, NSWindowDelegate {
 
     weak var cocoaCB: CocoaCB! = nil
@@ -75,18 +50,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     var border: Bool = true {
-        didSet { if !border { hideTitleBar() } }
-    }
-
-    var titleBarEffect: NSVisualEffectView?
-    var titleBar: NSView {
-        get { return (standardWindowButton(.closeButton)?.superview)! }
-    }
-    var titleBarHeight: CGFloat {
-        get { return NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled).size.height }
-    }
-    var titleButtons: [NSButton] {
-        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindowButton]).flatMap { standardWindowButton($0) } }
+        didSet { if !border { cocoaCB.titleBar.hide() } }
     }
 
     override var canBecomeKey: Bool { return true }
@@ -119,7 +83,6 @@ class Window: NSWindow, NSWindowDelegate {
         targetScreen = screen!
         currentScreen = screen!
         unfScreen = screen!
-        initTitleBar()
 
         if let app = NSApp as? Application {
             app.menuBar.register(#selector(setHalfWindowSize), for: MPM_H_SIZE)
@@ -128,115 +91,6 @@ class Window: NSWindow, NSWindowDelegate {
             app.menuBar.register(#selector(performMiniaturize(_:)), for: MPM_MINIMIZE)
             app.menuBar.register(#selector(performZoom(_:)), for: MPM_ZOOM)
         }
-    }
-
-    func initTitleBar() {
-        var f = contentView!.bounds
-        f.origin.y = f.size.height - titleBarHeight
-        f.size.height = titleBarHeight
-
-        styleMask.insert(.fullSizeContentView)
-        titleBar.alphaValue = 0
-        titlebarAppearsTransparent = true
-        titleBarEffect = CustomTtitleBar(frame: f)
-        titleBarEffect!.alphaValue = 0
-        titleBarEffect!.blendingMode = .withinWindow
-        titleBarEffect!.autoresizingMask = [.viewWidthSizable, .viewMinYMargin]
-
-        setTitleBarStyle(Int(mpv.macOpts!.macos_title_bar_style))
-        contentView!.addSubview(titleBarEffect!, positioned: .above, relativeTo: nil)
-    }
-
-    func setTitleBarStyle(_ style: Any) {
-        var effect: String
-
-        if style is Int {
-            switch style as! Int {
-            case 4:
-                effect = "auto"
-            case 3:
-                effect = "mediumlight"
-            case 2:
-                effect = "light"
-            case 1:
-                effect = "ultradark"
-            case 0: fallthrough
-            default:
-                effect = "dark"
-            }
-        } else {
-            effect = style as! String
-        }
-
-        if effect == "auto" {
-            let systemStyle = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
-            effect = systemStyle == nil ? "mediumlight" : "ultradark"
-        }
-
-        switch effect {
-        case "mediumlight":
-            appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
-            titleBarEffect!.material = .titlebar
-            titleBarEffect!.state = .followsWindowActiveState
-        case "light":
-            appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
-            titleBarEffect!.material = .light
-            titleBarEffect!.state = .active
-        case "ultradark":
-            appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
-            titleBarEffect!.material = .titlebar
-            titleBarEffect!.state = .followsWindowActiveState
-        case "dark": fallthrough
-        default:
-            appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
-            titleBarEffect!.material = .dark
-            titleBarEffect!.state = .active
-        }
-    }
-
-    func showTitleBar() {
-        if titleBarEffect == nil || (!border && !isInFullscreen) { return }
-        let loc = cocoaCB.view.convert(mouseLocationOutsideOfEventStream, from: nil)
-
-        titleButtons.forEach { $0.isHidden = false }
-        NSAnimationContext.runAnimationGroup({ (context) -> Void in
-            context.duration = 0.20
-            titleBar.animator().alphaValue = 1
-            if !isInFullscreen && !isAnimating {
-                titleBarEffect!.animator().alphaValue = 1
-                titleBarEffect!.isHidden = false
-            }
-        }, completionHandler: nil )
-
-        if loc.y > titleBarHeight {
-            hideTitleBarDelayed()
-        } else {
-            NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(hideTitleBar), object: nil)
-        }
-    }
-
-    func hideTitleBar() {
-        if titleBarEffect == nil { return }
-        if isInFullscreen && !isAnimating {
-            titleBarEffect!.alphaValue = 0
-            titleBarEffect!.isHidden = true
-            return
-        }
-        NSAnimationContext.runAnimationGroup({ (context) -> Void in
-            context.duration = 0.20
-            titleBar.animator().alphaValue = 0
-            titleBarEffect!.animator().alphaValue = 0
-        }, completionHandler: {
-            self.titleButtons.forEach { $0.isHidden = true }
-            self.titleBarEffect!.isHidden = true
-        })
-    }
-
-    func hideTitleBarDelayed() {
-        NSObject.cancelPreviousPerformRequests(withTarget: self,
-                                                 selector: #selector(hideTitleBar),
-                                                   object: nil)
-        perform(#selector(hideTitleBar), with: nil, afterDelay: 0.5)
     }
 
     override func toggleFullScreen(_ sender: Any?) {
@@ -288,7 +142,7 @@ class Window: NSWindow, NSWindowDelegate {
 
     func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenWithDuration duration: TimeInterval) {
         cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFit
-        hideTitleBar()
+        cocoaCB.titleBar.hide()
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
             context.duration = getFsAnimationDuration(duration - 0.05)
             window.animator().setFrame(targetScreen!.frame, display: true)
@@ -299,7 +153,7 @@ class Window: NSWindow, NSWindowDelegate {
         let newFrame = calculateWindowPosition(for: targetScreen!, withoutBounds: targetScreen == screen)
         let intermediateFrame = aspectFit(rect: newFrame, in: screen!.frame)
         cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFill
-        hideTitleBar()
+        cocoaCB.titleBar.hide()
         styleMask.remove(.fullScreen)
         setFrame(intermediateFrame, display: true)
 
@@ -314,7 +168,7 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
         cocoaCB.updateCusorVisibility()
         endAnimation(frame)
-        showTitleBar()
+        cocoaCB.titleBar.show()
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -516,6 +516,10 @@ class CocoaCB: NSObject {
             if let data = MPVHelper.mpvStringArrayToString(property.data) {
                 titleBar.set(material: data)
             }
+        case "macos-title-bar-color":
+            if let data = MPVHelper.mpvStringArrayToString(property.data) {
+                titleBar.set(color: data)
+            }
         default:
             break
         }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -508,9 +508,13 @@ class CocoaCB: NSObject {
             if let data = MPVHelper.mpvFlagToBool(property.data) {
                 window.keepAspect = data
             }
-        case "macos-title-bar-style":
+        case "macos-title-bar-appearance":
             if let data = MPVHelper.mpvStringArrayToString(property.data) {
-                titleBar.setStyle(data)
+                titleBar.set(appearance: data)
+            }
+        case "macos-title-bar-material":
+            if let data = MPVHelper.mpvStringArrayToString(property.data) {
+                titleBar.set(material: data)
             }
         default:
             break

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -22,6 +22,7 @@ class CocoaCB: NSObject {
 
     var mpv: MPVHelper!
     var window: Window!
+    var titleBar: TitleBar!
     var view: EventsView!
     var layer: VideoLayer!
     var link: CVDisplayLink?
@@ -99,6 +100,8 @@ class CocoaCB: NSObject {
         window.keepAspect = Bool(opts.keepaspect_window)
         window.title = title
         window.border = Bool(opts.border)
+
+        titleBar = TitleBar(frame: wr, window: window, cocoaCB: self)
 
         window.isRestorable = false
         window.makeMain()
@@ -507,7 +510,7 @@ class CocoaCB: NSObject {
             }
         case "macos-title-bar-style":
             if let data = MPVHelper.mpvStringArrayToString(property.data) {
-                window.setTitleBarStyle(data)
+                titleBar.setStyle(data)
             }
         default:
             break

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -436,7 +436,6 @@ class CocoaCB: NSObject {
             return VO_TRUE
         case VOCTRL_UPDATE_WINDOW_TITLE:
             let titleData = data!.assumingMemoryBound(to: Int8.self)
-            let title = String(cString: titleData)
             DispatchQueue.main.async {
                 ccb.title = String(cString: titleData)
             }

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -168,6 +168,7 @@ def build(ctx):
             ( "video/out/cocoa-cb/events_view.swift" ),
             ( "video/out/cocoa-cb/video_layer.swift" ),
             ( "video/out/cocoa-cb/window.swift" ),
+            ( "video/out/cocoa-cb/title_bar.swift" ),
             ( "video/out/cocoa_cb_common.swift" ),
         ]
 


### PR DESCRIPTION
`cocoa-cb: add support for mac 10.14 Dark mode and run time switching` provides everything PR #5995 does besides the run time switching on macOS earlier than 10.14, because Apple only added official support for it on the newest macOS version. see my comments on the other PR. it's also a bit simpler. that commit could theoretically be removed/merged since it's basically completely refactored in the next commit.

i decided to refactor the title bar styling completely because Apple broke and changed the majority of the stylings, so styling names and the actual look didn't match anymore. i removed the old option and added two new instead, that way the user has more freedom and it's hopefully a bit more future proof. not all combinations of appearances and materials make sense, some are probably redundant atm and some shouldn't even used/combined because they make the title bar unreadable. though i don't think it's our responsibility to filter out bad combinations because i picked reasonable defaults and the user should know what they are doing.

even though i was against adding custom colours to the title bar i was still asked a few times and decided to add them. after all i made the title bar styling a lot more extensive anyway.