### PR TITLE
Fix gbm.h/jpeglib.h detection outside of default search path

### DIFF
--- a/ci/build-freebsd.sh
+++ b/ci/build-freebsd.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-export CFLAGS="$CFLAGS -isystem/usr/local/include"
-export CXXFLAGS="$CXXFLAGS -isystem/usr/local/include"
-export LDFLAGS="$LDFLAGS -L/usr/local/lib"
-
 if [ ! -e "./waf" ] ; then
     python3 ./bootstrap.py
 fi

--- a/wscript
+++ b/wscript
@@ -268,10 +268,6 @@ iconv support use --disable-iconv.",
         'func': check_statement(['sys/consio.h', 'sys/ioctl.h'],
                                 'int m; ioctl(0, VT_GETMODE, &m)'),
     }, {
-        'name': 'gbm.h',
-        'desc': 'gbm.h',
-        'func': check_cc(header_name=['stdio.h', 'gbm.h']),
-    }, {
         'name': 'glibc-thread-name',
         'desc': 'GLIBC API for setting thread name',
         'func': check_statement('pthread.h',
@@ -482,7 +478,6 @@ video_output_features = [
     }, {
         'name': '--gbm',
         'desc': 'GBM',
-        'deps': 'gbm.h',
         'func': check_pkg_config('gbm'),
     } , {
         'name': '--wayland-scanner',
@@ -655,8 +650,7 @@ video_output_features = [
     }, {
         'name': '--jpeg',
         'desc': 'JPEG support',
-        'func': check_cc(header_name=['stdio.h', 'jpeglib.h'],
-                         lib='jpeg', use='libm'),
+        'func': check_pkg_config('libjpeg'),
     }, {
         'name': '--direct3d',
         'desc': 'Direct3D support',
@@ -667,14 +661,13 @@ video_output_features = [
         'desc': 'libshaderc SPIR-V compiler (shared library)',
         'deps': '!static-build',
         'groups': ['shaderc'],
-        'func': check_cc(header_name='shaderc/shaderc.h', lib='shaderc_shared'),
+        'func': check_pkg_config('shaderc'),
     }, {
         'name': 'shaderc-static',
         'desc': 'libshaderc SPIR-V compiler (static library)',
         'deps': '!shaderc-shared',
         'groups': ['shaderc'],
-        'func': check_cc(header_name='shaderc/shaderc.h',
-                         lib=['shaderc_combined', 'stdc++']),
+        'func': check_pkg_config('shaderc_combined'),
     }, {
         'name': '--shaderc',
         'desc': 'libshaderc SPIR-V compiler',


### PR DESCRIPTION
The following scenario maybe uncommon on Linux but BSDs separate base system and packages to avoid tainting build environment:
1. Install libjpeg-turbo under `/myprefix`
2. Make sure `libjpeg.pc` points to `/myprefix/include`
3. Run `waf configure`
4. Confirm `JPEG support` detection failed
5. Check  `build/config.log`
6. Notice `-I/myprefix/include` is missing

When a project provides *.pc file(s) it expects consumers to consult them how to find headers, what flags to use, etc. instead of probing them manually. Only when there's none one can blame BSDs for crippling the default environment. Fortunately, all affected places have *.pc files, so we can drop an ugly wart in FreeBSD CI config.
