### PR TITLE
command: fix bitrate rounding error

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -3494,7 +3494,7 @@ static int mp_property_packet_bitrate(void *ctx, struct m_property *prop,
 
     // Same story, but used kilobits for some reason.
     if (old)
-        return m_property_int64_ro(action, arg, rate / 1000.0 + 0.5);
+        return m_property_int64_ro(action, arg, llrint(rate / 1000.0));
 
     if (action == M_PROPERTY_PRINT) {
         rate /= 1000;
@@ -3505,7 +3505,7 @@ static int mp_property_packet_bitrate(void *ctx, struct m_property *prop,
         }
         return M_PROPERTY_OK;
     }
-    return m_property_int64_ro(action, arg, rate);
+    return m_property_int64_ro(action, arg, llrint(rate));
 }
 
 static int mp_property_cwd(void *ctx, struct m_property *prop,


### PR DESCRIPTION
When the (float) bitrate is returned, it is implicitely converted to an
int64 value, merely discarding the fractional part.

However the bitrate of a CBR track can vary a bit due to timestamp
precision loss after clock conversion (this can affect MPEG-TS audio
tracks). So a bitrate like 191999.999... results in 191999 when
being returned - instead of 192000.

To fix this, apply proper rounding.

----
I agree that my changes can be relicensed to LGPL 2.1 or later.