### PR TITLE
ao/audiounit: improve a/v sync

### DIFF
--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -155,7 +155,7 @@ static void start(struct ao *ao)
     struct priv *p = ao->priv;
     AVAudioSession *instance = AVAudioSession.sharedInstance;
 
-    p->device_latency = [instance outputLatency];
+    p->device_latency = [instance outputLatency] + [instance IOBufferDuration];
 
     OSStatus err = AudioOutputUnitStart(p->audio_unit);
     CHECK_CA_WARN("can't start audio unit");

--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -49,8 +49,8 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
         planes[n] = buffer_list->mBuffers[n].mData;
 
     int64_t end = mp_time_us();
-    end += ca_frames_to_us(ao, frames);
     end += p->device_latency * 1e6;
+    end += ca_get_latency(ts) + ca_frames_to_us(ao, frames);
     ao_read_data(ao, planes, frames, end);
     return noErr;
 }

--- a/audio/out/ao_coreaudio_utils.h
+++ b/audio/out/ao_coreaudio_utils.h
@@ -65,9 +65,7 @@ bool ca_asbd_is_better(AudioStreamBasicDescription *req,
                        AudioStreamBasicDescription *new);
 
 int64_t ca_frames_to_us(struct ao *ao, uint32_t frames);
-#if HAVE_COREAUDIO
 int64_t ca_get_latency(const AudioTimeStamp *ts);
-#endif
 
 #if HAVE_COREAUDIO
 bool ca_stream_supports_compressed(struct ao *ao, AudioStreamID stream);


### PR DESCRIPTION
In auditing the ao_audiounit code, I noticed several pieces which were missing. These make the implementation more "correct", and should theoretically improve a/v sync.

I haven't tested this very thoroughly, and in the random videos I tried it didn't seem to make any difference (atleast on my audio setup). A deeper investigation is warranted, perhaps using some kind of video sample optimized for checking lip sync.

cc @sergiou87 @rcombs @sixones @LukePulverenti @ebr11