### PR TITLE
client: fix potential mpv_command memory leak

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -1035,10 +1035,12 @@ static void cmd_complete(struct mp_cmd_ctx *cmd)
 
 static int run_client_command(mpv_handle *ctx, struct mp_cmd *cmd, mpv_node *res)
 {
-    if (!ctx->mpctx->initialized)
-        return MPV_ERROR_UNINITIALIZED;
     if (!cmd)
         return MPV_ERROR_INVALID_PARAMETER;
+    if (!ctx->mpctx->initialized) {
+        talloc_free(cmd);
+        return MPV_ERROR_UNINITIALIZED;
+    }
 
     cmd->sender = ctx->name;
 
@@ -1139,10 +1141,12 @@ static void async_cmd_fn(void *data)
 
 static int run_async_cmd(mpv_handle *ctx, uint64_t ud, struct mp_cmd *cmd)
 {
-    if (!ctx->mpctx->initialized)
-        return MPV_ERROR_UNINITIALIZED;
     if (!cmd)
         return MPV_ERROR_INVALID_PARAMETER;
+    if (!ctx->mpctx->initialized) {
+        talloc_free(cmd);
+        return MPV_ERROR_UNINITIALIZED;
+    }
 
     cmd->sender = ctx->name;
 


### PR DESCRIPTION
Currently, sending a command to an uninitialized mpv core will leak memory since the mp_cmd struct isn't freed. Reordered it to make sure it won't try to free the cmd if it doesn't exist.

I agree that my changes can be relicensed to LGPL 2.1 or later.
