### PR TITLE
vo_gpu/d3d11: misc fixups for adapter selection

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4705,6 +4705,10 @@ The following video options are currently all specific to ``--vo=gpu`` and
     Will pick the default adapter if unset. Alternatives are listed
     when the name "help" is given.
 
+    Checks for matches based on the start of the string, case
+    insensitive. Thus, if the description of the adapter starts with
+    the vendor name, that can be utilized as the selection parameter.
+
     Hardware decoders utilizing the D3D11 rendering abstraction's helper
     functionality to receive a device, such as D3D11VA or DXVA2's DXGI
     mode, will be affected by this choice.

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -117,7 +117,7 @@ static int d3d11_validate_adapter(struct mp_log *log,
     }
 
     if (!adapter_matched) {
-        mp_err(log, "No adapter with name '%.*s'!\n", BSTR_P(param));
+        mp_err(log, "No adapter matching '%.*s'!\n", BSTR_P(param));
     }
 
     return adapter_matched ? 0 : M_OPT_INVALID;

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -106,7 +106,7 @@ static int d3d11_validate_adapter(struct mp_log *log,
     }
 
     adapter_matched = mp_d3d11_list_or_verify_adapters(log,
-                                                       help ? NULL : &param,
+                                                       help ? bstr0(NULL) : param,
                                                        help ? &listing : NULL);
 
     if (help) {

--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -204,8 +204,9 @@ static IDXGIAdapter1 *get_d3d11_adapter(struct mp_log *log,
                                   adapter_description ? adapter_description : "<No Description>");
         }
 
-        if (adapter_description &&
-            bstr_equals0(requested_adapter_name, adapter_description))
+        if (adapter_description && requested_adapter_name.len &&
+            bstr_case_startswith(bstr0(adapter_description),
+                                 requested_adapter_name))
         {
             picked_adapter = adapter;
             break;
@@ -282,7 +283,7 @@ bool mp_d3d11_create_present_device(struct mp_log *log,
     adapter = get_d3d11_adapter(log, bstr0(adapter_name), NULL);
 
     if (adapter_name && !adapter) {
-        mp_warn(log, "Adapter '%s' was not found in the system! "
+        mp_warn(log, "Adapter matching '%s' was not found in the system! "
                      "Will fall back to the default adapter.\n",
                  adapter_name);
     }

--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -201,10 +201,10 @@ static IDXGIAdapter1 *get_d3d11_adapter(struct mp_log *log,
             bstr_xappend_asprintf(NULL, listing,
                                   "Adapter %u: vendor: %u, description: %s\n",
                                   adapter_num, desc.VendorId,
-                                  adapter_description ? adapter_description : "<No Description>");
+                                  adapter_description);
         }
 
-        if (adapter_description && requested_adapter_name.len &&
+        if (requested_adapter_name.len &&
             bstr_case_startswith(bstr0(adapter_description),
                                  requested_adapter_name))
         {

--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -209,10 +209,14 @@ static IDXGIAdapter1 *get_d3d11_adapter(struct mp_log *log,
                                  requested_adapter_name))
         {
             picked_adapter = adapter;
-            break;
         }
 
         talloc_free(adapter_description);
+
+        if (picked_adapter) {
+            break;
+        }
+
         SAFE_RELEASE(adapter);
     }
 

--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -160,7 +160,7 @@ static int get_feature_levels(int max_fl, int min_fl,
 }
 
 static IDXGIAdapter1 *get_d3d11_adapter(struct mp_log *log,
-                                        char *requested_adapter_name,
+                                        struct bstr requested_adapter_name,
                                         struct bstr *listing)
 {
     HRESULT hr = S_OK;
@@ -204,8 +204,8 @@ static IDXGIAdapter1 *get_d3d11_adapter(struct mp_log *log,
                                   adapter_description ? adapter_description : "<No Description>");
         }
 
-        if (requested_adapter_name && adapter_description &&
-            !strcmp(requested_adapter_name, adapter_description))
+        if (adapter_description &&
+            bstr_equals0(requested_adapter_name, adapter_description))
         {
             picked_adapter = adapter;
             break;
@@ -239,7 +239,7 @@ static HRESULT create_device(struct mp_log *log, IDXGIAdapter1 *adapter,
 }
 
 bool mp_d3d11_list_or_verify_adapters(struct mp_log *log,
-                                      bstr *adapter_name,
+                                      bstr adapter_name,
                                       bstr *listing)
 {
     IDXGIAdapter1 *picked_adapter = NULL;
@@ -248,11 +248,7 @@ bool mp_d3d11_list_or_verify_adapters(struct mp_log *log,
         return false;
     }
 
-    if ((picked_adapter = get_d3d11_adapter(log,
-                                            adapter_name ?
-                                            (char *)adapter_name->start : NULL,
-                                            listing)))
-    {
+    if ((picked_adapter = get_d3d11_adapter(log, adapter_name, listing))) {
         SAFE_RELEASE(picked_adapter);
         return true;
     }
@@ -283,7 +279,7 @@ bool mp_d3d11_create_present_device(struct mp_log *log,
         goto done;
     }
 
-    adapter = get_d3d11_adapter(log, adapter_name, NULL);
+    adapter = get_d3d11_adapter(log, bstr0(adapter_name), NULL);
 
     if (adapter_name && !adapter) {
         mp_warn(log, "Adapter '%s' was not found in the system! "

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -60,7 +60,7 @@ struct d3d11_device_opts {
 };
 
 bool mp_d3d11_list_or_verify_adapters(struct mp_log *log,
-                                      bstr *adapter_name,
+                                      bstr adapter_name,
                                       bstr *listing);
 
 bool mp_d3d11_create_present_device(struct mp_log *log,


### PR DESCRIPTION
1. Fixes up config file option based adapter selection by switching to bstr everywhere. I did think if I should have done it before, but I felt like being lazy. This cost me.
2. Switch adapter selection to a case insensitive startswith. Lets one do things a la `"intel"` or `"nvidia"`.
3. Removes an unnecessary nullptr check. `mp_to_utf8` will abort if something goes wrong.
4. Fix a memleak of the adapter description in case an adapter is picked.