### PR TITLE
stats: fix crash when aspect ratio is unavailable

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -545,7 +545,9 @@ local function add_video(s)
         append(s, r["h"], {prefix="x", nl="", indent=" ", prefix_sep=" ", no_prefix_markup=true})
     end
     append_property(s, "current-window-scale", {prefix="Window Scale:"})
-    append(s, format("%.2f", r["aspect"]), {prefix="Aspect Ratio:"})
+    if r["aspect"] ~= nil then
+        append(s, format("%.2f", r["aspect"]), {prefix="Aspect Ratio:"})
+    end
     append(s, r["pixelformat"], {prefix="Pixel Format:"})
 
     -- Group these together to save vertical space


### PR DESCRIPTION
When switching between files it's possible that r["aspect"] returns nil, resulting in a crash.

```
[stats] 
[stats] stack traceback:
[stats]         [C]: in function 'format'
[stats]         /home/eva/.config/mpv/scripts/stats.lua:548: in function 'add_video'
[stats]         /home/eva/.config/mpv/scripts/stats.lua:618: in function 'f'
[stats]         /home/eva/.config/mpv/scripts/stats.lua:828: in function 'print_page'
[stats]         /home/eva/.config/mpv/scripts/stats.lua:951: in function 'cb'
[stats]         mp.defaults:346: in function 'process_timers'
[stats]         mp.defaults:506: in function 'dispatch_events'
[stats]         mp.defaults:479: in function <mp.defaults:478>
[stats]         [C]: in ?
[stats]         [C]: in ?
[stats] Lua error: /home/eva/.config/mpv/scripts/stats.lua:548: bad argument #2 to 'format' (number expected, got nil)
```