### PR TITLE
wayland_common: rename “shell” into “wm_base”

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -70,7 +70,7 @@ struct vo_wayland_state {
 
     /* Shell */
     struct wl_surface       *surface;
-    struct xdg_wm_base      *shell;
+    struct xdg_wm_base      *wm_base;
     struct xdg_toplevel     *xdg_toplevel;
     struct xdg_surface      *xdg_surface;
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;


### PR DESCRIPTION
This is the naming xdg-shell stable adopted, it doesn’t make much sense to keep using “shell” everywhere with all functions calling it “wm_base”.

Finishes what 76211609e3c589dafe3ef9a36cacc06e8f56de09 started.