### PR TITLE
wayland: only render if we have frame callback

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -73,7 +73,6 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
         index = 0;
     }
     int64_t sec = (uint64_t) tv_sec_lo + ((uint64_t) tv_sec_hi << 32);
-    wl->sync[index].sbc = wl->user_sbc;
     wl->sync[index].ust = sec * 1000000LL + (uint64_t) tv_nsec / 1000;
     wl->sync[index].msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
     wl->sync[index].filled = true;
@@ -134,8 +133,25 @@ static void resize(struct ra_ctx *ctx)
     wl->vo->dheight = height;
 }
 
-static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
+static bool wayland_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
+    struct ra_ctx *ctx = sw->ctx;
+    struct vo_wayland_state *wl = ctx->vo->wl;
+
+    bool render = !wl->frame_wait || wl->opts->disable_vsync;
+
+    if (wl->frame_wait && wl->presentation)
+        vo_wayland_sync_clear(wl);
+
+    if (render)
+        wl->frame_wait = true;
+
+    return render ? ra_gl_ctx_start_frame(sw, out_fbo) : false;
+}
+
+static void wayland_egl_swap_buffers(struct ra_swapchain *sw)
+{
+    struct ra_ctx *ctx = sw->ctx;
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
@@ -144,13 +160,14 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
 
-    if (wl->presentation) {
-        wl->user_sbc += 1;
+    if (wl->presentation)
         wayland_sync_swap(wl);
-    }
-
-    wl->frame_wait = true;
 }
+
+static const struct ra_swapchain_fns wayland_egl_swapchain = {
+    .start_frame   = wayland_egl_start_frame,
+    .swap_buffers  = wayland_egl_swap_buffers,
+};
 
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
@@ -184,8 +201,8 @@ static bool egl_create_context(struct ra_ctx *ctx)
     mpegl_load_functions(&p->gl, wl->log);
 
     struct ra_gl_ctx_params params = {
-        .swap_buffers = wayland_egl_swap_buffers,
-        .get_vsync = wayland_egl_get_vsync,
+        .external_swapchain = &wayland_egl_swapchain,
+        .get_vsync          = &wayland_egl_get_vsync,
     };
 
     if (!ra_gl_ctx_init(ctx, &p->gl, params))

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -229,6 +229,11 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
     struct pl_swapchain_frame frame;
+    bool start = true;
+    if (p->params.start_frame)
+        start = p->params.start_frame(sw->ctx);
+    if (!start)
+        return false;
     if (!pl_swapchain_start_frame(p->swapchain, &frame))
         return false;
     if (!mppl_wrap_tex(sw->ctx->ra, frame.fbo, &p->proxy_tex))

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -7,6 +7,9 @@ struct ra_vk_ctx_params {
     // See ra_swapchain_fns.get_vsync.
     void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
 
+    // In case something special needs to be done when starting a frame.
+    bool (*start_frame)(struct ra_ctx *ctx);
+
     // In case something special needs to be done on the buffer swap.
     void (*swap_buffers)(struct ra_ctx *ctx);
 };

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -110,14 +110,11 @@ struct vo_wayland_state {
     /* Presentation Feedback */
     struct vo_wayland_sync *sync;
     int sync_size;
-    int64_t user_sbc;
     int64_t last_ust;
     int64_t last_msc;
-    int64_t last_sbc;
-    int64_t last_sbc_mp_time;
-    int64_t vsync_duration;
     int64_t last_skipped_vsyncs;
     int64_t last_queue_display_time;
+    int64_t vsync_duration;
 
     /* Input */
     struct wl_seat     *seat;
@@ -154,6 +151,7 @@ void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wakeup(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
 void vo_wayland_wait_frame(struct vo_wayland_state *wl);
+void vo_wayland_sync_clear(struct vo_wayland_state *wl);
 void wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_sync_shift(struct vo_wayland_state *wl);
 void queue_new_sync(struct vo_wayland_state *wl);


### PR DESCRIPTION
I thought I'd try a few ways to modify the swapchain for wayland so it renders smarter. Basically, the goal is to only ever render when we have the surface visible. This isn't trivial because of complicated reasons regarding wayland's behavior (inb4 wayland sucks). More details in the commit message.

TODO:
- [x] Check if vsync jitter increases with this (need to test on a compositor that doesn't have presentation time)
- [x] Figure out why the cursor doesn't initially autohide on sway
- [x] Fix benchmarking going whack (i.e. not working properly) with this
- [x] More testing