### PR TITLE
sws_utils: Fix a -Wunused-label that's only used by zimg

### DIFF
--- a/video/sws_utils.c
+++ b/video/sws_utils.c
@@ -309,7 +309,9 @@ int mp_sws_reinit(struct mp_sws_context *ctx)
     if (sws_init_context(ctx->sws, ctx->src_filter, ctx->dst_filter) < 0)
         return -1;
 
+#if HAVE_ZIMG
 success:
+#endif
     ctx->force_reload = false;
     *ctx->cached = *ctx;
     return 1;


### PR DESCRIPTION
51e141f7 adds support for zimg redirection, but the "success" goto label
is only used by this code. This means that with !HAVE_ZIMG, compiling
sws_utils results in a warning courtesy of -Wunused-label.

This kind of sucks, but is better than polluting the build output.