### PR TITLE
Wayland Pseudo-Client Side Decorations via OSC

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -341,6 +341,22 @@ Configurable Options
     ``--sub-use-margins`` option is set to ``yes``, the default). This may be
     fixed later.
 
+``windowcontrols``
+    Default: no (Do not show window controls)
+
+    Whether to show window management controls over the video, and if so,
+    which side of the window to place them. This may be desirable when the
+    window has no decorations, either because they have been explicitly
+    disabled (``border=no``) or because the current platform doesn't support
+    them (eg: gnome-shell with wayland).
+
+    The set of window controls is fixed, offering ``minimze``, ``maximize``,
+    and ``quit``. Not all platforms implement ``minimize`` and ``maximize``,
+    but ``quit`` will always work.
+
+    Supports ``left`` and ``right`` which will place the controls on those
+    respective sides.
+
 Script Commands
 ~~~~~~~~~~~~~~~
 

--- a/player/command.c
+++ b/player/command.c
@@ -2299,7 +2299,40 @@ static int mp_property_win_minimized(void *ctx, struct m_property *prop,
     if (vo_control(vo, VOCTRL_GET_WIN_STATE, &state) < 1)
         return M_PROPERTY_UNAVAILABLE;
 
-    return m_property_flag_ro(action, arg, state & VO_WIN_STATE_MINIMIZED);
+    switch (action) {
+    case M_PROPERTY_SET:
+        vo_control(vo, VOCTRL_MINIMIZE, 0);
+        return M_PROPERTY_OK;
+    case M_PROPERTY_GET:
+    case M_PROPERTY_GET_TYPE:
+        return m_property_flag_ro(action, arg, state & VO_WIN_STATE_MINIMIZED);
+    default:
+        return M_PROPERTY_NOT_IMPLEMENTED;
+    }
+}
+
+static int mp_property_win_maximized(void *ctx, struct m_property *prop,
+                                     int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    struct vo *vo = mpctx->video_out;
+    if (!vo)
+        return M_PROPERTY_UNAVAILABLE;
+
+    int state = 0;
+    if (vo_control(vo, VOCTRL_GET_WIN_STATE, &state) < 1)
+        return M_PROPERTY_UNAVAILABLE;
+
+    switch (action) {
+    case M_PROPERTY_SET:
+        vo_control(vo, VOCTRL_MAXIMIZE, 0);
+        return M_PROPERTY_OK;
+    case M_PROPERTY_GET:
+    case M_PROPERTY_GET_TYPE:
+        return m_property_flag_ro(action, arg, state & VO_WIN_STATE_MAXIMIZED);
+    default:
+        return M_PROPERTY_NOT_IMPLEMENTED;
+    }
 }
 
 static int mp_property_display_fps(void *ctx, struct m_property *prop,
@@ -3405,6 +3438,7 @@ static const struct m_property mp_properties_base[] = {
     PROPERTY_BITRATE("sub-bitrate", false, STREAM_SUB),
 
     {"window-minimized", mp_property_win_minimized},
+    {"window-maximized", mp_property_win_maximized},
     {"display-names", mp_property_display_names},
     {"display-fps", mp_property_display_fps},
     {"estimated-display-fps", mp_property_estimated_display_fps},
@@ -3484,7 +3518,7 @@ static const char *const *const mp_event_property_change[] = {
       "demuxer-cache-state"),
     E(MP_EVENT_WIN_RESIZE, "window-scale", "osd-width", "osd-height", "osd-par"),
     E(MP_EVENT_WIN_STATE, "window-minimized", "display-names", "display-fps",
-      "fullscreen"),
+      "fullscreen", "window-maximized"),
     E(MP_EVENT_CHANGE_PLAYLIST, "playlist", "playlist-pos", "playlist-pos-1",
       "playlist-count", "playlist/count"),
     E(MP_EVENT_CORE_IDLE, "core-idle", "eof-reached"),
@@ -3704,6 +3738,8 @@ static const struct property_osd_display {
     // By default, don't display the following properties on OSD
     {"pause", NULL},
     {"fullscreen", NULL},
+    {"window-minimized", NULL},
+    {"window-maximized", NULL},
     {0}
 };
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -126,10 +126,14 @@ enum mp_voctrl {
 
     /* private to vo_gpu */
     VOCTRL_EXTERNAL_RESIZE,
+
+    VOCTRL_MAXIMIZE,
+    VOCTRL_MINIMIZE,
 };
 
 // VOCTRL_GET_WIN_STATE
-#define VO_WIN_STATE_MINIMIZED 1
+#define VO_WIN_STATE_MINIMIZED (1 << 0)
+#define VO_WIN_STATE_MAXIMIZED (1 << 1)
 
 #define VO_TRUE         true
 #define VO_FALSE        false

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1342,6 +1342,25 @@ static int toggle_fullscreen(struct vo_wayland_state *wl)
     return VO_TRUE;
 }
 
