### PR TITLE
wayland: don't get data device if wl_seat is null

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1085,10 +1085,10 @@ int vo_wayland_init(struct vo *vo)
     if (create_xdg_surface(wl))
         return false;
 
-    if (wl->dnd_devman) {
+    if (wl->dnd_devman && wl->seat) {
         wl->dnd_ddev = wl_data_device_manager_get_data_device(wl->dnd_devman, wl->seat);
         wl_data_device_add_listener(wl->dnd_ddev, &data_device_listener, wl);
-    } else {
+    } else if (!wl->dnd_devman) {
         MP_VERBOSE(wl, "Compositor doesn't support the %s (ver. 3) protocol!\n",
                    wl_data_device_manager_interface.name);
     }


### PR DESCRIPTION
Possibly fixes #7058. @syphoxy, does this work for you?