### PR TITLE
ao_wasapi_utils: remove invalid audio session icon path (fixes #7269)

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -525,9 +525,8 @@ static void init_session_display(struct wasapi_state *state) {
                                          (void **)&state->pSessionControl);
     EXIT_ON_ERROR(hr);
 
-    wchar_t path[MAX_PATH+12] = {0};
+    wchar_t path[MAX_PATH] = {0};
     GetModuleFileNameW(NULL, path, MAX_PATH);
-    wcscat(path, L",-IDI_ICON1");
     hr = IAudioSessionControl_SetIconPath(state->pSessionControl, path, NULL);
     if (FAILED(hr)) {
         // don't goto exit_label here since SetDisplayName might still work


### PR DESCRIPTION
MPV audio sessions on Windows had an invalid audio session icon path, forcing mixer applications (e.g. sndvol, [EarTrumpet](https://github.com/File-New-Project/EarTrumpet/commit/880fa07a98ab482e9295d995cf95c2d20109b8fd)) to fallback to other methods of finding a usable icon. (It was neither a valid path or a properly formed [indirect string](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-privateextracticonsw).) `init_session_display` will now set a valid audio session icon path.