### PR TITLE
cocoa_common: remove deprecated VOCTRLs/VO_EVENTs

### DIFF
--- a/video/out/cocoa/window.m
+++ b/video/out/cocoa/window.m
@@ -239,16 +239,6 @@
     [self.adapter windowDidBecomeKey:notification];
 }
 
-- (void)windowDidMiniaturize:(NSNotification *)notification
-{
-    [self.adapter windowDidMiniaturize:notification];
-}
-
-- (void)windowDidDeminiaturize:(NSNotification *)notification
-{
-    [self.adapter windowDidDeminiaturize:notification];
-}
-
 - (void)windowWillMove:(NSNotification *)notification
 {
     [self.adapter windowWillMove:notification];

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -867,15 +867,6 @@ static int vo_cocoa_control_on_main_thread(struct vo *vo, int request, void *arg
     struct vo_cocoa_state *s = vo->cocoa;
 
     switch (request) {
-    case VOCTRL_FULLSCREEN:
-        return vo_cocoa_fullscreen(vo);
-    case VOCTRL_GET_FULLSCREEN:
-        *(int *)arg = s->fullscreen;
-        return VO_TRUE;
-    case VOCTRL_ONTOP:
-        return vo_cocoa_ontop(vo);
-    case VOCTRL_BORDER:
-        return vo_cocoa_window_border(vo);
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {
         int *sz = arg;
         NSRect rect = (s->fullscreen || vo->opts->fullscreen) ?
@@ -892,11 +883,6 @@ static int vo_cocoa_control_on_main_thread(struct vo *vo, int request, void *arg
         if(vo->opts->hidpi_window_scale)
             r = [s->current_screen convertRectToBacking:r];
         queue_new_video_size(vo, r.size.width, r.size.height);
-        return VO_TRUE;
-    }
-    case VOCTRL_GET_WIN_STATE: {
-        const bool minimized = [[s->view window] isMiniaturized];
-        *(int *)arg = minimized ? VO_WIN_STATE_MINIMIZED : 0;
         return VO_TRUE;
     }
     case VOCTRL_SET_CURSOR_VISIBILITY:
@@ -1048,7 +1034,6 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
 {
     struct vo_cocoa_state *s = self.vout->cocoa;
     s->fullscreen = 1;
-    s->pending_events |= VO_EVENT_FULLSCREEN_STATE;
     vo_cocoa_anim_unlock(self.vout);
 }
 
@@ -1056,7 +1041,6 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
 {
     struct vo_cocoa_state *s = self.vout->cocoa;
     s->fullscreen = 0;
-    s->pending_events |= VO_EVENT_FULLSCREEN_STATE;
     vo_cocoa_anim_unlock(self.vout);
 }
 
@@ -1107,16 +1091,6 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
     vo_cocoa_update_cursor_visibility(self.vout, false);
-}
-
-- (void)windowDidMiniaturize:(NSNotification *)notification
-{
-    flag_events(self.vout, VO_EVENT_WIN_STATE);
-}
-
-- (void)windowDidDeminiaturize:(NSNotification *)notification
-{
-    flag_events(self.vout, VO_EVENT_WIN_STATE);
 }
 
 - (void)windowWillMove:(NSNotification *)notification


### PR DESCRIPTION
See commit 4e4252f9169edc and the following as an example how this would
have to be done if done properly.

Since I'm unable to test on OSX, and nobody is interested in fixing this
code (including myself, actually), just remove the deprecated
definitions to make sure the code still builds. This will break runtime
switching of fullscreen, ontop, border. (The way the minimized state is
reported was also deprecated, but commit 40c2f2eeb05 already broke it
anyway.)

---

CC @pigoz @Akemi 

I think it's OK to break it this way, since users should use the swift backend anyway. Maybe it should be disabled by default too, if it isn't already.

Making the PR mainly for the CI.