### PR TITLE
cocoa-cb: wakeup vo when new events are available

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -34,6 +34,7 @@ class MPVHelper: NSObject {
     var mpvLog: OpaquePointer?
     var inputContext: OpaquePointer?
     var mpctx: UnsafeMutablePointer<MPContext>?
+    var vo: UnsafeMutablePointer<vo>?
     var macOpts: macos_opts?
     var fbo: GLint = 1
     let deinitLock = NSLock()

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -88,6 +88,7 @@ class CocoaCB: NSObject {
 
     func initBackend(_ vo: UnsafeMutablePointer<vo>) {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
+        mpv.vo = vo
         NSApp.setActivationPolicy(.regular)
         setAppIcon()
 
@@ -363,6 +364,7 @@ class CocoaCB: NSObject {
         eventsLock.lock()
         events |= ev
         eventsLock.unlock()
+        vo_wakeup(mpv.vo)
     }
 
     func checkEvents() -> Int {


### PR DESCRIPTION
no idea why i forgot to add it there. added the wakeup call like in the [old cocoa](https://github.com/mpv-player/mpv/blob/1842a932d37638c910f4471d85e81554076c3d2c/video/out/cocoa_common.m#L138) backend. the vo struct needs to be available for the flagEvents function (same as in the [old cocoa](https://github.com/mpv-player/mpv/blob/1842a932d37638c910f4471d85e81554076c3d2c/video/out/cocoa_common.m#L587) backend) since some of the events are sent by cocoa events and that struct wouldn't be available in these cases. 