### PR TITLE
vo/gpu: vulkan: Pass the device name option through to libplacebo

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -165,6 +165,7 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .async_transfer = p->opts->async_transfer,
         .async_compute = p->opts->async_compute,
         .queue_count = p->opts->queue_count,
+        .device_name = p->opts->device,
     });
     if (!vk->vulkan)
         goto error;


### PR DESCRIPTION
We collect a 'vulkan-device' option today but then don't actually
pass it on, so it's useless. Once that's fixed, it can be used
to select a specific vulkan device by name.

Tested with the new nvidia offload feature to select between the
nvidia and intel GPUs.
