### PR TITLE
vo_gpu: hwdec_drmprime_drm: add hwdec ctx

### DIFF
--- a/wscript
+++ b/wscript
@@ -554,7 +554,7 @@ video_output_features = [
         'name': '--drm',
         'desc': 'DRM',
         'deps': 'vt.h',
-        'func': check_pkg_config('libdrm'),
+        'func': check_pkg_config('libdrm', '>= 2.4.74'),
     }, {
         'name': '--drmprime',
         'desc': 'DRM Prime ffmpeg support',


### PR DESCRIPTION
This allows to use drm hwaccels that require a hwdevice.

Tested with exprimental [v4l2request hwaccel](https://github.com/Kwiboo/FFmpeg/compare/4.0.4-Leia-18.4...v4l2-request-hwaccel-4.0.4) and cedrus driver on an allwinner H3 device
running mpv with `--vo=gpu --gpu-context=drm --hwdec=drm`.

Added `libdrm` version requirement since `drmGetDeviceNameFromFd2` was added in 2.4.74.

I agree that my changes can be relicensed to LGPL 2.1 or later.