### PR TITLE
Update compile-windows.md

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -68,7 +68,7 @@ echo "MXE_TARGETS := i686-w64-mingw32.static" >> settings.mk
 # Build required packages. The following provide a minimum required to build
 # a reasonable mpv binary (though not an absolute minimum).
 
-make gcc ffmpeg libass jpeg lua
+make gcc ffmpeg libass jpeg lua luajit
 
 # Add MXE binaries to $PATH
 export PATH=/opt/mxe/usr/bin/:$PATH


### PR DESCRIPTION
fix MXE environment support lua5.1 or 5.2  by add luajit package for cross compile.

mxe cross compiler using lua 5.3.3 as default version , which not well support now：
[MXE defualt lua version](https://github.com/mxe/mxe/blob/d63639ff6e39d66d5b0d489ef17840af522e6dca/src/lua.mk#L7)
[FAQ I can’t see the OSC/OSD/GUI!](https://github.com/mpv-player/mpv/wiki/FAQ#i-cant-see-the-oscosdgui)