### PR TITLE
wayland: tweak xdg_surface creation and add wayland-app-id as a user option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5330,6 +5330,10 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     Currently only relevant for ``--gpu-api=d3d11``.
 
+``--wayland-app-id=<string>``
+    Set the client app id for Wayland-based video output methods. By default, "mpv"
+    is used.
+
 ``--wayland-disable-vsync=<yes|no>``
     Disable vsync for the wayland contexts (default: no). Useful for benchmarking
     the wayland context when combined with ``video-sync=display-desync``,

--- a/options/options.c
+++ b/options/options.c
@@ -124,6 +124,7 @@ static const m_option_t mp_vo_opt_list[] = {
     {"window-maximized", OPT_FLAG(window_maximized)},
     {"force-window-position", OPT_FLAG(force_window_position)},
     {"x11-name", OPT_STRING(winname)},
+    {"wayland-app-id", OPT_STRING(appid)},
     {"monitoraspect", OPT_FLOAT(force_monitor_aspect), M_RANGE(0.0, 9.0)},
     {"monitorpixelaspect", OPT_FLOAT(monitor_pixel_aspect),
         M_RANGE(1.0/32.0, 32.0)},

--- a/options/options.h
+++ b/options/options.h
@@ -23,6 +23,7 @@ typedef struct mp_vo_opts {
     int screen_id;
     int fsscreen_id;
     char *winname;
+    char *appid;
     int x11_netwm;
     int x11_bypass_compositor;
     int native_keyrepeat;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1055,9 +1055,8 @@ static int create_xdg_surface(struct vo_wayland_state *wl)
     wl->xdg_toplevel = xdg_surface_get_toplevel(wl->xdg_surface);
     xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
 
-    xdg_toplevel_set_title (wl->xdg_toplevel, "mpv");
-    xdg_toplevel_set_app_id(wl->xdg_toplevel, "mpv");
-
+    if (!wl->xdg_surface || !wl->xdg_toplevel)
+        return 1;
     return 0;
 }
 
@@ -1423,7 +1422,7 @@ static void do_minimize(struct vo_wayland_state *wl)
         xdg_toplevel_set_minimized(wl->xdg_toplevel);
 }
 
-static int update_window_title(struct vo_wayland_state *wl, char *title)
+static int update_window_title(struct vo_wayland_state *wl, const char *title)
 {
     if (!wl->xdg_toplevel)
         return VO_NOTAVAIL;
@@ -1544,7 +1543,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         return VO_TRUE;
     }
     case VOCTRL_UPDATE_WINDOW_TITLE:
-        return update_window_title(wl, (char *)arg);
+        return update_window_title(wl, (const char *)arg);
     case VOCTRL_SET_CURSOR_VISIBILITY:
         if (!wl->pointer)
             return VO_NOTAVAIL;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1060,6 +1060,17 @@ static int create_xdg_surface(struct vo_wayland_state *wl)
     return 0;
 }
 
+static void update_app_id(struct vo_wayland_state *wl)
+{
+    if (!wl->xdg_toplevel)
+        return;
+    if (!wl->vo_opts->appid) {
+        wl->vo_opts->appid = talloc_strdup(wl->vo_opts, "mpv");
+        m_config_cache_write_opt(wl->vo_opts_cache, &wl->vo_opts->appid);
+    }
+    xdg_toplevel_set_app_id(wl->xdg_toplevel, wl->vo_opts->appid);
+}
+
 static void set_border_decorations(struct vo_wayland_state *wl, int state)
 {
     if (!wl->xdg_toplevel_decoration) {
@@ -1126,6 +1137,7 @@ int vo_wayland_init(struct vo *vo)
     /* Can't be initialized during registry due to multi-protocol dependence */
     if (create_xdg_surface(wl))
         return false;
+    update_app_id(wl);
 
     const char *xdg_current_desktop = getenv("XDG_CURRENT_DESKTOP");
     if (xdg_current_desktop != NULL && strstr(xdg_current_desktop, "GNOME"))
@@ -1511,6 +1523,8 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
                 toggle_maximized(wl);
             if (opt == &opts->border)
                 set_border_decorations(wl, opts->border);
+            if (opt == &opts->appid)
+                update_app_id(wl);
         }
         return VO_TRUE;
     }


### PR DESCRIPTION
While I was adding `wayland-app-id` in, I noticed some silly things in `create_xdg_surface` which the first commit addresses (nothing too major). The second commit is a bit more opinionated hence the PR. It adds a new option, `--wayland-app-id` which can changed at runtime. For updating during runtime, I opted to use `m_config_cache_get_next_changed` and added the option to `vo_opts`. ~I don't think calling `m_config_cache_write_opt` is needed at any point since this property is entirely controlled by mpv and appears to already update correctly on its own, but feel free to correct me if I'm wrong.~ (That was wrong. I have to call it once initially). A couple of related observations.

1. `wayland-app-id` is pretty similar to `x11-name`. For this commit, I kept them as entirely separate arguments but they both just store a string that almost do the same thing. So there's an argument for merging the two I suppose.

2. Couldn't `VOCTRL_UPDATE_WINDOW_TITLE` be deprecated in favor of `m_config_cache_get_next_changed`? Obviously that would be out of scope for this, but it's something to consider.