### PR TITLE
wayland: disable display sync if window is hidden

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -718,7 +718,8 @@ static void adjust_audio_resample_speed(struct MPContext *mpctx, double vsync)
     struct MPOpts *opts = mpctx->opts;
     int mode = opts->video_sync;
 
-    if (mode != VS_DISP_RESAMPLE || mpctx->audio_status != STATUS_PLAYING) {
+    if (mode != VS_DISP_RESAMPLE || mpctx->audio_status != STATUS_PLAYING ||
+        mpctx->vo_chain->vo->hidden) {
         mpctx->speed_factor_a = mpctx->speed_factor_v;
         return;
     }
@@ -791,7 +792,7 @@ static void handle_display_sync_frame(struct MPContext *mpctx,
         mpctx->audio_drop_deprecated_msg = true;
     }
 
-    if (!VS_IS_DISP(mode))
+    if (!VS_IS_DISP(mode) || mpctx->vo_chain->vo->hidden)
         return;
     bool resample = mode == VS_DISP_RESAMPLE || mode == VS_DISP_RESAMPLE_VDROP ||
                     mode == VS_DISP_RESAMPLE_NONE;

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -151,7 +151,7 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation && !wl->hidden) {
+    if (wl->presentation) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -478,6 +478,7 @@ struct vo {
     struct m_config_cache *eq_opts_cache;
 
     bool want_redraw;   // redraw as soon as possible
+    bool hidden; // true if the window's state is hidden from the backend
 
     // current window state
     int dwidth;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -122,7 +122,7 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 static void wayland_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation && !wl->hidden) {
+    if (wl->presentation) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1616,11 +1616,11 @@ void vo_wayland_wait_frame(struct vo_wayland_state *wl, int frame_offset)
         wl->timeout_count += 1;
     } else {
         wl->timeout_count = 0;
-        wl->hidden = false;
+        wl->vo->hidden = false;
     }
     
     if (wl->timeout_count > wl->current_output->refresh_rate)
-        wl->hidden = true;
+        wl->vo->hidden = true;
 }
 
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -74,7 +74,6 @@ struct vo_wayland_state {
     float aspect_ratio;
     bool configured;
     bool frame_wait;
-    bool hidden;
     int timeout_count;
     int wakeup_pipe[2];
     int pending_vo_events;


### PR DESCRIPTION
Fixes #7223. The wayland backend needs to keep track of whether or not a
window is hidden when using presentation time. Since there is no
presentation feedback when the window is not in view, the previous
approach was to set the vo_sync_info structure to -1 when the window is
hidden. This seemed to work fine, but recent changes in Sway's
presentation time api (Weston was likely always broken and nobody
noticed) changed the behavior (i.e. creating a big a/v desync when
bringing a hidden window into view) as described in the above issue.

One way to deal with this is to just disable all the DS stuff when the
video is hidden and time video frames to audio. Trying to maintain ideal
DS on a hidden window is not really practical on wayland and not
terribly important. Like before, a window is assumed to be hidden when
vo_wayland_wait_frame times out 60 times (or whatever the monitor's
refresh rate is) in a row. If mpv receives frame callback from the
compositor, then the window is no longer hidden.