### PR TITLE
sub: fix SDH filtering after change

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -249,7 +249,7 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         for (int n = 0; r && r[n]; n++) {
             char *ass_line = r[n];
             if (sd->opts->sub_filter_SDH)
-                ass_line = filter_SDH(sd, track->event_format, 0, ass_line, 0);
+                ass_line = filter_SDH(sd, track->event_format, 1, ass_line, 0);
             if (ass_line)
                 ass_process_chunk(track, ass_line, strlen(ass_line),
                                   llrint(sub_pts * 1000),


### PR DESCRIPTION
The change, in an earlier commit, in format for ass to handle results
in a different number of fields to skip. Correct that so SDH filtering
works.

Should fix issue #7188

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.