### PR TITLE
ao/pulse: implement period_size

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -472,6 +472,7 @@ static int init(struct ao *ao)
     }
     ao->device_buffer = final_bufattr->tlength /
                         af_fmt_to_bytes(ao->format) / ao->channels.num;
+    ao->period_size = final_bufattr->minreq / af_fmt_to_bytes(ao->format) / ao->channels.num;
 
     pa_threaded_mainloop_unlock(priv->mainloop);
     return 0;


### PR DESCRIPTION
The idea behind period_size is that it's the minimum amount of data that your audio subsystem wants to fetch.

For PulseAudio, this is given by the minreq buffer attribute, which is in bytes for all channels. Hence the divisions.