### PR TITLE
Support HiDPI on Windows

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2533,10 +2533,10 @@ Window
         - ``--monitoraspect=16:9`` or ``--monitoraspect=1.7777``
 
 ``--hidpi-window-scale``, ``--no-hidpi-window-scale``
-    (OS X and X11 only)
+    (OS X, Windows and X11 only)
     Scale the window size according to the backing scale factor (default: yes).
     On regular HiDPI resolutions the window opens with double the size but appears
-    as having the same size as on none-HiDPI resolutions. This is the default OS X
+    as having the same size as on non-HiDPI resolutions. This is the default OS X
     behavior.
 
 ``--native-fs``, ``--no-native-fs``

--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -10,6 +10,7 @@
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings xmlns:ws="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
             <ws:dpiAware>True/PM</ws:dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
         </windowsSettings>
     </application>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -68,6 +68,7 @@ typedef enum MONITOR_DPI_TYPE {
 struct w32_api {
     HRESULT (WINAPI *pGetDpiForMonitor)(HMONITOR, MONITOR_DPI_TYPE, UINT*, UINT*);
     BOOL (WINAPI *pImmDisableIME)(DWORD);
+    BOOL (WINAPI *pAdjustWindowRectExForDpi)(LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle, UINT dpi);
 };
 
 struct vo_w32_state {
@@ -108,6 +109,7 @@ struct vo_w32_state {
     uint32_t o_dheight;
 
     int dpi;
+    double dpi_scale;
 
     bool disable_screensaver;
     bool cursor_visible;
@@ -146,16 +148,25 @@ struct vo_w32_state {
     HANDLE avrt_handle;
 };
 
-static void add_window_borders(HWND hwnd, RECT *rc)
+static void add_window_borders(struct vo_w32_state *w32, HWND hwnd, RECT *rc)
 {
-    AdjustWindowRect(rc, GetWindowLongPtrW(hwnd, GWL_STYLE), 0);
+    if (w32->api.pAdjustWindowRectExForDpi)
+        w32->api.pAdjustWindowRectExForDpi(
+            rc,
+            GetWindowLongPtrW(hwnd, GWL_STYLE),
+            0,
+            GetWindowLongPtrW(hwnd, GWL_EXSTYLE),
+            w32->dpi
+            );
+    else
+        AdjustWindowRect(rc, GetWindowLongPtrW(hwnd, GWL_STYLE), 0);
 }
 
 // basically a reverse AdjustWindowRect (win32 doesn't appear to have this)
-static void subtract_window_borders(HWND hwnd, RECT *rc)
+static void subtract_window_borders(struct vo_w32_state *w32, HWND hwnd, RECT *rc)
 {
     RECT b = { 0, 0, 0, 0 };
-    add_window_borders(hwnd, &b);
+    add_window_borders(w32, hwnd, &b);
     rc->left -= b.left;
     rc->top -= b.top;
     rc->right -= b.right;
@@ -521,16 +532,19 @@ static void update_dpi(struct vo_w32_state *w32)
     if (w32->api.pGetDpiForMonitor && w32->api.pGetDpiForMonitor(w32->monitor,
                                      MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK) {
         w32->dpi = (int)dpiX;
+        w32->dpi_scale = w32->opts->hidpi_window_scale ? w32->dpi / 96.0 : 1.0;
         MP_VERBOSE(w32, "DPI detected from the new API: %d\n", w32->dpi);
         return;
     }
     HDC hdc = GetDC(NULL);
     if (hdc) {
         w32->dpi = GetDeviceCaps(hdc, LOGPIXELSX);
+        w32->dpi_scale = w32->opts->hidpi_window_scale ? w32->dpi / 96.0 : 1.0;
         ReleaseDC(NULL, hdc);
         MP_VERBOSE(w32, "DPI detected from the old API: %d\n", w32->dpi);
     } else {
         w32->dpi = 96;
+        w32->dpi_scale = 1.0;
         MP_VERBOSE(w32, "Couldn't determine DPI, falling back to %d\n", w32->dpi);
     }
 }
@@ -816,7 +830,7 @@ static void fit_window_on_screen(struct vo_w32_state *w32)
 
     RECT screen = get_working_area(w32);
     if (w32->opts->border && w32->opts->fit_border)
-        subtract_window_borders(w32->window, &screen);
+        subtract_window_borders(w32, w32->window, &screen);
 
     if (fit_rect(&w32->windowrc, &screen)) {
         MP_VERBOSE(w32, "adjusted window bounds: %d:%d:%d:%d\n",
@@ -872,7 +886,7 @@ static void update_window_state(struct vo_w32_state *w32)
         return;
 
     RECT wr = w32->windowrc;
-    add_window_borders(w32->window, &wr);
+    add_window_borders(w32, w32->window, &wr);
 
     SetWindowPos(w32->window, w32->opts->ontop ? HWND_TOPMOST : HWND_NOTOPMOST,
                  wr.left, wr.top, rect_w(wr), rect_h(wr),
@@ -1003,7 +1017,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             // get client area of the windows if it had the rect rc
             // (subtracting the window borders)
             RECT r = *rc;
-            subtract_window_borders(w32->window, &r);
+            subtract_window_borders(w32, w32->window, &r);
             int c_w = rect_w(r), c_h = rect_h(r);
             float aspect = w32->o_dwidth / (float) MPMAX(w32->o_dheight, 1);
             int d_w = c_h * aspect - c_w;
@@ -1298,7 +1312,7 @@ static void gui_thread_reconfig(void *ptr)
     struct mp_rect screen = { r.left, r.top, r.right, r.bottom };
     struct vo_win_geometry geo;
 
-    vo_calc_window_geometry(vo, &screen, &geo);
+    vo_calc_window_geometry2(vo, &screen, w32->dpi_scale, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     bool reset_size = w32->o_dwidth != vo->dwidth ||
@@ -1353,6 +1367,11 @@ static void w32_api_load(struct vo_w32_state *w32)
     // Available since Win8.1
     w32->api.pGetDpiForMonitor = !shcore_dll ? NULL :
                 (void *)GetProcAddress(shcore_dll, "GetDpiForMonitor");
+
+    HMODULE user32_dll = LoadLibraryW(L"user32.dll");
+    // Available since Win10
+    w32->api.pAdjustWindowRectExForDpi = !user32_dll ? NULL :
+                (void *)GetProcAddress(user32_dll, "AdjustWindowRectExForDpi");
 
     // imm32.dll must be loaded dynamically
     // to account for machines without East Asian language support


### PR DESCRIPTION
I am running mpv on a retina display through RDC sometimes (yeahyreah I know...). That sets up the win10 session to be HiDPI (at 192dpi, or 2.0 x 96dpi).
Since the mpv manifest already defines `dpiAware` there is no scaling, including no scaling of the non-client areas. So the video small, but also the title bar is small.

This PR adds `dpiAwareness` for win10 PerMonitorV2 awareness, passes the scale factor into `vo_calc_window_geometry2` and also corrects the calculation of the borders in case PerMonitorV2 is active.

I agree that my changes can be relicensed to LGPL 2.1 or later.
