### PR TITLE
mp_image.c: change  mastering metadata color sig_peak calc,make the l…

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -989,7 +989,7 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
     if (!dst->params.color.sig_peak && sd) {
         AVMasteringDisplayMetadata *mdm = (AVMasteringDisplayMetadata *)sd->data;
         if (mdm->has_luminance)
-            dst->params.color.sig_peak = av_q2d(mdm->max_luminance) / MP_REF_WHITE;
+            dst->params.color.sig_peak = av_q2d(mdm->max_luminance) / ( 10000.0 * MP_REF_WHITE );
     }
 
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_A53_CC);


### PR DESCRIPTION
mp_image.c: change  mastering metadata color sig_peak calc,make the look's like HDR display in SDR.

I compared the display on SDR of other players with the display of real HDR screen, and found that the modification of parameters here is closer to the effect of display on HDR.