### PR TITLE
vd_lavc: increase the possible length of the hwdec name

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -132,7 +132,7 @@ const struct m_sub_options vd_lavc_conf = {
 
 struct hwdec_info {
     char name[64];
-    char method_name[16]; // non-unique name describing the hwdec method
+    char method_name[24]; // non-unique name describing the hwdec method
     const AVCodec *codec; // implemented by this codec
     enum AVHWDeviceType lavc_device; // if not NONE, get a hwdevice
     bool copying; // if true, outputs sw frames, or copy to sw ourselves


### PR DESCRIPTION
yeah i found it kinda unexpected that i had to use `videotoolbox-co`. first i thought the copy modes just didn't work on my end because of that. `--hwdec=help` showed `videotoolbox-co` and the manual says `videotoolbox-copy`.

i don't know if there was a reason for the 16 char length? i arbitrarily increased the size by 8 since 16 was also a multiple of 8 too.