### PR TITLE
osc: reset input handling state on a change in visibility mode

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2671,6 +2671,13 @@ function visibility_mode(mode, no_osd)
         mp.osd_message("OSC visibility: " .. mode)
     end
 
+    -- Reset the input state on a mode change. The input state will be
+    -- recalcuated on the next render cycle, except in 'never' mode where it
+    -- will just stay disabled.
+    mp.disable_key_bindings("input")
+    mp.disable_key_bindings("window-controls")
+    state.input_enabled = false
+
     update_margins()
     request_tick()
 end


### PR DESCRIPTION
Currently, the activation and deactivation of input handling is done
inside the render() loop, but this does not run when the osc mode is
`never` - which does make sense.

That means that if you are cycling the visibility mode, the input
state will be whatever it was at the time of the mode change. And,
as our modes are ordered `auto` -> `always` -> `never`, the input
state will be enabled when you cycle to `never`.

There are various ways you can imagine fixing this, and in this
change I propose we reset the input state to disabled on a mode
change, and then let render() re-enable input if that's appropriate.

Fixes #7298.
