### PR TITLE
Add edition information to stats.lua

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -472,9 +472,6 @@ local function add_file(s)
         append_property(s, "media-title", {prefix="Title:"})
     end
 
-    local fs = append_property(s, "file-size", {prefix="Size:"})
-    append_property(s, "file-format", {prefix="Format/Protocol:", nl=fs and "" or o.nl})
-
     local editions = mp.get_property_number("editions")
     local edition = mp.get_property_number("current-edition")
     local ed_cond = (edition and editions > 1)
@@ -494,6 +491,9 @@ local function add_file(s)
                         {prefix="(" .. tostring(ch_index + 1) .. "/", suffix=")", nl="",
                          indent=" ", prefix_sep=" ", no_prefix_markup=true})
     end
+
+    local fs = append_property(s, "file-size", {prefix="Size:"})
+    append_property(s, "file-format", {prefix="Format/Protocol:", nl=fs and "" or o.nl})
 
     local demuxer_cache = mp.get_property_native("demuxer-cache-state", {})
     if demuxer_cache["fw-bytes"] then

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -475,9 +475,21 @@ local function add_file(s)
     local fs = append_property(s, "file-size", {prefix="Size:"})
     append_property(s, "file-format", {prefix="Format/Protocol:", nl=fs and "" or o.nl})
 
+    local editions = mp.get_property_number("editions")
+    local edition = mp.get_property_number("current-edition")
+    local ed_cond = (edition and editions > 1)
+    if ed_cond then
+        append_property(s, "edition-list/" .. tostring(edition) .. "/title",
+                       {prefix="Edition:"})
+        append_property(s, "edition-list/count",
+                        {prefix="(" .. tostring(edition + 1) .. "/", suffix=")", nl="",
+                         indent=" ", prefix_sep=" ", no_prefix_markup=true})
+    end
+
     local ch_index = mp.get_property_number("chapter")
     if ch_index and ch_index >= 0 then
-        append_property(s, "chapter-list/" .. tostring(ch_index) .. "/title", {prefix="Chapter:"})
+        append_property(s, "chapter-list/" .. tostring(ch_index) .. "/title", {prefix="Chapter:",
+                        nl=ed_cond and "" or o.nl})
         append_property(s, "chapter-list/count",
                         {prefix="(" .. tostring(ch_index + 1) .. "/", suffix=")", nl="",
                          indent=" ", prefix_sep=" ", no_prefix_markup=true})


### PR DESCRIPTION
Before (no editions): https://0x0.st/iQW_.png
After (no editions): https://0x0.st/iQW2.png

Before (editions): https://0x0.st/iQW9.png
After (editions): https://0x0.st/iQWL.png

cc @Argon- 

Second commit could be dropped if it's controversial.