### PR TITLE
Add mouse-pos property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2567,6 +2567,20 @@ Property list
     Any of these properties may be unavailable or set to dummy values if the
     VO window is not created or visible.
 
+``mouse-pos``
+    Read-only - last known mouse position, normalizd to OSD dimensions.
+
+    Has the following sub-properties (which can be read as ``MPV_FORMAT_NODE``
+    or Lua table with ``mp.get_property_native``):
+
+    ``mouse-pos/x``, ``mouse-pos/y``
+        Last known coordinates of the mouse pointer.
+
+    ``mouse-pos/hover``
+        Boolean - whether the mouse pointer hovers the video window. The
+        coordinates should be ignored when this value is false, because the
+        video backends update them only when the pointer hovers the window.
+
 ``sub-text``
     The current subtitle text regardless of sub visibility. Formatting is
     stripped. If the subtitle is not text-based (i.e. DVD/BD subtitles), an

--- a/input/input.c
+++ b/input/input.c
@@ -122,6 +122,7 @@ struct input_ctx {
 
     // Mouse position on the consumer side (as command.c sees it)
     int mouse_x, mouse_y;
+    int mouse_hover;  // updated on mouse-enter/leave
     char *mouse_section; // last section to receive mouse event
 
     // Mouse position on the producer side (as the VO sees it)
@@ -719,8 +720,13 @@ static void mp_input_feed_key(struct input_ctx *ictx, int code, double scale,
     if (!opts->enable_mouse_movements && MP_KEY_IS_MOUSE(unmod) && !force_mouse)
         return;
     if (unmod == MP_KEY_MOUSE_LEAVE || unmod == MP_KEY_MOUSE_ENTER) {
+        ictx->mouse_hover = unmod == MP_KEY_MOUSE_ENTER;
         update_mouse_section(ictx);
-        mp_input_queue_cmd(ictx, get_cmd_from_keys(ictx, NULL, code));
+
+        mp_cmd_t *cmd = get_cmd_from_keys(ictx, NULL, code);
+        if (!cmd)  // queue dummy cmd so that mouse-pos can notify observers
+            cmd = mp_input_parse_cmd(ictx, bstr0("ignore"), "<internal>");
+        mp_input_queue_cmd(ictx, cmd);
         return;
     }
     double now = mp_time_sec();
@@ -962,11 +968,12 @@ mp_cmd_t *mp_input_read_cmd(struct input_ctx *ictx)
     return ret;
 }
 
-void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y)
+void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y, int *hover)
 {
     input_lock(ictx);
     *x = ictx->mouse_x;
     *y = ictx->mouse_y;
+    *hover = ictx->mouse_hover;
     input_unlock(ictx);
 }
 

--- a/input/input.h
+++ b/input/input.h
@@ -99,7 +99,7 @@ void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y);
 // Like mp_input_set_mouse_pos(), but ignore mouse disable option.
 void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y);
 
-void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y);
+void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y, int *hover);
 
 // Return whether we want/accept mouse input.
 bool mp_input_mouse_enabled(struct input_ctx *ictx);

