### PR TITLE
cocoa-cb: fix side by side Split View again

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -300,6 +300,7 @@ class Window: NSWindow, NSWindowDelegate {
         let intermediateFrame = aspectFit(rect: newFrame, in: screen!.frame)
         cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFill
         hideTitleBar()
+        styleMask.remove(.fullScreen)
         setFrame(intermediateFrame, display: true)
 
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
@@ -435,9 +436,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
-        let newFrame = !isAnimating && isInFullscreen ? targetScreen!.frame :
-                                                        frameRect
-        super.setFrame(newFrame, display: flag)
+        super.setFrame(frameRect, display: flag)
 
         if keepAspect {
             contentAspectRatio = unfsContentFrame!.size


### PR DESCRIPTION
basically some old and now unneeded code prevent the Split View to work properly in all cases.

Fixes #6443