### PR TITLE
cocoa: fix drawing on macOS 10.14

### DIFF
--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -46,6 +46,12 @@
     return self;
 }
 
+- (void)drawRect:(NSRect)rect
+{
+    [[NSColor blackColor] setFill];
+    NSRectFill(rect);
+}
+
 // mpv uses flipped coordinates, because X11 uses those. So let's just use them
 // as well without having to do any coordinate conversion of mouse positions.
 - (BOOL)isFlipped { return YES; }


### PR DESCRIPTION
filling both NSViews with any colour fixes the blank screen on macOS 10.14. though i have no bloody clue why it does that.

anyway i deprecated the cocoa backend and don't really care, though if we want to keep it (even if just for reference) it should at least draw something.

there are still all the other various issues. on resize the content behind the window flickers through and i am not sure if this is a new or old issue.