### PR TITLE
Allow vo changing at runtime

### DIFF
--- a/demux/demux.h
+++ b/demux/demux.h
@@ -290,6 +290,8 @@ void demux_block_reading(struct demuxer *demuxer, bool block);
 
 void demuxer_select_track(struct demuxer *demuxer, struct sh_stream *stream,
                           double ref_pts, bool selected);
+void demuxer_refresh_track(struct demuxer *demuxer, struct sh_stream *stream,
+                           double ref_pts);
 
 void demuxer_help(struct mp_log *log);
 

--- a/player/command.c
+++ b/player/command.c
@@ -6525,6 +6525,16 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
         mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
     }
 
+    if (opt_ptr == &opts->vo->video_driver_list) {
+        struct track *track = mpctx->current_track[0][STREAM_VIDEO];
+        uninit_video_out(mpctx);
+        reinit_video_chain(mpctx);
+        if (track)
+            reselect_demux_stream(mpctx, track, true);
+
+        mp_wakeup_core(mpctx);
+    }
+
     if (flags & UPDATE_AUDIO)
         reload_audio_output(mpctx);
 

--- a/player/core.h
+++ b/player/core.h
@@ -547,7 +547,8 @@ void mp_set_playlist_entry(struct MPContext *mpctx, struct playlist_entry *e);
 void mp_play_files(struct MPContext *mpctx);
 void update_demuxer_properties(struct MPContext *mpctx);
 void print_track_list(struct MPContext *mpctx, const char *msg);
-void reselect_demux_stream(struct MPContext *mpctx, struct track *track);
+void reselect_demux_stream(struct MPContext *mpctx, struct track *track,
+                           bool refresh_only);
 void prepare_playlist(struct MPContext *mpctx, struct playlist *pl);
 void autoload_external_files(struct MPContext *mpctx, struct mp_cancel *cancel);
 struct track *select_default_track(struct MPContext *mpctx, int order,


### PR DESCRIPTION
How to test:
* Bind some key to `cycle-values vo null gpu`
* Play a remote file so that the demuxer cache is active
* Press the key and observe that:
  - it works
  - the demuxer cache is not dropped when switching

Use case:
mpv-android has to disable video output while the app is in background since the surface disappears.
It currently does that by switching `vid` between `no` and `1`, which drops the demuxer cache every time the app is brought in/out of background, causing noticeable delay.