### PR TITLE
build: only check for EGL pc in one build option

### DIFF
--- a/wscript
+++ b/wscript
@@ -565,16 +565,15 @@ video_output_features = [
     } , {
         'name': '--egl-drm',
         'desc': 'OpenGL DRM EGL Backend',
-        'deps': 'drm && gbm',
+        'deps': 'drm && gbm && egl',
         'groups': [ 'gl' ],
-        'func': check_pkg_config('egl'),
+        'func': check_true,
     } , {
         'name': '--gl-wayland',
         'desc': 'OpenGL Wayland Backend',
-        'deps': 'wayland',
+        'deps': 'wayland && egl',
         'groups': [ 'gl' ],
-        'func': check_pkg_config('wayland-egl', '>= 9.0.0',
-                                 'egl',         '>= 1.5')
+        'func': check_pkg_config('wayland-egl', '>= 9.0.0')
     } , {
         'name': '--gl-win32',
         'desc': 'OpenGL Win32 Backend',
@@ -751,8 +750,7 @@ video_output_features = [
     }, {
         'name': 'egl-helpers',
         'desc': 'EGL helper functions',
-        'deps': 'egl-x11 || rpi || gl-wayland || egl-drm || ' +
-                'egl-angle-win32 || egl-android',
+        'deps': 'egl || rpi || egl-angle-win32 || egl-android',
         'func': check_true
     }
 ]


### PR DESCRIPTION
Previously, EGL as provided by a pkg-config was checked for independently in several places. The effect this had is that `--disable-egl` would not actually disable EGL from the build, as this only affected the "egl" option relied upon by egl-x11. wayland-gl and egl-drm did their own EGL checks.

By making wayland-gl and drm-egl depend on egl instead, we fix this behaviour and can simplify egl-helpers a bit, as we can now simply check whether egl or one of the other features providing some non-pc egl is enabled, instead of checking every single thing that might be pulling in egl.

Future work could make the "egl" option just be a catchall for any EGL implementation, so that brcmegl and angle and Android can piggyback on the egl option as well.
