### PR TITLE
wayland: add an option to disable vsync

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4720,6 +4720,14 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     Currently only relevant for ``--gpu-api=d3d11``.
 
+``--wayland-disable-vsync=<yes|no>``
+    Disable vsync for the wayland contexts. Useful for benchmarking the wayland
+    context when combined with ``video-sync=display-desync``, ``--no-audio``,
+    and ``--untimed=yes``. Only works with ``--gpu-context=wayland`` and
+    ``--gpu-context=waylandvk``.
+
+    Default: no.
+
 ``--spirv-compiler=<compiler>``
     Controls which compiler is used to translate GLSL to SPIR-V. This is
     (currently) only relevant for ``--gpu-api=vulkan`` and `--gpu-api=d3d11`.

--- a/options/options.c
+++ b/options/options.c
@@ -751,6 +751,10 @@ const m_option_t mp_opts[] = {
                ({"no", -1}, {"auto", 0}, {"windowed", 1}, {"yes", 2})),
 #endif
 
+#if HAVE_WAYLAND
+    OPT_FLAG("wayland-disable-vsync", wayland_disable_vsync, 0),
+#endif
+
 #if HAVE_CUDA_HWACCEL
     OPT_CHOICE_OR_INT("cuda-decode-device", cuda_device, 0,
                       0, INT_MAX, ({"auto", -1})),

--- a/options/options.h
+++ b/options/options.h
@@ -323,6 +323,8 @@ typedef struct MPOpts {
 
     int wingl_dwm_flush;
 
+    int wayland_disable_vsync;
+
     struct mp_resample_opts *resample_opts;
 
     struct gl_video_opts *gl_video_opts;

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -20,6 +20,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#include "options/m_config.h"
 #include "video/out/wayland_common.h"
 #include "context.h"
 #include "egl_helpers.h"
@@ -77,8 +78,13 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    int disable_vsync;
+    mp_read_option_raw(ctx->global, "wayland-disable-vsync", &m_option_type_flag,
+                       &disable_vsync);
+
     eglSwapBuffers(p->egl_display, p->egl_surface);
-    vo_wayland_wait_frame(wl);
+    if (!disable_vsync)
+    	vo_wayland_wait_frame(wl);
     wl->callback_wait = true;
 }
 

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -15,6 +15,7 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "options/m_config.h"
 #include "video/out/gpu/context.h"
 #include "video/out/wayland_common.h"
 
@@ -48,7 +49,12 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
 
-    vo_wayland_wait_frame(wl);
+    int disable_vsync;
+    mp_read_option_raw(ctx->global, "wayland-disable-vsync", &m_option_type_flag,
+                       &disable_vsync);
+
+    if (!disable_vsync)
+        vo_wayland_wait_frame(wl);
     wl->callback_wait = true;
 }
 


### PR DESCRIPTION
With the new wayland change, it actually makes it possible to benchmark
its performance with mpv. Add --wayland-disable-vsync as a user option
to skip waiting for a vblank.

It will silently fail if you use this on Xorg (i.e. no warning or anything), but I think that's fine because why would anyone expect it to do anything on anything other than wayland?