### PR TITLE
Fix Appveyor for libplacebo and recent MSYS2 changes

### DIFF
--- a/TOOLS/appveyor-build.sh
+++ b/TOOLS/appveyor-build.sh
@@ -10,11 +10,9 @@ export PYTHON=/usr/bin/python3
 "$PYTHON" bootstrap.py
 "$PYTHON" waf configure \
     --check-c-compiler=gcc \
-    --disable-egl-angle-lib \
     --enable-spirv-cross \
     --enable-d3d-hwaccel \
     --enable-d3d11 \
-    --enable-egl-angle \
     --enable-jpeg \
     --enable-lcms2 \
     --enable-libarchive \

--- a/TOOLS/appveyor-install.sh
+++ b/TOOLS/appveyor-install.sh
@@ -14,12 +14,12 @@ EOF
 # Install build dependencies for mpv
 pacman -S --noconfirm --needed \
     $MINGW_PACKAGE_PREFIX-toolchain \
-    $MINGW_PACKAGE_PREFIX-angleproject-git \
     $MINGW_PACKAGE_PREFIX-cmake \
     $MINGW_PACKAGE_PREFIX-lcms2 \
     $MINGW_PACKAGE_PREFIX-libarchive \
     $MINGW_PACKAGE_PREFIX-libass \
     $MINGW_PACKAGE_PREFIX-libjpeg-turbo \
+    $MINGW_PACKAGE_PREFIX-libplacebo \
     $MINGW_PACKAGE_PREFIX-lua51 \
     $MINGW_PACKAGE_PREFIX-ninja \
     $MINGW_PACKAGE_PREFIX-rubberband \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,12 @@ shallow_clone: true
 test: off
 
 install:
+  # Support for Ada and Objective-C was removed from MSYS2. GCC won't update if
+  # these packages are installed.
+  - >-
+    C:\msys64\usr\bin\pacman -R --noconfirm --noprogressbar
+    mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-objc mingw-w64-x86_64-gcc-ada
+    mingw-w64-x86_64-gcc-objc
   # Update core packages
   - C:\msys64\usr\bin\pacman -Syyuu --noconfirm --noprogressbar --ask=20
   # Update non-core packages


### PR DESCRIPTION
This should fix the Appveyor build (again.) ANGLE was removed from MSYS2, so the ANGLE build is no longer tested, but that's probably fine.