### PR TITLE
Use system LC_CTYPE for libarchive

### DIFF
--- a/osdep/io.h
+++ b/osdep/io.h
@@ -195,7 +195,7 @@ int msync(void *addr, size_t length, int flags);
 
 // These are stubs since there is not anything that helps with this on Windows.
 #define locale_t int
-#define LC_ALL_MASK 0
+#define LC_CTYPE_MASK 0
 locale_t newlocale(int, const char *, locale_t);
 locale_t uselocale(locale_t);
 void freelocale(locale_t);

--- a/stream/stream_libarchive.c
+++ b/stream/stream_libarchive.c
@@ -242,7 +242,7 @@ struct mp_archive *mp_archive_new(struct mp_log *log, struct stream *src,
 {
     struct mp_archive *mpa = talloc_zero(NULL, struct mp_archive);
     mpa->log = log;
-    mpa->locale = newlocale(LC_ALL_MASK, "C.UTF-8", (locale_t)0);
+    mpa->locale = newlocale(LC_CTYPE_MASK, "", (locale_t)0);
     if (!mpa->locale)
         goto err;
     mpa->arch = archive_read_new();


### PR DESCRIPTION
This should improve locale support for systems that don't have a `C.UTF-8` locale.

From my testing only `LC_CTYPE_MASK` was needed and `LC_ALL_MASK` appeared to be broken on some systems(note I tested this as part of a different application but it appears to be used in the same way here).