### PR TITLE
terminal: process input when foregrounded

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -45,6 +45,14 @@
 // Timeout in ms after which the (normally ambiguous) ESC key is detected.
 #define ESC_TIMEOUT 100
 
+// Timeout in ms after which the poll for input is aborted. The FG/BG state is
+// tested before every wait, and a positive value allows reactivating input
+// processing when mpv is brought to the foreground while it was running in the
+// background. In such a situation, an infinite timeout (-1) will keep mpv
+// waiting for input without realizing the terminal state changed - and thus
+// buffer all keypresses until ENTER is pressed.
+#define INPUT_TIMEOUT 1000
+
 static volatile struct termios tio_orig;
 static volatile int tio_orig_set;
 
@@ -397,7 +405,7 @@ static void *terminal_thread(void *ptr)
             { .events = POLLIN, .fd = death_pipe[0] },
             { .events = POLLIN, .fd = tty_in }
         };
-        int r = polldev(fds, stdin_ok ? 2 : 1, buf.len ? ESC_TIMEOUT : -1);
+        int r = polldev(fds, stdin_ok ? 2 : 1, buf.len ? ESC_TIMEOUT : INPUT_TIMEOUT);
         if (fds[0].revents)
             break;
         if (fds[1].revents) {


### PR DESCRIPTION
When mpv is in the background because it was started with
`mpv foo.mp3 &`, or the user did ctrl+z bg, and is then brought back to
the foreground with fg, it buffers input until you press enter. This
makes it accept input immediately.

Having a short interval isn't important, since input is buffered until
the next SIGALRM.

This always works if you do some normal operations while mpv is in the
background, but if you execute fg immediately unfortunately SIGTTIN
isn't sent sometimes, and I don't think there is a way to receive
SIGTTIN earlier. I think that the only alternative would be to always
keep the timer running, even when mpv isn't backgrounded.

Closes #8120.