### PR TITLE
ao_pulse: add the newly added mappings for TrueHD/DTS-HD formats

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -202,13 +202,18 @@ static const struct format_map {
 static pa_encoding_t map_digital_format(int format)
 {
     switch (format) {
-    case AF_FORMAT_S_AC3:   return PA_ENCODING_AC3_IEC61937;
-    case AF_FORMAT_S_EAC3:  return PA_ENCODING_EAC3_IEC61937;
-    case AF_FORMAT_S_MP3:   return PA_ENCODING_MPEG_IEC61937;
-    case AF_FORMAT_S_DTS:
-    case AF_FORMAT_S_DTSHD: return PA_ENCODING_DTS_IEC61937;
+    case AF_FORMAT_S_AC3:    return PA_ENCODING_AC3_IEC61937;
+    case AF_FORMAT_S_EAC3:   return PA_ENCODING_EAC3_IEC61937;
+    case AF_FORMAT_S_MP3:    return PA_ENCODING_MPEG_IEC61937;
+    case AF_FORMAT_S_DTS:    return PA_ENCODING_DTS_IEC61937;
+#ifdef PA_ENCODING_DTSHD_IEC61937
+    case AF_FORMAT_S_DTSHD:  return PA_ENCODING_DTSHD_IEC61937;
+#endif
 #ifdef PA_ENCODING_MPEG2_AAC_IEC61937
-    case AF_FORMAT_S_AAC:   return PA_ENCODING_MPEG2_AAC_IEC61937;
+    case AF_FORMAT_S_AAC:    return PA_ENCODING_MPEG2_AAC_IEC61937;
+#endif
+#ifdef PA_ENCODING_TRUEHD_IEC61937
+    case AF_FORMAT_S_TRUEHD: return PA_ENCODING_TRUEHD_IEC61937;
 #endif
     default:
         if (af_fmt_is_spdif(format))


### PR DESCRIPTION
Originally DTS-HD was mapped to PA_ENCODING_DTS_IEC61937 which I'm
actually not sure if it ever worked.

These identifiers were added in https://gitlab.freedesktop.org/pulseaudio/pulseaudio/commit/cdeac178019ed3e73840702cb1223df5edd9df43 , which was part of PA version 13. This is rather recent, and thus I'm continuing the ifdef trend (unfortunately).