### PR TITLE
 [RFC]The extremely short video loop plays abnormally, and the CPU occupanc…

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1753,10 +1753,10 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
         while (next && next->playback_short)
             next = playlist_entry_get_rel(next, -1);
         // Always allow jumping to first file
-        if (!next && mpctx->opts->loop_times == 1){
+        if (!next && mpctx->opts->loop_times == 1) {
             next = playlist_get_first(mpctx->playlist);
             while (next && next->playback_short)
-                next = playlist_entry_get_rel(next, 1);
+                next = playlist_entry_get_rel(next, -1);
         }
     }
     if (!next && mpctx->opts->loop_times != 1) {

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1753,8 +1753,11 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
         while (next && next->playback_short)
             next = playlist_entry_get_rel(next, -1);
         // Always allow jumping to first file
-        if (!next && mpctx->opts->loop_times == 1)
+        if (!next && mpctx->opts->loop_times == 1){
             next = playlist_get_first(mpctx->playlist);
+            while (next && next->playback_short)
+                next = playlist_entry_get_rel(next, 1);
+        }
     }
     if (!next && mpctx->opts->loop_times != 1) {
         if (direction > 0) {

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1756,7 +1756,7 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
         if (!next && mpctx->opts->loop_times == 1) {
             next = playlist_get_first(mpctx->playlist);
             while (next && next->playback_short)
-                next = playlist_entry_get_rel(next, -1);
+                next = playlist_entry_get_rel(next, 1);
         }
     }
     if (!next && mpctx->opts->loop_times != 1) {


### PR DESCRIPTION
player/loadfile.c:fixed the extremely short video loop bug

After modification，in loop mode, when the first video is playback_ short = true, automatically play the next normal video.

When I use it, I found that after setting the MPV loop playback mode and click prev button to play the 0.01s/0.001s extremely short video, the next normal video can not be played automatically,the CPU occupancy is too high and the close button is invalid.