### PR TITLE
osc: when fullscreened, un-maximise window control should un-fullscreen

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1065,13 +1065,19 @@ function window_controls(topbar)
 
     -- Maximize: 🗖 /🗗
     ne = new_element("maximize", "button")
-    if state.maximized then
+    if state.maximized or state.fullscreen then
         ne.content = "\238\132\148"
     else
         ne.content = "\238\132\147"
     end
     ne.eventresponder["mbtn_left_up"] =
-        function () mp.commandv("cycle", "window-maximized") end
+        function ()
+            if state.fullscreen then
+                mp.commandv("cycle", "fullscreen")
+            else
+                mp.commandv("cycle", "window-maximized")
+            end
+        end
     lo = add_layout("maximize")
     lo.geometry = alignment == "left" and third_geo or second_geo
     lo.style = osc_styles.wcButtons


### PR DESCRIPTION
It's a bit unintuitive today when you use the un-maximise control
while fullscreened. Depending on the VO in use, this might silently
change the maximise state without any visible effect, or it might
do nothing. It's less surprising if the control exits the fullscreen
state.

Note that the exact behaviour is still VO dependent. If the window
was maximised before being fullscreened, it might exit fullscreen
back to maximised or back to regular window mode.

I thought about trying to explicitly control that behaviour but
it makes the osc code weird and probably wouldn't work all the time.