### PR TITLE
vo_gpu: use highp float if available for GLES

### DIFF
--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -761,7 +761,12 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
     for (int n = 0; n < sc->num_exts; n++)
         ADD(header, "#extension %s : enable\n", sc->exts[n]);
     if (glsl_es) {
+        ADD(header, "#ifdef GL_FRAGMENT_PRECISION_HIGH\n");
+        ADD(header, "precision highp float;\n");
+        ADD(header, "#else\n");
         ADD(header, "precision mediump float;\n");
+        ADD(header, "#endif\n");
+        
         ADD(header, "precision mediump sampler2D;\n");
         if (sc->ra->caps & RA_CAP_TEX_3D)
             ADD(header, "precision mediump sampler3D;\n");


### PR DESCRIPTION
This fixes #6418 and #7846, and likely also fixes https://github.com/mpv-android/mpv-android/issues/196 and https://github.com/mpv-android/mpv-android/issues/276.

It seems using mediump float in the shader causes issues on iOS with kernel resampling, PQ HDR, and maybe more.

Apple suggests [here](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/BestPracticesforShaders/BestPracticesforShaders.html#//apple_ref/doc/uid/TP40008793-CH7-SW7)  “when in doubt, default to high precision”, so this changes GLES to use highp when it’s available (if GL_FRAGMENT_PRECISION_HIGH is defined). And it fixes all the problems I've seen.

Those mpv-android issues match the defects on iOS, so there’s a good chance this will help there as well, though I'm not able to test on Android.