### PR TITLE
build: link against single EGL provider

### DIFF
--- a/waftools/checks/generic.py
+++ b/waftools/checks/generic.py
@@ -7,7 +7,7 @@ from waflib import Utils
 __all__ = [
     "check_pkg_config", "check_pkg_config_mixed", "check_pkg_config_mixed_all",
     "check_pkg_config_cflags", "check_cc", "check_statement", "check_libs",
-    "check_headers", "compose_checks", "check_true", "any_version",
+    "check_headers", "compose_checks", "any_check", "check_true", "any_version",
     "load_fragment", "check_stub", "check_ctx_vars", "check_program",
     "check_pkg_config_datadir", "check_macos_sdk"]
 
@@ -178,6 +178,11 @@ def check_stub(ctx, dependency_identifier):
 def compose_checks(*checks):
     def fn(ctx, dependency_identifier):
         return all([check(ctx, dependency_identifier) for check in checks])
+    return fn
+
+def any_check(*checks):
+    def fn(ctx, dependency_identifier):
+        return any(check(ctx, dependency_identifier) for check in checks)
     return fn
 
 def load_fragment(fragment):

--- a/wscript
+++ b/wscript
@@ -548,14 +548,19 @@ video_output_features = [
         'func': check_libs(['GL', 'GL Xdamage'],
                    check_cc(fragment=load_fragment('gl_x11.c'),
                             use=['x11', 'libdl', 'pthreads']))
+    }, {
+        'name': '--rpi',
+        'desc': 'Raspberry Pi support',
+        'func': check_egl_provider(name='brcmegl', check=any_check(
+            check_pkg_config('brcmegl'),
+            check_pkg_config('/opt/vc/lib/pkgconfig/brcmegl.pc')
+            )),
+        'default': 'disable',
     } , {
         'name': '--egl',
         'desc': 'EGL 1.4',
         'groups': [ 'gl' ],
-        'func': compose_checks(
-            check_pkg_config('egl'),
-            check_statement(['EGL/egl.h'], 'int x[EGL_VERSION_1_4]')
-            ),
+        'func': check_egl_provider('1.4')
     } , {
         'name': '--egl-x11',
         'desc': 'OpenGL X11 EGL Backend',
@@ -708,12 +713,6 @@ video_output_features = [
         'desc': 'Direct3D 11 video output',
         'deps': 'win32-desktop && shaderc && spirv-cross',
         'func': check_cc(header_name=['d3d11_1.h', 'dxgi1_6.h']),
-    }, {
-        'name': '--rpi',
-        'desc': 'Raspberry Pi support',
-        'func': any_check(check_pkg_config('brcmegl'),
-                          check_pkg_config('/opt/vc/lib/pkgconfig/brcmegl.pc')),
-        'default': 'disable',
     } , {
         'name': '--ios-gl',
         'desc': 'iOS OpenGL ES hardware decoding interop support',

--- a/wscript
+++ b/wscript
@@ -711,7 +711,8 @@ video_output_features = [
     }, {
         'name': '--rpi',
         'desc': 'Raspberry Pi support',
-        'func': check_pkg_config('brcmegl'),
+        'func': any_check(check_pkg_config('brcmegl'),
+                          check_pkg_config('/opt/vc/lib/pkgconfig/brcmegl.pc')),
         'default': 'disable',
     } , {
         'name': '--ios-gl',
@@ -800,7 +801,8 @@ hwaccel_features = [
         'name': '--rpi-mmal',
         'desc': 'Raspberry Pi MMAL hwaccel',
         'deps': 'rpi',
-        'func': check_pkg_config('mmal'),
+        'func': any_check(check_pkg_config('mmal'),
+                          check_pkg_config('/opt/vc/lib/pkgconfig/mmal.pc')),
     }
 ]
 


### PR DESCRIPTION
when building with rpi EGL is provided by librcmegl library and libEGL
should not be linked then