### PR TITLE
cocoa-cb: migrate to swift 5 with swift 4 fallback

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -7,7 +7,7 @@ import fileinput
 from optparse import OptionParser
 
 def sh(command):
-    return os.popen(command).read()
+    return os.popen(command).read().strip()
 
 def bundle_path(binary_name):
     return "%s.app" % binary_name
@@ -80,7 +80,7 @@ def main():
 
     if options.deps:
         print("> bundling dependencies")
-        sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)]))
+        print(sh(" ".join(["TOOLS/dylib-unhell.py", target_binary(binary_name)])))
 
     print("done.")
 

--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -177,9 +177,11 @@ class MPVHelper: NSObject {
             sendWarning("Invalid ICC profile data.")
             return
         }
-        let iccSize = iccData.count
-        iccData.withUnsafeMutableBytes { (u8Ptr: UnsafeMutablePointer<UInt8>) in
-            let iccBstr = bstrdup(nil, bstr(start: u8Ptr, len: iccSize))
+        iccData.withUnsafeMutableBytes { (ptr: UnsafeMutableRawBufferPointer) in
+            guard let baseAddress = ptr.baseAddress, ptr.count > 0 else { return }
+
+            let u8Ptr = baseAddress.assumingMemoryBound(to: UInt8.self)
+            let iccBstr = bstrdup(nil, bstr(start: u8Ptr, len: ptr.count))
             var icc = mpv_byte_array(data: iccBstr.start, size: iccBstr.len)
             let params = mpv_render_param(type: MPV_RENDER_PARAM_ICC_PROFILE, data: &icc)
             mpv_render_context_set_parameter(mpvRenderContext, params)

--- a/osdep/macOS_swift_compat.swift
+++ b/osdep/macOS_swift_compat.swift
@@ -16,9 +16,68 @@
  */
 
 #if !HAVE_MACOS_10_14_FEATURES
-let NSAppearanceNameDarkAqua = "NSAppearanceNameDarkAqua"
-let NSAppearanceNameAccessibilityHighContrastAqua = "NSAppearanceNameAccessibilityAqua"
-let NSAppearanceNameAccessibilityHighContrastDarkAqua = "NSAppearanceNameAccessibilityDarkAqua"
-let NSAppearanceNameAccessibilityHighContrastVibrantLight = "NSAppearanceNameAccessibilityVibrantLight"
-let NSAppearanceNameAccessibilityHighContrastVibrantDark = "NSAppearanceNameAccessibilityVibrantDark"
+extension NSAppearance.Name {
+    static let darkAqua: NSAppearance.Name = NSAppearance.Name(rawValue: "NSAppearanceNameDarkAqua")
+    static let accessibilityHighContrastAqua: NSAppearance.Name = NSAppearance.Name(rawValue: "NSAppearanceNameAccessibilityAqua")
+    static let accessibilityHighContrastDarkAqua: NSAppearance.Name = NSAppearance.Name(rawValue: "NSAppearanceNameAccessibilityDarkAqua")
+    static let accessibilityHighContrastVibrantLight: NSAppearance.Name = NSAppearance.Name(rawValue: "NSAppearanceNameAccessibilityVibrantLight")
+    static let accessibilityHighContrastVibrantDark: NSAppearance.Name = NSAppearance.Name(rawValue: "NSAppearanceNameAccessibilityVibrantDark")
+}
 #endif
+
+extension NSPasteboard.PasteboardType {
+
+    static let fileURLCompat: NSPasteboard.PasteboardType = {
+        if #available(OSX 10.13, *) {
+            return .fileURL
+        } else {
+            return NSPasteboard.PasteboardType(kUTTypeURL as String)
+        }
+    } ()
+
+    static let URLCompat: NSPasteboard.PasteboardType = {
+        if #available(OSX 10.13, *) {
+            return .URL
+        } else {
+            return NSPasteboard.PasteboardType(kUTTypeFileURL as String)
+        }
+    } ()
+}
+
+#if !swift(>=5.0)
+extension Data {
+
+    mutating func withUnsafeMutableBytes<Type>(_ body: (UnsafeMutableRawBufferPointer) throws -> Type) rethrows -> Type {
+        let dataCount = count
+        return try withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) throws -> Type in
+            try body(UnsafeMutableRawBufferPointer(start: ptr, count: dataCount))
+        }
+    }
+}
+#endif
+
+#if !swift(>=4.2)
+extension NSDraggingInfo {
+
+    var draggingPasteboard: NSPasteboard {
+        get { return draggingPasteboard() }
+    }
+}
+#endif
+
+#if !swift(>=4.1)
+extension Array {
+
+    func compactMap<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
+        return try self.flatMap(transform)
+    }
+}
+
+extension NSWindow.Level {
+
+    static func +(left: NSWindow.Level, right: Int) -> NSWindow.Level {
+        return NSWindow.Level(left.rawValue + right)
+    }
+}
+#endif
+

