### PR TITLE
drm: add typedef for PFNEGLGETPLATFORMDISPLAYEXTPROC (#7314)

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -46,6 +46,11 @@
 
 #define USE_MASTER 0
 
+#ifndef EGL_EXT_platform_base
+typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC)
+    (EGLenum platform, void *native_display, const EGLint *attrib_list);
+#endif
+
 struct framebuffer
 {
     int fd;


### PR DESCRIPTION
extension is not mandatory and is not provided on ie Raspberry Pi