### PR TITLE
video/out/x11: add fs-screen fallback

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -77,6 +77,8 @@ Interface changes
       print a warning in this particular case.
     - deprecate -del for list options (use -remove instead, which is by content
       instead of by integer index)
+    - if `--fs` is used but `--fs-screen` is not set, mpv will now use `--screen`
+      instead.
  --- mpv 0.30.0 ---
     - add `--d3d11-output-format` to enable explicit selection of a D3D11
       swap chain format.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2582,8 +2582,8 @@ Window
 ``--fs-screen=<all|current|0-32>``
     In multi-monitor configurations (i.e. a single desktop that spans across
     multiple displays), this option tells mpv which screen to go fullscreen to.
-    If ``default`` is provided mpv will fallback on using the behavior
-    depending on what the user provided with the ``screen`` option.
+    If ``current`` is used mpv will fallback on what the user provided with
+    the ``screen`` option.
 
     .. admonition:: Note (X11)
 

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -473,6 +473,9 @@ static void vo_x11_update_screeninfo(struct vo *vo)
         XineramaScreenInfo *screens;
         int num_screens;
 
+        if (opts->fullscreen && opts->fsscreen_id == -1)
+            screen = opts->screen_id;
+
         screens = XineramaQueryScreens(x11->display, &num_screens);
         if (screen >= num_screens)
             screen = num_screens - 1;


### PR DESCRIPTION
Apparently there are two different options for controlling which screen an mpv window goes onto: --fs-screen and --screen. The former explicitly only controls which screen a fullscreened window goes onto, but does not appear to actually care about this option at runtime for X11, so pressing f will always fullscreen to the screen mpv is currently on. This means the option is of questionable usefulness for starters.

Making it worse, if you use --screen=1 --fs, mpv will actually fullscreen on screen 0, because --fs-screen isn't set. Instead of doing that, fall back to whatever --screen is set to.

Is `--fs-screen` really intended not to affect what happens at runtime at all? Because that's the current behaviour, I think, which seems counter-intuitive and possibly broken.
