### PR TITLE
doc: split BNF definitions of <command> & <argument> in separate lines

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -160,8 +160,9 @@ Flat command syntax
 This is the syntax used in input.conf, and referred to "input.conf syntax" in
 a number of other places.
 
-``<command> ::= [<prefixes>] <command_name> (<argument>)*``
-``<argument> ::= (<string> | " <quoted_string> " )``
+|
+| ``<command>  ::= [<prefixes>] <command_name> (<argument>)*``
+| ``<argument> ::= (<string> | " <quoted_string> ")``
 
 ``command_name`` is an unquoted string with the command name itself. See
 `List of Input Commands`_ for a list.


### PR DESCRIPTION
Having them in the same line made it hard to read in the man page.

--------------------
![file](https://user-images.githubusercontent.com/20175435/96759589-8d55b480-13d8-11eb-9789-f31b316a83d4.png)
![html](https://user-images.githubusercontent.com/20175435/96877140-9185de80-1479-11eb-844f-eac781020339.png)
