### PR TITLE
sub: Add --sub-stretch-durations option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2639,6 +2639,14 @@ Subtitles
         particular subtitles in mkv files) are always assumed to be UTF-8.
 
 
+``--sub-stretch-durations=<yes|no>``
+    Stretch a subtitle duration so it ends when the next one starts.
+    Should help with subtitles which erroneously have zero durations.
+
+    .. note::
+
+        Only applies to text subtitles.
+
 ``--sub-fix-timing=<yes|no>``
     Adjust subtitle timing is to remove minor gaps or overlaps between
     subtitles (if the difference is smaller than 210 ms, the gap or overlap

--- a/options/options.c
+++ b/options/options.c
@@ -291,6 +291,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"stretch-image-subs-to-screen", OPT_BOOL(stretch_image_subs)},
         {"image-subs-video-resolution", OPT_BOOL(image_subs_video_res)},
         {"sub-fix-timing", OPT_BOOL(sub_fix_timing)},
+        {"sub-stretch-durations", OPT_BOOL(sub_stretch_durations)},
         {"sub-pos", OPT_FLOAT(sub_pos), M_RANGE(0.0, 150.0)},
         {"sub-gauss", OPT_FLOAT(sub_gauss), M_RANGE(0.0, 3.0)},
         {"sub-gray", OPT_BOOL(sub_gray)},

--- a/options/options.h
+++ b/options/options.h
@@ -93,6 +93,7 @@ struct mp_subtitle_opts {
     bool stretch_image_subs;
     bool image_subs_video_res;
     bool sub_fix_timing;
+    bool sub_stretch_durations;
     bool sub_scale_by_window;
     bool sub_scale_with_window;
     bool ass_scale_with_window;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -341,7 +341,8 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         double sub_duration = 0;
         char **r = lavc_conv_decode(ctx->converter, packet, &sub_pts,
                                     &sub_duration);
-        if (packet->duration < 0 || sub_duration == UINT32_MAX) {
+        if (sd->opts->sub_stretch_durations ||
+            packet->duration < 0 || sub_duration == UINT32_MAX) {
             if (!ctx->duration_unknown) {
                 MP_WARN(sd, "Subtitle with unknown duration.\n");
                 ctx->duration_unknown = true;


### PR DESCRIPTION
 Stretch a subtitle duration so it ends when the next one starts.
 Should help with subtitles which erroneously have zero durations.

 I found such a subrip substitles stream in the wild.