### PR TITLE
mac: fix media key support for libmpv users

### DIFF
--- a/osdep/macos/remote_command_center.swift
+++ b/osdep/macos/remote_command_center.swift
@@ -87,14 +87,10 @@ class RemoteCommandCenter: NSObject {
         MPRemoteCommandCenter.shared().bookmarkCommand,
     ]
 
-    let application: Application
-
     var mpInfoCenter: MPNowPlayingInfoCenter { get { return MPNowPlayingInfoCenter.default() } }
     var isPaused: Bool = false { didSet { updatePlaybackState() } }
 
-    @objc init(app: Application) {
-        application = app
-
+    @objc override init() {
         super.init()
 
         for cmd in disabledCommands {
@@ -110,8 +106,10 @@ class RemoteCommandCenter: NSObject {
             }
         }
 
-        if let icon = application.getMPVIcon(), #available(macOS 10.13.2, *) {
-            let albumArt = MPMediaItemArtwork(boundsSize:icon.size) { _ in
+        if let app = NSApp as? Application, let icon = app.getMPVIcon(),
+               #available(macOS 10.13.2, *)
+        {
+            let albumArt = MPMediaItemArtwork(boundsSize: icon.size) { _ in
                 return icon
             }
             nowPlayingInfo[MPMediaItemPropertyArtwork] = albumArt
@@ -119,6 +117,13 @@ class RemoteCommandCenter: NSObject {
 
         mpInfoCenter.nowPlayingInfo = nowPlayingInfo
         mpInfoCenter.playbackState = .playing
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.makeCurrent),
+            name: NSApplication.willBecomeActiveNotification,
+            object: nil
+        )
     }
 
     @objc func stop() {
@@ -131,7 +136,7 @@ class RemoteCommandCenter: NSObject {
         mpInfoCenter.playbackState = .unknown
     }
 
-    @objc func makeCurrent() {
+    @objc func makeCurrent(notification: NSNotification) {
         mpInfoCenter.playbackState = .paused
         mpInfoCenter.playbackState = .playing
         updatePlaybackState()
@@ -160,7 +165,7 @@ class RemoteCommandCenter: NSObject {
             }
         }
 
-        application.handleMPKey(mpKey, withMask: Int32(state));
+        EventsResponder.sharedInstance().handleMPKey(mpKey, withMask: Int32(state))
 
         return .success
     }

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -99,8 +99,10 @@ static Application *mpv_shared_app(void)
 
 static void terminate_cocoa_application(void)
 {
-    [NSApp hide:NSApp];
-    [NSApp terminate:NSApp];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [NSApp hide:NSApp];
+        [NSApp terminate:NSApp];
+    });
 }
 
 @implementation Application
@@ -300,7 +302,9 @@ static void init_cocoa_application(bool regular)
         // Because activation policy has just been set to behave like a real
         // application, that policy must be reset on exit to prevent, among
         // other things, the menubar created here from remaining on screen.
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+        });
     });
 }
 

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -107,7 +107,6 @@ static void terminate_cocoa_application(void)
 @synthesize menuBar = _menu_bar;
 @synthesize openCount = _open_count;
 @synthesize cocoaCB = _cocoa_cb;
-@synthesize remoteCommandCenter = _remoteCommandCenter;
 
 - (void)sendEvent:(NSEvent *)event
 {
@@ -175,12 +174,6 @@ static const char macosx_icon[] =
     if ([self respondsToSelector:@selector(touchBar)])
         [(TouchBar *)self.touchBar processEvent:event];
 #endif
-#if HAVE_MACOS_MEDIA_PLAYER
-    // 10.12.2 runtime availability check
-    if ([self respondsToSelector:@selector(touchBar)]) {
-        [_remoteCommandCenter processEvent:event];
-    }
-#endif
     if (_cocoa_cb) {
         [_cocoa_cb processEvent:event];
     }
@@ -208,11 +201,6 @@ static const char macosx_icon[] =
     [_eventsResponder queueCommand:cmd];
 }
 
