### PR TITLE
video/out: add option to control legacy vo warning

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -59,6 +59,8 @@ Interface changes
       setting the properties to non-existing tracks may report it as selected
       track for a small time window, until it's forced back to "no". The exact
       details how this is handled may change in the future.
+    - add `--no-warn-compat-vo` to suppress the compatibility or legacy warning
+      when the VOs x11, xv, vdpau or vaapi are used.
  --- mpv 0.30.0 ---
     - add `--d3d11-output-format` to enable explicit selection of a D3D11
       swap chain format.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2964,6 +2964,10 @@ Window
 
     ``never`` asks the window manager to never disable the compositor.
 
+``--warn-compat-vo``, ``--no-warn-compat-vo``
+    Show a warning if a legacy/compatibility video output is used. On by
+    default.
+
 
 Disc Devices
 ------------

--- a/options/options.c
+++ b/options/options.c
@@ -164,6 +164,7 @@ static const m_option_t mp_vo_opt_list[] = {
     OPT_SUBSTRUCT("", drm_opts, drm_conf, 0),
 #endif
     OPT_INTRANGE("swapchain-depth", swapchain_depth, 0, 1, 8),
+    OPT_FLAG("warn-compat-vo", warn_compat_vo, 0),
     {0}
 };
 
@@ -191,6 +192,7 @@ const struct m_sub_options vo_sub_opts = {
         .ontop_level = -1,
         .timing_offset = 0.050,
         .swapchain_depth = 3,
+        .warn_compat_vo = 1,
     },
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -19,6 +19,7 @@ typedef struct mp_vo_opts {
     int all_workspaces;
     int window_minimized;
     int window_maximized;
+    int warn_compat_vo;
 
     int screen_id;
     int fsscreen_id;

--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -866,10 +866,12 @@ static int preinit(struct vo *vo)
     vo->hwdec_devs = hwdec_devices_create();
     hwdec_devices_add(vo->hwdec_devs, &p->mpvaapi->hwctx);
 
-    MP_WARN(vo, "Warning: this compatibility VO is low quality and may "
-                "have issues with OSD, scaling, screenshots and more.\n"
-                "vo=gpu is the preferred choice in any case and "
-                "includes VA-API support via hwdec=vaapi or vaapi-copy.\n");
+    if(vo->opts->warn_compat_vo) {
+        MP_WARN(vo, "Warning: this compatibility VO is low quality and may "
+                    "have issues with OSD, scaling, screenshots and more.\n"
+                    "vo=gpu is the preferred choice in any case and "
+                    "includes VA-API support via hwdec=vaapi or vaapi-copy.\n");
+    }
 
     return 0;
 

--- a/video/out/vo_vdpau.c
+++ b/video/out/vo_vdpau.c
@@ -1044,10 +1044,12 @@ static int preinit(struct vo *vo)
     vc->vdp->bitmap_surface_query_capabilities(vc->vdp_device, VDP_RGBA_FORMAT_A8,
                             &vc->supports_a8, &(uint32_t){0}, &(uint32_t){0});
 
-    MP_WARN(vo, "Warning: this compatibility VO is low quality and may "
-                "have issues with OSD, scaling, screenshots and more.\n"
-                "vo=gpu is the preferred choice in any case and "
-                "includes VDPAU support via hwdec=vdpau or vdpau-copy.\n");
+    if(vo->opts->warn_compat_vo) {
+        MP_WARN(vo, "Warning: this compatibility VO is low quality and may "
+                    "have issues with OSD, scaling, screenshots and more.\n"
+                    "vo=gpu is the preferred choice in any case and "
+                    "includes VDPAU support via hwdec=vdpau or vdpau-copy.\n");
+    }
 
     return 0;
 }

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -397,8 +397,10 @@ static int preinit(struct vo *vo)
         goto error;
 
     p->gc = XCreateGC(x11->display, x11->window, 0, NULL);
-    MP_WARN(vo, "Warning: this legacy VO has bad performance. Consider fixing "
-                "your graphics drivers, or not forcing the x11 VO.\n");
+    if(vo->opts->warn_compat_vo) {
+        MP_WARN(vo, "Warning: this legacy VO has bad performance. Consider fixing "
+                    "your graphics drivers, or not forcing the x11 VO.\n");
+    }
     return 0;
 
 error:

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -845,9 +845,11 @@ static int preinit(struct vo *vo)
     ctx->fo = XvListImageFormats(x11->display, ctx->xv_port,
                                  (int *) &ctx->formats);
 
-    MP_WARN(vo, "Warning: this legacy VO has bad quality and performance, "
-                "and will in particular result in blurry OSD and subtitles. "
-                "You should fix your graphics drivers, or not force the xv VO.\n");
+    if(vo->opts->warn_compat_vo) {
+        MP_WARN(vo, "Warning: this legacy VO has bad quality and performance, "
+                    "and will in particular result in blurry OSD and subtitles. "
+                    "You should fix your graphics drivers, or not force the xv VO.\n");
+    }
     return 0;
 
   error:


### PR DESCRIPTION
This adds the flag `--warn-compat-vo`/`--no-warn-compat-vo`, which allows users going through a rough patch in their life to disable the warning mpv shows whenever a user uses a suboptimal video output.

This option affects the warnings for the VOs xv, x11, vdpau and vaapi.

We intentionally do not mention how to disable this warning in the warning message itself to avoid users not properly reading it and just doing the first option-shaped thing they see in the message.