### PR TITLE
wayland: some toplevel config fixes

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -83,6 +83,8 @@ struct vo_wayland_state {
     int mouse_unscaled_y;
     int scaling;
     int touch_entries;
+    int toplevel_width;
+    int toplevel_height;
     uint32_t pointer_id;
     int display_fd;
     struct wl_callback       *frame_callback;


### PR DESCRIPTION
There were a couple of erroneous things in the handle_toplevel_config
function. Firstly, looping through the different states was not handled
correctly. Launching a window as maximized (can happen in sway for
example) was always stuck on true and would never be set to false. Fix
this by always checking if XDG_TOPLEVEL_STATE_MAXIMIZED is found or not.
Also do a similar thing for the fullscreen state.

Additionally, there were some issues with resizing windows and
window-scale going back to old sizes. The root of this problem is that
the width and height arguments of handle_toplevel_config aren't actually
guarenteed to be the actual width and height of the surface. There are
times when mpv will set the surface size on its own (like with
window-scale) which will be unknown to the toplevel listener. To
complicate matters, there are times when we do want to use the width and
height arguments (like when resizing with the mouse).

Fix this by checking if the width and height arguments reported by
handle_toplevel_config changed from the previous call of the function.
If the value is different, then we go ahead and use them when setting
mpv's geometry. If not, then we just ignore it.