### PR TITLE
af_scaletempo2: fix bug where speed was not set

### DIFF
--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -138,7 +138,6 @@ static bool init_scaletempo2(struct mp_filter *f)
     p->initialized = true;
     p->sent_final = false;
     p->frame_delay = 0;
-    p->speed = 1;
     mp_aframe_config_copy(p->cur_format, p->pending);
 
     mp_scaletempo2_init(&p->data, mp_aframe_get_channels(p->pending),


### PR DESCRIPTION
The `--speed` parameter did not work with `mpv --no-config whatever.mp3 --video=no --speed=2 --af=scaletempo2` as pointed out in https://github.com/mpv-player/mpv/pull/7865#issuecomment-664243401 .