### PR TITLE
wayland: update opaque region on runtime

### DIFF
--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -44,6 +44,7 @@ struct ra_ctx_fns {
     // optional.
     void (*wakeup)(struct ra_ctx *ctx);
     void (*wait_events)(struct ra_ctx *ctx, int64_t until_time_us);
+    void (*update_render_opts)(struct ra_ctx *ctx);
 
     // Initialize/destroy the 'struct ra' and possibly the underlying VO backend.
     // Not normally called by the user of the ra_ctx.

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -119,16 +119,10 @@ static void resize(struct ra_ctx *ctx)
 
     MP_VERBOSE(wl, "Handling resize on the egl side\n");
 
-    const int32_t width = wl->scaling*mp_rect_w(wl->geometry);
-    const int32_t height = wl->scaling*mp_rect_h(wl->geometry);
+    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
+    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
 
-    if (!ctx->opts.want_alpha) {
-        struct wl_region *region = wl_compositor_create_region(wl->compositor);
-        wl_region_add(region, 0, 0, width, height);
-        wl_surface_set_opaque_region(wl->surface, region);
-        wl_region_destroy(region);
-    }
-
+    vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
 
     if (p->egl_window)
@@ -296,6 +290,13 @@ static void wayland_egl_wait_events(struct ra_ctx *ctx, int64_t until_time_us)
     vo_wayland_wait_events(ctx->vo, until_time_us);
 }
 
+static void wayland_egl_update_render_opts(struct ra_ctx *ctx)
+{
+    struct vo_wayland_state *wl = ctx->vo->wl;
+    vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
+    wl_surface_commit(wl->surface);
+}
+
 static bool wayland_egl_init(struct ra_ctx *ctx)
 {
     if (!vo_wayland_init(ctx->vo)) {
@@ -307,12 +308,13 @@ static bool wayland_egl_init(struct ra_ctx *ctx)
 }
 
 const struct ra_ctx_fns ra_ctx_wayland_egl = {
-    .type           = "opengl",
-    .name           = "wayland",
-    .reconfig       = wayland_egl_reconfig,
-    .control        = wayland_egl_control,
-    .wakeup         = wayland_egl_wakeup,
-    .wait_events    = wayland_egl_wait_events,
-    .init           = wayland_egl_init,
-    .uninit         = wayland_egl_uninit,
+    .type               = "opengl",
+    .name               = "wayland",
+    .reconfig           = wayland_egl_reconfig,
+    .control            = wayland_egl_control,
+    .wakeup             = wayland_egl_wakeup,
+    .wait_events        = wayland_egl_wait_events,
+    .update_render_opts = wayland_egl_update_render_opts,
+    .init               = wayland_egl_init,
+    .uninit             = wayland_egl_uninit,
 };

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -201,11 +201,7 @@ static int resize(struct vo *vo)
     const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
     struct buffer *buf;
 
-    struct wl_region *region = wl_compositor_create_region(wl->compositor);
-    wl_region_add(region, 0, 0, width, height);
-    wl_surface_set_opaque_region(wl->surface, region);
-    wl_region_destroy(region);
-
+    vo_wayland_set_opaque_region(wl, 0);
     vo->want_redraw = true;
     vo->dwidth = width;
     vo->dheight = height;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -205,16 +205,10 @@ static bool resize(struct ra_ctx *ctx)
 
     MP_VERBOSE(wl, "Handling resize on the vk side\n");
 
-    const int32_t width = wl->scaling*mp_rect_w(wl->geometry);
-    const int32_t height = wl->scaling*mp_rect_h(wl->geometry);
+    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
+    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
 
-    if (!ctx->opts.want_alpha) {
-        struct wl_region *region = wl_compositor_create_region(wl->compositor);
-        wl_region_add(region, 0, 0, width, height);
-        wl_surface_set_opaque_region(wl->surface, region);
-        wl_region_destroy(region);
-    }
-
+    vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
     bool ok = ra_vk_ctx_resize(ctx, width, height);
     if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
@@ -250,13 +244,21 @@ static void wayland_vk_wait_events(struct ra_ctx *ctx, int64_t until_time_us)
     vo_wayland_wait_events(ctx->vo, until_time_us);
 }
 
+static void wayland_vk_update_render_opts(struct ra_ctx *ctx)
+{
+    struct vo_wayland_state *wl = ctx->vo->wl;
+    vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
+    wl_surface_commit(wl->surface);
+}
+
 const struct ra_ctx_fns ra_ctx_vulkan_wayland = {
-    .type           = "vulkan",
-    .name           = "waylandvk",
-    .reconfig       = wayland_vk_reconfig,
-    .control        = wayland_vk_control,
-    .wakeup         = wayland_vk_wakeup,
-    .wait_events    = wayland_vk_wait_events,
-    .init           = wayland_vk_init,
-    .uninit         = wayland_vk_uninit,
+    .type               = "vulkan",
+    .name               = "waylandvk",
+    .reconfig           = wayland_vk_reconfig,
+    .control            = wayland_vk_control,
+    .wakeup             = wayland_vk_wakeup,
+    .wait_events        = wayland_vk_wait_events,
+    .update_render_opts = wayland_vk_update_render_opts,
+    .init               = wayland_vk_init,
+    .uninit             = wayland_vk_uninit,
 };

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1612,6 +1612,20 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
     return VO_NOTIMPL;
 }
 
+void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha)
+{
+    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
+    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
+    if (!alpha) {
+        struct wl_region *region = wl_compositor_create_region(wl->compositor);
+        wl_region_add(region, 0, 0, width, height);
+        wl_surface_set_opaque_region(wl->surface, region);
+        wl_region_destroy(region);
+    } else {
+        wl_surface_set_opaque_region(wl->surface, NULL);
+    }
+}
+
 void vo_wayland_sync_clear(struct vo_wayland_state *wl)
 {
     struct vo_wayland_sync sync = {0, 0, 0, 0};

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -151,6 +151,7 @@ void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wakeup(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
 void vo_wayland_wait_frame(struct vo_wayland_state *wl);
+void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);
 void vo_wayland_sync_clear(struct vo_wayland_state *wl);
 void wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_sync_shift(struct vo_wayland_state *wl);


### PR DESCRIPTION
Follow up to the wayland opaque stuff. It's possible for a user to change `alpha` while a video is running and the renderer does update this properly (i.e. alpha can turn off and on). The previous wayland opaque commit had no way of detecting this so it could incorrectly have an opaque region set. This adds some functionality in `vo_gpu` to update the `ra_ctx` opts when this value is changed by the user and then allows the wayland backends to properly update their opaque regions.