### PR TITLE
configfiles: Fix utime retcode check

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -177,7 +177,7 @@ static bool copy_mtime(const char *f1, const char *f2)
         .modtime = st1.st_mtime,
     };
 
-    if (!utime(f2, &ut))
+    if (utime(f2, &ut) != 0)
         return false;
 
     return true;


### PR DESCRIPTION
In final fixups for #7139 it seems I managed to screw up utime error
checks. Everything still works, but we MP_WARN when we don't need to.