### PR TITLE
ci/appveyor: attempt to work around outdated msys2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,12 @@ shallow_clone: true
 test: off
 
 install:
+  # Work around age/brokenness of Appveyor's msys2 by adding the new
+  # maintainer's keyring.
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   # Support for Ada and Objective-C was removed from MSYS2. GCC won't update if
   # these packages are installed.
   - >-
@@ -23,6 +29,8 @@ install:
     mingw-w64-x86_64-gcc-objc
   # Update core packages
   - C:\msys64\usr\bin\pacman -Syyuu --noconfirm --noprogressbar --ask=20
+  # Explicitly kill any remaining msys2 processes after core update
+  - taskkill /f /fi "MODULES eq msys-2.0.dll"
   # Update non-core packages
   - C:\msys64\usr\bin\pacman -Suu --noconfirm --noprogressbar --ask=20
   # Install required MSYS2 packages


### PR DESCRIPTION
Based on the workarounds utilized in the MAME project:
1. mamedev/mame@4b4016110a71a5b84b9d19faf20238d20926088d
2. mamedev/mame@2d1bf3ed5cb1f4cdcc40b286a78c24f398217535
