### PR TITLE
DOCS: remove references to --video-stereo-mode

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1690,7 +1690,8 @@ Property list
         Intended display rotation in degrees (clockwise).
 
     ``video-params/stereo-in``
-        Source file stereo 3D mode. (See ``--video-stereo-mode`` option.)
+        Source file stereo 3D mode. (See the ``format`` video filter's
+        ``stereo-in`` option.)
 
     When querying the property with the client API using ``MPV_FORMAT_NODE``,
     or with Lua ``mp.get_property_native``, this will return a mpv_node with

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -986,22 +986,6 @@ Video
     which means the value ``0`` would rotate the video according to the
     rotation metadata.)
 
-``--video-stereo-mode=<no|mode>``
-    Set the stereo 3D output mode (default: ``mono``). This is mostly broken and
-    thus deprecated.
-
-    The pseudo-mode ``no`` disables automatic conversion completely.
-
-    The mode ``mono`` is an alias to ``ml``, which refers to the left frame in
-    2D. This is the default, which means mpv will try to show 3D movies in 2D,
-    instead of the mangled 3D image not intended for consumption (such as
-    showing the left and right frame side by side, etc.).
-
-    Use ``--video-stereo-mode=help`` to list all available modes. Check with
-    the ``stereo3d`` filter documentation to see what the names mean. Note that
-    some names refer to modes not supported by ``stereo3d`` - these modes can
-    appear in files, but can't be handled properly by mpv.
-
 ``--video-zoom=<value>``
     Adjust the video display scale factor by the given value. The parameter is
     given log 2. For example, ``--video-zoom=0`` is unscaled,

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -249,12 +249,13 @@ Available mpv-only filters are:
        :gamma1.2:     Scene-referred using a pure power OOTF (gamma=1.2)
 
     ``<stereo-in>``
-        Set the stereo mode the video is assumed to be encoded in. Takes the
-        same values as the ``--video-stereo-mode`` option.
+        Set the stereo mode the video is assumed to be encoded in. Use
+        ``--vf format:stereo-in=help`` to list all available modes. Check with
+        the ``stereo3d`` filter documentation to see what the names mean.
 
     ``<stereo-out>``
         Set the stereo mode the video should be displayed as. Takes the
-        same values as the ``--video-stereo-mode`` option.
+        same values as the ``stereo-in`` option.
 
     ``<rotate>``
         Set the rotation the video is assumed to be encoded with in degrees.

--- a/options/options.c
+++ b/options/options.c
@@ -858,6 +858,7 @@ const m_option_t mp_opts[] = {
     OPT_REPLACED("sub-paths", "sub-file-paths"),
     OPT_REMOVED("heartbeat-cmd", "use Lua scripting instead"),
     OPT_REMOVED("no-ometadata", "use --no-ocopy-metadata"),
+    OPT_REMOVED("video-stereo-mode", "removed, try --vf=stereo3d"),
 
     {0}
 };


### PR DESCRIPTION
This option was removed by a5610b2a but the documentation persisted.
Also adds an OPT_REMOVED.