--- a/player/command.c
+++ b/player/command.c
@@ -2633,12 +2633,13 @@ static int mp_property_mouse_pos(void *ctx, struct m_property *prop,
 
     case M_PROPERTY_GET: {
         struct mpv_node node;
-        int x, y;
-        mp_input_get_mouse_pos(mpctx->input, &x, &y);
+        int x, y, hover;
+        mp_input_get_mouse_pos(mpctx->input, &x, &y, &hover);
 
         node_init(&node, MPV_FORMAT_NODE_MAP, NULL);
         node_map_add_int64(&node, "x", x);
         node_map_add_int64(&node, "y", y);
+        node_map_add_flag(&node, "hover", hover);
         *(struct mpv_node *)arg = node;
 
         return M_PROPERTY_OK;

--- a/player/command.c
+++ b/player/command.c
@@ -2621,6 +2621,33 @@ static int mp_property_osd_ass(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
+static int mp_property_mouse_pos(void *ctx, struct m_property *prop,
+                                    int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+
+    switch (action) {
+    case M_PROPERTY_GET_TYPE:
+        *(struct m_option *)arg = (struct m_option){.type = CONF_TYPE_NODE};
+        return M_PROPERTY_OK;
+
+    case M_PROPERTY_GET: {
+        struct mpv_node node;
+        int x, y;
+        mp_input_get_mouse_pos(mpctx->input, &x, &y);
+
+        node_init(&node, MPV_FORMAT_NODE_MAP, NULL);
+        node_map_add_int64(&node, "x", x);
+        node_map_add_int64(&node, "y", y);
+        *(struct mpv_node *)arg = node;
+
+        return M_PROPERTY_OK;
+    }
+    }
+
+    return M_PROPERTY_NOT_IMPLEMENTED;
+}
+
 /// Video fps (RO)
 static int mp_property_fps(void *ctx, struct m_property *prop,
                            int action, void *arg)
@@ -3591,6 +3618,8 @@ static const struct m_property mp_properties_base[] = {
     {"osd-sym-cc", mp_property_osd_sym},
     {"osd-ass-cc", mp_property_osd_ass},
 
+    {"mouse-pos", mp_property_mouse_pos},
+
     // Subs
     {"sid", property_switch_track, .priv = (void *)(const int[]){0, STREAM_SUB}},
     {"secondary-sid", property_switch_track,
@@ -3710,6 +3739,7 @@ static const char *const *const mp_event_property_change[] = {
     E(MP_EVENT_CHANGE_PLAYLIST, "playlist", "playlist-pos", "playlist-pos-1",
       "playlist-count", "playlist/count", "playlist-current-pos",
       "playlist-playing-pos"),
+    E(MP_EVENT_INPUT_PROCESSED, "mouse-pos"),
     E(MP_EVENT_CORE_IDLE, "core-idle", "eof-reached"),
 };
 #undef E

--- a/player/command.h
+++ b/player/command.h
@@ -102,6 +102,7 @@ enum {
     MP_EVENT_CHANGE_PLAYLIST,
     MP_EVENT_CORE_IDLE,
     MP_EVENT_DURATION_UPDATE,
+    MP_EVENT_INPUT_PROCESSED,
 };
 
 bool mp_hook_test_completion(struct MPContext *mpctx, char *type);

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -745,16 +745,6 @@ static void push_nums_obj(js_State *J, const char * const names[],
     }
 }
 
-// args: none, return: object with properties x, y
-static void script_get_mouse_pos(js_State *J)
-{
-    int x, y;
-    mp_input_get_mouse_pos(jctx(J)->mpctx->input, &x, &y);
-    const char * const names[] = {"x", "y", NULL};
-    const double vals[] = {x, y};
-    push_nums_obj(J, names, vals);
-}
-
 // args: input-section-name, x0, y0, x1, y1
 static void script_input_set_section_mouse_area(js_State *J)
 {
@@ -1145,7 +1135,6 @@ static const struct fn_entry main_fns[] = {
     FN_ENTRY(get_wakeup_pipe, 0),
     FN_ENTRY(_hook_add, 3),
     FN_ENTRY(_hook_continue, 1),
-    FN_ENTRY(get_mouse_pos, 0),
     FN_ENTRY(input_set_section_mouse_area, 5),
     FN_ENTRY(last_error, 0),
     FN_ENTRY(_set_last_error, 1),

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -663,6 +663,7 @@ mp.get_script_file = function() { return mp.script_file };
 mp.get_script_directory = function() { return mp.script_path };
 mp.get_time = function() { return mp.get_time_ms() / 1000 };
 mp.utils.getcwd = function() { return mp.get_property("working-directory") };
+mp.get_mouse_pos = function() { return mp.get_property_native("mouse-pos") };
 mp.dispatch_event = dispatch_event;
 mp.process_timers = process_timers;
 mp.notify_idle_observers = notify_idle_observers;

--- a/player/lua.c
+++ b/player/lua.c
@@ -991,16 +991,6 @@ static int script_raw_abort_async_command(lua_State *L)
     return 0;
 }
 
-static int script_get_mouse_pos(lua_State *L)
-{
-    struct MPContext *mpctx = get_mpctx(L);
-    int px, py;
-    mp_input_get_mouse_pos(mpctx->input, &px, &py);
-    lua_pushnumber(L, px);
-    lua_pushnumber(L, py);
-    return 2;
-}
-
 static int script_get_time(lua_State *L)
 {
     struct script_ctx *ctx = get_ctx(L);
@@ -1242,7 +1232,6 @@ static const struct fn_entry main_fns[] = {
     AF_ENTRY(set_property_native),
     FN_ENTRY(raw_observe_property),
     FN_ENTRY(raw_unobserve_property),
-    FN_ENTRY(get_mouse_pos),
     FN_ENTRY(get_time),
     FN_ENTRY(input_set_section_mouse_area),
     FN_ENTRY(format_time),

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -42,6 +42,11 @@ function mp.input_disable_section(section)
     mp.commandv("disable-section", section)
 end
 
+function mp.get_mouse_pos()
+    local m = mp.get_property_native("mouse-pos")
+    return m.x, m.y
+end
+
 -- For dispatching script-binding. This is sent as:
 --      script-message-to $script_name $binding_name $keystate
 -- The array is indexed by $binding_name, and has functions like this as value:

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -110,13 +110,17 @@ void mp_core_unlock(struct MPContext *mpctx)
 // Process any queued user input.
 static void mp_process_input(struct MPContext *mpctx)
 {
+    int processed = 0;
     for (;;) {
         mp_cmd_t *cmd = mp_input_read_cmd(mpctx->input);
         if (!cmd)
             break;
         run_command(mpctx, cmd, NULL, NULL, NULL);
+        processed = 1;
     }
     mp_set_timeout(mpctx, mp_input_get_delay(mpctx->input));
+    if (processed)
+        mp_notify(mpctx, MP_EVENT_INPUT_PROCESSED, NULL);
 }
 
 double get_relative_time(struct MPContext *mpctx)


### PR DESCRIPTION
This patchset adds a new property `mouse-pos` which external clients can use to track position and hover.

Previously tracking position/hover was only possible by key-binding MOUSE_MOVE etc, but since the OSC force-binds most mouse events, it was impossible for scripts or other clients to track the position without disabling the OSC, and now it is possible.

Also, it adds a minor improvement for the `mouse` command - which will now trigger enter/leave for the default section when appropriate, while previously it didn't.