### PR TITLE
vo_d3d11: fix memory leak that 'ctx11' be not released and crash due to ctx->ra is null pointer access

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -161,14 +161,16 @@ static void d3d11_uninit(struct ra_ctx *ctx)
 {
     struct priv *p = ctx->priv;
 
-    ra_tex_free(ctx->ra, &p->backbuffer);
+    if (ctx->ra)
+        ra_tex_free(ctx->ra, &p->backbuffer);
     SAFE_RELEASE(p->swapchain);
     vo_w32_uninit(ctx->vo);
     SAFE_RELEASE(p->device);
 
     // Destory the RA last to prevent objects we hold from showing up in D3D's
     // leak checker
-    ctx->ra->fns->destroy(ctx->ra);
+    if (ctx->ra)
+        ctx->ra->fns->destroy(ctx->ra);
 }
 
 static const struct ra_swapchain_fns d3d11_swapchain = {

--- a/video/out/d3d11/hwdec_dxva2dxgi.c
+++ b/video/out/d3d11/hwdec_dxva2dxgi.c
@@ -148,7 +148,9 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
     struct priv_owner *o = mapper->owner->priv;
     struct priv *p = mapper->priv;
 
+    ID3D11Device_AddRef(o->dev11);
     p->dev11 = o->dev11;
+    IDirect3DDevice9Ex_AddRef(o->dev9);
     p->dev9 = o->dev9;
     ID3D11Device_GetImmediateContext(o->dev11, &p->ctx11);
 
@@ -409,6 +411,10 @@ static void mapper_uninit(struct ra_hwdec_mapper *mapper)
 
     for (int i = 0; i < p->queue_len; i++)
         surf_destroy(mapper, p->queue[i]);
+
+    SAFE_RELEASE(p->ctx11);
+    SAFE_RELEASE(p->dev9);
+    SAFE_RELEASE(p->dev11);
 }
 
 static int mapper_map(struct ra_hwdec_mapper *mapper)


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
