### PR TITLE
vo_drm: Implement triple buffering/N-buffering and presentation feedback

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1469,6 +1469,13 @@ Video
     this can break on streams not encoded by x264, or if a stream encoded by a
     newer x264 version contains no version info.
 
+``--swapchain-depth=<N>``
+    Allow up to N in-flight frames. This essentially controls the frame
+    latency. Increasing the swapchain depth can improve pipelining and prevent
+    missed vsyncs, but increases visible latency. This option only mandates an
+    upper limit, the implementation can use a lower latency than requested
+    internally. A setting of 1 means that the VO will wait for every frame to
+    become visible before starting to render the next frame. (Default: 3)
 
 Audio
 -----
@@ -5169,14 +5176,6 @@ The following video options are currently all specific to ``--vo=gpu`` and
     runtime (i.e. if the device is rotated), via the surfaceChanged callback.
 
     Android with ``--gpu-context=android`` only.
-
-``--swapchain-depth=<N>``
-    Allow up to N in-flight frames. This essentially controls the frame
-    latency. Increasing the swapchain depth can improve pipelining and prevent
-    missed vsyncs, but increases visible latency. This option only mandates an
-    upper limit, the implementation can use a lower latency than requested
-    internally. A setting of 1 means that the VO will wait for every frame to
-    become visible before starting to render the next frame. (Default: 3)
 
 ``--gpu-sw``
     Continue even if a software renderer is detected.

--- a/options/options.c
+++ b/options/options.c
@@ -160,6 +160,7 @@ static const m_option_t mp_vo_opt_list[] = {
 #if HAVE_DRM
     OPT_SUBSTRUCT("", drm_opts, drm_conf, 0),
 #endif
+    OPT_INTRANGE("swapchain-depth", swapchain_depth, 0, 1, 8),
     {0}
 };
 
@@ -186,6 +187,7 @@ const struct m_sub_options vo_sub_opts = {
         .mmcss_profile = "Playback",
         .ontop_level = -1,
         .timing_offset = 0.050,
+        .swapchain_depth = 3,
     },
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -59,6 +59,8 @@ typedef struct mp_vo_opts {
     struct sws_opts *sws_opts;
     // vo_drm
     struct drm_opts *drm_opts;
+
+    int swapchain_depth;  // max number of images to render ahead
 } mp_vo_opts;
 
 // Subtitle options needed by the subtitle decoders/renderers.

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -310,7 +310,7 @@ static bool d3d11_init(struct ra_ctx *ctx)
         .allow_warp = p->opts->warp != 0,
         .force_warp = p->opts->warp == 1,
         .max_feature_level = p->opts->feature_level,
-        .max_frame_latency = ctx->opts.swapchain_depth,
+        .max_frame_latency = ctx->vo->opts->swapchain_depth,
     };
     if (!mp_d3d11_create_present_device(ctx->log, &dopts, &p->device))
         goto error;
@@ -331,7 +331,7 @@ static bool d3d11_init(struct ra_ctx *ctx)
         .flip = p->opts->flip,
         // Add one frame for the backbuffer and one frame of "slack" to reduce
         // contention with the window manager when acquiring the backbuffer
-        .length = ctx->opts.swapchain_depth + 2,
+        .length = ctx->vo->opts->swapchain_depth + 2,
         .usage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
     };
     if (!mp_d3d11_create_swapchain(p->device, ctx->log, &scopts, &p->swapchain))

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -25,13 +25,16 @@
 #include <unistd.h>
 #include <limits.h>
 #include <math.h>
+#include <time.h>
 
 #include "drm_common.h"
 
 #include "common/common.h"
 #include "common/msg.h"
 #include "osdep/io.h"
+#include "osdep/timer.h"
 #include "misc/ctype.h"
+#include "video/out/vo.h"
 
 #define EVT_RELEASE 1
 #define EVT_ACQUIRE 2
@@ -899,4 +902,49 @@ void vt_switcher_poll(struct vt_switcher *s, int timeout_ms)
     case EVT_INTERRUPT:
         break;
     }
