### PR TITLE
wayland: update remaining legacy VOCTRL usage to options

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -72,7 +72,6 @@ struct vo_wayland_state {
     struct mp_rect geometry;
     struct mp_rect window_size;
     float aspect_ratio;
-    bool fullscreen;
     bool configured;
     bool frame_wait;
     bool hidden;


### PR DESCRIPTION
The remaining legacy VOCTRLs are for the fullscreen and border
properties. For fullscreen this largely just replacing the private
state field with the vo option but there are small semantic
differences that we need to be careful of.

For the border setting, it's trivial as we don't have external
mechanisms for changing the state, but I also can't test it as
I'm not using a compositor that supports it.