### PR TITLE
vo_gpu: allow user shader to fix texture offset

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4572,12 +4572,18 @@ The following video options are currently all specific to ``--vo=gpu`` and
         hook point can still cause that hook point to be saved, which has some
         minor overhead)
 
-    OFFSET <ox> <oy>
+    OFFSET <ox oy | ALIGN>
         Indicates a pixel shift (offset) introduced by this pass. These pixel
         offsets will be accumulated and corrected during the next scaling pass
         (``cscale`` or ``scale``). The default values are 0 0 which correspond
         to no shift. Note that offsets are ignored when not overwriting the
         hooked texture.
+
+        A special value of ``ALIGN`` will attempt to fix existing offset of
+        HOOKED by align it with reference. It requires HOOKED to be resizable
+        (see below). It works transparently with fragment shader. For compute
+        shader, the predefined ``texmap`` macro is required to handle coordinate
+        mapping.
 
     COMPONENTS <n>
         Specifies how many components of this pass's output are relevant and

--- a/video/out/gpu/user_shaders.c
+++ b/video/out/gpu/user_shaders.c
@@ -170,6 +170,7 @@ static bool parse_hook(struct mp_log *log, struct bstr *body,
     *out = (struct gl_user_shader_hook){
         .pass_desc = bstr0("(unknown)"),
         .offset = identity_trans,
+        .align_offset = false,
         .width = {{ SZEXP_VAR_W, { .varname = bstr0("HOOKED") }}},
         .height = {{ SZEXP_VAR_H, { .varname = bstr0("HOOKED") }}},
         .cond = {{ SZEXP_CONST, { .cval = 1.0 }}},
@@ -221,13 +222,18 @@ static bool parse_hook(struct mp_log *log, struct bstr *body,
         }
 
         if (bstr_eatstart0(&line, "OFFSET")) {
-            float ox, oy;
-            if (bstr_sscanf(line, "%f %f", &ox, &oy) != 2) {
-                mp_err(log, "Error while parsing OFFSET!\n");
-                return false;
+            line = bstr_strip(line);
+            if (bstr_equals0(line, "ALIGN")) {
+                out->align_offset = true;
+            } else {
+                float ox, oy;
+                if (bstr_sscanf(line, "%f %f", &ox, &oy) != 2) {
+                    mp_err(log, "Error while parsing OFFSET!\n");
+                    return false;
+                }
+                out->offset.t[0] = ox;
+                out->offset.t[1] = oy;
             }
-            out->offset.t[0] = ox;
-            out->offset.t[1] = oy;
             continue;
         }
 

--- a/video/out/gpu/user_shaders.h
+++ b/video/out/gpu/user_shaders.h
@@ -69,6 +69,7 @@ struct gl_user_shader_hook {
     struct bstr save_tex;
     struct bstr pass_body;
     struct gl_transform offset;
+    bool align_offset;
     struct szexp width[MAX_SZEXP_SIZE];
     struct szexp height[MAX_SZEXP_SIZE];
     struct szexp cond[MAX_SZEXP_SIZE];

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -16,11 +16,11 @@
  */
 
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 
 #include <libavutil/common.h>
 #include <libavutil/lfg.h>
@@ -2358,8 +2358,11 @@ static void pass_scale_main(struct gl_video *p)
     xy[0] /= p->texture_offset.m[0][0];
     xy[1] /= p->texture_offset.m[1][1];
 
-    bool downscaling = xy[0] < 1.0 || xy[1] < 1.0;
-    bool upscaling = !downscaling && (xy[0] > 1.0 || xy[1] > 1.0);
+    // The calculation of scale factor involves 32-bit float(from gl_transform),
+    // use non-strict equality test to tolerate precision loss.
+    bool downscaling = xy[0] < 1.0 - FLT_EPSILON || xy[1] < 1.0 - FLT_EPSILON;
+    bool upscaling = !downscaling && (xy[0] > 1.0 + FLT_EPSILON ||
+                                      xy[1] > 1.0 + FLT_EPSILON);
     double scale_factor = 1.0;
 
     struct scaler *scaler = &p->scaler[SCALER_SCALE];

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1347,6 +1347,7 @@ static void hook_prelude(struct gl_video *p, const char *name, int id,
     GLSLHF("#define %s_pos texcoord%d\n", name, id);
     GLSLHF("#define %s_size texture_size%d\n", name, id);
     GLSLHF("#define %s_rot texture_rot%d\n", name, id);
+    GLSLHF("#define %s_off texture_off%d\n", name, id);
     GLSLHF("#define %s_pt pixel_size%d\n", name, id);
     GLSLHF("#define %s_map texmap%d\n", name, id);
     GLSLHF("#define %s_mul %f\n", name, img.multiplier);


### PR DESCRIPTION
This commit essentially makes user shader able to fix offset (produced
by other prescaler, for example) like builtin `--scale`.

@haasn

Test I conducted to verify the commit works as expected:

1. Apply following patch to mpv, to disable offset fixing functionality of `--scale` (when `--scaler-resizes-only` kicks in). The following of the test assumes video is not resized (`--window-scale=1.0` for example).
~~~patch
diff --git a/video/out/gpu/video.c b/video/out/gpu/video.c
index 6004a0ab60..62def3e749 100644
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2336,12 +2336,8 @@ static void pass_scale_main(struct gl_video *p)
     struct scaler_config scaler_conf = p->opts.scaler[SCALER_SCALE];
     if (p->opts.scaler_resizes_only && !downscaling && !upscaling) {
         scaler_conf.kernel.name = "bilinear";
-        // For scaler-resizes-only, we round the texture offset to
-        // the nearest round value in order to prevent ugly blurriness
-        // (in exchange for slightly shifting the image by up to half a
-        // subpixel)
-        p->texture_offset.t[0] = roundf(p->texture_offset.t[0]);
-        p->texture_offset.t[1] = roundf(p->texture_offset.t[1]);
+        p->texture_offset.t[0] = 0.0;
+        p->texture_offset.t[1] = 0.0;
     }
     if (downscaling && p->opts.scaler[SCALER_DSCALE].kernel.name) {
         scaler_conf = p->opts.scaler[SCALER_DSCALE];
~~~
2. Applying following shader with `--no-scaler-resizes-only` defines the reference (`--scale` is used to fix offset).
~~~glsl
//!DESC add large offset
//!HOOK MAIN
//!BIND HOOKED
//!OFFSET 128 128
vec4 hook() {
    return HOOKED_texOff(vec2(0.0,0.0));
}
~~~
3. Applying the following two shaders (fragment and compute), with or without `--scaler-resizes-only` gives same result to reference in step 2.
~~~glsl
//!DESC add large offset
//!HOOK MAIN
//!BIND HOOKED
//!OFFSET 128 128
vec4 hook() {
    return HOOKED_texOff(vec2(0.0,0.0));
}
//!DESC fix the (non-existing) offset, fragment shader
//!HOOK MAIN
//!BIND HOOKED
//!OFFSET ALIGN
vec4 hook() {
    return HOOKED_texOff(vec2(0.0,0.0));
}
~~~

~~~glsl
//!DESC add large offset
//!HOOK MAIN
//!BIND HOOKED
//!OFFSET 128 128
vec4 hook() {
    return HOOKED_texOff(vec2(0.0,0.0));
}
//!DESC fix the (non-existing) offset, compute shader
//!HOOK MAIN
//!BIND HOOKED
//!OFFSET ALIGN
//!COMPUTE 16 16
void hook() {
    ivec2 pos = ivec2(gl_GlobalInvocationID);
    vec4 res = HOOKED_tex(HOOKED_map(pos));
    imageStore(out_image, pos, res);
}
~~~