### PR TITLE
player: do not rebase start time for subtitle streams

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -609,7 +609,7 @@ int mp_add_external_file(struct MPContext *mpctx, char *filename,
         goto err_out;
     enable_demux_thread(mpctx, demuxer);
 
-    if (opts->rebase_start_time)
+    if (filter != STREAM_SUB && opts->rebase_start_time)
         demux_set_ts_offset(demuxer, -demuxer->start_time);
 
     bool has_any = false;


### PR DESCRIPTION
As stated in the original commit message, if the demuxer set the start
time to the first subtitle packet, the subtitles would be shifted
incorrectly. It appears that it is the case for external PGS subtitles.

This reverts commit 520fc7403621156676b1ca183aed4911bf6c47b5.

Fixes #5485