### PR TITLE
demux: fix seek range update after head packets are pruned

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -1569,8 +1569,6 @@ static void prune_old_packets(struct demux_internal *in)
                 }
                 prev = prev->next;
             }
-
-            update_seek_ranges(range);
         }
 
         bool done = false;
@@ -1578,6 +1576,8 @@ static void prune_old_packets(struct demux_internal *in)
             done = queue->next_prune_target == queue->head;
             remove_head_packet(queue);
         }
+
+        update_seek_ranges(range);
 
         if (range != in->current_range && range->seek_start == MP_NOPTS_VALUE)
             free_empty_cached_ranges(in);


### PR DESCRIPTION
The seek range update was to early and did not take the removed head
packets into account. And therefore missed that the queue was not
BOF anymore.
This led to not be able to backward seek before the first packet of
the first seek range.

Fix it by moving the seek range update after the possible removal and
the change of the BOF flag.

Fixes: #6522


I agree that my changes can be relicensed to LGPL 2.1 or later.
