### PR TITLE
vo/gpu/drm: port to FreeBSD

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -845,6 +845,9 @@ bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log)
     vt_mode.mode = VT_PROCESS;
     vt_mode.relsig = RELEASE_SIGNAL;
     vt_mode.acqsig = ACQUIRE_SIGNAL;
+    // frsig is a signal for forced release. Not implemented on Linux,
+    // Solaris, BSDs but must be set to a valid signal on some of those.
+    vt_mode.frsig = SIGIO; // unused
     if (ioctl(s->tty_fd, VT_SETMODE, &vt_mode) < 0) {
         MP_ERR(s, "VT_SETMODE failed: %s\n", mp_strerror(errno));
         return false;

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -21,11 +21,18 @@
 #include <sys/ioctl.h>
 #include <poll.h>
 #include <sys/stat.h>
-#include <sys/vt.h>
 #include <unistd.h>
 #include <limits.h>
 #include <math.h>
 #include <time.h>
+
+#include "config.h"
+
+#if HAVE_CONSIO_H
+#include <sys/consio.h>
+#else
+#include <sys/vt.h>
+#endif
 
 #include "drm_common.h"
 

--- a/wscript
+++ b/wscript
@@ -283,6 +283,12 @@ iconv support use --disable-iconv.",
         'func': check_statement(['sys/vt.h', 'sys/ioctl.h'],
                                 'int m; ioctl(0, VT_GETMODE, &m)'),
     }, {
+        'name': 'consio.h',
+        'desc': 'consio.h',
+        'deps': '!vt.h',
+        'func': check_statement(['sys/consio.h', 'sys/ioctl.h'],
+                                'int m; ioctl(0, VT_GETMODE, &m)'),
+    }, {
         'name': 'gbm.h',
         'desc': 'gbm.h',
         'func': check_cc(header_name=['stdio.h', 'gbm.h']),
@@ -495,7 +501,7 @@ video_output_features = [
     }, {
         'name': '--drm',
         'desc': 'DRM',
-        'deps': 'vt.h',
+        'deps': 'vt.h || consio.h',
         'func': check_pkg_config('libdrm', '>= 2.4.74'),
     }, {
         'name': '--gbm',


### PR DESCRIPTION
Same as #6976 but limited to fixing `--gpu-context=drm`: upstreaming https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=238944

<details><summary>Example output</summary>

```
$ mpv --no-config --gpu-context=drm --hwdec=vaapi --msg-level=vo/gpu=v /path/to/foo.mp4
 (+) Video --vid=1 (*) (h264 852x480 28.366fps)
 (+) Audio --aid=1 (*) (aac 2ch 48000Hz)
[vo/gpu/opengl] Initializing GPU context 'drm'
[vo/gpu/opengl] Initializing KMS
[vo/gpu/opengl] Device name: /dev/dri/card0
[vo/gpu/opengl] Driver: i915 1.6.0 (20181204)
[vo/gpu/opengl/kms] Connector 97 currently connected to encoder 96
[vo/gpu/opengl/kms] Selected Encoder 96 with CRTC 47
[vo/gpu/opengl/kms] Selected mode: 3840x2160 (3840x2160@60.00Hz)
[vo/gpu/opengl] DRM Atomic support found
[vo/gpu/opengl/kms] Using primary plane 30 as draw plane
[vo/gpu/opengl/kms] Using overlay plane 37 as drmprime plane
[vo/gpu] GBM_FORMAT_ARGB8888 supported by draw plane.
[vo/gpu] Creating GBM device
[vo/gpu] Initializing GBM surface (3840 x 2160)
[vo/gpu/opengl] Initializing EGL
[vo/gpu/opengl] EGL_VERSION=1.4
[vo/gpu/opengl] EGL_VENDOR=Mesa Project
[vo/gpu/opengl] EGL_CLIENT_APIS=OpenGL OpenGL_ES
[vo/gpu/opengl] Trying to create Desktop OpenGL context.
[vo/gpu/opengl] Attempting to find EGLConfig matching GBM_FORMAT_ARGB8888
[vo/gpu/opengl] Found matching EGLConfig for GBM_FORMAT_ARGB8888
[vo/gpu/opengl] Initializing EGL surface
[vo/gpu] GL_VERSION='4.6 (Core Profile) Mesa 20.1.0-devel'
[vo/gpu] Detected desktop OpenGL 4.6.
[vo/gpu] GL_VENDOR='Intel Open Source Technology Center'
[vo/gpu] GL_RENDERER='Mesa DRI Intel(R) HD Graphics 530 (SKL GT2)'
[vo/gpu] GL_SHADING_LANGUAGE_VERSION='4.60'
[vo/gpu/opengl] Preparing framebuffer
[vo/gpu/opengl] Opening render node "/dev/dri/renderD128"
[vo/gpu] Testing FBO format rgba16f
[vo/gpu] Using FBO format rgba16f.
[vo/gpu] No advanced processing required. Enabling dumb mode.
[vo/gpu] Assuming 60.000000 FPS for display sync.
[vo/gpu] Loading hwdec driver 'vaapi-egl'
[vo/gpu/vaapi-egl] using VAAPI EGL interop
[vo/gpu/vaapi-egl] Trying to open a x11 VA display...
[vo/gpu/vaapi-egl] Trying to open a wayland VA display...
[vo/gpu/vaapi-egl] Trying to open a drm VA display...
[vo/gpu/vaapi-egl/vaapi] Initialized VAAPI: version 1.7
[vo/gpu/vaapi-egl] Going to probe surface formats (may log bogus errors)...
[ffmpeg] AVHWDeviceContext: Failed to query surface attributes: 20 (the requested function is not implemented).
[vo/gpu/vaapi-egl] failed to retrieve libavutil frame constraints
[vo/gpu/vaapi-egl] Done probing surface formats.
[vo/gpu] Loading hwdec driver 'vdpau-gl'
[vo/gpu] Loading failed.
[vo/gpu] Loading hwdec driver 'drmprime-drm'
[vo/gpu/drmprime-drm] Using primary plane 30 as draw plane
[vo/gpu/drmprime-drm] Using overlay plane 37 as drmprime plane
Using hardware decoding (vaapi).
AO: [pulse] 48000Hz stereo 2ch float
VO: [gpu] 852x480 vaapi[nv12]
[vo/gpu] reconfig to 852x480 vaapi[nv12] bt.601/bt.601-525/bt.1886/limited/display SP=1.000000 CL=mpeg2/4/h264
[vo/gpu] Resize: 3840x2160
[vo/gpu] Window size: 3840x2160 (Borders: l=0 t=0 r=0 b=0)
[vo/gpu] Video source: 852x480 (1:1)
[vo/gpu] Video display: (0, 0) 852x480 -> (3, 0) 3834x2160
[vo/gpu] Video scale: 4.500000/4.500000
[vo/gpu] OSD borders: l=3 t=0 r=3 b=0
[vo/gpu] Video borders: l=3 t=0 r=3 b=0
[vo/gpu] Reported display depth: 8
[vo/gpu] Testing FBO format rgba16f
[vo/gpu] Using FBO format rgba16f.
[vo/gpu] No advanced processing required. Enabling dumb mode.
AV: 00:00:01 / 00:25:56 (0%) A-V:  0.000
[vo/gpu] Reallocating OSD texture to 4096x256.
AV: 00:02:11 / 00:25:56 (8%) A-V:  0.004
[vo/gpu] Releasing VT
AV: 00:02:13 / 00:25:56 (8%) A-V:  0.000
[vo/gpu] Acquiring VT
AV: 00:02:14 / 00:25:56 (8%) A-V: -0.000 Dropped: 1

Exiting... (Quit)
```
</details>
