### PR TITLE
vo_gpu/d3d11: add support for configuring swap chain output format

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -25,6 +25,8 @@ Interface changes
 ::
 
  --- mpv 0.30.0 ---
+    - add `--d3d11-output-format` to enable explicit selection of a D3D11
+      swap chain format.
     - rewrite DVB channel switching to use an integer value
       `--dvbin-channel-switch-offset` for switching instead of the old
       stream controls which are now gone. Cycling this property up or down will

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4708,6 +4708,18 @@ The following video options are currently all specific to ``--vo=gpu`` and
     functionality to receive a device, such as D3D11VA or DXVA2's DXGI
     mode, will be affected by this choice.
 
+``--d3d11-output-format=<auto|rgba8|bgra8|rgb10_a2|rgba16f>``
+    Select a specific D3D11 output format to utilize for D3D11 rendering.
+    "auto" is the default, which will pick either rgba8 or rgb10_a2 depending
+    on the configured desktop bit depth. rgba16f and bgra8 are left out of
+    the autodetection logic, and are available for manual testing.
+
+    .. note::
+
+        Desktop bit depth querying is only available from an API available
+        from Windows 10. Thus on older systems it will only automatically
+        utilize the rgba8 output format.
+
 ``--d3d11va-zero-copy=<yes|no>``
     By default, when using hardware decoding with ``--gpu-api=d3d11``, the
     video image will be copied (GPU-to-GPU) from the decoder surface to a

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -36,6 +36,7 @@ struct d3d11_opts {
     int flip;
     int sync_interval;
     char *adapter_name;
+    int output_format;
 };
 
 #define OPT_BASE_STRUCT struct d3d11_opts
@@ -59,6 +60,12 @@ const struct m_sub_options d3d11_conf = {
         OPT_INTRANGE("d3d11-sync-interval", sync_interval, 0, 0, 4),
         OPT_STRING_VALIDATE("d3d11-adapter", adapter_name, 0,
                             d3d11_validate_adapter),
+        OPT_CHOICE("d3d11-output-format", output_format, 0,
+                   ({"auto",     DXGI_FORMAT_UNKNOWN},
+                    {"rgba8",    DXGI_FORMAT_R8G8B8A8_UNORM},
+                    {"bgra8",    DXGI_FORMAT_B8G8R8A8_UNORM},
+                    {"rgb10_a2", DXGI_FORMAT_R10G10B10A2_UNORM},
+                    {"rgba16f",  DXGI_FORMAT_R16G16B16A16_FLOAT})),
         {0}
     },
     .defaults = &(const struct d3d11_opts) {
@@ -67,6 +74,7 @@ const struct m_sub_options d3d11_conf = {
         .flip = 1,
         .sync_interval = 1,
         .adapter_name = NULL,
+        .output_format = DXGI_FORMAT_UNKNOWN,
     },
     .size = sizeof(struct d3d11_opts)
 };
@@ -372,6 +380,7 @@ static bool d3d11_init(struct ra_ctx *ctx)
         .window = vo_w32_hwnd(ctx->vo),
         .width = ctx->vo->dwidth,
         .height = ctx->vo->dheight,
+        .format = p->opts->output_format,
         .flip = p->opts->flip,
         // Add one frame for the backbuffer and one frame of "slack" to reduce
         // contention with the window manager when acquiring the backbuffer

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -162,7 +162,12 @@ static bool d3d11_reconfig(struct ra_ctx *ctx)
 
 static int d3d11_color_depth(struct ra_swapchain *sw)
 {
-    return 8;
+    struct priv *p = sw->priv;
+
+    if (!p->backbuffer)
+        return 0;
+
+    return p->backbuffer->params.format->component_depth[0];
 }
 
 static bool d3d11_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -71,6 +71,7 @@ struct d3d11_swapchain_opts {
     HWND window;
     int width;
     int height;
+    DXGI_FORMAT format;
 
     // Use DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL if possible
     bool flip;

--- a/wscript
+++ b/wscript
@@ -770,7 +770,7 @@ video_output_features = [
         'name': '--d3d11',
         'desc': 'Direct3D 11 video output',
         'deps': 'win32-desktop && shaderc && spirv-cross',
-        'func': check_cc(header_name=['d3d11_1.h', 'dxgi1_2.h']),
+        'func': check_cc(header_name=['d3d11_1.h', 'dxgi1_6.h']),
     }, {
         'name': '--rpi',
         'desc': 'Raspberry Pi support',


### PR DESCRIPTION
First part of getting to color space configuration (HDR and such).

Adds support for configuring the D3D11 swap chain format. For now we have  been utilizing 8bit RGBA, but other formats are available, such as 10bit RGB with 2bit alpha, 16bit floating point or 8bit BGRA.

The APIs querying the system output's information is surprisingly new, so the Windows dxgi header check is bumped from `dxgi1_2.h` to `dxgi1_6.h` (this is available at the very least on mingw-w64 6.x). The code should still work on Windows 7+, but the system output information will only be available for Windows 10 users at least according to what [MSDN says](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_6/nn-dxgi1_6-idxgioutput6)..

Current logic:
1. If a specific swap chain format is configured, that is utilized.
2. If any information on the output onto which swap chain is currently linked is not available, picks 8bit RGBA, just as before.
3. If the information on the output is available, either 8bit RGBA or 10bit RGB with 2bit alpha is utilized, depending on the bit depth.

Additionally, adds @rossy 's fix for the rendering bit depth that I have fixed up somewhat.

Fixes #5237 .