### PR TITLE
js: report scripts CPU/memory usage statistics

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -212,6 +212,10 @@ are missing.
 
 Memory usage is approximate and does not reflect internal fragmentation.
 
+JS scripts memory reporting is disabled by default because collecting the data
+at the JS side has an overhead. It can be enabled by exporting the env var
+``MPV_LEAK_REPORT=1`` before starting mpv, and will increase JS memory usage.
+
 If entries have ``/time`` and ``/cpu`` variants, the former gives the real time
 (monotonic clock), while the latter the thread CPU time (only if the
 corresponding pthread API works and is supported).


### PR DESCRIPTION
For stats page 4 (key `i`/`I`).

CPU time report is the same as at lua.c, but untested - doesn't seem to work on windows - also not for lua.

Memory reporting is disabled by default  due to additional overhead which the reporting requires, and can be enabled with env MPV_LEAK_REPORT=1.

See more info at the commit message.