### PR TITLE
options: add aselect, vselect and sselect options to be able to use libavformat stream specifiers

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -76,6 +76,8 @@ Interface changes
       network streams should not freeze the player core (only playback in
       uncached regions), and differing behavior should be reported as a bug.
       If --demuxer-thread=no is used, there are no guarantees.
+    - add --aselect, --vselect, --sselect to enable using libavformat stream
+      specifiers
  --- mpv 0.29.0 ---
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -64,6 +64,18 @@ Track Selection
     streamed with youtube-dl, because it saves bandwidth. This is done by
     setting the ytdl_format to "bestaudio/best" in the ytdl_hook.lua script.
 
+``--aselect=<stream_specifier[,stream_specifier,...]>``
+    Specify a list of stream specifiers which will be passed to the demuxer for
+    automatic stream selection. If the first specifier does not match any
+    streams then the second will be tried and so on. For now this only makes
+    sense when using the ``lavf`` demuxer.
+
+``--sselect=<...>``
+    Equivalent to ``--aselect`` and ``--vselect``, for subtitle tracks.
+
+``--vselect=<...>``
+    Equivalent to ``--aselect`` and ``--sselect``, for video tracks.
+
 ``--edition=<ID|auto>``
     (Matroska files only)
     Specify the edition (set of chapters) to use, where 0 is the first. If set

--- a/demux/demux.h
+++ b/demux/demux.h
@@ -38,6 +38,7 @@ enum demux_ctrl {
     DEMUXER_CTRL_GET_READER_STATE,
     DEMUXER_CTRL_GET_BITRATE_STATS, // double[STREAM_TYPE_COUNT]
     DEMUXER_CTRL_REPLACE_STREAM,
+    DEMUXER_CTRL_FIND_STREAM,
 };
 
 #define MAX_SEEK_RANGES 10
@@ -250,6 +251,12 @@ typedef struct {
     int progid;      //program id
     int aid, vid, sid; //audio, video and subtitle id
 } demux_program_t;
+
+typedef struct {
+    const char *specifier;  //demuxer specific stream specifier
+    enum stream_type type;  //stream_type to search for
+    int id;                 //demuxer specific found id (ff index)
+} demux_find_stream_t;
 
 void demux_free(struct demuxer *demuxer);
 void demux_cancel_and_free(struct demuxer *demuxer);

--- a/options/options.c
+++ b/options/options.c
@@ -435,6 +435,9 @@ const m_option_t mp_opts[] = {
     OPT_STRINGLIST("alang", stream_lang[STREAM_AUDIO], 0),
     OPT_STRINGLIST("slang", stream_lang[STREAM_SUB], 0),
     OPT_STRINGLIST("vlang", stream_lang[STREAM_VIDEO], 0),
+    OPT_STRINGLIST("aselect", stream_specifier[STREAM_AUDIO], 0),
+    OPT_STRINGLIST("sselect", stream_specifier[STREAM_SUB], 0),
+    OPT_STRINGLIST("vselect", stream_specifier[STREAM_VIDEO], 0),
     OPT_FLAG("track-auto-selection", stream_auto_sel, 0),
 
     OPT_STRING("lavfi-complex", lavfi_complex, UPDATE_LAVFI_COMPLEX),

--- a/options/options.h
+++ b/options/options.h
@@ -239,6 +239,7 @@ typedef struct MPOpts {
     double image_display_duration;
     char *lavfi_complex;
     int stream_id[2][STREAM_TYPE_COUNT];
+    char **stream_specifier[STREAM_TYPE_COUNT];
     char **stream_lang[STREAM_TYPE_COUNT];
     int stream_auto_sel;
     int audio_display;


### PR DESCRIPTION
MPV stream selection is only language based, the user might want to select
based on program number or source PID, this change makes it possible.

Property based change is not yet implemented, but should be doable.

I agree that my changes can be relicensed to LGPL 2.1 or later.