### PR TITLE
build: fix swift linking with upcoming xcode 11

### DIFF
--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -89,8 +89,16 @@ def process_libraries(libs_dict, binary, processed = []):
 def process_swift_libraries(binary):
     command = ['xcrun', '--find', 'swift-stdlib-tool']
     swiftStdlibTool = subprocess.check_output(command, universal_newlines=True).strip()
+    #from xcode11 the dynamic swift libs reside in a seperate directory from
+    #the std one, might need versioned paths for future swift versions
+    swiftLibPath = os.path.join(swiftStdlibTool, '../../lib/swift-5.0/macosx')
+    swiftLibPath = os.path.abspath(swiftLibPath)
 
     command = [swiftStdlibTool, '--copy', '--platform', 'macosx', '--scan-executable', binary, '--destination', lib_path(binary)]
+
+    if os.path.exists(swiftLibPath):
+        command.extend(['--source-libraries', swiftLibPath])
+
     subprocess.check_output(command, universal_newlines=True)
 
     print(">> setting additional rpath for swift libraries")

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -44,6 +44,7 @@ def __add_dynamic_swift_library_linking_flags(ctx, swift_library):
     if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("5.0"):
         ctx.env.append_value('LINKFLAGS', [
             '-Xlinker', '-rpath', '-Xlinker', '/usr/lib/swift',
+            '-L/usr/lib/swift',
         ])
 
     ctx.env.append_value('LINKFLAGS', [

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -580,12 +580,16 @@ def build(ctx):
         syms = True
         ctx.load("syms")
 
+    additonal_objects = ""
+    if ctx.dependency_satisfied('swift'):
+        additonal_objects = "osdep/macOS_swift.o"
+
     if ctx.dependency_satisfied('cplayer'):
         ctx(
             target       = "mpv",
             source       = main_fn_c,
             use          = ctx.dependencies_use() + ['objects'],
-            add_object   = "osdep/macOS_swift.o",
+            add_object   = additonal_objects,
             includes     = _all_includes(ctx),
             features     = "c cprogram" + (" syms" if syms else ""),
             export_symbols_def = "libmpv/mpv.def", # for syms=True
@@ -642,7 +646,7 @@ def build(ctx):
                 "target": "mpv",
                 "source":   ctx.filtered_sources(sources),
                 "use":      ctx.dependencies_use(),
-                "add_object": "osdep/macOS_swift.o",
+                "add_object": additonal_objects,
                 "includes": [ctx.bldnode.abspath(), ctx.srcnode.abspath()] + \
                              ctx.dependencies_includes(),
                 "features": features,


### PR DESCRIPTION
includes #6960. i am not sure if those additional xcode 11 changes should be merged before the actual release of xcode 11. several other projects have similar issues, xcode 11 Beta still has related bugs and it can well change again for the final release.

this was also tested with xcode 10.