### PR TITLE
Autoload .lrc lyrics

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -34,7 +34,7 @@
 
 static const char *const sub_exts[] = {"utf", "utf8", "utf-8", "idx", "sub",
                                        "srt", "rt", "ssa", "ass", "mks", "vtt",
-                                       "sup", "scc", "smi",
+                                       "sup", "scc", "smi", "lrc",
                                        NULL};
 
 static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",


### PR DESCRIPTION
Currently mpv doesn't load .lrc synced lyrics with the same filename as the song playing, unless you rename them to a supported extension like srt or load them with a Lua script. This pull request just adds lrc to the sub extensions so that the lyrics will be loaded.

Other people who encountered this issue:
[https://unix.stackexchange.com/questions/510422/play-lyrics-automatically-with-mpv](https://unix.stackexchange.com/questions/510422/play-lyrics-automatically-with-mpv)
[https://gist.github.com/guixxx/a349d27d271ca100685c3ce5fb1d5c9f](https://gist.github.com/guixxx/a349d27d271ca100685c3ce5fb1d5c9f)

I agree that my changes can be relicensed to LGPL 2.1 or later.
