### PR TITLE
demux: when loading mkv timeline, copy attachments from other sources

### DIFF
--- a/demux/demux_mkv_timeline.c
+++ b/demux/demux_mkv_timeline.c
@@ -225,6 +225,12 @@ static bool check_file_seg(struct tl_ctx *ctx, char *filename, int segment)
             }
 
             ctx->sources[i] = d;
+            for (int n = 0; n < d->num_attachments; n++) {
+                demuxer_add_attachment(ctx->sources[0], d->attachments[n].name,
+                                       d->attachments[n].type,
+                                       d->attachments[n].data,
+                                       d->attachments[n].data_size);
+            }
             return true;
         }
     }


### PR DESCRIPTION
When loading multi-segment mkv files, attachments in the included mkv
files were all ignored, because they were not in the track's main
demuxer. Copy the attachments to the main demuxer, so that the
attachments could be found.

Fixes #6503
