### PR TITLE
input: don't cycle pause property, mac: report playback state

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -149,6 +149,8 @@
 #PLAY cycle pause
 #PAUSE cycle pause
 #PLAYPAUSE cycle pause
+#PLAYONLY set pause no
+#PAUSEONLY set pause yes
 #STOP quit
 #FORWARD seek 60
 #REWIND seek -60

--- a/input/keycodes.c
+++ b/input/keycodes.c
@@ -151,6 +151,8 @@ static const struct key_name key_names[] = {
   { MP_KEY_RECORD,      "RECORD" },
   { MP_KEY_CHANNEL_UP,  "CHANNEL_UP" },
   { MP_KEY_CHANNEL_DOWN,"CHANNEL_DOWN" },
+  { MP_KEY_PLAYONLY,    "PLAYONLY" },
+  { MP_KEY_PAUSEONLY,   "PAUSEONLY" },
 
   // These are kept for backward compatibility
   { MP_KEY_PAUSE,   "XF86_PAUSE" },

--- a/input/keycodes.h
+++ b/input/keycodes.h
@@ -80,6 +80,8 @@
 #define MP_KEY_RECORD           (MP_KEY_MM_BASE+20)
 #define MP_KEY_CHANNEL_UP       (MP_KEY_MM_BASE+21)
 #define MP_KEY_CHANNEL_DOWN     (MP_KEY_MM_BASE+22)
+#define MP_KEY_PLAYONLY         (MP_KEY_MM_BASE+23)
+#define MP_KEY_PAUSEONLY        (MP_KEY_MM_BASE+24)
 
 /*  Function keys  */
 #define MP_KEY_F (MP_KEY_BASE+0x40)

--- a/osdep/macos/remote_command_center.swift
+++ b/osdep/macos/remote_command_center.swift
@@ -27,11 +27,11 @@ class RemoteCommandCenter: NSObject {
 
     var config: [MPRemoteCommand:[String:Any]] = [
         MPRemoteCommandCenter.shared().pauseCommand: [
-            "mpKey": MP_KEY_PAUSE,
+            "mpKey": MP_KEY_PAUSEONLY,
             "keyType": KeyType.normal
         ],
         MPRemoteCommandCenter.shared().playCommand: [
-            "mpKey": MP_KEY_PLAY,
+            "mpKey": MP_KEY_PLAYONLY,
             "keyType": KeyType.normal
         ],
         MPRemoteCommandCenter.shared().stopCommand: [
@@ -47,7 +47,7 @@ class RemoteCommandCenter: NSObject {
             "keyType": KeyType.normal
         ],
         MPRemoteCommandCenter.shared().togglePlayPauseCommand: [
-            "mpKey": MP_KEY_PLAYPAUSE,
+            "mpKey": MP_KEY_PLAY,
             "keyType": KeyType.normal
         ],
         MPRemoteCommandCenter.shared().seekForwardCommand: [

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -174,6 +174,12 @@ static const char macosx_icon[] =
     if ([self respondsToSelector:@selector(touchBar)])
         [(TouchBar *)self.touchBar processEvent:event];
 #endif
+#if HAVE_MACOS_MEDIA_PLAYER
+    // 10.12.2 runtime availability check
+    if ([self respondsToSelector:@selector(touchBar)]) {
+        [_remoteCommandCenter processEvent:event];
+    }
+#endif
     if (_cocoa_cb) {
         [_cocoa_cb processEvent:event];
     }


### PR DESCRIPTION
this changes some input commands and might break some other use cases. imo PLAY and PAUSE should explicitly set the proper pause state and only PLAYPAUSE should cycle the pause state.

i am not sure if there is a reason for this. the MP_KEY_* events are used in following files, so we need a bit of input of the related persons, @wm4 @philipl @sfan5 @rossy @Dudemanguy 

sry if i forgot someone.

osdep/w32_keyboard.c
video/out/vo_caca.c
video/out/wayland_common.c
video/out/vo_sdl.c
video/out/x11_common.c