### PR TITLE
manpage: document av1 addition to --hwdec-codecs default setting

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1596,7 +1596,7 @@ Video
     You can get the list of allowed codecs with ``mpv --vd=help``. Remove the
     prefix, e.g. instead of ``lavc:h264`` use ``h264``.
 
-    By default, this is set to ``h264,vc1,hevc,vp9``. Note that
+    By default, this is set to ``h264,vc1,hevc,vp9,av1``. Note that
     the hardware acceleration special codecs like ``h264_vdpau`` are not
     relevant anymore, and in fact have been removed from Libav in this form.
 


### PR DESCRIPTION
Document the change to add AV1 to the list of default hwdec
codecs, in commit 172146e9f7a231b5de21921d883612d18b13a717.
