### PR TITLE
add --watch-later-blacklist-properties

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -432,6 +432,19 @@ Program Behavior
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
+``--watch-later-blacklist-properties=<property1,property2,...>``
+    Prevents the listed properties from being saved in the "watch later" files.
+    Existing watch later data won't be modified and will still be applied
+    fully, but new watch later data won't contain these properties.
+
+    .. admonition:: Examples
+
+        - ``--watch-later-blacklist-properties=fullscreen``
+          Resuming a file won't restore the fullscreen state.
+        - ``--watch-later-blacklist-properties=volume,mute``
+          Resuming a file won't restore the volume or mute state.
+    
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/options/options.c
+++ b/options/options.c
@@ -632,6 +632,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("write-filename-in-watch-later-config", write_filename_in_watch_later_config, 0),
     OPT_FLAG("ignore-path-in-watch-later-config", ignore_path_in_watch_later_config, 0),
     OPT_STRING("watch-later-directory", watch_later_directory, M_OPT_FILE),
+    OPT_STRINGLIST("watch-later-blacklist-properties", watch_later_blacklist_properties, 0),
 
     OPT_FLAG("ordered-chapters", ordered_chapters, 0),
     OPT_STRING("ordered-chapters-files", ordered_chapters_files, M_OPT_FILE),

--- a/options/options.h
+++ b/options/options.h
@@ -247,6 +247,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
+    char **watch_later_blacklist_properties;
     int pause;
     int keep_open;
     int keep_open_pause;

--- a/player/core.h
+++ b/player/core.h
@@ -276,6 +276,7 @@ typedef struct MPContext {
     int quit_custom_rc;
     bool has_quit_custom_rc;
     char **resume_defaults;
+    bool *resume_blacklist;
 
     // Global file statistics
     int files_played;       // played without issues (even if stopped by user)


### PR DESCRIPTION
--watch-later-blacklist-properties=<property1,property2,...>

Prevents the listed properties from being saved in the "watch later" files.
Existing watch later data won't be modified and will still be applied
fully, but new watch later data won't contain these properties.

This is motivated by me thinking it silly for fullscreen state to be preserved.  It also addresses https://github.com/mpv-player/mpv/issues/4641

I agree that my changes can be relicensed to LGPL 2.1 or later.
