### PR TITLE
manpage: fix typo

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -777,10 +777,10 @@ expression returns true, the profile is applied, if it returns false, it is
 ignored. This Lua code execution is not sandboxed.
 
 Any variables in condition expressions can reference properties. If an
-identifier is not already by defined by Lua or mpv, it is interpreted as
-property. For example, ``pause`` would return the current pause status. If the
-variable name contains any ``_`` characters, they are turned into ``-``. For
-example, ``playback_time`` would return the property ``playback-time``.
+identifier is not already defined by Lua or mpv, it is interpreted as property.
+For example, ``pause`` would return the current pause status. If the variable
+name contains any ``_`` characters, they are turned into ``-``. For example,
+``playback_time`` would return the property ``playback-time``.
 
 A more robust way to access properties is using ``p.property_name`` or
 ``get("property-name", default_value)``. The automatic variable to property


### PR DESCRIPTION
Change 'already by defined' to 'already defined' and reformat the paragaph.