### PR TITLE
Only punish GNOME wayland users

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -78,14 +78,14 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_GL_DXINTEROP
     &ra_ctx_dxgl,
 #endif
+#if HAVE_GL_WAYLAND
+    &ra_ctx_wayland_egl,
+#endif
 #if HAVE_EGL_X11
     &ra_ctx_x11_egl,
 #endif
 #if HAVE_GL_X11
     &ra_ctx_glx,
-#endif
-#if HAVE_GL_WAYLAND
-    &ra_ctx_wayland_egl,
 #endif
 #if HAVE_EGL_DRM
     &ra_ctx_drm_egl,
@@ -100,11 +100,11 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_WIN32_DESKTOP
     &ra_ctx_vulkan_win,
 #endif
-#if HAVE_X11
-    &ra_ctx_vulkan_xlib,
-#endif
 #if HAVE_WAYLAND
     &ra_ctx_vulkan_wayland,
+#endif
+#if HAVE_X11
+    &ra_ctx_vulkan_xlib,
 #endif
 
 #endif

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1110,6 +1110,10 @@ int vo_wayland_init(struct vo *vo)
     if (create_xdg_surface(wl))
         return false;
 
+    const char *xdg_current_desktop = getenv("XDG_CURRENT_DESKTOP");
+    if (xdg_current_desktop != NULL && strstr(xdg_current_desktop, "GNOME"))
+        MP_WARN(wl, "GNOME's wayland compositor is known to have many serious issues with mpv. Switch to GNOME's xorg session for the best experience.\n");
+
     if (wl->dnd_devman && wl->seat) {
         wl->dnd_ddev = wl_data_device_manager_get_data_device(wl->dnd_devman, wl->seat);
         wl_data_device_add_listener(wl->dnd_ddev, &data_device_listener, wl);


### PR DESCRIPTION
Here's a compromise for the little wayland controversy earlier. The TL;DR is that gnome=bad, but everyone else works. I don't think it's fair to force sway users (that includes me) or anyone else to default to xwayland when the wayland backend works just fine on it.

Basically the just does two things: skip wayland on the autoprobe if GNOME is being used (i.e. use xwayland) and also explicitly print warnings that GNOME wayland is bad so hopefully users will be more encouraged to bug them and not us. It's also worth noting that xwayland is still  bad on GNOME, but there's less cosmetic issues so I figured it was worthwhile to do that.

I actually wasn't able to test explicitly setting `--gpu-context=wayland/waylandvk` on GNOME because it gave me mysterious display errors that I didn't care to try and solve but in theory it should print out the warning as well. `XDG_CURRENT_DESKTOP` seemed to be the correct environment variable to use for this. Hopefully this is set everywhere and has "GNOME" in its name somewhere.