### PR TITLE
Fix VAAPI build failure

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -12,8 +12,8 @@ Releases are listed here: https://github.com/mpv-player/mpv/releases
 ### Log file
 
 Make a log file made with -v -v or --log-file=output.txt, paste it to
-https://0x0.st/ or attach it the github issue, and replace this text with a
-link to it.
+https://0x0.st/ or attach it to the github issue, and replace this text with a
+link to it. If the issue is a build failure, upload build/config.log instead.
 
 If this is a normal runtime bug, and no log is provided, the issue will be
 closed for ignoring the issue template. This is because analyzing a bug without

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -108,10 +108,10 @@ static void uninit(struct ra_hwdec *hw)
 }
 
 const static vaapi_interop_init interop_inits[] = {
-#if HAVE_GL
+#if HAVE_VAAPI_EGL
     vaapi_gl_init,
 #endif
-#if HAVE_VULKAN
+#if HAVE_VAAPI_VULKAN
     vaapi_vk_init,
 #endif
     NULL


### PR DESCRIPTION
See first commit message. I got an email from someone who ran into this trying to build the AUR package. They had `plain-gl` and `vaapi-vulkan` but no `vaapi-egl`. On a system that normally would build with vaapi-egl, the build failure can be reproduced with `./waf configure --disable-vaapi-x-egl --disable-vaapi-wayland --disable-vaapi-drm`.

Second commit is hopefully self-explanatory too. Just tacked it on after realizing `build/config.log` usually ends up being asked for when debugging build failures.

(Wasn't sure if build: was the appropriate prefix for the commit message. It doesn't touch any build-specific files, but it feels like an exclusively build-related change to me.)