### PR TITLE
Delete "watch later" config when ending playback of a file

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -79,6 +79,10 @@ Interface changes
     - key/value list options do not accept ":" as item separator anymore,
       only ",". This means ":" is always considered part of the value.
     - remove deprecated --vo-vdpau-deint option
+    - delete the "watch later" config when ending the playback for a file; this
+      is in addition to deleting it when it is read on start-up, so this only
+      has an effect if the config has been re-written using
+      ``write-watch-later-config``.
  --- mpv 0.32.0 ---
     - change behavior when using legacy option syntax with options that start
       with two dashes (``--`` instead of a ``-``). Now, using the recommended

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -456,6 +456,14 @@ void mp_load_playback_resume(struct MPContext *mpctx, const char *file)
     talloc_free(fname);
 }
 
+void mp_clear_playback_resume(struct MPContext *mpctx, const char *file)
+{
+    char *fname = mp_get_playback_resume_config_filename(mpctx, file);
+    if (fname)
+        unlink(fname);
+    talloc_free(fname);
+}
+
 // Returns the first file that has a resume config.
 // Compared to hashing the playlist file or contents and managing separate
 // resume file for them, this is simpler, and also has the nice property

--- a/player/core.h
+++ b/player/core.h
@@ -513,6 +513,7 @@ void mp_parse_cfgfiles(struct MPContext *mpctx);
 void mp_load_auto_profiles(struct MPContext *mpctx);
 void mp_get_resume_defaults(struct MPContext *mpctx);
 void mp_load_playback_resume(struct MPContext *mpctx, const char *file);
+void mp_clear_playback_resume(struct MPContext *mpctx, const char *file);
 void mp_write_watch_later_conf(struct MPContext *mpctx);
 struct playlist_entry *mp_check_playlist_resume(struct MPContext *mpctx,
                                                 struct playlist *playlist);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1703,6 +1703,11 @@ terminate_playback:
 
     m_config_restore_backups(mpctx->mconfig);
 
+    if (mpctx->stop_play == AT_END_OF_FILE ||
+        mpctx->stop_play == PT_NEXT_ENTRY ||
+        mpctx->stop_play == PT_CURRENT_ENTRY)
+        mp_clear_playback_resume(mpctx, mpctx->filename);
+
     TA_FREEP(&mpctx->filter_root);
     talloc_free(mpctx->filtered_tags);
     mpctx->filtered_tags = NULL;


### PR DESCRIPTION
```
This is the most minimal change in mpv which allows having
"persistent" playback resuming.

The general problem that this change is attempting to help solve has
been described in #336, #3169 and #6574. Though persistent playback
position of a single file is generally a solved problem, this is not
the case for playlists, as described in #8138.

The motivation is facilitating intermittent playback of very large
playlists, consisting of hundreds of entries each many hours
long. Though the current "watch later" mechanism works well - provided
that the files each occur only once in that playlist, and are played
only via that playlist - the biggest issue is that the position is
lost completely should mpv exit uncleanly (e.g. due to a power
failure).  Existing workarounds (in the form of Lua scripts which call
write-watch-later-config periodically) fail in the playlist case, due
to the mechanism used by mpv to determine where within a playlist to
resume playback from.

However, it is possible to make the above scripts "just work" with one
simple change - delete the state file not just on startup (when it is
read), but also when ending the playback of a file. Doing so deletes
any saved positions written by write-watch-later-config; the script
can then proceed to immediately write a new one when the next file
is loaded, which altogether allows mpv to resume from the correct
playlist and file position upon next startup.

A Lua script which makes use of this change can be found here:
https://gist.github.com/CyberShadow/2f71a97fb85ed42146f6d9f522bc34ef
(A small modification of the one written by @Hakkin, in that this one
also saves the state immediately when a new file is loaded.)
```