### PR TITLE
js: require: don't use ~~/scripts/modules.js/

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,9 @@ Interface changes
     - directories in ~/.mpv/scripts/ (or equivalent) now have special semantics
       (see mpv Lua scripting docs)
     - names starting with "." in ~/.mpv/scripts/ (or equivalent) are now ignored
+    - js modules: ~~/scripts/modules.js/ is no longer used, common global path
+      can be set via script-opts/js-modules_common, directory scripts first
+      search at modules/ inside the directory.
  --- mpv 0.32.0 ---
     - change behavior when using legacy option syntax with options that start
       with two dashes (``--`` instead of a ``-``). Now, using the recommended

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,9 +28,8 @@ Interface changes
     - directories in ~/.mpv/scripts/ (or equivalent) now have special semantics
       (see mpv Lua scripting docs)
     - names starting with "." in ~/.mpv/scripts/ (or equivalent) are now ignored
-    - js modules: ~~/scripts/modules.js/ is no longer used, common global path
-      can be set via script-opts/js-modules_common, directory scripts first
-      search at modules/ inside the directory.
+    - js modules: ~~/scripts/modules.js/ is no longer used, common global paths
+      can be set via --js-require-paths, dir-scripts first check <dir>/modules/
  --- mpv 0.32.0 ---
     - change behavior when using legacy option syntax with options that start
       with two dashes (``--`` instead of a ``-``). Now, using the recommended

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -300,19 +300,21 @@ do work. In general, this is for mpv modules and not a node.js replacement.
 A ``.js`` file extension is always added to ``id``, e.g. ``require("./foo")``
 will load the file ``./foo.js`` and return its ``exports`` object.
 
