### PR TITLE
client API: fix missing property change events on MacOS

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -1589,8 +1589,9 @@ static bool update_prop(struct mpv_handle *ctx, struct observe_property *prop)
                 prop->async_updating = true;
                 ctx->async_counter += 1;
                 mp_dispatch_enqueue(ctx->mpctx->dispatch, update_prop_async, prop);
+            } else {
+                return false; // re-update later when the changed value comes in
             }
-            return false; // re-update later when the changed value comes in
         }
 
         m_option_copy(prop->type, &val, &prop->async_value);


### PR DESCRIPTION
When update_prop_async() successfully fetches a changed property value,
it sets prop->async_value_ts to prop->async_change_ts and forces with
prop->changed that the property gets re-checked.
mark_property_changed() also always sets prop->changed and increments
prop->async_change_ts to indicate an updated value can be fetched.
update_prop() then checks if prop->async_change_ts is greater
than prop->async_value_ts and trigger an async update.
But also this meant to not send a property change event to clients
because a new value can be fetched.

If the observed property changes every frame and then due to different
wakeup behaviour on MacOS the next mark_property_changed() is called
before gen_property_change_event() and therefore directly after
update_prop_async(), prop->async_change_ts was already incremented again
and indicated that a new value has to be retrieved with update_prop().
As a result the event for the last successful update_prop_async() was
never sent. This also meant that a property change event was never
generated for frame-based properties.

To fix this, update_prop() should always check if a new async_value is valid
and if so trigger a property change event even if a new one should be
fetched. But not if a async_update is currently in progress.

Fixes #7122

I agree that my changes can be relicensed to LGPL 2.1 or later.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.