### PR TITLE
drm_common: Add option to toggle use of atomic modesetting

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -488,6 +488,14 @@ Available video output drivers are:
         Mode ID to use (resolution and frame rate).
         (default: 0)
 
+    ``--drm-atomic=<no|auto>``
+        Toggle use of atomic modesetting. Mostly useful for debugging.
+
+        :no:    Use legacy modesetting.
+        :auto:  Use atomic modesetting, falling back to legacy modesetting if not available. (default)
+
+        Note: Only affects ``gpu-context=drm``. ``vo=drm`` supports legacy modesetting only.
+
     ``--drm-osd-plane-id=<number>``
         Select the DRM plane index to use for OSD (or OSD and video).
         Index is zero based, and related to crtc.

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -48,6 +48,7 @@ struct vt_switcher {
 struct drm_opts {
     char *drm_connector_spec;
     int drm_mode_id;
+    int drm_atomic;
     int drm_osd_plane_id;
     int drm_video_plane_id;
     int drm_format;
@@ -65,7 +66,8 @@ void vt_switcher_release(struct vt_switcher *s, void (*handler)(void*),
                          void *user_data);
 
 struct kms *kms_create(struct mp_log *log, const char *connector_spec,
-                       int mode_id, int osd_plane_id, int video_plane_id);
+                       int mode_id, int osd_plane_id, int video_plane_id,
+                       bool use_atomic);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -456,7 +456,7 @@ static void drm_egl_swap_buffers(struct ra_ctx *ctx)
             MP_WARN(ctx->vo, "Failed to commit atomic request (%d)\n", ret);
     } else {
         ret = drmModePageFlip(p->kms->fd, p->kms->crtc_id, p->fb->id,
-                                  DRM_MODE_PAGE_FLIP_EVENT, p);
+                              DRM_MODE_PAGE_FLIP_EVENT, p);
         if (ret) {
             MP_WARN(ctx->vo, "Failed to queue page flip: %s\n", mp_strerror(errno));
         }
@@ -587,7 +587,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     p->kms = kms_create(ctx->log, ctx->vo->opts->drm_opts->drm_connector_spec,
                         ctx->vo->opts->drm_opts->drm_mode_id,
                         ctx->vo->opts->drm_opts->drm_osd_plane_id,
-                        ctx->vo->opts->drm_opts->drm_video_plane_id);
+                        ctx->vo->opts->drm_opts->drm_video_plane_id,
+                        ctx->vo->opts->drm_opts->drm_atomic);
     if (!p->kms) {
         MP_ERR(ctx, "Failed to create KMS.\n");
         return false;

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -417,11 +417,10 @@ static int preinit(struct vo *vo)
         MP_WARN(vo, "Failed to set up VT switcher. Terminal switching will be unavailable.\n");
     }
 
-    p->kms = kms_create(
-        vo->log, vo->opts->drm_opts->drm_connector_spec,
-                 vo->opts->drm_opts->drm_mode_id,
-                 vo->opts->drm_opts->drm_osd_plane_id,
-                 vo->opts->drm_opts->drm_video_plane_id);
+    p->kms = kms_create(vo->log,
+                        vo->opts->drm_opts->drm_connector_spec,
+                        vo->opts->drm_opts->drm_mode_id,
+                        0, 0, false);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");
         goto err;


### PR DESCRIPTION
It is useful when debugging to be able to force atomic off, or as a
workaround if atomic breaks for some user for whatever reason.

I agree that my changes can be relicensed to LGPL 2.1 or later.
