### PR TITLE
man: clarify vavpp requirements

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -468,8 +468,9 @@ Available mpv-only filters are:
     other userdata type will result in hard crashes.
 
 ``vavpp``
-    VA-AP-API video post processing. Works with ``--vo=vaapi`` and ``--vo=gpu``
-    only. Currently deinterlaces. This filter is automatically inserted if
+    VA-API video post processing. Requires the system to support VA-API,
+    i.e. Linux/BSD only. Works with ``--vo=vaapi`` and ``--vo=gpu`` only.
+    Currently deinterlaces. This filter is automatically inserted if
     deinterlacing is requested (either using the ``d`` key, by default mapped to
     the command ``cycle deinterlace``, or the ``--deinterlace`` option).
 


### PR DESCRIPTION
I assume (but cannot confirm) that VA-AP-API is in fact a typo, because most if not all search engine results related to it are from mpv's manual page.

By changing this to VA-API and clarifying that this requires VA-API support on a system to use it, we can hopefully make it clear to unsuspecting Windows users that this is not the filter they're looking for.

Concerns #6690.
