### PR TITLE
build: make egl an explicit dep of vaapi-egl

### DIFF
--- a/wscript
+++ b/wscript
@@ -652,7 +652,7 @@ video_output_features = [
     }, {
         'name': 'vaapi-egl',
         'desc': 'VAAPI EGL',
-        'deps': 'vaapi-x-egl || vaapi-wayland || vaapi-drm',
+        'deps': 'egl && (vaapi-x-egl || vaapi-wayland || vaapi-drm)',
         'func': check_true,
     }, {
         'name': '--caca',


### PR DESCRIPTION
It's possible to build vaapi-egl even with `--disable-egl --disable-egl-drm --disable-egl-x11`, probably due to wayland, which is counterintuitive and probably not what most people want when they're trying to work around the RPi's broken graphics stack.

By making egl an explicit dependency for vaapi-egl, we make sure that EGL was actually enabled in some form.

Note: I do not know whether this is correct, because the logic behind the different EGL parts seems a bit confusing. For example, `egl-drm` does not actually require `egl` to be enabled, it just requires that pkg-config can pick up EGL. So technically, you could build something with `--disable-egl` before but still use egl-drm for vaapi-egl. Now since egl is required for vaapi-egl, it's no longer possible to do this, but who would do this and for what reason?

**Before this change:**
```
$ ./waf configure --disable-egl --disable-egl-drm --disable-egl-x11 | grep VAAPI
Checking for VAAPI acceleration                                           : yes 
Checking for VAAPI (X11 support)                                          : yes 
Checking for VAAPI (Wayland support)                                      : yes 
Checking for VAAPI (DRM/EGL support)                                      : egl-drm not found 
Checking for VAAPI EGL on X11                                             : egl-x11 not found 
Checking for VAAPI EGL                                                    : yes 
Checking for VAAPI Vulkan                                                 : yes 
```

**After this change:**
```
$ ./waf configure --disable-egl --disable-egl-drm --disable-egl-x11 | grep VAAPI
Checking for VAAPI acceleration                                           : yes 
Checking for VAAPI (X11 support)                                          : yes 
Checking for VAAPI (Wayland support)                                      : yes 
Checking for VAAPI (DRM/EGL support)                                      : egl-drm not found 
Checking for VAAPI EGL on X11                                             : egl-x11 not found 
Checking for VAAPI EGL                                                    : egl not found 
Checking for VAAPI Vulkan                                                 : yes
```