### PR TITLE
client API: add mpv_command_ret

### DIFF
--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -223,7 +223,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 103)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 104)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before
@@ -968,6 +968,22 @@ int mpv_command(mpv_handle *ctx, const char **args);
  * @return error code (the result parameter is not set on error)
  */
 int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result);
+
+/**
+ * This is essentially identical to mpv_command() but it also returns a result.
+ *
+ * Does not use OSD and string expansion by default.
+ *
+ * @param[in] args NULL-terminated list of strings. Usually, the first item
+ *                 is the command, and the following items are arguments.
+ * @param[out] result Optional, pass NULL if unused. If not NULL, and if the
+ *                    function succeeds, this is set to command-specific return
+ *                    data. You must call mpv_free_node_contents() to free it
+ *                    (again, only if the command actually succeeds).
+ *                    Not many commands actually use this at all.
+ * @return error code (the result parameter is not set on error)
+ */
+int mpv_command_ret(mpv_handle *ctx, const char **args, mpv_node *result);
 
 /**
  * Same as mpv_command, but use input.conf parsing for splitting arguments.

--- a/libmpv/mpv.def
+++ b/libmpv/mpv.def
@@ -5,6 +5,7 @@ mpv_command
 mpv_command_async
 mpv_command_node
 mpv_command_node_async
+mpv_command_ret
 mpv_command_string
 mpv_create
 mpv_create_client

--- a/player/client.c
+++ b/player/client.c
@@ -1086,6 +1086,15 @@ int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result)
     return r;
 }
 
+int mpv_command_ret(mpv_handle *ctx, const char **args, mpv_node *result)
+{
+    struct mpv_node rn = {.format = MPV_FORMAT_NONE};
+    int r = run_client_command(ctx, mp_input_parse_cmd_strv(ctx->log, args), &rn);
+    if (result && r >= 0)
+        *result = rn;
+    return r;
+}
+
 int mpv_command_string(mpv_handle *ctx, const char *args)
 {
     return run_client_command(ctx,


### PR DESCRIPTION
This change adds a version of `mpv_command` that also returns a result. The main rationale behind this is `mpv_client_command` requires defining multiple structs before you can even use it, which can result in a pretty painful to use interface just to get the result from something like `expand-text`.

There isn't really a good name for this function, so I'm open to suggestions on a better name for it.

Note: I originally wanted to change `mpv_command` itself, however that would result in a major API version bump which discouraged me from doing so. What we should do here is also open for discussion.

Usage example:

```c
//ctx is an mpv_handle
char *args[] = { "expand-text": "${media-title} | ${time-pos}", NULL };
mpv_node result;
int rc = mpv_command_ret(ctx, args, &result);
if (rc >= 0) {
    //do stuff with result
}
```

Edit: My changes are licensed under LGPL 2.1 or any later version.