### PR TITLE
Minor FreeBSD fixes from downstream

### DIFF
--- a/libmpv/mpv.def
+++ b/libmpv/mpv.def
@@ -1,3 +1,5 @@
+__progname
+environ
 mpv_abort_async_command
 mpv_client_api_version
 mpv_client_name

--- a/osdep/threads.c
+++ b/osdep/threads.c
@@ -21,6 +21,10 @@
 
 #include "config.h"
 
+#if HAVE_BSD_THREAD_NAME
+#include <pthread_np.h>
+#endif
+
 #include "threads.h"
 #include "timer.h"
 

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -21,10 +21,17 @@
 #include <sys/ioctl.h>
 #include <poll.h>
 #include <sys/stat.h>
-#include <sys/vt.h>
 #include <unistd.h>
 #include <limits.h>
 #include <math.h>
+
+#include "config.h"
+
+#if HAVE_CONSIO_H
+#include <sys/consio.h>
+#else
+#include <sys/vt.h>
+#endif
 
 #include "drm_common.h"
 

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -821,6 +821,9 @@ bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log)
     vt_mode.mode = VT_PROCESS;
     vt_mode.relsig = RELEASE_SIGNAL;
     vt_mode.acqsig = ACQUIRE_SIGNAL;
+    // frsig is a signal for forced release. Not implemented on Linux,
+    // Solaris, BSDs but must be set to a valid signal on some of those.
+    vt_mode.frsig = SIGIO; // ignored
     if (ioctl(s->tty_fd, VT_SETMODE, &vt_mode) < 0) {
         MP_ERR(s, "VT_SETMODE failed: %s\n", mp_strerror(errno));
         return false;

--- a/wscript
+++ b/wscript
@@ -307,7 +307,7 @@ iconv support use --disable-iconv.",
         'name': 'bsd-thread-name',
         'desc': 'BSD API for setting thread name',
         'deps': '!(glibc-thread-name || osx-thread-name)',
-        'func': check_statement('pthread.h',
+        'func': check_statement(['pthread.h', 'pthread_np.h'],
                                 'pthread_set_name_np(pthread_self(), "ducks")',
                                 use=['pthreads']),
     }, {

--- a/wscript
+++ b/wscript
@@ -288,6 +288,12 @@ iconv support use --disable-iconv.",
         'func': check_statement(['sys/vt.h', 'sys/ioctl.h'],
                                 'int m; ioctl(0, VT_GETMODE, &m)'),
     }, {
+        'name': 'consio.h',
+        'desc': 'consio.h',
+        'deps': '!vt.h',
+        'func': check_statement(['sys/consio.h', 'sys/ioctl.h'],
+                                'int m; ioctl(0, VT_GETMODE, &m)'),
+    }, {
         'name': 'gbm.h',
         'desc': 'gbm.h',
         'func': check_cc(header_name=['stdio.h', 'gbm.h']),
@@ -552,7 +558,7 @@ video_output_features = [
     }, {
         'name': '--drm',
         'desc': 'DRM',
-        'deps': 'vt.h',
+        'deps': 'vt.h || consio.h',
         'func': check_pkg_config('libdrm'),
     }, {
         'name': '--drmprime',


### PR DESCRIPTION
- [freebsd-ports@9a1c42985021](http://github.com/freebsd/freebsd-ports/commit/9a1c42985021) but nowadays even x86_64 is affected
- https://github.com/mpv-player/mpv/issues/6081#issuecomment-432489403 suggested `htop` but it won't help
- https://github.com/mpv-player/mpv/issues/1834 vs. [freebsd-ports#238944](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=238944)
