### PR TITLE
lua: unbreak mp.add_key_binding(key, fn)

### DIFF
--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -156,12 +156,12 @@ local function update_key_bindings()
 end
 
 local function add_binding(attrs, key, name, fn, rp)
-    rp = rp or ""
     if (type(name) ~= "string") and (name ~= nil) then
         rp = fn
         fn = name
         name = nil
     end
+    rp = rp or ""
     if name == nil then
         name = reserve_binding()
     end


### PR DESCRIPTION
Commit 311cc5b6 added the ability use flags while omitting name, but
broke the case where both name and flags are omitted.

Now omitting either name or flags or both works as documented.
