### PR TITLE
wayland: match x11 cursor behavior

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -72,6 +72,7 @@ static int set_cursor_visibility(struct vo_wayland_state *wl, bool on)
 {
     if (!wl->pointer)
         return VO_NOTAVAIL;
+    wl->cursor_visible = on;
     if (on) {
         if (spawn_cursor(wl))
             return VO_FALSE;
@@ -100,7 +101,7 @@ static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
     wl->pointer    = pointer;
     wl->pointer_id = serial;
 
-    set_cursor_visibility(wl, true);
+    set_cursor_visibility(wl, wl->cursor_visible);
     mp_input_put_key(wl->vo->input_ctx, MP_KEY_MOUSE_ENTER);
 }
 
@@ -997,6 +998,7 @@ int vo_wayland_init(struct vo *vo)
         .scaling = 1,
         .wakeup_pipe = {-1, -1},
         .dnd_fd = -1,
+        .cursor_visible = true,
     };
 
     wl_list_init(&wl->output_list);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -116,7 +116,12 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
                                   uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
 {
     struct vo_wayland_state *wl = data;
+    if (!wl->prev_fullscreen && wl->fullscreen) {
+        wl->prev_fullscreen = wl->fullscreen;
+        return;
+    }
 
+    wl->prev_fullscreen = wl->fullscreen;
     wl->mouse_x = wl_fixed_to_int(sx) * wl->scaling;
     wl->mouse_y = wl_fixed_to_int(sy) * wl->scaling;
 
@@ -999,6 +1004,7 @@ int vo_wayland_init(struct vo *vo)
         .wakeup_pipe = {-1, -1},
         .dnd_fd = -1,
         .cursor_visible = true,
+        .prev_fullscreen = vo->opts->fullscreen,
     };
 
     wl_list_init(&wl->output_list);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -101,6 +101,7 @@ struct vo_wayland_state {
     struct wl_cursor       *default_cursor;
     struct wl_surface      *cursor_surface;
     int                     allocated_cursor_scale;
+    bool                    cursor_visible;
 };
 
 int vo_wayland_init(struct vo *vo);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -102,6 +102,7 @@ struct vo_wayland_state {
     struct wl_surface      *cursor_surface;
     int                     allocated_cursor_scale;
     bool                    cursor_visible;
+    bool                    prev_fullscreen;
 };
 
 int vo_wayland_init(struct vo *vo);


### PR DESCRIPTION
This is forked from #6480 with just a few more lines to fix what I had mentioned there. I only made this since there didn't seem to be any activity from @t-8ch. This also fixes #6185. On wayland, the cursor should automatically hide without having to move it (which is the current behavior). Also, the cursor shouldn't reappear when going to fullscreen (which is what happened with @t-8ch's fix).

Also as a side note, I personally don't really think it's necessary to define a whole new `reset_cursor` function. I think the name is misleading and `set_cursor_visibility(wl, wl->cursor_visible)` is more than clear and sufficient. I left `reset_cursor` since like 50% of this is stolen from @t-8ch anyway, but I'll happily change it if the devs agree with me.

I agree that my changes can be relicensed to LGPL 2.1 or later.
