### PR TITLE
HDR changes

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6005,12 +6005,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
     additional effect of parametrizing the inverse OOTF, in order to get
     colorimetrically consistent results with the mastering display. For SDR, or
     when using an ICC (profile (``--icc-profile``), setting this to a value
-    above 100 essentially causes the display to be treated as if it were an HDR
+    above 203 essentially causes the display to be treated as if it were an HDR
     display in disguise. (See the note below)
 
     In ``auto`` mode (the default), the chosen peak is an appropriate value
-    based on the TRC in use. For SDR curves, it uses 100. For HDR curves, it
-    uses 100 * the transfer function's nominal peak.
+    based on the TRC in use. For SDR curves, it uses 203. For HDR curves, it
+    uses 203 * the transfer function's nominal peak.
 
     .. note::
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6058,6 +6058,9 @@ The following video options are currently all specific to ``--vo=gpu`` and
         color/brightness accuracy. This is roughly equivalent to
         ``--tone-mapping=reinhard --tone-mapping-param=0.24``. If possible,
         you should also enable ``--hdr-compute-peak`` for the best results.
+    bt.2390
+        Perceptual tone mapping curve (EETF) specified in ITU-R Report BT.2390.
+        This is the recommended curve to use for typical HDR-mastered content.
         (Default)
     gamma
         Fits a logarithmic transfer between the tone curves.

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -481,7 +481,7 @@ float mp_trc_nom_peak(enum mp_csp_trc trc)
 {
     switch (trc) {
     case MP_CSP_TRC_PQ:           return 10000.0 / MP_REF_WHITE;
-    case MP_CSP_TRC_HLG:          return 12.0;
+    case MP_CSP_TRC_HLG:          return 12.0 / MP_REF_WHITE_HLG;
     case MP_CSP_TRC_V_LOG:        return 46.0855;
     case MP_CSP_TRC_S_LOG1:       return 6.52;
     case MP_CSP_TRC_S_LOG2:       return 9.212;

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -145,9 +145,11 @@ struct mp_colorspace {
 
 // For many colorspace conversions, in particular those involving HDR, an
 // implicit reference white level is needed. Since this magic constant shows up
-// a lot, give it an explicit name. The value of 100 cd/m² comes from ITU-R
-// documents such as ITU-R BT.2100
-#define MP_REF_WHITE 100.0
+// a lot, give it an explicit name. The value of 203 cd/m² comes from ITU-R
+// Report BT.2408, and the value for HLG comes from the cited HLG 75% level
+// (transferred to scene space).
+#define MP_REF_WHITE 203.0
+#define MP_REF_WHITE_HLG 3.17955
 
 // Replaces unknown values in the first struct by those of the second struct
 void mp_colorspace_merge(struct mp_colorspace *orig, struct mp_colorspace *new);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -322,7 +322,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .background = {0, 0, 0, 255},
     .gamma = 1.0f,
     .tone_map = {
-        .curve = TONE_MAPPING_HABLE,
+        .curve = TONE_MAPPING_BT_2390,
         .curve_param = NAN,
         .max_boost = 1.0,
         .decay_rate = 100.0,
@@ -382,7 +382,8 @@ const struct m_sub_options gl_video_conf = {
             {"reinhard", TONE_MAPPING_REINHARD},
             {"hable",    TONE_MAPPING_HABLE},
             {"gamma",    TONE_MAPPING_GAMMA},
-            {"linear",   TONE_MAPPING_LINEAR})},
+            {"linear",   TONE_MAPPING_LINEAR},
+            {"bt.2390",  TONE_MAPPING_BT_2390})},
         {"hdr-compute-peak", OPT_CHOICE(tone_map.compute_peak,
             {"auto", 0},
             {"yes", 1},

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -94,6 +94,7 @@ enum tone_mapping {
     TONE_MAPPING_HABLE,
     TONE_MAPPING_GAMMA,
     TONE_MAPPING_LINEAR,
+    TONE_MAPPING_BT_2390,
 };
 
 struct gl_tone_map_opts {


### PR DESCRIPTION
1. Reinterpret SDR white as 203 cd/m² instead of 100 cd/m²
2. Implement BT.2390 EETF tone-mapping

While testing this I noticed that for some reason, the HDR peak detection seems broken on vulkan on my end. Not gonna merge this until I figure out why and if that's somehow a bug that only occurs in combination with this patch (for whatever reason?)