### PR TITLE
x11_common: added ICCCM WM_HINTS

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -756,6 +756,16 @@ static void vo_x11_decoration(struct vo *vo, bool d)
                     PropModeReplace, (unsigned char *) &mhints, 5);
 }
 
+static void vo_x11_wm_hints(struct vo *vo, Window window)
+{
+    struct vo_x11_state *x11 = vo->x11;
+    XWMHints hints = {0};
+    hints.flags = InputHint | StateHint;
+    hints.input = 1;
+    hints.initial_state = NormalState;
+    XSetWMHints(x11->display, window, &hints);
+}
+
 static void vo_x11_classhint(struct vo *vo, Window window, const char *name)
 {
     struct vo_x11_state *x11 = vo->x11;
@@ -1615,6 +1625,7 @@ bool vo_x11_create_vo_window(struct vo *vo, XVisualInfo *vis,
     if (x11->window == None) {
         vo_x11_create_window(vo, vis, (struct mp_rect){.x1 = 320, .y1 = 200 });
         vo_x11_classhint(vo, x11->window, classname);
+        vo_x11_wm_hints(vo, x11->window);
         x11->window_hidden = true;
     }
 


### PR DESCRIPTION
When the window is mapped, ICCCM WM_HINTS (specifically the input and
state fields) are set. To quote the spec, "The input field is used to
communicate to the window manager the input focus model used by the
client" and "[c]lients with the Passive and Locally Active models should
set the input flag to True". mpv falls under the Passive Input model,
so the input flag is set to true. The state hint is set to NormalState.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.