### PR TITLE
ci: replace mingw build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,17 @@ _macbase:
                    'pkg-config', 'python']
         update: true
 
+_mingwbase:
+  - &mingw
+    os: linux
+    addons:
+      apt:
+        packages: ['autoconf', 'automake', 'pkg-config', 'gcc-mingw-w64',
+                   'nasm', 'yasm']
+    cache:
+      directories:
+        - mingw_prefix/
+
 matrix:
   include:
     - <<: *macNew
@@ -32,10 +43,10 @@ matrix:
     - os: linux
       compiler: clang
       env: CONTAINER=registry.cirno.systems/kiwi/containers/mpv-ci:stable-deps CI_SCRIPT=ci/build-tumbleweed.sh
-    - os: linux
-      env: CONTAINER=registry.cirno.systems/kiwi/containers/mpv-ci-mingw64:i686 CI_SCRIPT=ci/build-mingw64.sh TARGET=i686-w64-mingw32
-    - os: linux
-      env: CONTAINER=registry.cirno.systems/kiwi/containers/mpv-ci-mingw64:x86_64 CI_SCRIPT=ci/build-mingw64.sh TARGET=x86_64-w64-mingw32
+    - <<: *mingw
+      env: CI_SCRIPT=ci/build-mingw64.sh TARGET=i686-w64-mingw32
+    - <<: *mingw
+      env: CI_SCRIPT=ci/build-mingw64.sh TARGET=x86_64-w64-mingw32
   allow_failures:
     - os: osx
       osx_image: xcode9.2
@@ -62,7 +73,7 @@ branches:
 before_install:
   - if [ "$TRAVIS_COMPILER" = "clang" ]; then export CXX="clang++"; fi
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then export CXX="g++"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker pull $CONTAINER; fi
+  - if [ -n "$CONTAINER" ]; then docker pull $CONTAINER; fi
   - |
         if [ "$TRAVIS_OS_NAME" = "freebsd" ]; then
             # Requested in ci/build-freebsd.sh
@@ -129,7 +140,14 @@ cache:
 
 script:
   - ./bootstrap.py
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then docker run --env CC --env TARGET -v $TRAVIS_BUILD_DIR:/build $CONTAINER /bin/sh -c "cd /build && $CI_SCRIPT"; fi
+  - |
+        if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+            if [ -n "$CONTAINER" ]; then
+                docker run --env CC --env TARGET -v $TRAVIS_BUILD_DIR:/build $CONTAINER /bin/sh -c "cd /build && $CI_SCRIPT"
+            else
+                $CI_SCRIPT
+            fi
+        fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./ci/build-macos.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "freebsd" ]; then ./ci/build-freebsd.sh; fi
 after_failure: cat ./build/config.log

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -1,32 +1,125 @@
-#!/bin/sh
-set -e
+#!/bin/bash -e
 
-_mingw_sysroot=/usr/$TARGET/sysroot
-_mingw_prefix=$_mingw_sysroot/mingw
-_mingw_exec_prefix=$_mingw_prefix
-_mingw_libdir=$_mingw_exec_prefix/lib
-_mingw_datadir=$_mingw_prefix/share
+prefix_dir=$PWD/mingw_prefix
+mkdir -p "$prefix_dir"
+ln -snf . "$prefix_dir/usr"
+ln -snf . "$prefix_dir/local"
 
-export PKG_CONFIG_PATH="$_mingw_libdir/pkgconfig:$_mingw_datadir/pkgconfig";
+wget="wget -nc --progress=bar:force"
+gitclone="git clone --depth=10"
+commonflags="--disable-static --enable-shared"
+
+export PKG_CONFIG_SYSROOT_DIR="$prefix_dir"
+export PKG_CONFIG_LIBDIR="$PKG_CONFIG_SYSROOT_DIR/lib/pkgconfig"
+
 export CC=$TARGET-gcc
 export CXX=$TARGET-g++
 export AR=$TARGET-ar
 export NM=$TARGET-nm
 export RANLIB=$TARGET-ranlib
-export CFLAGS="-O2 -mtune=intel -g -ggdb -pipe -Wall --param=ssp-buffer-size=4 -mms-bitfields -fmessage-length=0 -D_FORTIFY_SOURCE=2 -fexceptions -fasynchronous-unwind-tables -fstack-protector-strong -fno-ident"
-export LDFLAGS="-Wl,--no-keep-memory -fstack-protector-strong"
 
