### PR TITLE
vo_drm: fix flickering when setting pan/scan

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -327,10 +327,6 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     talloc_free(p->last_input);
     p->last_input = NULL;
 
-    struct framebuffer *buf = p->bufs;
-    for (unsigned int i = 0; i < p->buf_count; i++)
-        memset(buf[i].map, 0, buf[i].size);
-
     if (mp_sws_reinit(p->sws) < 0)
         return -1;
 


### PR DESCRIPTION
Turns out clearing all frambuffers in reconfig isn't such a great idea
when you also end up here when setting pan/scan.

I guess this is just a leftover from a previous iteration of vo_drm
where doing this made sense.