### PR TITLE
vo_wlshm, vo_drm: set image size with mp_image_set_size

### DIFF
--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -322,8 +322,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     p->cur_frame = mp_image_alloc(p->imgfmt, p->screen_w, p->screen_h);
     mp_image_params_guess_csp(&p->sws->dst);
     mp_image_set_params(p->cur_frame, &p->sws->dst);
-    p->cur_frame[0].w = p->screen_w;
-    p->cur_frame[0].h = p->screen_h;
+    mp_image_set_size(p->cur_frame, p->screen_w, p->screen_h);
 
     talloc_free(p->cur_frame_cropped);
     p->cur_frame_cropped = mp_image_new_dummy_ref(p->cur_frame);

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -112,8 +112,7 @@ static struct buffer *buffer_create(struct vo *vo, int width, int height)
     buf->vo = vo;
     buf->size = size;
     mp_image_set_params(&buf->mpi, &p->sws->dst);
-    buf->mpi.w = width;
-    buf->mpi.h = height;
+    mp_image_set_size(&buf->mpi, width, height);
     buf->mpi.planes[0] = data;
     buf->mpi.stride[0] = stride;
     buf->pool = wl_shm_create_pool(wl->shm, fd, size);


### PR DESCRIPTION
The image w and h members must match params.w and params.h, so
should not be changed directly. The helper function mp_image_set_size
is designed for this purpose, so just use that instead.

This prevents an assertion error with the rewritten draw_bmp.

Fixes #7721.