### PR TITLE
build: add missing includes to fix thread names on DragonFly/FreeBSD/OpenBSD

### DIFF
--- a/osdep/threads.c
+++ b/osdep/threads.c
@@ -24,6 +24,10 @@
 #include "threads.h"
 #include "timer.h"
 
+#if HAVE_BSD_THREAD_NAME
+#include <pthread_np.h>
+#endif
+
 int mpthread_mutex_init_recursive(pthread_mutex_t *mutex)
 {
     pthread_mutexattr_t attr;

--- a/wscript
+++ b/wscript
@@ -302,7 +302,7 @@ iconv support use --disable-iconv.",
         'name': 'bsd-thread-name',
         'desc': 'BSD API for setting thread name',
         'deps': '!(glibc-thread-name || osx-thread-name)',
-        'func': check_statement('pthread.h',
+        'func': check_statement(['pthread.h', 'pthread_np.h'],
                                 'pthread_set_name_np(pthread_self(), "ducks")',
                                 use=['pthreads']),
     }, {


### PR DESCRIPTION
Same as #6976 but limited to thread names: upstreaming https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242564

<details><summary>Example output</summary>

```diff
--- before
+++ after
@@ -1,28 +1,28 @@
 $ mpv --no-config /path/to/foo.mp4
 $ procstat -t $(pgrep mpv)
   PID    TID COMM                TDNAME              CPU  PRI STATE   WCHAN
-95441 101223 mpv                 -                    -1  132 sleep   select
+95441 101223 mpv                 mpv/terminal         -1  132 sleep   select
 95441 101286 mpv                 -                    -1  120 sleep   uwait
-95441 101313 mpv                 -                    -1  129 sleep   uwait
-95441 101325 mpv                 -                    -1  129 sleep   uwait
-95441 101336 mpv                 -                    -1  135 sleep   uwait
-95441 101349 mpv                 -                    -1  152 sleep   uwait
-95441 101795 mpv                 -                    -1  120 sleep   uwait
-95441 101926 mpv                 -                    -1  144 sleep   uwait
-95441 101977 mpv                 -                    -1  126 sleep   select
+95441 101313 mpv                 mpv/lua script (osc  -1  129 sleep   uwait
+95441 101325 mpv                 mpv/lua script (ytd  -1  129 sleep   uwait
+95441 101336 mpv                 mpv/lua script (sta  -1  135 sleep   uwait
+95441 101349 mpv                 mpv/lua script (con  -1  152 sleep   uwait
+95441 101795 mpv                 mpv/demux            -1  120 sleep   uwait
+95441 101926 mpv                 mpv/worker           -1  144 sleep   uwait
+95441 101977 mpv                 mpv/vo               -1  126 sleep   select
 95441 102074 mpv                 -                    -1  138 sleep   usem
 95441 102075 mpv                 mpv:disk$0           -1  152 sleep   uwait
 95441 102078 mpv                 mpv:disk$1           -1  152 sleep   uwait
 95441 102086 mpv                 mpv:disk$2           -1  152 sleep   uwait
 95441 102087 mpv                 mpv:disk$3           -1  152 sleep   uwait
 95441 102088 mpv                 -                    -1  123 sleep   uwait
 95441 102089 mpv                 -                    -1  123 sleep   uwait
 95441 102090 mpv                 -                    -1  123 sleep   uwait
 95441 102092 mpv                 -                    -1  126 sleep   uwait
 95441 102093 mpv                 -                    -1  126 sleep   uwait
 95441 102095 mpv                 -                    -1  123 sleep   uwait
 95441 102096 mpv                 -                    -1  123 sleep   uwait
 95441 102100 mpv                 -                    -1  123 sleep   uwait
 95441 102105 mpv                 -                    -1  123 sleep   uwait
 95441 102314 mpv                 -                    -1  123 sleep   select
-95441 102370 mpv                 -                    -1  123 sleep   uwait
+95441 102370 mpv                 mpv/ao               -1  123 sleep   uwait
```
</details>
