### PR TITLE
Add a mechanism for dropping frames and use it on wayland (sometimes)

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1009,6 +1009,7 @@ int handle_force_window(struct MPContext *mpctx, bool force)
         mpctx->video_out = init_best_video_out(mpctx->global, &ex);
         if (!mpctx->video_out)
             goto err;
+        mpctx->video_out->force_drops_allowed = !VS_IS_DISP(mpctx->opts->video_sync);
         mpctx->mouse_cursor_visible = true;
     }
 

--- a/player/video.c
+++ b/player/video.c
@@ -237,6 +237,7 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
             mpctx->error_playing = MPV_ERROR_VO_INIT_FAILED;
             goto err_out;
         }
+        mpctx->video_out->force_drops_allowed = !VS_IS_DISP(mpctx->opts->video_sync);
         mpctx->mouse_cursor_visible = true;
     }
 

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -107,6 +107,7 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
     }
 
     wl->frame_wait = false;
+    wl->may_drop = false;
 }
 
 static const struct wl_callback_listener frame_listener = {
@@ -143,6 +144,8 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
+
+    wl->may_drop = wl->frame_wait;
 
     if (wl->presentation) {
         wl->user_sbc += 1;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -468,6 +468,10 @@ struct vo {
 
     bool want_redraw;   // redraw as soon as possible
 
+    // Some backends may forcibly drop frames
+    bool force_drops_allowed;
+    bool force_drop;
+
     // current window state
     int dwidth;
     int dheight;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -97,6 +97,7 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
     }
 
     wl->frame_wait = false;
+    wl->may_drop = false;
 }
 
 static const struct wl_callback_listener frame_listener = {
@@ -109,6 +110,8 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
+
+    wl->may_drop = wl->frame_wait;
 
     if (wl->presentation) {
         wl->user_sbc += 1;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1526,6 +1526,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         check_dnd_fd(wl);
         *events |= wl->pending_vo_events;
         wl->pending_vo_events = 0;
+        wl->vo->force_drop = wl->may_drop;
         return VO_TRUE;
     }
     case VOCTRL_VO_OPTS_CHANGED: {

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -74,6 +74,7 @@ struct vo_wayland_state {
     int reduced_width;
     int reduced_height;
     bool frame_wait;
+    bool may_drop;
     bool state_change;
     bool toplevel_configured;
     int wakeup_pipe[2];


### PR DESCRIPTION
In the past, the wayland backend was driven by the frame callback which made wayland people happy but it was plagued with several issues (broken frame timings, display-resample breaking if the window was hidden, lua/osd rendering out of sync with the video, etc.) which led it to being reverted in favor of the current approach. This was great, but it was true that mpv would now always render frames despite the window being hidden which is deemed "wasteful".

This PR partially restores the old behavior of dropping frames on wayland (also it exposes a mechanism for other backends to use this if possible). It requires that you aren't using one of the fancy `video-sync` modes (i.e. `audio` (the default) or also `desync`).

I had to touch video and vo for this. Not really sure if this is a good way to go about it. I figured `VOCTRL_CHECK_EVENTS` would be logical to use since it's always executed before `render_frame`. `wlshm` was not implemented at this time since it would at least take adding frame callback to it, but it could also benefit from this.