### PR TITLE
travis: fix config validation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ notifications:
     channels:
       - "irc.freenode.org#mpv-devel"
     on_success: change
-    on_failure: change
+    on_failure: always
 
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 
-macbase:
+_macbase:
   - &macOld
     os: osx
     compiler: clang
@@ -42,8 +42,6 @@ matrix:
 dist: bionic
 services:
   - docker
-
-sudo: required
 
 env:
   global:


### PR DESCRIPTION
sudo key was deprecated in 2018 https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

otherwise see the warning here https://travis-ci.org/github/mpv-player/mpv/builds/665646319/config?utm_medium=notification&utm_source=github_status#rccb_mpv:.travis.yml@7768452f2d9e1f22.46

also activate the notifications again, since build have been fixed.