### PR TITLE
console: let type set the cursor position

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -62,8 +62,14 @@ Ctrl+W
 Commands
 --------
 
-``script-message-to console type <text>``
-    Show the console and pre-fill it with the provided text.
+``script-message-to console type <text> [<cursor_pos>]``
+    Show the console and pre-fill it with the provided text, optionally
+    specifying the initial cursor position as a positive integer starting from
+    1.
+
+    .. admonition:: Example for input.conf
+
+        ``% script-message-to console type "seek  absolute-percent" 6``
 
 Known issues
 ------------

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -214,8 +214,9 @@ end
 
 -- Show the repl if hidden and replace its contents with 'text'
 -- (script-message-to repl type)
-function show_and_type(text)
+function show_and_type(text, cursor_pos)
     text = text or ''
+    cursor_pos = tonumber(cursor_pos)
 
     -- Save the line currently being edited, just in case
     if line ~= text and line ~= '' and history[#history] ~= line then
@@ -223,7 +224,12 @@ function show_and_type(text)
     end
 
     line = text
-    cursor = line:len() + 1
+    if cursor_pos ~= nil and cursor_pos >= 1
+       and cursor_pos <= line:len() + 1 then
+        cursor = math.floor(cursor_pos)
+    else
+        cursor = line:len() + 1
+    end
     history_pos = #history + 1
     insert_mode = false
     if repl_active then
@@ -737,8 +743,8 @@ mp.add_key_binding(nil, 'enable', function()
 end)
 
 -- Add a script-message to show the REPL and fill it with the provided text
-mp.register_script_message('type', function(text)
-    show_and_type(text)
+mp.register_script_message('type', function(text, cursor_pos)
+    show_and_type(text, cursor_pos)
 end)
 
 -- Redraw the REPL when the OSD size changes. This is needed because the


### PR DESCRIPTION
This allows keybindings such as:

```
a script-message-to console type "seek :0 absolute" 6
% script-message-to console type "seek  absolute-percent" 6
```

The cursor position 0 isn't allowed because it has the weird effect of
filling the console with the text twice, leaving the cursor in the
middle.
Negative positions would put the cursor n characters before the end, and
positions greater than the text's length at the end. They seem to work
at first, but the console breaks when you move the cursor, so they
aren't allowed.
It seems that float values don't cause issues, but I'm using the
argument's floor anyway to be safe. Using >= 1 instead of > 0 ignores
values like 0.5.