### PR TITLE
Vulkan context for Android

### DIFF
--- a/video/out/android_common.c
+++ b/video/out/android_common.c
@@ -1,0 +1,113 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libavcodec/jni.h>
+#include <android/native_window_jni.h>
+
+#include "android_common.h"
+#include "common/msg.h"
+#include "options/m_config.h"
+#include "vo.h"
+
+struct android_opts {
+    struct m_geometry surface_size;
+};
+
+#define OPT_BASE_STRUCT struct android_opts
+const struct m_sub_options android_conf = {
+    .opts = (const struct m_option[]) {
+        OPT_SIZE_BOX("android-surface-size", surface_size, UPDATE_VO_RESIZE),
+        {0}
+    },
+    .size = sizeof(struct android_opts),
+};
+
+
+struct vo_android_state {
+    struct mp_log *log;
+    ANativeWindow *native_window;
+};
+
+int vo_android_init(struct vo *vo)
+{
+    vo->android = talloc_zero(vo, struct vo_android_state);
+    struct vo_android_state *ctx = vo->android;
+
+    *ctx = (struct vo_android_state){
+        .log = mp_log_new(ctx, vo->log, "android"),
+    };
+
+    jobject surface = (jobject)(intptr_t)vo->opts->WinID;
+    JavaVM *vm = (JavaVM *)av_jni_get_java_vm(NULL);
+    JNIEnv *env;
+    int ret = (*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6);
+    if (ret == JNI_EDETACHED) {
+        if ((*vm)->AttachCurrentThread(vm, &env, NULL) != 0) {
+            MP_FATAL(ctx, "Could not attach Java VM.\n");
+            goto fail;
+        }
+    }
+    ctx->native_window = ANativeWindow_fromSurface(env, surface);
+    (*vm)->DetachCurrentThread(vm);
+
+    return 1;
+fail:
+    talloc_free(ctx);
+    vo->android = NULL;
+    return 0;
+}
+
+void vo_android_uninit(struct vo *vo)
+{
+    struct vo_android_state *ctx = vo->android;
+    if (!ctx)
+        return;
+
+    if (ctx->native_window)
+        ANativeWindow_release(ctx->native_window);
+
+    talloc_free(ctx);
+    vo->android = NULL;
+}
+
+ANativeWindow *vo_android_native_window(struct vo *vo)
+{
+    struct vo_android_state *ctx = vo->android;
+    return ctx->native_window;
+}
+
+bool vo_android_surface_size(struct vo *vo, int *out_w, int *out_h)
+{
+    struct vo_android_state *ctx = vo->android;
+    void *tmp = talloc_new(NULL);
+    struct android_opts *opts = mp_get_config_group(tmp, vo->global, &android_conf);
+
+    int w = opts->surface_size.w, h = opts->surface_size.h;
+    if (!w)
+        w = ANativeWindow_getWidth(ctx->native_window);
+    if (!h)
+        h = ANativeWindow_getHeight(ctx->native_window);
+
+    talloc_free(tmp);
+    if (w <= 0 || h <= 0) {
+        MP_ERR(ctx, "Failed to get height and width.\n");
+        return false;
+    }
+    *out_w = w;
+    *out_h = h;
+    return true;
+}

--- a/video/out/android_common.h
+++ b/video/out/android_common.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <android/native_window_jni.h>
+
+#include "common/common.h"
+
+struct vo;
+
+int vo_android_init(struct vo *vo);
+void vo_android_uninit(struct vo *vo);
+ANativeWindow *vo_android_native_window(struct vo *vo);
+bool vo_android_surface_size(struct vo *vo, int *w, int *h);

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -49,6 +49,7 @@ extern const struct ra_ctx_fns ra_ctx_android;
 extern const struct ra_ctx_fns ra_ctx_vulkan_wayland;
 extern const struct ra_ctx_fns ra_ctx_vulkan_win;
 extern const struct ra_ctx_fns ra_ctx_vulkan_xlib;
+extern const struct ra_ctx_fnd ra_ctx_vulkan_android;
 
 /* Direct3D 11 */
 extern const struct ra_ctx_fns ra_ctx_d3d11;
