### PR TITLE
stream_file: disable read ahead for remote files on macOS

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -340,8 +340,15 @@ static int open_f(stream_t *stream, struct stream_open_args *args)
     stream->get_size = get_size;
     stream->close = s_close;
 
-    if (check_stream_network(p->fd))
+    if (check_stream_network(p->fd)) {
         stream->streaming = true;
+#if HAVE_COCOA
+        if (fcntl(p->fd, F_RDAHEAD, 0) < 0) {
+            MP_VERBOSE(stream, "Cannot disable read ahead on file '%s': %s\n",
+                       filename, mp_strerror(errno));
+        }
+#endif
+    }
 
     p->orig_size = get_size(stream);
 


### PR DESCRIPTION
couldn't really test this because of the reproducibility of it.

see vlc for a similar fix. https://github.com/videolan/vlc/commit/b8b8c438f8f65a93da82364c8fea1dbf987c4a8e https://trac.videolan.org/vlc/ticket/8446

Fixes #4434