### PR TITLE
command: add delete-watch-later-config

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -145,6 +145,8 @@ Interface changes
     - change the default of --hwdec to "no" on RPI. The default used to be "mmal"
       specifically if 'Raspberry Pi support' was enabled at configure time
       (equivalent to --enable-rpi). Use --hwdec=mmal to get the old behavior.
+    - add `delete-watch-later-config` command to complement
+      `write-watch-later-config`
  --- mpv 0.30.0 ---
     - add `--d3d11-output-format` to enable explicit selection of a D3D11
       swap chain format.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -724,6 +724,13 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     Write the resume config file that the ``quit-watch-later`` command writes,
     but continue playback normally.
 
+``delete-watch-later-config [<filename>]``
+    Delete any existing resume config file that was written by
+    ``quit-watch-later`` or ``write-watch-later-config``. If a filename is
+    specified, then the deleted config is for that file; otherwise, it is the
+    same one as would be written by ``quit-watch-later`` or
+    ``write-watch-later-config`` in the current circumstance.
+
 ``stop [<flags>]``
     Stop playback and clear playlist. With default settings, this is
     essentially like ``quit``. Useful for the client API: playback can be

--- a/player/command.c
+++ b/player/command.c
@@ -5688,6 +5688,17 @@ static void cmd_write_watch_later_config(void *p)
     mp_write_watch_later_conf(mpctx);
 }
 
+static void cmd_delete_watch_later_config(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    char *filename = cmd->args[0].v.s;
+    if (filename && !*filename)
+        filename = NULL;
+    mp_delete_watch_later_conf(mpctx, filename);
+}
+
 static void cmd_mouse(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6238,6 +6249,8 @@ const struct mp_cmd_def mp_cmds[] = {
     },
 
     { "write-watch-later-config", cmd_write_watch_later_config },
+    { "delete-watch-later-config", cmd_delete_watch_later_config,
+        {{"filename", OPT_STRING(v.s), .flags = MP_CMD_OPT_ARG} }},
 
     { "mouse", cmd_mouse, { {"x", OPT_INT(v.i)},
                             {"y", OPT_INT(v.i)},

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -433,6 +433,23 @@ exit:
     talloc_free(conffile);
 }
 
+void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file)
+{
+    if (!file) {
+        struct playlist_entry *cur = mpctx->playing;
+        if (!cur)
+            return;
+        file = cur->filename;
+        if (!file)
+            return;
+    }
+
+    char *fname = mp_get_playback_resume_config_filename(mpctx, file);
+    if (fname)
+        unlink(fname);
+    talloc_free(fname);
+}
+
 void mp_load_playback_resume(struct MPContext *mpctx, const char *file)
 {
     if (!mpctx->opts->position_resume)

--- a/player/core.h
+++ b/player/core.h
@@ -514,6 +514,7 @@ void mp_load_auto_profiles(struct MPContext *mpctx);
 void mp_get_resume_defaults(struct MPContext *mpctx);
 void mp_load_playback_resume(struct MPContext *mpctx, const char *file);
 void mp_write_watch_later_conf(struct MPContext *mpctx);
+void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file);
 struct playlist_entry *mp_check_playlist_resume(struct MPContext *mpctx,
                                                 struct playlist *playlist);
 


### PR DESCRIPTION
```
This introduces the delete-watch-later-config command, to complement
write-watch-later-config. This is an alternative to #8141.

The general problem that this change is attempting to help solve has
been described in #336, #3169 and #6574. Though persistent playback
position of a single file is generally a solved problem, this is not
the case for playlists, as described in #8138.

The motivation is facilitating intermittent playback of very large
playlists, consisting of hundreds of entries each many hours
long. Though the current "watch later" mechanism works well - provided
that the files each occur only once in that playlist, and are played
only via that playlist - the biggest issue is that the position is
lost completely should mpv exit uncleanly (e.g. due to a power
failure).  Existing workarounds (in the form of Lua scripts which call
write-watch-later-config periodically) fail in the playlist case, due
to the mechanism used by mpv to determine where within a playlist to
resume playback from.

The missing puzzle piece needed to allow scripts to implement a
complete solution to this problem is simply a way to clean up the
watch-later configuration that the script asked mpv to write using
write-watch-later-config. With that in place, scripts can then
register an end-file event listener, check the stop playback reason,
and in the "eof" and "stop" case, invoke delete-watch-later-config to
delete any saved positions written by write-watch-later-config. The
script can then proceed to immediately write a new one when the next
file is loaded, which altogether allows mpv to resume from the correct
playlist and file position upon next startup.

Because events are delivered and executed asynchronously,
delete-watch-later-config takes an optional filename argument, to
allow scripts to clear watch-later configuration for files after mpv
had already moved on from playing them and proceeded to another file.

A Lua script which makes use of this change can be found here:
https://gist.github.com/CyberShadow/2f71a97fb85ed42146f6d9f522bc34ef
(A modification of the one written by @Hakkin, in that this one takes
advantage of the new command, and also saves the state immediately
when a new file is loaded.)
```