### PR TITLE
vout/opengl: dynamically load eglGetPlatformDisplay

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -163,8 +163,8 @@ static bool egl_create_context(struct ra_ctx *ctx)
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
     struct vo_wayland_state *wl = ctx->vo->wl;
 
-    if (!(p->egl_display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR,
-                                                 wl->display, NULL)))
+    if (!(p->egl_display = mpegl_get_platform_display(EGL_PLATFORM_WAYLAND_KHR,
+                                                      wl->display, NULL)))
         return false;
 
     if (eglInitialize(p->egl_display, NULL, NULL) != EGL_TRUE)

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -104,8 +104,13 @@ static bool mpegl_init(struct ra_ctx *ctx)
     if (!vo_x11_init(vo))
         goto uninit;
 
-    p->egl_display = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR,
-                                           vo->x11->display, NULL);
+    if (!(p->egl_display = mpegl_get_platform_display(EGL_PLATFORM_X11_KHR,
+                                                      vo->x11->display, NULL)))
+    {
+        MP_MSG(ctx, msgl, "EGL 1.5 display not available.\n");
+        goto uninit;
+    }
+
     if (!eglInitialize(p->egl_display, NULL, NULL)) {
         MP_MSG(ctx, msgl, "Could not initialize EGL.\n");
         goto uninit;

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -51,6 +51,8 @@ struct mp_egl_config_attr {
 
 #define MP_EGL_ATTRIB(id) {id, # id}
 
+static PFNEGLGETPLATFORMDISPLAYPROC egl_get_platform_display  = NULL;
+
 static const struct mp_egl_config_attr mp_egl_attribs[] = {
     MP_EGL_ATTRIB(EGL_CONFIG_ID),
     MP_EGL_ATTRIB(EGL_RED_SIZE),
@@ -276,4 +278,14 @@ void mpegl_load_functions(struct GL *gl, struct mp_log *log)
     mpgl_load_functions2(gl, mpegl_get_proc_address, NULL, egl_exts, log);
     if (!gl->SwapInterval)
         gl->SwapInterval = swap_interval;
+}
+
+EGLDisplay mpegl_get_platform_display(EGLenum platform, void *native_display, const EGLAttrib *attrib_list)
+{
+    if (!egl_get_platform_display &&
+        !(egl_get_platform_display = mpegl_get_proc_address(NULL, "eglGetPlatformDisplay"))) {
+        return NULL;
+    }
+
+    return egl_get_platform_display(platform, native_display, attrib_list);
 }

--- a/video/out/opengl/egl_helpers.h
+++ b/video/out/opengl/egl_helpers.h
@@ -29,4 +29,6 @@ bool mpegl_create_context_cb(struct ra_ctx *ctx, EGLDisplay display,
 struct GL;
 void mpegl_load_functions(struct GL *gl, struct mp_log *log);
 
+EGLDisplay mpegl_get_platform_display(EGLenum platform, void *native_display, const EGLAttrib *attrib_list);
+
 #endif


### PR DESCRIPTION
This will enable a binary built with the Wayland and X11 EGL
contexts to actually execute on a driver without this specific
function implemented, such as nvidia's 340 series drivers
(last updated June 2018).

Similar loading was already done by the ANGLE and the DRM EGL
contexts before for eglGetPlatformDisplayEXT, so this just brings
us in line with those modules.

Fixes #7179