### PR TITLE
wayland: support maximize/minimize on startup

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1314,6 +1314,12 @@ int vo_wayland_reconfig(struct vo *vo)
         }
     }
 
+    if (wl->vo_opts->window_maximized)
+        xdg_toplevel_set_maximized(wl->xdg_toplevel);
+
+    if (wl->vo_opts->window_minimized)
+        xdg_toplevel_set_minimized(wl->xdg_toplevel);
+
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
     wl_surface_commit(wl->surface);
     wl->pending_vo_events |= VO_EVENT_RESIZE;


### PR DESCRIPTION
Allow the --window-maximized and --window-minimized flags to actually
work when the player is started on wayland. If the compositor doesn't
support maximization or minimization, then these options just do
nothing.