### PR TITLE
build: more Swift build changes in preparation for the swift 5 migration and other things

### DIFF
--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -74,4 +74,5 @@ def __find_swift_compiler(ctx):
 def configure(ctx):
     if ctx.env.DEST_OS == "darwin":
         __find_macos_sdk(ctx)
-        __find_swift_compiler(ctx)
+        if ctx.options.enable_swift is not False:
+            __find_swift_compiler(ctx)

--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -10,6 +10,15 @@ def __write_config_h__(ctx):
     __cp_to_variant__(ctx, ctx.options.variant, 'config.h')
     ctx.end_msg("config.h", "PINK")
 
+def __add_swift_defines__(ctx):
+    if ctx.dependency_satisfied("swift"):
+        ctx.start_msg("Adding conditional Swift flags:")
+        from waflib.Tools.c_config import DEFKEYS, INCKEYS
+        for define in ctx.env[DEFKEYS]:
+            if ctx.is_defined(define) and ctx.get_define(define) == "1":
+                ctx.env.SWIFT_FLAGS.extend(["-D", define])
+        ctx.end_msg("yes")
+
 # Approximately escape the string as C string literal
 def __escape_c_string(s):
     return s.replace("\"", "\\\"").replace("\n", "\\n")
@@ -32,4 +41,5 @@ def __add_mpv_defines__(ctx):
 
 def configure(ctx):
     __add_mpv_defines__(ctx)
+    __add_swift_defines__(ctx)
     __write_config_h__(ctx)


### PR DESCRIPTION
commit "cocoa-cb: remove all force unwrappings of optionals" (#6595) can be ignored, it's only in there for a follow up commit.

some explanation to the 4 commits:
1. was something discussed with @avih. no point in checking for swift things when swift was disabled.
2. all our configure flags that are written to config.h were only imported as normal vars in swift and could not be used as conditional compiler flags. the changes import those flags to swift too. the swift flags are a bit restricted. they can only be set or unset, nor value can be passed to them. with that being said only flags that are true/1 are being set for swift. they are not actively used yet, but will be with a follow up PR.
3. are changes in preparation for the swift 5 migration. the swift lib search was slightly adjusted so it first searches for the lib relative to the swift executable. reason for this is, that none Apple provided toolchains (from swift.org for example) are not picked up by the "xcode-select" tool and a mismatch of swift compiler and libs would happen in that case. since there is no other way to get that path, we will first search for the swift libs relative to the swift executable. if no libs are found we will fall back to the old "xcode-select" way. furthermore, since Apple doesn't provide any static libs starting with swift 5 anymore, we additionally search for the static libs. even if we don't use them yet.
4. our auto detection of swift libs and compiler executable work okay'ish in the past, but wasn't infallible. now with the upcoming swift 5 release, even more conditions were added and changed. depending on the new various and different setup our auto detection is bound to fail even more. because of that i decided to make our swift lib and executable paths configurable on configure, for the that everything fails the knowledgable user (most like the one with a special setup) can at least adjust the paths themselves.  paths can be adjusted like:
```
SWIFT_LIB_DYNAMIC="LIB_PATH1" SWIFT_LIB_STATIC="LIB_PATH2" SWIFT="SWIFT_PATH" ./waf configure
```