-An id is relative (to the script which ``require``'d it) if it starts with
-``./`` or ``../``. Otherwise, it's considered a "top-level id" (CommonJS term).
+An id which starts with ``./`` or ``../`` is relative to the script or module
+which ``require`` it. Otherwise it's considered a top-level id.
 
-Top level id is evaluated as absolute filesystem path if possible, e.g. ``/x/y``
-or ``~/x``. Otherwise, it's considered a global module id and searched at
-``scripts/modules.js/`` in mpv config dirs - in normal config search order. E.g.
-``require("x")`` is searched as file ``x.js`` at those dirs, and id ``foo/x`` is
-searched as file ``x.js`` inside dir ``foo`` at those dirs.
+Top-level id is evaluated as absolute filesystem path if possible, e.g. ``/x/y``
+or ``~/x``. Otherwise it's considered a global module id and searched according
+to ``mp.module_paths`` in normal array order, e.g. ``require("x")`` tries to
+load ``x.js`` at one of the array paths, and id ``foo/x`` tries to load ``x.js``
+inside dir ``foo`` at one of the paths.
 
-Search paths for global module id's are at the array ``mp.module_paths``, which
-is searched in order. Initially it contains one item: ``~~/scripts/modules.js``
-such that it behaves as described above. Modifying it will affect future
-``require`` calls with global module id's which are not already loaded/cached.
+``mp.module_paths`` is empty by default except for scripts which are loaded as
+a directory, where it contains one path - ``modules/`` inside that directory.
+Additionally the option ``--script-opts=js-modules_common=...`` can be used to
+append one common global path to this array which applies to all scripts.
+Modifying ``mp.module_paths`` from a script will affect future ``require`` calls
+of global module id's which are not already loaded/cached.
 
 No ``global`` variable, but a module's ``this`` at its top lexical scope is the
 global object - also in strict mode. If you have a module which needs ``global``

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -309,10 +309,10 @@ to ``mp.module_paths`` in normal array order, e.g. ``require("x")`` tries to
 load ``x.js`` at one of the array paths, and id ``foo/x`` tries to load ``x.js``
 inside dir ``foo`` at one of the paths.
 
-``mp.module_paths`` is empty by default except for scripts which are loaded as
-a directory, where it contains one path - ``modules/`` inside that directory.
-Additionally the option ``--script-opts=js-modules_common=...`` can be used to
-append one common global path to this array which applies to all scripts.
+The ``mp.module_paths`` array is initialized from the ``--js-require-paths``
+option which is empty by default. Scripts which are loaded as directory always
+prepend ``<directory>/modules/`` to the array, i.e. with highest priority.
+(``--js-require-paths`` is a path list option, see `List Options`_ for details).
 Modifying ``mp.module_paths`` from a script will affect future ``require`` calls
 of global module id's which are not already loaded/cached.
 

--- a/options/options.c
+++ b/options/options.c
@@ -398,6 +398,9 @@ static const m_option_t mp_opts[] = {
     OPT_FLAG("load-stats-overlay", lua_load_stats, UPDATE_BUILTIN_SCRIPTS),
     OPT_FLAG("load-osd-console", lua_load_console, UPDATE_BUILTIN_SCRIPTS),
 #endif
+#if HAVE_JAVASCRIPT
+    OPT_PATHLIST("js-require-paths", js_require_paths, M_OPT_FILE),
+#endif
 
 // ------------------------- stream options --------------------
 

--- a/options/options.h
+++ b/options/options.h
@@ -137,6 +137,7 @@ typedef struct MPOpts {
     char **lua_ytdl_raw_options;
     int lua_load_stats;
     int lua_load_console;
+    char **js_require_paths;
 
     int auto_load_scripts;
 

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -59,6 +59,7 @@ static const char *const builtin_files[][3] = {
 // Represents a loaded script. Each has its own js state.
 struct script_ctx {
     const char *filename;
+    const char *path; // NULL if single file
     struct mpv_handle *client;
     struct MPContext *mpctx;
     struct mp_log *log;
@@ -477,6 +478,7 @@ static int s_load_javascript(struct mp_script_args *args)
         .log = args->log,
         .last_error_str = talloc_strdup(ctx, "Cannot initialize JavaScript"),
         .filename = args->filename,
+        .path = args->path,
     };
 
     int r = -1;
@@ -1280,6 +1282,9 @@ static void add_functions(js_State *J, struct script_ctx *ctx)
 
     js_pushstring(J, ctx->filename);
     js_setproperty(J, -2, "script_file");
+
+    js_pushstring(J, ctx->path ? ctx->path : "");
+    js_setproperty(J, -2, "script_path");
 
     js_pop(J, 2);  // leave the stack as we got it
 }

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -457,12 +457,17 @@ function process_timers() {
    - A module has "privacy of its top scope", runs in its own function context.
  - No id identity with symlinks - a valid choice which others make too.
  - require("X") always maps to "X.js" -> require("foo.js") is file "foo.js.js".
- - Global modules search paths are 'scripts/modules.js/' in mpv config dirs.
+ - Global modules search paths are at mp.module_paths - see docs.
  - A main script could e.g. require("./abc") to load a non-global module.
  - Module id supports mpv path enhancements, e.g. ~/foo, ~~/bar, ~~desktop/baz
  *********************************************************************/
 
-mp.module_paths = ["~~/scripts/modules.js"];  // global modules search paths
+mp.module_paths = [];  // global module id's search paths
+if (mp.script_path)  // loaded as a directory
+    mp.module_paths.push(mp.utils.join_path(mp.script_path, "modules"));
+var mc = mp.get_property_native("options/script-opts")["js-modules_common"];
+if (mc)
+    mp.module_paths.push(mc);
 
 // Internal meta top-dirs. Users should not rely on these names.
 var MODULES_META = "~~modules",

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -462,12 +462,10 @@ function process_timers() {
  - Module id supports mpv path enhancements, e.g. ~/foo, ~~/bar, ~~desktop/baz
  *********************************************************************/
 
-mp.module_paths = [];  // global module id's search paths
-if (mp.script_path)  // loaded as a directory
-    mp.module_paths.push(mp.utils.join_path(mp.script_path, "modules"));
-var mc = mp.get_property_native("options/script-opts")["js-modules_common"];
-if (mc)
-    mp.module_paths.push(mc);
+// global module id's search paths array
+mp.module_paths = mp.get_property_native("js-require-paths") || [];
+if (mp.script_path)  // loaded as a directory, add+prioritize  <dir>/modules/
+    mp.module_paths.unshift(mp.utils.join_path(mp.script_path, "modules"));
 
 // Internal meta top-dirs. Users should not rely on these names.
 var MODULES_META = "~~modules",


### PR DESCRIPTION
This means that stand alone scripts now don't have a common modules
path by default, and directory-scripts (introduced at da38caff) now
have one default path which is "modules/" inside the directory.

Additionally --script-opts=js-modules_common=... can be used to append
one common global path to mp.module_paths which affects all scripts.

This addresses the changes at da38caff and somewhat follows b86bfc90 .