### PR TITLE
Fix url detection to conform to RFC3986

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -37,6 +37,7 @@
 #include "mpv_talloc.h"
 #include "osdep/io.h"
 #include "osdep/path.h"
+#include "misc/ctype.h"
 
 // In order of decreasing priority: the first has highest priority.
 static const mp_get_platform_path_cb path_resolvers[] = {
@@ -315,12 +316,15 @@ bool mp_is_url(bstr path)
     int proto = bstr_find0(path, "://");
     if (proto < 1)
         return false;
-    // The protocol part must be alphanumeric, otherwise it's not an URL.
+    // Per RFC3986, the first character of the protocol must be alphanumeric, 
+    // the rest must be alphanumeric plus - + and .
     for (int i = 0; i < proto; i++) {
         unsigned char c = path.start[i];
-        if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') &&
-            !(c >= '0' && c <= '9') && c != '_')
+        if ((i == 0 && !mp_isalpha(c)) ||
+            (!mp_isalnum(c) && c != '.' && c != '-' && c != '+'))
+        {
             return false;
+        }
     }
     return true;
 }


### PR DESCRIPTION
According to [the RFC](https://tools.ietf.org/html/rfc3986#section-3.1), the scheme ('protocol') portion of a URI is allowed to contain the characters +, -, and .   (However the first character must be a letter.)

This probably isn't really a big deal, but in the unlikely case that somebody tries to use a URI containing +, - or ., strange things can currently happen such as:
```

    local playlist = {"#EXTM3U"}
    table.insert(playlist,"#EXTINF:0,wood fish")
    table.insert(playlist,"https://www.youtube.com/watch?v=OMCHf4GfWbU")
    table.insert(playlist,"#EXTINF:0,things go wrong here")
    table.insert(playlist,"foo-bar://http://example.com")

    mp.set_property("stream-open-filename", "memory://" .. table.concat(playlist,"\n"))

--results in this playlist(filenames):
--
--1. https://www.youtube.com/watch?v=OMCHf4GfWbU
--2. memory://#EXTM3U
--   #EXTINF:0,wood fish
--   https://www.youtube.com/watch?v=OMCHf4GfWbU
--   #EXTINF:0,things go wrong here
--   foo-bar://http://foo-bar://http://example.com

--Expected playlist(filenames) was:
--
--1. https://www.youtube.com/watch?v=OMCHf4GfWbU
--2. foo-bar://http://example.com
```

I agree that my changes can be relicensed to LGPL 2.1 or later.
