### PR TITLE
zsh completion: helper functions in private namespace

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -35,7 +35,7 @@ zstyle -a ":completion:*:*:$service:*" tag-order tag_order ||
 
 typeset -ga _mpv_completion_arguments _mpv_completion_protocols
 
-function generate_arguments {
+function _mpv_generate_arguments {
 
   _mpv_completion_arguments=()
 
@@ -143,7 +143,7 @@ function generate_arguments {
 
 }
 
-function generate_protocols {
+function _mpv_generate_protocols {
   _mpv_completion_protocols=()
   local list_protos_line
   for list_protos_line in "${(@f)$($words[1] --list-protocols)}"; do
@@ -153,7 +153,7 @@ function generate_protocols {
   done
 }
 
-function generate_if_changed {
+function _mpv_generate_if_changed {
   # Called with $1 = 'arguments' or 'protocols'. Generates the respective list
   # on the first run and re-generates it if the executable being completed for
   # is different than the one we used to generate the cached list.
@@ -168,7 +168,7 @@ function generate_if_changed {
     # However, we can't rely on PCRE being available, so we keep all our
     # patterns POSIX-compatible.
     zmodload -s -F zsh/pcre C:pcre-match && setopt re_match_pcre
-    generate_$1
+    _mpv_generate_$1
     _mpv_completion_binary[$1]=$current_binary
   fi
 }
@@ -177,7 +177,7 @@ function generate_if_changed {
 # an option. This way, the user should never see a delay when just completing a
 # filename.
 if [[ $words[$CURRENT] == -* ]]; then
-  generate_if_changed arguments
+  _mpv_generate_if_changed arguments
 fi
 
 local rc=1
@@ -237,7 +237,7 @@ case $state in
       if _requested urls; then
         while _next_label urls expl URL; do
           _urls "$expl[@]" && rc=0
-          generate_if_changed protocols
+          _mpv_generate_if_changed protocols
           compadd -S '' "$expl[@]" $_mpv_completion_protocols && rc=0
         done
       fi


### PR DESCRIPTION
The generate_xxx() helpers, once defined, would appear as
user-visible functions; this would lead to unexpected and
confusing completion suggestions for gene<tab> after having
once run mpv in that shell.

This PR adds the prefix '_mpv_' to all completion functions
as a convention to make them less user-visible and less likely
to collide with other packages.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.