### PR TITLE
Possible wayland touch improvements

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5506,7 +5506,7 @@ The following video options are currently all specific to ``--vo=gpu`` and
     there are no server side decorations from the compositor.
 
 ``--wayland-edge-pixels-touch=<value>``
-    Defines the size of an edge border (default: 64) to initiate client side
+    Defines the size of an edge border (default: 32) to initiate client side
     resizes events in the wayland contexts with touch events.
 
 ``--spirv-compiler=<compiler>``

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -70,7 +70,6 @@ struct vo_wayland_state {
     int pending_vo_events;
     int scaling;
     int timeout_count;
-    int touch_entries;
     int wakeup_pipe[2];
 
     /* idle-inhibit */


### PR DESCRIPTION
If somebody that has touch stuff + a wayland compositor could actually test that this works like how I hope it works, that would be very much appreciated. Tagging @soloturn since he expressed interest in touch screen stuff on wayland.

What hopefully happens with this PR:
* One finger touch and move -> the window drags
* One finger touch and move around the edge of the window -> the window resizes
* Two finger touch and move -> the window resizes
* Touching on a visible osc -> actually behaves like a mouse click
* Doing more than two touches at a time (i.e. 3+ fingers) is completely ignored

What won't happen:
* Two finger move (Hopefully this is fine? I don't think adding a ton of extra complexity for a two finger move and a two finger resize is worth it when you can just use one finger.)

I'm assuming that, on a two finger touch, the compositor will consider the serial generated from the first finger as invalid (because a new serial with a new touch event is created) and thus stop any events associated with that touch. But I have no idea if this actually occurs. If it does not, it might be possible that moving the first finger touch would move the window while the second finger resizes it.

Also, the default edge border for finger touches is 64 pixels. Is that too big? I have no idea, but maybe the default should be smaller (32?). If someone could play around with the `--wayland-edge-pixels-touch` option and give some opinions on this, that would be nice.

Maybe closes #7693.