### PR TITLE
vo_gpu: hwdec_cuda: Improve interop selection mechanism

### DIFF
--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -50,6 +50,8 @@ struct cuda_mapper_priv {
     void *ext[4];
 };
 
+typedef bool (*cuda_interop_init)(const struct ra_hwdec *hw);
+
 bool cuda_gl_init(const struct ra_hwdec *hw);
 
 bool cuda_vk_init(const struct ra_hwdec *hw);

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -118,8 +118,8 @@ bool cuda_gl_init(const struct ra_hwdec *hw) {
             return false;
         }
     } else {
-        // This is not an error.
-        return true;
+        // This is not an OpenGL RA.
+        return false;
     }
 
     CUdevice display_dev;

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -292,8 +292,8 @@ bool cuda_vk_init(const struct ra_hwdec *hw) {
             return false;
         }
     } else {
-        // This is not an error.
-        return true;
+        // This is not a Vulkan RA.
+        return false;
     }
 
     if (!cu->cuImportExternalMemory) {


### PR DESCRIPTION
This change updates the interop selection to match what I did for
VAAPI, by iterating through an array of init functions until one
of them works.