### PR TITLE
ytdl_hook: support alternative youtube-dl path

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -954,6 +954,11 @@ Program Behavior
         if available, allowing for video/audio selection in runtime (default:
         no). It's disabled ("no") by default for performance reasons.
 
+    ``ytdl_path=youtube-dl``
+        Configure path to youtube-dl executable or a compatible fork's.
+        The default "youtube-dl" looks for the executable in PATH. In a Windows
+        environment the suffix extension ".exe" is always appended.
+
     .. admonition:: Why do the option names mix ``_`` and ``-``?
 
         I have no idea.

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -8,16 +8,18 @@ local o = {
     use_manifests = false,
     all_formats = false,
     force_all_formats = true,
+    ytdl_path = "youtube-dl",
 }
 
 local ytdl = {
-    path = "youtube-dl",
+    path = nil,
     searched = false,
     blacklisted = {}
 }
 
 options.read_options(o, nil, function()
     ytdl.blacklisted = {} -- reparse o.exclude next time
+    ytdl.searched = false
 end)
 
 local chapter_list = {}
@@ -690,7 +692,7 @@ function run_ytdl_hook(url)
     -- check for youtube-dl in mpv's config dir
     if not (ytdl.searched) then
         local exesuf = (package.config:sub(1,1) == '\\') and '.exe' or ''
-        local ytdl_mcd = mp.find_config_file("youtube-dl" .. exesuf)
+        local ytdl_mcd = mp.find_config_file(o.ytdl_path .. exesuf)
         if not (ytdl_mcd == nil) then
             msg.verbose("found youtube-dl at: " .. ytdl_mcd)
             ytdl.path = ytdl_mcd

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -693,7 +693,10 @@ function run_ytdl_hook(url)
     if not (ytdl.searched) then
         local exesuf = (package.config:sub(1,1) == '\\') and '.exe' or ''
         local ytdl_mcd = mp.find_config_file(o.ytdl_path .. exesuf)
-        if not (ytdl_mcd == nil) then
+        if ytdl_mcd == nil then
+            msg.verbose("No youtube-dl found with path "..o.ytdl_path..exesuf.." in config directories")
+            ytdl.path = o.ytdl_path
+        else
             msg.verbose("found youtube-dl at: " .. ytdl_mcd)
             ytdl.path = ytdl_mcd
         end


### PR DESCRIPTION
Allows using a youtube-dl not in PATH or a compatible fork of youtube-dl.

Can probably be tested with https://github.com/blackjack4494/yt-dlc, but I didn't get to test it myself yet.