### PR TITLE
video/out/gpu: Add a `storable` flag to ra_format

### DIFF
--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -233,6 +233,9 @@ static void setup_formats(struct ra *ra)
             .pixel_size     = d3dfmt->bytes,
             .linear_filter  = (support & sup_filter) == sup_filter,
             .renderable     = (support & sup_render) == sup_render,
+            // TODO: Check whether it's a storage format
+            // https://docs.microsoft.com/en-us/windows/desktop/direct3d12/typed-unordered-access-view-loads
+            .storable       = true,
         };
 
         if (support & D3D11_FORMAT_SUPPORT_TEXTURE1D)

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -107,6 +107,7 @@ struct ra_format {
                             // only applies to 2-component textures
     bool linear_filter;     // linear filtering available from shader
     bool renderable;        // can be used for render targets
+    bool storable;          // can be used for storage images
     bool dummy_format;      // is not a real ra_format but a fake one (e.g. FBO).
                             // dummy formats cannot be used to create textures
 

--- a/video/out/gpu/utils.c
+++ b/video/out/gpu/utils.c
@@ -185,7 +185,7 @@ bool ra_tex_resize(struct ra *ra, struct mp_log *log, struct ra_tex **tex,
 
     mp_dbg(log, "Resizing texture: %dx%d\n", w, h);
 
-    if (!fmt || !fmt->renderable || !fmt->linear_filter) {
+    if (!fmt || !fmt->renderable || !fmt->linear_filter || !fmt->storable) {
         mp_err(log, "Format %s not supported.\n", fmt ? fmt->name : "(unset)");
         return false;
     }

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -150,6 +150,9 @@ static int ra_init_gl(struct ra *ra, GL *gl)
             .linear_filter  = gl_fmt->flags & F_TF,
             .renderable     = (gl_fmt->flags & F_CR) &&
                               (gl->mpgl_caps & MPGL_CAP_FB),
+            // TODO: Check whether it's a storable format
+            // https://www.khronos.org/opengl/wiki/Image_Load_Store
+            .storable       = true,
         };
 
         int csize = gl_component_size(gl_fmt->type) * 8;

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -88,6 +88,7 @@ struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log)
             .pixel_size = plfmt->texel_size,
             .linear_filter = plfmt->caps & PL_FMT_CAP_LINEAR,
             .renderable = plfmt->caps & PL_FMT_CAP_RENDERABLE,
+            .storable = plfmt->caps & PL_FMT_CAP_STORABLE,
             .glsl_format = plfmt->glsl_format,
         };
 


### PR DESCRIPTION
While `ra` supports the concept of a texture as a storage
destination, it does not support the concept of a texture format
being usable for a storage texture. This can lead to us attempting
to create a texture from an incompatible format, with undefined
results.

So, let's introduce an explicit format flag for storage and use
it. In `ra_pl` we can simply reflect the `storable` flag. For
GL and D3D, we'll need to write some new code to do the compatibility
checks. I'm not going to do it here because it's not a regression;
we were already implicitly assuming all formats were storable.

Fixes #6657