+static int toggle_maximized(struct vo_wayland_state *wl)
+{
+    if (!wl->xdg_toplevel)
+        return VO_NOTAVAIL;
+    if (wl->maximized)
+        xdg_toplevel_unset_maximized(wl->xdg_toplevel);
+    else
+        xdg_toplevel_set_maximized(wl->xdg_toplevel);
+    return VO_TRUE;
+}
+
+static int do_minimize(struct vo_wayland_state *wl)
+{
+    if (!wl->xdg_toplevel)
+        return VO_NOTAVAIL;
+    xdg_toplevel_set_minimized(wl->xdg_toplevel);
+    return VO_TRUE;
+}
+
 static int update_window_title(struct vo_wayland_state *wl, char *title)
 {
     if (!wl->xdg_toplevel)
@@ -1428,6 +1447,10 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         *(char ***)arg = get_displays_spanned(wl);
         return VO_TRUE;
     }
+    case VOCTRL_GET_WIN_STATE: {
+        *(int *)arg = wl->maximized ? VO_WIN_STATE_MAXIMIZED : 0;
+        return VO_TRUE;
+    }
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {
         int *s = arg;
         s[0] = mp_rect_w(wl->geometry)*wl->scaling;
@@ -1455,6 +1478,10 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         return update_window_title(wl, (char *)arg);
     case VOCTRL_FULLSCREEN:
         return toggle_fullscreen(wl);
+    case VOCTRL_MAXIMIZE:
+        return toggle_maximized(wl);
+    case VOCTRL_MINIMIZE:
+        return do_minimize(wl);
     case VOCTRL_SET_CURSOR_VISIBILITY:
         return set_cursor_visibility(wl, *(bool *)arg);
     case VOCTRL_BORDER:

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -47,17 +47,18 @@ const struct m_sub_options wayland_conf = {
     .opts = (const struct m_option[]) {
         OPT_INTRANGE("wayland-frame-wait-offset", frame_offset, 0, -500, 3000),
         OPT_FLAG("wayland-disable-vsync", disable_vsync, 0),
+        OPT_INTRANGE("wayland-edge-pixels-pointer", edge_pixels_pointer, 10, 0, INT_MAX),
+        OPT_INTRANGE("wayland-edge-pixels-touch", edge_pixels_touch, 64, 0, INT_MAX),
         {0},
     },
     .size = sizeof(struct wayland_opts),
     .defaults = &(struct wayland_opts) {
         .frame_offset = 1000,
         .disable_vsync = false,
+        .edge_pixels_pointer = 10,
+        .edge_pixels_touch = 64,
     },
 };
-
-#define POINTER_EDGE_PIXELS 5
-#define TOUCH_EDGE_PIXELS 64
 
 static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base, uint32_t serial)
 {
@@ -246,7 +247,7 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
         // Implement an edge resize zone if there are no decorations
         if (!wl->xdg_toplevel_decoration &&
             check_for_resize(wl, wl->mouse_unscaled_x, wl->mouse_unscaled_y,
-                             POINTER_EDGE_PIXELS, &edges))
+                             wl->opts->edge_pixels_pointer, &edges))
             xdg_toplevel_resize(wl->xdg_toplevel, wl->seat, serial, edges);
         else
             window_move(wl, serial);
@@ -291,7 +292,7 @@ static void touch_handle_down(void *data, struct wl_touch *wl_touch,
     struct vo_wayland_state *wl = data;
 
     enum xdg_toplevel_resize_edge edge;
-    if (check_for_resize(wl, x_w, y_w, TOUCH_EDGE_PIXELS, &edge)) {
+    if (check_for_resize(wl, x_w, y_w, wl->opts->edge_pixels_touch, &edge)) {
         wl->touch_entries = 0;
         xdg_toplevel_resize(wl->xdg_toplevel, wl->seat, serial, edge);
         return;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -979,9 +979,8 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
         vo_query_and_reset_events(wl->vo, VO_EVENT_LIVE_RESIZING);
 
     if (width > 0 && height > 0) {
-        if (!wl->fullscreen) {
-            if (wl->vo->opts->keepaspect && wl->vo->opts->keepaspect_window &&
-                !wl->maximized) {
+        if (!wl->fullscreen && !wl->maximized) {
+            if (wl->vo->opts->keepaspect && wl->vo->opts->keepaspect_window) {
                 if (width > height)
                     width  = height * wl->aspect_ratio;
                 else

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -28,6 +28,8 @@
 struct wayland_opts {
     int frame_offset;
     int disable_vsync;
+    int edge_pixels_pointer;
+    int edge_pixels_touch;
 };
 
 struct vo_wayland_sync {

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -77,6 +77,8 @@ struct vo_wayland_state {
     int pending_vo_events;
     int mouse_x;
     int mouse_y;
+    int mouse_unscaled_x;
+    int mouse_unscaled_y;
     int scaling;
     int touch_entries;
     uint32_t pointer_id;


### PR DESCRIPTION
I had previously mused about the possibility of doing CSDs on the cheap using OSC, so I dicided to just give it a go. It's a bit weird but it definitely works:

![Screenshot from 2019-11-26 09-22-02](https://user-images.githubusercontent.com/512286/69591643-4592a580-102e-11ea-9396-a4af961b155e.png)

Along the way, I also fixed a wayland maximize bug and added support for triggering resize operations with a mouse.

This isn't exactly an RFC but it's also not fully complete. There's some control layout configs you'd probably want to add,and you might want to argue for implementing window control commands for other VOs (x11, win32, etc) although I think these controls have little to no value outside of Wayland.