### PR TITLE
sd_ass, osd_libass: Don't use deprecated libass symbols

### DIFF
--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -63,7 +63,7 @@ static void create_ass_renderer(struct osd_state *osd, struct ass_state *ass)
 
     mp_ass_configure_fonts(ass->render, osd->opts->osd_style,
                            osd->global, ass->log);
-    ass_set_aspect_ratio(ass->render, 1.0, 1.0);
+    ass_set_pixel_aspect(ass->render, 1.0);
 }
 
 static void destroy_ass_renderer(struct ass_state *ass)
@@ -622,7 +622,7 @@ static void append_ass(struct ass_state *ass, struct mp_osd_res *res,
     update_playres(ass, res);
 
     ass_set_frame_size(ass->render, res->w, res->h);
-    ass_set_aspect_ratio(ass->render, res->display_par, 1.0);
+    ass_set_pixel_aspect(ass->render, res->display_par);
 
     int ass_changed;
     *img_list = ass_render_frame(ass->render, ass->track, 0, &ass_changed);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -418,13 +418,11 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     ass_set_shaper(priv, opts->ass_shaper);
     int set_force_flags = 0;
     if (total_override)
-        set_force_flags |= ASS_OVERRIDE_BIT_STYLE | ASS_OVERRIDE_BIT_FONT_SIZE;
+        set_force_flags |= ASS_OVERRIDE_BIT_STYLE | ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
     if (opts->ass_style_override == 4) // 'scale'
-        set_force_flags |= ASS_OVERRIDE_BIT_FONT_SIZE;
-#if LIBASS_VERSION >= 0x01201001
+        set_force_flags |= ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
     if (converted)
         set_force_flags |= ASS_OVERRIDE_BIT_ALIGNMENT;
-#endif
 #ifdef ASS_JUSTIFY_AUTO
     if ((converted || opts->ass_style_override) && opts->ass_justify)
         set_force_flags |= ASS_OVERRIDE_BIT_JUSTIFY;

--- a/wscript
+++ b/wscript
@@ -312,7 +312,7 @@ iconv support use --disable-iconv.",
     }, {
         'name': 'libass',
         'desc': 'SSA/ASS support',
-        'func': check_pkg_config('libass', '>= 0.12.1'),
+        'func': check_pkg_config('libass', '>= 0.12.2'),
         'req': True,
         'fmsg': "Unable to find development files for libass, or the version " +
                 "found is too old. Aborting."


### PR DESCRIPTION
Replaces `ass_set_aspect_ratio` calls with `ass_set_pixel_aspect` and `ASS_OVERRIDE_BIT_FONT_SIZE` with its newer alias `ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE`.
The latter requires to bump the minimal libass version from `0.12.1` (07.01.2015) to `0.12.2` (07.05.2015).

Purely cosmetic, might avoid deprecation warnings in [the future](https://github.com/libass/libass/pull/421).