### PR TITLE
wayland: disable when linux-event-codes isn’t available

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -19,7 +19,7 @@
 #include <limits.h>
 #include <poll.h>
 #include <unistd.h>
-#include <linux/input.h>
+#include <linux/input-event-codes.h>
 #include <time.h>
 #include "common/msg.h"
 #include "options/m_config.h"

--- a/wscript
+++ b/wscript
@@ -302,6 +302,10 @@ iconv support use --disable-iconv.",
         'func': check_statement('sys/vfs.h',
                                 'struct statfs fs; fstatfs(0, &fs); fs.f_namelen')
     }, {
+        'name': 'linux-input-event-codes',
+        'desc': "Linux's input-event-codes.h",
+        'func': check_cc(header_name=['linux/input-event-codes.h']),
+    }, {
         'name' : '--lua',
         'desc' : 'Lua',
         'func': check_lua,
@@ -491,7 +495,7 @@ video_output_features = [
     } , {
         'name': '--wayland',
         'desc': 'Wayland',
-        'deps': 'wayland-protocols && wayland-scanner',
+        'deps': 'wayland-protocols && wayland-scanner && linux-input-event-codes',
         'func': check_pkg_config('wayland-client', '>= 1.15.0',
                                  'wayland-cursor', '>= 1.15.0',
                                  'xkbcommon',      '>= 0.3.0'),


### PR DESCRIPTION
The `wl_pointer` interface defines button argument as “a button code as defined in the Linux kernel's linux/input-event-codes.h header file, e.g. `BTN_LEFT`.”

We could `#define` these few buttons ourselves, but there is no system to test it on, so for now let’s disable Wayland support on them.

This is a call to non-Linux system maintainers, please help test this backend on your system and report issues you find, or even working state.