### PR TITLE
external_files: add .pgs subtitle extension

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -34,7 +34,7 @@
 
 static const char *const sub_exts[] = {"utf", "utf8", "utf-8", "idx", "sub",
                                        "srt", "rt", "ssa", "ass", "mks", "vtt",
-                                       "sup", "scc", "smi", "lrc",
+                                       "sup", "scc", "smi", "lrc", "pgs",
                                        NULL};
 
 static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",


### PR DESCRIPTION
Unsure why this was never added, making this simple PR since it probably was an oversight.