### PR TITLE
wayland: conditionally commit surface on resize

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -128,6 +128,8 @@ static void resize(struct ra_ctx *ctx)
     if (p->egl_window)
         wl_egl_window_resize(p->egl_window, width, height, 0, 0);
 
+    if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
+        wl_surface_commit(wl->surface);
     wl->vo->dwidth  = width;
     wl->vo->dheight = height;
 }

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -194,7 +194,10 @@ static int resize(struct vo *vo)
         p->free_buffers = buf->next;
         talloc_free(buf);
     }
-    return mp_sws_reinit(p->sws);
+    int ret = mp_sws_reinit(p->sws);
+    if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
+        wl_surface_commit(wl->surface);
+    return ret;
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -198,7 +198,10 @@ static bool resize(struct ra_ctx *ctx)
     const int32_t height = wl->scaling*mp_rect_h(wl->geometry);
 
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
-    return ra_vk_ctx_resize(ctx, width, height);
+    bool ok = ra_vk_ctx_resize(ctx, width, height);
+    if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
+        wl_surface_commit(wl->surface);
+    return ok;
 }
 
 static bool wayland_vk_reconfig(struct ra_ctx *ctx)


### PR DESCRIPTION
I figured out a workaround for the sway border issue. To easily reproduce the issue: have an up-to-date mpv (at least db0f9fab), open a video in a non-floating mode (tiled/tabbed/stacking), set the window scale to 2 (alt+2 by default), and then float the window (meta+spacebar by default). The commit message has a longer explanation but basically we just explicitly commit the newly sized surface (as long as it is not fullscreen or maximized) so sway/wlroots can correctly see the new size and update its border dimensions correctly. This shouldn't have any negative impacts.