+export CFLAGS="-O2 -pipe -Wall -D_FORTIFY_SOURCE=2"
+export LDFLAGS="-fstack-protector-strong"
+
+function builddir () {
+    [ -d "$1/builddir" ] && rm -rf "$1/builddir"
+    mkdir -p "$1/builddir"
+    pushd "$1/builddir"
+}
+
+function makeplusinstall () {
+    make -j$(nproc)
+    make DESTDIR="$prefix_dir" install
+}
+
+function gettar () {
+    name="${1##*/}"
+    [ -d "${name%%.*}" ] && return 0
+    $wget "$1"
+    tar -xaf "$name"
+}
+
+## iconv
+if [ ! -e "$prefix_dir/lib/libiconv.dll.a" ]; then
+    ver=1.16
+    gettar "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ver}.tar.gz"
+    builddir libiconv-${ver}
+    ../configure --host=$TARGET $commonflags
+    makeplusinstall
+    popd
+fi
+
+## zlib
+if [ ! -e "$prefix_dir/lib/libz.dll.a" ]; then
+    ver=1.2.11
+    gettar "https://zlib.net/zlib-${ver}.tar.gz"
+    pushd zlib-${ver}
+    make -fwin32/Makefile.gcc PREFIX=$TARGET- SHARED_MODE=1 \
+        DESTDIR="$prefix_dir" install \
+        BINARY_PATH=/bin INCLUDE_PATH=/include LIBRARY_PATH=/lib
+    popd
+fi
+
+## ffmpeg
+if [ ! -e "$prefix_dir/lib/libavcodec.dll.a" ]; then
+    [ -d ffmpeg ] || $gitclone https://github.com/FFmpeg/FFmpeg.git ffmpeg
+    builddir ffmpeg
+    ../configure --pkg-config=pkg-config --target-os=mingw32 \
+        --enable-cross-compile --cross-prefix=$TARGET- --arch=${TARGET%%-*} \
+        $commonflags \
+        --disable-{stripping,doc,programs,muxers,encoders,devices}
+    makeplusinstall
+    popd
+fi
+
+## freetype2
+if [ ! -e "$prefix_dir/lib/libfreetype.dll.a" ]; then
+    ver=2.10.2
+    gettar "https://download.savannah.gnu.org/releases/freetype/freetype-${ver}.tar.gz"
+    builddir freetype-${ver}
+    ZLIB_LIBS="-L'$prefix_dir/lib' -lz" \
+    ../configure --host=$TARGET $commonflags --with-png=no
+    makeplusinstall
+    popd
+fi
+[ -f "$prefix_dir/lib/libfreetype.dll.a" ] || { echo "libtool fuckup"; exit 1; }
+
+## fribidi
+if [ ! -e "$prefix_dir/lib/libfribidi.dll.a" ]; then
+    ver=1.0.9
+    gettar "https://github.com/fribidi/fribidi/releases/download/v${ver}/fribidi-${ver}.tar.xz"
+    builddir fribidi-${ver}
+    ../configure --host=$TARGET $commonflags
+    makeplusinstall
+    popd
+fi
+
+## libass
+if [ ! -e "$prefix_dir/lib/libass.dll.a" ]; then
+    [ -d libass ] || $gitclone https://github.com/libass/libass.git
+    builddir libass
+    [ -f ../configure ] || (cd .. && ./autogen.sh)
+    ../configure --host=$TARGET $commonflags
+    makeplusinstall
+    popd
+fi
+
+## lua
+if [ ! -e "$prefix_dir/lib/liblua.a" ]; then
+    ver=5.2.4
+    gettar "https://www.lua.org/ftp/lua-${ver}.tar.gz"
+    pushd lua-${ver}
+    make PLAT=mingw INSTALL_TOP="$prefix_dir" TO_BIN=/dev/null \
+        CC="$CC" AR="$AR r" all install
+    make INSTALL_TOP="$prefix_dir" pc >"$prefix_dir/lib/pkgconfig/lua.pc"
+    printf 'Name: Lua\nDescription:\nVersion: ${version}\nLibs: -L${libdir} -llua\nCflags: -I${includedir}\n' \
+        >>"$prefix_dir/lib/pkgconfig/lua.pc"
+    popd
+fi
+
+## mpv
+PKG_CONFIG=pkg-config CFLAGS="-I'$prefix_dir/include'" LDFLAGS="-L'$prefix_dir/lib'" \
 python3 ./waf configure \
-    --enable-static-build \
-    --enable-libmpv-shared \
-    --enable-lua \
-    --enable-javascript \
-    --enable-libarchive \
-    --enable-libbluray \
-    --enable-dvdnav \
-    --enable-uchardet \
-    --enable-vulkan \
-    --enable-shaderc \
-    --enable-rubberband \
-    --enable-lcms2
+    --enable-libmpv-shared --lua=52
+
 python3 ./waf build --verbose


### PR DESCRIPTION
Instead of a prebuilt docker container, pull deps ourselves and build them.

This leverages travis caching to not build ffmpeg + the rest every time.
No rebuilds will happen unless caches are manually deleted [here](https://travis-ci.org/github/mpv-player/mpv/caches). This could be changed to rebuild if library versions are bumped in the CI script if desired.

Usual buildtime (with cache) is ~3 minutes. Uncached builds take ~15 minutes.