### PR TITLE
README.md: remove dead homebrew-mpv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ Most activity happens on the IRC channel and the github issue tracker.
 
 [releases]: https://github.com/mpv-player/mpv/releases
 [mpv-build]: https://github.com/mpv-player/mpv-build
-[homebrew-mpv]: https://github.com/mpv-player/homebrew-mpv
 [issue-tracker]:  https://github.com/mpv-player/mpv/issues
 [ffmpeg_vs_libav]: https://github.com/mpv-player/mpv/wiki/FFmpeg-versus-Libav
 [release-policy]: https://github.com/mpv-player/mpv/blob/master/DOCS/release-policy.md


### PR DESCRIPTION
Link wasn’t attached to anything, and was referencing an archived repo anyway.

However (and this is a repeat of https://github.com/mpv-player/mpv-build/pull/122), you may want to consider reviving that repo, seeing as [the homebrew formula was removed](https://github.com/Homebrew/homebrew-core/commit/41444d526c40b93069b7f0c5414539deb0534179). There is [a cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/mpv.rb) but it uses [the prebuilt binaries from `stolendata`](https://laboratory.stolendata.net/~djinn/mpv_osx/) as [referenced on your website](https://mpv.io/installation/).

The formula was almost four times more popular than the cask (6,938 vs 1,848 downloads in the last 90 days), which is why I mentioned reviving the formula on your side.

I’m a Homebrew Cask maintainer, so feel free to ask any clarification on the formula vs cask.