@@ -93,6 +94,9 @@ static const struct ra_ctx_fns *contexts[] = {
 // Vulkan contexts:
 #if HAVE_VULKAN
 
+#if HAVE_ANDROID
+    &ra_ctx_vulkan_android,
+#endif
 #if HAVE_WIN32_DESKTOP
     &ra_ctx_vulkan_win,
 #endif

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -447,6 +447,7 @@ struct vo {
     struct vo_w32_state *w32;
     struct vo_cocoa_state *cocoa;
     struct vo_wayland_state *wl;
+    struct vo_android_state *android;
     struct mp_hwdec_devices *hwdec_devs;
     struct input_ctx *input_ctx;
     struct osd_state *osd;

--- a/video/out/vulkan/context_android.c
+++ b/video/out/vulkan/context_android.c
@@ -1,0 +1,94 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_android.h>
+
+#include "video/out/android_common.h"
+#include "common.h"
+#include "context.h"
+#include "utils.h"
+
+struct priv {
+    struct mpvk_ctx vk;
+};
+
+static void android_uninit(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+    ra_vk_ctx_uninit(ctx);
+    mpvk_uninit(&p->vk);
+
+    vo_android_uninit(ctx->vo);
+}
+
+static bool android_init(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
+    struct mpvk_ctx *vk = &p->vk;
+    int msgl = ctx->opts.probing ? MSGL_V : MSGL_ERR;
+
+    if (!vo_android_init(ctx->vo))
+        goto fail;
+
+    if (!mpvk_init(vk, ctx, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
+        goto fail;
+
+    VkAndroidSurfaceCreateInfoKHR info = {
+         .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+         .window = vo_android_native_window(ctx->vo)
+    };
+
+    VkInstance inst = vk->vkinst->instance;
+    VkResult res = vkCreateAndroidSurfaceKHR(inst, &info, NULL, &vk->surface);
+    if (res != VK_SUCCESS) {
+        MP_MSG(ctx, msgl, "Failed creating Android surface\n");
+        goto fail;
+    }
+
+    if (!ra_vk_ctx_init(ctx, vk, VK_PRESENT_MODE_FIFO_KHR))
+        goto fail;
+
+    return true;
+fail:
+    android_uninit(ctx);
+    return false;
+}
+
+static bool android_reconfig(struct ra_ctx *ctx)
+{
+    int w, h;
+    if (!vo_android_surface_size(ctx->vo, &w, &h))
+        return false;
+
+    ra_vk_ctx_resize(ctx, w, h);
+    return true;
+}
+
+static int android_control(struct ra_ctx *ctx, int *events, int request, void *arg)
+{
+    return VO_NOTIMPL;
+}
+
+const struct ra_ctx_fns ra_ctx_vulkan_android = {
+    .type           = "vulkan",
+    .name           = "androidvk",
+    .reconfig       = android_reconfig,
+    .control        = android_control,
+    .init           = android_init,
+    .uninit         = android_uninit,
+};

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -488,6 +488,7 @@ def build(ctx):
         ( "video/out/vo_x11.c" ,                 "x11" ),
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),
+        ( "video/out/vulkan/context_android.c",  "vulkan && android" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
         ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -402,6 +402,7 @@ def build(ctx):
         ( "video/img_format.c" ),
         ( "video/mp_image.c" ),
         ( "video/mp_image_pool.c" ),
+        ( "video/out/android_common.c",          "android" ),
         ( "video/out/aspect.c" ),
         ( "video/out/bitmap_packer.c" ),
         ( "video/out/cocoa/events_view.m",       "cocoa" ),


### PR DESCRIPTION
Todo:
- [x] move common code with `video/out/opengl/context_android.c` somewhere else
- [x] decide if this code should / needs to support the use of [vulkan wrapper](https://github.com/KhronosGroup/Vulkan-Tools/tree/master/common):
  no, `InitVulkan()` can be called by support code external to mpv.

how to test: use with[`sfan5/vk`](https://github.com/mpv-android/mpv-android/tree/sfan5/vk) branch of mpv-android