### PR TITLE
Add support for vaapi hwdec on vulkan/RADV

### DIFF
--- a/video/out/hwdec/hwdec_vaapi_vk.c
+++ b/video/out/hwdec/hwdec_vaapi_vk.c
@@ -48,7 +48,7 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper)
             .format = format->priv,
             .sampleable = true,
             .sample_mode = format->linear_filter ? PL_TEX_SAMPLE_LINEAR
-                                                    : PL_TEX_SAMPLE_NEAREST,
+                                                 : PL_TEX_SAMPLE_NEAREST,
             .import_handle = PL_HANDLE_DMA_BUF,
             .shared_mem = (struct pl_shared_mem) {
                 .handle = {
@@ -56,6 +56,9 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper)
                 },
                 .size = size,
                 .offset = offset,
+#if PL_API_VER >= 88
+                .drm_format_mod = p->desc.objects[id].drm_format_modifier,
+#endif
             },
         };
 

--- a/video/out/hwdec/hwdec_vaapi_vk.c
+++ b/video/out/hwdec/hwdec_vaapi_vk.c
@@ -15,6 +15,9 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
+#include <unistd.h>
+
 #include "config.h"
 #include "hwdec_vaapi.h"
 #include "video/out/placebo/ra_pl.h"
@@ -40,6 +43,29 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper)
         int fd = p->desc.objects[id].fd;
         uint32_t size = p->desc.objects[id].size;
         uint32_t offset = p->desc.layers[n].offset[0];
+
+#if PL_API_VER >= 88
+        // AMD drivers do not return the size in the surface description, so we
+        // need to query it manually. The reason we guard this logic behind
+        // PL_API_VER >= 88 is that the same drivers also require DRM format
+        // modifier support in order to not produce corrupted textures, so
+        // having this #ifdef merely exists to protect users from combining
+        // too-new mpv with too-old libplacebo.
+        if (size == 0) {
+            size = lseek(fd, 0, SEEK_END);
+            if (size == -1) {
+                MP_ERR(mapper, "Cannot obtain size of object with fd %d: %s\n",
+                       fd, mp_strerror(errno));
+                return false;
+            }
+            off_t err = lseek(fd, 0, SEEK_SET);
+            if (err == -1) {
+                MP_ERR(mapper, "Failed to reset offset for fd %d: %s\n",
+                       fd, mp_strerror(errno));
+                return false;
+            }
+        }
+#endif
 
         struct pl_tex_params tex_params = {
             .w = mp_image_plane_w(&p->layout, n),


### PR DESCRIPTION
Requires two changes, notably the inclusion of DRM format modifiers. (Needs recent libplacebo)

Fixes #7666
