### PR TITLE
cocoa-cb: report precise vsyncs with a high precision timer

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4909,6 +4909,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     OS X only.
 
+``--cocoa-cb-precise-timer=<yes|no>``
+    Use a high precision timer to report vsyncs (default: yes). This will reduce
+    vsync jitter but slightly increases CPU usage.
+
+    OS X only.
+
 ``--macos-title-bar-style=<dark|ultradark|light|mediumlight|auto>``
     Sets the styling of the title bar (default: dark).
     OS X and cocoa-cb only

--- a/osdep/macOS_precise_timer.swift
+++ b/osdep/macOS_precise_timer.swift
@@ -1,0 +1,141 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+class PreciseTimer {
+
+    weak var cocoaCB: CocoaCB!
+    var mpv: MPVHelper! {
+        get { return cocoaCB == nil ? nil : cocoaCB.mpv }
+    }
+
+    let condition = NSCondition()
+    var events: [[String:Any]] = []
+    var timebaseRatio: Double = 1.0
+    var isRunning: Bool = true
+    var isHighPrecision: Bool = false
+
+    var thread: pthread_t?
+    var threadPort: thread_port_t? = nil
+    let typeNumber: mach_msg_type_number_t
+    let policyFlavor = thread_policy_flavor_t(THREAD_TIME_CONSTRAINT_POLICY)
+    let policyCount = MemoryLayout<thread_time_constraint_policy>.size /
+                          MemoryLayout<integer_t>.size
+
+    init(cocoaCB ccb: CocoaCB) {
+        cocoaCB = ccb
+        var timebase: mach_timebase_info = mach_timebase_info()
+        var attr: pthread_attr_t = pthread_attr_t()
+        var param: sched_param = sched_param()
+        mach_timebase_info(&timebase)
+        pthread_attr_init(&attr)
+
+        typeNumber = mach_msg_type_number_t(policyCount)
+        timebaseRatio = (Double(timebase.numer) / Double(timebase.denom)) / CVGetHostClockFrequency()
+        param.sched_priority = sched_get_priority_max(SCHED_FIFO)
+        pthread_attr_setschedparam(&attr, &param)
+        pthread_attr_setschedpolicy(&attr, SCHED_FIFO)
+        pthread_create(&thread, &attr, entryC, MPVHelper.bridge(obj: self))
+        threadPort = pthread_mach_thread_np(thread!)
+    }
+
+    func updatePolicy(refreshRate: Double = 60.0) {
+        let period = UInt32(1.0 / refreshRate / timebaseRatio)
+        var policy = thread_time_constraint_policy(
+            period: period,
+            computation: UInt32(200000),
+            constraint:  period / 10,
+            preemptible: 1
+        )
+
+        let success = withUnsafeMutablePointer(to: &policy) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: policyCount) {
+                thread_policy_set(threadPort!, policyFlavor, $0, typeNumber)
+            }
+        }
+
+        isHighPrecision = success == KERN_SUCCESS
+        if !isHighPrecision {
+            mpv.sendWarning("Couldn't create a high precision timer")
+        }
+    }
+
+    func terminate() {
+        condition.lock()
+        isRunning = false
+        condition.signal()
+        condition.unlock()
+        pthread_kill(thread!, SIGALRM)
+        pthread_join(thread!, nil)
+    }
+
+    func scheduleAt(time: UInt64, closure: @escaping () -> () ) {
+        condition.lock()
+        let firstEventTime = events.first?["time"] as? UInt64 ?? 0
+        let lastEventTime = events.last?["time"] as? UInt64 ?? 0
+        events.append(["time": time, "closure": closure])
+
+        if lastEventTime > time {
+            events.sort{ ($0["time"] as! UInt64) < ($1["time"] as! UInt64) }
+        }
+
+        condition.signal()
+        condition.unlock()
+
+        if firstEventTime > time {
+            pthread_kill(thread!, SIGALRM)
+        }
+    }
+
+    let threadSignal: @convention(c) (Int32) -> () = { (sig: Int32) in }
+
+    let entryC: @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? = { (ptr: UnsafeMutableRawPointer) in
+        let ptimer: PreciseTimer = MPVHelper.bridge(ptr: ptr)
+        ptimer.entry()
+        return nil
+    }
+
+    func entry() {
+        signal(SIGALRM, threadSignal)
+
+        while isRunning {
+            condition.lock()
+            while events.count == 0 && isRunning {
+                condition.wait()
+            }
+
+            if !isRunning { break }
+
+            let event = events.first
+            condition.unlock()
+
+            let time = event?["time"] as! UInt64
+            let closure = event?["closure"] as! () -> ()
+
+            mach_wait_until(time)
+
+            condition.lock()
+            if (events.first?["time"] as! UInt64) == time && isRunning {
+                closure()
+                events.removeFirst()
+            }
+            condition.unlock()
+        }
+    }
+
+}

--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -24,6 +24,7 @@ struct macos_opts {
     int macos_title_bar_style;
     int macos_fs_animation_duration;
     int cocoa_cb_sw_renderer;
+    int cocoa_cb_precise_timer;
 };
 
 // multithreaded wrapper for mpv_main

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -51,12 +51,14 @@ const struct m_sub_options macos_conf = {
                           ({"default", -1})),
         OPT_CHOICE("cocoa-cb-sw-renderer", cocoa_cb_sw_renderer, 0,
                    ({"auto", -1}, {"no", 0}, {"yes", 1})),
+        OPT_FLAG("cocoa-cb-precise-timer", cocoa_cb_precise_timer, 0),
         {0}
     },
     .size = sizeof(struct macos_opts),
     .defaults = &(const struct macos_opts){
         .macos_fs_animation_duration = -1,
         .cocoa_cb_sw_renderer = -1,
+        .cocoa_cb_precise_timer = 1,
     },
 };
 

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -164,6 +164,7 @@ def build(ctx):
     if ctx.dependency_satisfied('macos-cocoa-cb'):
         swift_source = [
             ( "osdep/macOS_mpv_helper.swift" ),
+            ( "osdep/macOS_precise_timer.swift" ),
             ( "video/out/cocoa-cb/events_view.swift" ),
             ( "video/out/cocoa-cb/video_layer.swift" ),
             ( "video/out/cocoa-cb/window.swift" ),


### PR DESCRIPTION
i conducted thorough [tests](https://github.com/Akemi/macos_precise_timing_tests) with various timers and concluded this setup is the most precise with reasonable CPU usage. the CPU usage increase within mpv is between 0% and 0.3% on a logical core. imo quite reasonable.

before, on a ~60hz display with a ~24fps video the usual vsync-jitter was between 0.027 and 0.032 on my system. with the new precise timer the jitter decreased to 0.002 to 0.003. which is at least 10 times as good as before.

using for example asyncAfter with a dedicated high priority DispatchQueue leads to around 0.055 vsync-jitter, which is double of what we have right now. on a side note, it also has a weird issue with grouping timely close events when idling (see my tests).