### PR TITLE
cocoa-cb: remove all force unwrappings of optionals

### DIFF
--- a/osdep/macOS_swift_extensions.swift
+++ b/osdep/macOS_swift_extensions.swift
@@ -21,7 +21,7 @@ extension NSScreen {
 
     public var displayID: CGDirectDisplayID {
         get {
-            return deviceDescription["NSScreenNumber"] as! CGDirectDisplayID
+            return deviceDescription["NSScreenNumber"] as? CGDirectDisplayID ?? 0
         }
     }
 
@@ -37,8 +37,8 @@ extension NSScreen {
 
             repeat {
                 object = IOIteratorNext(iter)
-                let info = IODisplayCreateInfoDictionary(object, IOOptionBits(kIODisplayOnlyPreferredName)).takeRetainedValue() as! [String:AnyObject]
-                if (info[kDisplayVendorID] as? UInt32 == CGDisplayVendorNumber(displayID) &&
+                if let info = IODisplayCreateInfoDictionary(object, IOOptionBits(kIODisplayOnlyPreferredName)).takeRetainedValue() as? [String:AnyObject],
+                    (info[kDisplayVendorID] as? UInt32 == CGDisplayVendorNumber(displayID) &&
                     info[kDisplayProductID] as? UInt32 == CGDisplayModelNumber(displayID) &&
                     info[kDisplaySerialNumber] as? UInt32 ?? 0 == CGDisplaySerialNumber(displayID))
                 {
@@ -60,11 +60,11 @@ extension NSScreen {
 extension NSColor {
 
     convenience init(hex: String) {
-        let int = Int(hex.dropFirst(), radix: 16)
-        let alpha = CGFloat((int! >> 24) & 0x000000FF)/255
-        let red   = CGFloat((int! >> 16) & 0x000000FF)/255
-        let green = CGFloat((int! >> 8)  & 0x000000FF)/255
-        let blue  = CGFloat((int!)       & 0x000000FF)/255
+        let int = Int(hex.dropFirst(), radix: 16) ?? 0
+        let alpha = CGFloat((int >> 24) & 0x000000FF)/255
+        let red   = CGFloat((int >> 16) & 0x000000FF)/255
+        let green = CGFloat((int >> 8)  & 0x000000FF)/255
+        let blue  = CGFloat((int)       & 0x000000FF)/255
 
         self.init(calibratedRed: red, green: green, blue: blue, alpha: alpha)
     }

--- a/video/out/cocoa-cb/video_layer.swift
+++ b/video/out/cocoa-cb/video_layer.swift
@@ -19,62 +19,60 @@ import Cocoa
 import OpenGL.GL
 import OpenGL.GL3
 
+let glVersions: [CGLOpenGLProfile] = [
+    kCGLOGLPVersion_3_2_Core,
+    kCGLOGLPVersion_Legacy
+]
+
+let glFormatBase: [CGLPixelFormatAttribute] = [
+    kCGLPFAOpenGLProfile,
+    kCGLPFAAccelerated,
+    kCGLPFADoubleBuffer
+]
+
+let glFormatSoftwareBase: [CGLPixelFormatAttribute] = [
+    kCGLPFAOpenGLProfile,
+    kCGLPFARendererID,
+    CGLPixelFormatAttribute(UInt32(kCGLRendererGenericFloatID)),
+    kCGLPFADoubleBuffer
+]
+
+let glFormatOptional: [CGLPixelFormatAttribute] = [
+    kCGLPFABackingStore,
+    kCGLPFAAllowOfflineRenderers,
+    kCGLPFASupportsAutomaticGraphicsSwitching
+]
+
+let attributeLookUp: [UInt32:String] = [
+    kCGLOGLPVersion_3_2_Core.rawValue:     "kCGLOGLPVersion_3_2_Core",
+    kCGLOGLPVersion_Legacy.rawValue:       "kCGLOGLPVersion_Legacy",
+    kCGLPFAOpenGLProfile.rawValue:         "kCGLPFAOpenGLProfile",
+    UInt32(kCGLRendererGenericFloatID):    "kCGLRendererGenericFloatID",
+    kCGLPFARendererID.rawValue:            "kCGLPFARendererID",
+    kCGLPFAAccelerated.rawValue:           "kCGLPFAAccelerated",
+    kCGLPFADoubleBuffer.rawValue:          "kCGLPFADoubleBuffer",
+    kCGLPFABackingStore.rawValue:          "kCGLPFABackingStore",
+    kCGLPFAAllowOfflineRenderers.rawValue: "kCGLPFAAllowOfflineRenderers",
+    kCGLPFASupportsAutomaticGraphicsSwitching.rawValue: "kCGLPFASupportsAutomaticGraphicsSwitching",
+]
+
 class VideoLayer: CAOpenGLLayer {
 
     weak var cocoaCB: CocoaCB!
-    var mpv: MPVHelper! {
-        get { return cocoaCB == nil ? nil : cocoaCB.mpv }
-    }
+    var mpv: MPVHelper { get { return cocoaCB.mpv } }
 
     let videoLock = NSLock()
     let displayLock = NSLock()
+    let cglContext: CGLContextObj
+    let cglPixelFormat: CGLPixelFormatObj
     var needsFlip: Bool = false
     var forceDraw: Bool = false
-    var cglContext: CGLContextObj? = nil
-    var cglPixelFormat: CGLPixelFormatObj? = nil
-    var surfaceSize: NSSize?
+    var surfaceSize: NSSize = NSSize(width: 0, height: 0)
 
     enum Draw: Int { case normal = 1, atomic, atomicEnd }
     var draw: Draw = .normal
 
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue.draw")
-
-    let glVersions: [CGLOpenGLProfile] = [
-        kCGLOGLPVersion_3_2_Core,
-        kCGLOGLPVersion_Legacy
-    ]
-
-    let glFormatBase: [CGLPixelFormatAttribute] = [
-        kCGLPFAOpenGLProfile,
-        kCGLPFAAccelerated,
-        kCGLPFADoubleBuffer
-    ]
-
-    let glFormatSoftwareBase: [CGLPixelFormatAttribute] = [
-        kCGLPFAOpenGLProfile,
-        kCGLPFARendererID,
-        CGLPixelFormatAttribute(UInt32(kCGLRendererGenericFloatID)),
-        kCGLPFADoubleBuffer
-    ]
-
-    let glFormatOptional: [CGLPixelFormatAttribute] = [
-        kCGLPFABackingStore,
-        kCGLPFAAllowOfflineRenderers,
-        kCGLPFASupportsAutomaticGraphicsSwitching
-    ]
-
-    let attributeLookUp: [UInt32:String] = [
-        kCGLOGLPVersion_3_2_Core.rawValue:     "kCGLOGLPVersion_3_2_Core",
-        kCGLOGLPVersion_Legacy.rawValue:       "kCGLOGLPVersion_Legacy",
-        kCGLPFAOpenGLProfile.rawValue:         "kCGLPFAOpenGLProfile",
-        UInt32(kCGLRendererGenericFloatID):    "kCGLRendererGenericFloatID",
-        kCGLPFARendererID.rawValue:            "kCGLPFARendererID",
-        kCGLPFAAccelerated.rawValue:           "kCGLPFAAccelerated",
-        kCGLPFADoubleBuffer.rawValue:          "kCGLPFADoubleBuffer",
-        kCGLPFABackingStore.rawValue:          "kCGLPFABackingStore",
-        kCGLPFAAllowOfflineRenderers.rawValue: "kCGLPFAAllowOfflineRenderers",
-        kCGLPFASupportsAutomaticGraphicsSwitching.rawValue: "kCGLPFASupportsAutomaticGraphicsSwitching",
-    ]
 
     var needsICCUpdate: Bool = false {
         didSet {
@@ -95,24 +93,30 @@ class VideoLayer: CAOpenGLLayer {
 
     init(cocoaCB ccb: CocoaCB) {
         cocoaCB = ccb
+        cglPixelFormat = VideoLayer.createPixelFormat(ccb.mpv)
+        cglContext = VideoLayer.createContext(ccb.mpv, cglPixelFormat)
         super.init()
         autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
         backgroundColor = NSColor.black.cgColor
 
-        cglPixelFormat = copyCGLPixelFormat(forDisplayMask: 0)
-        CGLCreateContext(cglPixelFormat!, nil, &cglContext)
         var i: GLint = 1
-        CGLSetParameter(cglContext!, kCGLCPSwapInterval, &i)
-        CGLSetCurrentContext(cglContext!)
+        CGLSetParameter(cglContext, kCGLCPSwapInterval, &i)
+        CGLSetCurrentContext(cglContext)
 
         mpv.initRender()
         mpv.setRenderUpdateCallback(updateCallback, context: self)
         mpv.setRenderControlCallback(cocoaCB.controlCallback, context: cocoaCB)
     }
 
+    //necessary for when the layer containing window changes the screen
     override init(layer: Any) {
-        let oldLayer = layer as! VideoLayer
+        guard let oldLayer = layer as? VideoLayer else {
+            fatalError("init(layer: Any) passed an invalid layer")
+        }
         cocoaCB = oldLayer.cocoaCB
+        surfaceSize = oldLayer.surfaceSize
+        cglPixelFormat = oldLayer.cglPixelFormat
+        cglContext = oldLayer.cglContext
         super.init()
     }
 
@@ -127,7 +131,7 @@ class VideoLayer: CAOpenGLLayer {
         if inLiveResize == false {
             isAsynchronous = false
         }
-        return mpv != nil && cocoaCB.backendState == .initialized &&
+        return cocoaCB.backendState == .initialized &&
                (forceDraw || mpv.isRenderUpdateFrame())
     }
 
@@ -147,7 +151,7 @@ class VideoLayer: CAOpenGLLayer {
         }
 
         updateSurfaceSize()
-        mpv.drawRender(surfaceSize!, ctx)
+        mpv.drawRender(surfaceSize, ctx)
 
         if needsICCUpdate {
             needsICCUpdate = false
@@ -158,12 +162,12 @@ class VideoLayer: CAOpenGLLayer {
     func updateSurfaceSize() {
         var dims: [GLint] = [0, 0, 0, 0]
         glGetIntegerv(GLenum(GL_VIEWPORT), &dims)
-        surfaceSize = NSMakeSize(CGFloat(dims[2]), CGFloat(dims[3]))
+        surfaceSize = NSSize(width: CGFloat(dims[2]), height: CGFloat(dims[3]))
 
-        if NSEqualSizes(surfaceSize!, NSZeroSize) {
+        if NSEqualSizes(surfaceSize, NSZeroSize) {
             surfaceSize = bounds.size
-            surfaceSize!.width *= contentsScale
-            surfaceSize!.height *= contentsScale
+            surfaceSize.width *= contentsScale
+            surfaceSize.height *= contentsScale
         }
     }
 
@@ -182,28 +186,65 @@ class VideoLayer: CAOpenGLLayer {
     }
 
     override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj {
-        if cglPixelFormat != nil { return cglPixelFormat! }
+        return cglPixelFormat
+    }
 
+    override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj {
+        contentsScale = cocoaCB.window?.backingScaleFactor ?? 1.0
+        return cglContext
+    }
+
+    let updateCallback: mpv_render_update_fn = { (ctx) in
+        let layer: VideoLayer = unsafeBitCast(ctx, to: VideoLayer.self)
+        layer.update()
+    }
+
+    override func display() {
+        displayLock.lock()
+        let isUpdate = needsFlip
+        super.display()
+        CATransaction.flush()
+        if isUpdate && needsFlip {
+            CGLSetCurrentContext(cglContext)
+            if mpv.isRenderUpdateFrame() {
+                mpv.drawRender(NSZeroSize, cglContext, skip: true)
+            }
+        }
+        displayLock.unlock()
+    }
+
+    func update(force: Bool = false) {
+        if force { forceDraw = true }
+        queue.async {
+            if self.forceDraw || !self.inLiveResize {
+                self.needsFlip = true
+                self.display()
+            }
+        }
+    }
+
+    class func createPixelFormat(_ mpv: MPVHelper) -> CGLPixelFormatObj {
         var pix: CGLPixelFormatObj?
         var err: CGLError = CGLError(rawValue: 0)
+        let swRender = mpv.macOpts?.cocoa_cb_sw_renderer ?? -1
 
-        if mpv.macOpts!.cocoa_cb_sw_renderer != 1 {
-            (pix, err) = createPixelFormat()
+        if swRender != 1 {
+            (pix, err) = VideoLayer.findPixelFormat(mpv)
         }
 
-        if (err != kCGLNoError || pix == nil) && mpv.macOpts!.cocoa_cb_sw_renderer != 0 {
-            (pix, err) = createPixelFormat(software: true)
+        if (err != kCGLNoError || pix == nil) && swRender != 0 {
+            (pix, err) = VideoLayer.findPixelFormat(mpv, software: true)
         }
 
-        if err != kCGLNoError || pix == nil {
+        guard let pixelFormat = pix, err == kCGLNoError else {
             mpv.sendError("Couldn't create any CGL pixel format")
             exit(1)
         }
 
-        return pix!
+        return pixelFormat
     }
 
-    func createPixelFormat(software: Bool = false) -> (CGLPixelFormatObj?, CGLError) {
+    class func findPixelFormat(_ mpv: MPVHelper, software: Bool = false) -> (CGLPixelFormatObj?, CGLError) {
         var pix: CGLPixelFormatObj?
         var err: CGLError = CGLError(rawValue: 0)
         var npix: GLint = 0
@@ -221,7 +262,7 @@ class VideoLayer: CAOpenGLLayer {
                     glFormat.remove(at: index)
                 } else {
                     let attArray = glFormat.map({ (value: _CGLPixelFormatAttribute) -> String in
-                        return attributeLookUp[value.rawValue]!
+                        return attributeLookUp[value.rawValue] ?? "unknown attribute"
                     })
 
                     mpv.sendVerbose("Created CGL pixel format with attributes: " +
@@ -236,45 +277,23 @@ class VideoLayer: CAOpenGLLayer {
                         "\(software ? "software" : "hardware accelerated") " +
                         "CGL pixel format: \(errS) (\(err.rawValue))")
 
-        if software == false && mpv.macOpts!.cocoa_cb_sw_renderer == -1 {
+        if software == false && (mpv.macOpts?.cocoa_cb_sw_renderer ?? -1) == -1 {
             mpv.sendWarning("Falling back to software renderer")
         }
 
         return (pix, err)
     }
 
-    override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj {
-        contentsScale = cocoaCB.window.backingScaleFactor
-        return cglContext!
-    }
+    class func createContext(_ mpv: MPVHelper, _ pixelFormat: CGLPixelFormatObj) -> CGLContextObj {
+        var context: CGLContextObj?
+        let error = CGLCreateContext(pixelFormat, nil, &context)
 
-    let updateCallback: mpv_render_update_fn = { (ctx) in
-        let layer: VideoLayer = MPVHelper.bridge(ptr: ctx!)
-        layer.update()
-    }
-
-    override func display() {
-        displayLock.lock()
-        let isUpdate = needsFlip
-        super.display()
-        CATransaction.flush()
-        if isUpdate && needsFlip {
-            CGLSetCurrentContext(cglContext!)
-            if mpv.isRenderUpdateFrame() {
-                mpv.drawRender(NSZeroSize, cglContext!, skip: true)
-            }
+        guard let cglContext = context, error == kCGLNoError else {
+            let errS = String(cString: CGLErrorString(error))
+            mpv.sendError("Couldn't create a CGLContext: " + errS)
+            exit(1)
         }
-        displayLock.unlock()
-    }
 
-    func update(force: Bool = false) {
-        if force { forceDraw = true }
-        queue.async {
-            if self.forceDraw || !self.inLiveResize {
-                self.needsFlip = true
-                self.display()
-            }
-        }
+        return cglContext
     }
-
 }

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -20,9 +20,7 @@ import Cocoa
 class Window: NSWindow, NSWindowDelegate {
 
     weak var cocoaCB: CocoaCB! = nil
-    var mpv: MPVHelper! {
-        get { return cocoaCB == nil ? nil : cocoaCB.mpv }
-    }
+    var mpv: MPVHelper { get { return cocoaCB.mpv } }
 
     var targetScreen: NSScreen?
     var previousScreen: NSScreen?
@@ -37,12 +35,12 @@ class Window: NSWindow, NSWindowDelegate {
 
     var keepAspect: Bool = true {
         didSet {
-            if !isInFullscreen {
-                unfsContentFrame = convertToScreen(contentView!.frame)
+            if let contentViewFrame = contentView?.frame, !isInFullscreen {
+                unfsContentFrame = convertToScreen(contentViewFrame)
             }
 
             if keepAspect {
-                contentAspectRatio = unfsContentFrame!.size
+                contentAspectRatio = unfsContentFrame?.size ?? contentAspectRatio
             } else {
                 resizeIncrements = NSSize(width: 1.0, height: 1.0)
             }
@@ -50,7 +48,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     var border: Bool = true {
-        didSet { if !border { cocoaCB.titleBar.hide() } }
+        didSet { if !border { cocoaCB.titleBar?.hide() } }
     }
 
     override var canBecomeKey: Bool { return true }
@@ -74,10 +72,10 @@ class Window: NSWindow, NSWindowDelegate {
 
         // workaround for an AppKit bug where the NSWindow can't be placed on a
         // none Main screen NSScreen outside the Main screen's frame bounds
-        if screen != NSScreen.main() {
+        if let wantedScreen = screen, screen != NSScreen.main() {
             var absoluteWantedOrigin = contentRect.origin
-            absoluteWantedOrigin.x += screen!.frame.origin.x
-            absoluteWantedOrigin.y += screen!.frame.origin.y
+            absoluteWantedOrigin.x += wantedScreen.frame.origin.x
+            absoluteWantedOrigin.y += wantedScreen.frame.origin.y
 
             if !NSEqualPoints(absoluteWantedOrigin, self.frame.origin) {
                 self.setFrameOrigin(absoluteWantedOrigin)
@@ -89,13 +87,16 @@ class Window: NSWindow, NSWindowDelegate {
         minSize = NSMakeSize(160, 90)
         collectionBehavior = .fullScreenPrimary
         delegate = self
-        contentView!.addSubview(view)
-        view.frame = contentView!.frame
 
-        unfsContentFrame = convertToScreen(contentView!.frame)
-        targetScreen = screen!
-        currentScreen = screen!
-        unfScreen = screen!
+        if let cView = contentView {
+            cView.addSubview(view)
+            view.frame = cView.frame
+            unfsContentFrame = convertToScreen(cView.frame)
+        }
+
+        targetScreen = screen
+        currentScreen = screen
+        unfScreen = screen
 
         if let app = NSApp as? Application {
             app.menuBar.register(#selector(setHalfWindowSize), for: MPM_H_SIZE)
@@ -123,13 +124,13 @@ class Window: NSWindow, NSWindowDelegate {
             previousScreen = screen
         }
 
-        if !isInFullscreen {
-            unfsContentFrame = convertToScreen(contentView!.frame)
+        if let contentViewFrame = contentView?.frame, !isInFullscreen {
+            unfsContentFrame = convertToScreen(contentViewFrame)
             unfScreen = screen
         }
         // move window to target screen when going to fullscreen
-        if !isInFullscreen && (targetScreen != screen) {
-            let frame = calculateWindowPosition(for: targetScreen!, withoutBounds: false)
+        if let tScreen = targetScreen, !isInFullscreen && (tScreen != screen) {
+            let frame = calculateWindowPosition(for: tScreen, withoutBounds: false)
             setFrame(frame, display: true)
         }
 
@@ -154,19 +155,21 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenWithDuration duration: TimeInterval) {
-        cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFit
-        cocoaCB.titleBar.hide()
+        guard let tScreen = targetScreen else { return }
+        cocoaCB.view?.layerContentsPlacement = .scaleProportionallyToFit
+        cocoaCB.titleBar?.hide()
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
             context.duration = getFsAnimationDuration(duration - 0.05)
-            window.animator().setFrame(targetScreen!.frame, display: true)
+            window.animator().setFrame(tScreen.frame, display: true)
         }, completionHandler: { })
     }
 
     func window(_ window: NSWindow, startCustomAnimationToExitFullScreenWithDuration duration: TimeInterval) {
-        let newFrame = calculateWindowPosition(for: targetScreen!, withoutBounds: targetScreen == screen)
-        let intermediateFrame = aspectFit(rect: newFrame, in: screen!.frame)
-        cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFill
-        cocoaCB.titleBar.hide()
+        guard let tScreen = targetScreen, let currentScreen = screen else { return }
+        let newFrame = calculateWindowPosition(for: tScreen, withoutBounds: tScreen == screen)
+        let intermediateFrame = aspectFit(rect: newFrame, in: currentScreen.frame)
+        cocoaCB.view?.layerContentsPlacement = .scaleProportionallyToFill
+        cocoaCB.titleBar?.hide()
         styleMask.remove(.fullScreen)
         setFrame(intermediateFrame, display: true)
 
@@ -181,27 +184,29 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
         cocoaCB.updateCusorVisibility()
         endAnimation(frame)
-        cocoaCB.titleBar.show()
+        cocoaCB.titleBar?.show()
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
+        guard let tScreen = targetScreen else { return }
         isInFullscreen = false
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
-        endAnimation(calculateWindowPosition(for: targetScreen!, withoutBounds: targetScreen == screen))
-        cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFit
+        endAnimation(calculateWindowPosition(for: tScreen, withoutBounds: targetScreen == screen))
+        cocoaCB.view?.layerContentsPlacement = .scaleProportionallyToFit
     }
 
     func windowDidFailToEnterFullScreen(_ window: NSWindow) {
-        let newFrame = calculateWindowPosition(for: targetScreen!, withoutBounds: targetScreen == screen)
+        guard let tScreen = targetScreen else { return }
+        let newFrame = calculateWindowPosition(for: tScreen, withoutBounds: targetScreen == screen)
         setFrame(newFrame, display: true)
         endAnimation()
     }
 
     func windowDidFailToExitFullScreen(_ window: NSWindow) {
-        let newFrame = targetScreen!.frame
-        setFrame(newFrame, display: true)
+        guard let targetFrame = targetScreen?.frame else { return }
+        setFrame(targetFrame, display: true)
         endAnimation()
-        cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFit
+        cocoaCB.view?.layerContentsPlacement = .scaleProportionallyToFit
     }
 
     func endAnimation(_ newFrame: NSRect = NSZeroRect) {
@@ -213,29 +218,31 @@ class Window: NSWindow, NSWindowDelegate {
         }
 
         isAnimating = false
-        cocoaCB.layer.update()
+        cocoaCB.layer?.update()
         cocoaCB.checkShutdown()
     }
 
     func setToFullScreen() {
+        guard let targetFrame = targetScreen?.frame else { return }
         styleMask.insert(.fullScreen)
         NSApp.presentationOptions = [.autoHideMenuBar, .autoHideDock]
-        setFrame(targetScreen!.frame, display: true)
+        setFrame(targetFrame, display: true)
         endAnimation()
         isInFullscreen = true
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
-        cocoaCB.layer.update()
+        cocoaCB.layer?.update()
     }
 
     func setToWindow() {
-        let newFrame = calculateWindowPosition(for: targetScreen!, withoutBounds: targetScreen == screen)
+        guard let tScreen = targetScreen else { return }
+        let newFrame = calculateWindowPosition(for: tScreen, withoutBounds: targetScreen == screen)
         NSApp.presentationOptions = []
         setFrame(newFrame, display: true)
         styleMask.remove(.fullScreen)
         endAnimation()
         isInFullscreen = false
         cocoaCB.flagEvents(VO_EVENT_FULLSCREEN_STATE)
-        cocoaCB.layer.update()
+        cocoaCB.layer?.update()
     }
 
     func getFsAnimationDuration(_ def: Double) -> Double{
@@ -243,35 +250,37 @@ class Window: NSWindow, NSWindowDelegate {
         if duration == "default" {
             return def
         } else {
-            return Double(duration)!/1000
+            return (Double(duration) ?? 0.2)/1000
         }
     }
 
     func setOnTop(_ state: Bool, _ ontopLevel: Any) {
+        let stdLevel = Int(CGWindowLevelForKey(.normalWindow))
+
         if state {
             if ontopLevel is Int {
-                switch ontopLevel as! Int {
+                switch ontopLevel as? Int {
                 case -1:
                     level = Int(CGWindowLevelForKey(.floatingWindow))
                 case -2:
                     level = Int(CGWindowLevelForKey(.statusWindow))+1
                 default:
-                    level = ontopLevel as! Int
+                    level = ontopLevel as? Int ?? stdLevel
                 }
             } else {
-                switch ontopLevel as! String {
+                switch ontopLevel as? String {
                 case "window":
                     level = Int(CGWindowLevelForKey(.floatingWindow))
                 case "system":
                     level = Int(CGWindowLevelForKey(.statusWindow))+1
                 default:
-                    level = Int(ontopLevel as! String)!
+                    level = Int(ontopLevel as? String ?? "") ?? stdLevel
                 }
             }
             collectionBehavior.remove(.transient)
             collectionBehavior.insert(.managed)
         } else {
-            level = Int(CGWindowLevelForKey(.normalWindow))
+            level = stdLevel
         }
     }
 
@@ -292,7 +301,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func updateSize(_ size: NSSize) {
-        if size != contentView!.frame.size {
+        if let currentSize = contentView?.frame.size, size != currentSize {
             let newContentFrame = centeredContentSize(for: frame, size: size)
             if !isInFullscreen {
                 updateFrame(newContentFrame)
@@ -305,8 +314,8 @@ class Window: NSWindow, NSWindowDelegate {
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
         super.setFrame(frameRect, display: flag)
 
-        if keepAspect {
-            contentAspectRatio = unfsContentFrame!.size
+        if let size = unfsContentFrame?.size, keepAspect {
+            contentAspectRatio = size
         }
     }
 
@@ -328,10 +337,13 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func calculateWindowPosition(for tScreen: NSScreen, withoutBounds: Bool) -> NSRect {
-        var newFrame = frameRect(forContentRect: unfsContentFrame!)
+        guard let contentFrame = unfsContentFrame, let screen = unfScreen else {
+            return frame
+        }
+        var newFrame = frameRect(forContentRect: contentFrame)
         let targetFrame = tScreen.frame
         let targetVisibleFrame = tScreen.visibleFrame
-        let unfsScreenFrame = unfScreen!.frame
+        let unfsScreenFrame = screen.frame
         let visibleWindow = NSIntersectionRect(unfsScreenFrame, newFrame)
 
         // calculate visible area of every side
@@ -398,10 +410,12 @@ class Window: NSWindow, NSWindowDelegate {
             return frameRect
         }
 
+        guard let ts: NSScreen = tScreen ?? screen ?? NSScreen.main() else {
+            return frameRect
+        }
         var nf: NSRect = frameRect
-        let ts: NSScreen = tScreen ?? screen ?? NSScreen.main()!
         let of: NSRect = frame
-        let vf: NSRect = (isAnimating ? targetScreen! : ts).visibleFrame
+        let vf: NSRect = (isAnimating ? (targetScreen ?? ts) : ts).visibleFrame
         let ncf: NSRect = contentRect(forFrameRect: nf)
 
         // screen bounds top and bottom
@@ -451,19 +465,19 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func windowDidChangeScreenProfile(_ notification: Notification) {
-        cocoaCB.layer.needsICCUpdate = true
+        cocoaCB.layer?.needsICCUpdate = true
     }
 
     func windowDidChangeBackingProperties(_ notification: Notification) {
-        cocoaCB.layer.contentsScale = backingScaleFactor
+        cocoaCB.layer?.contentsScale = backingScaleFactor
     }
 
     func windowWillStartLiveResize(_ notification: Notification) {
-        cocoaCB.layer.inLiveResize = true
+        cocoaCB.layer?.inLiveResize = true
     }
 
     func windowDidEndLiveResize(_ notification: Notification) {
-        cocoaCB.layer.inLiveResize = false
+        cocoaCB.layer?.inLiveResize = false
     }
 
     func windowShouldClose(_ sender: Any) -> Bool {
@@ -489,7 +503,7 @@ class Window: NSWindow, NSWindowDelegate {
 
     func windowDidChangeOcclusionState(_ notification: Notification) {
         if occlusionState.contains(.visible) {
-            cocoaCB.layer.update(force: true)
+            cocoaCB.layer?.update(force: true)
         }
     }
 


### PR DESCRIPTION
only the last commit is relevant. this removes all the forced unwrapping of optionals, with a few exceptions. one is the cocoaCB object which is always available, it's only an optional in some cases because weak vars have to be optionals. the other exception are the cgl pixel format and the context. both are initialised at init of the layer, but couldn't be nicely set before the super.init call.

otherwise this will most likely fix many segfaults that can only be reproduced in very rare conditions if at all.

this depends on following PRs  #6337 #6469 #6491 #6487 #6466 #6336 #5878 #6317 (#6277).


