### PR TITLE
vo_sixel: Add polling in draw_frame to resize

### DIFF
--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -346,7 +346,26 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     SIXELSTATUS status;
     struct mp_image *mpi = NULL;
 
-    if (frame->repeat && !frame->redraw) {
+    int  prev_rows   = priv->num_rows;
+    int  prev_cols   = priv->num_cols;
+    int  prev_height = vo->dheight;
+    int  prev_width  = vo->dwidth;
+    bool resized     = false;
+    update_canvas_dimensions(vo);
+
+    if (prev_rows != priv->num_rows || prev_cols != priv->num_cols ||
+        prev_width != vo->dwidth || prev_height != vo->dheight)
+    {
+        set_sixel_output_parameters(vo);
+        // Not checking for vo->config_ok because draw_frame is never called
+        // with a failed reconfig.
+        update_sixel_swscaler(vo, vo->params);
+
+        printf(ESC_CLEAR_SCREEN);
+        resized = true;
+    }
+
+    if (frame->repeat && !frame->redraw && !resized) {
         // Frame is repeated, and no need to update OSD either
         priv->skip_frame_draw = true;
         return;

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -495,7 +495,7 @@ static void uninit(struct vo *vo)
 
 const struct vo_driver video_out_sixel = {
     .name = "sixel",
-    .description = "libsixel",
+    .description = "terminal graphics using sixels",
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,


### PR DESCRIPTION
Check for any changes in rows/cols/width/height and trigger the reconfig inside draw_frame. On resizing terminal window, sixel output frame should adjust accordingly.