### PR TITLE
DVB fixes (slow hardware, VDR channels.conf)

### DIFF
--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -356,9 +356,14 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
             mod[0] = '\0';
             // It's a VDR-style config line.
             parse_vdr_par_string(vdr_par_str, ptr);
-            // Units in VDR-style config files are divided by 1000.
-            ptr->freq *=  1000UL;
-            ptr->srate *=  1000UL;
+            // Frequency in VDR-style config files is in MHz for DVB-S,
+            // and may be in MHz, kHz or Hz for DVB-C and DVB-T.
+            // General rule to get useful units is to multiply by 1000 until value is larger than 1000000.
+            while (ptr->freq < 1000000UL) {
+                ptr->freq *= 1000UL;
+            }
+            // Symbol rate in VDR-style config files is divided by 1000.
+            ptr->srate *= 1000UL;
             switch (delsys) {
             case SYS_DVBT:
             case SYS_DVBT2:

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -747,7 +747,7 @@ static int dvb_streaming_read(stream_t *stream, char *buffer, int size)
             tries --;
             pfds[0].fd = fd;
             pfds[0].events = POLLIN | POLLPRI;
-            if (poll(pfds, 1, 500) <= 0) {
+            if (poll(pfds, 1, 2000) <= 0) {
                 MP_ERR(stream, "dvb_streaming_read, failed with "
                         "errno %d when reading %d bytes\n", errno, size - pos);
                 errno = 0;


### PR DESCRIPTION
Discussion in https://github.com/mpv-player/mpv/pull/6372 has highlighted two issues which are fixed in this commit series:
- VDR `channels.conf` is rather flexible about units for the frequency (it accepts Hz, kHz and MHz). We now do as VDR does and multiply the value provided in the config file by 1000 until 1000000 is reached. This fixes compatibility especially with more recent `channels.conf` files. 
- DVB-T2 hardware in some cases seems to be too slow to actually deliver data within 2.5 seconds(!) after tuning. Increase the timeout to 10 seconds. 

I agree that my changes can be relicensed to LGPL 2.1 or later.

Thanks to @berndbb both for finding the issues and for testing my fixes on his HW!