### PR TITLE
sub: implement sub-scale for DVD/Vobsubs

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1670,12 +1670,17 @@ Subtitles
         styling in the main subtitle stream.
 
 ``--sub-scale=<0-100>``
-    Factor for the text subtitle font size (default: 1).
+    Factor for the subtitle size (default: 1).
 
     .. note::
 
-        This affects ASS subtitles as well, and may lead to incorrect subtitle
-        rendering. Use with care, or use ``--sub-font-size`` instead.
+        For text subtitles, this changes the font size. Affects ASS subtitles
+        as well, and may lead to incorrect subtitle rendering. Use with care,
+        or use ``--sub-font-size`` instead.
+
+        May position DVD/Vobsubs incorrectly if the subtitles are not at the
+        bottom center of the screen. A value other than 1 also switches to
+        software subtitle scaling for DVD/Vobsubs. Might be slow.
 
 ``--sub-scale-by-window=<yes|no>``
     Whether to scale subtitles with the window size (default: yes). If this is

--- a/sub/img_convert.c
+++ b/sub/img_convert.c
@@ -30,7 +30,8 @@
 #include "video/mp_image.h"
 #include "video/sws_utils.h"
 
-void mp_blur_rgba_sub_bitmap(struct sub_bitmap *d, double gblur)
+void mp_blur_scale_rgba_sub_bitmap(struct sub_bitmap *d, double gblur,
+                                   double scale)
 {
     struct mp_image *tmp1 = mp_image_alloc(IMGFMT_BGRA, d->w, d->h);
     if (tmp1) { // on OOM, skip region
@@ -41,6 +42,12 @@ void mp_blur_rgba_sub_bitmap(struct sub_bitmap *d, double gblur)
         s.planes[0] = d->bitmap;
 
         mp_image_copy(tmp1, &s);
+
+        if (scale != 1.0) {
+            d->w *= scale;
+            d->h *= scale;
+            mp_image_set_size(&s, d->w, d->h);
+        }
 
         mp_image_sw_blur_scale(&s, tmp1, gblur);
     }

--- a/sub/img_convert.h
+++ b/sub/img_convert.h
@@ -8,7 +8,8 @@ struct sub_bitmap;
 struct mp_rect;
 
 // Sub postprocessing
-void mp_blur_rgba_sub_bitmap(struct sub_bitmap *d, double gblur);
+void mp_blur_scale_rgba_sub_bitmap(struct sub_bitmap *d, double gblur,
+                                   double scale);
 
 bool mp_sub_bitmaps_bb(struct sub_bitmaps *imgs, struct mp_rect *out_bb);
 

--- a/video/sws_utils.c
+++ b/video/sws_utils.c
@@ -286,8 +286,10 @@ int mp_image_sw_blur_scale(struct mp_image *dst, struct mp_image *src,
 {
     struct mp_sws_context *ctx = mp_sws_alloc(NULL);
     ctx->flags = mp_sws_hq_flags;
-    ctx->src_filter = sws_getDefaultFilter(gblur, gblur, 0, 0, 0, 0, 0);
-    ctx->force_reload = true;
+    if (gblur != 0.0) {
+        ctx->src_filter = sws_getDefaultFilter(gblur, gblur, 0, 0, 0, 0, 0);
+        ctx->force_reload = true;
+    }
     int res = mp_sws_scale(ctx, dst, src);
     talloc_free(ctx);
     return res;


### PR DESCRIPTION
Use libswscale to scale DVD/Vobsubs, as what has been done in the
DVD/Vobsubs blurring code.

The subjective part is the position of the subtitle after scaling. I
choose to fix the bottom-center point of the subtitle bitmap, because
commonly subtitles are placed near the bottom of the video. This is also
consistent with the behavior when a text subtitle is scaled.

Fixes #6417
