### PR TITLE
libarchive: add fallback for systems without C.UTF-8

### DIFF
--- a/osdep/io.h
+++ b/osdep/io.h
@@ -196,6 +196,7 @@ int msync(void *addr, size_t length, int flags);
 // These are stubs since there is not anything that helps with this on Windows.
 #define locale_t int
 #define LC_ALL_MASK 0
+#define LC_CTYPE_MASK 0
 locale_t newlocale(int, const char *, locale_t);
 locale_t uselocale(locale_t);
 void freelocale(locale_t);

--- a/stream/stream_libarchive.c
+++ b/stream/stream_libarchive.c
@@ -244,8 +244,11 @@ struct mp_archive *mp_archive_new(struct mp_log *log, struct stream *src,
     struct mp_archive *mpa = talloc_zero(NULL, struct mp_archive);
     mpa->log = log;
     mpa->locale = newlocale(LC_ALL_MASK, "C.UTF-8", (locale_t)0);
-    if (!mpa->locale)
-        goto err;
+    if (!mpa->locale) {
+        mpa->locale = newlocale(LC_CTYPE_MASK, "", (locale_t)0);
+        if (!mpa->locale)
+            goto err;
+    }
     mpa->arch = archive_read_new();
     mpa->primary_src = src;
     if (!mpa->arch)


### PR DESCRIPTION
Suggested in IRC as a possible fix to #5759 and #6488. Currently libarchive uses C.UTF-8 as a locale, but that is debian specific and thus broken on other linux distros and macOS. This PR leaves C.UTF-8 as the default, but falls back to LC_CTYPE which should just use the environment variable of the current system. Of course, this also supersedes #6438 and #6268. 

I agree that my changes can be relicensed to LGPL 2.1 or later.
