### PR TITLE
cocoa-cb: fix a Cocoa window position on init bug

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -107,6 +107,19 @@ class Window: NSWindow, NSWindowDelegate {
         self.init(contentRect: contentRect,
                   styleMask: [.titled, .closable, .miniaturizable, .resizable],
                   backing: .buffered, defer: false, screen: screen)
+
+        // workaround for an AppKit bug where the NSWindow can't be placed on a
+        // none Main screen NSScreen outside the Main screen's frame bounds
+        if screen != NSScreen.main() {
+            var absoluteWantedOrigin = contentRect.origin
+            absoluteWantedOrigin.x += screen!.frame.origin.x
+            absoluteWantedOrigin.y += screen!.frame.origin.y
+
+            if !NSEqualPoints(absoluteWantedOrigin, self.frame.origin) {
+                self.setFrameOrigin(absoluteWantedOrigin)
+            }
+        }
+
         cocoaCB = ccb
         title = cocoaCB.title
         minSize = NSMakeSize(160, 90)


### PR DESCRIPTION
yeah, a very dumb bug. i never noticed from my testings since my secondary screen had a smaller resolution than my main one.

i conducted some tests, wrote a small [test script](https://github.com/Akemi/test_secondary_screen_window_position) and wrote down my findings. this probably should be reported to Apple.

Fixes #6453