### PR TITLE
demux: prefer rar over libarchive

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -77,10 +77,10 @@ const demuxer_desc_t *const demuxer_list[] = {
     &demuxer_desc_tv,
 #endif
     &demuxer_desc_matroska,
+    &demuxer_desc_rar,
 #if HAVE_LIBARCHIVE
     &demuxer_desc_libarchive,
 #endif
-    &demuxer_desc_rar,
     &demuxer_desc_lavf,
     &demuxer_desc_mf,
     &demuxer_desc_playlist,


### PR DESCRIPTION
Discussed in IRC. mpv's internal rar demuxer is capable of handling
multi-part rars with recovery records while libarchive fails. If
something goes wrong with the internal rar demuxer, it will try again
with libarchive anyway. So this should overall be a net gain plus users
avoid potential ickiness with libarchive.

I agree that my changes can be relicensed to LGPL 2.1 or later.
