### PR TITLE
build: lower version requirement for EGL

### DIFF
--- a/wscript
+++ b/wscript
@@ -629,7 +629,7 @@ video_output_features = [
         'deps': 'wayland',
         'groups': [ 'gl' ],
         'func': check_pkg_config('wayland-egl', '>= 9.0.0',
-                                 'egl',         '>= 9.0.0')
+                                 'egl',         '>= 1.5')
     } , {
         'name': '--gl-win32',
         'desc': 'OpenGL Win32 Backend',


### PR DESCRIPTION
`egl.pc` can be provided either by mesa or libglvnd. The latter doesn't
follow the same version scheme as mesa but instead uses the API version
that the library exposes, which is 1.5 for EGL[1]

[1] https://github.com/NVIDIA/libglvnd/commit/0dfaea2bcb7cdcc785f95e244223bd004a2d7fba#diff-b58a140c00ea99fb9a708e15afaade62R8
