### PR TITLE
DOCS: update *-add usage to reflect multiple items being deprecated

### DIFF
--- a/DOCS/encoding.rst
+++ b/DOCS/encoding.rst
@@ -30,9 +30,13 @@ section::
   [myencprofile]
   vf-add = scale=480:-2
   ovc = libx264
-  ovcopts-add = preset=medium,tune=fastdecode
+  ovcopts-add = preset=medium
+  ovcopts-add = tune=fastdecode
   ovcopts-add = crf=23
-  ovcopts-add = maxrate=1500k,bufsize=1000k,rc_init_occupancy=900k,refs=2
+  ovcopts-add = maxrate=1500k
+  ovcopts-add = bufsize=1000k
+  ovcopts-add = rc_init_occupancy=900k
+  ovcopts-add = refs=2
   ovcopts-add = profile=baseline
   oac = aac
   oacopts-add = b=96k

--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -17,8 +17,9 @@ You can encode files from one format/codec to another using this facility.
 
     This is a key/value list option. See `List Options`_ for details.
 
-    ``--ofopts-add=<options1[,options2,...]>``
-        Appends the options given as arguments to the options list.
+    ``--ofopts-add=<option>``
+        Appends the option given as an argument to the options list. (Passing
+        multiple options is currently still possible, but deprecated.)
 
     ``--ofopts=""``
         Completely empties the options list.
@@ -42,8 +43,9 @@ You can encode files from one format/codec to another using this facility.
 
     This is a key/value list option. See `List Options`_ for details.
 
-    ``--oacopts-add=<options1[,options2,...]>``
-        Appends the options given as arguments to the options list.
+    ``--oacopts-add=<option>``
+        Appends the option given as an argument to the options list. (Passing
+        multiple options is currently still possible, but deprecated.)
 
     ``--oacopts=""``
         Completely empties the options list.
@@ -74,8 +76,9 @@ You can encode files from one format/codec to another using this facility.
 
     This is a key/value list option. See `List Options`_ for details.
 
-    ``--ovcopts-add=<options1[,options2,...]>``
-        Appends the options given as arguments to the options list.
+    ``--ovcopts-add=<option>``
+        Appends the option given as an argument to the options list. (Passing
+        multiple options is currently still possible, but deprecated.)
 
     ``--ovcopts=""``
         Completely empties the options list.


### PR DESCRIPTION
4a2f268f67b1505630724b6f8df960fce25770f0 changed the `-add` usage to `-append` in the encoding_profiles.conf so that may be better for this encoding.rst change.

https://github.com/mpv-player/mpv/blob/9eb399193eda34612a016f0310cb4b2aebaabaa1/DOCS/man/mpv.rst L502, 527, 546 still have `-add          Append 1 or more filters (same syntax as -set)` which is technically correct, but doesn't mention that this is a deprecated feature. Not sure how/if I should've updated these.