### PR TITLE
wayland: update Maximize and Minimize handling to use new options

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6151,10 +6151,6 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
             vo_control(mpctx->video_out, VOCTRL_BORDER, 0);
         if (opt_ptr == &opts->vo->all_workspaces)
             vo_control(mpctx->video_out, VOCTRL_ALL_WORKSPACES, 0);
-        if (opt_ptr == &opts->vo->window_minimized)
-            vo_control(mpctx->video_out, VOCTRL_MINIMIZE, 0);
-        if (opt_ptr == &opts->vo->window_maximized)
-            vo_control(mpctx->video_out, VOCTRL_MAXIMIZE, 0);
     }
 
     if (opt_ptr == &opts->vo->taskbar_progress)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -92,8 +92,6 @@ enum mp_voctrl {
     VOCTRL_ALL_WORKSPACES,
     VOCTRL_GET_FULLSCREEN,
     VOCTRL_GET_WIN_STATE,               // int* (VO_WIN_STATE_* flags)
-    VOCTRL_MAXIMIZE,
-    VOCTRL_MINIMIZE,
 
     VOCTRL_UPDATE_WINDOW_TITLE,         // char*
     VOCTRL_UPDATE_PLAYBACK_STATE,       // struct voctrl_playback_state*
@@ -136,7 +134,6 @@ enum mp_voctrl {
 
 // VOCTRL_GET_WIN_STATE (legacy, ignored)
 #define VO_WIN_STATE_MINIMIZED (1 << 0)
-#define VO_WIN_STATE_MAXIMIZED (1 << 1)
 
 #define VO_TRUE         true
 #define VO_FALSE        false

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -65,12 +65,14 @@ struct vo_wayland_state {
     struct wl_registry   *registry;
     struct wayland_opts  *opts;
 
+    struct m_config_cache *vo_opts_cache;
+    struct mp_vo_opts *vo_opts;
+
     /* State */
     struct mp_rect geometry;
     struct mp_rect window_size;
     float aspect_ratio;
     bool fullscreen;
-    bool maximized;
     bool configured;
     bool frame_wait;
     bool hidden;


### PR DESCRIPTION
I wanted to get this done quickly as I introduced the new VOCTRL
behaviour for minimize and maximize and it was immediately made
legacy, so best to purge it before anyone gets confused.

I did not sort out fullscreen as that's more involved and not something
I've educated myself about yet. But I did replace the VOCTRL_FULLSCREEN
usage with the new option change mechanism as that seemed simple
enough.