--- a/osdep/macOS_swift_compat.swift
+++ b/osdep/macOS_swift_compat.swift
@@ -1,0 +1,24 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !HAVE_MACOS_10_14_FEATURES
+let NSAppearanceNameDarkAqua = "NSAppearanceNameDarkAqua"
+let NSAppearanceNameAccessibilityHighContrastAqua = "NSAppearanceNameAccessibilityAqua"
+let NSAppearanceNameAccessibilityHighContrastDarkAqua = "NSAppearanceNameAccessibilityDarkAqua"
+let NSAppearanceNameAccessibilityHighContrastVibrantLight = "NSAppearanceNameAccessibilityVibrantLight"
+let NSAppearanceNameAccessibilityHighContrastVibrantDark = "NSAppearanceNameAccessibilityVibrantDark"
+#endif

--- a/osdep/macOS_swift_extensions.swift
+++ b/osdep/macOS_swift_extensions.swift
@@ -17,11 +17,15 @@
 
 import Cocoa
 
+extension NSDeviceDescriptionKey {
+    static let screenNumber = NSDeviceDescriptionKey("NSScreenNumber")
+}
+
 extension NSScreen {
 
     public var displayID: CGDirectDisplayID {
         get {
-            return deviceDescription["NSScreenNumber"] as? CGDirectDisplayID ?? 0
+            return deviceDescription[.screenNumber] as? CGDirectDisplayID ?? 0
         }
     }
 

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -214,6 +214,7 @@ class TitleBar: NSVisualEffectView {
         default:                break
         }
 
+#if HAVE_MACOS_10_11_FEATURES
         if #available(macOS 10.11, *) {
             switch string {
             case "2,", "menu":          return .menu
@@ -224,7 +225,8 @@ class TitleBar: NSVisualEffectView {
             default:                    break
             }
         }
-
+#endif
+#if HAVE_MACOS_10_14_FEATURES
         if #available(macOS 10.14, *) {
             switch string {
             case "5,", "headerView":            return .headerView
@@ -239,6 +241,7 @@ class TitleBar: NSVisualEffectView {
             default:                            break
             }
         }
+#endif
 
         return .titlebar
     }

