### PR TITLE
sub/lavc_conv: skip ReadOrder reset when subtitle decoder gets flushed

### DIFF
--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -86,6 +86,7 @@ struct lavc_conv *lavc_conv_create(struct mp_log *log, const char *codec_name,
     if (mp_lavc_set_extradata(avctx, extradata, extradata_len) < 0)
         goto error;
     av_dict_set(&opts, "sub_text_format", "ass", 0);
+    av_dict_set(&opts, "flags2", "+ass_ro_flush_noop", 0);
     if (strcmp(codec_name, "eia_608") == 0)
         av_dict_set(&opts, "real_time", "1", 0);
     if (avcodec_open2(avctx, codec, &opts) < 0)


### PR DESCRIPTION
During initial testing with US closed captions, ARIB captions,
timed text in MP4 or the specific external SRT files I tested with
there were no hints that this flag would be needed for seeking to
work.

Unfortunately, that result seems to have been incorrect.

Fixes #6970