-- (void)handleMPKey:(int)key withMask:(int)mask
-{
-    [_eventsResponder handleMPKey:key withMask:mask];
-}
-
 - (void)stopMPV:(char *)cmd
 {
     if (![_eventsResponder queueCommand:cmd])
@@ -226,11 +214,6 @@ static const char macosx_icon[] =
             andSelector:@selector(handleQuitEvent:withReplyEvent:)
           forEventClass:kCoreEventClass
              andEventID:kAEQuitApplication];
-}
-
-- (void)applicationWillBecomeActive:(NSNotification *)notification
-{
-    [_remoteCommandCenter makeCurrent];
 }
 
 - (void)handleQuitEvent:(NSAppleEventDescriptor *)event
@@ -306,13 +289,6 @@ static void init_cocoa_application(bool regular)
     NSApp = mpv_shared_app();
     [NSApp setDelegate:NSApp];
     [NSApp setMenuBar:[[MenuBar alloc] init]];
-
-#if HAVE_MACOS_MEDIA_PLAYER
-    // 10.12.2 runtime availability check
-    if ([NSApp respondsToSelector:@selector(touchBar)]) {
-        [NSApp setRemoteCommandCenter:[[RemoteCommandCenter alloc] initWithApp:NSApp]];
-    }
-#endif
 
     // Will be set to Regular from cocoa_common during UI creation so that we
     // don't create an icon when playing audio only files.

--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -20,7 +20,6 @@
 #import "osdep/macosx_menubar_objc.h"
 
 @class CocoaCB;
-@class RemoteCommandCenter;
 struct mpv_event;
 struct mpv_handle;
 
@@ -29,7 +28,6 @@ struct mpv_handle;
 - (NSImage *)getMPVIcon;
 - (void)processEvent:(struct mpv_event *)event;
 - (void)queueCommand:(char *)cmd;
-- (void)handleMPKey:(int)key withMask:(int)mask;
 - (void)stopMPV:(char *)cmd;
 - (void)openFiles:(NSArray *)filenames;
 - (void)setMpvHandle:(struct mpv_handle *)ctx;
@@ -39,5 +37,4 @@ struct mpv_handle;
 @property(nonatomic, retain) MenuBar *menuBar;
 @property(nonatomic, assign) size_t openCount;
 @property(nonatomic, retain) CocoaCB *cocoaCB;
-@property(nonatomic, retain) RemoteCommandCenter *remoteCommandCenter;
 @end

--- a/osdep/macosx_events_objc.h
+++ b/osdep/macosx_events_objc.h
@@ -20,6 +20,7 @@
 #import <Cocoa/Cocoa.h>
 #include "osdep/macosx_events.h"
 
+@class RemoteCommandCenter;
 struct input_ctx;
 
 @interface EventsResponder : NSObject
@@ -38,5 +39,7 @@ struct input_ctx;
 - (bool)processKeyEvent:(NSEvent *)event;
 
 - (BOOL)handleMPKey:(int)key withMask:(int)mask;
+
+@property(nonatomic, retain) RemoteCommandCenter *remoteCommandCenter;
 
 @end

