### PR TITLE
build: minor swift build changes

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -1,6 +1,7 @@
 from waftools import inflector
 from waftools.checks.generic import *
 from waflib import Utils
+from distutils.version import StrictVersion
 import os
 
 __all__ = ["check_pthreads", "check_iconv", "check_lua",
@@ -114,9 +115,8 @@ def check_cocoa(ctx, dependency_identifier):
 
 def check_swift(ctx, dependency_identifier):
     if ctx.env.SWIFT_VERSION:
-        major = int(ctx.env.SWIFT_VERSION.split('.')[0])
         ctx.add_optional_message(dependency_identifier,
-                                 'version found: ' + ctx.env.SWIFT_VERSION)
-        if major >= 3:
+                                 'version found: ' + str(ctx.env.SWIFT_VERSION))
+        if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("3.0"):
             return True
     return False

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -114,9 +114,13 @@ def check_cocoa(ctx, dependency_identifier):
     return res
 
 def check_swift(ctx, dependency_identifier):
+    minVer = StrictVersion("3.0")
     if ctx.env.SWIFT_VERSION:
-        ctx.add_optional_message(dependency_identifier,
-                                 'version found: ' + str(ctx.env.SWIFT_VERSION))
-        if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("3.0"):
+        if StrictVersion(ctx.env.SWIFT_VERSION) >= minVer:
+            ctx.add_optional_message(dependency_identifier,
+                                     'version found: ' + str(ctx.env.SWIFT_VERSION))
             return True
+    ctx.add_optional_message(dependency_identifier,
+                             "'swift >= " + str(minVer) + "' not found, found " +
+                             str(ctx.env.SWIFT_VERSION or None))
     return False

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -114,7 +114,7 @@ def check_cocoa(ctx, dependency_identifier):
     return res
 
 def check_swift(ctx, dependency_identifier):
-    minVer = StrictVersion("3.0")
+    minVer = StrictVersion("3.0.2")
     if ctx.env.SWIFT_VERSION:
         if StrictVersion(ctx.env.SWIFT_VERSION) >= minVer:
             ctx.add_optional_message(dependency_identifier,

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -1,5 +1,6 @@
 import re
 from waflib import Utils
+from distutils.version import StrictVersion
 
 def __run(cmd):
     try:
@@ -15,12 +16,11 @@ def __add_swift_flags(ctx):
         "-target", "x86_64-apple-macosx10.10"
     ]
 
-    ver = re.compile("(?i)version\s?([\d.]+)")
-    ctx.env.SWIFT_VERSION = ver.search(__run([ctx.env.SWIFT, '-version'])).group(1)
-    major, minor = [int(n) for n in ctx.env.SWIFT_VERSION.split('.')[:2]]
+    verRe = re.compile("(?i)version\s?([\d.]+)")
+    ctx.env.SWIFT_VERSION = verRe.search(__run([ctx.env.SWIFT, '-version'])).group(1)
 
     # the -swift-version parameter is only supported on swift 3.1 and newer
-    if major >= 3 and minor >= 1 or major >= 4:
+    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("3.1"):
         ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "3" ])
 
     if ctx.is_debug_build():


### PR DESCRIPTION
i didn't really like the version check and decided to use an undocumented class (StrictVersion) from [distutils.version](https://svn.python.org/projects/python/trunk/Lib/distutils/version.py). it's used by many other projects too, though i am not quite sure about the current state ([PEP386](https://www.python.org/dev/peps/pep-0386/) and [PEP440](https://www.python.org/dev/peps/pep-0440/)). apparently a replacement was planned but never merged since 2014? wasn't sure if we want it in.

the second commit adjusts the swift check output message to match the rest, eg in the form of `no ('lib >= lib_min_ver' not found)` when failing, additional it outputs the found version. the latter because it makes debugging easier for me.

the last one is just a minor version bump to the needed swift version. i was a fool to assume it would just work with any 3.0.x swift version.

i could squash all the commits, but thought this way might be better so we exactly know what changed.

tested everything with python 2 and 3.