### PR TITLE
ytdl_hook: fix typo in unexpected error message

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -761,7 +761,7 @@ function run_ytdl_hook(url)
         if result.error_string and result.error_string == "init" then
             err = err .. "not found or not enough permissions"
         elseif not result.killed_by_us then
-            err = err .. "unexpected error ocurred"
+            err = err .. "unexpected error occurred"
         else
             err = string.format("%s returned '%d'", err, es)
         end


### PR DESCRIPTION
Fixes a typo in ytdl_hook when errors occur, I was noticing this from time to time when playing media through youtube-dl. I didn't test this locally before posting the PR.