### PR TITLE
vo_gpu: opengl: disable compute shaders for old GLSL

### DIFF
--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -124,6 +124,12 @@ static int ra_init_gl(struct ra *ra, GL *gl)
     if (gl->BlitFramebuffer)
         ra->caps |= RA_CAP_BLIT;
 
+    // Disable compute shaders for GLSL < 420. This work-around is needed since
+    // some buggy OpenGL drivers expose compute shaders for lower GLSL versions,
+    // despite the spec requiring 420+.
+    if (ra->glsl_version < 420)
+        ra->caps &= ~RA_CAP_COMPUTE;
+
     int gl_fmt_features = gl_format_feature_flags(gl);
 
     for (int n = 0; gl_formats[n].internal_format; n++) {


### PR DESCRIPTION
Fixes #6272.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