+}
+
+void drm_pflip_cb(int fd, unsigned int msc, unsigned int sec,
+                  unsigned int usec, void *data)
+{
+    struct drm_pflip_cb_closure *closure = data;
+
+    struct drm_vsync_tuple *vsync = closure->vsync;
+    // frame_vsync->ust is the timestamp of the pageflip that happened just before this flip was queued
+    // frame_vsync->msc is the sequence number of the pageflip that happened just before this flip was queued
+    // frame_vsync->sbc is the sequence number for the frame that was just flipped to screen
+    struct drm_vsync_tuple *frame_vsync = closure->frame_vsync;
+    struct vo_vsync_info *vsync_info = closure->vsync_info;
+
+    const bool ready =
+        (vsync->msc != 0) &&
+        (frame_vsync->ust != 0) && (frame_vsync->msc != 0);
+
+    const uint64_t ust = (sec * 1000000LL) + usec;
+
+    const unsigned int msc_since_last_flip = msc - vsync->msc;
+
+    vsync->ust = ust;
+    vsync->msc = msc;
+
+    if (ready) {
+        // Convert to mp_time
+        struct timespec ts;
+        if (clock_gettime(CLOCK_MONOTONIC, &ts))
+            goto fail;
+        const uint64_t now_monotonic = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
+        const uint64_t ust_mp_time = mp_time_us() - (now_monotonic - vsync->ust);
+
+        const uint64_t     ust_since_enqueue = vsync->ust - frame_vsync->ust;
+        const unsigned int msc_since_enqueue = vsync->msc - frame_vsync->msc;
+        const unsigned int sbc_since_enqueue = vsync->sbc - frame_vsync->sbc;
+
+        vsync_info->vsync_duration = ust_since_enqueue / msc_since_enqueue;
+        vsync_info->skipped_vsyncs = msc_since_last_flip - 1; // Valid iff swap_buffers is called every vsync
+        vsync_info->last_queue_display_time = ust_mp_time + (sbc_since_enqueue * vsync_info->vsync_duration);
+    }
+
+fail:
+    *closure->waiting_for_flip = false;
+    talloc_free(closure);
 }

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -55,6 +55,12 @@ struct drm_opts {
     struct m_geometry drm_draw_surface_size;
 };
 
+struct drm_vsync_tuple {
+    uint64_t ust;
+    unsigned int msc;
+    unsigned int sbc;
+};
+
 bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log);
 void vt_switcher_destroy(struct vt_switcher *s);
 void vt_switcher_poll(struct vt_switcher *s, int timeout_ms);

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -61,6 +61,13 @@ struct drm_vsync_tuple {
     unsigned int sbc;
 };
 
+struct drm_pflip_cb_closure {
+    struct drm_vsync_tuple *frame_vsync; // vsync tuple when the frame that just flipped was queued
+    struct drm_vsync_tuple *vsync; // vsync tuple of the latest page flip. drm_pflip_cb updates this
+    struct vo_vsync_info *vsync_info; // where the drm_pflip_cb routine writes its output
+    bool *waiting_for_flip; // drm_pflip_cb writes false here before returning
+};
+
 bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log);
 void vt_switcher_destroy(struct vt_switcher *s);
 void vt_switcher_poll(struct vt_switcher *s, int timeout_ms);
@@ -77,5 +84,9 @@ struct kms *kms_create(struct mp_log *log, const char *connector_spec,
                        bool use_atomic);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
+
+// DRM Page Flip callback
+void drm_pflip_cb(int fd, unsigned int msc, unsigned int sec,
+                  unsigned int usec, void *data);
 
 #endif

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -10,7 +10,6 @@ struct ra_ctx_opts {
     int want_alpha;      // create an alpha framebuffer if possible
     int debug;           // enable debugging layers/callbacks etc.
     bool probing;        // the backend was auto-probed
-    int swapchain_depth; // max number of images to render ahead
 };
 
 struct ra_ctx {

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -306,7 +306,7 @@ void ra_gl_ctx_swap_buffers(struct ra_swapchain *sw)
             check_pattern(p, step);
     }
 
