### PR TITLE
wayland: simplify mouse wheel direction calculation

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -251,9 +251,8 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
                                 uint32_t time, uint32_t axis, wl_fixed_t value)
 {
     struct vo_wayland_state *wl = data;
-    if (wl_fixed_to_double(value) == 0)
-        return;
-    double val = wl_fixed_to_double(value)/abs(wl_fixed_to_double(value));
+
+    double val = wl_fixed_to_double(value) < 0 ? -1 : 1;
     switch (axis) {
     case WL_POINTER_AXIS_VERTICAL_SCROLL:
         if (value > 0)


### PR DESCRIPTION
Based on an idea by sfan5. Remove abs usage, and instead just
check for negative value, and set variable to either +/-1.