### PR TITLE
github: automatically close issues that ignore the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/6_question.md
+++ b/.github/ISSUE_TEMPLATE/6_question.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+### Your Question
+
 Don't ask questions about issues, errors or problems you have and instead open
 a proper issue with the right template from the previous selection.
 

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -1,0 +1,20 @@
+comment: "You either ignored the Issue Template, deleted important parts of it
+or opened an Issue without any Template. Please open a new Issue and deligently
+fill out the Template with all informations asked for. Don't delete the headers
+or it might be automatically closed again."
+issueConfigs:
+- content:
+  - "Important Information"
+  - "Reproduction steps"
+  - "Log file"
+- content:
+  - "mpv version and platform versions"
+  - "Reproduction steps"
+  - "Log file"
+- content:
+  - "Expected behavior of the wanted feature"
+  - "Log file"
+- content:
+  - "Your Question"
+caseInsensitive: false
+label: "priority:ignored-issue-template"


### PR DESCRIPTION
needs this app to be installed https://github.com/offu/close-issue-app

i am not sure if this will be actually useful. i tried it on my fork https://github.com/Akemi/mpv/issues?q=is%3Aopen+is%3Aissue

another one that might be useful and i was looking into https://github.com/dessant/label-actions