### PR TITLE
Fix typo and improve phrasing in the description

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -1,16 +1,17 @@
+
 -- This script automatically loads playlist entries before and after the
--- the currently played file. It does so by scanning the directory a file is
--- located in when starting playback. It sorts the directory entries
+-- the file currently being played. It does so by scanning the directory of the
+-- current file when playback begins. It sorts the directory entries
 -- alphabetically, and adds entries before and after the current file to
--- the internal playlist. (It stops if the it would add an already existing
+-- the internal playlist. (It stops if it will add an already existing
 -- playlist entry at the same position - this makes it "stable".)
 -- Add at most 5000 * 2 files when starting a file (before + after).
 
 --[[
-To configure this script use file autoload.conf in director script-opts (the "script-opts"
-directory must be in the mpv configuration directory, typically ~/.config/mpv/).
+To configure this script, place the autoload.conf file inside the script-opts directory.
+The "script-opts" directory must be in the mpv configuration directory, typically ~/.config/mpv/.
 
-Example configuration would be:
+An example configuration:
 
 disabled=false
 images=false


### PR DESCRIPTION
Fix the typo: 'director' as 'directory'.
Make the script description more clear and natural.