### PR TITLE
man: fix --watch-later-directory formatting

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -427,7 +427,6 @@ Program Behavior
     the player with Shift+Q.
 
 ``--watch-later-directory=<path>``
-
     The directory in which to store the "watch later" temporary files.
 
     The default is a subdirectory named "watch_later" underneath the


### PR DESCRIPTION
Extra line prevents the sub-title formatting.
Removing it, the option is formatted like the others.

With extra line:
![image](https://user-images.githubusercontent.com/6820963/48972101-8b3c1d00-f02c-11e8-8491-278d82f2a670.png)