### PR TITLE
command: add "platform" property

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -79,6 +79,7 @@ Interface changes
     - key/value list options do not accept ":" as item separator anymore,
       only ",". This means ":" is always considered part of the value.
     - remove deprecated --vo-vdpau-deint option
+    - add "platform" property
  --- mpv 0.32.0 ---
     - change behavior when using legacy option syntax with options that start
       with two dashes (``--`` instead of a ``-``). Now, using the recommended

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3169,6 +3169,12 @@ Property list
     in a somewhat weird form (apparently "hex BCD"), indicating the release
     version of the libass library linked to mpv.
 
+``platform``
+    Return a string describing what target platform mpv was built for. This is
+    one of the following values: ``win32`` (desktop Windows), ``uwp``,
+    ``macos``, ``tvos``, ``bsd/linux`` (any non-Apple non-Android POSIX),
+    ``android``, ``unknown`` (fallback value)
+
 ``options/<name>`` (RW)
     Read-only access to value of option ``--<name>``. Most options can be
     changed at runtime by writing to this property. Note that many options

--- a/osdep/utils.c
+++ b/osdep/utils.c
@@ -1,0 +1,40 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "utils.h"
+#include "config.h"
+
+mp_target_platform get_target_platform(void)
+{
+#if HAVE_UWP
+    return MP_PLATFORM_UWP;
+#endif
+#if HAVE_WIN32_DESKTOP
+    return MP_PLATFORM_WIN32;
+#endif
+#if defined(TARGET_OS_TV) && TARGET_OS_TV
+    return MP_PLATFORM_TVOS;
+#elif defined(__APPLE__)
+    return MP_PLATFORM_MACOS;
+#endif
+#if HAVE_ANDROID
+    return MP_PLATFORM_ANDROID;
+#elif HAVE_POSIX
+    return MP_PLATFORM_BSD_LINUX;
+#endif
+    return MP_PLATFORM_UNKNOWN;
+}

--- a/osdep/utils.h
+++ b/osdep/utils.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MP_OSDEP_UTILS_H_
+#define MP_OSDEP_UTILS_H_
+
+typedef enum {
+    MP_PLATFORM_UNKNOWN,
+    MP_PLATFORM_WIN32,
+    MP_PLATFORM_UWP,
+    MP_PLATFORM_MACOS,
+    MP_PLATFORM_BSD_LINUX,
+    MP_PLATFORM_ANDROID,
+    MP_PLATFORM_TVOS
+} mp_target_platform;
+
+// Array for enum to string conversion
+static const char *const platform_enum_to_str[] = {
+    "unknown",
+    "win32",
+    "uwp",
+    "macos",
+    "bsd/linux",
+    "android",
+    "tvos"
+};
+
+// Return an enum describing the target platform mpv has been built for
+mp_target_platform get_target_platform(void);
+
+#endif

--- a/player/command.c
+++ b/player/command.c
@@ -42,6 +42,7 @@
 #include "filters/f_decoder_wrapper.h"
 #include "command.h"
 #include "osdep/timer.h"
+#include "osdep/utils.h"
 #include "common/common.h"
 #include "input/input.h"
 #include "input/keycodes.h"
@@ -3191,6 +3192,14 @@ static int mp_property_libass_version(void *ctx, struct m_property *prop,
     return m_property_int64_ro(action, arg, ass_library_version());
 }
 
+static int mp_property_platform(void *ctx, struct m_property *prop,
+                                int action, void *arg)
+{
+    const char* platform = platform_enum_to_str[get_target_platform()];
+    return m_property_strdup_ro(action, arg, platform);
+}
+
+
 static int mp_property_alias(void *ctx, struct m_property *prop,
                              int action, void *arg)
 {
@@ -3648,6 +3657,7 @@ static const struct m_property mp_properties_base[] = {
     {"input-bindings", mp_property_bindings},
 
     {"shared-script-properties", mp_property_script_props},
+    {"platform", mp_property_platform},
 
     M_PROPERTY_ALIAS("video", "vid"),
     M_PROPERTY_ALIAS("audio", "aid"),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -553,6 +553,7 @@ def build(ctx):
         ( "osdep/win32/pthread.c",               "win32-internal-pthreads"),
         ( "osdep/windows_utils.c",               "os-cygwin" ),
         ( "osdep/windows_utils.c",               "os-win32" ),
+        ( "osdep/utils.c" ),
 
         ## tree_allocator
         "ta/ta.c", "ta/ta_talloc.c", "ta/ta_utils.c"


### PR DESCRIPTION
Add a read-only property that returns a string roughly identifying what target platform mpv was built for.

Occasionally, scripts need to make OS-dependant choices such as which subprocess to call. While ideally they would probe for precisely what they need, the platform property can give them a hint as to what to try first, and what the preferred method of doing a certain thing "natively" is.

This change was inspired when I saw some ugly platform probing code in user scripts; every user script that does do something non-portable at any stage would need to add similar ugly boilerplate. mpv already has some information about what kind of system it is running on, based on what it was built for. Hence, it would make sense for mpv to expose some of the work its build system has already done in a simple to access and easy to understand set of categories a target system may fit into.

The biggest argument against this change from what I can imagine is that platforms in general are a lie, since (thankfully) all major operating systems are not mutually exclusive sets of APIs and conventions. They like to derive from each other or emulate support for other APIs with various degrees of success.

However, it's also clear to most developers that some conventions are in place for different OSes due to how users of those operating systems typically use them; for example, one may define an "EDITOR" environment variable on Windows, but typically Windows people will not do this because Microsoft hides environment variable settings about 3 generations of Windows control panel UIs deep in their broken mess of a graphical user interface.

I have only tested this change on Linux; I'd appreciate if we could at least have someone test it on desktop Windows and macOS, as those are the likeliest three targets to run mpv.