### PR TITLE
stream_dvb: Remove call to stream_drop_buffers in fill_buffer.

### DIFF
--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -836,8 +836,6 @@ int dvb_set_channel(stream_t *stream, unsigned int adapter, unsigned int n)
     MP_VERBOSE(stream, "DVB_SET_CHANNEL: new channel name=%s, adapter: %d, "
                "channel %d\n", channel->name, devno, n);
 
-    stream_drop_buffers(stream);
-
     if (channel->freq != state->last_freq) {
         if (!dvb_tune(priv, channel->delsys, channel->freq,
                       channel->pol, channel->srate, channel->diseqc,


### PR DESCRIPTION
The call was hidden very well, via
dvb_streaming_read -> dvb_update_config
-> dvb_streaming_start -> dvb_set_channel,
and broke the stream buffering logic.
Dropping that call does not noticeably slow down channel switches.

Fixes #7602 . 