### PR TITLE
audio: only lock ao buffer for push mode APIs

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -288,9 +288,14 @@ int ao_control(struct ao *ao, enum aocontrol cmd, void *arg)
     struct buffer_state *p = ao->buffer_state;
     int r = CONTROL_UNKNOWN;
     if (ao->driver->control) {
-        pthread_mutex_lock(&p->lock);
+        // Only need to lock in push mode.
+        if (ao->driver->write)
+            pthread_mutex_lock(&p->lock);
+
         r = ao->driver->control(ao, cmd, arg);
-        pthread_mutex_unlock(&p->lock);
+
+        if (ao->driver->write)
+            pthread_mutex_unlock(&p->lock);
     }
     return r;
 }


### PR DESCRIPTION
The pull mode APIs don't require locking calls to read the buffer or send
ao_controls. Locks were added in b83bdd1, which introduced deadlocks in
ao_wasapi.

This also allows cleanup of some of the special cases required to avoid
other deadlocks by holding unnecessary locks for pull mode.