### PR TITLE
manpage: update requirements for vdpau hwdec use

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -947,7 +947,8 @@ Video
     :auto:      enable best hw decoder (see below)
     :yes:       exactly the same as ``auto``
     :auto-copy: enable best hw decoder with copy-back (see below)
-    :vdpau:     requires ``--vo=gpu`` or ``--vo=vdpau`` (Linux only)
+    :vdpau:     requires ``--vo=gpu`` with ``--gpu-context=x11``,
+                or ``--vo=vdpau`` (Linux only)
     :vdpau-copy: copies video back into system RAM (Linux with some GPUs only)
     :vaapi:     requires ``--vo=gpu`` or ``--vo=vaapi`` (Linux only)
     :vaapi-copy: copies video back into system RAM (Linux with some GPUs only)


### PR DESCRIPTION
We default to EGL instead of GLX now, which means vdpau only works if we explicitly specify that we want a GLX context, as vdpau lacks interop for EGL.

Update the hwdec documentation to reflect this.

Concerns #6980.
