### PR TITLE
vo/gpu: fix check on src/dst peak mismatch

### DIFF
--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -774,7 +774,7 @@ void pass_color_map(struct gl_shader_cache *sc, bool is_linear,
     // operations needs it
     bool need_linear = src.gamma != dst.gamma ||
                        src.primaries != dst.primaries ||
-                       src.sig_peak > dst.sig_peak ||
+                       src.sig_peak != dst.sig_peak ||
                        need_ootf;
 
     if (need_linear && !is_linear) {


### PR DESCRIPTION
In the past, src peak was always equal to or higher than dst peak. But
since `--target-peak` got introduced, this could no longer be the case.
This leads to an incorrect result (scaling for peak mismatch in gamma
light) unless some other option (CMS, --linear-scaling, etc.) forces the
linearization.

Fixes #6533