### PR TITLE
WIP: vo_gpu: Add support for hwdec auto-profiles for vo_gpu config

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -129,8 +129,7 @@ static void mp_load_per_file_config(struct MPContext *mpctx)
     }
 }
 
-static void mp_auto_load_profile(struct MPContext *mpctx, char *category,
-                                 bstr item)
+void mp_load_auto_profile(struct MPContext *mpctx, char *category, bstr item)
 {
     if (!item.len)
         return;
@@ -146,9 +145,9 @@ static void mp_auto_load_profile(struct MPContext *mpctx, char *category,
 
 void mp_load_auto_profiles(struct MPContext *mpctx)
 {
-    mp_auto_load_profile(mpctx, "protocol",
+    mp_load_auto_profile(mpctx, "protocol",
                          mp_split_proto(bstr0(mpctx->filename), NULL));
-    mp_auto_load_profile(mpctx, "extension",
+    mp_load_auto_profile(mpctx, "extension",
                          bstr0(mp_splitext(mpctx->filename, NULL)));
 
     mp_load_per_file_config(mpctx);

--- a/player/core.h
+++ b/player/core.h
@@ -499,6 +499,7 @@ void reload_audio_output(struct MPContext *mpctx);
 
 // configfiles.c
 void mp_parse_cfgfiles(struct MPContext *mpctx);
+void mp_load_auto_profile(struct MPContext *mpctx, char *category, bstr item);
 void mp_load_auto_profiles(struct MPContext *mpctx);
 void mp_get_resume_defaults(struct MPContext *mpctx);
 void mp_load_playback_resume(struct MPContext *mpctx, const char *file);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -27,6 +27,8 @@
 
 #include "video.h"
 
+#include "player/client.h"
+#include "player/core.h"
 #include "misc/bstr.h"
 #include "options/m_config.h"
 #include "common/global.h"
@@ -855,6 +857,9 @@ static void init_video(struct gl_video *p)
     }
 
     if (hwdec) {
+        mp_load_auto_profile(mp_client_api_get_core(p->global->client_api),
+                             "hwdec", bstr0(hwdec->driver->name));
+
         if (hwdec->driver->overlay_frame) {
             MP_WARN(p, "Using HW-overlay mode. No GL filtering is performed "
                        "on the video!\n");


### PR DESCRIPTION
I'm not sure if this is truly a general purpose feature, but I've
found myself really wanting this when I switch between nvdec and
vaapi when testing changes (using hybrid graphics). The high quality
vo_gpu settings are too taxing for poor Intel GPU but work fine on
the nvidia.

So, using an auto-profile means I can set things like scale/cscale,
etc basedon the hwdec. Obviously the behaviour is subtle - some
configs will be ignored because the components they configure
have already been initialsed, so trying to exactly document what
configs work and which ones don't would be hard.

Still, there might be value here.