### PR TITLE
vo_gpu/d3d11: adapter selection by name

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,8 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
+    - add `--d3d11-adapter` to enable explicit selection of a D3D11 rendering
+      adapter by name.
     - rename `--drm-osd-plane-id` to `--drm-draw-plane`, `--drm-video-plane-id` to
       `--drm-drmprime-video-plane` and `--drm-osd-size` to `--drm-draw-surface-size`
       to better reflect what the options actually control, that the values they

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4675,11 +4675,10 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Schedule each frame to be presented for this number of VBlank intervals.
     (default: 1) Setting to 1 will enable VSync, setting to 0 will disable it.
 
-``--d3d11-adapter=<adapter name>``
+``--d3d11-adapter=<adapter name|help>``
     Select a specific D3D11 adapter to utilize for D3D11 rendering.
     Will pick the default adapter if unset. Alternatives are listed
-    when the d3d11 back-end is initialized with verbosity level verbose
-    or higher.
+    when the name "help" is given.
 
     Hardware decoders utilizing the D3D11 rendering abstraction's helper
     functionality to receive a device, such as D3D11VA or DXVA2's DXGI

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4675,6 +4675,16 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Schedule each frame to be presented for this number of VBlank intervals.
     (default: 1) Setting to 1 will enable VSync, setting to 0 will disable it.
 
+``--d3d11-adapter=<adapter name>``
+    Select a specific D3D11 adapter to utilize for D3D11 rendering.
+    Will pick the default adapter if unset. Alternatives are listed
+    when the d3d11 back-end is initialized with verbosity level verbose
+    or higher.
+
+    Hardware decoders utilizing the D3D11 rendering abstraction's helper
+    functionality to receive a device, such as D3D11VA or DXVA2's DXGI
+    mode, will be affected by this choice.
+
 ``--d3d11va-zero-copy=<yes|no>``
     By default, when using hardware decoding with ``--gpu-api=d3d11``, the
     video image will be copied (GPU-to-GPU) from the decoder surface to a

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -314,6 +314,7 @@ static bool d3d11_init(struct ra_ctx *ctx)
         .force_warp = p->opts->warp == 1,
         .max_feature_level = p->opts->feature_level,
         .max_frame_latency = ctx->vo->opts->swapchain_depth,
+        .adapter_name = p->opts->adapter_name,
     };
     if (!mp_d3d11_create_present_device(ctx->log, &dopts, &p->device))
         goto error;

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -31,6 +31,7 @@ struct d3d11_opts {
     int warp;
     int flip;
     int sync_interval;
+    char *adapter_name;
 };
 
 #define OPT_BASE_STRUCT struct d3d11_opts
@@ -52,6 +53,7 @@ const struct m_sub_options d3d11_conf = {
                     {"9_1", D3D_FEATURE_LEVEL_9_1})),
         OPT_FLAG("d3d11-flip", flip, 0),
         OPT_INTRANGE("d3d11-sync-interval", sync_interval, 0, 0, 4),
+        OPT_STRING("d3d11-adapter", adapter_name, 0),
         {0}
     },
     .defaults = &(const struct d3d11_opts) {
@@ -59,6 +61,7 @@ const struct m_sub_options d3d11_conf = {
         .warp = -1,
         .flip = 1,
         .sync_interval = 1,
+        .adapter_name = NULL,
     },
     .size = sizeof(struct d3d11_opts)
 };

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -59,6 +59,10 @@ struct d3d11_device_opts {
     char *adapter_name;
 };
 
+bool mp_d3d11_list_or_verify_adapters(struct mp_log *log,
+                                      bstr *adapter_name,
+                                      bstr *listing);
+
 bool mp_d3d11_create_present_device(struct mp_log *log,
                                     struct d3d11_device_opts *opts,
                                     ID3D11Device **dev_out);

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -52,6 +52,11 @@ struct d3d11_device_opts {
     // not supported, device creation will fail.
     // If unset, defaults to D3D_FEATURE_LEVEL_9_1
     int min_feature_level;
+
+    // The adapter name to utilize if a specific adapter is required
+    // If unset, the default adapter will be utilized when creating
+    // a device.
+    char *adapter_name;
 };
 
 bool mp_d3d11_create_present_device(struct mp_log *log,


### PR DESCRIPTION
Further steps:
* [x] Initial PoC made.
* [x] List adapter names in a better way that can be utilized from either command line or an application.
* [x] General clean-up
* [x] ~~Move `video/d3d11.c` to utilize the same things (seemingly utilized by hwdecs).~~
↑ so apparently d3d11va already expects the `ra_d3d11_create` helper to have been run, which is only run exactly where we do our selection. So hwdec is already affected ＼(^o^)／ .

Test build [here](https://megumin.fushizen.eu/builds/2019-04-20T10-33-mpv-git-a11bcb3d84-pr6647_d3d11_adapter_name.7z).
Usage (before we have added a listing):
1. Open and close a file with `--msg-level=vo/gpu/d3d11=v` (or use a log file)
2. See the listing
    ```
   [vo/gpu/d3d11] Initializing GPU context 'd3d11'
   [vo/gpu/d3d11] Adapter 0: vendor: 4318, description: NVIDIA GeForce GTX 1080
   [vo/gpu/d3d11] Adapter 1: vendor: 5140, description: Microsoft Basic Render Driver
    ```
3. Use the description with `--d3d11-adapter-name`.
4. Bacon!