### PR TITLE
Add 'udp_multicast' to rtsp-transport options

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4563,7 +4563,7 @@ Network
         option is ignored (or should be ignored) on RTSP URLs. You can still
         set the timeout option directly with ``--demuxer-lavf-o``.
 
-``--rtsp-transport=<lavf|udp|tcp|http>``
+``--rtsp-transport=<lavf|udp|udp_multicast|tcp|http>``
     Select RTSP transport method (default: tcp). This selects the underlying
     network transport when playing ``rtsp://...`` URLs. The value ``lavf``
     leaves the decision to libavformat.

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -102,7 +102,9 @@ const struct m_sub_options demux_lavf_conf = {
                ({"lavf", 0},
                 {"udp", 1},
                 {"tcp", 2},
-                {"http", 3})),
+                {"http", 3},
+                {"udp_multicast", 4}
+                )),
         OPT_CHOICE("demuxer-lavf-linearize-timestamps", linearize_ts, 0,
                    ({"no", 0}, {"auto", -1}, {"yes", 1})),
         OPT_FLAG("demuxer-lavf-propagate-opts", propagate_opts, 0),
@@ -984,6 +986,7 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
         case 1: transport = "udp";  break;
         case 2: transport = "tcp";  break;
         case 3: transport = "http"; break;
+        case 4: transport = "udp_multicast"; break;
         }
         if (transport)
             av_dict_set(&dopts, "rtsp_transport", transport, 0);


### PR DESCRIPTION
Add 'udp_multicast' to rtsp-transport options and add the rtsp allowed-media-types options.

See https://www.ffmpeg.org/ffmpeg-protocols.html#toc-rtsp for more information.