### PR TITLE
audio: remove a duplicate clearing of a struct variable

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -187,7 +187,6 @@ static void ao_chain_reset_state(struct ao_chain *ao_c)
 {
     ao_c->last_out_pts = MP_NOPTS_VALUE;
     ao_c->out_eof = false;
-    ao_c->underrun = false;
     ao_c->start_pts_known = false;
     ao_c->start_pts = MP_NOPTS_VALUE;
     ao_c->untimed_throttle = false;


### PR DESCRIPTION
Fixes #8301. duplicate is in line 194.

https://github.com/mpv-player/mpv/blob/master/player/audio.c#L186-L195