### PR TITLE
input: add keybind command

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -576,6 +576,13 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     empty string, ``KEYUP`` will be set on all keys. Otherwise, ``KEYUP`` will
     only be set on the key specified by ``name``.
 
+``keybind <name> <command>``
+    Binds a key to an input command. ``command`` must be a complete command
+    containing all the desired arguments and flags. Both ``name`` and
+    ``command`` use the ``input.conf`` naming scheme. This is primarily
+    useful for the client API. Note that ``keybind`` cannot be bound to
+    another ``keybind`` command.
+
 ``audio-add <url> [<flags> [<title> [<lang>]]]``
     Load the given audio file. See ``sub-add`` command.
 

--- a/input/input.c
+++ b/input/input.c
@@ -1432,6 +1432,44 @@ void mp_input_run_cmd(struct input_ctx *ictx, const char **cmd)
     mp_input_queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
 }
 
+void mp_input_bind_key(struct input_ctx *ictx, int key, bstr command)
+{
+    struct cmd_bind_section *bs = ictx->cmd_bind_sections;
+    struct cmd_bind *bind = NULL;
+
+    for (int n = 0; n < bs->num_binds; n++) {
+        struct cmd_bind *b = &bs->binds[n];
+        if (bind_matches_key(b, 1, &key) && b->is_builtin == false) {
+            bind = b;
+            break;
+        }
+    }
+
+    if (!bind) {
+        struct cmd_bind empty = {{0}};
+        MP_TARRAY_APPEND(bs, bs->binds, bs->num_binds, empty);
+        bind = &bs->binds[bs->num_binds - 1];
+    }
+
+    bind_dealloc(bind);
+
+    *bind = (struct cmd_bind) {
+        .cmd = bstrdup0(bs->binds, command),
+        .location = talloc_strdup(bs->binds, "keybind-command"),
+        .owner = bs,
+        .is_builtin = false,
+        .num_keys = 1,
+    };
+    memcpy(bind->keys, &key, 1 * sizeof(bind->keys[0]));
+    if (mp_msg_test(ictx->log, MSGL_DEBUG)) {
+        char *s = mp_input_get_key_combo_name(&key, 1);
+        MP_TRACE(ictx, "add:section='%s' key='%s'%s cmd='%s' location='%s'\n",
+                 bind->owner->section, s, bind->is_builtin ? " builtin" : "",
+                 bind->cmd, bind->location);
+        talloc_free(s);
+    }
+}
+
 struct mp_input_src_internal {
     pthread_t thread;
     bool thread_running;

--- a/input/input.h
+++ b/input/input.h
@@ -203,6 +203,9 @@ bool mp_input_use_media_keys(struct input_ctx *ictx);
 // Like mp_input_parse_cmd_strv, but also run the command.
 void mp_input_run_cmd(struct input_ctx *ictx, const char **cmd);
 
+// Binds a command to a key.
+void mp_input_bind_key(struct input_ctx *ictx, int key, bstr command);
+
 void mp_input_set_repeat_info(struct input_ctx *ictx, int rate, int delay);
 
 void mp_input_pipe_add(struct input_ctx *ictx, const char *filename);

--- a/player/command.c
+++ b/player/command.c
@@ -5891,6 +5891,21 @@ static void cmd_key(void *p)
     }
 }
 
+static void cmd_key_bind(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    int code = mp_input_get_key_from_name(cmd->args[0].v.s);
+    if (code < 0) {
+        MP_ERR(mpctx, "%s is not a valid input name.\n", cmd->args[0].v.s);
+        cmd->success = false;
+        return;
+    }
+    const char *target_cmd = cmd->args[1].v.s;
+    mp_input_bind_key(mpctx->input, code, bstr0(target_cmd));
+}
+
 static void cmd_apply_profile(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6226,6 +6241,8 @@ const struct mp_cmd_def mp_cmds[] = {
                             OPT_INT("button", v.i, 0, OPTDEF_INT(-1)),
                             OPT_CHOICE("mode", v.i, MP_CMD_OPT_ARG,
                                        ({"single", 0}, {"double", 1})), }},
+    { "keybind", cmd_key_bind, { OPT_STRING("name", v.s, 0),
+                                 OPT_STRING("cmd", v.s, 0) }},
     { "keypress", cmd_key, { OPT_STRING("name", v.s, 0) },
         .priv = &(const int){0}},
     { "keydown", cmd_key, { OPT_STRING("name", v.s, 0) },


### PR DESCRIPTION
This adds `keybind` as a command which allows users to set input commands to specific keys. This is primarily useful for the client api and lua scripting although it does work in input.conf as well. There's maybe a couple of things people won't like though.

- The argument order is `keyname` and then `command` so for example an entry in `input.conf` would look like this: `keybind CTRL+l "add volume 10"`. To me, this looks better than `keybind "add volume 10" CTRL+l` but maybe people disagree.

- I exposed a new function, `mp_input_bind_keys`, to the header that copies parts of the `bind_keys` function for this. `bind_keys` is clearly geared towards parsing a file so I didn't think modifying it would be appropriate. I did make the choice of calling the location `keybind-command` so that name gets returned if mpv triggers an error from an improperly formatted command. That could be changed to something else if someone has a better idea.

Sidenote: I think it's impossible to use `keybind` to bind to another `keybind` command because of the formatting can never be correct but I'm not totally 100% sure yet so I didn't note it in the docs.
