### PR TITLE
[player,wscript]: os:win cplugins support

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -692,6 +692,76 @@ off_t mp_lseek(int fd, off_t offset, int whence)
     return _lseeki64(fd, offset, whence);
 }
 
+_Thread_local
+static struct {
+    DWORD errcode;
+    char *errstring;
+} mp_dl_result = {
+    .errcode = 0,
+    .errstring = NULL
+};
+
+static void mp_dl_free(void)
+{
+    if (mp_dl_result.errstring != NULL) {
+        talloc_free(mp_dl_result.errstring);
+    }
+}
+
+static void mp_dl_init(void)
+{
+    atexit(mp_dl_free);
+}
+
+void *mp_dlopen(const char *filename, int flag)
+{
+    wchar_t *wfilename = mp_from_utf8(NULL, filename);    
+    HMODULE lib = LoadLibraryW(wfilename);
+    talloc_free(wfilename);
+    mp_dl_result.errcode = GetLastError();
+    return (void *)lib;
+}
+
+void *mp_dlsym(void *handle, const char *symbol)
+{
+    FARPROC addr = GetProcAddress((HMODULE)handle, symbol);
+    mp_dl_result.errcode = GetLastError();
+    return (void *)addr;
+}
+
+char *mp_dlerror(void)
+{
+    static pthread_once_t once_init_dlerror = PTHREAD_ONCE_INIT;
+    pthread_once(&once_init_dlerror, mp_dl_init);
+    mp_dl_free();
+
+    if (mp_dl_result.errcode == 0)
+        return NULL;
+    
+    // convert error code to a string message
+    LPWSTR werrstring = NULL;
+    FormatMessageW(
+        FORMAT_MESSAGE_FROM_SYSTEM
+            | FORMAT_MESSAGE_IGNORE_INSERTS
+            | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+        NULL,
+        mp_dl_result.errcode,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL),
+        (LPWSTR) &werrstring,
+        0,
+        NULL);
+    mp_dl_result.errcode = 0;
+    
+    if (werrstring) {
+        mp_dl_result.errstring = mp_to_utf8(NULL, werrstring);
+        LocalFree(werrstring);
+    }
+    
+    return mp_dl_result.errstring == NULL
+        ? "unknown error"
+        : mp_dl_result.errstring;
+}
+
 #if HAVE_UWP
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 {

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -106,6 +106,9 @@ int mp_mkdir(const char *path, int mode);
 char *mp_win32_getcwd(char *buf, size_t size);
 char *mp_getenv(const char *name);
 off_t mp_lseek(int fd, off_t offset, int whence);
+void *mp_dlopen(const char *filename, int flag);
+void *mp_dlsym(void *handle, const char *symbol);
+char *mp_dlerror(void);
 
 // mp_stat types. MSVCRT's dev_t and ino_t are way too short to be unique.
 typedef uint64_t mp_dev_t_;
@@ -164,6 +167,12 @@ void mp_globfree(mp_glob_t *pglob);
 
 #undef lseek
 #define lseek(...) mp_lseek(__VA_ARGS__)
+
+#define RTLD_NOW 0
+#define RTLD_LOCAL 0
+#define dlopen(fn,fg) mp_dlopen((fn), (fg))
+#define dlsym(h,s) mp_dlsym((h), (s))
+#define dlerror mp_dlerror
 
 // Affects both "stat()" and "struct stat".
 #undef stat


### PR DESCRIPTION
Hi,
I was wondering why there wasn't cplugins support for windows,
so I gave it a try and it worked fine with a toy extension I'm developing.

I'm not very familiar with WAF build system, I hope the changes are appreciated.
About `scripting.c`, the `HAVE_CPLUGINS` section is not the best looking code (many #if/#else/#endif)... if you know or want any pattern to be applied I'll gladly try to refactor.

I only tested building and running on windows target with this changes, other platforms should need a test.