### PR TITLE
wscript: check tvOS define's value to be nonzero

### DIFF
--- a/wscript
+++ b/wscript
@@ -158,7 +158,10 @@ main_dependencies = [
     }, {
         'name': '--tvos',
         'desc': 'tvOS environment',
-        'func': check_statement('TargetConditionals.h', 'int x = TARGET_OS_TV;'),
+        'func': check_statement(
+            ['TargetConditionals.h', 'assert.h'],
+            'static_assert(TARGET_OS_TV, "TARGET_OS_TV defined to zero!")'
+        ),
     }, {
         'name': '--egl-android',
         'desc': 'Android EGL support',


### PR DESCRIPTION
TARGET_OS_TV seems to always be defined, but set according to the
build configuration. This fixes all Apple configurations being
mis-identified as tvOS.