### PR TITLE
wayland: use presentation time

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4728,6 +4728,21 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     Currently only relevant for ``--gpu-api=d3d11``.
 
+``--wayland-frame-wait-offset=<-100..3000>``
+    Control the amount of offset (in microseconds) to add to wayland's frame wait
+    (default 1000). The wayland context assumes that if frame callback or presentation
+    feedback isn't received within a certain amount of time then the video is being
+    rendered offscreen. The time it waits is equal to how long it takes your monitor
+    to display a frame (i.e. 1/refresh rate) plus the offset. In general, staying
+    close to your monitor's refresh rate is preferred, but with a small offset in
+    case a frame takes a little long to display.
+
+``--wayland-disable-vsync=<yes|no>``
+    Disable vsync for the wayland contexts (default: no). Useful for benchmarking
+    the wayland context when combined with ``video-sync=display-desync``,
+    ``--no-audio``, and ``--untimed=yes``. Only works with ``--gpu-context=wayland``
+    and ``--gpu-context=waylandvk``.
+
 ``--spirv-compiler=<compiler>``
     Controls which compiler is used to translate GLSL to SPIR-V. This is
     (currently) only relevant for ``--gpu-api=vulkan`` and `--gpu-api=d3d11`.

--- a/options/options.c
+++ b/options/options.c
@@ -91,6 +91,7 @@ extern const struct m_sub_options angle_conf;
 extern const struct m_sub_options cocoa_conf;
 extern const struct m_sub_options macos_conf;
 extern const struct m_sub_options android_conf;
