### PR TITLE
CoreAudio_exclusive: fix #4478, #3072, #5238 and other improvements

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,8 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
+    - add `--coreaudio-integer-mode`, `--coreaudio-buffer-size`,
+    `--coreaudio-power-saving` and `--coreaudio-iocycle-usage`.
     - rename `--drm-osd-plane-id` to `--drm-draw-plane`, `--drm-video-plane-id` to
       `--drm-drmprime-video-plane` and `--drm-osd-size` to `--drm-draw-surface-size`
       to better reflect what the options actually control, that the values they

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -109,6 +109,35 @@ Available audio output drivers are:
     Native Mac OS X audio output driver using direct device access and
     exclusive mode (bypasses the sound server).
 
+    ``--coreaudio-integer-mode=<yes|no>``
+        Switch between Integer Mode and Float Mode (default: yes). Integer Mode allows
+        sending DAC native format (e.g. 16, 24 or 32 Bit integer) directly to the lowest
+        level in CoreAudio and bypassing the format converter. Not all devices
+        support Integer Mode. Turn off Integer Mode results in coverting audio
+        stream to 32 Bit float format. This option has no affect on SPDIF format.
+
+    ``--coreaudio-buffer-size=<0-24576>``
+        Specify the number of CoreAudio Frame Buffer Size, which represents the amount
+        of data sending to DAC at a time. Setting to a higer value can reduce CPU use
+        and thus save power. However, higer value might cause clicks during playpack,
+        especially in Integer Mode. The actual Frame Buffer Size (shown in
+        "Latency property fsiz") in use can vary with different MacOS version, device
+        and audio format. This option has no affect on SPDIF format. Default: 1024.
+
+    ``--coreaudio-power-saving=<yes|no>``
+        Setting CoreAudio Frame Buffer Size to 4096, or device's maximum avaliable value
+        (default: yes). This option has no affect on SPDIF format or when Integer Mode
+        is on.
+
+    ``--coreaudio-iocycle-usage=<0-1>``
+        Specify the number of IO cycle usage, which indicates how much of the
+        client portion of the IO cycle the process will use. Lower value may improve
+        sound quality, but can also cause corruption and leave "skipping cycle
+        due to overload" message in Console. It is intended for playing music only,
+        as any value that is lower than 1 will lead to A/V sync issues. This option
+        has no affect on SPDIF format. Default: 1.
+
+
 ``openal``
     OpenAL audio output driver
 

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -116,16 +116,16 @@ Available audio output drivers are:
         support Integer Mode. Turn off Integer Mode results in coverting audio
         stream to 32 Bit float format. This option has no effect on SPDIF format.
 
-    ``--coreaudio-buffer-size=<0-24576>``
-        Specify the number of CoreAudio Frame Buffer Size, which represents the amount
+    ``--coreaudio-buffer-size=<0-4096>``
+        Specify the number of CoreAudio IO Buffer Size, which represents the amount
         of data sending to DAC at a time. Setting to a higer value can reduce CPU use
         and thus save power. However, higer value might cause clicks during playpack,
