### PR TITLE
wayland: create current_output in wayland_reconfig

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1213,11 +1213,12 @@ int vo_wayland_reconfig(struct vo *vo)
 
     MP_VERBOSE(wl, "Reconfiguring!\n");
 
-    /* Surface enter events happen later but we already know the outputs and we'd
-     * like to know the output the surface would be on (for scaling or fullscreen),
-     * so if fsscreen_id is set or there's only one possible output, use it. */
-    if (((!wl->current_output) && (wl_list_length(&wl->output_list) == 1)) ||
-        (vo->opts->fullscreen && (vo->opts->fsscreen_id >= 0))) {
+    /* Surface enter events happen later but certain config options require the
+     * current_output to be created in order for the video to actually render.
+     * Only skip this if --fs is specified without a fsscreen_id so the video
+     * renders on the same screen and not the one with idx 0. */
+    if ((!wl->current_output) &&
+        !(vo->opts->fullscreen && (vo->opts->fsscreen_id < 0))) {
         int idx = 0;
         if (vo->opts->fullscreen && (vo->opts->fsscreen_id >= 0))
             idx = vo->opts->fsscreen_id;


### PR DESCRIPTION
Certain mpv config options require wl->current_output to be created
before the video can actually start rendering. Just always create it
here if the current_output doesn't exist (the one exception being the
--fs option with no --fs-screen flag). Incidentally, this also fixes
--fs-screen not working on wayland.

Fixes #6653.