### PR TITLE
[WIP] path: use backslash when joining paths on windows

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -279,8 +279,20 @@ char *mp_path_join_bstr(void *talloc_ctx, struct bstr p1, struct bstr p2)
     have_separator = endchar1 == '/';
 #endif
 
-    return talloc_asprintf(talloc_ctx, "%.*s%s%.*s", BSTR_P(p1),
-                           have_separator ? "" : "/", BSTR_P(p2));
+    char *path = talloc_asprintf(talloc_ctx, "%.*s%s%.*s", BSTR_P(p1),
+                                 have_separator ? "" : "/", BSTR_P(p2));
+#if HAVE_DOS_PATHS
+    struct bstr p = bstr0(path);
+    test = (p.len >= 2 && p.start[1] == ':') || p.start[0] == '\\';
+    if (test) {
+        char *pos = strchr(path, '/');
+        while (pos) {
+            *pos = '\\';
+            pos = strchr(path, '/');
+        }
+    }
+#endif
+    return path;
 }
 
 char *mp_path_join(void *talloc_ctx, const char *p1, const char *p2)


### PR DESCRIPTION
#6565.

- [ ] When playing a file, convert `/` to `\`.
- [ ] When playing a directory, use `\` when adding files to the playlist (notice this process is recursive). Should also work for relative paths.
- [ ] Print config file paths with `\`.
- [ ] `mp.utils.join_path` converts `/` to `\` when the joined path is an absolute path (starts with `X:` or `\` or `/`) or the path contains `\` already. In the manual tell users if this function just receives two random strings, it uses `/` to be safe. (i.e., not intended be used to construct relative file paths on windows, if `\` is desired. But users can always convert on their own in the script.)
- [ ] What if mpv is run in a mingw shell?

