### PR TITLE
wayland: remove wayland-frame-wait-offset option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4986,15 +4986,6 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     Currently only relevant for ``--gpu-api=d3d11``.
 
-``--wayland-frame-wait-offset=<-500..3000>``
-    Control the amount of offset (in microseconds) to add to wayland's frame wait
-    (default 1000). The wayland context assumes that if frame callback or presentation
-    feedback isn't received within a certain amount of time then the video is being
-    rendered offscreen. The time it waits is equal to how long it takes your monitor
-    to display a frame (i.e. 1/refresh rate) plus the offset. In general, staying
-    close to your monitor's refresh rate is preferred, but with a small offset in
-    case a frame takes a little long to display.
-
 ``--wayland-disable-vsync=<yes|no>``
     Disable vsync for the wayland contexts (default: no). Useful for benchmarking
     the wayland context when combined with ``video-sync=display-desync``,

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -142,7 +142,7 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 
     eglSwapBuffers(p->egl_display, p->egl_surface);
     if (!wl->opts->disable_vsync)
-        vo_wayland_wait_frame(wl, wl->opts->frame_offset);
+        vo_wayland_wait_frame(wl);
 
     if (wl->presentation)
         wayland_sync_swap(wl);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -111,7 +111,7 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
     }
 
     if (!wl->opts->disable_vsync)
-        vo_wayland_wait_frame(wl, wl->opts->frame_offset);
+        vo_wayland_wait_frame(wl);
 
     if (wl->presentation)
         wayland_sync_swap(wl);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -45,7 +45,6 @@
 #define OPT_BASE_STRUCT struct wayland_opts
 const struct m_sub_options wayland_conf = {
     .opts = (const struct m_option[]) {
-        OPT_INTRANGE("wayland-frame-wait-offset", frame_offset, 0, -500, 3000),
         OPT_FLAG("wayland-disable-vsync", disable_vsync, 0),
         OPT_INTRANGE("wayland-edge-pixels-pointer", edge_pixels_pointer, 10, 0, INT_MAX),
         OPT_INTRANGE("wayland-edge-pixels-touch", edge_pixels_touch, 64, 0, INT_MAX),
@@ -53,7 +52,6 @@ const struct m_sub_options wayland_conf = {
     },
     .size = sizeof(struct wayland_opts),
     .defaults = &(struct wayland_opts) {
-        .frame_offset = 1000,
         .disable_vsync = false,
         .edge_pixels_pointer = 10,
         .edge_pixels_touch = 64,
@@ -1587,14 +1585,14 @@ void vo_wayland_wakeup(struct vo *vo)
     (void)write(wl->wakeup_pipe[1], &(char){0}, 1);
 }
 
-void vo_wayland_wait_frame(struct vo_wayland_state *wl, int frame_offset)
+void vo_wayland_wait_frame(struct vo_wayland_state *wl)
 {
     struct pollfd fds[1] = {
         {.fd = wl->display_fd,     .events = POLLIN },
     };
 
     double vblank_time = 1e6 / wl->current_output->refresh_rate;
-    int64_t finish_time = mp_time_us() + vblank_time + (int64_t)frame_offset;
+    int64_t finish_time = mp_time_us() + vblank_time;
 
     while (wl->frame_wait && finish_time > mp_time_us()) {
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -26,7 +26,6 @@
 #include "input/event.h"
 
 struct wayland_opts {
-    int frame_offset;
     int disable_vsync;
     int edge_pixels_pointer;
     int edge_pixels_touch;
@@ -148,7 +147,7 @@ void vo_wayland_check_events(struct vo *vo);
 void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wakeup(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
-void vo_wayland_wait_frame(struct vo_wayland_state *wl, int frame_offset);
+void vo_wayland_wait_frame(struct vo_wayland_state *wl);
 void wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_sync_shift(struct vo_wayland_state *wl);
 void queue_new_sync(struct vo_wayland_state *wl);


### PR DESCRIPTION
This originally existed as a hack for weston. In certain scenarios, a
frame taking too long to render would cause vo_wayland_wait_frame to
timeout which would result in a ton of dropped frames. The naive
solution was to just to add a slight delay to the time value. If a
frame took too long, it would likely to fall under the timeout value and
all was well. This was exposed to the user since the default delay
(1000) was completely arbitrary.

However with presentation time, this doesn't appear to be neccesary.
Fresh frames that take longer than the display's refresh rate (16.666 ms
in most cases) behave well in Weston. In the other two main compositors
without presentation time (GNOME and Plasma), they also do not
experience any ill effects. It's better not to overcomplicate things, so
this "feature" can be removed now.