### PR TITLE
demux: make ALBUM ReplayGain tags optional when using libavformat

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1326,8 +1326,10 @@ Audio
     Since mpv 0.18.1, this always controls the internal mixer (aka "softvol").
 
 ``--replaygain=<no|track|album>``
-    Adjust volume gain according to the track-gain or album-gain replaygain
-    value stored in the file metadata (default: no replaygain).
+    Adjust volume gain according to replaygain values stored in the file
+    metadata. With ``--replaygain=no`` (the default), perform no adjustment.
+    With ``--replaygain=track``, apply track gain. With ``--replaygain=album``,
+    apply album gain if present and fall back to track gain otherwise.
 
 ``--replaygain-preamp=<db>``
     Pre-amplification gain in dB to apply to the selected replaygain gain

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -1946,12 +1946,17 @@ static struct replaygain_data *decode_rgain(struct mp_log *log,
 {
     struct replaygain_data rg = {0};
 
+    // Set values in *rg, using track gain as a fallback for album gain if the
+    // latter is not present. This behavior matches that in demux/demux_lavf.c's
+    // export_replaygain; if you change this, please make equivalent changes
+    // there too.
     if (decode_gain(log, tags, "REPLAYGAIN_TRACK_GAIN", &rg.track_gain) >= 0 &&
         decode_peak(log, tags, "REPLAYGAIN_TRACK_PEAK", &rg.track_peak) >= 0)
     {
         if (decode_gain(log, tags, "REPLAYGAIN_ALBUM_GAIN", &rg.album_gain) < 0 ||
             decode_peak(log, tags, "REPLAYGAIN_ALBUM_PEAK", &rg.album_peak) < 0)
         {
+            // Album gain is undefined; fall back to track gain.
             rg.album_gain = rg.track_gain;
             rg.album_peak = rg.track_peak;
         }

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2004 Michael Niedermayer <michaelni@gmx.at>
+ * Copyright (C) 2018 Google LLC
  *
  * This file is part of mpv.
  *
@@ -561,17 +562,27 @@ static void export_replaygain(demuxer_t *demuxer, struct sh_stream *sh,
         av_rgain = (AVReplayGain*)src_sd->data;
         rgain    = talloc_ptrtype(demuxer, rgain);
 
-        rgain->track_gain = (av_rgain->track_gain != INT32_MIN) ?
-            av_rgain->track_gain / 100000.0f : 0.0;
+        // Set values in *rgain, using track gain as a fallback for album gain
+        // if the latter is not present. This behavior matches that in
+        // demux/demux.c's decode_rgain; if you change this, please make
+        // equivalent changes there too.
+        if (av_rgain->track_gain != INT32_MIN && av_rgain->track_peak != 0.0) {
+            // Track gain is defined.
+            rgain->track_gain = av_rgain->track_gain / 100000.0f;
+            rgain->track_peak = av_rgain->track_peak / 100000.0f;
 
-        rgain->track_peak = (av_rgain->track_peak != 0.0) ?
-            av_rgain->track_peak / 100000.0f : 1.0;
-
-        rgain->album_gain = (av_rgain->album_gain != INT32_MIN) ?
-            av_rgain->album_gain / 100000.0f : 0.0;
-
-        rgain->album_peak = (av_rgain->album_peak != 0.0) ?
-            av_rgain->album_peak / 100000.0f : 1.0;
+            if (av_rgain->album_gain != INT32_MIN &&
+                av_rgain->album_peak != 0.0)
+            {
+                // Album gain is also defined.
+                rgain->album_gain = av_rgain->album_gain / 100000.0f;
+                rgain->album_peak = av_rgain->album_peak / 100000.0f;
+            } else {
+                // Album gain is undefined; fall back to track gain.
+                rgain->album_gain = rgain->track_gain;
+                rgain->album_peak = rgain->track_peak;
+            }
+        }
 
         // This must be run only before the stream was added, otherwise there
         // will be race conditions with accesses from the user thread.


### PR DESCRIPTION
I agree that my changes can be relicensed to LGPL 2.1 or later.