### PR TITLE
path: use XDG cache and XDG data dirs by default

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -29,6 +29,9 @@ Interface changes
  --- mpv 0.34.0 ---
     - add `--screen-name` and `--fs-screen-name` flags to allow selecting the 
       screen by its name instead of the index
+    - the watch_later directory is now stored in "~/.local/share/mpv" by default (unix)
+    - the cache-dir option defaults to "~/.cache/mpv" instead of none (unix). For
+      other platforms/configurations, the cache is stored in mpv's config directory.
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1561,7 +1561,7 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
 
     See `Script location`_ for details.
 
-``~/.config/mpv/watch_later/``
+``~/.local/share/mpv/watch_later/``
     Contains temporary config files needed for resuming playback of files with
     the watch later feature. See for example the ``Q`` key binding, or the
     ``quit-watch-later`` input command.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -754,7 +754,7 @@ Program Behavior
     The directory in which to store the "watch later" temporary files.
 
     The default is a subdirectory named "watch_later" underneath the
-    config directory (usually ``~/.config/mpv/``).
+    local data directory (usually ``~/.local/share/mpv/``).
 
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
@@ -4585,8 +4585,6 @@ Cache
     This makes sense only with ``--cache``. If the normal cache is disabled,
     this option is ignored.
 
-    You need to set ``--cache-dir`` to use this.
-
     The cache file is append-only. Even if the player appears to prune data, the
     file space freed by it is not reused. The cache file is deleted when
     playback is closed.
@@ -4609,7 +4607,7 @@ Cache
     continue to use the cache file that was opened first.
 
 ``--cache-dir=<path>``
-    Directory where to create temporary files (default: none).
+    Directory where to create temporary files (usually ``~/.cache/mpv``).
 
     Currently, this is used for ``--cache-on-disk`` only.
 

--- a/demux/cache.c
+++ b/demux/cache.c
@@ -100,10 +100,11 @@ struct demux_cache *demux_cache_create(struct mpv_global *global,
     cache->fd = -1;
 
     char *cache_dir = cache->opts->cache_dir;
-    if (!(cache_dir && cache_dir[0])) {
-        MP_ERR(cache, "No cache data directory supplied.\n");
-        goto fail;
-    }
+    if (!(cache_dir && cache_dir[0]))
+        cache_dir = mp_find_user_file(NULL, global, "cache", "");
+
+    if (!mp_path_exists(cache_dir))
+        mp_mk_user_dir(global, "cache", cache_dir);
 
     cache->filename = mp_path_join(cache, cache_dir, "mpv-cache-XXXXXX.dat");
     cache->fd = mp_mkostemps(cache->filename, 4, O_CLOEXEC);

--- a/options/path.c
+++ b/options/path.c
@@ -100,15 +100,21 @@ static const char *mp_get_platform_path(void *talloc_ctx,
     return NULL;
 }
 
-char *mp_find_user_config_file(void *talloc_ctx, struct mpv_global *global,
-                               const char *filename)
+char *mp_find_user_file(void *talloc_ctx, struct mpv_global *global,
+                        const char *type, const char *filename)
 {
     void *tmp = talloc_new(NULL);
-    char *res = (char *)mp_get_platform_path(tmp, global, config_dirs[0]);
+    char *res;
+    /* If the user forces a configdir, always return this path. */
+    if (global->configdir) {
+        res = (char *)mp_get_platform_path(tmp, global, config_dirs[0]);
+    } else {
+        res = (char *)mp_get_platform_path(tmp, global, type);
+    }
     if (res)
         res = mp_path_join(talloc_ctx, res, filename);
     talloc_free(tmp);
-    MP_DBG(global, "config path: '%s' -> '%s'\n", filename, res ? res : "-");
+    MP_DBG(global, "path: '%s' -> '%s'\n", filename, res ? res : "-");
     return res;
 }
 
@@ -376,9 +382,9 @@ void mp_mkdirp(const char *dir)
     talloc_free(path);
 }
 
