### PR TITLE
Prevent wraparound in D3D11 queued frames calculation

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -296,8 +296,9 @@ static void d3d11_get_vsync(struct ra_swapchain *sw, struct vo_vsync_info *info)
 
         // Now guess the timestamp of the last submitted frame based on the
         // timestamp of the frame at SyncRefreshCount and the frame rate
+        int queued_frames = submit_count - expected_sync_pc;
         int64_t last_queue_display_time_qpc = stats.SyncQPCTime.QuadPart +
-            (submit_count - expected_sync_pc) * p->vsync_duration_qpc;
+            queued_frames * p->vsync_duration_qpc;
 
         // Only set the estimated display time if it's after the last submission
         // time. It could be before if mpv skips a lot of frames.


### PR DESCRIPTION
I don't know if this bug can occur with flip-model present, but it might be possible if SyncRefreshCount can advance past PresentRefreshCount, and the docs aren't clear about whether this can happen on dropped frames or not.