### PR TITLE
Update Swift version

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -178,8 +178,8 @@ class MPVHelper: NSObject {
             return
         }
         let iccSize = iccData.count
-        iccData.withUnsafeMutableBytes { (u8Ptr: UnsafeMutablePointer<UInt8>) in
-            let iccBstr = bstrdup(nil, bstr(start: u8Ptr, len: iccSize))
+        iccData.withUnsafeMutableBytes { (u8Ptr: UnsafeMutableRawBufferPointer) in
+            let iccBstr = bstrdup(nil, bstr(start: u8Ptr.baseAddress!.bindMemory(to: UInt8.self, capacity: iccSize), len: iccSize))
             var icc = mpv_byte_array(data: iccBstr.start, size: iccBstr.len)
             let params = mpv_render_param(type: MPV_RENDER_PARAM_ICC_PROFILE, data: &icc)
             mpv_render_context_set_parameter(mpvRenderContext, params)

--- a/osdep/macOS_swift_extensions.swift
+++ b/osdep/macOS_swift_extensions.swift
@@ -21,7 +21,7 @@ extension NSScreen {
 
     public var displayID: CGDirectDisplayID {
         get {
-            return deviceDescription["NSScreenNumber"] as? CGDirectDisplayID ?? 0
+            return deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? 0
         }
     }
 

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -75,7 +75,11 @@ class EventsView: NSView {
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+#if swift(>=5.0)
+        guard let types = sender.draggingPasteboard.types else { return [] }
+#else
         guard let types = sender.draggingPasteboard().types else { return [] }
+#endif
         if types.contains(EventsView.fileURLType) ||
            types.contains(EventsView.URLType) ||
            types.contains(NSPasteboard.PasteboardType.string)
@@ -96,8 +100,12 @@ class EventsView: NSView {
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+#if swift(>=5.0)
+        let pb = sender.draggingPasteboard
+#else
         let pb = sender.draggingPasteboard()
-        guard let types = sender.draggingPasteboard().types else { return false }
+#endif
+        guard let types = pb.types else { return false }
         if types.contains(EventsView.fileURLType) {
             if let files = pb.propertyList(forType: EventsView.fileURLType) as? [Any] {
                 EventsResponder.sharedInstance().handleFilesArray(files)
@@ -235,7 +243,7 @@ class EventsView: NSView {
         var delta: Double
         var cmd: Int32
 
-        if fabs(event.deltaY) >= fabs(event.deltaX) {
+        if abs(event.deltaY) >= abs(event.deltaX) {
             delta = Double(event.deltaY) * 0.1;
             cmd = delta > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN;
         } else {
@@ -243,7 +251,7 @@ class EventsView: NSView {
             cmd = delta > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT;
         }
 
-        mpv.putAxis(cmd, delta: fabs(delta))
+        mpv.putAxis(cmd, delta: abs(delta))
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -259,7 +267,7 @@ class EventsView: NSView {
             let deltaY = modifiers.contains(.shift) ? event.scrollingDeltaX : event.scrollingDeltaY
             var mpkey: Int32
 
-            if fabs(deltaY) >= fabs(deltaX) {
+            if abs(deltaY) >= abs(deltaX) {
                 mpkey = deltaY > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN;
             } else {
                 mpkey = deltaX > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT;

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -29,7 +29,7 @@ class TitleBar: NSVisualEffectView {
         get { return NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled).size.height }
     }
     var buttons: [NSButton] {
-        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindowButton]).flatMap { cocoaCB.window?.standardWindowButton($0) } }
+        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindow.ButtonType]).compactMap { cocoaCB.window?.standardWindowButton($0) } }
     }
 
     override var material: NSVisualEffectView.Material {
@@ -57,7 +57,7 @@ class TitleBar: NSVisualEffectView {
         super.init(frame: f)
         alphaValue = 0
         blendingMode = .withinWindow
-        autoresizingMask = [.viewWidthSizable, .viewMinYMargin]
+        autoresizingMask = [.width, .minYMargin]
         systemBar?.alphaValue = 0
         state = .followsWindowActiveState
         wantsLayer = true
@@ -148,7 +148,7 @@ class TitleBar: NSVisualEffectView {
         }
     }
 
-    func hide() {
+    @objc func hide() {
         guard let window = cocoaCB.window else { return }
         if window.isInFullscreen && !window.isAnimating {
             alphaValue = 0
@@ -175,26 +175,26 @@ class TitleBar: NSVisualEffectView {
     func appearanceFrom(string: String) -> NSAppearance? {
         switch string {
         case "1", "aqua":
-            return NSAppearance(named: NSAppearanceNameAqua)
+            return NSAppearance(named: NSAppearance.Name.aqua)
         case "3", "vibrantLight":
-            return NSAppearance(named: NSAppearanceNameVibrantLight)
+            return NSAppearance(named: NSAppearance.Name.vibrantLight)
         case "4", "vibrantDark":
-            return NSAppearance(named: NSAppearanceNameVibrantDark)
+            return NSAppearance(named: NSAppearance.Name.vibrantDark)
         default: break
         }
 
         if #available(macOS 10.14, *) {
             switch string {
             case "2", "darkAqua":
-                return NSAppearance(named: NSAppearanceNameDarkAqua)
+                return NSAppearance(named: NSAppearance.Name.darkAqua)
             case "5", "aquaHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastAqua)
+                return NSAppearance(named: NSAppearance.Name.accessibilityHighContrastAqua)
             case "6", "darkAquaHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastDarkAqua)
+                return NSAppearance(named: NSAppearance.Name.accessibilityHighContrastDarkAqua)
             case "7", "vibrantLightHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastVibrantLight)
+                return NSAppearance(named: NSAppearance.Name.accessibilityHighContrastVibrantLight)
             case "8", "vibrantDarkHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastVibrantDark)
+                return NSAppearance(named: NSAppearance.Name.accessibilityHighContrastVibrantDark)
             case "0", "auto": fallthrough
             default:
                 return nil

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -54,7 +54,7 @@ class Window: NSWindow, NSWindowDelegate {
     override var canBecomeKey: Bool { return true }
     override var canBecomeMain: Bool { return true }
 
-    override var styleMask: NSWindowStyleMask {
+    override var styleMask: NSWindow.StyleMask {
         get { return super.styleMask }
         set {
             let responder = firstResponder
@@ -72,7 +72,7 @@ class Window: NSWindow, NSWindowDelegate {
 
         // workaround for an AppKit bug where the NSWindow can't be placed on a
         // none Main screen NSScreen outside the Main screen's frame bounds
-        if let wantedScreen = screen, screen != NSScreen.main() {
+        if let wantedScreen = screen, screen != NSScreen.main {
             var absoluteWantedOrigin = contentRect.origin
             absoluteWantedOrigin.x += wantedScreen.frame.origin.x
             absoluteWantedOrigin.y += wantedScreen.frame.origin.y
@@ -261,26 +261,26 @@ class Window: NSWindow, NSWindowDelegate {
             if ontopLevel is Int {
                 switch ontopLevel as? Int {
                 case -1:
-                    level = Int(CGWindowLevelForKey(.floatingWindow))
+                    level = NSWindow.Level(Int(CGWindowLevelForKey(.floatingWindow)))
                 case -2:
-                    level = Int(CGWindowLevelForKey(.statusWindow))+1
+                    level = NSWindow.Level(Int(CGWindowLevelForKey(.statusWindow))+1)
                 default:
-                    level = ontopLevel as? Int ?? stdLevel
+                    level = NSWindow.Level(ontopLevel as? Int ?? stdLevel)
                 }
             } else {
                 switch ontopLevel as? String {
                 case "window":
-                    level = Int(CGWindowLevelForKey(.floatingWindow))
+                    level = NSWindow.Level(Int(CGWindowLevelForKey(.floatingWindow)))
                 case "system":
-                    level = Int(CGWindowLevelForKey(.statusWindow))+1
+                    level = NSWindow.Level(Int(CGWindowLevelForKey(.statusWindow))+1)
                 default:
-                    level = Int(ontopLevel as? String ?? "") ?? stdLevel
+                    level = NSWindow.Level(Int(ontopLevel as? String ?? "") ?? stdLevel)
                 }
             }
             collectionBehavior.remove(.transient)
             collectionBehavior.insert(.managed)
         } else {
-            level = stdLevel
+            level = NSWindow.Level(stdLevel)
         }
     }
 
@@ -410,7 +410,7 @@ class Window: NSWindow, NSWindowDelegate {
             return frameRect
         }
 
-        guard let ts: NSScreen = tScreen ?? screen ?? NSScreen.main() else {
+        guard let ts: NSScreen = tScreen ?? screen ?? NSScreen.main else {
             return frameRect
         }
         var nf: NSRect = frameRect
@@ -443,9 +443,9 @@ class Window: NSWindow, NSWindowDelegate {
         return nf
     }
 
-    func setNormalWindowSize() { setWindowScale(1.0) }
-    func setHalfWindowSize()   { setWindowScale(0.5) }
-    func setDoubleWindowSize() { setWindowScale(2.0) }
+    @objc func setNormalWindowSize() { setWindowScale(1.0) }
+    @objc func setHalfWindowSize()   { setWindowScale(0.5) }
+    @objc func setDoubleWindowSize() { setWindowScale(2.0) }
 
     func setWindowScale(_ scale: Double) {
         mpv.commandAsync(["osd-auto", "set", "window-scale", "\(scale)"])
@@ -480,7 +480,7 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.layer?.inLiveResize = false
     }
 
-    func windowShouldClose(_ sender: Any) -> Bool {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
         cocoa_put_key(SWIFT_KEY_CLOSE_WIN)
         return false
     }

--- a/video/out/cocoa/events_view.m
+++ b/video/out/cocoa/events_view.m
@@ -39,8 +39,8 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        [self registerForDraggedTypes:@[NSFilenamesPboardType,
-                                        NSURLPboardType]];
+        [self registerForDraggedTypes:@[NSPasteboardTypeFileURL,
+                                        NSPasteboardTypeURL]];
         [self setAutoresizingMask:NSViewWidthSizable|NSViewHeightSizable];
     }
     return self;
@@ -305,8 +305,8 @@
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
     NSArray *types = [pboard types];
-    if ([types containsObject:NSFilenamesPboardType] ||
-        [types containsObject:NSURLPboardType]) {
+    if ([types containsObject:NSPasteboardTypeFileURL] ||
+        [types containsObject:NSPasteboardTypeURL]) {
         return NSDragOperationCopy;
     } else {
         return NSDragOperationNone;
@@ -316,11 +316,11 @@
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
-    if ([[pboard types] containsObject:NSFilenamesPboardType]) {
-        NSArray *pbitems = [pboard propertyListForType:NSFilenamesPboardType];
+    if ([[pboard types] containsObject:NSPasteboardTypeFileURL]) {
+        NSArray *pbitems = [pboard propertyListForType:NSPasteboardTypeFileURL];
         [self.adapter handleFilesArray:pbitems];
         return YES;
-    } else if ([[pboard types] containsObject:NSURLPboardType]) {
+    } else if ([[pboard types] containsObject:NSPasteboardTypeURL]) {
         NSURL *url = [NSURL URLFromPasteboard:pboard];
         [self.adapter handleFilesArray:@[[url absoluteString]]];
         return YES;

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -29,7 +29,7 @@ class CocoaCB: NSObject {
 
     var cursorHidden: Bool = false
     var cursorVisibilityWanted: Bool = true
-    var isShuttingDown: Bool = false
+    @objc var isShuttingDown: Bool = false
 
     var title: String = "mpv" {
         didSet { if let window = window { window.title = title } }
@@ -52,7 +52,7 @@ class CocoaCB: NSObject {
 
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue")
 
-    init(_ mpvHandle: OpaquePointer) {
+    @objc init(_ mpvHandle: OpaquePointer) {
         mpv = MPVHelper(mpvHandle)
         super.init()
         layer = VideoLayer(cocoaCB: self)
@@ -97,7 +97,7 @@ class CocoaCB: NSObject {
             mpv.sendError("Something went wrong, no View was initialized")
             exit(1)
         }
-        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main() else {
+        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main else {
             mpv.sendError("Something went wrong, no Screen was found")
             exit(1)
         }
@@ -135,7 +135,7 @@ class CocoaCB: NSObject {
 
     func updateWindowSize(_ vo: UnsafeMutablePointer<vo>) {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
-        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main() else {
+        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main else {
             mpv.sendWarning("Couldn't update Window size, no Screen available")
             return
         }
@@ -170,7 +170,7 @@ class CocoaCB: NSObject {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
         CVDisplayLinkCreateWithActiveCGDisplays(&link)
 
-        guard let screen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main(),
+        guard let screen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main,
               let link = self.link else
         {
             mpv.sendWarning("Couldn't start DisplayLink, no Screen or DisplayLink available")
@@ -279,17 +279,17 @@ class CocoaCB: NSObject {
         // the polinomial approximation for apple lmu value -> lux was empirically
         // derived by firefox developers (Apple provides no documentation).
         // https://bugzilla.mozilla.org/show_bug.cgi?id=793728
-        let power_c4 = 1 / pow(10, 27)
-        let power_c3 = 1 / pow(10, 19)
-        let power_c2 = 1 / pow(10, 12)
-        let power_c1 = 1 / pow(10, 5)
+        let power_c4 = 1 / pow(10.0, 27.0)
+        let power_c3 = 1 / pow(10.0, 19.0)
+        let power_c2 = 1 / pow(10.0, 12.0)
+        let power_c1 = 1 / pow(10.0, 5.0)
 
-        let term4 = -3.0 * power_c4 * pow(Decimal(v), 4)
-        let term3 = 2.6 * power_c3 * pow(Decimal(v), 3)
-        let term2 = -3.4 * power_c2 * pow(Decimal(v), 2)
-        let term1 = 3.9 * power_c1 * Decimal(v)
+        let term4 = -3.0 * power_c4 * pow(Double(v), 4.0)
+        let term3 = 2.6 * power_c3 * pow(Double(v), 3.0)
+        let term2 = -3.4 * power_c2 * pow(Double(v), 2.0)
+        let term1 = 3.9 * power_c1 * Double(v)
 
-        let lux = Int(ceil( Double((term4 + term3 + term2 + term1 - 0.19) as NSNumber)))
+        let lux = Int(ceil(term4 + term3 + term2 + term1 - 0.19))
         return Int(lux > 0 ? lux : 0)
     }
 
@@ -370,7 +370,7 @@ class CocoaCB: NSObject {
     }
 
     func getScreenBy(id screenID: Int) -> NSScreen? {
-        guard let screens = NSScreen.screens() else { return nil}
+        let screens = NSScreen.screens
         if screenID >= screens.count {
             mpv.sendInfo("Screen ID \(screenID) does not exist, falling back to current device")
             return nil
@@ -486,7 +486,7 @@ class CocoaCB: NSObject {
                 var count: Int32 = 0
                 let screen = ccb.window != nil ? ccb.window?.screen :
                                                  ccb.getScreenBy(id: Int(opts.screen_id)) ??
-                                                 NSScreen.main()
+                                                 NSScreen.main
                 let displayName = screen?.displayName ?? "Unknown"
 
                 SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
@@ -545,7 +545,7 @@ class CocoaCB: NSObject {
         }
     }
 
-    func processEvent(_ event: UnsafePointer<mpv_event>) {
+    @objc func processEvent(_ event: UnsafePointer<mpv_event>) {
         switch event.pointee.event_id {
         case MPV_EVENT_SHUTDOWN:
             shutdown()

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -20,8 +20,8 @@ def __add_swift_flags(ctx):
     ctx.env.SWIFT_VERSION = verRe.search(__run([ctx.env.SWIFT, '-version'])).group(1)
 
     # the -swift-version parameter is only supported on swift 3.1 and newer
-    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("3.1"):
-        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "3" ])
+    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("4.0"):
+        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "4" ])
 
     if ctx.is_debug_build():
         ctx.env.SWIFT_FLAGS.append("-g")
@@ -33,11 +33,14 @@ def __add_swift_library_linking_flags(ctx, swift_library):
     ctx.env.append_value('LINKFLAGS', [
         '-L%s' % swift_library,
         '-Xlinker', '-force_load_swift_libs', '-lc++',
+        '-Wl,-rpath,/usr/lib/swift'
     ])
 
 def __find_swift_library(ctx):
     swift_library_paths = [
+        'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx',
         'Toolchains/XcodeDefault.xctoolchain/usr/lib/swift_static/macosx',
+        'usr/lib/swift/macosx'
         'usr/lib/swift_static/macosx'
     ]
     dev_path = __run(['xcode-select', '-p'])[1:]

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -19,8 +19,9 @@ def __add_swift_flags(ctx):
     verRe = re.compile("(?i)version\s?([\d.]+)")
     ctx.env.SWIFT_VERSION = verRe.search(__run([ctx.env.SWIFT, '-version'])).group(1)
 
-    # the -swift-version parameter is only supported on swift 3.1 and newer
-    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("4.0"):
+    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("5.0"):
+        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "5" ])
+    else:
         ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "4" ])
 
     if ctx.is_debug_build():

--- a/wscript
+++ b/wscript
@@ -601,7 +601,8 @@ video_output_features = [
         'groups': [ 'gl' ],
         'func': check_statement('IOSurface/IOSurface.h',
                                 'IOSurfaceRef surface;',
-                                framework='IOSurface')
+                                framework='IOSurface',
+                                cflags=['-DGL_SILENCE_DEPRECATION'])
     } , {
         'name': '--gl-x11',
         'desc': 'OpenGL X11 Backend',


### PR DESCRIPTION
Latest Xcode (10.2) drops Swift 3 support, so this needed doing.
It also drops the static Swift libs in favor of dynamic; on current macOS (10.14.4), those libs are found at /usr/lib/swift, so this PR uses that, but I'm not sure if that's true on older versions; we might have to add something to ship them in redistributable builds somehow.

Also fixes some deprecation warnings in Obj-C code, and silences all OpenGL deprecation warnings, since they're pretty noisy.