--- a/video/out/cocoa-cb/events_view.swift
+++ b/video/out/cocoa-cb/events_view.swift
@@ -200,7 +200,7 @@ class EventsView: NSView {
     func signalMouseEvent(_ event: NSEvent, _ state: UInt32) {
         hasMouseDown = state == MP_KEY_STATE_DOWN
         let mpkey = getMpvButton(event)
-        cocoa_put_key_with_modifiers((mpkey | Int32(state)), Int32(event.modifierFlags.rawValue));
+        cocoa_put_key_with_modifiers((mpkey | Int32(state)), Int32(event.modifierFlags.rawValue))
     }
 
     func signalMouseMovement(_ event: NSEvent) {
@@ -219,11 +219,11 @@ class EventsView: NSView {
         var cmd: Int32
 
         if abs(event.deltaY) >= abs(event.deltaX) {
-            delta = Double(event.deltaY) * 0.1;
-            cmd = delta > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN;
+            delta = Double(event.deltaY) * 0.1
+            cmd = delta > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN
         } else {
-            delta = Double(event.deltaX) * 0.1;
-            cmd = delta > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT;
+            delta = Double(event.deltaX) * 0.1
+            cmd = delta > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT
         }
 
         mpv?.putAxis(cmd, delta: abs(delta))
@@ -243,9 +243,9 @@ class EventsView: NSView {
             var mpkey: Int32
 
             if abs(deltaY) >= abs(deltaX) {
-                mpkey = deltaY > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN;
+                mpkey = deltaY > 0 ? SWIFT_WHEEL_UP : SWIFT_WHEEL_DOWN
             } else {
-                mpkey = deltaX > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT;
+                mpkey = deltaX > 0 ? SWIFT_WHEEL_RIGHT : SWIFT_WHEEL_LEFT
             }
 
             cocoa_put_key_with_modifiers(mpkey, Int32(modifiers.rawValue))
@@ -285,12 +285,12 @@ class EventsView: NSView {
     func getMpvButton(_ event: NSEvent) -> Int32 {
         let buttonNumber = event.buttonNumber
         switch (buttonNumber) {
-            case 0:  return SWIFT_MBTN_LEFT;
-            case 1:  return SWIFT_MBTN_RIGHT;
-            case 2:  return SWIFT_MBTN_MID;
-            case 3:  return SWIFT_MBTN_BACK;
-            case 4:  return SWIFT_MBTN_FORWARD;
-            default: return SWIFT_MBTN9 + Int32(buttonNumber - 5);
+            case 0:  return SWIFT_MBTN_LEFT
+            case 1:  return SWIFT_MBTN_RIGHT
+            case 2:  return SWIFT_MBTN_MID
+            case 3:  return SWIFT_MBTN_BACK
+            case 4:  return SWIFT_MBTN_FORWARD
+            default: return SWIFT_MBTN9 + Int32(buttonNumber - 5)
         }
     }
 }

--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -337,7 +337,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func aspectFit(rect r: NSRect, in rTarget: NSRect) -> NSRect {
-        var s = rTarget.width / r.width;
+        var s = rTarget.width / r.width
         if r.height*s > rTarget.height {
             s = rTarget.height / r.height
         }

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -355,7 +355,7 @@ class CocoaCB: NSObject {
             let displayID = ccb.window?.screen?.displayID ?? display
 
             if displayID == display {
-                ccb.libmpv.sendVerbose("Detected display mode change, updating screen refresh rate");
+                ccb.libmpv.sendVerbose("Detected display mode change, updating screen refresh rate")
                 ccb.flagEvents(VO_EVENT_WIN_STATE)
             }
         }
@@ -490,7 +490,7 @@ class CocoaCB: NSObject {
                              ccb.getTargetScreen(forFullscreen: false)?.backingScaleFactor ??
                              NSScreen.main?.backingScaleFactor ?? 1.0
                 scaleFactor.pointee = Double(factor)
-                return VO_TRUE;
+                return VO_TRUE
             }
             return VO_FALSE
         case VOCTRL_RESTORE_SCREENSAVER:

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -395,8 +395,10 @@ void vo_cocoa_init(struct vo *vo)
     cocoa_add_event_monitor(vo);
 
     if (!s->embedded) {
-        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-        set_application_icon(NSApp);
+        run_on_main_thread(vo, ^{
+            [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+            set_application_icon(NSApp);
+        });
     }
 }
 


### PR DESCRIPTION
this is kinda a mess. media key support was only available when our own app/runloop was started and not an external one is used (libmpv). this moves the media key support to the mac events which are always available.

this is still a bit messy and i would like to rewrite the whole thing. as of now, touchbar and cocoa-cb support are not available via libmpv because of aforementioned reason. i want to cleanly separate mpv independent features from the mpv dependent parts, eg at the end we will only have a very rather small NSApplication and a separate component that handles and manages features like media keys, touchbar, etc. hopefully this will also prevent some more breakages in the future.

fixes https://github.com/mpv-player/mpv-examples/issues/29