### PR TITLE
command: notify on multiply

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -4151,6 +4151,7 @@ static bool is_property_set(int action, void *val)
     case M_PROPERTY_SWITCH:
     case M_PROPERTY_SET_STRING:
     case M_PROPERTY_SET_NODE:
+    case M_PROPERTY_MULTIPLY:
         return true;
     case M_PROPERTY_KEY_ACTION: {
         struct m_property_action_arg *key = val;


### PR DESCRIPTION
doing multiply on a property is also a set property command
and the change should be notified so others can observe the change

For example, without this lua scripts cannot observe when volume changes.