### PR TITLE
vo_sixel: bug fixes

### DIFF
--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -162,7 +162,10 @@ static void dealloc_dithers_and_buffer(struct vo* vo)
 {
     struct priv* priv = vo->priv;
 
-    talloc_free(priv->buffer);
+    if (priv->buffer) {
+        talloc_free(priv->buffer);
+        priv->buffer = NULL;
+    }
 
     if (priv->dither) {
         sixel_dither_unref(priv->dither);
@@ -295,6 +298,10 @@ static int sixel_write(char *data, int size, void *priv)
 static void flip_page(struct vo *vo)
 {
     struct priv* priv = vo->priv;
+
+    // Make sure that image and dither are valid before drawing
+    if (priv->buffer == NULL || priv->dither == NULL)
+        return;
 
     // Go to the offset row and column, then display the image
     printf(ESC_GOTOXY, priv->top, priv->left);

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -38,6 +38,9 @@
 
 #define IMGFMT IMGFMT_RGB24
 
+#define TERMINAL_FALLBACK_DEFAULT_WIDTH 80
+#define TERMINAL_FALLBACK_DEFAULT_HEIGHT 25
+
 #define ESC_HIDE_CURSOR "\033[?25l"
 #define ESC_RESTORE_CURSOR "\033[?25h"
 #define ESC_CLEAR_SCREEN "\033[2J"
@@ -82,8 +85,8 @@ static void validate_offset_values(struct vo* vo)
     struct priv* priv = vo->priv;
     int top = priv->top;
     int left = priv->left;
-    int terminal_width = 0;
-    int terminal_height = 0;
+    int terminal_width = TERMINAL_FALLBACK_DEFAULT_WIDTH;
+    int terminal_height = TERMINAL_FALLBACK_DEFAULT_HEIGHT;
 
     terminal_get_size(&terminal_width, &terminal_height);
 


### PR DESCRIPTION
Avoid dereferencing NULL pointers in `flip_page`.
Also when buffer is freed, set it to NULL to prevent possible use after free.

Add default terminal width and height in case of `terminal_get_size` failures.