### PR TITLE
cocoa-cb: don't make window active when minimized on file change

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -81,6 +81,7 @@ class CocoaCB: NSObject {
 
     func uninit() {
         window?.orderOut(nil)
+        window?.close()
         mpv = nil
     }
 
@@ -129,6 +130,7 @@ class CocoaCB: NSObject {
         titleBar = TitleBar(frame: wr, window: window, cocoaCB: self)
 
         window.isRestorable = false
+        window.isReleasedWhenClosed = false
         window.makeMain()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -153,7 +155,10 @@ class CocoaCB: NSObject {
         }
 
         let wr = getWindowGeometry(forScreen: targetScreen, videoOut: vo)
-        if !(window?.isVisible ?? false) {
+        if !(window?.isVisible ?? false) &&
+           !(window?.isMiniaturized ?? false) &&
+           !NSApp.isHidden
+        {
             window?.makeKeyAndOrderFront(nil)
         }
         layer?.atomicDrawingStart()


### PR DESCRIPTION
this makes the behaviour more similar to the old cocoa backend.

one corner case that can't be completely fixed is, when minimized and a file without a video track is played (window is removed) and the next file has a video track again. when the next file is played the window is made active again again and deminimized. there is no way to add a window again without making it active/deminimize. this can be worked around with --force-window.