### PR TITLE
vo_drm: support zimg, require zimg for 30 bit

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -548,6 +548,10 @@ Available video output drivers are:
         xrgb2101010 is a packed 30 bits per pixel/10 bits per channel packed RGB
         format with 2 bits of padding.
 
+        Currently, you need to build mpv with libzimg and enable it with
+        ``--sws-allow-zimg=yes``, or initialization with the 30 bit format will
+        fail.
+
         There are cases when xrgb2101010 will work with the ``drm`` VO, but not
         with the ``drm`` backend for the ``gpu`` VO. This is because with the
         ``gpu`` VO, in addition to requiring support in your DRM driver,


### PR DESCRIPTION
This trivially enables use of zimg. You still need to use
--sws-allow-zimg to use it.

In addition, it removes the vo_drm-specific 30 bit RGB support, and uses
zimg's support for it. Like vo_drm, zimg's wrapper simply repacks from
GBRP to RGB30 in C, but it's still a worthy cleanup, as the zimg wrapper
need a concept of "packing" image output anyway. There also might be a
minor performance benefit due to doing the conversion slice-wise and
reducing cache thrashing (whether this positive effect really happens
with typical slice/image/cache sizes is unknown).