### PR TITLE
video/out/vulkan: add MoltenVK context

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3175,6 +3175,10 @@ Window
     ``--hwdec=mediacodec`` for direct rendering using MediaCodec, or with
     ``--vo=gpu --gpu-context=android`` (with or without ``--hwdec=mediacodec-copy``).
 
+    If compiled with MoltenVK on iOS/tvOS/macOS, the ID is interpreted as
+    ``CAMetalLayer *``. Pass it as a value cast to ``intptr_t``. Use with
+    ``--vo=gpu --gpu-api=vulkan --gpu-context=moltenvk``
+
 ``--no-window-dragging``
     Don't move the window when clicking on it and moving the mouse pointer.
 

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -50,6 +50,7 @@ extern const struct ra_ctx_fns ra_ctx_vulkan_wayland;
 extern const struct ra_ctx_fns ra_ctx_vulkan_win;
 extern const struct ra_ctx_fns ra_ctx_vulkan_xlib;
 extern const struct ra_ctx_fns ra_ctx_vulkan_android;
+extern const struct ra_ctx_fns ra_ctx_vulkan_moltenvk;
 
 /* Direct3D 11 */
 extern const struct ra_ctx_fns ra_ctx_d3d11;
@@ -94,6 +95,9 @@ static const struct ra_ctx_fns *contexts[] = {
 // Vulkan contexts:
 #if HAVE_VULKAN
 
+#if HAVE_MOLTENVK
+    &ra_ctx_vulkan_moltenvk,
+#endif
 #if HAVE_ANDROID
     &ra_ctx_vulkan_android,
 #endif

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -22,6 +22,9 @@
 #if HAVE_WIN32_DESKTOP
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
+#if HAVE_MOLTENVK
+#include <MoltenVK/mvk_vulkan.h>
+#endif
 
 #include <libplacebo/vulkan.h>
 

--- a/video/out/vulkan/context_moltenvk.m
+++ b/video/out/vulkan/context_moltenvk.m
@@ -1,0 +1,96 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <QuartzCore/CAMetalLayer.h>
+#include <MoltenVK/mvk_vulkan.h>
+
+#include "common.h"
+#include "context.h"
+#include "utils.h"
+
+struct priv {
+    struct mpvk_ctx vk;
+    CAMetalLayer *layer;
+};
+
+static void moltenvk_uninit(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+    ra_vk_ctx_uninit(ctx);
+    mpvk_uninit(&p->vk);
+}
+
+static bool moltenvk_init(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
+    struct mpvk_ctx *vk = &p->vk;
+    int msgl = ctx->opts.probing ? MSGL_V : MSGL_ERR;
+
+    if (ctx->vo->opts->WinID == -1) {
+        MP_MSG(ctx, msgl, "WinID missing\n");
+        goto fail;
+    }
+
+    if (!mpvk_init(vk, ctx, VK_EXT_METAL_SURFACE_EXTENSION_NAME))
+        goto fail;
+
+    p->layer = (__bridge CAMetalLayer *)(intptr_t)ctx->vo->opts->WinID;
+    VkMetalSurfaceCreateInfoEXT info = {
+         .sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
+         .pLayer = p->layer,
+    };
+
+    struct ra_vk_ctx_params params = {0};
+
+    VkInstance inst = vk->vkinst->instance;
+    VkResult res = vkCreateMetalSurfaceEXT(inst, &info, NULL, &vk->surface);
+    if (res != VK_SUCCESS) {
+        MP_MSG(ctx, msgl, "Failed creating MoltenVK surface\n");
+        goto fail;
+    }
+
+    if (!ra_vk_ctx_init(ctx, vk, params, VK_PRESENT_MODE_FIFO_KHR))
+        goto fail;
+
+    return true;
+fail:
+    moltenvk_uninit(ctx);
+    return false;
+}
+
+static bool moltenvk_reconfig(struct ra_ctx *ctx)
+{
+    struct priv *p = ctx->priv;
+    CGSize s = p->layer.drawableSize;
+    ra_vk_ctx_resize(ctx, s.height, s.height);
+    return true;
+}
+
+static int moltenvk_control(struct ra_ctx *ctx, int *events, int request, void *arg)
+{
+    return VO_NOTIMPL;
+}
+
+const struct ra_ctx_fns ra_ctx_vulkan_moltenvk = {
+    .type           = "vulkan",
+    .name           = "moltenvk",
+    .reconfig       = moltenvk_reconfig,
+    .control        = moltenvk_control,
+    .init           = moltenvk_init,
+    .uninit         = moltenvk_uninit,
+};

--- a/wscript
+++ b/wscript
@@ -158,6 +158,13 @@ main_dependencies = [
         'desc': 'Android environment',
         'func': check_statement('android/api-level.h', '(void)__ANDROID__'),  # arbitrary android-specific header
     }, {
+        'name': '--ios',
+        'desc': 'iOS environment',
+        'func': check_statement(
+            ['TargetConditionals.h', 'assert.h'],
+            'static_assert(TARGET_OS_IPHONE, "TARGET_OS_IPHONE defined to zero!")'
+        ),
+    }, {
         'name': '--tvos',
         'desc': 'tvOS environment',
         'func': check_statement(
@@ -726,6 +733,11 @@ video_output_features = [
         'desc':  'Vulkan context support',
         'deps': 'libplacebo',
         'func': check_pkg_config('vulkan'),
+    }, {
+        'name': '--moltenvk',
+        'desc':  'MoltenVK support',
+        'deps': 'ios || tvos || cocoa',
+        'func': check_cc(header_name=['MoltenVK/mvk_vulkan.h']),
     }, {
         'name': 'vaapi-vulkan',
         'desc': 'VAAPI Vulkan',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -501,6 +501,7 @@ def build(ctx):
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),
         ( "video/out/vulkan/context_android.c",  "vulkan && android" ),
+        ( "video/out/vulkan/context_moltenvk.m", "moltenvk" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
         ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),


### PR DESCRIPTION
Similar to #7482, but without any of the macOS specific bits. Instead, the underlying `CAMetalLayer*` can be passed in via `--wid=`

I tested this briefly on iOS and it worked.

cc @Akemi @qiudaomao 