### PR TITLE
wlshm: Use memfd_create() instead of shm_open() on Linux

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -77,7 +77,7 @@ const struct vo_driver *const video_out_drivers[] =
 #if HAVE_DIRECT3D
     &video_out_direct3d,
 #endif
-#if HAVE_WAYLAND
+#if HAVE_WAYLAND && HAVE_MEMFD_CREATE
     &video_out_wlshm,
 #endif
 #if HAVE_XV

--- a/wscript
+++ b/wscript
@@ -323,6 +323,12 @@ iconv support use --disable-iconv.",
         'func': check_statement('sys/vfs.h',
                                 'struct statfs fs; fstatfs(0, &fs); fs.f_namelen')
     }, {
+        'name': 'memfd_create',
+        'desc': "Linux's memfd_create()",
+        'deps': 'os-linux',
+        'func': check_statement('sys/mman.h',
+                                'memfd_create("mpv", MFD_CLOEXEC | MFD_ALLOW_SEALING)')
+    }, {
         'name': '--libsmbclient',
         'desc': 'Samba support (makes mpv GPLv3)',
         'deps': 'libdl && gpl',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -488,7 +488,7 @@ def build(ctx):
         ( "video/out/vo_tct.c" ),
         ( "video/out/vo_vaapi.c",                "vaapi-x11 && gpl" ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),
-        ( "video/out/vo_wlshm.c",                "wayland" ),
+        ( "video/out/vo_wlshm.c",                "wayland && memfd_create" ),
         ( "video/out/vo_x11.c" ,                 "x11" ),
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),


### PR DESCRIPTION
This syscall avoids the need to guess an unused filename in /dev/shm and
allows seals to be placed on it.  We immediately return if no fd got
returned, as there isn’t anything we can do otherwise.

Seals especially allow the compositor to drop the SIGBUS protections,
since the kernel promises the fd won’t ever shrink.