+extern const struct m_sub_options wayland_conf;
 extern const struct m_sub_options vaapi_conf;
 
 static const struct m_sub_options screenshot_conf = {
@@ -744,6 +745,10 @@ const m_option_t mp_opts[] = {
 
 #if HAVE_EGL_ANDROID
     OPT_SUBSTRUCT("", android_opts, android_conf, 0),
+#endif
+
+#if HAVE_WAYLAND
+    OPT_SUBSTRUCT("", wayland_opts, wayland_conf, 0),
 #endif
 
 #if HAVE_GL_WIN32

--- a/options/options.h
+++ b/options/options.h
@@ -335,6 +335,7 @@ typedef struct MPOpts {
     struct cocoa_opts *cocoa_opts;
     struct macos_opts *macos_opts;
     struct android_opts *android_opts;
+    struct wayland_opts *wayland_opts;
     struct dvd_opts *dvd_opts;
     struct vaapi_opts *vaapi_opts;
 

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -139,7 +139,8 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     }
 
     eglSwapBuffers(p->egl_display, p->egl_surface);
-    vo_wayland_wait_frame(wl);
+    if (!wl->opts->disable_vsync)
+        vo_wayland_wait_frame(wl, wl->opts->frame_offset);
 
     if (wl->presentation)
         wayland_sync_swap(wl);

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -25,6 +25,9 @@
 #include "egl_helpers.h"
 #include "utils.h"
 
+// Generated from presentation-time.xml
+#include "video/out/wayland/presentation-time.h"
+
 struct priv {
     GL gl;
     EGLDisplay egl_display;
@@ -45,13 +48,62 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
 
     wl->frame_callback = wl_surface_frame(wl->surface);
     wl_callback_add_listener(wl->frame_callback, &frame_listener, wl);
-    wl->callback_wait = false;
+    wl->frame_wait = false;
 }
 
 static const struct wl_callback_listener frame_listener = {
     frame_callback,
 };
 
+static const struct wp_presentation_feedback_listener feedback_listener;
+
+static void feedback_sync_output(void *data, struct wp_presentation_feedback *fback,
+                               struct wl_output *output)
+{
+}
+
+static void feedback_presented(void *data, struct wp_presentation_feedback *fback,
+                              uint32_t tv_sec_hi, uint32_t tv_sec_lo,
+                              uint32_t tv_nsec, uint32_t refresh_nsec,
+                              uint32_t seq_hi, uint32_t seq_lo,
+                              uint32_t flags)
+{
+    struct vo_wayland_state *wl = data;
+    wp_presentation_feedback_destroy(fback);
+    vo_wayland_sync_shift(wl);
+
+    // Very similar to oml_sync_control, in this case we assume that every
+    // time the compositor receives feedback, a buffer swap has been already
+    // been performed.
+    //
+    // Notes:
+    //  - tv_sec_lo + tv_sec_hi is the equivalent of oml's ust
+    //  - seq_lo + seq_hi is the equivalent of oml's msc
+    //  - these values are updated everytime the compositor receives feedback.
+
+    int index = last_available_sync(wl);
+    if (index < 0) {
+        queue_new_sync(wl);
+        index = 0;
+    }
+    int64_t sec = (uint64_t) tv_sec_lo + ((uint64_t) tv_sec_hi << 32);
+    wl->sync[index].sbc = wl->user_sbc;
+    wl->sync[index].ust = sec * 1000000LL + (uint64_t) tv_nsec / 1000;
+    wl->sync[index].msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
+    wl->sync[index].refresh_usec = (uint64_t)refresh_nsec/1000;
+    wl->sync[index].filled = true;
+}
+
+static void feedback_discarded(void *data, struct wp_presentation_feedback *fback)
+{
+    wp_presentation_feedback_destroy(fback);
+}
+
+static const struct wp_presentation_feedback_listener feedback_listener = {
+    feedback_sync_output,
+    feedback_presented,
+    feedback_discarded,
+};
 
 static void resize(struct ra_ctx *ctx)
 {
@@ -77,9 +129,32 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    if (wl->presentation) {
+        wl->feedback = wp_presentation_feedback(wl->presentation, wl->surface);
+        wp_presentation_feedback_add_listener(wl->feedback, &feedback_listener, wl);
+        wl->user_sbc += 1;
+        int index = last_available_sync(wl);
+        if (index < 0)
+            queue_new_sync(wl);
+    }
+
     eglSwapBuffers(p->egl_display, p->egl_surface);
     vo_wayland_wait_frame(wl);
-    wl->callback_wait = true;
+
+    if (wl->presentation)
+        wayland_sync_swap(wl);
+
+    wl->frame_wait = true;
+}
+
+static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
+{
+    struct vo_wayland_state *wl = ctx->vo->wl;
+    if (wl->presentation) {
+        info->vsync_duration = wl->vsync_duration;
+        info->skipped_vsyncs = wl->last_skipped_vsyncs;
+        info->last_queue_display_time = wl->last_queue_display_time;
+    }
 }
 
 static bool egl_create_context(struct ra_ctx *ctx)
@@ -103,6 +178,7 @@ static bool egl_create_context(struct ra_ctx *ctx)
 
     struct ra_gl_ctx_params params = {
         .swap_buffers = wayland_egl_swap_buffers,
+        .get_vsync = wayland_egl_get_vsync,
     };
 
     if (!ra_gl_ctx_init(ctx, &p->gl, params))

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -4,6 +4,9 @@
 #include "common.h"
 
 struct ra_vk_ctx_params {
+    // See ra_swapchain_fns.get_vsync.
+    void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
+
     // In case something special needs to be done on the buffer swap.
     void (*swap_buffers)(struct ra_ctx *ctx);
 };

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -110,7 +110,8 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
             queue_new_sync(wl);
     }
 
-    vo_wayland_wait_frame(wl);
+    if (!wl->opts->disable_vsync)
+        vo_wayland_wait_frame(wl, wl->opts->frame_offset);
 
     if (wl->presentation)
         wayland_sync_swap(wl);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -22,6 +22,9 @@
 #include "context.h"
 #include "utils.h"
 
+// Generated from presentation-time.xml
+#include "video/out/wayland/presentation-time.h"
+
 struct priv {
     struct mpvk_ctx vk;
 };
@@ -37,19 +40,92 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
 
     wl->frame_callback = wl_surface_frame(wl->surface);
     wl_callback_add_listener(wl->frame_callback, &frame_listener, wl);
-    wl->callback_wait = false;
+    wl->frame_wait = false;
 }
 
 static const struct wl_callback_listener frame_listener = {
     frame_callback,
 };
 
