### PR TITLE
Added handling of modifiers getting forwarded from FFMPEG to drm API

### DIFF
--- a/video/out/drm_prime.c
+++ b/video/out/drm_prime.c
@@ -41,10 +41,8 @@ int drm_prime_create_framebuffer(struct mp_log *log, int fd, AVDRMFrameDescripto
                 mp_err(log, "Failed to retrieve the Prime Handle from handle %d (%d).\n", object, descriptor->objects[object].fd);
                 goto fail;
             }
-            if(object == 0 && descriptor->objects[object].format_modifier) {
+            if(object == 0) {
                 modifiers[object] = descriptor->objects[object].format_modifier;
-            } else if (object == 0) {
-                modifiers[object] = 0;
             }
         }
 


### PR DESCRIPTION
* changed drmModeAddFB2 to drmModeAddFB2WithModifiers
* set Modifiers flag in API call
* fetched and set modifiers accordingly to kernel constraints


As already discussed in #7492 here are the change to handle modifiers.