### PR TITLE
github: add several issue templates and a warning to not ignore them

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_dont_ignore.md
+++ b/.github/ISSUE_TEMPLATE/1_dont_ignore.md
@@ -1,0 +1,16 @@
+---
+name: 'README: DO NOT IGNORE OR DELETE THE ISSUE TEMPLATE'
+about: 'Chose and fill out one of the following templates!'
+title: ''
+labels: priority:ignored-issue-template
+assignees: ''
+
+---
+
+We ask you to not ignore the issue template. Fill it out as good and correct as
+possible. Issues that don't adhere to our request will be closed for ignoring
+the issue template. This is because analyzing a bug without a log file is harder
+than necessary. Low quality bug reports are noise.
+
+Please go back and chose the proper issue template. Opening issues with this
+template will be closed immediately.

--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.md
@@ -1,0 +1,46 @@
+---
+name: 'Report a Linux Bug'
+about: 'Create a report for a runtime related Linux Bug'
+title: ''
+labels: 'os:linux'
+assignees: ''
+
+---
+
+### Important Information
+
+Provide following Information:
+- mpv version
+- Linux Distribution and Version
+- Source of the mpv binary
+- If known which version of mpv introduced the problem
+- Window Manager and version
+- GPU driver and version
+- Possible screenshot or video of visual glitches
+
+If you're not using git master or the latest release, update.
+Releases are listed here: https://github.com/mpv-player/mpv/releases
+
+### Reproduction steps
+
+Describe the reproduction steps as precise as possible. It's very likely that
+the bug you experience wasn't reproduced by the developer because the workflow
+differes from your own.
+
+### Expected behavior
+
+### Actual behavior
+
+### Log file
+
+Make a log file made with -v -v or --log-file=output.txt, paste it to
+https://0x0.st/ or attach it to the github issue, and replace this text with a
+link to it.
+
+The issue will be closed for ignoring the issue template.
+
+### Sample files
+
+Sample files needed to reproduce this issue can be uploaded to https://0x0.st/
+or similar sites. (Only needed if the issue cannot be reproduced without it.)
+Do not use garbage like "cloud storage", especially not Google Drive.

--- a/.github/ISSUE_TEMPLATE/2_bug_report_macos.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_macos.md
@@ -1,0 +1,46 @@
+---
+name: 'Report a macOS Bug'
+about: 'Create a report for a runtime related macOS Bug'
+title: ''
+labels: 'os:mac'
+assignees: ''
+
+---
+
+### Important Information
+
+Provide following Information:
+- mpv version
+- macOS Version
+- Source of the mpv binary or bundle
+- If known which version of mpv introduced the problem
+- Possible screenshot or video of visual glitches
+
+If you're not using git master or the latest release, update.
+Releases are listed here: https://github.com/mpv-player/mpv/releases
+
+### Reproduction steps
+
+Describe the reproduction steps as precise as possible. It's very likely that
+the bug you experience wasn't reproduced by the developer because the workflow
+differes from your own.
+
+### Expected behavior
+
+### Actual behavior
+
+### Log file
+
+Make a log file made with -v -v or --log-file=output.txt, paste it to
+https://0x0.st/ or attach it to the github issue, and replace this text with a
+link to it.
+
+In the case of a crash please provide the macOS Crash Report (Backtrace).
+
+The issue will be closed for ignoring the issue template.
+
+### Sample files
+
+Sample files needed to reproduce this issue can be uploaded to https://0x0.st/
+or similar sites. (Only needed if the issue cannot be reproduced without it.)
+Do not use garbage like "cloud storage", especially not Google Drive.

--- a/.github/ISSUE_TEMPLATE/2_bug_report_windows.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_windows.md
@@ -1,0 +1,44 @@
+---
+name: 'Report a Windows Bug'
+about: 'Create a report for a runtime related Windows Bug'
+title: ''
+labels: 'os:win'
+assignees: ''
+
+---
+
+### Important Information
+
+Provide following Information:
+- mpv version
+- Windows Version
+- Source of the mpv binary
+- If known which version of mpv introduced the problem
+- Possible screenshot or video of visual glitches
+
+If you're not using git master or the latest release, update.
+Releases are listed here: https://github.com/mpv-player/mpv/releases
+
+### Reproduction steps
+
+Describe the reproduction steps as precise as possible. It's very likely that
+the bug you experience wasn't reproduced by the developer because the workflow
+differes from your own.
+
+### Expected behavior
+
+### Actual behavior
+
+### Log file
+
+Make a log file made with -v -v or --log-file=output.txt, paste it to
+https://0x0.st/ or attach it to the github issue, and replace this text with a
+link to it.
+
+The issue will be closed for ignoring the issue template.
+
+### Sample files
+
+Sample files needed to reproduce this issue can be uploaded to https://0x0.st/
+or similar sites. (Only needed if the issue cannot be reproduced without it.)
+Do not use garbage like "cloud storage", especially not Google Drive.

