### PR TITLE
build: Swift and bundle changes in preparation for Swift 5 migration Part 2

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -7,7 +7,7 @@ import fileinput
 from optparse import OptionParser
 
 def sh(command):
-    return os.popen(command).read()
+    return os.popen(command).read().strip()
 
 def bundle_path(binary_name):
     return "%s.app" % binary_name
@@ -80,7 +80,7 @@ def main():
 
     if options.deps:
         print("> bundling dependencies")
-        sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)]))
+        print(sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)])))
 
     print("done.")
 

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -74,4 +74,5 @@ def __find_swift_compiler(ctx):
 def configure(ctx):
     if ctx.env.DEST_OS == "darwin":
         __find_macos_sdk(ctx)
-        __find_swift_compiler(ctx)
+        if ctx.options.enable_swift is not False:
+            __find_swift_compiler(ctx)

--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -10,6 +10,15 @@ def __write_config_h__(ctx):
     __cp_to_variant__(ctx, ctx.options.variant, 'config.h')
     ctx.end_msg("config.h", "PINK")
 
+def __add_swift_defines__(ctx):
+    if ctx.dependency_satisfied("swift"):
+        ctx.start_msg("Adding conditional Swift flags:")
+        from waflib.Tools.c_config import DEFKEYS, INCKEYS
+        for define in ctx.env[DEFKEYS]:
+            if ctx.is_defined(define) and ctx.get_define(define) == "1":
+                ctx.env.SWIFT_FLAGS.extend(["-D", define])
+        ctx.end_msg("yes")
+
 # Approximately escape the string as C string literal
 def __escape_c_string(s):
     return s.replace("\"", "\\\"").replace("\n", "\\n")
@@ -32,4 +41,5 @@ def __add_mpv_defines__(ctx):
 
 def configure(ctx):
     __add_mpv_defines__(ctx)
+    __add_swift_defines__(ctx)
     __write_config_h__(ctx)

--- a/wscript
+++ b/wscript
@@ -125,6 +125,11 @@ build_options = [
         'desc': 'generate a clang compilation database',
         'func': check_true,
         'default': 'disable',
+    } , {
+        'name': '--swift-static',
+        'desc': 'static Swift linking',
+        'deps': 'os-darwin',
+        'func': check_ctx_vars('SWIFT_LIB_STATIC')
     }
 ]
 


### PR DESCRIPTION
this depends on #6635 (and could theoretically supersede that PR), only the last 3 commits are relevant.

1. for now static linking is still the default. it will be changed to the preferred Apple way (dynamic) when we migrate to swift 5. reasoning, Apple doesn't bundle static libs anymore starting with xcode 10.2/swift5 and with swift 3 static linking was what xcode did prior to swift 4. the linking command line arguments and procedure was blatantly copied from xcode build logs.
2. our bundle script was adjusted so it bundles the dynamic std library of necessary.

for informations sake. the mpv binary will look for the std dynamic swift libs in various places in following order:
1. /usr/lib/swift (only swift 5 because of ABI compatibility/stability)
2. the dev directory which was used for linking
3. in the bundle lib folder (only in the bundle)

this will most likely fix #6232.