### PR TITLE
command: save state on stop when user requested save-position-on-quit

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5085,6 +5085,13 @@ static void cmd_stop(void *p)
 
     if (!(flags & 1))
         playlist_clear(mpctx->playlist);
+
+    if (mpctx->opts->player_idle_mode < 2 &&
+        mpctx->opts->position_save_on_quit)
+    {
+        mp_write_watch_later_conf(mpctx);
+    }
+
     if (mpctx->stop_play != PT_QUIT)
         mpctx->stop_play = PT_STOP;
     mp_wakeup_core(mpctx);


### PR DESCRIPTION
Execution of "stop" command in the case when idle mode was not enabled
resulted in player termination scenario not honoring user setting
"save-position-on-quit" from config file. This patch addresses the
issue by checking for "save-position-on-quit" in cmd_stop and saving
state when idle mode is not enabled.