### PR TITLE
wlshm: re-enable on FreeBSD

### DIFF
--- a/wscript
+++ b/wscript
@@ -302,12 +302,6 @@ iconv support use --disable-iconv.",
         'func': check_statement('sys/vfs.h',
                                 'struct statfs fs; fstatfs(0, &fs); fs.f_namelen')
     }, {
-        'name': 'memfd_create',
-        'desc': "Linux's memfd_create()",
-        'deps': 'os-linux',
-        'func': check_statement('sys/mman.h',
-                                'memfd_create("mpv", MFD_CLOEXEC | MFD_ALLOW_SEALING)')
-    }, {
         'name' : '--lua',
         'desc' : 'Lua',
         'func': check_lua,
@@ -501,6 +495,12 @@ video_output_features = [
         'func': check_pkg_config('wayland-client', '>= 1.15.0',
                                  'wayland-cursor', '>= 1.15.0',
                                  'xkbcommon',      '>= 0.3.0'),
+    } , {
+        'name': 'memfd_create',
+        'desc': "Linux's memfd_create()",
+        'deps': 'wayland',
+        'func': check_statement('sys/mman.h',
+                                'memfd_create("mpv", MFD_CLOEXEC | MFD_ALLOW_SEALING)')
     } , {
         'name': '--x11',
         'desc': 'X11',


### PR DESCRIPTION
FreeBSD 13.0 [added](https://github.com/freebsd/freebsd/commit/575e351fdd996f72921b87e71c2c26466e887ed2) `memfd_create`. Let's relax configure check in case DragonFly follows suit.

<details><summary>Example output</summary>

```
$ mpv --no-config --msg-level=vo=v --vo=wlshm http://www.jell.yfish.us/media/jellyfish-3-mbps-hd-h264.mkv
 (+) Video --vid=1 (*) (h264 1920x1080 29.970fps)
[vo/wlshm/wayland] Registered for protocol wl_shm
[vo/wlshm/wayland] Registered for protocol wl_compositor
[vo/wlshm/wayland] Registered for protocol wl_data_device_manager
[vo/wlshm/wayland] Registered for protocol zwp_idle_inhibit_manager_v1
[vo/wlshm/wayland] Registered for protocol xdg_wm_base
[vo/wlshm/wayland] Registered for protocol zxdg_decoration_manager_v1
[vo/wlshm/wayland] Registered for protocol wp_presentation
[vo/wlshm/wayland] Registered for protocol wl_seat
[vo/wlshm/wayland] Registered for protocol wl_output
[vo/wlshm/wayland] Enabling server decorations
[vo/wlshm/wayland] Registered output Goldstar Company Ltd LG Ultra HD (0x24):
[vo/wlshm/wayland]      x: 0px, y: 0px
[vo/wlshm/wayland]      w: 3840px (600mm), h: 2160px (340mm)
[vo/wlshm/wayland]      scale: 1
[vo/wlshm/wayland]      Hz: 60.000000
VO: [wlshm] 1920x1080 yuv420p
[vo/wlshm] reconfig to 1920x1080 yuv420p bt.709/bt.709/bt.1886/limited/display SP=1.000000 CL=mpeg2/4/h264
[vo/wlshm/wayland] Reconfiguring!
[vo/wlshm] Window size: 1920x1080 (Borders: l=0 t=0 r=0 b=0)
[vo/wlshm] Video source: 1920x1080 (1:1)
[vo/wlshm] Video display: (0, 0) 1920x1080 -> (0, 0) 1920x1080
[vo/wlshm] Video scale: 1.000000/1.000000
[vo/wlshm] OSD borders: l=0 t=0 r=0 b=0
[vo/wlshm] Video borders: l=0 t=0 r=0 b=0
[vo/wlshm/wayland] Enabling idle inhibitor
V: 00:00:00 / 00:00:30 (0%) Cache: 0.1s/11KB
[vo/wlshm/wayland] Given DND offer with mime type text/plain
[vo/wlshm/wayland] Given DND offer with mime type text/plain;charset=utf-8
[vo/wlshm/wayland] Resizing due to xdg from 1920x1080 to 3840x2160
[vo/wlshm] Window size: 3840x2160 (Borders: l=0 t=0 r=0 b=0)
[vo/wlshm] Video source: 1920x1080 (1:1)
[vo/wlshm] Video display: (0, 0) 1920x1080 -> (0, 0) 3840x2160
[vo/wlshm] Video scale: 2.000000/2.000000
[vo/wlshm] OSD borders: l=0 t=0 r=0 b=0
[vo/wlshm] Video borders: l=0 t=0 r=0 b=0
(Buffering) V: 00:00:00 / 00:00:30 (0%) Dropped: 1 Cache: 0.2s/105KB
[vo/wlshm/wayland] Disabling the idle inhibitor
(Buffering) V: 00:00:00 / 00:00:30 (0%) Dropped: 1 Cache: 0.2s/105KB
[vo/wlshm/wayland] Surface entered output Goldstar Company Ltd LG Ultra HD (0x24), scale = 1
[vo/wlshm] Assuming 60.000000 FPS for display sync.
(Buffering) V: 00:00:00 / 00:00:30 (0%) Dropped: 1 Cache: 1.0s/474KB
[vo/wlshm/wayland] Enabling idle inhibitor
V: 00:00:29 / 00:00:30 (100%) Dropped: 589 Cache: 0.0s
[vo/wlshm/wayland] Disabling the idle inhibitor

Exiting... (End of file)
[vo/wlshm/wayland] Deregistering output Goldstar Company Ltd LG Ultra HD (0x24)
```
</details>
