### PR TITLE
[WIP] context_drm_egl: Implement triple buffering

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -262,6 +262,7 @@ static const struct gl_functions gl_functions[] = {
     },
     {
         .ver_core = 320,
+        .ver_es_core = 300,
         .extension = "GL_ARB_sync",
         .functions = (const struct gl_function[]) {
             DEF_FN(FenceSync),

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -248,7 +248,7 @@ bool ra_gl_ctx_submit_frame(struct ra_swapchain *sw, const struct vo_frame *fram
     if (p->opts->use_glfinish)
         gl->Finish();
 
-    if (gl->FenceSync && !p->params.external_swapchain) {
+    if (gl->FenceSync && !p->params.disable_vsync_fences) {
         GLsync fence = gl->FenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
         if (fence)
             MP_TARRAY_APPEND(p, p->vsync_fences, p->num_vsync_fences, fence);

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -28,9 +28,13 @@ struct ra_gl_ctx_params {
     // side up
     bool flipped;
 
+    // Set to true to disable the software simulation of --swapchain-depth. Only
+    // relevant if both ra_gl_ctx_submit_frame and ra_gl_ctx_submit_frame are
+    // called (directly or indirectly) as part of the swapchain.
+    bool disable_vsync_fences;
+
     // If this is set to non-NULL, then the ra_gl_ctx will consider the GL
-    // implementation to be using an external swapchain, which disables the
-    // software simulation of --swapchain-depth. Any functions defined by this
+    // implementation to be using an external swapchain. Any functions defined by this
     // ra_swapchain_fns structs will entirely replace the equivalent ra_gl_ctx
     // functions in the resulting ra_swapchain.
     const struct ra_swapchain_fns *external_swapchain;

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -606,6 +606,7 @@ static bool angle_init(struct ra_ctx *ctx)
         .swap_buffers = angle_swap_buffers,
         .flipped = p->flipped,
         .external_swapchain = p->dxgi_swapchain ? &dxgi_swapchain_fns : NULL,
+        .disable_vsync_fences = true,
     };
 
     if (!ra_gl_ctx_init(ctx, gl, params))

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -544,6 +544,14 @@ static void drm_egl_uninit(struct ra_ctx *ctx)
     if (p->vt_switcher_active)
         vt_switcher_destroy(&p->vt_switcher);
 
+    // According to GBM documentation all BO:s must be released before
+    // gbm_surface_destroy can be called on the surface.
+    for (unsigned int i = MP_ARRAY_SIZE(p->gbm.bo); i != 0; --i) {
+        struct gbm_bo *bo = p->gbm.bo[i-1];
+        if (bo)
+            gbm_surface_release_buffer(p->gbm.surface, bo);
+    }
+
     eglMakeCurrent(p->egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                    EGL_NO_CONTEXT);
     eglDestroyContext(p->egl.display, p->egl.context);

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -552,11 +552,10 @@ static bool dxgl_init(struct ra_ctx *ctx)
     if (d3d_size_dependent_create(ctx) < 0)
         goto fail;
 
-    static const struct ra_swapchain_fns empty_swapchain_fns = {0};
     struct ra_gl_ctx_params params = {
         .swap_buffers = dxgl_swap_buffers,
         .flipped = true,
-        .external_swapchain = &empty_swapchain_fns,
+        .disable_vsync_fences = true,
     };
 
     if (!ra_gl_ctx_init(ctx, gl, params))

--- a/video/out/opengl/context_vdpau.c
+++ b/video/out/opengl/context_vdpau.c
@@ -323,6 +323,7 @@ static bool vdpau_init(struct ra_ctx *ctx)
     struct ra_gl_ctx_params params = {
         .swap_buffers = vdpau_swap_buffers,
         .external_swapchain = &vdpau_swapchain,
+        .disable_vsync_fences = true,
         .flipped = true,
     };
 

--- a/video/out/opengl/libmpv_gl.c
+++ b/video/out/opengl/libmpv_gl.c
@@ -40,15 +40,13 @@ static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
         .allow_sw = true,
     };
 
-    static const struct ra_swapchain_fns empty_swapchain_fns = {0};
     struct ra_gl_ctx_params gl_params = {
         // vo_opengl_cb is essentially like a gigantic external swapchain where
         // the user is in charge of presentation / swapping etc. But we don't
         // actually need to provide any of these functions, since we can just
-        // not call them to begin with - so just set it to an empty object to
-        // signal to ra_gl_p that we don't care about its latency emulation
-        // functionality
-        .external_swapchain = &empty_swapchain_fns
+        // not call them to begin with - so set disable_vsync_fences to signal
+        // to ra_gl_p that we don't care about its latency emulation functionality
+        .disable_vsync_fences = true,
     };
 
     p->gl->SwapInterval = NULL; // we shouldn't randomly change this, so lock it


### PR DESCRIPTION
This PR replaces #6244.

This series of commits implements triple buffering for gpu-context=drm, bringing its performance in line with gpu-context=x11 and gpu-context=x11egl.

Since I found that the fences in `video/out/opengl/context.c` was quite important to synchronize things, this also includes a few fixes to make sure we can have them when:
- OpenGL ES 3.0+ is being used (supports fencing, but the code for it was missing)
- That the use of the fences/latency emulation can be toggled independently of having an external_swapchain

I agree that my changes can be relicensed to LGPL 2.1 or later.
