### PR TITLE
wayland: use hidpi-window-scale option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2850,7 +2850,7 @@ Window
         - ``--monitoraspect=16:9`` or ``--monitoraspect=1.7777``
 
 ``--hidpi-window-scale``, ``--no-hidpi-window-scale``
-    (OS X and X11 only)
+    (OS X, X11, and Wayland only)
     Scale the window size according to the backing scale factor (default: yes).
     On regular HiDPI resolutions the window opens with double the size but appears
     as having the same size as on none-HiDPI resolutions. This is the default OS X

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1251,6 +1251,8 @@ int vo_wayland_reconfig(struct vo *vo)
         } else {
             wl_out = out->output;
             wl->current_output = out;
+            if (!vo->opts->hidpi_window_scale)
+                out->scale = 1;
             wl->scaling = out->scale;
             screenrc = wl->current_output->geometry;
         }


### PR DESCRIPTION
Just hacking around with scale values on sway seems to work. I can double check later on my actual HiDPI display to make sure nothing weird happens.