-    while (p->num_vsync_fences >= sw->ctx->opts.swapchain_depth) {
+    while (p->num_vsync_fences >= sw->ctx->vo->opts->swapchain_depth) {
         gl->ClientWaitSync(p->vsync_fences[0], GL_SYNC_FLUSH_COMMANDS_BIT, 1e9);
         gl->DeleteSync(p->vsync_fences[0]);
         MP_TARRAY_REMOVE_AT(p->vsync_fences, p->num_vsync_fences, 0);

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -226,7 +226,7 @@ static bool d3d11_device_create(struct ra_ctx *ctx)
         .force_warp = o->d3d11_warp == 1,
         .max_feature_level = o->d3d11_feature_level,
         .min_feature_level = D3D_FEATURE_LEVEL_9_3,
-        .max_frame_latency = ctx->opts.swapchain_depth,
+        .max_frame_latency = ctx->vo->opts->swapchain_depth,
     };
     if (!mp_d3d11_create_present_device(vo->log, &device_opts, &p->d3d11_device))
         return false;
@@ -294,7 +294,7 @@ static bool d3d11_swapchain_surface_create(struct ra_ctx *ctx)
         .flip = o->flip,
         // Add one frame for the backbuffer and one frame of "slack" to reduce
         // contention with the window manager when acquiring the backbuffer
-        .length = ctx->opts.swapchain_depth + 2,
+        .length = ctx->vo->opts->swapchain_depth + 2,
         .usage = DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_SHADER_INPUT,
     };
     if (!mp_d3d11_create_swapchain(p->d3d11_device, vo->log, &swapchain_opts,

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -603,7 +603,8 @@ static void drm_egl_swap_buffers(struct ra_swapchain *sw)
     enqueue_bo(ctx, new_bo);
     new_fence(ctx);
 
-    while (drain || p->gbm.num_bos > ctx->opts.swapchain_depth || !gbm_surface_has_free_buffers(p->gbm.surface)) {
+    while (drain || p->gbm.num_bos > ctx->vo->opts->swapchain_depth ||
+           !gbm_surface_has_free_buffers(p->gbm.surface)) {
         if (p->waiting_for_flip) {
             wait_on_flip(ctx);
             swapchain_step(ctx);

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -54,16 +54,9 @@ struct framebuffer
     uint32_t id;
 };
 
-struct vsync_tuple
-{
-    uint64_t ust;
-    unsigned int msc;
-    unsigned int sbc;
-};
-
 struct gbm_frame {
     struct gbm_bo *bo;
-    struct vsync_tuple vsync;
+    struct drm_vsync_tuple vsync;
 };
 
 struct gbm
@@ -106,7 +99,7 @@ struct priv {
     bool still;
     bool paused;
 
-    struct vsync_tuple vsync;
+    struct drm_vsync_tuple vsync;
     struct vo_vsync_info vsync_info;
 
     struct mpv_opengl_drm_params_v2 drm_params;

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -346,7 +346,7 @@ static void fill_presentparams(struct ra_ctx *ctx,
         .BackBufferHeight = ctx->vo->dheight ? ctx->vo->dheight : 1,
         // Add one frame for the backbuffer and one frame of "slack" to reduce
         // contention with the window manager when acquiring the backbuffer
-        .BackBufferCount = ctx->opts.swapchain_depth + 2,
+        .BackBufferCount = ctx->vo->opts->swapchain_depth + 2,
         .SwapEffect = IsWindows7OrGreater() ? D3DSWAPEFFECT_FLIPEX : D3DSWAPEFFECT_FLIP,
         // Automatically get the backbuffer format from the display format
         .BackBufferFormat = D3DFMT_UNKNOWN,
@@ -398,7 +398,7 @@ static int d3d_create(struct ra_ctx *ctx)
         return -1;
     }
 
-    IDirect3DDevice9Ex_SetMaximumFrameLatency(p->device, ctx->opts.swapchain_depth);
+    IDirect3DDevice9Ex_SetMaximumFrameLatency(p->device, ctx->vo->opts->swapchain_depth);
 
     // Register the Direct3D device with WGL_NV_dx_interop
     p->device_h = gl->DXOpenDeviceNV(p->device);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -163,7 +163,7 @@ static bool fb_setup_double_buffering(struct vo *vo)
     struct priv *p = vo->priv;
 
     p->front_buf = 0;
-    for (unsigned int i = 0; i < 2; i++) {
+    for (unsigned int i = 0; i < BUF_COUNT; i++) {
         p->bufs[i].width = p->kms->mode.mode.hdisplay;
         p->bufs[i].height = p->kms->mode.mode.vdisplay;
     }

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <sys/mman.h>
 #include <poll.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <libswscale/swscale.h>
@@ -45,10 +46,9 @@
 #define BYTES_PER_PIXEL 4
 #define BITS_PER_PIXEL 32
 #define USE_MASTER 0
-#define BUF_COUNT 2
 
-// Modulo that works correctly for negative numbers
-#define MOD(a,b) ((((a)%(b))+(b))%(b))
+#define BUF_COUNT 4
+#define SWAPCHAIN_DEPTH 3
 
 struct framebuffer {
     uint32_t width;
@@ -58,6 +58,16 @@ struct framebuffer {
     uint32_t handle;
     uint8_t *map;
     uint32_t fb;
+};
+
+struct kms_frame {
+    struct framebuffer *fb;
+    struct drm_vsync_tuple vsync;
+};
+
+struct pflip_cb_closure {
+    struct priv *priv;
+    struct kms_frame *frame;
 };
 
 struct priv {
@@ -74,7 +84,13 @@ struct priv {
     struct framebuffer bufs[BUF_COUNT];
     int front_buf;
     bool active;
-    bool pflip_happening;
+    bool waiting_for_flip;
+    bool still;
+    bool paused;
+
+    struct kms_frame **fb_queue;
+    unsigned int fb_queue_len;
+    struct framebuffer *cur_fb;
 
     uint32_t depth;
     enum mp_imgfmt imgfmt;
@@ -88,6 +104,9 @@ struct priv {
     struct mp_rect dst;
     struct mp_osd_res osd;
     struct mp_sws_context *sws;
+
+    struct drm_vsync_tuple vsync;
+    struct vo_vsync_info vsync_info;
 };
 
 static void fb_destroy(int fd, struct framebuffer *buf)
@@ -158,7 +177,7 @@ err:
     return false;
 }
 
-static bool fb_setup_double_buffering(struct vo *vo)
+static bool fb_setup_buffers(struct vo *vo)
 {
     struct priv *p = vo->priv;
 
@@ -178,14 +197,59 @@ static bool fb_setup_double_buffering(struct vo *vo)
         }
     }
 
+    p->cur_fb = &p->bufs[0];
+
     return true;
 }
 
-static void page_flipped(int fd, unsigned int frame, unsigned int sec,
+static void page_flipped(int fd, unsigned int msc, unsigned int sec,
                          unsigned int usec, void *data)
 {
-    struct priv *p = data;
-    p->pflip_happening = false;
+    struct pflip_cb_closure *closure = data;
+    struct priv *p = closure->priv;
+
+    // frame->vsync.ust is the timestamp of the pageflip that happened just before this flip was queued
+    // frame->vsync.msc is the sequence number of the pageflip that happened just before this flip was queued
+    // frame->vsync.sbc is the sequence number for the frame that was just flipped to screen
+    struct kms_frame *frame = closure->frame;
+
+    const bool ready =
+        (p->vsync.msc != 0) &&
+        (frame->vsync.ust != 0) && (frame->vsync.msc != 0);
+
+    const uint64_t ust = (sec * 1000000LL) + usec;
+
+    const unsigned int msc_since_last_flip = msc - p->vsync.msc;
+
+    p->vsync.ust = ust;
+    p->vsync.msc = msc;
+
+    if (ready) {
+        // Convert to mp_time
+        struct timespec ts;
+        if (clock_gettime(CLOCK_MONOTONIC, &ts))
+            goto fail;
+        const uint64_t now_monotonic = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
+        const uint64_t ust_mp_time = mp_time_us() - (now_monotonic - p->vsync.ust);
+
+        const uint64_t     ust_since_enqueue = p->vsync.ust - frame->vsync.ust;
+        const unsigned int msc_since_enqueue = p->vsync.msc - frame->vsync.msc;
+        const unsigned int sbc_since_enqueue = p->vsync.sbc - frame->vsync.sbc;
+
+        p->vsync_info.vsync_duration = ust_since_enqueue / msc_since_enqueue;
+        p->vsync_info.skipped_vsyncs = msc_since_last_flip - 1; // Valid iff swap_buffers is called every vsync
+        p->vsync_info.last_queue_display_time = ust_mp_time + (sbc_since_enqueue * p->vsync_info.vsync_duration);
+    }
+
+fail:
+    p->waiting_for_flip = false;
+    talloc_free(closure);
+}
+
+static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
+{
+    struct priv *p = vo->priv;
+    *info = p->vsync_info;
 }
 
 static bool crtc_setup(struct vo *vo)
@@ -195,7 +259,7 @@ static bool crtc_setup(struct vo *vo)
         return true;
     p->old_crtc = drmModeGetCrtc(p->kms->fd, p->kms->crtc_id);
     int ret = drmModeSetCrtc(p->kms->fd, p->kms->crtc_id,
-                             p->bufs[MOD(p->front_buf - 1, BUF_COUNT)].fb,
+                             p->cur_fb->fb,
                              0, 0, &p->kms->connector->connector_id, 1,
                              &p->kms->mode.mode);
     p->active = true;
@@ -211,7 +275,7 @@ static void crtc_release(struct vo *vo)
     p->active = false;
 
     // wait for current page flip
-    while (p->pflip_happening) {
+    while (p->waiting_for_flip) {
         int ret = drmHandleEvent(p->kms->fd, &p->ev);
         if (ret) {
             MP_ERR(vo, "drmHandleEvent failed: %i\n", ret);
@@ -319,15 +383,48 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     if (mp_sws_reinit(p->sws) < 0)
         return -1;
 
+    p->vsync_info.vsync_duration = 0;
+    p->vsync_info.skipped_vsyncs = -1;
+    p->vsync_info.last_queue_display_time = -1;
+
     vo->want_redraw = true;
     return 0;
 }
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void wait_on_flip(struct vo *vo)
 {
     struct priv *p = vo->priv;
 
-    if (p->active) {
+    // poll page flip finish event
+    while (p->waiting_for_flip) {
+        const int timeout_ms = 3000;
+        struct pollfd fds[1] = { { .events = POLLIN, .fd = p->kms->fd } };
+        poll(fds, 1, timeout_ms);
+        if (fds[0].revents & POLLIN) {
+            const int ret = drmHandleEvent(p->kms->fd, &p->ev);
+            if (ret != 0) {
+                MP_ERR(vo, "drmHandleEvent failed: %i\n", ret);
+                return;
+            }
+        }
+    }
+}
+
+static struct framebuffer *get_new_fb(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+
+    p->front_buf++;
+    p->front_buf %= BUF_COUNT;
+
+    return &p->bufs[p->front_buf];
+}
+
+static void draw_image(struct vo *vo, mp_image_t *mpi, struct framebuffer *front_buf)
+{
+    struct priv *p = vo->priv;
+
+    if (p->active && front_buf != NULL) {
         if (mpi) {
             struct mp_image src = *mpi;
             struct mp_rect src_rc = p->src;
@@ -346,8 +443,6 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
             mp_image_clear(p->cur_frame, 0, 0, p->cur_frame->w, p->cur_frame->h);
             osd_draw_on_image(vo->osd, p->osd, 0, 0, p->cur_frame);
         }
-
-        struct framebuffer *front_buf = &p->bufs[p->front_buf];
 
         if (p->depth == 30) {
             // Pack GBRP10 image into XRGB2101010 for DRM
@@ -386,35 +481,99 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
     }
 }
 
-static void flip_page(struct vo *vo)
+static void enqueue_frame(struct vo *vo, struct framebuffer *fb)
 {
     struct priv *p = vo->priv;
-    if (!p->active || p->pflip_happening)
+
+    p->vsync.sbc++;
+    struct kms_frame *new_frame = talloc(p, struct kms_frame);
+    new_frame->fb = fb;
+    new_frame->vsync = p->vsync;
+    MP_TARRAY_APPEND(p, p->fb_queue, p->fb_queue_len, new_frame);
+}
+
+static void dequeue_frame(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+
+    talloc_free(p->fb_queue[0]);
+    MP_TARRAY_REMOVE_AT(p->fb_queue, p->fb_queue_len, 0);
+}
+
+static void swapchain_step(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+
+    if (p->fb_queue_len > 0) {
+        dequeue_frame(vo);
+    }
+}
+
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
+{
+    struct priv *p = vo->priv;
+
+    if (!p->active)
         return;
 
-    int ret = drmModePageFlip(p->kms->fd, p->kms->crtc_id,
-                              p->bufs[p->front_buf].fb,
-                              DRM_MODE_PAGE_FLIP_EVENT, p);
+    p->still = frame->still;
+
+    // we redraw the entire image when OSD needs to be redrawn
+    const bool repeat = frame->repeat && !frame->redraw;
+
+    struct framebuffer *fb =  &p->bufs[p->front_buf];
+    if (!repeat) {
+        fb = get_new_fb(vo);
+        draw_image(vo, mp_image_new_ref(frame->current), fb);
+    }
+
+    enqueue_frame(vo, fb);
+}
+
+static void queue_flip(struct vo *vo, struct kms_frame *frame)
+{
+    int ret = 0;
+    struct priv *p = vo->priv;
+
+    p->cur_fb = frame->fb;
+
+    // Alloc and fill the data struct for the page flip callback
+    struct pflip_cb_closure *data = talloc(p, struct pflip_cb_closure);
+    data->priv = p;
+    data->frame = frame;
+
+    ret = drmModePageFlip(p->kms->fd, p->kms->crtc_id,
+                          p->cur_fb->fb,
+                          DRM_MODE_PAGE_FLIP_EVENT, data);
     if (ret) {
         MP_WARN(vo, "Failed to queue page flip: %s\n", mp_strerror(errno));
     } else {
-        p->front_buf++;
-        p->front_buf %= BUF_COUNT;
-        p->pflip_happening = true;
+        p->waiting_for_flip = true;
     }
 
-    // poll page flip finish event
-    const int timeout_ms = 3000;
-    struct pollfd fds[1] = {
-        { .events = POLLIN, .fd = p->kms->fd },
-    };
-    poll(fds, 1, timeout_ms);
-    if (fds[0].revents & POLLIN) {
-        ret = drmHandleEvent(p->kms->fd, &p->ev);
-        if (ret != 0) {
-            MP_ERR(vo, "drmHandleEvent failed: %i\n", ret);
-            return;
+}
+
+static void flip_page(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+    const bool drain = p->paused || p->still;
+
+    if (!p->active)
+        return;
+
+    while (drain || p->fb_queue_len > SWAPCHAIN_DEPTH) {
+        if (p->waiting_for_flip) {
+            wait_on_flip(vo);
+            swapchain_step(vo);
         }
+        if (p->fb_queue_len <= 1)
+            break;
+        if (!p->fb_queue[1] || !p->fb_queue[1]->fb) {
+            MP_ERR(vo, "Hole in swapchain?\n");
+            swapchain_step(vo);
+            continue;
+        }
+        queue_flip(vo, p->fb_queue[1]);
     }
 }
 
@@ -423,6 +582,10 @@ static void uninit(struct vo *vo)
     struct priv *p = vo->priv;
 
     crtc_release(vo);
+
+    while (p->fb_queue_len > 0) {
+        swapchain_step(vo);
+    }
 
     if (p->kms) {
         for (unsigned int i = 0; i < BUF_COUNT; i++)
@@ -471,8 +634,8 @@ static int preinit(struct vo *vo)
         p->imgfmt = IMGFMT_XRGB8888;
     }
 
-    if (!fb_setup_double_buffering(vo)) {
-        MP_ERR(vo, "Failed to set up double buffering.\n");
+    if (!fb_setup_buffers(vo)) {
+        MP_ERR(vo, "Failed to set up buffers.\n");
         goto err;
     }
 
@@ -499,6 +662,10 @@ static int preinit(struct vo *vo)
     }
     mp_verbose(vo->log, "Monitor pixel aspect: %g\n", vo->monitor_par);
 
+    p->vsync_info.vsync_duration = 0;
+    p->vsync_info.skipped_vsyncs = -1;
+    p->vsync_info.last_queue_display_time = -1;
+
     return 0;
 
 err:
@@ -518,9 +685,6 @@ static int control(struct vo *vo, uint32_t request, void *arg)
     case VOCTRL_SCREENSHOT_WIN:
         *(struct mp_image**)arg = mp_image_new_copy(p->cur_frame);
         return VO_TRUE;
-    case VOCTRL_REDRAW_FRAME:
-        draw_image(vo, p->last_input);
-        return VO_TRUE;
     case VOCTRL_SET_PANSCAN:
         if (vo->config_ok)
             reconfig(vo, vo->params);
@@ -532,6 +696,17 @@ static int control(struct vo *vo, uint32_t request, void *arg)
         *(double*)arg = fps;
         return VO_TRUE;
     }
+    case VOCTRL_PAUSE:
+        vo->want_redraw = true;
+        p->paused = true;
+        return VO_TRUE;
+    case VOCTRL_RESUME:
+        p->paused = false;
+        p->vsync_info.last_queue_display_time = -1;
+        p->vsync_info.skipped_vsyncs = 0;
+        p->vsync.ust = 0;
+        p->vsync.msc = 0;
+        return VO_TRUE;
     }
     return VO_NOTIMPL;
 }
@@ -545,8 +720,9 @@ const struct vo_driver video_out_drm = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
+    .get_vsync = get_vsync,
     .uninit = uninit,
     .wait_events = wait_events,
     .wakeup = wakeup,

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -315,13 +315,8 @@ static const m_option_t options[] = {
     OPT_STRING_VALIDATE("gpu-api", context_type, 0, ra_ctx_validate_api),
     OPT_FLAG("gpu-debug", opts.debug, 0),
     OPT_FLAG("gpu-sw", opts.allow_sw, 0),
-    OPT_INTRANGE("swapchain-depth", opts.swapchain_depth, 0, 1, 8),
     {0}
 };
-
-static const struct gpu_priv defaults = { .opts = {
-    .swapchain_depth = 3,
-}};
 
 const struct vo_driver video_out_gpu = {
     .description = "Shader-based GPU Renderer",
@@ -339,6 +334,5 @@ const struct vo_driver video_out_gpu = {
     .wakeup = wakeup,
     .uninit = uninit,
     .priv_size = sizeof(struct gpu_priv),
-    .priv_defaults = &defaults,
     .options = options,
 };

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -179,7 +179,7 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
     struct pl_vulkan_swapchain_params params = {
         .surface = vk->surface,
         .present_mode = preferred_mode,
-        .swapchain_depth = ctx->opts.swapchain_depth,
+        .swapchain_depth = ctx->vo->opts->swapchain_depth,
     };
 
     if (p->opts->swap_mode >= 0) // user override


### PR DESCRIPTION
This ports the same kind of swapchain that context_drm_egl has to vo_drm, which should increase performance significantly by allowing the CPU to run more independently of vsync/not waste time waiting for vsync that could be spent drawing to a back buffer. This arrangement could easily cause high vsync jitter in display-resample mode, so presentation feedback becomes neccessary and is implemented in the same commit.

Further improvements include allowing vo_drm to requeue the same FB for repeat frames, which should help when playing videos with FPS lower than the display FPS in video-sync=display-resample mode by not wasting cycles on redrawing the same frame again.

<strike>TODO: Make the swapchain depth of vo_drm adjustable using --swapchain-depth or otherwise.</strike>