### PR TITLE
stream_cb interface improvements

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,6 +32,7 @@ API changes
 
 ::
  --- mpv 0.30.0 ---
+ 1.106  - Add cancel_fn to mpv_stream_cb_info
  1.105  - Fix deadlock problems with MPV_RENDER_PARAM_ADVANCED_CONTROL and if
           the "vd-lavc-dr" option is enabled (which it is by default).
           There were no actual API changes.

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -223,7 +223,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 105)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(1, 106)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before

--- a/libmpv/stream_cb.h
+++ b/libmpv/stream_cb.h
@@ -148,6 +148,22 @@ typedef int64_t (*mpv_stream_cb_size_fn)(void *cookie);
 typedef void (*mpv_stream_cb_close_fn)(void *cookie);
 
 /**
+ * Cancel callback used to implement a custom stream.
+ *
+ * This callback is used to interrupt any current or future read and seek
+ * operations. It will be called from a separate thread than the demux
+ * thread, and should not block.
+ *
+ * This callback can be NULL.
+ *
+ * Available since API 1.106.
+ *
+ * @param cookie opaque cookie identifying the stream,
+ *               returned from mpv_stream_cb_open_fn
+ */
+typedef void (*mpv_stream_cb_cancel_fn)(void *cookie);
+
+/**
  * See mpv_stream_cb_open_ro_fn callback.
  */
 typedef struct mpv_stream_cb_info {
@@ -170,6 +186,7 @@ typedef struct mpv_stream_cb_info {
     mpv_stream_cb_seek_fn seek_fn;
     mpv_stream_cb_size_fn size_fn;
     mpv_stream_cb_close_fn close_fn;
+    mpv_stream_cb_cancel_fn cancel_fn; /* since API 1.106 */
 } mpv_stream_cb_info;
 
 /**


### PR DESCRIPTION
Some added callbacks I've been using with custom stream_cb backends.

The first commit adds a straightforward `cancel_fn` which integrates the new mp_cancel feature.

The second commit adds `seek_time_fn` which covers a much more obscure use-case, and may require lavf patches depending on the demuxer used (tested with mpegts using https://patchwork.ffmpeg.org/patch/12604/).