### PR TITLE
mac: use visible frame rectangle for window geometry calculation

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,8 +27,13 @@ Interface changes
 ::
 
  --- mpv 0.34.0 ---
-    - add `--screen-name` and `--fs-screen-name` flags to allow selecting the 
+    - add `--screen-name` and `--fs-screen-name` flags to allow selecting the
       screen by its name instead of the index
+    - add `--macos-geometry-calculation` to change the rectangle used for screen
+      position and size calculation. the old behavior used the whole screen,
+      which didn't take the menu bar and Dock into account. The new default
+      behaviour includes both. To revert to the old behavior set this to
+      `whole`.
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5914,6 +5914,16 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     macOS only.
 
+``--macos-geometry-calculation=<visible|whole>``
+    This changes the rectangle which is used to calculate the screen position
+    and size of the window (default: visible). ``visible`` takes the the menu
+    bar and Dock into account and the window is only positioned/sized within the
+    visible screen frame rectangle, ``whole`` takes the whole screen frame
+    rectangle and ignores the menu bar and Dock. Other previous restrictions
+    still apply, like the window can't be placed on top of the menu bar etc.
+
+    macOS only.
+
 ``--android-surface-size=<WxH>``
     Set dimensions of the rendering surface used by the Android gpu context.
     Needs to be set by the embedding application if the dimensions change during

--- a/osdep/macosx_application.h
+++ b/osdep/macosx_application.h
@@ -21,6 +21,11 @@
 #include "osdep/macosx_menubar.h"
 #include "options/m_option.h"
 
+enum {
+    FRAME_VISIBLE = 0,
+    FRAME_WHOLE,
+};
+
 struct macos_opts {
     int macos_title_bar_style;
     int macos_title_bar_appearance;
@@ -29,6 +34,7 @@ struct macos_opts {
     int macos_fs_animation_duration;
     int macos_force_dedicated_gpu;
     int macos_app_activation_policy;
+    int macos_geometry_calculation;
     int cocoa_cb_sw_renderer;
     int cocoa_cb_10bit_context;
 };

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -65,6 +65,8 @@ const struct m_sub_options macos_conf = {
         {"macos-force-dedicated-gpu", OPT_FLAG(macos_force_dedicated_gpu)},
         {"macos-app-activation-policy", OPT_CHOICE(macos_app_activation_policy,
             {"regular", 0}, {"accessory", 1}, {"prohibited", 2})},
+        {"macos-geometry-calculation", OPT_CHOICE(macos_geometry_calculation,
+            {"visible", FRAME_VISIBLE}, {"whole", FRAME_WHOLE})},
         {"cocoa-cb-sw-renderer", OPT_CHOICE(cocoa_cb_sw_renderer,
             {"auto", -1}, {"no", 0}, {"yes", 1})},
         {"cocoa-cb-10bit-context", OPT_FLAG(cocoa_cb_10bit_context)},


### PR DESCRIPTION
this changes the previous behaviour. one can't place the window anymore outside of the visible screen rectangle anymore. this means the window can't be placed on the menu bar or the dock area (as long as the dock is visible) anymore.

i am not sure if this behaviour makes sense in all circumstances and maybe we need a flag to change this behaviour?

Fixes #8272

some examples how the behaviour differs now. the window in the foreground is the new behaviour:
autofit=100%x100%:
![autofit=100%x100%](https://user-images.githubusercontent.com/680386/102017399-0df4b980-3d67-11eb-84aa-fd6a2581d599.png)

autofit=50%x50%:
![autofit=50%x50%](https://user-images.githubusercontent.com/680386/102017404-177e2180-3d67-11eb-847b-f6597271fc00.png)

geometry=500x250+100%+100%
![geometry=500x250+100%+100%](https://user-images.githubusercontent.com/680386/102017406-1816b800-3d67-11eb-829f-b17ee6c703e6.png)

geometry=500x250+0%+100%
![geometry=500x250+0%+100%](https://user-images.githubusercontent.com/680386/102017408-1947e500-3d67-11eb-8d5d-16780d9a303c.png)