-        especially in Integer Mode. The actual Frame Buffer Size (shown in
+        especially in Integer Mode. The actual value (shown in
         "Latency property fsiz") in use can vary with different MacOS version, device
         and audio format. This option has no effect on SPDIF format. Default: 1024.
 
     ``--coreaudio-power-saving=<yes|no>``
-        Setting CoreAudio Frame Buffer Size to 4096, or device's maximum avaliable value
+        Setting CoreAudio IO Buffer Size to device's maximum avaliable value
         (default: no). This option has no effect on SPDIF format or when Integer Mode
         is on.
 

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -114,7 +114,7 @@ Available audio output drivers are:
         sending DAC native format (e.g. 16, 24 or 32 Bit integer) directly to the lowest
         level in CoreAudio and bypassing the format converter. Not all devices
         support Integer Mode. Turn off Integer Mode results in coverting audio
-        stream to 32 Bit float format. This option has no affect on SPDIF format.
+        stream to 32 Bit float format. This option has no effect on SPDIF format.
 
     ``--coreaudio-buffer-size=<0-24576>``
         Specify the number of CoreAudio Frame Buffer Size, which represents the amount
@@ -122,11 +122,11 @@ Available audio output drivers are:
         and thus save power. However, higer value might cause clicks during playpack,
         especially in Integer Mode. The actual Frame Buffer Size (shown in
         "Latency property fsiz") in use can vary with different MacOS version, device
-        and audio format. This option has no affect on SPDIF format. Default: 1024.
+        and audio format. This option has no effect on SPDIF format. Default: 1024.
 
     ``--coreaudio-power-saving=<yes|no>``
         Setting CoreAudio Frame Buffer Size to 4096, or device's maximum avaliable value
-        (default: yes). This option has no affect on SPDIF format or when Integer Mode
+        (default: no). This option has no effect on SPDIF format or when Integer Mode
         is on.
 
     ``--coreaudio-iocycle-usage=<0-1>``
@@ -135,7 +135,7 @@ Available audio output drivers are:
         sound quality, but can also cause corruption and leave "skipping cycle
         due to overload" message in Console. It is intended for playing music only,
         as any value that is lower than 1 will lead to A/V sync issues. This option
-        has no affect on SPDIF format. Default: 1.
+        has no effect on SPDIF format. Default: 1.
 
 
 ``openal``

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -158,7 +158,7 @@ static int init(struct ao *ao)
         goto coreaudio_error;
 
     AudioStreamBasicDescription asbd;
-    ca_fill_asbd(ao, &asbd, 0);
+    ca_fill_asbd(ao, &asbd);
 
     SetAudioPowerHintToFavorSavingPower();
 
@@ -179,7 +179,7 @@ static void init_physical_format(struct ao *ao)
     void *tmp = talloc_new(NULL);
 
     AudioStreamBasicDescription asbd;
-    ca_fill_asbd(ao, &asbd, 0);
+    ca_fill_asbd(ao, &asbd);
 
     AudioStreamID *streams;
     size_t n_streams;

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -221,9 +221,19 @@ static void init_physical_format(struct ao *ao)
 
             ca_print_asbd(ao, "- ", stream_asbd);
 
-            if (!best_asbd.mFormatID || ca_asbd_is_better(&asbd, &best_asbd,
-                                                          stream_asbd, 1, 0))
+            UInt32 Transport_Type;
+            CA_GET_O(p->device, kAudioDevicePropertyTransportType, &Transport_Type);
+            CHECK_CA_WARN("failed to get device transport type");
+
+            if (Transport_Type == (kAudioDeviceTransportTypeBluetooth | kAudioDeviceTransportTypeBluetoothLE)){
+                if (!best_asbd.mFormatID || ca_asbd_is_better(&asbd, &best_asbd,
+                    stream_asbd, 0, 1))
                 best_asbd = *stream_asbd;
+            }else{
+                if (!best_asbd.mFormatID || ca_asbd_is_better(&asbd, &best_asbd,
+                    stream_asbd, 1, 0))
+                    best_asbd = *stream_asbd;
+            }
         }
 
         if (best_asbd.mFormatID) {

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -158,7 +158,9 @@ static int init(struct ao *ao)
         goto coreaudio_error;
 
     AudioStreamBasicDescription asbd;
-    ca_fill_asbd(ao, &asbd);
+    ca_fill_asbd(ao, &asbd, 0);
+
+    SetAudioPowerHintToFavorSavingPower();
 
     if (!init_audiounit(ao, asbd))
         goto coreaudio_error;
@@ -177,7 +179,7 @@ static void init_physical_format(struct ao *ao)
     void *tmp = talloc_new(NULL);
 
     AudioStreamBasicDescription asbd;
-    ca_fill_asbd(ao, &asbd);
+    ca_fill_asbd(ao, &asbd, 0);
 
     AudioStreamID *streams;
     size_t n_streams;
@@ -220,7 +222,7 @@ static void init_physical_format(struct ao *ao)
             ca_print_asbd(ao, "- ", stream_asbd);
 
             if (!best_asbd.mFormatID || ca_asbd_is_better(&asbd, &best_asbd,
-                                                          stream_asbd))
+                                                          stream_asbd, 1, 0))
                 best_asbd = *stream_asbd;
         }
 
@@ -231,7 +233,7 @@ static void init_physical_format(struct ao *ao)
                          &p->original_asbd);
             CHECK_CA_WARN("could not get current physical stream format");
 