--- a/video/out/cocoa-cb/title_bar.swift
+++ b/video/out/cocoa-cb/title_bar.swift
@@ -29,7 +29,7 @@ class TitleBar: NSVisualEffectView {
         get { return NSWindow.frameRect(forContentRect: CGRect.zero, styleMask: .titled).size.height }
     }
     var buttons: [NSButton] {
-        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindowButton]).flatMap { cocoaCB.window?.standardWindowButton($0) } }
+        get { return ([.closeButton, .miniaturizeButton, .zoomButton] as [NSWindow.ButtonType]).compactMap { cocoaCB.window?.standardWindowButton($0) } }
     }
 
     override var material: NSVisualEffectView.Material {
@@ -57,7 +57,7 @@ class TitleBar: NSVisualEffectView {
         super.init(frame: f)
         alphaValue = 0
         blendingMode = .withinWindow
-        autoresizingMask = [.viewWidthSizable, .viewMinYMargin]
+        autoresizingMask = [.width, .minYMargin]
         systemBar?.alphaValue = 0
         state = .followsWindowActiveState
         wantsLayer = true
@@ -148,7 +148,7 @@ class TitleBar: NSVisualEffectView {
         }
     }
 
-    func hide() {
+    @objc func hide() {
         guard let window = cocoaCB.window else { return }
         if window.isInFullscreen && !window.isAnimating {
             alphaValue = 0
@@ -175,26 +175,26 @@ class TitleBar: NSVisualEffectView {
     func appearanceFrom(string: String) -> NSAppearance? {
         switch string {
         case "1", "aqua":
-            return NSAppearance(named: NSAppearanceNameAqua)
+            return NSAppearance(named: .aqua)
         case "3", "vibrantLight":
-            return NSAppearance(named: NSAppearanceNameVibrantLight)
+            return NSAppearance(named: .vibrantLight)
         case "4", "vibrantDark":
-            return NSAppearance(named: NSAppearanceNameVibrantDark)
+            return NSAppearance(named: .vibrantDark)
         default: break
         }
 
         if #available(macOS 10.14, *) {
             switch string {
             case "2", "darkAqua":
-                return NSAppearance(named: NSAppearanceNameDarkAqua)
+                return NSAppearance(named: .darkAqua)
             case "5", "aquaHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastAqua)
+                return NSAppearance(named: .accessibilityHighContrastAqua)
             case "6", "darkAquaHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastDarkAqua)
+                return NSAppearance(named: .accessibilityHighContrastDarkAqua)
             case "7", "vibrantLightHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastVibrantLight)
+                return NSAppearance(named: .accessibilityHighContrastVibrantLight)
             case "8", "vibrantDarkHighContrast":
-                return NSAppearance(named: NSAppearanceNameAccessibilityHighContrastVibrantDark)
+                return NSAppearance(named: .accessibilityHighContrastVibrantDark)
             case "0", "auto": fallthrough
             default:
                 return nil

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -54,7 +54,7 @@ class Window: NSWindow, NSWindowDelegate {
     override var canBecomeKey: Bool { return true }
     override var canBecomeMain: Bool { return true }
 
-    override var styleMask: NSWindowStyleMask {
+    override var styleMask: NSWindow.StyleMask {
         get { return super.styleMask }
         set {
             let responder = firstResponder
@@ -72,7 +72,7 @@ class Window: NSWindow, NSWindowDelegate {
 
         // workaround for an AppKit bug where the NSWindow can't be placed on a
         // none Main screen NSScreen outside the Main screen's frame bounds
-        if let wantedScreen = screen, screen != NSScreen.main() {
+        if let wantedScreen = screen, screen != NSScreen.main {
             var absoluteWantedOrigin = contentRect.origin
             absoluteWantedOrigin.x += wantedScreen.frame.origin.x
             absoluteWantedOrigin.y += wantedScreen.frame.origin.y
@@ -255,26 +255,26 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func setOnTop(_ state: Bool, _ ontopLevel: Any) {
-        let stdLevel = Int(CGWindowLevelForKey(.normalWindow))
+        let stdLevel: NSWindow.Level = .normal
 
         if state {
             if ontopLevel is Int {
                 switch ontopLevel as? Int {
                 case .some(-1):
-                    level = Int(CGWindowLevelForKey(.floatingWindow))
+                    level = .floating
                 case .some(-2):
-                    level = Int(CGWindowLevelForKey(.statusWindow))+1
+                    level = .statusBar + 1
                 default:
-                    level = ontopLevel as? Int ?? stdLevel
+                    level = NSWindow.Level(ontopLevel as? Int ?? stdLevel.rawValue)
                 }
             } else {
                 switch ontopLevel as? String {
                 case .some("window"):
-                    level = Int(CGWindowLevelForKey(.floatingWindow))
+                    level = .floating
                 case .some("system"):
-                    level = Int(CGWindowLevelForKey(.statusWindow))+1
+                    level = .statusBar + 1
                 default:
-                    level = Int(ontopLevel as? String ?? "") ?? stdLevel
+                    level = NSWindow.Level(Int(ontopLevel as? String ?? "") ?? stdLevel.rawValue)
                 }
             }
             collectionBehavior.remove(.transient)
@@ -410,7 +410,7 @@ class Window: NSWindow, NSWindowDelegate {
             return frameRect
         }
 
-        guard let ts: NSScreen = tScreen ?? screen ?? NSScreen.main() else {
+        guard let ts: NSScreen = tScreen ?? screen ?? NSScreen.main else {
             return frameRect
         }
         var nf: NSRect = frameRect
@@ -443,9 +443,9 @@ class Window: NSWindow, NSWindowDelegate {
         return nf
     }
 
-    func setNormalWindowSize() { setWindowScale(1.0) }
-    func setHalfWindowSize()   { setWindowScale(0.5) }
-    func setDoubleWindowSize() { setWindowScale(2.0) }
+    @objc func setNormalWindowSize() { setWindowScale(1.0) }
+    @objc func setHalfWindowSize()   { setWindowScale(0.5) }
+    @objc func setDoubleWindowSize() { setWindowScale(2.0) }
 
     func setWindowScale(_ scale: Double) {
         mpv.commandAsync(["osd-auto", "set", "window-scale", "\(scale)"])
@@ -480,7 +480,7 @@ class Window: NSWindow, NSWindowDelegate {
         cocoaCB.layer?.inLiveResize = false
     }
 
-    func windowShouldClose(_ sender: Any) -> Bool {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
         cocoa_put_key(SWIFT_KEY_CLOSE_WIN)
         return false
     }

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -260,18 +260,18 @@ class Window: NSWindow, NSWindowDelegate {
         if state {
             if ontopLevel is Int {
                 switch ontopLevel as? Int {
-                case -1:
+                case .some(-1):
                     level = Int(CGWindowLevelForKey(.floatingWindow))
-                case -2:
+                case .some(-2):
                     level = Int(CGWindowLevelForKey(.statusWindow))+1
                 default:
                     level = ontopLevel as? Int ?? stdLevel
                 }
             } else {
                 switch ontopLevel as? String {
-                case "window":
+                case .some("window"):
                     level = Int(CGWindowLevelForKey(.floatingWindow))
-                case "system":
+                case .some("system"):
                     level = Int(CGWindowLevelForKey(.statusWindow))+1
                 default:
                     level = Int(ontopLevel as? String ?? "") ?? stdLevel

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -29,7 +29,7 @@ class CocoaCB: NSObject {
 
     var cursorHidden: Bool = false
     var cursorVisibilityWanted: Bool = true
-    var isShuttingDown: Bool = false
+    @objc var isShuttingDown: Bool = false
 
     var title: String = "mpv" {
         didSet { if let window = window { window.title = title } }
@@ -52,7 +52,7 @@ class CocoaCB: NSObject {
 
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue")
 
-    init(_ mpvHandle: OpaquePointer) {
+    @objc init(_ mpvHandle: OpaquePointer) {
         mpv = MPVHelper(mpvHandle)
         super.init()
         layer = VideoLayer(cocoaCB: self)
@@ -97,7 +97,7 @@ class CocoaCB: NSObject {
             mpv.sendError("Something went wrong, no View was initialized")
             exit(1)
         }
-        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main() else {
+        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main else {
             mpv.sendError("Something went wrong, no Screen was found")
             exit(1)
         }
@@ -135,7 +135,7 @@ class CocoaCB: NSObject {
 
     func updateWindowSize(_ vo: UnsafeMutablePointer<vo>) {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
-        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main() else {
+        guard let targetScreen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main else {
             mpv.sendWarning("Couldn't update Window size, no Screen available")
             return
         }
@@ -170,7 +170,7 @@ class CocoaCB: NSObject {
         let opts: mp_vo_opts = vo.pointee.opts.pointee
         CVDisplayLinkCreateWithActiveCGDisplays(&link)
 
-        guard let screen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main(),
+        guard let screen = getScreenBy(id: Int(opts.screen_id)) ?? NSScreen.main,
               let link = self.link else
         {
             mpv.sendWarning("Couldn't start DisplayLink, no Screen or DisplayLink available")
@@ -279,18 +279,19 @@ class CocoaCB: NSObject {
         // the polinomial approximation for apple lmu value -> lux was empirically
         // derived by firefox developers (Apple provides no documentation).
         // https://bugzilla.mozilla.org/show_bug.cgi?id=793728
-        let power_c4 = 1 / pow(10, 27)
-        let power_c3 = 1 / pow(10, 19)
-        let power_c2 = 1 / pow(10, 12)
-        let power_c1 = 1 / pow(10, 5)
+        let power_c4: Double = 1 / pow(10, 27)
+        let power_c3: Double = 1 / pow(10, 19)
+        let power_c2: Double = 1 / pow(10, 12)
+        let power_c1: Double = 1 / pow(10, 5)
 
-        let term4 = -3.0 * power_c4 * pow(Decimal(v), 4)
-        let term3 = 2.6 * power_c3 * pow(Decimal(v), 3)
-        let term2 = -3.4 * power_c2 * pow(Decimal(v), 2)
-        let term1 = 3.9 * power_c1 * Decimal(v)
+        let lum = Double(v)
+        let term4: Double = -3.0 * power_c4 * pow(lum, 4.0)
+        let term3: Double = 2.6 * power_c3 * pow(lum, 3.0)
+        let term2: Double = -3.4 * power_c2 * pow(lum, 2.0)
+        let term1: Double = 3.9 * power_c1 * lum
 
-        let lux = Int(ceil( Double((term4 + term3 + term2 + term1 - 0.19) as NSNumber)))
-        return Int(lux > 0 ? lux : 0)
+        let lux = Int(ceil(term4 + term3 + term2 + term1 - 0.19))
+        return lux > 0 ? lux : 0
     }
 
     var lightSensorCallback: IOServiceInterestCallback = { (ctx, service, messageType, messageArgument) -> Void in
@@ -370,14 +371,13 @@ class CocoaCB: NSObject {
     }
 
     func getScreenBy(id screenID: Int) -> NSScreen? {
-        guard let screens = NSScreen.screens() else { return nil}
-        if screenID >= screens.count {
+        if screenID >= NSScreen.screens.count {
             mpv.sendInfo("Screen ID \(screenID) does not exist, falling back to current device")
             return nil
         } else if screenID < 0 {
             return nil
         }
-        return screens[screenID]
+        return NSScreen.screens[screenID]
     }
 
     func getWindowGeometry(forScreen targetScreen: NSScreen,
@@ -486,7 +486,7 @@ class CocoaCB: NSObject {
                 var count: Int32 = 0
                 let screen = ccb.window != nil ? ccb.window?.screen :
                                                  ccb.getScreenBy(id: Int(opts.screen_id)) ??
-                                                 NSScreen.main()
+                                                 NSScreen.main
                 let displayName = screen?.displayName ?? "Unknown"
 
                 SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
@@ -544,7 +544,7 @@ class CocoaCB: NSObject {
         }
     }
 
-    func processEvent(_ event: UnsafePointer<mpv_event>) {
+    @objc func processEvent(_ event: UnsafePointer<mpv_event>) {
         switch event.pointee.event_id {
         case MPV_EVENT_SHUTDOWN:
             shutdown()

--- a/waftools/checks/generic.py
+++ b/waftools/checks/generic.py
@@ -1,5 +1,6 @@
 import os
 import inflector
+from distutils.version import StrictVersion
 from waflib.ConfigSet import ConfigSet
 from waflib import Utils
 
@@ -8,7 +9,7 @@ __all__ = [
     "check_pkg_config_cflags", "check_cc", "check_statement", "check_libs",
     "check_headers", "compose_checks", "check_true", "any_version",
     "load_fragment", "check_stub", "check_ctx_vars", "check_program",
-    "check_pkg_config_datadir"]
+    "check_pkg_config_datadir", "check_macos_sdk"]
 
 any_version = None
 
@@ -186,3 +187,13 @@ def load_fragment(fragment):
     fragment_code = fp.read()
     fp.close()
     return fragment_code
+
+def check_macos_sdk(version):
+    def fn(ctx, dependency_identifier):
+        if ctx.env.MACOS_SDK_VERSION:
+            if StrictVersion(ctx.env.MACOS_SDK_VERSION) >= StrictVersion(version):
+                ctx.define(inflector.define_key(dependency_identifier), 1)
+                return True
+        return False
+
+    return fn

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -116,14 +116,26 @@ def __find_swift_library(ctx):
 
 def __find_macos_sdk(ctx):
     ctx.start_msg('Checking for macOS SDK')
-    sdk = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
-    sdk_build_version = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-build-version' ])
+    sdk = None
+    sdk_build_version = None
+
+    #look for set macOS SDK paths and version in passed environment variables
+    if 'MACOS_SDK' in ctx.environ:
+        sdk = ctx.environ['MACOS_SDK']
+    if 'MACOS_SDK_VERSION' in ctx.environ:
+        ctx.env.MACOS_SDK_VERSION = ctx.environ['MACOS_SDK_VERSION']
+
+    #find macOS SDK paths and version
+    if not sdk:
+        sdk = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
+    if not ctx.env.MACOS_SDK_VERSION:
+        sdk_build_version = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-build-version' ])
 
     if sdk:
         ctx.end_msg(sdk)
         ctx.env.MACOS_SDK = sdk
 
-        if sdk_build_version:
+        if sdk_build_version and not ctx.env.MACOS_SDK_VERSION:
             verRe = re.compile("(\d+)(\D+)(\d+)")
             version_parts = verRe.search(sdk_build_version)
             major = int(version_parts.group(1))-4

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -74,4 +74,5 @@ def __find_swift_compiler(ctx):
 def configure(ctx):
     if ctx.env.DEST_OS == "darwin":
         __find_macos_sdk(ctx)
-        __find_swift_compiler(ctx)
+        if ctx.options.enable_swift is not False:
+            __find_swift_compiler(ctx)

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -1,4 +1,5 @@
 import re
+import string
 import os.path
 from waflib import Utils
 from distutils.version import StrictVersion
@@ -116,9 +117,18 @@ def __find_swift_library(ctx):
 def __find_macos_sdk(ctx):
     ctx.start_msg('Checking for macOS SDK')
     sdk = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-path'])
+    sdk_build_version = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-build-version' ])
+
     if sdk:
         ctx.end_msg(sdk)
         ctx.env.MACOS_SDK = sdk
+
+        if sdk_build_version:
+            verRe = re.compile("(\d+)(\D+)(\d+)")
+            version_parts = verRe.search(sdk_build_version)
+            major = int(version_parts.group(1))-4
+            minor = string.ascii_lowercase.index(version_parts.group(2).lower())
+            ctx.env.MACOS_SDK_VERSION = '10.' + str(major) + '.' + str(minor)
     else:
         ctx.end_msg(False)
 

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -21,9 +21,9 @@ def __add_swift_flags(ctx):
     verRe = re.compile("(?i)version\s?([\d.]+)")
     ctx.env.SWIFT_VERSION = verRe.search(__run([ctx.env.SWIFT, '-version'])).group(1)
 
-    # the -swift-version parameter is only supported on swift 3.1 and newer
-    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("3.1"):
-        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "3" ])
+    # prevent possible breakages with future swift versions
+    if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("6.0"):
+        ctx.env.SWIFT_FLAGS.extend([ "-swift-version", "5" ])
 
     if ctx.is_debug_build():
         ctx.env.SWIFT_FLAGS.append("-g")
@@ -109,7 +109,7 @@ def __find_swift_library(ctx):
         ctx.end_msg(False)
 
     enableStatic = getattr(ctx.options, 'enable_swift-static')
-    if (enableStatic or enableStatic == None) and 'SWIFT_LIB_STATIC' in swift_libraries:
+    if (enableStatic) and 'SWIFT_LIB_STATIC' in swift_libraries:
         __add_static_swift_library_linking_flags(ctx, swift_libraries['SWIFT_LIB_STATIC'])
     else:
         __add_dynamic_swift_library_linking_flags(ctx, swift_libraries['SWIFT_LIB_DYNAMIC'])
@@ -136,7 +136,6 @@ def __find_macos_sdk(ctx):
         sdk_version = __run(['xcrun', '--sdk', 'macosx', '--show-sdk-version' ])
 
     if sdk:
-        ctx.end_msg(sdk)
         ctx.env.MACOS_SDK = sdk
         build_version = '10.10.0'
 
@@ -161,6 +160,8 @@ def __find_macos_sdk(ctx):
                 ctx.env.MACOS_SDK_VERSION = build_version
             else:
                 ctx.env.MACOS_SDK_VERSION = sdk_version
+
+        ctx.end_msg(sdk + ' (version found: ' + ctx.env.MACOS_SDK_VERSION + ')')
     else:
         ctx.end_msg(False)
 

--- a/waftools/generators/headers.py
+++ b/waftools/generators/headers.py
@@ -10,6 +10,15 @@ def __write_config_h__(ctx):
     __cp_to_variant__(ctx, ctx.options.variant, 'config.h')
     ctx.end_msg("config.h", "PINK")
 
+def __add_swift_defines__(ctx):
+    if ctx.dependency_satisfied("swift"):
+        ctx.start_msg("Adding conditional Swift flags:")
+        from waflib.Tools.c_config import DEFKEYS, INCKEYS
+        for define in ctx.env[DEFKEYS]:
+            if ctx.is_defined(define) and ctx.get_define(define) == "1":
+                ctx.env.SWIFT_FLAGS.extend(["-D", define])
+        ctx.end_msg("yes")
+
 # Approximately escape the string as C string literal
 def __escape_c_string(s):
     return s.replace("\"", "\\\"").replace("\n", "\\n")
@@ -32,4 +41,5 @@ def __add_mpv_defines__(ctx):
 
 def configure(ctx):
     __add_mpv_defines__(ctx)
+    __add_swift_defines__(ctx)
     __write_config_h__(ctx)

--- a/wscript
+++ b/wscript
@@ -125,6 +125,11 @@ build_options = [
         'desc': 'generate a clang compilation database',
         'func': check_true,
         'default': 'disable',
+    } , {
+        'name': '--swift-static',
+        'desc': 'static Swift linking',
+        'deps': 'os-darwin',
+        'func': check_ctx_vars('SWIFT_LIB_STATIC')
     }
 ]
 

--- a/wscript
+++ b/wscript
@@ -927,7 +927,17 @@ standalone_features = [
             framework_name=['AppKit'],
             compile_filename='test-touchbar.m',
             linkflags='-fobjc-arc')
-     }, {
+    }, {
+        'name': '--macos-10-11-features',
+        'desc': 'macOS 10.11 SDK Features',
+        'deps': 'cocoa',
+        'func': check_macos_sdk('10.11')
+    }, {
+        'name': '--macos-10-14-features',
+        'desc': 'macOS 10.14 SDK Features',
+        'deps': 'cocoa',
+        'func': check_macos_sdk('10.14')
+    }, {
         'name': '--macos-cocoa-cb',
         'desc': 'macOS opengl-cb backend',
         'deps': 'cocoa  && swift',

--- a/wscript
+++ b/wscript
@@ -129,7 +129,8 @@ build_options = [
         'name': '--swift-static',
         'desc': 'static Swift linking',
         'deps': 'os-darwin',
-        'func': check_ctx_vars('SWIFT_LIB_STATIC')
+        'func': check_ctx_vars('SWIFT_LIB_STATIC'),
+        'default': 'disable'
     }
 ]
 
@@ -940,7 +941,7 @@ standalone_features = [
     }, {
         'name': '--macos-cocoa-cb',
         'desc': 'macOS opengl-cb backend',
-        'deps': 'cocoa  && swift',
+        'deps': 'cocoa && swift',
         'func': check_true
     }
 ]

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -165,6 +165,7 @@ def build(ctx):
         swift_source = [
             ( "osdep/macOS_mpv_helper.swift" ),
             ( "osdep/macOS_swift_extensions.swift" ),
+            ( "osdep/macOS_swift_compat.swift" ),
             ( "video/out/cocoa-cb/events_view.swift" ),
             ( "video/out/cocoa-cb/video_layer.swift" ),
             ( "video/out/cocoa-cb/window.swift" ),


### PR DESCRIPTION
this depends on #6635 #6655 #6637.

1. the macOS SDK path and version was made configurable, so one can overwrite the autodetected values in the case of fail detection and none Apple toolchains.
2. with the removal of optional force unwrappings we broke building on macOS 10.12, this is fixed before the migration to swift 5/4
3. the swift 5 migration was tested on various platforms and combinations of toolchains. building works with all Apple provided toolchains from 10.12.6/xcode 9.1/swift 4 onwards. in some combinations the swift 5 toolchains from swift.org work too.
4. i tired to keep all compatibility stuff in a separate file. that way it's less intrusive and can easily be removed later when unneeded.

```
success:
macOS 10.12.6	SDK10.13		xcode 9.2	swift 4.0.3
macOS 10.13.6	SDK10.13		xcode 9.4	swift 4.1.2
macOS 10.13.6	SDK10.14 (manually)	xcode 9.4	swift 5 (swift.org toolchain)
macOS 10.13.6	SDK10.14		xcode 10.1	swift 5 (swift.org toolchain)
macOS 10.14.4	SDK10.14		xcode 10.2	swift 5

fail:
macOS 10.12.6	SDK10.14 (manually)	xcode 8.3.3	swift 5 (swift.org toolchain)
macOS 10.12.6	SDK10.14 (manually)	xcode 9.1	swift 5 (swift.org toolchain)
macOS 10.13.6	SDK10.13		xcode 9.4	swift 5 (swift.org toolchain)
```

the swift.org toolchain can be used like this. sdk path and version might need to be specified depending on your installed xcode version
```
export TOOLCHAINS=swift
MACOS_SDK="PATH/TO/SDK10.14.4" MACOS_SDK_VERSION="10.14.4" ./waf configure
```

no rebase of the existing PR since the changes made afterwards made rebasing a pain, and because a lot of work was put into it to make the build actually work on older setups. the code also got a style improvement.

tests are appreciated.