-void mp_mk_config_dir(struct mpv_global *global, char *subdir)
+void mp_mk_user_dir(struct mpv_global *global, const char *type, char *subdir)
 {
-    char *dir = mp_find_user_config_file(NULL, global, subdir);
+    char *dir = mp_find_user_file(NULL, global, type, subdir);
     if (dir)
         mp_mkdirp(dir);
     talloc_free(dir);

--- a/options/path.h
+++ b/options/path.h
@@ -34,11 +34,11 @@ void mp_init_paths(struct mpv_global *global, struct MPOpts *opts);
 char *mp_find_config_file(void *talloc_ctx, struct mpv_global *global,
                           const char *filename);
 
-// Like mp_find_config_file(), but search only the local writable user config
-// dir. Also, this returns a result even if the file does not exist. Calling
-// it with filename="" is equivalent to retrieving the user config dir.
-char *mp_find_user_config_file(void *talloc_ctx, struct mpv_global *global,
-                               const char *filename);
+// Search for local writable user files (config, data, or cache). This returns
+// a result even if the file does not exist. Calling it with filename="" is
+// equivalent to retrieving the user config dir.
+char *mp_find_user_file(void *talloc_ctx, struct mpv_global *global,
+                        const char *type, const char *filename);
 
 // Find all instances of the given config file. Paths are returned in order
 // from lowest to highest priority. filename can contain multiple names
@@ -90,6 +90,6 @@ bool mp_is_url(bstr path);
 bstr mp_split_proto(bstr path, bstr *out_url);
 
 void mp_mkdirp(const char *dir);
-void mp_mk_config_dir(struct mpv_global *global, char *subdir);
+void mp_mk_user_dir(struct mpv_global *global, const char *type, char *subdir);
 
 #endif /* MPLAYER_PATH_H */

--- a/osdep/path-uwp.c
+++ b/osdep/path-uwp.c
@@ -26,7 +26,9 @@ WINBASEAPI DWORD WINAPI GetCurrentDirectoryW(DWORD nBufferLength, LPWSTR lpBuffe
 
 const char *mp_get_platform_path_uwp(void *talloc_ctx, const char *type)
 {
-    if (strcmp(type, "home") == 0) {
+    if (strcmp(type, "home") == 0 || strcmp(type, "cache") == 0 ||
+        strcmp(type, "data") == 0)
+    {
         wchar_t homeDir[_MAX_PATH];
         if (GetCurrentDirectoryW(_MAX_PATH, homeDir) != 0)
             return mp_to_utf8(talloc_ctx, homeDir);

--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -85,10 +85,15 @@ const char *mp_get_platform_path_win(void *talloc_ctx, const char *type)
 {
     pthread_once(&path_init_once, path_init);
     if (portable_path) {
-        if (strcmp(type, "home") == 0)
+        if (strcmp(type, "home") == 0 || strcmp(type, "cache") == 0 ||
+            strcmp(type, "data") == 0)
+        {
             return portable_path;
+        }
     } else {
-        if (strcmp(type, "home") == 0)
+        if (strcmp(type, "home") == 0 || strmcp(type, "cache") == 0 ||
+            strcmp(type, "data") == 0)
+        {
             return mp_get_win_app_dir(talloc_ctx);
         if (strcmp(type, "exe_dir") == 0)
             return mp_get_win_exe_dir(talloc_ctx);

--- a/osdep/path.h
+++ b/osdep/path.h
@@ -11,6 +11,13 @@
 //  "global"        the least priority, global config file location
 //  "desktop"       path to desktop contents
 //
+//  These additional type values are also defined. It is only used if
+//  the native mpv-specific user config dir is defined and only has any
+//  special meaning on unix platforms (elsewhere, the user config dir is
+//  returned).
+//  "cache"         path to local user cache files
+//  "data"          path to local user data files
+//
 // It is allowed to return a static string, so the caller must set talloc_ctx
 // to something other than NULL to avoid memory leaks.
 typedef const char *(*mp_get_platform_path_cb)(void *talloc_ctx, const char *type);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -63,7 +63,7 @@ void mp_parse_cfgfiles(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
 
-    mp_mk_config_dir(mpctx->global, "");
+    mp_mk_user_dir(mpctx->global, "home", "");
 
     char *p1 = mp_get_user_path(NULL, mpctx->global, "~~home/");
     char *p2 = mp_get_user_path(NULL, mpctx->global, "~~old_home/");
@@ -226,7 +226,7 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
 
     if (!mpctx->cached_watch_later_configdir) {
         mpctx->cached_watch_later_configdir =
-            mp_find_user_config_file(mpctx, mpctx->global, MP_WATCH_LATER_CONF);
+            mp_find_user_file(mpctx, mpctx->global, "data", MP_WATCH_LATER_CONF);
     }
 
     if (mpctx->cached_watch_later_configdir)
@@ -349,7 +349,7 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     if (!conffile)
         goto exit;
 
-    mp_mk_config_dir(mpctx->global, mpctx->cached_watch_later_configdir);
+    mp_mk_user_dir(mpctx->global, "data", mpctx->cached_watch_later_configdir);
 
     MP_INFO(mpctx, "Saving state.\n");
 


### PR DESCRIPTION
I have zero idea how other OSes work. I assume separating out data/cache makes sense on any *nix, but I'm not sure about macos. Anyway, this makes mpv store its watch_later directory in XDG_DATA_HOME (\~/.local/share/mpv). Additionally, mpv has a `--cache-dir` option (which is not set by default) and is used by `--cache-on-disk`. Using `--cache-on-disk` required you to set a specific `--cache-dir` which I thought was silly so I made it default to XDG_CACHE_HOME (\~/.cache/mpv).

The XDG_CACHE_HOME and XDG_DATA_HOME directories are only used if a using the XDG_CONFIG_HOME path (\~/.config/mpv) which is the default. If someone is explicitly using the old ~/.mpv path, then the cache and watch_later files are stored in ~/.mpv. Non-unix should still work the same as before.