### PR TITLE
drm: fix libmpv ABI breakage introduced in 351c083487050c88adb0e3d60f…

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,6 +32,8 @@ API changes
 
 ::
  --- mpv 0.30.0 ---
+ 1.104  - Deprecate struct mpv_opengl_drm_params. Replaced by mpv_opengl_drm_params_v2
+        - Deprecate MPV_RENDER_PARAM_DRM_DISPLAY. Replaced by MPV_RENDER_PARAM_DRM_DISPLAY_V2.
  1.103  - redo handling of async commands
         - add mpv_event_command and make it possible to return values from
           commands issued with mpv_command_async() or mpv_command_node_async()

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -223,7 +223,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 103)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 104)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before

--- a/libmpv/render.h
+++ b/libmpv/render.h
@@ -277,8 +277,7 @@ typedef enum mpv_render_param_type {
      */
     MPV_RENDER_PARAM_SKIP_RENDERING = 13,
     /**
-     * DRM display, contains drm display handles.
-     * Valid for mpv_render_context_create().
+     * Deprecated. Not supported. Use MPV_RENDER_PARAM_DRM_DISPLAY_V2 instead.
      * Type : struct mpv_opengl_drm_params*
      */
     MPV_RENDER_PARAM_DRM_DISPLAY = 14,
@@ -288,6 +287,12 @@ typedef enum mpv_render_param_type {
      * Type : struct mpv_opengl_drm_draw_surface_size*
      */
     MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE = 15,
+    /**
+     * DRM display, contains drm display handles.
+     * Valid for mpv_render_context_create().
+     * Type : struct mpv_opengl_drm_params_v2*
+    */
+    MPV_RENDER_PARAM_DRM_DISPLAY_V2 = 16,
 } mpv_render_param_type;
 
 /**

--- a/libmpv/render_gl.h
+++ b/libmpv/render_gl.h
@@ -150,11 +150,32 @@ typedef struct mpv_opengl_fbo {
 } mpv_opengl_fbo;
 
 /**
- * For MPV_RENDER_PARAM_DRM_DISPLAY.
+ * Deprecated. For MPV_RENDER_PARAM_DRM_DISPLAY.
  */
 typedef struct mpv_opengl_drm_params {
+    int fd;
+    int crtc_id;
+    int connector_id;
+    struct _drmModeAtomicReq **atomic_request_ptr;
+    int render_fd;
+} mpv_opengl_drm_params;
+
+/**
+ * For MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE.
+ */
+typedef struct mpv_opengl_drm_draw_surface_size {
     /**
-     * DRM fd (int). Set to a negative number if invalid.
+     * size of the draw plane surface in pixels.
+     */
+    int width, height;
+} mpv_opengl_drm_draw_surface_size;
+
+/**
+ * For MPV_RENDER_PARAM_DRM_DISPLAY_V2.
+ */
+typedef struct mpv_opengl_drm_params_v2 {
+    /**
+     * DRM fd (int). Set to -1 if invalid.
      */
     int fd;
 
@@ -177,20 +198,11 @@ typedef struct mpv_opengl_drm_params {
 
     /**
      * DRM render node. Used for VAAPI interop.
-     * Set to a negative number if invalid.
+     * Set to -1 if invalid.
      */
     int render_fd;
-} mpv_opengl_drm_params;
+} mpv_opengl_drm_params_v2;
 
-/**
- * For MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE.
- */
-typedef struct mpv_opengl_drm_draw_surface_size {
-    /**
-     * size of the draw plane surface in pixels.
-     */
-    int width, height;
-} mpv_opengl_drm_draw_surface_size;
 
 /**
  * For backwards compatibility with the old naming of mpv_opengl_drm_draw_surface_size

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -32,13 +32,13 @@ static const struct native_resource_entry native_resource_map[] = {
         .name = "wl",
         .size = 0,
     },
-    [MPV_RENDER_PARAM_DRM_DISPLAY] = {
-        .name = "drm_params",
-        .size = sizeof (mpv_opengl_drm_params),
-    },
     [MPV_RENDER_PARAM_DRM_DRAW_SURFACE_SIZE] = {
         .name = "drm_draw_surface_size",
         .size = sizeof (mpv_opengl_drm_draw_surface_size),
+    },
+    [MPV_RENDER_PARAM_DRM_DISPLAY_V2] = {
+        .name = "drm_params_v2",
+        .size = sizeof (mpv_opengl_drm_params_v2),
     },
 };
 

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -86,8 +86,8 @@ static VADisplay *create_wayland_va_display(struct ra *ra)
 
 static VADisplay *create_drm_va_display(struct ra *ra)
 {
-    mpv_opengl_drm_params *params = ra_get_native_resource(ra, "drm_params");
-    if (!params || params->render_fd < 0)
+    mpv_opengl_drm_params_v2 *params = ra_get_native_resource(ra, "drm_params_v2");
+    if (!params || params->render_fd == -1)
         return NULL;
 
     return vaGetDisplayDRM(params->render_fd);

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -101,7 +101,7 @@ struct priv {
     struct vsync_tuple vsync;
     struct vo_vsync_info vsync_info;
 
-    struct mpv_opengl_drm_params drm_params;
+    struct mpv_opengl_drm_params_v2 drm_params;
     struct mpv_opengl_drm_draw_surface_size draw_surface_size;
 };
 
@@ -851,7 +851,7 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     if (rendernode_path) {
         MP_VERBOSE(ctx, "Opening render node \"%s\"\n", rendernode_path);
         p->drm_params.render_fd = open(rendernode_path, O_RDWR | O_CLOEXEC);
-        if (p->drm_params.render_fd < 0) {
+        if (p->drm_params.render_fd == -1) {
             MP_WARN(ctx, "Cannot open render node \"%s\": %s. VAAPI hwdec will be disabled\n",
                     rendernode_path, mp_strerror(errno));
         }
@@ -868,7 +868,7 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     if (!ra_gl_ctx_init(ctx, &p->gl, params))
         return false;
 
-    ra_add_native_resource(ctx->ra, "drm_params", &p->drm_params);
+    ra_add_native_resource(ctx->ra, "drm_params_v2", &p->drm_params);
     ra_add_native_resource(ctx->ra, "drm_draw_surface_size", &p->draw_surface_size);
 
     p->vsync_info.vsync_duration = 0;

--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -146,8 +146,8 @@ static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
 
     // grab atomic request from native resources
     if (p->ctx) {
-        struct mpv_opengl_drm_params *drm_params;
-        drm_params = (mpv_opengl_drm_params *)ra_get_native_resource(hw->ra, "drm_params");
+        struct mpv_opengl_drm_params_v2 *drm_params;
+        drm_params = (mpv_opengl_drm_params_v2 *)ra_get_native_resource(hw->ra, "drm_params_v2");
         if (!drm_params) {
             MP_ERR(hw, "Failed to retrieve drm params from native resources\n");
             return -1;
@@ -250,9 +250,9 @@ static int init(struct ra_hwdec *hw)
     drmprime_video_plane = opts->drm_drmprime_video_plane;
     talloc_free(tmp);
 
-    struct mpv_opengl_drm_params *drm_params;
+    struct mpv_opengl_drm_params_v2 *drm_params;
 
-    drm_params = ra_get_native_resource(hw->ra, "drm_params");
+    drm_params = ra_get_native_resource(hw->ra, "drm_params_v2");
     if (drm_params) {
         p->ctx = drm_atomic_create_context(p->log, drm_params->fd, drm_params->crtc_id,
                                            drm_params->connector_id, draw_plane, drmprime_video_plane);


### PR DESCRIPTION
…2174850f869018

Extending the client-allocated mpv_opengl_drm_params struct
constituted a break of ABI that could cause UB.

Create a clean break by deprecating "drm_params" and related structs
and enum values, and replacing it with "drm_params_v2".

Also fix some comments and code that wrongly assumed that open could
return any other negative number than -1 for failure.

This commit updates the libmpv version to 1.104
