### PR TITLE
vd_lavc: add AV1 to the default allowed hwdec codec list

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -135,7 +135,7 @@ const struct m_sub_options vd_lavc_conf = {
         .framedrop = AVDISCARD_NONREF,
         .dr = 1,
         .hwdec_api = "no",
-        .hwdec_codecs = "h264,vc1,hevc,vp9",
+        .hwdec_codecs = "h264,vc1,hevc,vp9,av1",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;
         // for example, if vo_gpu increases the number of reference surfaces for


### PR DESCRIPTION
Now that the first hwaccel implementations are coming in, it makes
sense to allow this format.