--- a/.github/ISSUE_TEMPLATE/3_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.md
@@ -1,9 +1,27 @@
-### mpv version and platform
+---
+name: 'Report a Bug for a different Platform'
+about: 'Create a report for a runtime related Bug'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Important Information
+
+Provide following Information:
+- mpv version
+- Platform and Version
+- Source of the mpv binary
 
 If you're not using git master or the latest release, update.
 Releases are listed here: https://github.com/mpv-player/mpv/releases
 
 ### Reproduction steps
+
+Describe the reproduction steps as precise as possible. It's very likely that
+the bug you experience wasn't reproduced by the developer because the workflow
+differes from your own.
 
 ### Expected behavior
 
@@ -13,11 +31,7 @@ Releases are listed here: https://github.com/mpv-player/mpv/releases
 
 Make a log file made with -v -v or --log-file=output.txt, paste it to
 https://0x0.st/ or attach it to the github issue, and replace this text with a
-link to it. If the issue is a build failure, upload build/config.log instead.
-
-If this is a normal runtime bug, and no log is provided, the issue will be
-closed for ignoring the issue template. This is because analyzing a bug without
-a log file is harder than necessary. Low quality bug reports are noise.
+link to it.
 
 ### Sample files
 

--- a/.github/ISSUE_TEMPLATE/4_bug_report_build.md
+++ b/.github/ISSUE_TEMPLATE/4_bug_report_build.md
@@ -1,0 +1,30 @@
+---
+name: 'Report a build Problem'
+about: 'Create a report for a build related Bug'
+title: ''
+labels: 'core:waf'
+assignees: ''
+
+---
+
+### mpv version and platform versions
+
+If you're not using git master or the latest release, update.
+Releases are listed here: https://github.com/mpv-player/mpv/releases
+
+### Reproduction steps
+
+Describe the reproduction steps as precise as possible. It's very likely that
+the bug you experience wasn't reproduced by the developer because the workflow
+differes from your own.
+
+### Expected behavior
+
+### Actual behavior
+
+### Log file
+
+Upload build/config.log or ./waf configure output to https://0x0.st/ or attach
+it to the github issue, and replace this text with a link to it.
+
+The issue will be closed for ignoring the issue template.

--- a/.github/ISSUE_TEMPLATE/5_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/5_feature_request.md
@@ -1,0 +1,15 @@
+---
+name: 'Request a new Feature'
+about: 'Create a request for a new feature'
+title: ''
+labels: 'meta:feature-request'
+assignees: ''
+
+---
+
+Before requesting a new feature make sure it hasn't been requested yet.
+https://github.com/mpv-player/mpv/labels/meta%3Afeature-request
+
+### Expected behavior of the wanted feature
+
+### Alternative behavior of the wanted feature

--- a/.github/ISSUE_TEMPLATE/6_question.md
+++ b/.github/ISSUE_TEMPLATE/6_question.md
@@ -1,0 +1,11 @@
+---
+name: 'Ask a Question'
+about: 'Ask a question about mpv'
+title: ''
+labels: 'meta:question'
+assignees: ''
+
+---
+
+Before asking a question make sure it hasn't been asked or answered yet.
+https://github.com/mpv-player/mpv/labels/meta%3Aquestion

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: mpv irc channel
+    url: https://mpv.io/community/
+    about: Feel free to ask question here irc://irc.freenode.net/mpv
+  - name: mpv irc developer channel
+    url: https://mpv.io/community/
+    about: Ask question related to the development of mpv here
+           irc://irc.freenode.net/mpv-devel


### PR DESCRIPTION
i split up the issue template for our 3 major platforms, build problems, feature requests and questions. those templates are automatically labelled with the respective applicable labels.  otherwise there is one 'blank' issue template that doesn't fall in any category and a prominent `do not ignore the issue template` message.

furthermore the linux template needs some more adjustments, since i am not sure for what info we should ask for (marked with the question mark in the template for now).

live demo can be seen here https://github.com/Akemi/mpv/issues/new/choose

sadly one can't create direct contact_links for the irc channels. apparently the url can't start with irc://