### PR TITLE
Expose & show hardware pixfmt in stats.lua

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2299,6 +2299,10 @@ Property list
         The pixel format as string. This uses the same names as used in other
         places of mpv.
 
+    ``video-params/hw-pixelformat``
+        The underlying pixel format as string. This is relevant for some cases
+        of hardware decoding and unavailable otherwise.
+
     ``video-params/average-bpp``
         Average bits-per-pixel as integer. Subsampled planar formats use a
         different resolution, which is the reason this value can sometimes be
@@ -2357,6 +2361,7 @@ Property list
 
         MPV_FORMAT_NODE_MAP
             "pixelformat"       MPV_FORMAT_STRING
+            "hw-pixelformat"    MPV_FORMAT_STRING
             "w"                 MPV_FORMAT_INT64
             "h"                 MPV_FORMAT_INT64
             "dw"                MPV_FORMAT_INT64

--- a/player/command.c
+++ b/player/command.c
@@ -2195,6 +2195,8 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
 
     struct m_sub_property props[] = {
         {"pixelformat",     SUB_PROP_STR(mp_imgfmt_to_name(p.imgfmt))},
+        {"hw-pixelformat",  SUB_PROP_STR(mp_imgfmt_to_name(p.hw_subfmt)),
+                            .unavailable = !p.hw_subfmt},
         {"average-bpp",     SUB_PROP_INT(bpp),
                             .unavailable = !bpp},
         {"w",               SUB_PROP_INT(p.w)},

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -549,6 +549,10 @@ local function add_video(s)
         append(s, format("%.2f", r["aspect"]), {prefix="Aspect Ratio:"})
     end
     append(s, r["pixelformat"], {prefix="Pixel Format:"})
+    if r["hw-pixelformat"] ~= nil then
+        append(s, r["hw-pixelformat"], {prefix_sep="[", nl="", indent=" ",
+                suffix="]"})
+    end
 
     -- Group these together to save vertical space
     local prim = append(s, r["primaries"], {prefix="Primaries:"})


### PR DESCRIPTION
e.g. with nvdec:
![grafik](https://user-images.githubusercontent.com/1042418/96239848-7bbb7980-0fa0-11eb-8c99-e6f0118234e5.png)
