### PR TITLE
option: add --watch-later-blacklist-properties option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -81,6 +81,7 @@ Interface changes
     - remove deprecated --vo-vdpau-deint option
     - add `delete-watch-later-config` command to complement
       `write-watch-later-config`
+    - add `--watch-later-blacklist-properties` option.
  --- mpv 0.32.0 ---
     - change behavior when using legacy option syntax with options that start
       with two dashes (``--`` instead of a ``-``). Now, using the recommended

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -746,6 +746,23 @@ Program Behavior
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
+``--watch-later-blacklist-properties=<all|property1,property2,...>``
+    Prevents the listed properties from being saved in the "watch later" files.
+    Existing watch later data won't be modified and will still be applied
+    fully, but new watch later data won't contain these properties.
+
+    The special name "all" blacklists as many properties as possible. The
+    starting position is always saved and restored.
+
+    .. admonition:: Examples
+
+        - ``--watch-later-blacklist-properties=fullscreen``
+          Resuming a file won't restore the fullscreen state.
+        - ``--watch-later-blacklist-properties=volume,mute``
+          Resuming a file won't restore the volume or mute state.
+        - ``--watch-later-blacklist-properties=all``
+          Resuming a file won't restore any property except the starting position.
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/options/options.c
+++ b/options/options.c
@@ -686,6 +686,7 @@ static const m_option_t mp_opts[] = {
         OPT_FLAG(ignore_path_in_watch_later_config)},
     {"watch-later-directory", OPT_STRING(watch_later_directory),
         .flags = M_OPT_FILE},
+    {"watch-later-blacklist-properties", OPT_STRINGLIST(watch_later_blacklist_properties)},
 
     {"ordered-chapters", OPT_FLAG(ordered_chapters)},
     {"ordered-chapters-files", OPT_STRING(ordered_chapters_files),

--- a/options/options.h
+++ b/options/options.h
@@ -248,6 +248,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
+    char **watch_later_blacklist_properties;
     int pause;
     int keep_open;
     int keep_open_pause;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -373,26 +373,22 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     for (int i = 0; backup_properties[i]; i++) {
         const char *pname = backup_properties[i];
 
-        if (opts->watch_later_blacklist_properties) {
-            bool blacklist_all = false;
-            bool blacklist_one = false;
-            for (int n = 0; opts->watch_later_blacklist_properties[n]; n++) {
-                const char *opt = opts->watch_later_blacklist_properties[n];
-                if (opt[0]) {
-                    if (strcmp(opt, "all") == 0) {
-                        blacklist_all = true;
-                        break;
-                    } else if (strcmp(opt, pname) == 0) {
-                        blacklist_one = true;
-                        break;
-                    }
-                }
-            }
-            if (blacklist_all) {
+        bool blacklist_all = false;
+        bool blacklist_one = false;
+        for (int n = 0; opts->watch_later_blacklist_properties && opts->watch_later_blacklist_properties[n]; n++) {
+            const char *opt = opts->watch_later_blacklist_properties[n];
+            if (strcmp(opt, "all") == 0) {
+                blacklist_all = true;
                 break;
-            } else if (blacklist_one) {
-                continue;
+            } else if (strcmp(opt, pname) == 0) {
+                blacklist_one = true;
+                break;
             }
+        }
+        if (blacklist_all) {
+            break;
+        } else if (blacklist_one) {
+            continue;
         }
 
         char *val = NULL;


### PR DESCRIPTION
This option allows user to skip backing up specific properties for watch later feature. The "all" special value skips all properties.

I chose to do "skipping" to preserve backward compatibility. Let me know if the opposite is desired.

Since the list of properties is fixed and fairly short, I don't think it is worth sorting or using hash set to accelerate the lookup.

Do I also need to update documentation?

Related issue: https://github.com/mpv-player/mpv/issues/4641