### PR TITLE
vo_gpu: vulkan: only rotate the queues on swap

### DIFF
--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -796,12 +796,6 @@ error:
 
     vk->num_cmds_queued = 0;
 
-    // Rotate the queues to ensure good parallelism across frames
-    for (int i = 0; i < vk->num_pools; i++) {
-        struct vk_cmdpool *pool = vk->pools[i];
-        pool->idx_queues = (pool->idx_queues + 1) % pool->num_queues;
-    }
-
     return ret;
 }
 


### PR DESCRIPTION
Makes performance slightly better when using multiple queues by avoiding
unnecessary semaphores due to bad queue selection.

Also remove an aeons-old workaround for an nvidia bug that only ever
existed in the earliest beta vulkan drivers anyway.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
