### PR TITLE
options: add watch-later-blacklist

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -432,6 +432,16 @@ Program Behavior
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
+``--watch-later-blacklist=<property1,property2,...>``
+    Do not restore listed properties from ``watch later`` files.
+
+    .. admonition:: Examples
+
+        - ``--watch-later-blacklist=fullscreen``
+          Resuming a file won't restore the fullscreen state.
+        - ``--watch-later-blacklist=volume,mute``
+          Resuming a file won't restore the volume or mute state.
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/options/m_config.h
+++ b/options/m_config.h
@@ -154,6 +154,7 @@ enum {
     M_SETOPT_NO_FIXED = 64,         // Reject M_OPT_FIXED options
     M_SETOPT_NO_PRE_PARSE = 128,    // Reject M_OPT_PREPARSE options
     M_SETOPT_NO_OVERWRITE = 256,    // Skip options marked with FROM_*
+    M_SETOPT_WATCH_LATER = 512,     // Ignore options in watch later blacklist
 };
 
 // Flags for safe option setting during runtime.

--- a/options/options.c
+++ b/options/options.c
@@ -632,6 +632,7 @@ const m_option_t mp_opts[] = {
     OPT_FLAG("write-filename-in-watch-later-config", write_filename_in_watch_later_config, 0),
     OPT_FLAG("ignore-path-in-watch-later-config", ignore_path_in_watch_later_config, 0),
     OPT_STRING("watch-later-directory", watch_later_directory, M_OPT_FILE),
+    OPT_STRINGLIST("watch-later-blacklist", watch_later_blacklist, 0),
 
     OPT_FLAG("ordered-chapters", ordered_chapters, 0),
     OPT_STRING("ordered-chapters-files", ordered_chapters_files, M_OPT_FILE),

--- a/options/options.h
+++ b/options/options.h
@@ -247,6 +247,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
+    char **watch_later_blacklist;
     int pause;
     int keep_open;
     int keep_open_pause;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -397,7 +397,8 @@ void mp_load_playback_resume(struct MPContext *mpctx, const char *file)
         m_config_backup_opt(mpctx->mconfig, "start");
         MP_INFO(mpctx, "Resuming playback. This behavior can "
                "be disabled with --no-resume-playback.\n");
-        try_load_config(mpctx, fname, M_SETOPT_PRESERVE_CMDLINE, MSGL_V);
+        try_load_config(mpctx, fname, M_SETOPT_PRESERVE_CMDLINE |
+                                      M_SETOPT_WATCH_LATER, MSGL_V);
         unlink(fname);
     }
     talloc_free(fname);


### PR DESCRIPTION
Do not restore properties in "watch-later-blacklist" from "watch later" files.

Idea from #6373. But this commit does the work when resuming playback. The behaviour of `mp_write_watch_later_conf` is not changed. So this option can be modified and should take effect when mpv starts to load files.

I agree that my changes can be relicensed to LGPL 2.1 or later.
