### PR TITLE
vf_fingerprint: use aligned_alloc instead of posix_memalign

### DIFF
--- a/video/filter/vf_fingerprint.c
+++ b/video/filter/vf_fingerprint.c
@@ -136,8 +136,8 @@ static void reinit_fmt(struct mp_filter *f, struct mp_image *mpi)
 
     size_t tmp_size;
     if (!zimg_filter_graph_get_tmp_size(p->zimg_graph, &tmp_size)) {
-        if (posix_memalign(&p->zimg_tmp, ZIMG_ALIGN, tmp_size))
-            p->zimg_tmp = NULL;
+        tmp_size = MP_ALIGN_UP(tmp_size, ZIMG_ALIGN);
+        p->zimg_tmp = aligned_alloc(ZIMG_ALIGN, tmp_size);
     }
 
     if (!p->zimg_tmp) {

--- a/wscript
+++ b/wscript
@@ -214,6 +214,11 @@ main_dependencies = [
                 'atomic_int_least64_t test = ATOMIC_VAR_INIT(123);'
                 'atomic_fetch_add(&test, 1)'))
     }, {
+        # C11; technically we still support C99
+        'name': 'aligned_alloc',
+        'desc': 'C11 aligned_alloc()',
+        'func': check_statement('stdlib.h', 'aligned_alloc(1, 1)'),
+    }, {
         'name': 'atomics',
         'desc': 'stdatomic.h support or slow emulation',
         'func': check_true,
@@ -386,6 +391,7 @@ iconv support use --disable-iconv.",
         'func': check_pkg_config('rubberband', '>= 1.8.0'),
     }, {
         'name': '--zimg',
+        'deps': 'aligned_alloc',
         'desc': 'libzimg support (for vf_fingerprint)',
         'func': check_pkg_config('zimg', '>= 2.9'),
     }, {


### PR DESCRIPTION
I was assuming posix_memalign was the most portable function to use, but
MinGW does not provide it for some reason. Supposedly it provides  C11
aligned_alloc(), and that function is more elegant than posix_memalign()
anyway, so switch to that.

Just to be sure, add a configure test for aligned_alloc(). In theory we
still support C99.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
---
Should fixes the CI build, will merge once it's confirmed.