### PR TITLE
audio: block ao buffer for keep-open

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -846,8 +846,11 @@ static void handle_keep_open(struct MPContext *mpctx)
                 seek_to_last_frame(mpctx);
             mpctx->playback_pts = mpctx->last_vo_pts;
         }
-        if (opts->keep_open_pause)
+        if (opts->keep_open_pause) {
+            if (mpctx->ao)
+                ao_drain(mpctx->ao);
             set_pause_state(mpctx, true);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #6898. This prevents the pause state from triggering before the audio output is
finished playing back audio. This is particularly helpful for gapless playback.
