### PR TITLE
Replace crossc with SPIRV-Cross' built-in C API

### DIFF
--- a/TOOLS/appveyor-build.sh
+++ b/TOOLS/appveyor-build.sh
@@ -11,7 +11,7 @@ export PYTHON=/usr/bin/python3
 "$PYTHON" waf configure \
     --check-c-compiler=gcc \
     --disable-egl-angle-lib \
-    --enable-crossc \
+    --enable-spirv-cross \
     --enable-d3d-hwaccel \
     --enable-d3d11 \
     --enable-egl-angle \

--- a/TOOLS/appveyor-install.sh
+++ b/TOOLS/appveyor-install.sh
@@ -62,10 +62,11 @@ pacman -Sc --noconfirm
     ninja install
 )
 
-# Compile crossc
+# Compile SPIRV-Cross
 (
-    git clone --depth=1 https://github.com/rossy/crossc && cd crossc
-    git submodule update --init
+    git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Cross && cd SPIRV-Cross
 
-    make -j4 install prefix=$MINGW_PREFIX
+    mkdir build && cd build
+    cmake -GNinja -DSPIRV_CROSS_SHARED=ON -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX ..
+    ninja install
 )

--- a/wscript
+++ b/wscript
@@ -747,13 +747,13 @@ video_output_features = [
         'deps': 'shaderc-shared || shaderc-static',
         'func': check_true,
     }, {
-        'name': '--crossc',
-        'desc': 'libcrossc SPIR-V translator',
-        'func': check_pkg_config('crossc'),
+        'name': '--spirv-cross',
+        'desc': 'SPIRV-Cross SPIR-V shader converter',
+        'func': check_pkg_config('spirv-cross-c-shared'),
     }, {
         'name': '--d3d11',
         'desc': 'Direct3D 11 video output',
-        'deps': 'win32-desktop && shaderc && crossc',
+        'deps': 'win32-desktop && shaderc && spirv-cross',
         'func': check_cc(header_name=['d3d11_1.h', 'dxgi1_2.h']),
     }, {
         # We need MMAL/bcm_host/dispmanx APIs. Also, most RPI distros require


### PR DESCRIPTION
SPIRV-Cross recently added its own built-in C API, which makes crossc kind of unnecessary. This replaces crossc usage with the SPIRV-Cross C API.

Note: I'm not sure if this should be merged right away, because I'm not sure if the current version of SPIRV-Cross is suitable for static linking. Instead, I'm happy for this to be merged at @lachs0r or @shinchiro's convenience (though I'd like to deprecate crossc sooner or later.)