### PR TITLE
wscript_build.py: use -Wl,--subsystem,console instead

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -628,7 +628,7 @@ def build(ctx):
             )
 
             wrapctx.env.cprogram_PATTERN = "%s.com"
-            wrapflags = ['-municode', '-mconsole']
+            wrapflags = ['-municode', '-Wl,--subsystem,console']
             wrapctx.env.CFLAGS = ctx.env.CFLAGS + wrapflags
             wrapctx.env.LAST_LINKFLAGS = ctx.env.LAST_LINKFLAGS + wrapflags
 


### PR DESCRIPTION
Fixes an issue with clang not using the -mconsole option if mwindows
is present resulting in mpv.com being a gui program instead of a
console program.

Does not interfere with gcc compilation.

result without this patch

```
file .\mpv.com .\mpv.exe
.\mpv.com: PE32+ executable (GUI) x86-64 (stripped to external PDB)
.\mpv.exe: PE32+ executable (GUI) x86-64 (stripped to external PDB)
```

both executables open the mpv gui with out console output.

result with this patch

```
file .\mpv.com .\mpv.exe
.\mpv.com: PE32+ executable (console) x86-64 (stripped to external PDB)
.\mpv.exe: PE32+ executable (GUI) x86-64 (stripped to external PDB)
```

mpv.com properly outputs text to console instead of instantly opening
a gui

`, for MS Windows` removed from the end of file outputs to reduce col
count

https://github.com/m-ab-s/media-autobuild_suite/issues/1794
