### PR TITLE
auto_profiles: fix compile_cond on lua 5.1

### DIFF
--- a/player/lua/auto_profiles.lua
+++ b/player/lua/auto_profiles.lua
@@ -136,15 +136,19 @@ setmetatable(p, {
 })
 
 local function compile_cond(name, s)
-    -- (pre 5.2 ignores the extra arguments)
-    local chunk, err = load("return " .. s, "profile " .. name .. " condition",
-                            "t", evil_magic)
+    local code, chunkname = "return " .. s, "profile " .. name .. " condition"
+    local chunk, err
+    if setfenv then -- lua 5.1
+        chunk, err = loadstring(code, chunkname)
+        if chunk then
+            setfenv(chunk, evil_magic)
+        end
+    else -- lua 5.2
+        chunk, err = load(code, chunkname, "t", evil_magic)
+    end
     if not chunk then
         msg.error("Profile '" .. name .. "' condition: " .. err)
         chunk = function() return false end
-    end
-    if setfenv then
-        setfenv(chunk, evil_magic)
     end
     return chunk
 end

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -66,6 +66,7 @@ def check_lua(ctx, dependency_identifier):
         ( 'luajit', 'luajit >= 2.0.0' ),
         ( '51',     'lua >= 5.1.0 lua < 5.2.0'),
         ( '51obsd', 'lua51 >= 5.1.0'), # OpenBSD
+        ( '51arch', 'lua51 >= 5.1.0'), # Arch
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
         ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
     ]


### PR DESCRIPTION
CC @jrejaud
If you don't want to go through the trouble of building mpv from this branch, you could test this by disabling the built-in version of the auto_profiles script with `--load-auto-profiles=no` and putting the [patched version](https://raw.githubusercontent.com/mpv-player/mpv/b3c111c65bf4a96c924eed07571297c6a8ca9e0e/player/lua/auto_profiles.lua) in `~/.config/mpv/scripts/`.

---

Lua 5.1 can't handle calling load() on a string. It looks like the existing code was trying to cater to 5.1, with the comment and the setfenv code. It probably worked on 5.1 at some point, but wasn't tested there after some change.

Also added detection of lua51 on Arch, just because that was the easiest way for me to test this. Might as well have it, though.