### PR TITLE
vo_gpu: hwdec_cuda: Synchronise OpenGL Interop

### DIFF
--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -249,6 +249,8 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
                 goto error;
         }
     }
+    if (p_owner->do_full_sync)
+        CHECK_CU(cu->cuStreamSynchronize(0));
 
  error:
    eret = CHECK_CU(cu->cuCtxPopCurrent(&dummy));

--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -32,6 +32,9 @@ struct cuda_hw_priv {
     // Stored as int to avoid depending on libplacebo enum
     int handle_type;
 
+    // Do we need to do a full CPU sync after copying
+    bool do_full_sync;
+
     bool (*ext_init)(struct ra_hwdec_mapper *mapper,
                      const struct ra_format *format, int n);
     void (*ext_uninit)(const struct ra_hwdec_mapper *mapper, int n);

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -164,6 +164,9 @@ bool cuda_gl_init(const struct ra_hwdec *hw) {
         }
     }
 
+    // We don't have a way to do a GPU sync after copying
+    p->do_full_sync = true;
+
     p->ext_init = cuda_ext_gl_init;
     p->ext_uninit = cuda_ext_gl_uninit;
 


### PR DESCRIPTION
Previously, there appeared to be implicit synchronisation in the
GL interop path, and we never observed any visual glitches. However,
recently, I started seeing stuttering in the GL path and on closer
examination it looked like read-before-write behaviour where GL
would display an old frame again rather than the current one.

After verifying that disabling hwdec made the problem go away,
I tried adding a cuStreamSynchronize() after the memcpys and that
also resolved the problem, so it's clearly sync related.

cuStreamSynchronize() is a CPU sync and so more heavy-weight than
you want, but it's the only tool we have. There is no mechanism
defined for synchronising GL to CUDA (It looks like there is a way
to synchronise CUDA to EGL but it appears one way and so wouldn't
directly address this problem).

Anyway, empirically, the output now looks the same as with hwdec
off.