### PR TITLE
vo_gpu: hwdec_vaapi: Synchronise after exporting VA surface

### DIFF
--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -423,6 +423,9 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
             p->esh_not_implemented = true;
         goto esh_failed;
     }
+    vaSyncSurface(display, va_surface_id(mapper->src));
+    // No need to error out if sync fails, but good to know if it did.
+    CHECK_VA_STATUS(mapper, "vaSyncSurface()");
     p->surface_acquired = true;
 
 #if HAVE_GL


### PR DESCRIPTION
This is documented as required (although we did not do it in
the old GL codepath, with no visible problems) and I have seen
transient artifacts after seeking which _appear_ to have gone
away after introducing this.