### PR TITLE
wayland: add wayland-display-socket option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5367,6 +5367,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
     ``--no-audio``, and ``--untimed=yes``. Only works with ``--gpu-context=wayland``
     and ``--gpu-context=waylandvk``.
 
+``--wayland-display-socket=<string>``
+    Specify the name of the wayland socket mpv attempts to connect to. By default,
+    mpv will simply pass "NULL" which will then try to connect to the compositor
+    currently in use. Note that this will only have an effect during startup since
+    closing the connection to the wl_display will terminate the client.
+
 ``--wayland-edge-pixels-pointer=<value>``
     Defines the size of an edge border (default: 10) to initiate client side
     resize events in the wayland contexts with the mouse. This is only active if

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -46,6 +46,7 @@
 const struct m_sub_options wayland_conf = {
     .opts = (const struct m_option[]) {
         {"wayland-disable-vsync", OPT_FLAG(disable_vsync)},
+        {"wayland-display-socket", OPT_STRING(display_socket)},
         {"wayland-edge-pixels-pointer", OPT_INT(edge_pixels_pointer),
             M_RANGE(0, INT_MAX)},
         {"wayland-edge-pixels-touch", OPT_INT(edge_pixels_touch),
@@ -55,6 +56,7 @@ const struct m_sub_options wayland_conf = {
     .size = sizeof(struct wayland_opts),
     .defaults = &(struct wayland_opts) {
         .disable_vsync = false,
+        .display_socket = NULL,
         .edge_pixels_pointer = 10,
         .edge_pixels_touch = 64,
     },
@@ -1125,7 +1127,6 @@ int vo_wayland_init(struct vo *vo)
     struct vo_wayland_state *wl = vo->wl;
 
     *wl = (struct vo_wayland_state) {
-        .display = wl_display_connect(NULL),
         .vo = vo,
         .log = mp_log_new(wl, vo->log, "wayland"),
         .scaling = 1,
@@ -1134,7 +1135,15 @@ int vo_wayland_init(struct vo *vo)
         .cursor_visible = true,
         .vo_opts_cache = m_config_cache_alloc(wl, vo->global, &vo_sub_opts),
     };
+    wl->opts = mp_get_config_group(wl, wl->vo->global, &wayland_conf);
     wl->vo_opts = wl->vo_opts_cache->opts;
+
+    wl->display = wl_display_connect(wl->opts->display_socket);
+    if (!wl->display) {
+        MP_WARN(wl, "Display socket %s not found/unavailable! Falling back to NULL!\n", wl->opts->display_socket);
+        wl->display = wl_display_connect(NULL);
+    }
+    wl->display_fd = wl_display_get_fd(wl->display);
 
     wl_list_init(&wl->output_list);
 
@@ -1204,8 +1213,6 @@ int vo_wayland_init(struct vo *vo)
         MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
                    zwp_idle_inhibit_manager_v1_interface.name);
 
-    wl->opts = mp_get_config_group(wl, wl->vo->global, &wayland_conf);
-    wl->display_fd = wl_display_get_fd(wl->display);
     mp_make_wakeup_pipe(wl->wakeup_pipe);
 
     return true;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -27,6 +27,7 @@
 
 struct wayland_opts {
     int disable_vsync;
+    char *display_socket;
     int edge_pixels_pointer;
     int edge_pixels_touch;
 };


### PR DESCRIPTION
As per the client API, a client can connect to any arbitrary wayland
socket. mpv has always just passed NULL which connected to the
compositor currently in use, but one could just as easily pass the name
of a different socket (i.e. the value of WAYLAND_DISPLAY). Here, we just
expose this argument as a user configurable option. If the user passes a
socket name that does not exist, then print a warning and fall back to
NULL.