### PR TITLE
context_drm_egl: Add ifdeffery to egl_get_display

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -37,6 +37,14 @@
 #include "common.h"
 #include "context.h"
 
+#ifndef EGL_PLATFORM_GBM_MESA
+#define EGL_PLATFORM_GBM_MESA 0x31D7
+#endif
+
+#ifndef EGL_PLATFORM_GBM_KHR
+#define EGL_PLATFORM_GBM_KHR 0x31D7
+#endif
+
 #define USE_MASTER 0
 
 struct framebuffer


### PR DESCRIPTION
A user reported problems compiling because EGL_PLATFORM_GBM_KHR was undefined. This user was using nVidias proprietary driver without glvnd which might explain this missing?