### PR TITLE
vo_gpu: improve tone mapping desaturation

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -47,6 +47,12 @@ Interface changes
     - support for `--spirv-compiler=nvidia` has been removed, leaving `shaderc`
       as the only option. The `--spirv-compiler` option itself has been marked
       as deprecated, and may be removed in the future.
+    - split up `--tone-mapping-desaturate`` into strength + exponent, instead of
+      only using a single value (which previously just controlled the exponent).
+      The strength now linearly blends between the desaturated and non-desaturated
+      versions of a color.
+    - add `--tone-mapping-per-channel`, which allows users to enable the
+      "hollywood" style of tone mapping.
  --- mpv 0.29.0 ---
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5233,6 +5233,16 @@ The following video options are currently all specific to ``--vo=gpu`` and
     linear
         Specifies the scale factor to use while stretching. Defaults to 1.0.
 
+``--tone-mapping-per-channel``
+    Enabling this option (default: no) does tone-mapping per channel instead
+    of linearly. Per-channel tone mapping tends to distort overly bright
+    colors towards white, unless they're sufficiently close to the primaries.
+    If you prefer the "Hollywood" look, enabling this option might improve the
+    aesthetic result of tone mapping at the cost of colorimetric accuracy.
+
+    When enabling this option, it's strongly recommended to also disable
+    ``--tone-mapping-desaturate``.
+
 ``--hdr-compute-peak=<auto|yes|no>``
     Compute the HDR peak and frame average brightness per-frame instead of
     relying on tagged metadata. These values are averaged over local regions as
@@ -5243,17 +5253,23 @@ The following video options are currently all specific to ``--vo=gpu`` and
     The special value ``auto`` (default) will enable HDR peak computation
     automatically if compute shaders and SSBOs are supported.
 
-``--tone-mapping-desaturate=<value>``
-    Apply desaturation for highlights. The parameter essentially controls the
-    steepness of the desaturation curve. The higher the parameter, the more
-    aggressively colors will be desaturated. This setting helps prevent
-    unnaturally blown-out colors for super-highlights, by (smoothly) turning
-    into white instead. This makes images feel more natural, at the cost of
-    reducing information about out-of-range colors.
+``--tone-mapping-desaturate=<0.0..1.0>``
+    Apply desaturation for highlights. The parameter controls the strength of
+    the desaturation curve. A value of 0.0 completely disables it, while a
+    value of 1.0 means that overly bright colors will be completely white.
+    Values in between apply progressively more/less aggressive desaturation.
+    This setting helps prevent unnaturally blown-out colors for
+    super-highlights, by (smoothly) turning them into white instead. This makes
+    images feel more natural, at the cost of reducing information about
+    out-of-range colors. The default value of 0.5 provides a good balance.
 
-    The default of 0.5 provides a good balance. This value is weaker than the
-    ACES ODT curves' recommendation, but works better for most content in
-    practice. A setting of 0.0 disables this option.
+``--tone-mapping-desaturate-exponent=<value>``
+    This setting controls the exponent of the desaturation curve, which
+    controls how bright a color needs to be in order to start being
+    desaturated. The default of 20.0 provides a reasonable balance. This value
+    is weaker than the ACES ODT curves' recommendation, but works better for
+    most content in practice. Decreasing this exponent makes the curve more
+    aggressive.
 
 ``--gamut-warning``
     If enabled, mpv will mark all clipped/out-of-gamut pixels that exceed a

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -98,6 +98,16 @@ enum tone_mapping {
 // How many frames to average over for HDR peak detection
 #define PEAK_DETECT_FRAMES 63
 
+struct gl_tone_map_opts {
+    int curve;
+    float curve_param;
+    int compute_peak;
+    float desat;
+    float desat_exp;
+    int per_channel; // bool
+    int gamut_warning; // bool
+};
+
 struct gl_video_opts {
     int dumb_mode;
     struct scaler_config scaler[4];
@@ -107,11 +117,7 @@ struct gl_video_opts {
     int target_prim;
     int target_trc;
     int target_peak;
-    int tone_mapping;
-    int compute_hdr_peak;
-    float tone_mapping_param;
-    float tone_mapping_desat;
-    int gamut_warning;
+    struct gl_tone_map_opts tone_map;
     int correct_downscaling;
     int linear_downscaling;
     int linear_upscaling;

--- a/video/out/gpu/video_shaders.h
+++ b/video/out/gpu/video_shaders.h
@@ -40,11 +40,9 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
 void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 void pass_delinearize(struct gl_shader_cache *sc, enum mp_csp_trc trc);
 
-void pass_color_map(struct gl_shader_cache *sc,
+void pass_color_map(struct gl_shader_cache *sc, bool is_linear,
                     struct mp_colorspace src, struct mp_colorspace dst,
-                    enum tone_mapping algo, float tone_mapping_param,
-                    float tone_mapping_desat, bool use_detected_peak,
-                    bool gamut_warning, bool is_linear);
+                    const struct gl_tone_map_opts *opts);
 
 void pass_sample_deband(struct gl_shader_cache *sc, struct deband_opts *opts,
                         AVLFG *lfg, enum mp_csp_trc trc);


### PR DESCRIPTION
We split up the desaturation algorithm into strength and exponent, which
allows users to use less aggressive desaturation settings without
affecting the overall curve.

We also allow using "hollywood" style (per channel) desaturation instead
of our linear tone mapping, by adding --tone-mapping-per-channel.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
