### PR TITLE
demux: remove redundant seek range update

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2322,8 +2322,6 @@ static void prune_old_packets(struct demux_internal *in)
                 update_seek_ranges(range);
         }
 
-        update_seek_ranges(range);
-
         if (range != in->current_range && range->seek_start == MP_NOPTS_VALUE)
             free_empty_cached_ranges(in);
     }


### PR DESCRIPTION
This was a leftover from commit b2752321 which fixed #6522 but after
the recent demux refactoring this fix is superseded by commit 0f6cda4ab.
Remove the redundant update call.