### PR TITLE
wayland: simplify presentation time

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -35,7 +35,6 @@ struct vo_wayland_sync {
     int64_t ust;
     int64_t msc;
     int64_t sbc;
-    int64_t last_mp_time;
     bool filled;
 };
 


### PR DESCRIPTION
Ran into some funny (although not harmful) behavior with presentation time that this corrects. Start a video with `--pause` and `--video-sync=display-resample`, hide the video, and then unpause it again. Before this commit, you'll get A/V desync. If you wait long enough, it recovers. Putting the video back in view again immediately recovers it. The only negative thing this change appears to do for me is that the vsync jitter value spikes up really high if you put a window back in view after it is hidden long enough (it goes back to zero on the stats after some time). However, I do not see any visuals anomalies from that nor does mpv desync so it appears to just be an ugly number that happens as a result of switching in and out of view and not actually anything harmful for playback. Here for testing.
