### PR TITLE
sub: introduce the sub-ass-scale-dialog-only option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2219,6 +2219,12 @@ Subtitles
 
     Default: no.
 
+``--sub-ass-scale-dialog-only=<yes|no>``
+    When scaling ASS subtitles, scale only the parts that look like dialog.
+    Other elements (like signs) will be left intact.
+
+    Default: no.
+
 ``--embeddedfonts=<yes|no>``
     Use fonts embedded in Matroska container files and ASS scripts (default:
     yes). These fonts can be used for SSA/ASS subtitle rendering.

--- a/options/options.c
+++ b/options/options.c
@@ -260,6 +260,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-scale-by-window", OPT_FLAG(sub_scale_by_window)},
         {"sub-scale-with-window", OPT_FLAG(sub_scale_with_window)},
         {"sub-ass-scale-with-window", OPT_FLAG(ass_scale_with_window)},
+        {"sub-ass-scale-dialog-only", OPT_FLAG(ass_scale_dialog_only)},
         {"sub", OPT_SUBSTRUCT(sub_style, sub_style_conf)},
         {"sub-clear-on-seek", OPT_FLAG(sub_clear_on_seek)},
         {"teletext-page", OPT_INT(teletext_page), M_RANGE(1, 999)},

--- a/options/options.h
+++ b/options/options.h
@@ -79,6 +79,7 @@ struct mp_subtitle_opts {
     int sub_scale_by_window;
     int sub_scale_with_window;
     int ass_scale_with_window;
+    int ass_scale_dialog_only;
     struct osd_style_opts *sub_style;
     float sub_scale;
     float sub_gauss;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -421,6 +421,8 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         set_force_flags |= ASS_OVERRIDE_BIT_STYLE | ASS_OVERRIDE_BIT_FONT_SIZE;
     if (opts->ass_style_override == 4) // 'scale'
         set_force_flags |= ASS_OVERRIDE_BIT_FONT_SIZE;
+    if (opts->ass_scale_dialog_only)
+        set_force_flags |= ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
 #if LIBASS_VERSION >= 0x01201001
     if (converted)
         set_force_flags |= ASS_OVERRIDE_BIT_ALIGNMENT;


### PR DESCRIPTION
Scaling ASS subtitles (using --sub-scale) with signs scales the fonts of
both regular dialog and of those signs. It also causes background overlays
to move away from their intended position (even if the text stays in
place). This breaks signs badly, to the point of illegibility.

libass has a flag (ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE) that makes it
detect normal dialog lines and only apply scaling to those. This mpv option
simply enables that flag.

ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE is normally enabled by default in
libass but this default is lost because mpv clears all override flags when
it initialises libass.