### PR TITLE
wayland: always create wl_output before rendering

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1213,12 +1213,7 @@ int vo_wayland_reconfig(struct vo *vo)
 
     MP_VERBOSE(wl, "Reconfiguring!\n");
 
-    /* Surface enter events happen later but certain config options require the
-     * current_output to be created in order for the video to actually render.
-     * Only skip this if --fs is specified without a fsscreen_id so the video
-     * renders on the same screen and not the one with idx 0. */
-    if ((!wl->current_output) &&
-        !(vo->opts->fullscreen && (vo->opts->fsscreen_id < 0))) {
+    if (!wl->current_output) {
         int idx = 0;
         if (vo->opts->fullscreen && (vo->opts->fsscreen_id >= 0))
             idx = vo->opts->fsscreen_id;
@@ -1255,7 +1250,11 @@ int vo_wayland_reconfig(struct vo *vo)
             wl->geometry.x1  = mp_rect_w(wl->current_output->geometry)/wl->scaling;
             wl->geometry.y1  = mp_rect_h(wl->current_output->geometry)/wl->scaling;
         } else {
-            xdg_toplevel_set_fullscreen(wl->xdg_toplevel, wl_out);
+            if (vo->opts->fsscreen_id < 0) {
+                xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
+            } else {
+                xdg_toplevel_set_fullscreen(wl->xdg_toplevel, wl_out);
+            }
         }
     }
 


### PR DESCRIPTION
I previously skipped creating the wl_output if the --fullscreen flag
with no --fsscreen_id was inputted, so the fullscreen video lands on the
correct output (where mpv was launched). This has breakage if someone
combines the --autofit flag (or other similar options with it). Instead,
just actually read xdg_shell spec and realize that you can pass NULL
to xdg_toplevel_set_fullscreen and let the compositor choose the
output if the user doesn't specify it. If this has issues, get a better
compositor.

I (or someone else) just needs to test this on multimonitors to make sure `--fullscreen` works right (i.e. fullscreen on the same output you launched the mpv window on) before I merge it. But I'd be very surprised if it didn't work as expected.

Fixes #7011