### PR TITLE
stream_slice: interpret `end` as offset if it starts with '+'

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1208,6 +1208,8 @@ PROTOCOLS
     ``start`` and ``end`` represent a byte range and accept
     suffixes such as ``KiB`` and ``MiB``. ``end`` is optional.
 
+    if ``end`` starts with ``+``, it is considered as offset from ``start``.
+
     Only works with seekable streams.
 
     Examples::
@@ -1216,6 +1218,11 @@ PROTOCOLS
 
       This starts reading from cap.ts after seeking 1 GiB, then
       reads until reaching 2 GiB or end of file.
+
+      mpv slice://1g-+2g@cap.ts
+
+      This starts reading from cap.ts after seeking 1 GiB, then
+      reads until reaching 3 GiB or end of file.
 
       mpv slice://100m@appending://cap.ts
 

--- a/stream/stream_slice.c
+++ b/stream/stream_slice.c
@@ -116,10 +116,14 @@ static int parse_slice_range(stream_t *stream)
     if (m_option_parse(stream->log, &opt, bstr0("slice_start"), start, &p->slice_start) < 0)
         return STREAM_ERROR;
 
+    bool max_end_is_offset = bstr_startswith0(end, "+");
     if (has_end) {
         if (m_option_parse(stream->log, &opt, bstr0("slice_max_end"), end, &p->slice_max_end) < 0)
             return STREAM_ERROR;
     }
+
+    if (max_end_is_offset)
+      p->slice_max_end += p->slice_start;
 
     if (p->slice_max_end && p->slice_max_end < p->slice_start) {
         MP_ERR(stream, "The byte range end (%"PRId64") can't be smaller than the start (%"PRId64"): '%s'\n",


### PR DESCRIPTION
Example:
 * slice://1g-2g@file.ts (1 to 2)
 * slice://1g-+2g@file.ts (1 to 3)