### PR TITLE
player: fix checking for playback active state

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -128,7 +128,7 @@ void update_core_idle_state(struct MPContext *mpctx)
     bool eof = mpctx->video_status == STATUS_EOF &&
                mpctx->audio_status == STATUS_EOF;
     bool active = !mpctx->paused && mpctx->restart_complete &&
-                  mpctx->stop_play && mpctx->in_playloop && !eof;
+                  !mpctx->stop_play && mpctx->in_playloop && !eof;
 
     if (mpctx->playback_active != active) {
         mpctx->playback_active = active;


### PR DESCRIPTION
The "eof-reached" property never goes to true. See 8816e1117ee65039dbb5700219ba3537d3e5290e.

I agree that my changes can be relicensed to LGPL 2.1 or later.
