### PR TITLE
ao/jack: set device_buffer to JACK buffer size

### DIFF
--- a/audio/out/ao_jack.c
+++ b/audio/out/ao_jack.c
@@ -246,6 +246,8 @@ static int init(struct ao *ao)
     jack_set_process_callback(p->client, process, ao);
 
     ao->samplerate = jack_get_sample_rate(p->client);
+    // The actual device buffer can change, but this is enough for pre-buffer
+    ao->device_buffer = jack_get_buffer_size(p->client);
 
     jack_set_buffer_size_callback(p->client, buffer_size_cb, ao);
     jack_set_graph_order_callback(p->client, graph_order_cb, ao);


### PR DESCRIPTION
This change sets the device_buffer member of the ao struct for the JACK ao to whatever value we read during init.

While JACK allows changing the audio buffer size on-the-fly (you can do this for example through DBus), having it somehow reconfigure the entire audio buffer logic of mpv that depends on device_buffer in some way when that happens only leads to audio dropout and weird code. device_buffer's role is mostly for prebuffer from what I understand, which means that simply setting it to its current value in the init function is fine.