### PR TITLE
player: expose bitrate and rotation value on tracks

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -91,6 +91,8 @@ Interface changes
     - remove deprecated --chapter option
     - deprecate --record-file
     - add `--demuxer-cue-codepage`
+    - add ``track-list/N/demux-bitrate``, ``track-list/N/demux-rotation`` and
+      ``track-list/N/demux-par`` property
  --- mpv 0.29.0 ---
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2038,6 +2038,15 @@ Property list
     ``track-list/N/demux-fps``
         Video FPS as indicated by the container. (Not always accurate.)
 
+    ``track-list/N/demux-bitrate``
+        Audio average bitrate, in bits per second. (Not always accurate.)
+
+    ``track-list/N/demux-rotation``
+        Video clockwise rotation metadata, in degrees.
+
+    ``track-list/N/demux-par``
+        Pixel aspect ratio.
+
     ``track-list/N/audio-channels`` (deprecated)
         Deprecated alias for ``track-list/N/demux-channel-count``.
 
@@ -2079,6 +2088,9 @@ Property list
                 "demux-channels"    MPV_FORMAT_STRING
                 "demux-samplerate"  MPV_FORMAT_INT64
                 "demux-fps"         MPV_FORMAT_DOUBLE
+                "demux-bitrate"     MPV_FORMAT_INT64
+                "demux-rotation"    MPV_FORMAT_INT64
+                "demux-par"         MPV_FORMAT_DOUBLE
                 "audio-channels"    MPV_FORMAT_INT64
                 "replaygain-track-peak" MPV_FORMAT_DOUBLE
                 "replaygain-track-gain" MPV_FORMAT_DOUBLE

--- a/player/command.c
+++ b/player/command.c
@@ -2024,6 +2024,10 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
     struct replaygain_data rg = has_rg ? *track->stream->codec->replaygain_data
                                        : (struct replaygain_data){0};
 
+    double par = 0.0;
+    if (p.par_h)
+        par = p.par_w / (double) p.par_h;
+
     struct m_sub_property props[] = {
         {"id",          SUB_PROP_INT(track->user_tid)},
         {"type",        SUB_PROP_STR(stream_type_name(track->type)),
@@ -2060,6 +2064,9 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
         {"demux-samplerate", SUB_PROP_INT(p.samplerate),
                         .unavailable = !p.samplerate},
         {"demux-fps",   SUB_PROP_DOUBLE(p.fps), .unavailable = p.fps <= 0},
+        {"demux-bitrate",  SUB_PROP_INT(p.bitrate), .unavailable = p.bitrate <= 0},
+        {"demux-rotation", SUB_PROP_INT(p.rotate),  .unavailable = p.rotate <= 0},
+        {"demux-par",      SUB_PROP_DOUBLE(par),    .unavailable = par <= 0},
         {"replaygain-track-peak", SUB_PROP_FLOAT(rg.track_peak),
                         .unavailable = !has_rg},
         {"replaygain-track-gain", SUB_PROP_FLOAT(rg.track_gain),


### PR DESCRIPTION
They may be useful  for people who want to select tracks manually.

I agree that my changes can be relicensed to LGPL 2.1 or later.
