### PR TITLE
[RFC] vo_gpu: hwdec_vdpau: Remove direct_mode

### DIFF
--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -43,7 +43,6 @@ struct ra_hwdec_mapper {
     // The common code won't mess with these, so you can e.g. set them in the
     // .init() callback.
     struct ra_tex *tex[4];
-    bool vdpau_fields;
 };
 
 // This can be used to map frames of a specific hw format as GL textures.


### PR DESCRIPTION
As we are less and less interested in vpdpau, with nvdec and vaapi
being better choices in general on nvidia and AMD respectively, we
might consider removing direct_mode, where we bypass the vdpau
mixer and work directly with yuv textures. Normally, working with
yuv textures would be great, but vdpau built in an assumption that
all frames are delivered as separate fields, causing us to have
to re-interleave them.

nvidia then introduces a new OpenGL extension that can return the
yuv frames as frames, but we can't just unconditionally switch to
that as we'd want to keep supporting older hardware where the drivers
are no longer getting new features. The end result is that we
wouldn't be able to get rid of the old code paths.

Removing direct_mode means we always use the mixer, and work with
rgba frame textures. There are some theoretical limitations to
this, but in practice they probably don't matter much - unsupported
colourspaces don't matter because without 10bit decoding support,
we can't use them anyway, and apparently we're not doing separate
chroma scaling these days, so scaling the rbga doesn't really lose
anything (and the vdpau hq scaling option remains available).

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.