### PR TITLE
Request the UTF-8 code page by setting activeCodePage in the manifest

### DIFF
--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -11,6 +11,7 @@
         <windowsSettings>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
         </windowsSettings>
     </application>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/windows/uwp/design/globalizing/use-utf8-code-page

This fixes Unicode file names in Lua's built-in I/O library in Windows 10 1903 and up. For example, this script:
```lua
file = io.open("C:\\mpv\\💯.txt", "w")
file:write("test\n")
file:close(file)
```

Creates the following file before this change:
![image](https://user-images.githubusercontent.com/162837/89521726-5f25f700-d823-11ea-90af-c2ad2b5000f2.png)

And creates this file after the change:
![image](https://user-images.githubusercontent.com/162837/89521753-71a03080-d823-11ea-8604-57cda39c149a.png)

It might affect other dependencies as well, since I doubt they're all as strict at using wide-char APIs as we are, though Lua was the most obvious one I could think of.