### PR TITLE
macosx_compat.h fix typo

### DIFF
--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -55,7 +55,7 @@ static const NSEventModifierFlags NSEventModifierFlagOption = NSAlternateKeyMask
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9)
 typedef NSUInteger NSModalResponse;
-static const NSModalResponse NSModalResponseOK = NSFileHandlingPanelOKButton
+static const NSModalResponse NSModalResponseOK = NSFileHandlingPanelOKButton;
 #endif
 
 #endif


### PR DESCRIPTION
missing a ";"

I agree that my changes can be relicensed to LGPL 2.1 or later.
