### PR TITLE
opengl/context_wayland: Fix crash on configure before initial reconfig

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -45,7 +45,9 @@ static void resize(struct ra_ctx *ctx)
     const int32_t height = wl->scaling*mp_rect_h(wl->geometry);
 
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
-    wl_egl_window_resize(p->egl_window, width, height, 0, 0);
+
+    if (p->egl_window)
+        wl_egl_window_resize(p->egl_window, width, height, 0, 0);
 
     wl->vo->dwidth  = width;
     wl->vo->dheight = height;


### PR DESCRIPTION
If the compositor sends a configure event before the surface is initially
mapped, resize gets called before the egl_window gets created, resulting
in a crash in wl_egl_window_resize.

This was fixed back in 618361c697, but was reintroduced when the wayland
code was rewritten in 68f9ee7e0b.