### PR TITLE
DOCS/man/mpv.rst: Fix big-cache profile example

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -630,7 +630,8 @@ or at runtime with the ``apply-profile <name>`` command.
 
         # a profile that can be enabled with --profile=big-cache
         [big-cache]
-        cache=123400
+        cache=yes
+        demuxer-max-bytes=123400KiB
         demuxer-readahead-secs=20
 
         [slow]


### PR DESCRIPTION
The cache options were changed, and this commit
fixes the example big-cache profile to use the
new cache options.