### PR TITLE
vo_gpu: hwdec_vaapi: Handle lack of object size with AMD drivers

### DIFF
--- a/video/out/hwdec/hwdec_vaapi_vk.c
+++ b/video/out/hwdec/hwdec_vaapi_vk.c
@@ -15,6 +15,9 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
+#include <unistd.h>
+
 #include "config.h"
 #include "hwdec_vaapi.h"
 #include "video/out/placebo/ra_pl.h"
@@ -40,6 +43,22 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper)
         int fd = p->desc.objects[id].fd;
         uint32_t size = p->desc.objects[id].size;
         uint32_t offset = p->desc.layers[n].offset[0];
+
+        // AMD drivers do not return the size in the surface description.
+        if (size == 0) {
+            size = lseek(fd, 0, SEEK_END);
+            if (size == -1) {
+                MP_ERR(mapper, "Cannot obtain size of object with fd %d: %s\n",
+                       fd, mp_strerror(errno));
+                return false;
+            }
+            off_t err = lseek(fd, 0, SEEK_SET);
+            if (err == -1) {
+                MP_ERR(mapper, "Failed to reset offset for fd %d: %s\n",
+                       fd, mp_strerror(errno));
+                return false;
+            }
+        }
 
         struct pl_tex_params tex_params = {
             .w = mp_image_plane_w(&p->layout, n),


### PR DESCRIPTION
It turns out that the AMD driver doesn't bother to set the size
field in the descriptor for an exported VA surface. I guess they
assume the caller can always use lseek() and don't bother. So, we
need to use lseek() in these situations.
