### PR TITLE
options.lua: fixed bug when detecting changes to script-opts

### DIFF
--- a/player/lua/options.lua
+++ b/player/lua/options.lua
@@ -144,15 +144,17 @@ local function read_options(options, identifier, on_update)
             local new_opts = opt_table_copy(conf_and_default_opts)
             parse_opts(val, new_opts)
             local changelist = {}
+            local changed = false
             for key, val in pairs(new_opts) do
                 if not opt_equal(last_opts[key], val) then
                     -- copy to user
                     options[key] = opt_copy(val)
                     changelist[key] = true
+                    changed = true
                 end
             end
             last_opts = new_opts
-            if #changelist then
+            if changed then
                 on_update(changelist)
             end
         end)

--- a/player/lua/options.lua
+++ b/player/lua/options.lua
@@ -144,17 +144,15 @@ local function read_options(options, identifier, on_update)
             local new_opts = opt_table_copy(conf_and_default_opts)
             parse_opts(val, new_opts)
             local changelist = {}
-            local changed = false
             for key, val in pairs(new_opts) do
                 if not opt_equal(last_opts[key], val) then
                     -- copy to user
                     options[key] = opt_copy(val)
                     changelist[key] = true
-                    changed = true
                 end
             end
             last_opts = new_opts
-            if changed then
+            if next(changelist) ~= nil then
                 on_update(changelist)
             end
         end)


### PR DESCRIPTION
options.lua was set up to only call the on_update function when the
size of changelist was not nil, a.k.a. when there were changes to that
particular scripts' options.

However, lua seems to measure the size as 0 by default, and since this
isn't an array the size never accurately measured the changes anyway.
Therefore, the function was being called any time script opts changed.

This commit uses the next() function to test if changelist is empty.

This changes the behavior to match what was discussed in:
https://github.com/mpv-player/mpv/commit/12843dcea10f2b474aa7ffdee007999caad77762


I've done some tests and everything seems to be working.