### PR TITLE
vo_gpu: d3d11: add support for exclusive fullscreen

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5158,6 +5158,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
     use of compute shaders over fragment shaders wherever possible. Enabled by
     default, although Nvidia users may want to disable it.
 
+``--d3d11-exclusive-fs=<yes|no>``
+    Switches the D3D11 swap chain fullscreen state to 'fullscreen' when
+    fullscreen video is requested. Also known as "exclusive fullscreen" or
+    "D3D fullscreen" in other applications. Gives mpv full control of
+    rendering on the swap chain's screen. Off by default.
+
 ``--d3d11-warp=<yes|no|auto>``
     Use WARP (Windows Advanced Rasterization Platform) with the D3D11 GPU
     backend (default: auto). This is a high performance software renderer. By


### PR DESCRIPTION
Picked up from @rossy's box o' nifty features.

Lets the application fully control the rendering onto the screen
instead of the compositor.

Test build [here](https://kuroko.fushizen.eu/mpv_binaries/2018-11-19T22-13-mpv-git-f7d921d892-exclusive_fs.7z).