### PR TITLE
vo_gpu: EGL: hack for alpha on different platforms

### DIFF
--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -116,6 +116,9 @@ static bool mpegl_init(struct ra_ctx *ctx)
         .refine_config = ctx->opts.want_alpha ? pick_xrgba_config : NULL,
     };
 
+    if (!strcmp(eglQueryString(p->egl_display, EGL_VENDOR), "Mesa Project"))
+        ctx->opts.want_alpha = 0;
+
     EGLConfig config;
     if (!mpegl_create_context_cb(ctx, p->egl_display, cb, &p->egl_context, &config))
         goto uninit;

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -120,7 +120,7 @@ static bool create_context(struct ra_ctx *ctx, EGLDisplay display,
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
         EGL_BLUE_SIZE, 8,
-        EGL_ALPHA_SIZE, 0,
+        EGL_ALPHA_SIZE, ctx->opts.want_alpha ? 1 : 0,
         EGL_RENDERABLE_TYPE, rend,
         EGL_NONE
     };


### PR DESCRIPTION
7fb972f fixed transparency on x11/EGL/Mesa but happened to also break it
for wayland and nvidia. Ideally on wayland, you should just be able to
pick the right EGLConfig that has alpha but this doesn't seem to work
because reasons. So just go back to setting the EGL_ALPHA_SIZE bit if
the user asks for alpha. Apparently this worked before for nvidia as
well. The hack is to just run an eglQueryString in the x11egl context.
If it picks up Mesa as the EGL_VENDOR, then force ctx->opts.want_alpha
to 0 and let pick_xrgba_config take care of the rest.