### PR TITLE
vo_gpu: opengl: use EGL 1.5 API except not really but kind of (???????)

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -28,6 +28,8 @@
 // Generated from presentation-time.xml
 #include "video/out/wayland/presentation-time.h"
 
+#define EGL_PLATFORM_WAYLAND_EXT 0x31D8
+
 struct priv {
     GL gl;
     EGLDisplay egl_display;
@@ -163,8 +165,9 @@ static bool egl_create_context(struct ra_ctx *ctx)
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
     struct vo_wayland_state *wl = ctx->vo->wl;
 
-    if (!(p->egl_display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR,
-                                                 wl->display, NULL)))
+    if (!(p->egl_display = mpegl_get_display(EGL_PLATFORM_WAYLAND_EXT,
+                                             "EGL_EXT_platform_wayland",
+                                             wl->display)))
         return false;
 
     if (eglInitialize(p->egl_display, NULL, NULL) != EGL_TRUE)

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -28,6 +28,8 @@
 #include "oml_sync.h"
 #include "utils.h"
 
+#define EGL_PLATFORM_X11_EXT 0x31D5
+
 struct priv {
     GL gl;
     EGLDisplay egl_display;
@@ -104,8 +106,9 @@ static bool mpegl_init(struct ra_ctx *ctx)
     if (!vo_x11_init(vo))
         goto uninit;
 
-    p->egl_display = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR,
-                                           vo->x11->display, NULL);
+    p->egl_display = mpegl_get_display(EGL_PLATFORM_X11_EXT,
+                                       "EGL_EXT_platform_x11",
+                                        vo->x11->display);
     if (!eglInitialize(p->egl_display, NULL, NULL)) {
         MP_MSG(ctx, msgl, "Could not initialize EGL.\n");
         goto uninit;

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -277,3 +277,68 @@ void mpegl_load_functions(struct GL *gl, struct mp_log *log)
     if (!gl->SwapInterval)
         gl->SwapInterval = swap_interval;
 }
+
+// This is similar to eglGetPlatformDisplay(platform, native_display, NULL),
+// except that it 1. may use eglGetPlatformDisplayEXT, 2. checks for the
+// platform client extension platform_ext_name, and 3. does not support passing
+// an attrib list, because the type for that parameter is different in the EXT
+// and standard functions (EGL can't not fuck up, no matter what).
+//  platform: e.g. EGL_PLATFORM_X11_KHR
+//  platform_ext_name: e.g. "EGL_KHR_platform_x11"
+//  native_display: e.g. X11 Display*
+// Returns EGL_NO_DISPLAY on failure.
+// Warning: might return a EGL 1.4 display. It's worth noting that the EGL
+// version can apparently be different at runtime depending on the chosen
+// platform.
+// Sometimes, you may want to query both KHR and EXT variants of a platform
+// definition (why do they define them twice? they're crazy). Then just call
+// this twice.
+EGLDisplay mpegl_get_display(EGLenum platform, const char *platform_ext_name,
+                             void *native_display)
+{
+    // EGL is awful. Designed as ultra-portable library, it fails at dealing
+    // with slightly more complex environment than its short-sighted design
+    // could deal with. So they invented an awful, awful kludge that modifies
+    // EGL standard behavior, the EGL_EXT_client_extensions extension. EGL 1.4
+    // normally is to return NULL when querying EGL_EXTENSIONS, however, with
+    // that extension, it'll return the set of "client extensions", which may
+    // include EGL_EXT_platform_base.
+
+    // Prerequisite: check the platform extension.
+    // If this is either EGL 1.5 or 1.4 with EGL_EXT_client_extensions, then
+    // this must return a valid extension string.
+    const char *exts = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+    if (!exts || !gl_check_extension(exts, platform_ext_name))
+        return EGL_NO_DISPLAY;
+
+    // Before we go through the EGL 1.4 BS, try if we can use native EGL 1.5
+    // It appears that EGL 1.4 is specified to _require_ an initialized display
+    // for EGL_VERSION, while EGL 1.5 is _required_ to return the EGL version.
+    const char *version = eglQueryString(EGL_NO_DISPLAY, EGL_VERSION);
+    // Of course we have to go through the excruciating pain of parsing a
+    // version string, since EGL provides no other way without a display.
+    int ma = 0, mi = 0;
+    if (sscanf(version, "%d.%d ", &ma, &mi) == 2 && (ma > 1 || mi >= 5)) {
+        // This is EGL 1.5. It must support querying standard functions through
+        // eglGetProcAddress(). Note that on EGL 1.4, the function may be
+        // considered unknown, but could return non-NULL (because EGL is crazy).
+        PFNEGLGETPLATFORMDISPLAYPROC GetPlatformDisplay =
+            (void *)eglGetProcAddress("eglGetPlatformDisplay");
+        // (It should be impossible to be NULL, but uh.)
+        if (GetPlatformDisplay)
+            return GetPlatformDisplay(platform, native_display, NULL);
+    }
+
+    // (It should be impossible to be missing, but uh.)
+    if (!gl_check_extension(exts, "EGL_EXT_client_extensions"))
+        return EGL_NO_DISPLAY;
+
+    EGLDisplay (*GetPlatformDisplayEXT)(EGLenum, void *, const EGLint *) =
+        (void *)eglGetProcAddress("eglGetPlatformDisplayEXT");
+
+    // (It should be impossible to be NULL, but uh.)
+    if (GetPlatformDisplayEXT)
+        return GetPlatformDisplayEXT(platform, native_display, NULL);
+
+    return EGL_NO_DISPLAY;
+}

--- a/video/out/opengl/egl_helpers.h
+++ b/video/out/opengl/egl_helpers.h
@@ -29,4 +29,7 @@ bool mpegl_create_context_cb(struct ra_ctx *ctx, EGLDisplay display,
 struct GL;
 void mpegl_load_functions(struct GL *gl, struct mp_log *log);
 
+EGLDisplay mpegl_get_display(EGLenum platform, const char *platform_ext_name,
+                             void *native_display);
+
 #endif


### PR DESCRIPTION
This tries to deal with the crazy EGL situation. The summary is that
Mesa was fine with their eglGetDisplay() shithack for years, but may
suddenly feel like not doing it anymore, so we should probably use
eglGetPlatformDisplay(), except that is EGL 1.5 only, and the very
regrettable graphics company (also known as Nvidia) ships drivers (for
old hardware I think) that are EGL 1.4 only, so trying to run mpv there
crashes in the dynamic linker, so we have to go through awful
compatibility because everything is fucking bullshit, Jesus Christ. Did
I mention yet how much I hate EGL? It's supposed to avoid these problems
in the first place, but completely fails at it. What a POS.

I'm not sure whether the EGL 1.5 code path (by parsing the EGL_VERSION)
is really needed, but if you ask me, it feels slightly saner.

Also, unlike before, we actually check the extension string for the
individual platform extensions, because who knows, some EGL
implementations might curse us if we pass unknown platform parameters.
(But actually, the more I think about this, the more bullshit it is.)

X11 and Wayland were the only ones trying to call eglGetPlatformDisplay,
so they're the only ones which are adjusted in this commit.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.