### PR TITLE
 cocoa-cb: add conditional compilation for Dark Mode features

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -7,7 +7,7 @@ import fileinput
 from optparse import OptionParser
 
 def sh(command):
-    return os.popen(command).read()
+    return os.popen(command).read().strip()
 
 def bundle_path(binary_name):
     return "%s.app" % binary_name
@@ -80,7 +80,7 @@ def main():
 
     if options.deps:
         print("> bundling dependencies")
-        sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)]))
+        print(sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)])))
 
     print("done.")
 

--- a/osdep/macOS_swift_compat.swift
+++ b/osdep/macOS_swift_compat.swift
@@ -1,0 +1,24 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !HAVE_MACOS_10_14_FEATURES
+let NSAppearanceNameDarkAqua = "NSAppearanceNameDarkAqua"
+let NSAppearanceNameAccessibilityHighContrastAqua = "NSAppearanceNameAccessibilityAqua"
+let NSAppearanceNameAccessibilityHighContrastDarkAqua = "NSAppearanceNameAccessibilityDarkAqua"
+let NSAppearanceNameAccessibilityHighContrastVibrantLight = "NSAppearanceNameAccessibilityVibrantLight"
+let NSAppearanceNameAccessibilityHighContrastVibrantDark = "NSAppearanceNameAccessibilityVibrantDark"
+#endif

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -214,6 +214,7 @@ class TitleBar: NSVisualEffectView {
         default:                break
         }
 
+#if HAVE_MACOS_10_11_FEATURES
         if #available(macOS 10.11, *) {
             switch string {
             case "2,", "menu":          return .menu
@@ -224,7 +225,8 @@ class TitleBar: NSVisualEffectView {
             default:                    break
             }
         }
-
+#endif
+#if HAVE_MACOS_10_14_FEATURES
         if #available(macOS 10.14, *) {
             switch string {
             case "5,", "headerView":            return .headerView
@@ -239,6 +241,7 @@ class TitleBar: NSVisualEffectView {
             default:                            break
             }
         }
+#endif
 
         return .titlebar
     }

--- a/waftools/checks/generic.py
+++ b/waftools/checks/generic.py
@@ -1,5 +1,6 @@
 import os
 import inflector
+from distutils.version import StrictVersion
 from waflib.ConfigSet import ConfigSet
 from waflib import Utils
 
@@ -8,7 +9,7 @@ __all__ = [
     "check_pkg_config_cflags", "check_cc", "check_statement", "check_libs",
     "check_headers", "compose_checks", "check_true", "any_version",
     "load_fragment", "check_stub", "check_ctx_vars", "check_program",
-    "check_pkg_config_datadir"]
+    "check_pkg_config_datadir", "check_macos_sdk"]
 
 any_version = None
 
@@ -186,3 +187,13 @@ def load_fragment(fragment):
     fragment_code = fp.read()
     fp.close()
     return fragment_code
+
+def check_macos_sdk(version):
+    def fn(ctx, dependency_identifier):
+        if ctx.env.MACOS_SDK_VERSION:
+            if StrictVersion(ctx.env.MACOS_SDK_VERSION) >= StrictVersion(version):
+                ctx.define(inflector.define_key(dependency_identifier), 1)
+                return True
+        return False
+
+    return fn

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -74,4 +74,5 @@ def __find_swift_compiler(ctx):
 def configure(ctx):
     if ctx.env.DEST_OS == "darwin":
         __find_macos_sdk(ctx)
-        __find_swift_compiler(ctx)
+        if ctx.options.enable_swift is not False:
+            __find_swift_compiler(ctx)

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -1,4 +1,5 @@
 import re
+import string
 import os.path
 from waflib import Utils
 from distutils.version import StrictVersion
@@ -116,9 +117,18 @@ def __find_swift_library(ctx):
 def __find_macos_sdk(ctx):
     ctx.start_msg('Checking for macOS SDK')
     sdk = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
+    sdk_build_version = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-build-version' ])
+
     if sdk:
         ctx.end_msg(sdk)
         ctx.env.MACOS_SDK = sdk
+
+        if sdk_build_version:
+            verRe = re.compile("(\d+)(\D+)(\d+)")
+            version_parts = verRe.search(sdk_build_version)
+            major = int(version_parts.group(1))-4
+            minor = string.ascii_lowercase.index(version_parts.group(2).lower())
+            ctx.env.MACOS_SDK_VERSION = '10.' + str(major) + '.' + str(minor)
     else:
         ctx.end_msg(False)
 

--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -10,6 +10,15 @@ def __write_config_h__(ctx):
     __cp_to_variant__(ctx, ctx.options.variant, 'config.h')
     ctx.end_msg("config.h", "PINK")
 
+def __add_swift_defines__(ctx):
+    if ctx.dependency_satisfied("swift"):
+        ctx.start_msg("Adding conditional Swift flags:")
+        from waflib.Tools.c_config import DEFKEYS, INCKEYS
+        for define in ctx.env[DEFKEYS]:
+            if ctx.is_defined(define) and ctx.get_define(define) == "1":
+                ctx.env.SWIFT_FLAGS.extend(["-D", define])
+        ctx.end_msg("yes")
+
 # Approximately escape the string as C string literal
 def __escape_c_string(s):
     return s.replace("\"", "\\\"").replace("\n", "\\n")
@@ -32,4 +41,5 @@ def __add_mpv_defines__(ctx):
 
 def configure(ctx):
     __add_mpv_defines__(ctx)
+    __add_swift_defines__(ctx)
     __write_config_h__(ctx)

--- a/wscript
+++ b/wscript
@@ -125,6 +125,11 @@ build_options = [
         'desc': 'generate a clang compilation database',
         'func': check_true,
         'default': 'disable',
+    } , {
+        'name': '--swift-static',
+        'desc': 'static Swift linking',
+        'deps': 'os-darwin',
+        'func': check_ctx_vars('SWIFT_LIB_STATIC')
     }
 ]
 

--- a/wscript
+++ b/wscript
@@ -927,7 +927,17 @@ standalone_features = [
             framework_name=['AppKit'],
             compile_filename='test-touchbar.m',
             linkflags='-fobjc-arc')
-     }, {
+    }, {
+        'name': '--macos-10-11-features',
+        'desc': 'macOS 10.11 SDK Features',
+        'deps': 'cocoa',
+        'func': check_macos_sdk('10.11')
+    }, {
+        'name': '--macos-10-14-features',
+        'desc': 'macOS 10.14 SDK Features',
+        'deps': 'cocoa',
+        'func': check_macos_sdk('10.14')
+    }, {
         'name': '--macos-cocoa-cb',
         'desc': 'macOS opengl-cb backend',
         'deps': 'cocoa  && swift',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -165,6 +165,7 @@ def build(ctx):
         swift_source = [
             ( "osdep/macOS_mpv_helper.swift" ),
             ( "osdep/macOS_swift_extensions.swift" ),
+            ( "osdep/macOS_swift_compat.swift" ),
             ( "video/out/cocoa-cb/events_view.swift" ),
             ( "video/out/cocoa-cb/video_layer.swift" ),
             ( "video/out/cocoa-cb/window.swift" ),


### PR DESCRIPTION
only the last two commits is relevant. the forward declaration doesn't need to be used, and we could directly use a conditional compilation if wanted.

access to NSVisualEffectView.Material can't be fixed via a forward declaration because the enum can't be extended.

depends on #6635 and #6655, fixes #6621