+static const struct wp_presentation_feedback_listener feedback_listener;
+
+static void feedback_sync_output(void *data, struct wp_presentation_feedback *fback,
+                               struct wl_output *output)
+{
+}
+
+static void feedback_presented(void *data, struct wp_presentation_feedback *fback,
+                              uint32_t tv_sec_hi, uint32_t tv_sec_lo,
+                              uint32_t tv_nsec, uint32_t refresh_nsec,
+                              uint32_t seq_hi, uint32_t seq_lo,
+                              uint32_t flags)
+{
+    struct vo_wayland_state *wl = data;
+    wp_presentation_feedback_destroy(fback);
+    vo_wayland_sync_shift(wl);
+
+    // Very similar to oml_sync_control, in this case we assume that every
+    // time the compositor receives feedback, a buffer swap has been already
+    // been performed.
+    //
+    // Notes:
+    //  - tv_sec_lo + tv_sec_hi is the equivalent of oml's ust
+    //  - seq_lo + seq_hi is the equivalent of oml's msc
+    //  - these values are updated everytime the compositor receives feedback.
+
+    int index = last_available_sync(wl);
+    if (index < 0) {
+        queue_new_sync(wl);
+        index = 0;
+    }
+    int64_t sec = (uint64_t) tv_sec_lo + ((uint64_t) tv_sec_hi << 32);
+    wl->sync[index].sbc = wl->user_sbc;
+    wl->sync[index].ust = sec * 1000000LL + (uint64_t) tv_nsec / 1000;
+    wl->sync[index].msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
+    wl->sync[index].refresh_usec = (uint64_t)refresh_nsec/1000;
+    wl->sync[index].filled = true;
+}
+
+static void feedback_discarded(void *data, struct wp_presentation_feedback *fback)
+{
+    wp_presentation_feedback_destroy(fback);
+}
+
+static const struct wp_presentation_feedback_listener feedback_listener = {
+    feedback_sync_output,
+    feedback_presented,
+    feedback_discarded,
+};
+
 static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    if (wl->presentation) {
+        wl->feedback = wp_presentation_feedback(wl->presentation, wl->surface);
+        wp_presentation_feedback_add_listener(wl->feedback, &feedback_listener, wl);
+        wl->user_sbc += 1;
+        int index = last_available_sync(wl);
+        if (index < 0)
+            queue_new_sync(wl);
+    }
+
     vo_wayland_wait_frame(wl);
-    wl->callback_wait = true;
+
+    if (wl->presentation)
+        wayland_sync_swap(wl);
+
+    wl->frame_wait = true;
+}
+
+static void wayland_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
+{
+    struct vo_wayland_state *wl = ctx->vo->wl;
+    if (wl->presentation) {
+        info->vsync_duration = wl->vsync_duration;
+        info->skipped_vsyncs = wl->last_skipped_vsyncs;
+        info->last_queue_display_time = wl->last_queue_display_time;
+    }
 }
 
 static void wayland_vk_uninit(struct ra_ctx *ctx)
@@ -81,6 +157,7 @@ static bool wayland_vk_init(struct ra_ctx *ctx)
 
     struct ra_vk_ctx_params params = {
         .swap_buffers = wayland_vk_swap_buffers,
+        .get_vsync = wayland_vk_get_vsync,
     };
 
     VkInstance inst = vk->vkinst->instance;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -25,6 +25,11 @@
 #include "vo.h"
 #include "input/event.h"
 
+struct wayland_opts {
+    int frame_offset;
+    int disable_vsync;
+};
+
 struct vo_wayland_sync {
     int64_t ust;
     int64_t msc;
@@ -56,6 +61,7 @@ struct vo_wayland_state {
     struct wl_shm        *shm;
     struct wl_compositor *compositor;
     struct wl_registry   *registry;
+    struct wayland_opts  *opts;
 
     /* State */
     struct mp_rect geometry;
@@ -136,7 +142,7 @@ void vo_wayland_check_events(struct vo *vo);
 void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wakeup(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
-void vo_wayland_wait_frame(struct vo_wayland_state *wl);
+void vo_wayland_wait_frame(struct vo_wayland_state *wl, int frame_offset);
 void wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_sync_shift(struct vo_wayland_state *wl);
 void queue_new_sync(struct vo_wayland_state *wl);

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -130,6 +130,12 @@ def build(ctx):
             protocol  = "unstable/idle-inhibit/idle-inhibit-unstable-v1",
             target    = "video/out/wayland/idle-inhibit-v1.h")
         ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "stable/presentation-time/presentation-time",
+            target    = "video/out/wayland/presentation-time.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "stable/presentation-time/presentation-time",
+            target    = "video/out/wayland/presentation-time.h")
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
             protocol  = "unstable/xdg-decoration/xdg-decoration-unstable-v1",
             target    = "video/out/wayland/xdg-decoration-v1.c")
         ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
@@ -499,6 +505,7 @@ def build(ctx):
         ( "video/out/vulkan/utils.c",            "vulkan" ),
         ( "video/out/w32_common.c",              "win32-desktop" ),
         ( "video/out/wayland/idle-inhibit-v1.c", "wayland" ),
+        ( "video/out/wayland/presentation-time.c", "wayland" ),
         ( "video/out/wayland/xdg-decoration-v1.c", "wayland" ),
         ( "video/out/wayland/xdg-shell.c",       "wayland" ),
         ( "video/out/wayland_common.c",          "wayland" ),


### PR DESCRIPTION
This makes use of the presentation time protocol for the wayland
context. ~~Unfortunately, using the stats lua script (or any other similar
script that constantly renders new things on the screen) breaks the
timings since wayland will register every script update as a
callback+presentation which then screws up the vsync values. There's
probably not a sane way to workaround this, but~~ the vsync numbers really
are much improved otherwise.

Closes #6236.
