### PR TITLE
vo_gpu: hwdec_vaegl: Remove support for old-style interop

### DIFF
--- a/video/out/hwdec/hwdec_vaapi.h
+++ b/video/out/hwdec/hwdec_vaapi.h
@@ -34,9 +34,6 @@ struct priv_owner {
     void (*interop_uninit)(const struct ra_hwdec_mapper *mapper);
 
     bool (*interop_map)(struct ra_hwdec_mapper *mapper);
-    bool (*interop_map_legacy)(struct ra_hwdec_mapper *mapper,
-                               const VABufferInfo *buffer_info,
-                               const int *drm_fmts);
     void (*interop_unmap)(struct ra_hwdec_mapper *mapper);
 };
 
@@ -45,14 +42,8 @@ struct priv {
     struct mp_image layout;
     struct ra_tex *tex[4];
 
-    VAImage current_image;
-    bool buffer_acquired;
-
-#if VA_CHECK_VERSION(1, 1, 0)
-    bool esh_not_implemented;
     VADRMPRIMESurfaceDescriptor desc;
     bool surface_acquired;
-#endif
 
     void *interop_mapper_priv;
 };

--- a/video/out/hwdec/hwdec_vaapi_gl.c
+++ b/video/out/hwdec/hwdec_vaapi_gl.c
@@ -139,7 +139,6 @@ static void vaapi_gl_mapper_uninit(const struct ra_hwdec_mapper *mapper)
 
 static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper)
 {
-#if VA_CHECK_VERSION(1, 1, 0)
     struct priv *p_mapper = mapper->priv;
     struct vaapi_gl_mapper_priv *p = p_mapper->interop_mapper_priv;
 
@@ -172,52 +171,6 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper)
         mapper->tex[n] = p_mapper->tex[n];
     }
     gl->BindTexture(GL_TEXTURE_2D, 0);
-#endif
-    return true;
-}
-
-static bool vaapi_gl_map_legacy(struct ra_hwdec_mapper *mapper,
-                                const VABufferInfo *buffer_info,
-                                const int *drm_fmts) {
-    struct priv *p_mapper = mapper->priv;
-    struct vaapi_gl_mapper_priv *p = p_mapper->interop_mapper_priv;
-
-    GL *gl = ra_gl_get(mapper->ra);
-
-    VAImage *va_image = &p_mapper->current_image;
-
-    for (int n = 0; n < p_mapper->num_planes; n++) {
-        int attribs[20] = {EGL_NONE};
-        int num_attribs = 0;
-
-        const struct ra_format *fmt = p_mapper->tex[n]->params.format;
-        int n_comp = fmt->num_components;
-        int comp_s = fmt->component_size[n] / 8;
-        if (n_comp < 1 || n_comp > 3 || comp_s < 1 || comp_s > 2)
-            return false;
-        int drm_fmt = drm_fmts[n_comp - 1 + (comp_s - 1) * 4];
-        if (!drm_fmt)
-            return false;
-
-        ADD_ATTRIB(EGL_LINUX_DRM_FOURCC_EXT, drm_fmt);
-        ADD_ATTRIB(EGL_WIDTH, p_mapper->tex[n]->params.w);
-        ADD_ATTRIB(EGL_HEIGHT, p_mapper->tex[n]->params.h);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_FD_EXT, buffer_info->handle);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_OFFSET_EXT, va_image->offsets[n]);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_PITCH_EXT, va_image->pitches[n]);
-
-        p->images[n] = p->CreateImageKHR(eglGetCurrentDisplay(),
-            EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
-        if (!p->images[n])
-            return false;
-
-        gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[n]);
-        p->EGLImageTargetTexture2DOES(GL_TEXTURE_2D, p->images[n]);
-
-        mapper->tex[n] = p_mapper->tex[n];
-    }
-    gl->BindTexture(GL_TEXTURE_2D, 0);
-
     return true;
 }
 
@@ -262,7 +215,6 @@ bool vaapi_gl_init(const struct ra_hwdec *hw)
     p->interop_init = vaapi_gl_mapper_init;
     p->interop_uninit = vaapi_gl_mapper_uninit;
     p->interop_map = vaapi_gl_map;
-    p->interop_map_legacy = vaapi_gl_map_legacy;
     p->interop_unmap = vaapi_gl_unmap;
 
     return true;

--- a/video/vaapi.c
+++ b/video/vaapi.c
@@ -109,10 +109,8 @@ struct mp_vaapi_ctx *va_initialize(VADisplay *display, struct mp_log *plog,
     hwctx->free = free_device_ref;
     hwctx->user_opaque = res;
 
-#if VA_CHECK_VERSION(1, 0, 0)
     vaSetErrorCallback(display, va_error_callback, res);
     vaSetInfoCallback(display,  va_info_callback,  res);
-#endif
 
     int major, minor;
     int status = vaInitialize(display, &major, &minor);

--- a/wscript
+++ b/wscript
@@ -726,22 +726,22 @@ video_output_features = [
         'name': '--vaapi',
         'desc': 'VAAPI acceleration',
         'deps': 'libdl && (x11 || wayland || egl-drm)',
-        'func': check_pkg_config('libva', '>= 0.36.0'),
+        'func': check_pkg_config('libva', '>= 1.1.0'),
     }, {
         'name': '--vaapi-x11',
         'desc': 'VAAPI (X11 support)',
         'deps': 'vaapi && x11',
-        'func': check_pkg_config('libva-x11', '>= 0.36.0'),
+        'func': check_pkg_config('libva-x11', '>= 1.1.0'),
     }, {
         'name': '--vaapi-wayland',
         'desc': 'VAAPI (Wayland support)',
         'deps': 'vaapi && gl-wayland',
-        'func': check_pkg_config('libva-wayland', '>= 0.36.0'),
+        'func': check_pkg_config('libva-wayland', '>= 1.1.0'),
     }, {
         'name': '--vaapi-drm',
         'desc': 'VAAPI (DRM/EGL support)',
         'deps': 'vaapi && egl-drm',
-        'func': check_pkg_config('libva-drm', '>= 0.36.0'),
+        'func': check_pkg_config('libva-drm', '>= 1.1.0'),
     }, {
         'name': '--vaapi-x-egl',
         'desc': 'VAAPI EGL on X11',


### PR DESCRIPTION
In vaapi 1.1.0 (which confusingly is libva release 2.1.0), they
introduced a new surface export API that is more efficient, and
we've been supporting that and the old API ever since (Feb 2018).

If we drop support for the old API, we can do some fairly nice cleanup
of the code.

Note that the pkgconfig entries are explicitly versioned by the API
version and not the library version. I confirmed the upstream pkgconfig
files.
