### PR TITLE
Fix shaderc dependencies in the Appveyor build

### DIFF
--- a/TOOLS/appveyor-install.sh
+++ b/TOOLS/appveyor-install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
 set -e
 
+export PYTHON=/usr/bin/python3
+
 # Write an empty fonts.conf to speed up fc-cache
 export FONTCONFIG_FILE=/dummy-fonts.conf
 cat >"$FONTCONFIG_FILE" <<EOF
@@ -52,15 +54,12 @@ pacman -Sc --noconfirm
 # Compile shaderc
 (
     git clone --depth=1 https://github.com/google/shaderc && cd shaderc
-    git clone --depth=1 https://github.com/google/glslang.git third_party/glslang
-    git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Tools.git third_party/spirv-tools
-    git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-headers
+    "$PYTHON" utils/git-sync-deps
 
     mkdir build && cd build
     cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DSHADERC_SKIP_TESTS=ON \
           -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX ..
     ninja install
-    cp -f libshaderc/libshaderc_shared.dll $MINGW_PREFIX/bin/
 )
 
 # Compile crossc


### PR DESCRIPTION
This fixes the Appveyor build, which has been broken for a while. Not sure if anyone still cares about it now that Travis is testing Windows as well, but I suppose it's nice to verify that mpv still builds on native Windows.