### PR TITLE
sub: add application/font-sfnt to the list of font mime types

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -100,6 +100,7 @@ static const char *const font_mimetypes[] = {
     "application/vnd.ms-opentype",
     "application/x-font-ttf",
     "application/x-font", // probably incorrect
+    "application/font-sfnt",
     "font/collection",
     "font/otf",
     "font/sfnt",


### PR DESCRIPTION
According to both file(1) and
https://www.iana.org/assignments/media-types/application/font-sfnt
application/font-sfnt is also a valid mime type for (at least some) .ttf
files.