### PR TITLE
osd_libass: set ScaledBorderAndShadow

### DIFF
--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -132,6 +132,7 @@ static void create_ass_track(struct osd_state *osd, struct osd_object *obj,
     track->Timer = 100.;
     track->WrapStyle = 1; // end-of-line wrapping instead of smart wrapping
     track->Kerning = true;
+    track->ScaledBorderAndShadow = true;
 
     update_playres(ass, &obj->vo_res);
 }


### PR DESCRIPTION
libass recently [switched](https://github.com/libass/libass/pull/390) the default from 1 to 0 for compatibility with ASS scripts that rely on the historical/VSFilter default of 0.

libass does attempt to detect and avoid breaking scripts that rely on the historic libass-only default of 1, but it doesn’t cover tracks created directly through the API, so set the header explicitly.

Ideally this PR should’ve been submitted before the change landed in libass, but we forgot to check mpv’s OSD. Sorry.

Fixes #7900.