### PR TITLE
wscript: Accept glvnd’s egl.pc version

### DIFF
--- a/wscript
+++ b/wscript
@@ -636,7 +636,7 @@ video_output_features = [
         'deps': 'wayland',
         'groups': [ 'gl' ],
         'func': check_pkg_config('wayland-egl', '>= 9.0.0',
-                                 'egl',         '>= 9.0.0')
+                                 'egl',         '>= 1.5')
     } , {
         'name': '--gl-win32',
         'desc': 'OpenGL Win32 Backend',


### PR DESCRIPTION
Mesa was traditionally providing libEGL and thus egl.pc, but recently
this responsibility got transfered to glvnd, which adopted the EGL API
version instead of the Mesa version it originates from.  This led to the
version moving back from 9.0.0 to 1.5, thus breaking a bunch of
software, including mpv.