### PR TITLE
build: sort dependencies (to make build deterministic)

### DIFF
--- a/waftools/dependencies.py
+++ b/waftools/dependencies.py
@@ -215,7 +215,7 @@ def env_fetch(tx):
     return fn
 
 def dependencies_use(ctx):
-    return [inflector.storage_key(dep) for dep in ctx.env.satisfied_deps]
+    return [inflector.storage_key(dep) for dep in sorted(ctx.env.satisfied_deps)]
 
 BuildContext.filtered_sources = filtered_sources
 BuildContext.pick_first_matching_dep = pick_first_matching_dep


### PR DESCRIPTION
Fixes #7855.

Satisfied dependencies are stored in a set, so order is dependent on hash seed. The only other use I see is in `__get_features_string__` in headers.py, which is already being sorted.

On my machine, and with --disable-build-date, this produces bit-identical libmpv.so on repeated clean/configure/build.