### PR TITLE
Bring back DVB channel switching

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -20,6 +20,15 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
+    - rewrite DVB channel switching to use an integer value
+      `--dvbin-channel-switch-offset` for switching instead of the old
+      stream controls which are now gone. Cycling this property up or down will
+      change the offset to the channel which was initially tuned to.
+      Example for `input.conf`: `H cycle dvbin-channel-switch-offset up`,
+      `K cycle dvbin-channel-switch-offset down`.
+    - adapt `stream_dvb` to support writing to `dvbin-prog` at runtime
+      and also to consistently use dvbin-configuration over URI parameters
+      when provided
     - add `--d3d11-adapter` to enable explicit selection of a D3D11 rendering
       adapter by name.
     - rename `--drm-osd-plane-id` to `--drm-draw-plane`, `--drm-video-plane-id` to

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4195,6 +4195,13 @@ Network
 DVB
 ---
 
+``--dvbin-prog=<string>``
+    This defines the program to tune to. Usually, you may specify this
+    by using a stream URI like ``"dvb://ZDF HD"``, but you can tune to a
+    different channel by writing to this property at runtime.
+    Also see ``dvbin-channel-switch-offset`` for more useful channel
+    switching functionality.
+
 ``--dvbin-card=<0-15>``
     Specifies using card number 0-15 (default: 0).
 
@@ -4230,6 +4237,15 @@ DVB
     on-the-fly, e.g. for regional news.
 
     Default: ``no``
+
+``--dvbin-channel-switch-offset=<integer>``
+    This value is not meant for setting via configuration, but used in channel
+    switching. An ``input.conf`` can ``cycle`` this value ``up`` and ``down``
+    to perform channel switching. This number effectively gives the offset
+    to the initially tuned to channel in the channel list.
+
+    An example ``input.conf`` could contain:
+    ``H cycle dvbin-channel-switch-offset up``, ``K cycle dvbin-channel-switch-offset down``
 
 ALSA audio output options
 -------------------------

