### PR TITLE
DOCS: fix typo on sub-filter-regex-enable

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2766,7 +2766,7 @@ Subtitles
 ``--sub-filter-regex-enable=<yes|no>``
     Whether to enable regex filtering (default: yes). Note that if no regexes
     are added to the ``--sub-filter-regex`` list, setting this option to ``yes``
-    has no default. It's meant to easily disable or enable filtering
+    has no effect. It's meant to easily disable or enable filtering
     temporarily.
 
 ``--sub-create-cc-track=<yes|no>``


### PR DESCRIPTION
just fixes a tiny typo for the `--sub-filter-regex-enable` docs

Instead of 
> ...setting this option to ``yes`` has no default.

It's now
> setting this option to ``yes`` has no **effect**.