### PR TITLE
render api: fix use-after-free

### DIFF
--- a/player/client.h
+++ b/player/client.h
@@ -49,8 +49,7 @@ bool mp_set_main_render_context(struct mp_client_api *client_api,
                                 struct mpv_render_context *ctx, bool active);
 struct mpv_render_context *
 mp_client_api_acquire_render_context(struct mp_client_api *ca);
-void kill_video_async(struct mp_client_api *client_api, void (*fin)(void *ctx),
-                      void *fin_ctx);
+void kill_video_async(struct mp_client_api *client_api);
 
 bool mp_streamcb_lookup(struct mpv_global *g, const char *protocol,
                         void **out_user_data, mpv_stream_cb_open_ro_fn *out_fn);


### PR DESCRIPTION
render api needs to wait for vo to be destroyed before frees the context. The purpose of kill_cb is to wake up render api after vo is destroyed, but uninit did that before kill_cb, so kill_cb tries using the freed memory. Remove kill_cb to fix the issue as uninit is able to do the work.

This PR is a replacement for #6538. It's been a long time since nobody cares about  issue #6531. Although `#6538` is a solution to the problem, I think this pull request looks more straightforward. Also be aware of the corner case in `#6538`. If `#6538` is a more effective solution, just close the PR. See #6538 for detail.

I agree that my changes can be relicensed to LGPL 2.1 or later.
