### PR TITLE
player: don't load external files when reading from stdin

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -821,7 +821,7 @@ void autoload_external_files(struct MPContext *mpctx, struct mp_cancel *cancel)
 {
     if (mpctx->opts->sub_auto < 0 && mpctx->opts->audiofile_auto < 0)
         return;
-    if (!mpctx->opts->autoload_files)
+    if (!mpctx->opts->autoload_files || strcmp(mpctx->filename, "-") == 0)
         return;
 
     void *tmp = talloc_new(NULL);


### PR DESCRIPTION
As mentioned in the issue #6450 trying to load files for the 'filename' `-` isn't very useful when reading a stream from stdin. I'm not sure if this was the right place to check for this edgecase. But it works out.

would resolve #6450 