### PR TITLE
[RFC] wayland: reconfigure cursor on pointer enter event

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -72,6 +72,7 @@ static int set_cursor_visibility(struct vo_wayland_state *wl, bool on)
 {
     if (!wl->pointer)
         return VO_NOTAVAIL;
+    wl->cursor_visible = on;
     if (on) {
         if (spawn_cursor(wl))
             return VO_FALSE;
@@ -91,6 +92,11 @@ static int set_cursor_visibility(struct vo_wayland_state *wl, bool on)
     return VO_TRUE;
 }
 
+static void reset_cursor(struct vo_wayland_state *wl)
+{
+        set_cursor_visibility(wl, wl->cursor_visible);
+}
+
 static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
                                  uint32_t serial, struct wl_surface *surface,
                                  wl_fixed_t sx, wl_fixed_t sy)
@@ -100,7 +106,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
     wl->pointer    = pointer;
     wl->pointer_id = serial;
 
-    set_cursor_visibility(wl, true);
+    reset_cursor(wl);
     mp_input_put_key(wl->vo->input_ctx, MP_KEY_MOUSE_ENTER);
 }
 
@@ -997,6 +1003,7 @@ int vo_wayland_init(struct vo *vo)
         .scaling = 1,
         .wakeup_pipe = {-1, -1},
         .dnd_fd = -1,
+        .cursor_visible = true,
     };
 
     wl_list_init(&wl->output_list);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -101,6 +101,7 @@ struct vo_wayland_state {
     struct wl_cursor       *default_cursor;
     struct wl_surface      *cursor_surface;
     int                     allocated_cursor_scale;
+    bool                    cursor_visible;
 };
 
 int vo_wayland_init(struct vo *vo);


### PR DESCRIPTION
On wayland the cursor has to be configured each time the pointer enters.
Currently if the window (re)gains the focus, the pointer is not hidden,
even when configured. After the mouse has been moved the pointer hides
correctly.

https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_pointer:

    wl_pointer::enter - enter event

    ...

    When a seat's focus enters a surface, the pointer image is undefined
    and a client should respond to this event by setting an appropriate
    pointer image with the set_cursor request.

Fixes #6185.

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>
I agree that my changes can be relicensed to LGPL 2.1 or later.
