### PR TITLE
vo_gpu: vulkan: Always use KHR suffix types and defines

### DIFF
--- a/video/out/vulkan/malloc.c
+++ b/video/out/vulkan/malloc.c
@@ -136,9 +136,9 @@ static struct vk_slab *slab_alloc(struct mpvk_ctx *vk, struct vk_heap *heap,
 #if HAVE_WIN32_DESKTOP
         .handleTypes = IsWindows8OrGreater()
 		? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR
-		: VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT,
+		: VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR,
 #else
-        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT,
+        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR,
 #endif
     };
 
@@ -158,8 +158,8 @@ static struct vk_slab *slab_alloc(struct mpvk_ctx *vk, struct vk_heap *heap,
         for (int i = 0; i < vk->num_pools; i++)
             qfs[i] = vk->pools[i]->qf;
 
-        VkExternalMemoryBufferCreateInfo ebinfo = {
-            .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO,
+        VkExternalMemoryBufferCreateInfoKHR ebinfo = {
+            .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR,
             .handleTypes = eminfo.handleTypes,
         };
 

--- a/video/out/vulkan/ra_vk.c
+++ b/video/out/vulkan/ra_vk.c
@@ -951,7 +951,7 @@ static bool ra_vk_mem_get_external_info(struct ra *ra, struct vk_memslice *mem, 
         .memory = mem->vkmem,
         .handleType = IsWindows8OrGreater()
             ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR
-            : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT,
+            : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR,
     };
 
     VK_LOAD_PFN(vkGetMemoryWin32HandleKHR);

--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -333,12 +333,12 @@ bool mpvk_get_phys_device_uuid(struct mpvk_ctx *vk, uint8_t uuid_out[VK_UUID_SIZ
 {
     assert(vk->physd);
 
-    VkPhysicalDeviceIDProperties idprops = {
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES,
+    VkPhysicalDeviceIDPropertiesKHR idprops = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHR,
     };
 
-    VkPhysicalDeviceProperties2 props = {
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
+    VkPhysicalDeviceProperties2KHR props = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR,
         .pNext = &idprops,
     };
 


### PR DESCRIPTION
I was inconsistent about this originally, as the functionality was
moved into the core spec in 1.1 and so both suffixed and unsuffixed
versions of everything exist and can be mixed together.

There's no reason to fail to build with 1.0.39+ so I'm fixing the
names.