### PR TITLE
command: make current-window-scale writeable

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -42,6 +42,7 @@ Interface changes
       instead be used to specifically set the contrast to any value.
     - add a `--watch-later-options` option to allow configuring which
       options quit-watch-later saves
+    - make `current-window-scale` writeable and use it in the default input.conf
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2518,26 +2518,20 @@ Property list
     enabled, or after precise seeking). Files with imprecise timestamps (such
     as Matroska) might lead to unstable results.
 
-``window-scale`` (RW)
+``current-window-scale`` (RW)
     Window size multiplier. Setting this will resize the video window to the
     values contained in ``dwidth`` and ``dheight`` multiplied with the value
     set with this property. Setting ``1`` will resize to original video size
     (or to be exact, the size the video filters output). ``2`` will set the
-    double size, ``0.5`` halves the size.
+    double size, ``0.5`` halves the size. When reading this property, this
+    returns the scale value calculated from the current window size.
 
-    See ``current-window-scale`` for the value derived from the actual window
-    size.
+    The similarly named ``window-scale`` option behaves like a typical mpv
+    option. It does not pay attention to realtime window changes and only
+    updates if the user changes its value. In most cases, you probably want
+    to set ``current-window-scale`` directly.
 
-    Since mpv 0.31.0, this always returns the previously set value (or the
-    default value), instead of the value implied by the actual window size.
-    Before mpv 0.31.0, this returned what ``current-window-scale`` returns now,
-    after the window was created.
-
-``current-window-scale``
-    The ``window-scale`` value calculated from the current window size. This
-    has the same value as ``window-scale`` if the window size was not changed
-    since setting the option, and the window size was not restricted in other
-    ways. The property is unavailable if no video is active.
+    ``current-window-scale`` is unavailable if no video is active.
 
 ``focused``
     Whether the window has focus. Might not be supported by all VOs.

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -118,9 +118,9 @@
 #6 add gamma 1
 #7 add saturation -1
 #8 add saturation 1
-#Alt+0 set window-scale 0.5
-#Alt+1 set window-scale 1.0
-#Alt+2 set window-scale 2.0
+#Alt+0 set current-window-scale 0.5
+#Alt+1 set current-window-scale 1.0
+#Alt+2 set current-window-scale 2.0
 # toggle deinterlacer (automatically inserts or removes required filter)
 #d cycle deinterlace
 #r add sub-pos -1                       # move subtitles up

--- a/player/command.c
+++ b/player/command.c
@@ -2316,6 +2316,24 @@ static int mp_property_video_frame_info(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
+static int update_window_scale(struct MPContext *mpctx, double scale)
+{
+    struct vo *vo = mpctx->video_out;
+    if (!vo)
+        return -1;
+
+    struct mp_image_params params = get_video_out_params(mpctx);
+    int vid_w, vid_h;
+    mp_image_params_get_dsize(&params, &vid_w, &vid_h);
+    if (vid_w < 1 || vid_h < 1)
+        return -1;
+
+    int s[2] = {vid_w * scale, vid_h * scale};
+    if (s[0] > 0 && s[1] > 0)
+        vo_control(vo, VOCTRL_SET_UNFS_WINDOW_SIZE, s);
+    return 0;
+}
+
 static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
                                             int action, void *arg)
 {
@@ -2324,38 +2342,29 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
     if (!vo)
         return M_PROPERTY_UNAVAILABLE;
 
-    struct mp_image_params params = get_video_out_params(mpctx);
-    int vid_w, vid_h;
-    mp_image_params_get_dsize(&params, &vid_w, &vid_h);
-    if (vid_w < 1 || vid_h < 1)
-        return M_PROPERTY_UNAVAILABLE;
+    switch (action) {
+    case M_PROPERTY_SET:
+        if (update_window_scale(mpctx, *(double *)arg) < 0)
+            return M_PROPERTY_UNAVAILABLE;
+        return M_PROPERTY_OK;
+    case M_PROPERTY_GET_TYPE:
+    case M_PROPERTY_GET: ;
+        struct mp_image_params params = get_video_out_params(mpctx);
+        int vid_w, vid_h;
+        mp_image_params_get_dsize(&params, &vid_w, &vid_h);
+        if (vid_w < 1 || vid_h < 1)
+            return M_PROPERTY_UNAVAILABLE;
 
-    int s[2];
-    if (vo_control(vo, VOCTRL_GET_UNFS_WINDOW_SIZE, s) <= 0 ||
-        s[0] < 1 || s[1] < 1)
-        return M_PROPERTY_UNAVAILABLE;
+        int s[2];
+        if (vo_control(vo, VOCTRL_GET_UNFS_WINDOW_SIZE, s) <= 0 ||
+            s[0] < 1 || s[1] < 1)
+            return M_PROPERTY_UNAVAILABLE;
 
-    double xs = (double)s[0] / vid_w;
-    double ys = (double)s[1] / vid_h;
-    return m_property_double_ro(action, arg, (xs + ys) / 2);
-}
-
-static void update_window_scale(struct MPContext *mpctx)
-{
-    struct vo *vo = mpctx->video_out;
-    if (!vo)
-        return;
-
-    struct mp_image_params params = get_video_out_params(mpctx);
-    int vid_w, vid_h;
-    mp_image_params_get_dsize(&params, &vid_w, &vid_h);
-    if (vid_w < 1 || vid_h < 1)
-        return;
-
-    double scale = mpctx->opts->vo->window_scale;
-    int s[2] = {vid_w * scale, vid_h * scale};
-    if (s[0] > 0 && s[1] > 0)
-        vo_control(vo, VOCTRL_SET_UNFS_WINDOW_SIZE, s);
+        double xs = (double)s[0] / vid_w;
+        double ys = (double)s[1] / vid_h;
+        return m_property_double_ro(action, arg, (xs + ys) / 2);
+    }
+    return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
 static int mp_property_display_fps(void *ctx, struct m_property *prop,
@@ -6701,7 +6710,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     }
 
     if (opt_ptr == &opts->vo->window_scale)
-        update_window_scale(mpctx);
+        update_window_scale(mpctx, opts->vo->window_scale);
 
     if (opt_ptr == &opts->cursor_autohide_delay)
         mpctx->mouse_timer = 0;


### PR DESCRIPTION
Somewhat confusingly, mpv has both a window-scale option and a
current-window-scale property. The documentation lists window-scale
under properties (and it is technically is one), but at its core it is
actually an option which means it behaves subtly different. Options in
mpv are runtime-configurable, but they only change anything if the value
of the option itself changes. window-scale is an option and not meant to
keep track of the actual scale of the window (intended behavior
introduced by d07b7f0). This causes window-scale to do nothing in
certain cases (ex: the window is manually resized and window-scale is
set to 1.00 again). This is logical and consistent with the behavior of
the rest of the mpv options, but it also makes it a poor candidate for
setting the mpv window scale dynamically.

As a remedy, we can just make current-window-scale writeable instead.
current-window-scale is intended to always report the actual scale of
the window and keep track of any window size changes made by the user.
By making this property also writeable, it allows the user to have more
intuitive behavior (i.e. setting current-window-scale to 1.00 always
sets the window to a scale of 1). Additionally, the default input.conf
is changed to use current-window-scale instead of window-scale. The
window-scale documentation under property list is removed since it is
already documented under options and users should probably set the
current-window-scale property instead in most cases.