### PR TITLE
ao/lavc: add channels and channel_layout to AVFrame

### DIFF
--- a/audio/out/ao_lavc.c
+++ b/audio/out/ao_lavc.c
@@ -209,6 +209,8 @@ static void encode(struct ao *ao, double apts, void **data)
         AVFrame *frame = av_frame_alloc();
         frame->format = af_to_avformat(ao->format);
         frame->nb_samples = ac->aframesize;
+        frame->channels = encoder->channels;
+        frame->channel_layout = encoder->channel_layout;
 
         size_t num_planes = af_fmt_is_planar(ao->format) ? ao->channels.num : 1;
         assert(num_planes <= AV_NUM_DATA_POINTERS);


### PR DESCRIPTION
FFmpeg expects those fields to be set on the `AVFrame` when encoding audio, not doing so will cause the `avcodec_send_frame` call to return `EINVAL` (at least in recent builds).

Fixes #7909