### PR TITLE
osc: add option to disable santa hat

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -368,6 +368,11 @@ Configurable Options
     Supports ``left`` and ``right`` which will place the controls on those
     respective sides.
 
+``greenandgrumpy``
+    Default: no
+
+    Set to ``yes`` to reduce festivity (i.e. disable santa hat in December.)
+
 Script Commands
 ~~~~~~~~~~~~~~~
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -46,7 +46,8 @@ local user_opts = {
     boxmaxchars = 80,           -- title crop threshold for box layout
     boxvideo = false,           -- apply osc_param.video_margins to video
     windowcontrols = "auto",    -- whether to show window controls
-    windowcontrols_alignment = "right" -- which side to show window controls on
+    windowcontrols_alignment = "right", -- which side to show window controls on
+    greenandgrumpy = false,     -- disable santa hat
 }
 
 -- read options from config and command-line
@@ -2469,7 +2470,7 @@ function tick()
         end
 
         -- Santa hat
-        if is_december then
+        if is_december and not user_opts.greenandgrumpy then
             for i, line in ipairs(santa_hat_lines) do
                 ass:new_event()
                 ass:append(line_prefix .. line)


### PR DESCRIPTION
A minority of users have expressed a dislike of hats, calling them "cancer [that] don't belong in software" describing the people who add them as "shitty circlejerks" and "chucklefuck."

While I personally disagree with those opinions, it's probably easier to let them have it their way. For that reason this adds the option `greenandgrumpy` to the osc, which allows users to disable the hat.