--- a/player/command.c
+++ b/player/command.c
@@ -137,6 +137,8 @@ static int edit_filters(struct MPContext *mpctx, struct mp_log *log,
 static int set_filters(struct MPContext *mpctx, enum stream_type mediatype,
                        struct m_obj_settings *new_chain);
 
+static bool is_property_set(int action, void *val);
+
 static int mp_property_do_silent(const char *name, int action, void *val,
                                  struct MPContext *ctx);
 
@@ -2889,6 +2891,19 @@ static int mp_property_cursor_autohide(void *ctx, struct m_property *prop,
     return r;
 }
 
+static int mp_property_dvb_channel(void *ctx, struct m_property *prop,
+                                   int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    int r = mp_property_generic_option(mpctx, prop, action, arg);
+    if (r == M_PROPERTY_OK && is_property_set(action, arg)) {
+        if (!mpctx->stop_play) {
+            mpctx->stop_play = PT_CURRENT_ENTRY;
+        }
+    }
+    return r;
+}
+
 static int mp_property_playlist_pos_x(void *ctx, struct m_property *prop,
                                       int action, void *arg, int base)
 {
@@ -3513,6 +3528,8 @@ static const struct m_property mp_properties_base[] = {
     {"chapter-list", mp_property_list_chapters},
     {"track-list", property_list_tracks},
     {"edition-list", property_list_editions},
+
+    {"dvbin-prog", mp_property_dvb_channel},
 
     {"playlist", mp_property_playlist},
     {"playlist-pos", mp_property_playlist_pos},

--- a/player/command.c
+++ b/player/command.c
@@ -3530,6 +3530,7 @@ static const struct m_property mp_properties_base[] = {
     {"edition-list", property_list_editions},
 
     {"dvbin-prog", mp_property_dvb_channel},
+    {"dvbin-channel-switch-offset", mp_property_dvb_channel},
 
     {"playlist", mp_property_playlist},
     {"playlist-pos", mp_property_playlist_pos},

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -121,6 +121,7 @@ typedef struct {
     int cfg_timeout;
     char *cfg_file;
     int cfg_full_transponder;
+    int cfg_channel_switch_offset;
 } dvb_opts_t;
 
 typedef struct {

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -186,7 +186,6 @@ typedef struct {
 
 void dvb_update_config(stream_t *);
 int dvb_parse_path(stream_t *);
-int dvb_step_channel(stream_t *, int);
 int dvb_set_channel(stream_t *, unsigned int, unsigned int);
 dvb_state_t *dvb_get_state(stream_t *);
 void dvb_free_state(dvb_state_t *);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -183,6 +183,7 @@ typedef struct {
     )
 #endif
 
+void dvb_update_config(stream_t *);
 int dvb_parse_path(stream_t *);
 int dvb_step_channel(stream_t *, int);
 int dvb_set_channel(stream_t *, unsigned int, unsigned int);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -129,6 +129,9 @@ typedef struct {
 
     dvb_state_t *state;
 
+    char *prog;
+    int devno;
+
     dvb_opts_t *opts;
     struct m_config_cache *opts_cache;
 } dvb_priv_t;
@@ -181,6 +184,7 @@ typedef struct {
     )
 #endif
 
+int dvb_parse_path(stream_t *);
 int dvb_step_channel(stream_t *, int);
 int dvb_set_channel(stream_t *, unsigned int, unsigned int);
 dvb_state_t *dvb_get_state(stream_t *);

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -110,7 +110,6 @@ typedef struct {
 
     int is_on;
     int retry;
-    int timeout;
     unsigned int last_freq;
     bool switching_channel;
     bool stream_used;

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -117,16 +117,20 @@ typedef struct {
 } dvb_state_t;
 
 typedef struct {
-    struct mp_log *log;
-
-    dvb_state_t *state;
-
     char *cfg_prog;
     int cfg_devno;
     int cfg_timeout;
     char *cfg_file;
-
     int cfg_full_transponder;
+} dvb_opts_t;
+
+typedef struct {
+    struct mp_log *log;
+
+    dvb_state_t *state;
+
+    dvb_opts_t *opts;
+    struct m_config_cache *opts_cache;
 } dvb_priv_t;
 
 
@@ -176,7 +180,6 @@ typedef struct {
         DELSYS_BIT(SYS_DVBC_ANNEX_C)                                    \
     )
 #endif
-
 
 int dvb_step_channel(stream_t *, int);
 int dvb_set_channel(stream_t *, unsigned int, unsigned int);

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -1026,7 +1026,6 @@ static int dvb_streaming_start(stream_t *stream, char *progname)
     MP_VERBOSE(stream, "\r\ndvb_streaming_start(PROG: %s, ADAPTER: %d)\n",
                progname, priv->devno);
 
-    state->is_on = 0;
     list = state->adapters[state->cur_adapter].list;
     for (i = 0; i < list->NUM_CHANNELS; i ++) {
         if (!strcmp(list->channels[i].name, progname)) {
@@ -1204,6 +1203,7 @@ dvb_state_t *dvb_get_state(stream_t *stream)
         return NULL;
     memset(state, 0x00, sizeof(dvb_state_t));
     state->switching_channel = false;
+    state->is_on = 0;
     state->stream_used = true;
     state->fe_fd = state->dvr_fd = -1;
     for (unsigned int i = 0; i < MAX_ADAPTERS; i++) {

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -878,101 +878,17 @@ int dvb_set_channel(stream_t *stream, unsigned int adapter, unsigned int n)
     return 1;
 }
 
-int dvb_step_channel(stream_t *stream, int dir)
-{
-    unsigned int new_current;
-    dvb_priv_t *priv = stream->priv;
-    dvb_state_t *state = priv->state;
-    dvb_channels_list_t *list = state->adapters[state->cur_adapter].list;
-
-    MP_VERBOSE(stream, "DVB_STEP_CHANNEL dir %d\n", dir);
-
-    if (list == NULL) {
-        MP_ERR(stream, "dvb_step_channel: NULL list_ptr, quit\n");
-        return 0;
-    }
-
-    new_current = (list->NUM_CHANNELS + list->current +
-                  (dir >= 0 ? 1 : -1)) % list->NUM_CHANNELS;
-
-    return dvb_set_channel(stream, state->cur_adapter, new_current);
-}
-
 static int dvbin_stream_control(struct stream *s, int cmd, void *arg)
 {
     dvb_priv_t *priv  = (dvb_priv_t *) s->priv;
     dvb_state_t *state = priv->state;
     dvb_channels_list_t *list = NULL;
 
-
-#if 0
-    switch (cmd) {
-    case STREAM_CTRL_DVB_SET_CHANNEL: {
-        unsigned int *iarg = arg;
-        MP_VERBOSE(s, "dvbin_stream_control: cmd STREAM_CTRL_DVB_SET_CHANNEL: %i, %i\n", iarg[1], iarg[0]);
-        r = dvb_set_channel(s, iarg[1], iarg[0]);
-        if (r) {
-          // Stream will be pulled down after channel switch,
-          // persist state.
-          state->switching_channel = true;
-          return STREAM_OK;
-        }
-        return STREAM_ERROR;
-    }
-    case STREAM_CTRL_DVB_STEP_CHANNEL: {
-        MP_VERBOSE(s, "dvbin_stream_control: cmd STREAM_CTRL_DVB_STEP_CHANNEL: %i\n", (*(int *)arg));
-        r = dvb_step_channel(s, (*(int *)arg));
-        if (r) {
-          // Stream will be pulled down after channel switch,
-          // persist state.
-          state->switching_channel = true;
-          return STREAM_OK;
-        }
-        return STREAM_ERROR;
-    }
-    }
-#endif
-
     if (state->cur_adapter >= state->adapters_count)
         return STREAM_ERROR;
     list = state->adapters[state->cur_adapter].list;
 
     switch (cmd) {
-#if 0
-    case STREAM_CTRL_GET_TV_FREQ:
-        (*(unsigned int*)arg) = list->channels[list->current].freq;
-        return STREAM_ERROR;
-    case STREAM_CTRL_DVB_SET_CHANNEL_NAME: {
-        char *progname = *((char**)arg);
-        unsigned int new_channel = (~(unsigned int)0);
-        MP_VERBOSE(s, "dvbin_stream_control: cmd STREAM_CTRL_DVB_SET_CHANNEL_NAME: %s\n", progname);
-        for (unsigned int i=0; i < list->NUM_CHANNELS; ++i) {
-           if (!strcmp(list->channels[i].name, progname)) {
-               new_channel = i;
-               break;
-            }
-        }
-        if (new_channel == -1) {
-              MP_ERR(s, "Program '%s' not found for adapter %d!\n",
-                     progname, state->adapters[state->cur_adapter].devno);
-              return STREAM_ERROR;
-        }
-        r = dvb_set_channel(s, state->cur_adapter, new_channel);
-        if (r) {
-          // Stream will be pulled down after channel switch,
-          // persist state.
-          state->switching_channel = true;
-          return STREAM_OK;
-        }
-        return STREAM_ERROR;
-    }
-    case STREAM_CTRL_DVB_GET_CHANNEL_NAME: {
-        MP_VERBOSE(s, "dvbin_stream_control: cmd STREAM_CTRL_DVB_GET_CHANNEL_NAME\n");
-        char *progname = list->channels[list->current].name;
-        *(char **)arg = talloc_strdup(NULL, progname);
-        return STREAM_OK;
-    }
-#endif
     case STREAM_CTRL_GET_METADATA: {
         struct mp_tags *metadata = talloc_zero(NULL, struct mp_tags);
         char *progname = list->channels[list->current].name;

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -78,6 +78,7 @@ const struct m_sub_options stream_dvb_conf = {
         OPT_INTRANGE("timeout", cfg_timeout, 0, 1, 30),
         OPT_STRING("file", cfg_file, M_OPT_FILE),
         OPT_FLAG("full-transponder", cfg_full_transponder, 0),
+        OPT_INT("channel-switch-offset", cfg_channel_switch_offset, 0),
         {0}
     },
     .size = sizeof(dvb_opts_t),
@@ -1044,6 +1045,12 @@ static int dvb_streaming_start(stream_t *stream, char *progname)
     }
 
     list->current = i;
+
+    // When switching channels, cfg_channel_switch_offset
+    // keeps the offset to the initially chosen channel.
+    list->current = (list->NUM_CHANNELS + list->current + priv->opts->cfg_channel_switch_offset) % list->NUM_CHANNELS;
+    channel = &(list->channels[list->current]);
+    MP_INFO(stream, "Tuning to channel \"%s\"...\n", channel->name);
     MP_VERBOSE(stream, "PROGRAM NUMBER %d: name=%s, freq=%u\n", i,
                channel->name, channel->freq);
 


### PR DESCRIPTION
This commit series essentially brings back DVB channel switching. 

Basically, the commit messages contain everything, and I tried to be mostly atomic in my commits, but here a short summary (which sadly got almost as long as the summary of the commit messages):
- Some refactoring to allow checking options for updates as suggested by @wm4 in #6781 . This also cleaned up the option mess in `stream_dvb` by finally keeping them cleanly in a separate struct. 
- More refactoring, since `stream_dvb` accepts some configuration via the stream-URI and also via config parameters. Now, the logic is in one place, and config parameters (if set) always win (e.g. you can finally set a program by name via `dvbin-prog` as expected!). 
- Polling the options for changes. Done in `streaming_read` for lack of a better place, with a throttling since there's no need to react too fast. 
- Adding `dvbin-channel-switch-offset`. Since the channel list is dynamically chosen depending on connected and selected adapters, and there is no communication backchannel, we now have a property to select the offset from the initially chosen channel. 
- Documentation updates!

A user can now for example put this:
```
H cycle dvbin-channel-switch-offset up
K cycle dvbin-channel-switch-offset down
Q set dvbin-prog "ZDF HD"
```
in `input.conf`, and switch channels by pressing `H` and `K`, or tune to `ZDF HD` explicitly by pressing `Q`. 
Channel switching also got a bit faster again due to some cleanups. 

Comments, suggestions and a review very welcome. I am especially unsure if the throttling is really needed, or if there is a better place to poll. 