### PR TITLE
video/w32_common: switch full screening to options cache

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1578,14 +1578,13 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 
             if (changed_option == &vo_opts->fullscreen) {
                 reinit_window_state(w32);
+            } else if (changed_option == &vo_opts->ontop) {
+                update_window_state(w32);
             }
         }
 
         return VO_TRUE;
     }
-    case VOCTRL_ONTOP:
-        update_window_state(w32);
-        return VO_TRUE;
     case VOCTRL_BORDER:
         update_window_style(w32);
         update_window_state(w32);

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1580,15 +1580,14 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
                 reinit_window_state(w32);
             } else if (changed_option == &vo_opts->ontop) {
                 update_window_state(w32);
+            } else if (changed_option == &vo_opts->border) {
+                update_window_style(w32);
+                update_window_state(w32);
             }
         }
 
         return VO_TRUE;
     }
-    case VOCTRL_BORDER:
-        update_window_style(w32);
-        update_window_state(w32);
-        return VO_TRUE;
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {
         int *s = arg;
 

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -991,6 +991,9 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         }
 
         // Window may have been minimized or restored
+        w32->opts->window_minimized = IsIconic(w32->window);
+        m_config_cache_write_opt(w32->opts_cache,
+                                 &w32->opts->window_minimized);
         signal_events(w32, VO_EVENT_WIN_STATE);
 
         update_display_info(w32);
@@ -1613,9 +1616,6 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         reinit_window_state(w32);
         return VO_TRUE;
     }
-    case VOCTRL_GET_WIN_STATE:
-        *(int *)arg = IsIconic(w32->window) ? VO_WIN_STATE_MINIMIZED : 0;
-        return VO_TRUE;
     case VOCTRL_SET_CURSOR_VISIBILITY:
         w32->cursor_visible = *(bool *)arg;
 


### PR DESCRIPTION
* Instead of following VOCTRL_FULLSCREEN, check for option changes.
* Instead of signaling VO_EVENT_FULLSCREEN_STATE, update the cached
  option structure and have it propagated to the origin.

Additionally, gets rid of all the straight usage of the VO options
structure.

Done in a similar style to the Wayland common file, where in case
of reading the value, the "payload" from cache is utilized.