### PR TITLE
vo_gpu: allow DR path even when DR is unavailable

### DIFF
--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -435,6 +435,9 @@ struct ra_fns {
     // NULL then all buffers are always usable.
     bool (*buf_poll)(struct ra *ra, struct ra_buf *buf);
 
+    // Create a `ra_buf` mapping an existing host pointer. May fail. Optional.
+    struct ra_buf *(*buf_map_ptr)(struct ra *ra, const void *ptr, size_t size);
+
     // Returns the layout requirements of a uniform buffer element. Optional,
     // but must be implemented if RA_CAP_BUF_RO is supported.
     struct ra_layout (*uniform_layout)(struct ra_renderpass_input *inp);


### PR DESCRIPTION
Even when using `vd-lavc-dr`, some circumstances could cause the DR code
to get disabled, for example the existence of extra CPU filters that
cause the resulting avbuffers to no longer correspond to `ra_bufs`.

In this case, we can still enable DR, for at least the libplacebo-based
contexts, by directly importing the host pointer into a dedicated,
temporary ra_buf which we then free explicitly as soon as we no longer
need it.

I made the PL_API_VER depend on >=89 even though this functionality was
introduced in API ver 85 because the initial implementation required
page-aligned host pointers, whereas newer libplacebo does not.

It might be worth introducing an extra option to explicitly disable
this, for debugging. Ideally it'd be cool if it could also depend on the
value of `vd-lavc-dr`, but I don't know how to propagate that option
properly.