### PR TITLE
build: make Lua detection more friendly?

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -66,7 +66,6 @@ def check_lua(ctx, dependency_identifier):
         ( 'luajit', 'luajit >= 2.0.0' ),
         ( '51',     'lua >= 5.1.0 lua < 5.2.0'),
         ( '51obsd', 'lua51 >= 5.1.0'), # OpenBSD
-        ( '51arch', 'lua51 >= 5.1.0'), # Arch
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
         ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
     ]

--- a/wscript
+++ b/wscript
@@ -958,15 +958,15 @@ def configure(ctx):
         while re.match('\$\{([^}]+)\}', ctx.env[varname]):
             ctx.env[varname] = Utils.subst_vars(ctx.env[varname], ctx.env)
 
+    if ctx.options.LUA_VER:
+        ctx.options.enable_lua = True
+
     ctx.parse_dependencies(build_options)
     ctx.parse_dependencies(main_dependencies)
     ctx.parse_dependencies(libav_dependencies)
     ctx.parse_dependencies(audio_output_features)
     ctx.parse_dependencies(video_output_features)
     ctx.parse_dependencies(hwaccel_features)
-
-    if ctx.options.LUA_VER:
-        ctx.options.enable_lua = True
 
     if ctx.options.SWIFT_FLAGS:
         ctx.env.SWIFT_FLAGS.extend(split(ctx.options.SWIFT_FLAGS))


### PR DESCRIPTION
Picking up from #8355.

The upside is you can use `./waf configure --lua=52` regardless of how your distro packages Lua versions. Also threw in a little over-engineering to make the used Lua version a bit clearer in logs ("List of enabled features" just showed "52", will now show "lua52").

The downside is losing the ability to pick between the different packaging variants if you somehow end up with more than one for the same version on your machine, and that logs will no long differentiate between said variants. I don't see much harm there, but admittedly the benefit of this patch is similarly small.

The first commit at least should be a simple win, though.