### PR TITLE
osdep: add compile time option to default to xdg

### DIFF
--- a/wscript
+++ b/wscript
@@ -829,6 +829,11 @@ standalone_features = [
         'desc': 'macOS libmpv backend',
         'deps': 'cocoa && swift',
         'func': check_true
+    }, {
+        'name': '--xdg',
+        'desc': 'xdg basedir specification config support as default',
+        'default': 'disable',
+        'func': check_true,
     }
 ]
 


### PR DESCRIPTION
This commit adds a `--enable-xdg` configure flag that will switch
the order mpv looks for configurations by default. Instead of
looking in `$HOME/.mpv` first, it will check `$XDG_CONFIG_DIR/mpv`.

This is disabled by default.