### PR TITLE
vulkan/wayland: fix another build breakage

### DIFF
--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -23,7 +23,7 @@
 #include "utils.h"
 
 // Generated from presentation-time.xml
-#include "video/out/wayland/presentation-time.h"
+#include "generated/wayland/presentation-time.h"
 
 struct priv {
     struct mpvk_ctx vk;


### PR DESCRIPTION
Commit 07b0c18bad6cb168191d390f10db998eb7201b67 introduced some build breakages. Some breakages were fixed on c1fc5354c3c15b46d77adf4d27d38b8b27fa9dfd and a1adafe9664f1665e7f4d0d53053683fe617d50e. This one is still remaining.

This commit fixes the following build error:

```
[153/521] Compiling video/out/vulkan/context_wayland.c
../video/out/vulkan/context_wayland.c:26:10: fatal error: video/out/wayland/presentation-time.h: No such file or directory
   26 | #include "video/out/wayland/presentation-time.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Relevant to: #7802