### PR TITLE
man/ao/sdl: drop no longer supported --sdl-bufcnt

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -160,10 +160,6 @@ Available audio output drivers are:
         obtained exact buffer size. A value of 0 selects the sound system
         default.
 
-    ``--sdl-bufcnt=<count>``
-        Sets the number of extra audio buffers in mpv. Usually needs not be
-        changed.
-
 ``null``
     Produces no audio output but maintains video playback speed. You can use
     ``--ao=null --ao-null-untimed`` for benchmarking.


### PR DESCRIPTION
```
$ mpv --ao=sdl --sdl-bufcnt=1234 --msg-level=ao=v /path/to/foo.mp3
Error parsing option sdl-bufcnt (option not found)
Setting commandline option --sdl-bufcnt=1234 failed.
Exiting... (Fatal error)

$ mpv --list-options | fgrep sdl-
 --sdl-buflen                     Float (default: 0.000)
 --sdl-sw                         Flag (default: no)
 --sdl-switch-mode                Flag (default: no)
 --sdl-vsync                      Flag (default: yes)
```
