### PR TITLE
waf: fix wayland-scanner deprecation warning

### DIFF
--- a/waftools/generators/sources.py
+++ b/waftools/generators/sources.py
@@ -66,7 +66,7 @@ def __wayland_protocol_code__(ctx, **kwargs):
         kwargs['source'] = '{}/{}'.format(kwargs['proto_dir'], file_name)
 
     ctx(
-        rule   = __wayland_scanner_cmd__(ctx, 'code', kwargs['proto_dir'],
+        rule   = __wayland_scanner_cmd__(ctx, 'private-code', kwargs['proto_dir'],
                                          file_name,
                                          protocol_is_vendored),
         name   = os.path.basename(kwargs['target']),

--- a/wscript
+++ b/wscript
@@ -570,8 +570,8 @@ video_output_features = [
         'name': '--wayland',
         'desc': 'Wayland',
         'deps': 'wayland-protocols && wayland-scanner',
-        'func': check_pkg_config('wayland-client', '>= 1.6.0',
-                                 'wayland-cursor', '>= 1.6.0',
+        'func': check_pkg_config('wayland-client', '>= 1.15.0',
+                                 'wayland-cursor', '>= 1.15.0',
                                  'xkbcommon',      '>= 0.3.0'),
     } , {
         'name': '--x11',


### PR DESCRIPTION
Use `private-code` instead of `code` here.<sup>[1](https://gitlab.freedesktop.org/wayland/wayland/commit/9b76def674f0a0b99f5850cc800017fc4e03af7d)</sup>