### PR TITLE
player: Optionally validate st_mtime when restoring playback state

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -25,6 +25,8 @@ Interface changes
 ::
 
  --- mpv 0.31.0 ---
+    - add `--resume-playback-check-mtime` to check consistent mtime when
+      restoring playback state.
     - add `--d3d11-output-csp` to enable explicit selection of a D3D11
       swap chain color space.
     - the --sws- options and similar now affect vo_image and screenshot

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -714,6 +714,13 @@ Program Behavior
     subdirectory (usually ``~/.config/mpv/watch_later/``).
     See ``quit-watch-later`` input command.
 
+``--resume-playback-check-mtime``
+    Only restore the playback position from the ``watch_later`` configuration
+    subdirectory (usually ``~/.config/mpv/watch_later/``) if the file's
+    modification time is the same as at the time of saving. This may prevent
+    skipping forward in files with the same name which have different content.
+    (Default: ``no``)
+
 ``--profile=<profile1,profile2,...>``
     Use the given profile(s), ``--profile=help`` displays a list of the
     defined profiles.

--- a/options/options.c
+++ b/options/options.c
@@ -631,6 +631,7 @@ const m_option_t mp_opts[] = {
     OPT_ALIAS("loop", "loop-file"),
 
     OPT_FLAG("resume-playback", position_resume, 0),
+    OPT_FLAG("resume-playback-check-mtime", position_check_mtime, 0),
     OPT_FLAG("save-position-on-quit", position_save_on_quit, 0),
     OPT_FLAG("write-filename-in-watch-later-config", write_filename_in_watch_later_config, 0),
     OPT_FLAG("ignore-path-in-watch-later-config", ignore_path_in_watch_later_config, 0),

--- a/options/options.h
+++ b/options/options.h
@@ -232,6 +232,7 @@ typedef struct MPOpts {
     double ab_loop[2];
     double step_sec;
     int position_resume;
+    int position_check_mtime;
     int position_save_on_quit;
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -172,6 +172,9 @@ void mp_globfree(mp_glob_t *pglob);
 #undef fstat
 #define fstat(...) mp_fstat(__VA_ARGS__)
 
+#define utime(...) _utime(__VA_ARGS__)
+#define utimbuf _utimbuf
+
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
 int munmap(void *addr, size_t length);
 int msync(void *addr, size_t length, int flags);


### PR DESCRIPTION
I often watch sporting events. On many occasions I get files with the
same filename for each session. For example, for F1 I might have the
following directory structure:

    F1/
        FP1.mkv
        FP2.mkv
        FP3.mkv
        Qualification.mkv
        Race.mkv

Since usually one simply watches one race after the other, I usually
just rsync the new event's files over the old ones, so, for example,
Race.mkv will be replaced from the file for the last event with the file
from the new event.

One problem with this is that I like to use --resume-playback for other
kinds of media, so I have it on by default. That works great for, say, a
movie, but doesn't work so well with this scheme, because you can
trivially forget to pass --no-resume-playback on the command line and
end up 2 hours in, watching spoilers as the race results scroll down the
screen :-)

This patch adds a new option, --resume-playback-check-mtime, which
validates that the file's mtime hasn't changed since the watch_later
configuration was saved. It does this by setting the watch_later
configuration to have the same mtime as the file after it is saved.

Switching back and forth between checking mtime and not checking mtime
works fine, as we only choose whether to compare based on it, but we
update the watch_later configuration mtime regardless of its value.