### PR TITLE
vo_gpu: initial attempt at boosting OSD textures to HDR ref. white

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2630,6 +2630,9 @@ static void pass_colormanage(struct gl_video *p, struct mp_colorspace src,
         tone_map.compute_peak = -1;
     }
 
+    // boost to reference white IFF we are doing OSD, input is not HDR and output is HDR
+    tone_map.boost_to_hdr_reference_white = (osd && !mp_trc_is_hdr(src.gamma) && mp_trc_is_hdr(dst.gamma));
+
     // Adapt from src to dst as necessary
     pass_color_map(p->sc, p->use_linear && !osd, src, dst, &tone_map);
 

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -107,6 +107,7 @@ struct gl_tone_map_opts {
     float desat;
     float desat_exp;
     int gamut_warning; // bool
+    bool boost_to_hdr_reference_white; // aka Graphics White, ref: BT.2408-3
 };
 
 struct gl_video_opts {

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -810,6 +810,11 @@ void pass_color_map(struct gl_shader_cache *sc, bool is_linear,
     // Tone map to prevent clipping due to excessive brightness
     if (src.sig_peak > dst.sig_peak)
         pass_tone_map(sc, src.sig_peak, dst.sig_peak, opts);
+    else if (opts->boost_to_hdr_reference_white) {
+        // Boost the image from source to 203 nits (HDR reference white)
+        GLSLF("// Boost from src to HDR ref./graphics white\n");
+        GLSLF("color.rgb *= vec3(%f);\n", 2.03 / mp_trc_nom_peak(src.gamma));
+    }
 
     // Adapt to the right colorspace if necessary
     if (src.primaries != dst.primaries) {


### PR DESCRIPTION
Initial WIP test midnight patch. Not yet tested with actual HDR output, but verified that with `--target-trc=pq` you get the following for the OSD texture:
```
[   0.473][d][vo/gpu/opengl] [ 14] // color mapping
[   0.473][d][vo/gpu/opengl] [ 15] // linearize
[   0.473][d][vo/gpu/opengl] [ 16] color.rgb = clamp(color.rgb, 0.0, 1.0);
[   0.473][d][vo/gpu/opengl] [ 17] color.rgb = mix(color.rgb * vec3(1.0/12.92), pow((color.rgb + vec3(0.055))/vec3(1.055), vec3(2.4)), lessThan(vec3(0.04045), color.rgb));
[   0.473][d][vo/gpu/opengl] [ 18] color.rgb *= vec3(1.0/1.000000);
[   0.473][d][vo/gpu/opengl] [ 19] color.rgb *= vec3(1.000000);
[   0.473][d][vo/gpu/opengl] [ 20] // Boost from src to HDR ref./graphics white
[   0.473][d][vo/gpu/opengl] [ 21] color.rgb *= vec3(2.030000);
[   0.473][d][vo/gpu/opengl] [ 22] color.rgb *= vec3(0.010000);
[   0.473][d][vo/gpu/opengl] [ 23] // delinearize
[   0.473][d][vo/gpu/opengl] [ 24] color.rgb = clamp(color.rgb, 0.0, 1.0);
[   0.473][d][vo/gpu/opengl] [ 25] color.rgb *= vec3(100.000000);
[   0.473][d][vo/gpu/opengl] [ 26] color.rgb *= vec3(1.0/100.000000);
[   0.473][d][vo/gpu/opengl] [ 27] color.rgb = pow(color.rgb, vec3(0.159302));
[   0.473][d][vo/gpu/opengl] [ 28] color.rgb = (vec3(0.835938) + vec3(18.851562) * color.rgb) 
[   0.473][d][vo/gpu/opengl] [ 29]              / (vec3(1.0) + vec3(18.687500) * color.rgb);
[   0.473][d][vo/gpu/opengl] [ 30] color.rgb = pow(color.rgb, vec3(78.843750));
[   0.473][d][vo/gpu/opengl] [ 31] out_color = color;
```