### PR TITLE
cocoa-cb: fix title bar button state on start up

### DIFF
--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -55,6 +55,8 @@ class TitleBar: NSVisualEffectView {
                            frame.size.width, TitleBar.height)
         cocoaCB = ccb
         super.init(frame: f)
+        buttons.forEach { $0.isHidden = true }
+        isHidden = true
         alphaValue = 0
         blendingMode = .withinWindow
         autoresizingMask = [.width, .minYMargin]


### PR DESCRIPTION
title bar buttons were still clickable right after start up even though they were invisible. just makes the state consistent.

[edit]
only the last commit is relevant, depends on #6595.