### PR TITLE
ytdl_hook: support thumbnails

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -481,7 +481,7 @@ local function formats_to_edl(json, formats, use_all_formats)
     return res
 end
 
-local function add_single_video(json)
+local function add_single_video(json, thumbnail, allthumbs)
     local streamurl = ""
     local format_info = ""
     local max_bitrate = 0
@@ -603,6 +603,32 @@ local function add_single_video(json)
         end
     end
 
+    -- add thumbnails
+    if (thumbnail == true) and not (json.thumbnails == nil) then
+        local thumb = nil
+        local thumb_height = -1
+
+        for _, thumb_info in ipairs(json.thumbnails) do
+            if not (thumb_info.url == nil) then
+                if (allthumbs == true) then
+                    msg.verbose("adding thumbnail")
+                    mp.commandv("video-add", thumb_info.url, "auto")
+                    thumb_height = 0
+                elseif ((thumb_info.height or 0) > thumb_height) then
+                    thumb = thumb_info.url
+                    thumb_height = thumb_info.height or 0
+                end
+            end
+        end
+
+        if not (thumb == nil) then
+            msg.verbose("adding thumbnail")
+            mp.commandv("video-add", thumb, "auto")
+        elseif (thumb_height == -1) then
+            msg.verbose("No thumbnail url")
+        end
+    end
+
     -- add chapters
     if json.chapters then
         msg.debug("Adding pre-parsed chapters")
@@ -700,6 +726,8 @@ function run_ytdl_hook(url)
     local format = mp.get_property("options/ytdl-format")
     local raw_options = mp.get_property_native("options/ytdl-raw-options")
     local allsubs = true
+    local thumbnail = false
+    local allthumbs = false
     local proxy = nil
     local use_playlist = false
 
@@ -731,6 +759,11 @@ function run_ytdl_hook(url)
         end
         if (param == "sub-lang") and (arg ~= "") then
             allsubs = false
+        elseif (param == "write-thumbnail") then
+            thumbnail = true
+        elseif (param == "write-all-thumbnails") then
+            thumbnail = true
+            allthumbs = true
         elseif (param == "proxy") and (arg ~= "") then
             proxy = arg
         elseif (param == "yes-playlist") then
@@ -858,7 +891,7 @@ function run_ytdl_hook(url)
 
         elseif self_redirecting_url and #json.entries == 1 then
             msg.verbose("Playlist with single entry detected.")
-            add_single_video(json.entries[1])
+            add_single_video(json.entries[1], thumbnail, allthumbs)
         else
             local playlist_index = parse_yt_playlist(url, json)
             local playlist = {"#EXTM3U"}
@@ -904,7 +937,7 @@ function run_ytdl_hook(url)
         end
 
     else -- probably a video
-        add_single_video(json)
+        add_single_video(json, thumbnail, allthumbs)
     end
     msg.debug('script running time: '..os.clock()-start_time..' seconds')
 end


### PR DESCRIPTION
Similar to `write-sub=`, adding `write-thumbnail=` to raw-options will add the highest resolution thumbnail as a video track.

Closes #7041

Whether to add thumbnails or not is passed to `add_single_video()`, didn't want to duplicate the `raw_options` loop.
This may be bad for extensibility.