### PR TITLE
lua: fix mp.file_info for large files

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -1131,7 +1131,10 @@ static int script_file_info(lua_State *L)
         "mode", "size",
         "atime", "mtime", "ctime", NULL
     };
-    const unsigned int stat_values[] = {
+
+    // using lua_Number as st_size can overflow 32-bit and
+    // lua_Integer might be 32-bit on some systems
+    const lua_Number stat_values[] = {
         statbuf.st_mode,
         statbuf.st_size,
         statbuf.st_atime,
@@ -1141,7 +1144,7 @@ static int script_file_info(lua_State *L)
 
     // Add all fields
     for (int i = 0; stat_names[i]; i++) {
-        lua_pushinteger(L, stat_values[i]);
+        lua_pushnumber(L, stat_values[i]);
         lua_setfield(L, -2, stat_names[i]);
     }
 


### PR DESCRIPTION
`size` field with `unsigned int` was truncated to 4GB
