### PR TITLE
stats: merge multiple properties into one line

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -430,7 +430,8 @@ local function add_file(s)
         append_property(s, "media-title", {prefix="Title:"})
     end
 
-    append_property(s, "file-format", {prefix="Format/Protocol:"})
+    local fs = append_property(s, "file-size", {prefix="Size:"})
+    append_property(s, "file-format", {prefix="Format/Protocol:", nl=fs and "" or o.nl})
 
     local ch_index = mp.get_property_number("chapter")
     if ch_index and ch_index >= 0 then
@@ -460,7 +461,6 @@ local function add_file(s)
                    indent=o.prefix_sep, no_prefix_markup=true})
         end
     end
-    append_property(s, "file-size", {prefix="Size:"})
 end
 
 
@@ -539,9 +539,9 @@ local function add_audio(s)
 
     append(s, "", {prefix=o.nl .. o.nl .. "Audio:", nl="", indent=""})
     append_property(s, "audio-codec", {prefix_sep="", nl="", indent=""})
-    append(s, r["format"], {prefix="Format:"})
+    local cc = append(s, r["channel-count"], {prefix="Channels:"})
+    append(s, r["format"], {prefix="Format:", nl=cc and "" or o.nl})
     append(s, r["samplerate"], {prefix="Sample Rate:", suffix=" Hz"})
-    append(s, r["channel-count"], {prefix="Channels:"})
     append_property(s, "packet-audio-bitrate", {prefix="Bitrate:", suffix=" kbps"})
     append_filters(s, "af", "Filters:")
 end


### PR DESCRIPTION
Merge file-size/file-format and audio channel-count/format into one line
respectively. This fixes stats overflowing the screen in larger than
19:6 aspect ratios. In this case a problem was reported for ~21:9 which
should be common enough for us to "support" it.

Screenshots illustrating the problem by @Akemi: https://0x0.st/s7lL.png https://0x0.st/s7lp.png
