### PR TITLE
build: actually detect supported warning options

### DIFF
--- a/waftools/detections/compiler.py
+++ b/waftools/detections/compiler.py
@@ -13,8 +13,8 @@ def __get_cc_env_vars__(cc):
 
 def __test_and_add_flags__(ctx, flags):
     for flag in flags:
-        ctx.check_cc(cflags=flag, uselib_store="compiler", mandatory=False)
-    ctx.env.CFLAGS += ctx.env.CFLAGS_compiler
+        if ctx.check_cc(cflags='-Werror ' + flag, mandatory=False):
+            ctx.env.CFLAGS += [flag]
 
 def __add_generic_flags__(ctx):
     ctx.env.CFLAGS += ["-D_ISOC99_SOURCE", "-D_GNU_SOURCE",


### PR DESCRIPTION
Previously the options were tested by compiling a test program with the
option, and support was "detected" if the compilation didn't fail.

However, both gcc and clang only issue a warning on unknown warning option,
hence it never failed and all the warn options were detected as supported.

Now the tested option is used together with -Werror, which makes it fail
if it warns that the warning option is unknown.

Fixes clang unknown option warnings -Wno-format-truncation since 4a6b56f .