### PR TITLE
cache_init: output "Cache fill" progress relative to target precache

### DIFF
--- a/stream/cache.c
+++ b/stream/cache.c
@@ -791,7 +791,7 @@ int stream_cache_init(stream_t *cache, stream_t *stream,
         if (stream_control(s->cache, STREAM_CTRL_GET_CACHE_INFO, &info) < 0)
             break;
         mp_msg(s->log, MSGL_STATUS,  "Cache fill: %5.2f%% "
-               "(%" PRId64 " bytes)", 100.0 * info.fill / s->buffer_size,
+               "(%" PRId64 " bytes)", 100.0 * info.fill / min,
                info.fill);
         if (info.fill >= min)
             break;


### PR DESCRIPTION
Change is trivial so opening this directly as a PR rather than an issue, feel free to treat it as an issue (e.g. just close if you disagree; it is subjective and I won't argue about this)


Starting mpv with --cache-initial=x would output "Cache fill: x% (y bytes)" with the percentage being relative to the full buffer size, leading to something like mpv starting to play when the percentage reached a few percents.

As the user is probably waiting in front of their terminal staring at the percentage I think it makes more sense to output that percentage relative to the precache target, so mpv will start playing when the number reaches 100% instead of some lower arbitrary value.


I agree that my changes can be relicensed to LGPL 2.1 or later.
