### PR TITLE
Make ytdl_hook safe url match non-greedy

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -134,7 +134,7 @@ local function edl_escape(url)
 end
 
 local function url_is_safe(url)
-    local proto = type(url) == "string" and url:match("^(.+)://") or nil
+    local proto = type(url) == "string" and url:match("^(.-)://") or nil
     local safe = proto and safe_protos[proto]
     if not safe then
         msg.error(("Ignoring potentially unsafe url: '%s'"):format(url))


### PR DESCRIPTION
The previous regexp is greedy and might eat up more
than the protocol if the rest of the url contains a non
encoded `://` at a later point.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.