### PR TITLE
x11: fix cursor hiding initial state

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1425,6 +1425,7 @@ static void vo_x11_create_window(struct vo *vo, XVisualInfo *vis,
     XSetWMProtocols(x11->display, x11->window, protos, 1);
 
     x11->mouse_cursor_set = false;
+    x11->mouse_cursor_visible = true;
     vo_update_cursor(vo);
 
     if (x11->xim) {

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -88,8 +88,9 @@ struct vo_x11_state {
     bool pseudo_mapped; // not necessarily mapped, but known window size
     int fs;     // whether we assume the window is in fullscreen mode
 
-    bool mouse_cursor_visible;
-    bool mouse_cursor_set;
+    bool mouse_cursor_visible; // whether we want the cursor to be visible (only
+                               // takes effect when the window is focused)
+    bool mouse_cursor_set; // whether the cursor is *currently* *hidden*
     bool has_focus;
     long orig_layer;
 


### PR DESCRIPTION
Regression from 8e3308d687c3acdd0d572015b06efd5b492d93ee.

Broken cases were:
* --no-cursor-autohide acted like --cursor-autohide=always.
* --cursor-autohide-fs-only always hid the cursor if starting
  non-fullscreen; entering fullscreen at least once fixed it.

Also added brief descriptions of the two cursor visibility state variables since I had a bit of trouble keeping them straight when I was debugging this.