### PR TITLE
win32: scripting utils.get_env_list(): use UTF-8

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -682,6 +682,12 @@ char *mp_getenv(const char *name)
     return NULL;
 }
 
+char ***mp_penviron()
+{
+    mp_getenv("");  // ensure init
+    return &utf8_environ;  // `environ' should be an l-value
+}
+
 off_t mp_lseek(int fd, off_t offset, int whence)
 {
     HANDLE h = (HANDLE)_get_osfhandle(fd);

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -105,6 +105,13 @@ int mp_closedir(DIR *dir);
 int mp_mkdir(const char *path, int mode);
 char *mp_win32_getcwd(char *buf, size_t size);
 char *mp_getenv(const char *name);
+
+#ifdef environ  /* mingw defines it as _environ */
+#undef environ
+#endif
+#define environ (*mp_penviron())  /* ensure initialization and l-value */
+char ***mp_penviron(void);
+
 off_t mp_lseek(int fd, off_t offset, int whence);
 
 // mp_stat types. MSVCRT's dev_t and ino_t are way too short to be unique.
@@ -204,6 +211,8 @@ void freelocale(locale_t);
 #else /* __MINGW32__ */
 
 #include <sys/mman.h>
+
+extern char **environ;
 
 #endif /* __MINGW32__ */
 

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -47,8 +47,6 @@
 #include "client.h"
 #include "libmpv/client.h"
 
-extern char **environ;
-
 // List of builtin modules and their contents as strings.
 // All these are generated from player/javascript/*.js
 static const char *const builtin_files[][3] = {

--- a/player/lua.c
+++ b/player/lua.c
@@ -53,8 +53,6 @@
 #include "client.h"
 #include "libmpv/client.h"
 
-extern char **environ;
-
 // List of builtin modules and their contents as strings.
 // All these are generated from player/lua/*.lua
 static const char * const builtin_lua_scripts[][2] = {


### PR DESCRIPTION
lua/js utils.get_env_list() uses `environ' which was ANSI, thus
it broke any unicode names/values.

mpv already has an internal utf8_environ for win32, but it's used
only at the getenv(..) wrapper and not exposed in itself, and also it
has lazy initialization - on first getenv() call.

Now `environ' maps to a function which ensures initialization while
keeping it an l-value (like posix expects).

The cost of this fuglyness is that files should include osdep/io.h
(which now declares environ as extern) rather than declaring it
themselves, or else the build will break on mingw.