### PR TITLE
build: fix macOS arm builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
       osx_image: xcode10.1
     - <<: *mac
       osx_image: xcode9.2
+      env:
+        - HOMEBREW_NO_AUTO_UPDATE=1
+        - HOMEBREW_NO_INSTALL_CLEANUP=1
+        - CI_SWIFT_FLAGS="\-target x86_64-apple-macosx10.12"
     - os: freebsd
       compiler: clang
     - os: linux

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -19,7 +19,8 @@ PKG_CONFIG_PATH="${FFMPEG_SYSROOT}/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" pytho
     --variant="${MPV_VARIANT}" \
     --prefix="${MPV_INSTALL_PREFIX}" \
     --enable-{gl,iconv,lcms2,libmpv-shared,lua,jpeg,plain-gl,zlib} \
-    --enable-{cocoa,coreaudio,gl-cocoa,macos-cocoa-cb,macos-touchbar,videotoolbox-gl}
+    --enable-{cocoa,coreaudio,gl-cocoa,macos-cocoa-cb,macos-touchbar,videotoolbox-gl} \
+    --swift-flags="${CI_SWIFT_FLAGS}"
 
 python3 ./waf build --variant="${MPV_VARIANT}" -j4
 

--- a/waftools/detections/compiler_swift.py
+++ b/waftools/detections/compiler_swift.py
@@ -17,7 +17,6 @@ def __add_swift_flags(ctx):
     ctx.env.SWIFT_FLAGS = [
         "-frontend", "-c", "-sdk", ctx.env.MACOS_SDK,
         "-enable-objc-interop", "-emit-objc-header", "-parse-as-library",
-        "-target", "x86_64-apple-macosx10.10"
     ]
 
     verRe = re.compile("(?i)version\s?([\d.]+)")
@@ -150,7 +149,7 @@ def __find_macos_sdk(ctx):
             # convert build version to a version string
             # first 2 two digits are the major version, starting with 15 which is 10.11 (offset of 4)
             # 1 char is the minor version, A => 0, B => 1 and ongoing
-            # las digits are bugfix version, which are nor relevant for us
+            # last digits are bugfix version, which are not relevant for us
             # eg 16E185 => 10.12.4, 17A360 => 10.13, 18B71 => 10.14.1
             if sdk_build_version and isinstance(sdk_build_version, str):
                 verRe = re.compile("(\d+)(\D+)(\d+)")
@@ -158,6 +157,9 @@ def __find_macos_sdk(ctx):
                 major = int(version_parts.group(1)) - 4
                 minor = string.ascii_lowercase.index(version_parts.group(2).lower())
                 build_version = '10.' + str(major) + '.' + str(minor)
+                # from 20 onwards macOS 11.0 starts
+                if int(version_parts.group(1)) >= 20:
+                    build_version = '11.' + str(minor)
 
             if not isinstance(sdk_version, str):
                 sdk_version = '10.10.0'

--- a/wscript
+++ b/wscript
@@ -182,7 +182,7 @@ main_dependencies = [
         'name': '--swift',
         'desc': 'macOS Swift build tools',
         'deps': 'os-darwin',
-        'func': check_swift,
+        'func': compose_checks(check_swift, check_macos_sdk('10.10')),
     }, {
         'name': '--uwp',
         'desc': 'Universal Windows Platform',


### PR DESCRIPTION
if the macOS sdk build version list on wiki (https://en.wikipedia.org/wiki/Xcode#Xcode_11.x_-_12.x_(since_SwiftUI_framework)) is to be trusted, the scheme needs some more updates in the future. though we can't really tell now without more releases.

for now i added the macOS 11 case.