-            if (ca_asbd_equals(&p->original_asbd, &best_asbd)) {
+            if (ca_asbd_equals(&p->original_asbd, &best_asbd, 0)) {
                 MP_VERBOSE(ao, "Requested format already set, not changing.\n");
                 p->original_asbd.mFormatID = 0;
                 break;

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -500,7 +500,7 @@ static int init(struct ao *ao)
     err = CA_GET(p->stream, kAudioStreamPropertyVirtualFormat, &p->stream_asbd);
     CHECK_CA_ERROR("could not get stream's virtual format");
 
-    ca_print_asbd(ao, "Virtual format: ", &p->stream_asbd);
+    ca_print_asbd(ao, "Virtual format:", &p->stream_asbd);
 
     if (!ca_init_chmap(ao, p->device))
         goto coreaudio_error;

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -532,18 +532,13 @@ static int init(struct ao *ao)
         goto coreaudio_error;
     }
 
-    // In Integer Mode, our format must match one of deivce's avaliable physical format.
-    if ((af_fmt_is_pcm(ao->format) && (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable))){
+    // As there is no equivalent 20/24 Bit in mpv's audio format, we need to manually insert "autoconvert".
+    if (af_fmt_is_pcm(ao->format) && (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable)
+        && ((p->stream_asbd.mBitsPerChannel == 24) || (p->stream_asbd.mBitsPerChannel == 20))){
         int OurBitsPerChannel = af_fmt_to_bytes(ao->format) * 8;
-        if ((p->stream_asbd.mBitsPerChannel > OurBitsPerChannel)
-            && (p->stream_asbd.mBitsPerChannel > 16)){ // Devices that don't offer 16 bit.
+        if (p->stream_asbd.mBitsPerChannel > OurBitsPerChannel){
             ao->format = AF_FORMAT_S32;
             MP_VERBOSE(ao, "Device is %u bit, greater than our %u bit, request s32.\n",
-                p->stream_asbd.mBitsPerChannel, OurBitsPerChannel);
-        }else if ((p->stream_asbd.mBitsPerChannel < OurBitsPerChannel)
-            && (p->stream_asbd.mBitsPerChannel < 20)){ // 16 bit only device needs to request s16.
-            ao->format = AF_FORMAT_S16;
-            MP_VERBOSE(ao, "Device is %u bit, less than our %u bit, request s16.\n",
                 p->stream_asbd.mBitsPerChannel, OurBitsPerChannel);
         }
     }

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -75,12 +75,90 @@ struct priv {
     // Output s16 physical format, float32 virtual format, ac3/dts mpv format
     int spdif_hack;
 
+    struct ao_convert_fmt convert;
+
+    int integer_mode;
+
+    int buffersize;
+
+    int power_saving;
+
+    Float32 IOCycleUsage;
+
     bool changed_mixing;
 
     atomic_bool reload_requested;
 
     uint32_t hw_latency_us;
 };
+
+static int device_property(struct ao *ao)
+{
+    struct priv *p = ao->priv;
+    AudioStreamRangedDescription *formats;
+    size_t n_formats;
+
+    OSStatus err = CA_GET_ARY(p->device, kAudioStreamPropertyAvailablePhysicalFormats,
+                     &formats, &n_formats);
+    if (err != noErr)
+    MP_VERBOSE(ao, "Error: could not get number of device formats\n");
+    int maxbitdepth_physical = 0;
+    int integer_mode_avaliable = 0;
+    int max_mBytesPerPacket = 0;
+    int aligned_high = 0;
+    int minbitdepth_physical = 256;
+    for (int j = 0; j < n_formats; j++) {
+        AudioStreamBasicDescription *stream_asbd = &formats[j].mFormat;
+        if (stream_asbd->mFormatID == kAudioFormatLinearPCM){ // Exclude spdif format
+            if (stream_asbd->mBitsPerChannel > maxbitdepth_physical)
+                maxbitdepth_physical = stream_asbd->mBitsPerChannel;
+            if (stream_asbd->mBitsPerChannel < minbitdepth_physical)
+                minbitdepth_physical = stream_asbd->mBitsPerChannel;
+            if (stream_asbd->mFormatFlags & kAudioFormatFlagIsNonMixable)
+                integer_mode_avaliable = 1;
+            if (stream_asbd->mBytesPerPacket > max_mBytesPerPacket)
+                max_mBytesPerPacket = stream_asbd->mBytesPerPacket;
+            if (stream_asbd->mFormatFlags & kLinearPCMFormatFlagIsAlignedHigh)
+                aligned_high = 1;
+            }
+        }
+
+    int device_type = 0;
+    // 20 Bit device support is not tested.
+    if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 24)
+        && (max_mBytesPerPacket == 8) && (aligned_high == 0)){
+        device_type = 1; // unpacked 24 bit aligned low devce.
+        if (minbitdepth_physical == 24)
+            device_type = 7; // unpacked 24 bit aligned low devce which doesn't offer 16 bit format.
+    }else if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 24)
+        && (max_mBytesPerPacket == 8) && (aligned_high == 1)){
+        device_type = 2; // unpacked 24 bit aligned high devce.
+        if (minbitdepth_physical == 24)
+            device_type = 8; // unpacked 24 bit aligned high devce which doesn't offer 16 bit format.
+    }else if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 24) && (max_mBytesPerPacket == 6)){
+        device_type = 3; // packed 24 Bit device.
+        if (minbitdepth_physical == 24)
+            device_type = 9; // packed 24 Bit device which doesn't offer 16 bit format.
+    }else if ((integer_mode_avaliable == 0) && (maxbitdepth_physical == 32)){
+        device_type = 4; // 32 Bit device w/o Integer Mode.
+    }else if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 32) && (minbitdepth_physical == 24)){
+        device_type = 5; // 32 Bit device which doesn't offer 16 bit format.
+    }else if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 16)){
+        device_type = 6; // 16 Bit device which doesn't offer 32 bit format.
+    }else if ((integer_mode_avaliable == 0) && (maxbitdepth_physical == 24)){
+        device_type = 10; // 24 Bit device w/o Integer Mode.
+    }else if ((integer_mode_avaliable == 0) && (maxbitdepth_physical == 20)){
+        device_type = 11; // 20 Bit device w/o Integer Mode.
+    }else if ((integer_mode_avaliable == 1) && (maxbitdepth_physical == 20)
+        && (max_mBytesPerPacket == 8) && (aligned_high == 0)){
+        device_type = 12; // 20 bit aligned low devce (shown in optical output).
+        if (minbitdepth_physical == 20)
+            device_type = 13; // 20 bit aligned low devce which doesn't offer 16 bit format.
+    }
+
+    talloc_free(formats);
+    return device_type;
+}
 
 static OSStatus property_listener_cb(
     AudioObjectID object, uint32_t n_addresses,
@@ -94,7 +172,7 @@ static OSStatus property_listener_cb(
     AudioStreamBasicDescription f;
     OSErr err = CA_GET(p->stream, kAudioStreamPropertyVirtualFormat, &f);
     CHECK_CA_WARN("could not get stream format");
-    if (err != noErr || !ca_asbd_equals(&p->stream_asbd, &f)) {
+    if (err != noErr || !ca_asbd_equals(&p->stream_asbd, &f, 0)) {
         if (atomic_compare_exchange_strong(&p->reload_requested,
                                            &(bool){false}, true))
         {
@@ -167,7 +245,18 @@ static OSStatus render_cb_compressed(
     struct priv *p   = ao->priv;
     AudioBuffer buf  = out_data->mBuffers[p->stream_idx];
     int requested    = buf.mDataByteSize;
-    int sstride      = p->spdif_hack ? 4 * ao->channels.num : ao->sstride;
+
+    int sstride;
+
+    int device_type = device_property(ao);
+    if (((device_type == 3) ||(device_type == 9))
+        && ((ao->format == (AF_FORMAT_S32) || ao->format == AF_FORMAT_S32P))){
+        // Otherwise coreaudio doesn't get all the frames it expects, and plays at 0.75x normal speed/buzzes.
+        sstride = p->spdif_hack ? 4 * ao->channels.num : 6;
+        MP_DBG(ao,"Hacking sstride, device type: %d.\n", device_type);
+    }else{
+        sstride = p->spdif_hack ? 4 * ao->channels.num : ao->sstride;
+    }
 
     int pseudo_frames = requested / sstride;
 
@@ -181,7 +270,24 @@ static OSStatus render_cb_compressed(
     end += p->hw_latency_us + ca_get_latency(ts)
         + ca_frames_to_us(ao, pseudo_frames);
 
-    ao_read_data(ao, &buf.mData, pseudo_frames, end);
+    // Change feeding format. Only needed for packed 24 Bit and (maybe) unpacked 24 bit aligned high device
+    // in 24/32 Bit Integer Mode.
+    if ((ao->format == AF_FORMAT_S32) || (ao->format == AF_FORMAT_S32P)){
+        if ((device_type == 3) || (device_type == 9)){
+            p->convert = (struct ao_convert_fmt){
+            .src_fmt = ao->format,
+            .dst_bits = 24,
+            .channels = ao->channels.num,
+            };
+            ao_read_data_converted(ao, &p->convert,
+            &buf.mData, pseudo_frames, end);
+            MP_DBG(ao, "24 Bit packed device (%d), convert to s24.\n", device_type);
+        }else{
+            ao_read_data(ao, &buf.mData, pseudo_frames, end);
+        }
+    }else{
+        ao_read_data(ao, &buf.mData, pseudo_frames, end);
+    }
 
     if (p->spdif_hack)
         bad_hack_mygodwhy(buf.mData, pseudo_frames * ao->channels.num);
@@ -244,26 +350,37 @@ static int find_best_format(struct ao *ao, AudioStreamBasicDescription *out_fmt)
 
     // Build ASBD for the input format
     AudioStreamBasicDescription asbd;
-    ca_fill_asbd(ao, &asbd);
-    ca_print_asbd(ao, "our format:", &asbd);
+
+    int device_type = device_property(ao);
+
+    ca_fill_asbd(ao, &asbd, 0);
+    ca_print_asbd(ao, "Our format:", &asbd);
 
     *out_fmt = (AudioStreamBasicDescription){0};
-
     AudioStreamRangedDescription *formats;
     size_t n_formats;
     OSStatus err;
 
     err = CA_GET_ARY(p->stream, kAudioStreamPropertyAvailablePhysicalFormats,
                      &formats, &n_formats);
-    CHECK_CA_ERROR("could not get number of stream formats");
+    CHECK_CA_ERROR("could not get number of stream formats.");
 
     for (int j = 0; j < n_formats; j++) {
         AudioStreamBasicDescription *stream_asbd = &formats[j].mFormat;
 
-        ca_print_asbd(ao, "- ", stream_asbd);
+        ca_print_asbd(ao, "-", stream_asbd);
 
-        if (!out_fmt->mFormatID || ca_asbd_is_better(&asbd, out_fmt, stream_asbd))
+        if (((device_type == 4) || (device_type == 10) || (device_type == 11))
+            && (asbd.mBitsPerChannel == 16) && (af_fmt_is_pcm(ao->format))){
+            if (!out_fmt->mFormatID || ca_asbd_is_better(&asbd, out_fmt, stream_asbd, 0, 1))
             *out_fmt = *stream_asbd;
+        }else if ((p->integer_mode == false) && (af_fmt_is_pcm(ao->format))){
+            if (!out_fmt->mFormatID || ca_asbd_is_better(&asbd, out_fmt, stream_asbd, 1, 1))
+            *out_fmt = *stream_asbd;
+        }else{
+            if (!out_fmt->mFormatID || ca_asbd_is_better(&asbd, out_fmt, stream_asbd, 0, 0))
+            *out_fmt = *stream_asbd;
+        }
     }
 
     talloc_free(formats);
@@ -284,9 +401,53 @@ static int init(struct ao *ao)
     int original_format = ao->format;
 
     OSStatus err = ca_select_device(ao, ao->device, &p->device);
-    CHECK_CA_ERROR_L(coreaudio_error_nounlock, "failed to select device");
+    CHECK_CA_ERROR_L(coreaudio_error_nounlock, "failed to select device.");
 
-    ao->format = af_fmt_from_planar(ao->format);
+    int device_type = device_property(ao);
+
+    if (device_type == 1){
+        MP_DBG(ao, "This device (%d) is unpacked 24 Bit aligned low.\n", device_type);
+    }else if (device_type == 2){
+        MP_DBG(ao, "This device (%d) is unpacked 24 Bit aligned high.)\n", device_type);
+    }else if (device_type == 3){
+        MP_DBG(ao, "This device (%d) is packed 24 Bit.\n", device_type);
+    }else if (device_type == 4){
+        MP_DBG(ao, "This device (%d) is 32 Bit, doesn't support Integer Mode.\n", device_type);
+    }else if (device_type == 5){
+        MP_VERBOSE(ao, "This device (%d) is 32 Bit, doesn't offer 16 Bit format.\n", device_type);
+    }else if (device_type == 6){
+        MP_VERBOSE(ao, "This device (%d) is 16 Bit, doesn't offer 32 Bit format.\n", device_type);
+    }else if (device_type == 7){
+        MP_VERBOSE(ao, "This device (%d) is unpacked 24 Bit aligned low, doesn't offer 16 Bit format.\n",
+            device_type);
+    }else if (device_type == 8){
+        MP_VERBOSE(ao, "This device (%d) is unpacked 24 Bit aligned high, doesn't offer 16 Bit format.\n",
+            device_type);
+    }else if (device_type == 9){
+        MP_VERBOSE(ao, "This device (%d) is packed 24 Bit, doesn't offer 16 Bit format.\n", device_type);
+    }else if (device_type == 10){
+        MP_DBG(ao, "This device (%d) is 24 Bit, doesn't support Integer Mode.\n", device_type);
+    }else if (device_type == 11){
+        MP_DBG(ao, "This device (%d) is 20 Bit, doesn't support Integer Mode.\n", device_type);
+    }else if (device_type == 12){
+        MP_DBG(ao, "This device (%d) is 20 Bit aligned low.\n", device_type);
+    }else if (device_type == 13){
+        MP_VERBOSE(ao, "This device (%d) is unpacked 20 Bit aligned low, doesn't offer 16 Bit format.\n",
+            device_type);
+    }
+
+    // In Integer Mode, our format must match one of deivce's avaliable physical format.
+    if (((device_type == 5) || (device_type == 7) || (device_type == 8)
+        || (device_type == 9) || (device_type == 13)) && (af_fmt_is_pcm(ao->format))){
+        ao->format = AF_FORMAT_S32;
+        MP_VERBOSE(ao, "Request s32 format for device %d.\n", device_type);
+    // Float mode will convert everything to float.
+    }else if ((device_type == 6) && p->integer_mode && af_fmt_is_pcm(ao->format)){
+        ao->format = AF_FORMAT_S16;
+        MP_VERBOSE(ao, "Request s16 format for device %d.\n", device_type);
+    }else{
+        ao->format = af_fmt_from_planar(ao->format);
+    }
 
     if (!af_fmt_is_pcm(ao->format) && !af_fmt_is_spdif(ao->format)) {
         MP_ERR(ao, "Unsupported format.\n");
@@ -315,6 +476,9 @@ static int init(struct ao *ao)
     err = ca_lock_device(p->device, &p->hog_pid);
     CHECK_CA_WARN("failed to set hogmode");
 
+    err = ca_get_Device_Transport_Type(ao, p->device);
+    CHECK_CA_WARN("failed to get device transport type");
+
     err = ca_disable_mixing(ao, p->device, &p->changed_mixing);
     CHECK_CA_WARN("failed to disable mixing");
 
@@ -333,13 +497,45 @@ static int init(struct ao *ao)
     // virtual format.
     ca_change_physical_format_sync(ao, p->stream, hwfmt);
 
-    if (!ca_init_chmap(ao, p->device))
-        goto coreaudio_error;
-
     err = CA_GET(p->stream, kAudioStreamPropertyVirtualFormat, &p->stream_asbd);
     CHECK_CA_ERROR("could not get stream's virtual format");
 
-    ca_print_asbd(ao, "virtual format", &p->stream_asbd);
+    ca_print_asbd(ao, "Virtual format: ", &p->stream_asbd);
+
+    if (!ca_init_chmap(ao, p->device))
+        goto coreaudio_error;
+
+    err = ca_get_ao_volume(ao, p->device, ao->channels.num);
+    CHECK_CA_WARN("failed to check volume");
+
+    err = ca_get_Terminal_Type(ao, p->stream);
+    CHECK_CA_WARN("failed to check stream terminal type");
+
+    if (p->IOCycleUsage != 1 && af_fmt_is_pcm(ao->format)){
+    err = ca_IO_Cycle_Usage(ao, p->device, &p->IOCycleUsage);
+    CHECK_CA_WARN("failed to set IOCycleUsage");
+    }
+
+    // Setting frame buffer size is for LPCM only. We don't want to mess up spdif, although we actually can't.
+    // Power Saving Mode (large buffer size) may cause clicks, commonly seen in Integer Mode.
+    if (af_fmt_is_pcm(ao->format)){
+        if (p->power_saving){
+            if (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable){
+                MP_VERBOSE(ao, "Integer Mode is ON. \n");
+                err = ca_set_frame_buffer_size(ao, p->device, &p->buffersize);
+                CHECK_CA_WARN("failed to set buffersize");
+            }else{
+                    err = ca_get_frame_buffer_size(ao, p->device);
+                    CHECK_CA_WARN("failed to get buffersize range");
+                    err = SetAudioPowerHintToFavorSavingPower();
+                    MP_VERBOSE(ao, "Set audio I/O buffer size to 4096 or device's max.\n");
+                    CHECK_CA_WARN("failed to set Power Saving Mode");
+            }
+        }else{
+        err = ca_set_frame_buffer_size(ao, p->device, &p->buffersize);
+        CHECK_CA_WARN("failed to set buffersize");
+        }
+    }
 
     if (p->stream_asbd.mChannelsPerFrame > MP_NUM_CHANNELS) {
         MP_ERR(ao, "unsupported number of channels: %d > %d.\n",
@@ -347,7 +543,32 @@ static int init(struct ao *ao)
         goto coreaudio_error;
     }
 
-    int new_format = ca_asbd_to_mp_format(&p->stream_asbd);
+    int new_format;
+    AudioStreamBasicDescription asbd;
+
+    if ((device_type == 3) || (device_type == 9)){
+        ca_fill_asbd(ao, &asbd, 1);
+        MP_DBG(ao,"ca_fill_asbd_packed_24_bit_device_hack (%d).\n", device_type);
+    }else{
+        ca_fill_asbd(ao, &asbd, 0);
+    }
+
+
+    if (((device_type == 3) || (device_type == 9)) && (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable)
+        && (asbd.mBitsPerChannel == 32)){
+        new_format = ca_asbd_to_mp_format(&p->stream_asbd, 1, 1);
+        MP_DBG(ao, "Hacking %u Bit stream on packed 24 Bit device (%d) in Integer Mode.\n",
+            asbd.mBitsPerChannel, device_type);
+    }else if (((device_type == 1) || (device_type == 2) || (device_type == 7)
+        || (device_type == 8) || (device_type == 12) || (device_type == 13))
+        && (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable)
+        && (asbd.mBitsPerChannel == 32)) {
+        new_format = ca_asbd_to_mp_format(&p->stream_asbd, 1, 0);
+        MP_DBG(ao, "Hacking %u Bit stream on unpacked 20/24 Bit device (%d) in Integer Mode.\n",
+            asbd.mBitsPerChannel, device_type);
+    }else{
+        new_format = ca_asbd_to_mp_format(&p->stream_asbd, 0, 0);
+    }
 
     // If both old and new formats are spdif, avoid changing it due to the
     // imperfect mapping between mp and CA formats.
@@ -375,7 +596,7 @@ static int init(struct ao *ao)
         err = CA_GET(p->stream, kAudioStreamPropertyPhysicalFormat,
                      &physical_format);
         CHECK_CA_ERROR("could not get stream's physical format");
-        int ph_format = ca_asbd_to_mp_format(&physical_format);
+        int ph_format = ca_asbd_to_mp_format(&physical_format, 0, 0);
         if (ao->format != AF_FORMAT_FLOAT || ph_format != AF_FORMAT_S16) {
             MP_ERR(ao, "Wrong parameters for spdif hack (%d / %d)\n",
                    ao->format, ph_format);
@@ -385,7 +606,7 @@ static int init(struct ao *ao)
     }
 
     p->hw_latency_us = ca_get_device_latency_us(ao, p->device);
-    MP_VERBOSE(ao, "base latency: %d microseconds\n", (int)p->hw_latency_us);
+    MP_VERBOSE(ao, "Base latency: %d microseconds\n", (int)p->hw_latency_us);
 
     err = enable_property_listener(ao, true);
     CHECK_CA_ERROR("cannot install format change listener during init");
@@ -463,9 +684,18 @@ const struct ao_driver audio_out_coreaudio_exclusive = {
         .stream = 0,
         .stream_idx = -1,
         .changed_mixing = false,
+        .buffersize = 1024, // Default value is 512, increase to 1024 as per Apple's Suggestion
+                            // (https://developer.apple.com/library/archive/technotes/tn2321/_index.html)
+        .IOCycleUsage = 1,
+        .integer_mode = 1,
     },
     .options = (const struct m_option[]){
         OPT_FLAG("spdif-hack", spdif_hack, 0),
+        OPT_INTRANGE("buffer-size", buffersize, 0, 1, 24576), // Is it possible to set min and max values which are
+        // retrieved from "OSStatus err = CA_GET_O(device, kAudioDevicePropertyBufferFrameSizeRange, &value_range);"
+        OPT_FLAG("integer-mode", integer_mode, 0),
+        OPT_FLOATRANGE("iocycle-usage", IOCycleUsage, 0, 0, 1),
+        OPT_FLAG("power-saving", power_saving, 0),
         {0}
     },
     .options_prefix = "coreaudio",

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -517,7 +517,7 @@ static int init(struct ao *ao)
                     err = ca_get_frame_buffer_size(ao, p->device);
                     CHECK_CA_WARN("failed to get buffersize range");
                     err = SetAudioPowerHintToFavorSavingPower();
-                    MP_VERBOSE(ao, "Set audio I/O buffer size to 4096 or device's max.\n");
+                    MP_VERBOSE(ao, "Set audio I/O buffer size to maximum value.\n");
                     CHECK_CA_WARN("failed to set Power Saving Mode");
             }
         }else{
@@ -690,8 +690,7 @@ const struct ao_driver audio_out_coreaudio_exclusive = {
     },
     .options = (const struct m_option[]){
         OPT_FLAG("spdif-hack", spdif_hack, 0),
-        OPT_INTRANGE("buffer-size", buffersize, 0, 1, 24576), // Is it possible to set min and max values which are
-        // retrieved from "OSStatus err = CA_GET_O(device, kAudioDevicePropertyBufferFrameSizeRange, &value_range);"
+        OPT_INTRANGE("buffer-size", buffersize, 0, 1, 4096),
         OPT_FLAG("integer-mode", integer_mode, 0),
         OPT_FLOATRANGE("iocycle-usage", IOCycleUsage, 0, 0, 1),
         OPT_FLAG("power-saving", power_saving, 0),

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -356,7 +356,7 @@ static int find_best_format(struct ao *ao, AudioStreamBasicDescription *out_fmt)
         ca_print_asbd(ao, "-", stream_asbd);
 
         if (((device_type == 4) || (device_type == 10) || (device_type == 11))
-            && (asbd.mBitsPerChannel == 16) && (af_fmt_is_pcm(ao->format))){
+            && (asbd.mBitsPerChannel == 16) && (af_fmt_is_pcm(ao->format)) && (p->spdif_hack == 0)){
             if (!out_fmt->mFormatID || ca_asbd_is_better(&asbd, out_fmt, stream_asbd, 0, 1))
             *out_fmt = *stream_asbd;
         }else if ((p->integer_mode == false) && (af_fmt_is_pcm(ao->format))){

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -353,7 +353,7 @@ static int find_best_format(struct ao *ao, AudioStreamBasicDescription *out_fmt)
 
     int device_type = device_property(ao);
 
-    ca_fill_asbd(ao, &asbd, 0);
+    ca_fill_asbd(ao, &asbd);
     ca_print_asbd(ao, "Our format:", &asbd);
 
     *out_fmt = (AudioStreamBasicDescription){0};
@@ -546,13 +546,7 @@ static int init(struct ao *ao)
     int new_format;
     AudioStreamBasicDescription asbd;
 
-    if ((device_type == 3) || (device_type == 9)){
-        ca_fill_asbd(ao, &asbd, 1);
-        MP_DBG(ao,"ca_fill_asbd_packed_24_bit_device_hack (%d).\n", device_type);
-    }else{
-        ca_fill_asbd(ao, &asbd, 0);
-    }
-
+    ca_fill_asbd(ao, &asbd);
 
     if (((device_type == 3) || (device_type == 9)) && (p->stream_asbd.mFormatFlags & kAudioFormatFlagIsNonMixable)
         && (asbd.mBitsPerChannel == 32)){

--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -115,12 +115,17 @@ OSStatus ca_get_Device_Transport_Type(struct ao *ao, AudioDeviceID device)
     if (err == noErr){
         // "kAudioDevicePropertyDataSource" only works for limited Transport Type,
         // e.g. not work for USB or Bluetooth connection.
-        if (err1 == noErr){
-            MP_VERBOSE(ao, "Device transport type: %s, data source: %s\n",
-                mp_tag_str(CFSwapInt32HostToBig(Transport_Type)),
-                mp_tag_str(CFSwapInt32HostToBig(Source)));
+        if (Transport_Type == kAudioDeviceTransportTypeUnknown){
+                MP_VERBOSE(ao, "Device transport type: unknown\n");
         }else{
-            MP_VERBOSE(ao, "Device transport type: %s\n", mp_tag_str(CFSwapInt32HostToBig(Transport_Type)));
+            if (err1 == noErr){
+                //Transport_Type = kAudioDeviceTransportTypeUnknown ? "unknow": Transport_Type;
+                MP_VERBOSE(ao, "Device transport type: %s, data source: %s\n",
+                    mp_tag_str(CFSwapInt32HostToBig(Transport_Type)),
+                    mp_tag_str(CFSwapInt32HostToBig(Source)));
+            }else{
+                MP_VERBOSE(ao, "Device transport type: %s\n", mp_tag_str(CFSwapInt32HostToBig(Transport_Type)));
+            }
         }
     }
     return err;
@@ -167,10 +172,14 @@ OSStatus ca_get_Terminal_Type(struct ao *ao, AudioDeviceID device)
   	propertyAddress.mElement  = kAudioObjectPropertyElementMaster;
   	propertyAddress.mSelector = kAudioStreamPropertyTerminalType;
 
-  	OSStatus ret = AudioObjectGetPropertyData(device, &propertyAddress, 0, NULL, &size, &val);
-  	if (ret == noErr) {
-    	MP_VERBOSE(ao, "Stream Terminal Type: %s\n",  mp_tag_str_hex(CFSwapInt32HostToBig(val)));
-  	}
+    OSStatus ret = AudioObjectGetPropertyData(device, &propertyAddress, 0, NULL, &size, &val);
+    if (ret == noErr) {
+        if (val == kAudioStreamTerminalTypeUnknown){
+            MP_VERBOSE(ao, "Stream Terminal Type: unknown\n");
+        }else{
+            MP_VERBOSE(ao, "Stream Terminal Type: %s\n", mp_tag_str_hex(CFSwapInt32HostToBig(val)));
+        }
+    }
   	return ret;
 }
 

--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -438,6 +438,16 @@ bool ca_asbd_equals(const AudioStreamBasicDescription *a,
               (spdif || a->mBytesPerPacket == b->mBytesPerPacket) &&
               (spdif || a->mChannelsPerFrame == b->mChannelsPerFrame) &&
               a->mSampleRate == b->mSampleRate;
+    }else if(integer_mode_hack == 2){
+        int flags = kAudioFormatFlagIsNonMixable | kAudioFormatFlagIsFloat |
+        kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsBigEndian;
+        return (a->mFormatFlags & flags) == (b->mFormatFlags & flags) &&
+              a->mBitsPerChannel == b->mBitsPerChannel &&
+              ca_normalize_formatid(a->mFormatID) ==
+              ca_normalize_formatid(b->mFormatID) &&
+              (spdif || a->mBytesPerPacket == b->mBytesPerPacket) &&
+              (spdif || a->mChannelsPerFrame == b->mChannelsPerFrame) &&
+              a->mSampleRate == b->mSampleRate;
     }else{
         int flags = kAudioFormatFlagIsPacked | kAudioFormatFlagIsFloat |
         kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsBigEndian;
@@ -770,7 +780,7 @@ bool ca_change_physical_format_sync(struct ao *ao, AudioStreamID stream,
         if (!CHECK_CA_WARN("could not retrieve physical format"))
             break;
 
-        format_set = ca_asbd_equals(&change_format, &actual_format, 0);
+        format_set = ca_asbd_equals(&change_format, &actual_format, 2);
         if (format_set)
             break;
 

--- a/audio/out/ao_coreaudio_utils.h
+++ b/audio/out/ao_coreaudio_utils.h
@@ -54,7 +54,7 @@ OSStatus ca_select_device(struct ao *ao, char* name, AudioDeviceID *device);
 #endif
 
 bool ca_formatid_is_compressed(uint32_t formatid);
-void ca_fill_asbd(struct ao *ao, AudioStreamBasicDescription *asbd, int packed_24_hack);
+void ca_fill_asbd(struct ao *ao, AudioStreamBasicDescription *asbd);
 void ca_print_asbd(struct ao *ao, const char *description,
                    const AudioStreamBasicDescription *asbd);
 bool ca_asbd_equals(const AudioStreamBasicDescription *a,

--- a/audio/out/ao_coreaudio_utils.h
+++ b/audio/out/ao_coreaudio_utils.h
@@ -54,23 +54,31 @@ OSStatus ca_select_device(struct ao *ao, char* name, AudioDeviceID *device);
 #endif
 
 bool ca_formatid_is_compressed(uint32_t formatid);
-void ca_fill_asbd(struct ao *ao, AudioStreamBasicDescription *asbd);
+void ca_fill_asbd(struct ao *ao, AudioStreamBasicDescription *asbd, int packed_24_hack);
 void ca_print_asbd(struct ao *ao, const char *description,
                    const AudioStreamBasicDescription *asbd);
 bool ca_asbd_equals(const AudioStreamBasicDescription *a,
-                    const AudioStreamBasicDescription *b);
-int ca_asbd_to_mp_format(const AudioStreamBasicDescription *asbd);
+                    const AudioStreamBasicDescription *b, int integer_mode_hack);
+int ca_asbd_to_mp_format(const AudioStreamBasicDescription *asbd, int integer_mode_hack, int packed_24_hack);
 bool ca_asbd_is_better(AudioStreamBasicDescription *req,
                        AudioStreamBasicDescription *old,
-                       AudioStreamBasicDescription *new);
-
+                       AudioStreamBasicDescription *new,
+                       int mixableflag,
+                       int bytesflag);
 int64_t ca_frames_to_us(struct ao *ao, uint32_t frames);
 int64_t ca_get_latency(const AudioTimeStamp *ts);
 
 #if HAVE_COREAUDIO
+OSStatus ca_get_ao_volume(struct ao *ao, AudioDeviceID device, UInt32 channel);
+OSStatus SetAudioPowerHintToFavorSavingPower(void);
 bool ca_stream_supports_compressed(struct ao *ao, AudioStreamID stream);
 OSStatus ca_lock_device(AudioDeviceID device, pid_t *pid);
 OSStatus ca_unlock_device(AudioDeviceID device, pid_t *pid);
+OSStatus ca_get_frame_buffer_size(struct ao *ao, AudioDeviceID device);
+OSStatus ca_set_frame_buffer_size(struct ao *ao, AudioDeviceID device, int *buffersize);
+OSStatus ca_IO_Cycle_Usage(struct ao *ao, AudioDeviceID device, Float32 *IOCycleUsage);
+OSStatus ca_get_Terminal_Type(struct ao *ao, AudioDeviceID device);
+OSStatus ca_get_Device_Transport_Type(struct ao *ao, AudioDeviceID device);
 OSStatus ca_disable_mixing(struct ao *ao, AudioDeviceID device, bool *changed);
 OSStatus ca_enable_mixing(struct ao *ao, AudioDeviceID device, bool changed);
 int64_t ca_get_device_latency_us(struct ao *ao, AudioDeviceID device);

--- a/common/common.c
+++ b/common/common.c
@@ -299,6 +299,23 @@ char *mp_tag_str_buf(char *buf, size_t buf_size, uint32_t tag)
     return buf;
 }
 
+char *mp_tag_str_buf_hex(char *buf, size_t buf_size, uint32_t tag)
+{
+    if (buf_size < 1)
+        return buf;
+    buf[0] = '\0';
+    for (int n = 0; n < 4; n++) {
+        uint8_t val = (tag >> (n * 8)) & 0xFF;
+        if (mp_isalnum(val) || val == '_' || val == ' ') {
+            mp_snprintf_cat(buf, buf_size, "%c", val);
+        } else {
+            if (val != 0)
+            mp_snprintf_cat(buf, buf_size, "0x%01X", val);
+        }
+    }
+    return buf;
+}
+
 char *mp_tprintf_buf(char *buf, size_t buf_size, const char *format, ...)
 {
     va_list ap;

--- a/common/common.h
+++ b/common/common.h
@@ -96,6 +96,9 @@ char *mp_strerror_buf(char *buf, size_t buf_size, int errnum);
 char *mp_tag_str_buf(char *buf, size_t buf_size, uint32_t tag);
 #define mp_tag_str(t) mp_tag_str_buf((char[22]){0}, 22, t)
 
+char *mp_tag_str_buf_hex(char *buf, size_t buf_size, uint32_t tag);
+#define mp_tag_str_hex(t) mp_tag_str_buf_hex((char[22]){0}, 22, t)
+
 // Return a printf(format, ...) formatted string of the given SIZE. SIZE must
 // be a compile time constant. The result is allocated on the stack and valid
 // only within the current block scope.


### PR DESCRIPTION
I am not a programmer, and only with very limited coding knowledge. If you have any suggestion, please kindly tell me exactly what I should do. Otherwise, I probably can't understand what you are talking about. Sorry.

There is one minor issue I'm not sure how to solve. I tried to modify `mp_tag_str_buf` to show hexadecimal number, but it prints "0x30x1" rather than "0x301".

I acknowledge that I received great help from the following parties:
	@downthomas,
	@wm4,
	@badgerkin;

and I took reference from the following code.
	https://github.com/cmus/cmus/blob/master/op/coreaudio.c (cmus, GNU General Public License v2.0)


I agree that my changes can be relicensed to LGPL 2.1 or later.
