### PR TITLE
Fix build with ffmpeg compiled with --disable-everything

### DIFF
--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -24,8 +24,6 @@
 #include "stheader.h"
 #include "common/av_common.h"
 
-#define HAVE_QT_TAGS (LIBAVFORMAT_VERSION_MICRO >= 100)
-
 static const char *lookup_tag(int type, uint32_t tag)
 {
     const struct AVCodecTag *av_tags[3] = {0};

--- a/wscript
+++ b/wscript
@@ -483,6 +483,12 @@ FFmpeg/Libav libraries. Git master is recommended."
         'desc': 'LZO support in libavutil',
         'func': check_statement('libavutil/lzo.h',
                                 'int i = AV_LZO_OUTPUT_PADDING')
+    }, {
+        'name': 'qt-tags',
+        'desc': 'MOV atom support in libavformat',
+        'func': check_statement('libavformat/avformat.h',
+                                'avformat_get_mov_video_tags()',
+                                lib='avformat')
     }
 ]
 

--- a/wscript
+++ b/wscript
@@ -478,6 +478,11 @@ FFmpeg/Libav libraries. Git master is recommended."
         'name': '--libavdevice',
         'desc': 'libavdevice',
         'func': check_pkg_config('libavdevice', '>= 57.0.0'),
+    }, {
+        'name': 'libavutil-lzo',
+        'desc': 'LZO support in libavutil',
+        'func': check_statement('libavutil/lzo.h',
+                                'int i = AV_LZO_OUTPUT_PADDING')
     }
 ]
 


### PR DESCRIPTION
This adds two checks, which is better than assuming ffmpeg supports those features.