### PR TITLE
update --geometry/autofit options at runtime

### DIFF
--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -111,6 +111,10 @@ struct vo_x11_state {
     bool size_changed_during_fs;
     bool pos_changed_during_fs;
 
+    /* The geometry/autofit option was changed while the window was maximized.
+     * Wait until the state changes to resize. */
+    bool pending_geometry_change;
+
     XComposeStatus compose_status;
 
     /* XShm stuff */


### PR DESCRIPTION
Related issue: #8379

I cherry-picked wm4's commit for x11 from another branch (with one minor change in the includes so vdpau would compile correctly) and also implemented this feature for wayland. wm4's changes in x11 will only work with `--geometry` but in wayland it will work with the `--autofit` options as well.