### PR TITLE
wayland: fix presentation time

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -151,7 +151,7 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation) {
+    if (wl->presentation && !wl->hidden) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -246,9 +246,18 @@ static void swap_buffers(struct ra_swapchain *sw)
         p->params.swap_buffers(sw->ctx);
 }
 
+static void get_vsync(struct ra_swapchain *sw,
+                      struct vo_vsync_info *info)
+{
+    struct priv *p = sw->priv;
+    if (p->params.get_vsync)
+        p->params.get_vsync(sw->ctx, info);
+}
+
 static const struct ra_swapchain_fns vulkan_swapchain = {
     .color_depth   = color_depth,
     .start_frame   = start_frame,
     .submit_frame  = submit_frame,
     .swap_buffers  = swap_buffers,
+    .get_vsync     = get_vsync,
 };

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -122,7 +122,7 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 static void wayland_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation) {
+    if (wl->presentation && !wl->hidden) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1552,6 +1552,16 @@ void vo_wayland_wait_frame(struct vo_wayland_state *wl, int frame_offset)
         wl_display_read_events(wl->display);
         wl_display_dispatch_pending(wl->display);
     }
+
+    if (wl->frame_wait) {
+        wl->timeout_count += 1;
+    } else {
+        wl->timeout_count = 0;
+        wl->hidden = false;
+    }
+    
+    if (wl->timeout_count > wl->current_output->refresh_rate)
+        wl->hidden = true;
 }
 
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -71,6 +71,8 @@ struct vo_wayland_state {
     bool maximized;
     bool configured;
     bool frame_wait;
+    bool hidden;
+    int timeout_count;
     int wakeup_pipe[2];
     int pending_vo_events;
     int mouse_x;


### PR DESCRIPTION
There's 2 stupid things here that need to be fixed. First of all,
vulkan wasn't actually using presentation time because somehow the
get_vsync function in context.c disappeared. Secondly, if the mpv window
was hidden it was updating the ust time based on the refresh_usec but
really it should simply just not feed any information to the vsync info
structure. So this adds some logic to assume whether or not a window is
hidden.

Fixes #7079. @aufkrawall, thanks for all the testing. This solves the problem for me. If it works for you in Sway and Plasma (no presentation time but just a double check to make sure nothing here interferes with it which it shouldn't), then I can merge it.