### PR TITLE
vo_gpu: hwdec_cuda: Reduce message level of errors while probing

### DIFF
--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -37,6 +37,7 @@ int check_cu(const struct ra_hwdec *hw, CUresult err, const char *func)
     const char *err_string;
 
     struct cuda_hw_priv *p = hw->priv;
+    int level = hw->probing ? MSGL_V : MSGL_ERR;
 
     MP_TRACE(hw, "Calling %s\n", func);
 
@@ -46,10 +47,10 @@ int check_cu(const struct ra_hwdec *hw, CUresult err, const char *func)
     p->cu->cuGetErrorName(err, &err_name);
     p->cu->cuGetErrorString(err, &err_string);
 
-    MP_ERR(hw, "%s failed", func);
+    MP_MSG(hw, level, "%s failed", func);
     if (err_name && err_string)
-        MP_ERR(hw, " -> %s: %s", err_name, err_string);
-    MP_ERR(hw, "\n");
+        MP_MSG(hw, level, " -> %s: %s", err_name, err_string);
+    MP_MSG(hw, level, "\n");
 
     return -1;
 }

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -270,6 +270,7 @@ static bool cuda_ext_vk_signal(const struct ra_hwdec_mapper *mapper, int n)
 
 bool cuda_vk_init(const struct ra_hwdec *hw) {
     int ret = 0;
+    int level = hw->probing ? MSGL_V : MSGL_ERR;
     struct cuda_hw_priv *p = hw->priv;
     CudaFunctions *cu = p->cu;
 
@@ -297,7 +298,7 @@ bool cuda_vk_init(const struct ra_hwdec *hw) {
     }
 
     if (!cu->cuImportExternalMemory) {
-        MP_ERR(hw, "CUDA hwdec with Vulkan requires driver version 410.48 or newer.\n");
+        MP_MSG(hw, level, "CUDA hwdec with Vulkan requires driver version 410.48 or newer.\n");
         return false;
     }
 
@@ -325,7 +326,7 @@ bool cuda_vk_init(const struct ra_hwdec *hw) {
     }
 
     if (display_dev == -1) {
-        MP_ERR(hw, "Could not match Vulkan display device in CUDA.\n");
+        MP_MSG(hw, level, "Could not match Vulkan display device in CUDA.\n");
         return false;
     }
 


### PR DESCRIPTION
We should only be printing errors that occur when not probing, to
avoid creating the impression that something is wrong - and errors
during probing isn't a problem.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.