### PR TITLE
stream_dvb: Remove implicit fallthroughs

### DIFF
--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -378,7 +378,13 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                 }
                 if (!DELSYS_IS_SET(delsys_mask, delsys))
                     continue; /* Skip channel. */
-               /* PASSTROUTH */
+                mp_verbose(log, "VDR, %s, NUM: %d, NUM_FIELDS: %d, NAME: %s, "
+                           "FREQ: %d, SRATE: %d, T2: %s",
+                           get_dvb_delsys(delsys),
+                           list->NUM_CHANNELS, fields,
+                           ptr->name, ptr->freq, ptr->srate,
+                           (delsys == SYS_DVBT2) ? "yes" : "no");
+                break;
             case SYS_DVBC_ANNEX_A:
             case SYS_DVBC_ANNEX_C:
             case SYS_ATSC:
@@ -418,7 +424,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                     }
                 }
 
-                mp_verbose(log, "%s NUM: %d, NUM_FIELDS: %d, NAME: %s, "
+                mp_verbose(log, "VDR, %s, NUM: %d, NUM_FIELDS: %d, NAME: %s, "
                            "FREQ: %d, SRATE: %d, POL: %c, DISEQC: %d, S2: %s, "
                            "StreamID: %d, SID: %d",
                            get_dvb_delsys(delsys),
@@ -1197,14 +1203,16 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                 case SYS_DVBT:
                     if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBT2))
                         continue; /* Add all channels later with T2. */
-                    /* PASSTOUTH */
+                    conf_file_name = "channels.conf.ter";
+                    break;
                 case SYS_DVBT2:
                     conf_file_name = "channels.conf.ter";
                     break;
                 case SYS_DVBS:
                     if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBS2))
                         continue; /* Add all channels later with S2. */
-                    /* PASSTOUTH */
+                    conf_file_name = "channels.conf.sat";
+                    break;
                 case SYS_DVBS2:
                     conf_file_name = "channels.conf.sat";
                     break;


### PR DESCRIPTION
This silences the warnings (and fixes the typo in the comment
which marked the fallthrough as explicit before).

@wm4: I'm opening this minimalistic change as a PR since I am not sure if we want this attribute markup in the code. If you prefer the comment markup (leaving the warnings in), feel free to close. 

Redesigning the code to avoid the fallthroughs would mean reworking the logic, which I'd love to avoid - actually, I think we have one of the extra-rare cases here where explicit fallthroughs in some branches of the case statement are helpful to improve readability. 