### PR TITLE
wayland: use mp_time deltas for presentation time

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -92,7 +92,6 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
     wl->sync[index].sbc = wl->user_sbc;
     wl->sync[index].ust = sec * 1000000LL + (uint64_t) tv_nsec / 1000;
     wl->sync[index].msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
-    wl->sync[index].refresh_usec = (uint64_t)refresh_nsec/1000;
     wl->sync[index].filled = true;
 }
 
@@ -153,7 +152,7 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation && !wl->hidden) {
+    if (wl->presentation) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -82,7 +82,6 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
     wl->sync[index].sbc = wl->user_sbc;
     wl->sync[index].ust = sec * 1000000LL + (uint64_t) tv_nsec / 1000;
     wl->sync[index].msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
-    wl->sync[index].refresh_usec = (uint64_t)refresh_nsec/1000;
     wl->sync[index].filled = true;
 }
 
@@ -122,7 +121,7 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 static void wayland_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation && !wl->hidden) {
+    if (wl->presentation) {
         info->vsync_duration = wl->vsync_duration;
         info->skipped_vsyncs = wl->last_skipped_vsyncs;
         info->last_queue_display_time = wl->last_queue_display_time;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -35,7 +35,7 @@ struct vo_wayland_sync {
     int64_t ust;
     int64_t msc;
     int64_t sbc;
-    int64_t refresh_usec;
+    int64_t last_mp_time;
     bool filled;
 };
 
@@ -75,7 +75,6 @@ struct vo_wayland_state {
     int reduced_height;
     bool configured;
     bool frame_wait;
-    bool hidden;
     int timeout_count;
     int wakeup_pipe[2];
     int pending_vo_events;


### PR DESCRIPTION
One not-so-nice hack in the wayland code is the assumption of when a
window is hidden (out of view from the compositor) and an arbitrary
delay for enabling/disabling the usage of presentation time. Since you
do not receive any presentation feedback when a window is hidden on
wayland (a feature or misfeature depending on who you ask), the ust is
updated based on the refresh_nsec statistic gathered from the previous
feedback event.

The flaw with this is that refresh_nsec basically just reports back the
display's refresh rate (1 / refresh_rate * 10^9). It doesn't tell you
how long the vsync interval really was. So as a video is left playing
out of view, the wl->last_queue_display_time becomes increasingly
inaccurate. This led to a vsync spike when bringing the mpv window back
into sight after it was hidden for a period of time. The hack for
working around this is to just wait a while before enabling presentation
time again. The discrepancy between the "bogus"
wl->last_queue_display_time and the actual value you get from the
feedback only happens initially after a switch. If you just discard
those values, you avoid the dramatic vsync spike.

It turns out that there's a smarter way to do this. Just use mp_time_us
deltas. The whole reason for these hacks is because
wl->last_queue_display_time wasn't close enough to how long it would
take for a frame to actually display if it wasn't hidden. Instead, mpv's
internal timer can be used, and the difference between wayland_sync_swap
calls is a close enough proxy for the vsync interval (certainly better
than using the monitor's refresh rate). This avoids the entire conundrum
of massive vsync spikes when bringing the player back into view, and it
means we can get rid of extra crap like wl->hidden.