### PR TITLE
stream_file: avoid double free

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -161,7 +161,6 @@ static void s_close(stream_t *s)
     struct priv *p = s->priv;
     if (p->close)
         close(p->fd);
-    talloc_free(p->cancel);
 }
 
 // If url is a file:// URL, return the local filename, otherwise return NULL.


### PR DESCRIPTION
`s->priv->cancel` will be freed when `s` is freed.

cc a0cce7f775e97aa364d166c278c49df1325e6cc7 @eric 