### PR TITLE
Fix vulkan validation errors in CUDA/Vulkan Interop

### DIFF
--- a/video/out/opengl/hwdec_cuda.c
+++ b/video/out/opengl/hwdec_cuda.c
@@ -424,6 +424,7 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
             .d = 1,
             .format = format,
             .render_src = true,
+            .host_mutable = p_owner->is_vk,
             .src_linear = format->linear_filter,
         };
 

--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -192,6 +192,7 @@ bool mpvk_instance_init(struct mpvk_ctx *vk, struct mp_log *log,
 
     // Enable whatever extensions were compiled in.
     const char *extensions[] = {
+        VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
         VK_KHR_SURFACE_EXTENSION_NAME,
         surf_ext_name,


### PR DESCRIPTION
After running with gpu debugging, I found two validation errors in the current cuda/vulkan interop.