### PR TITLE
[IDEA] Implement part_file:// for reading a part of a file

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1165,6 +1165,15 @@ PROTOCOLS
     ``PATH`` itself should start with a third ``/`` to make the path an
     absolute path.
 
+``part_file://PATH@start[-end]``
+
+    Like ``file://``, but takes a byte range. ``end`` is optional.
+    ``start`` and ``end`` accept suffixes such as ``KiB`` and ``MiB``.
+
+    Example::
+
+      mpv part_file://captured_stream.ts@1g-2g
+
 ``appending://PATH``
 
     Play a local file, but assume it's being appended to. This is useful for

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -482,7 +482,7 @@ const m_option_type_t m_option_type_int64 = {
     .equal = int64_equal,
 };
 
-static int parse_byte_size(struct mp_log *log, const m_option_t *opt,
+int parse_byte_size(struct mp_log *log, const m_option_t *opt,
                            struct bstr name, struct bstr param, void *dst)
 {
     if (param.len == 0)

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -566,6 +566,10 @@ int m_option_required_params(const m_option_t *opt);
 
 extern const char m_option_path_separator;
 
+
+int parse_byte_size(struct mp_log *log, const m_option_t *opt,
+                           struct bstr name, struct bstr param, void *dst);
+
 // Cause a compilation warning if typeof(expr) != type.
 // Should be used with pointer types only.
 #define MP_EXPECT_TYPE(type, expr) (0 ? (type)0 : (expr))

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -51,6 +51,7 @@ extern const stream_info_t stream_info_ffmpeg;
 extern const stream_info_t stream_info_ffmpeg_unsafe;
 extern const stream_info_t stream_info_avdevice;
 extern const stream_info_t stream_info_file;
+extern const stream_info_t stream_info_part_file;
 extern const stream_info_t stream_info_fd;
 extern const stream_info_t stream_info_ifo_dvdnav;
 extern const stream_info_t stream_info_dvdnav;
@@ -88,6 +89,7 @@ static const stream_info_t *const stream_list[] = {
     &stream_info_mf,
     &stream_info_edl,
     &stream_info_file,
+    &stream_info_part_file,
     &stream_info_fd,
     &stream_info_cb,
     NULL


### PR DESCRIPTION
I don't know if this should be merged. But I'm sharing it in case someone needs it in the future.

---

Add support for reading a byte range from a file via the `part_file://` protocol.

Syntax is part_file://PATH@start[-end] where end is a maximum (read until end or eof).

Size suffixes support in `m_option` is reused so they can be used with start/end.

This can be very useful with e.g. large MPEGTS streams with corruption or time-stamp jumps or other issues in them.

This also facilitates keeping the interesting part of a stream without any copying in modern Linux systems:

     mpv part_file://large_cap.ts@4G-10G
     truncate -s 10G large_cap.ts
     fallocate -c -o 0 -l 4G large_cap.ts