### PR TITLE
wayland: check for modifier keys on pointer events

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -119,6 +119,7 @@ struct vo_wayland_state {
     int64_t vsync_duration;
 
     /* Input */
+    uint32_t keyboard_code;
     struct wl_seat     *seat;
     struct wl_pointer  *pointer;
     struct wl_touch    *touch;


### PR DESCRIPTION
The pointer button event had no code to handle any modifier keys. So
this meant input combinations like Shift+MTBN_LEFT did not work. Fix
this by ripping out the modifier-checking code in keyboard key event to
a separate function and using it for both the keyboard and mouse events.
In the case of the mouse, it is possible that the keyboard may not exist
so be sure to check before trying to get any modifiers. Fixes #8239.