### PR TITLE
ass_mp: reset packer when allocation fails

### DIFF
--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -230,8 +230,10 @@ static bool pack(struct mp_ass_packer *p, struct sub_bitmaps *res, int imgfmt)
     {
         talloc_free(p->cached_img);
         p->cached_img = mp_image_alloc(imgfmt, p->packer->w, p->packer->h);
-        if (!p->cached_img)
+        if (!p->cached_img) {
+            packer_reset(p->packer);
             return false;
+        }
         talloc_steal(p, p->cached_img);
     }
 


### PR DESCRIPTION
Sometimes the atlas can get so large that it exceeds the maximum allowed size for an mp_image. Since the atlas will never shrink naturally, this breaks subtitles entirely until mpv is restarted. Reset the packer so that subtitles can rendered properly once the atlas fits again.

This is a partial workaround for #6286.