### PR TITLE
swift build and bundle optimisations and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: c
 matrix:
   include:
     - os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11
       compiler: clang
     - os: osx
       osx_image: xcode10.1

--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -89,8 +89,16 @@ def process_libraries(libs_dict, binary, processed = []):
 def process_swift_libraries(binary):
     command = ['xcrun', '--find', 'swift-stdlib-tool']
     swiftStdlibTool = subprocess.check_output(command, universal_newlines=True).strip()
+    # from xcode11 on the dynamic swift libs reside in a separate directory from
+    # the std one, might need versioned paths for future swift versions
+    swiftLibPath = os.path.join(swiftStdlibTool, '../../lib/swift-5.0/macosx')
+    swiftLibPath = os.path.abspath(swiftLibPath)
 
     command = [swiftStdlibTool, '--copy', '--platform', 'macosx', '--scan-executable', binary, '--destination', lib_path(binary)]
+
+    if os.path.exists(swiftLibPath):
+        command.extend(['--source-libraries', swiftLibPath])
+
     subprocess.check_output(command, universal_newlines=True)
 
     print(">> setting additional rpath for swift libraries")

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -44,6 +44,7 @@ def __add_dynamic_swift_library_linking_flags(ctx, swift_library):
     if StrictVersion(ctx.env.SWIFT_VERSION) >= StrictVersion("5.0"):
         ctx.env.append_value('LINKFLAGS', [
             '-Xlinker', '-rpath', '-Xlinker', '/usr/lib/swift',
+            '-L/usr/lib/swift',
         ])
 
     ctx.env.append_value('LINKFLAGS', [

--- a/waftools/generators/sources.py
+++ b/waftools/generators/sources.py
@@ -96,8 +96,8 @@ def __wayland_protocol_header__(ctx, **kwargs):
 @TaskGen.feature('apply_link')
 @TaskGen.after_method('process_source', 'process_use', 'apply_link', 'process_uselib_local', 'propagate_uselib_vars', 'do_the_symbol_stuff')
 def handle_add_object(tgen):
-    if getattr(tgen, 'add_object', None):
-        for input in Utils.to_list(tgen.add_object):
+    if getattr(tgen, 'add_objects', None):
+        for input in tgen.add_objects:
             input_node = tgen.path.find_resource(input)
             if input_node is not None:
                 tgen.link_task.inputs.append(input_node)

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -580,16 +580,16 @@ def build(ctx):
         syms = True
         ctx.load("syms")
 
-    additonal_objects = ""
+    additonal_objects = []
     if ctx.dependency_satisfied('swift'):
-        additonal_objects = "osdep/macOS_swift.o"
+        additonal_objects.append("osdep/macOS_swift.o")
 
     if ctx.dependency_satisfied('cplayer'):
         ctx(
             target       = "mpv",
             source       = main_fn_c,
             use          = ctx.dependencies_use() + ['objects'],
-            add_object   = additonal_objects,
+            add_objects  = additonal_objects,
             includes     = _all_includes(ctx),
             features     = "c cprogram" + (" syms" if syms else ""),
             export_symbols_def = "libmpv/mpv.def", # for syms=True
@@ -646,7 +646,7 @@ def build(ctx):
                 "target": "mpv",
                 "source":   ctx.filtered_sources(sources),
                 "use":      ctx.dependencies_use(),
-                "add_object": additonal_objects,
+                "add_objects": additonal_objects,
                 "includes": [ctx.bldnode.abspath(), ctx.srcnode.abspath()] + \
                              ctx.dependencies_includes(),
                 "features": features,


### PR DESCRIPTION
includes #6961. tested this on a machine that had an older than swift 5 version where ABI compatibility wasn't yet there and it just crashed.