### PR TITLE
mac: fix usage of temporary pointers and dangling pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,18 +36,13 @@ matrix:
     - <<: *mac
       osx_image: xcode12.2
     - <<: *mac
-      osx_image: xcode10.1
+      osx_image: xcode11.3
+    - <<: *mac
+      osx_image: xcode9.4
       env:
         - HOMEBREW_NO_AUTO_UPDATE=1
         - HOMEBREW_NO_INSTALL_CLEANUP=1
         - CI_HOMEBREW_HASH=7242872d7878f1a4c2706e5837faafcf0782b58d
-    - <<: *mac
-      osx_image: xcode9.2
-      env:
-        - HOMEBREW_NO_AUTO_UPDATE=1
-        - HOMEBREW_NO_INSTALL_CLEANUP=1
-        - CI_SWIFT_FLAGS="\-target x86_64-apple-macosx10.12"
-        - CI_HOMEBREW_HASH=55e02323812604add9a69bab8730319b9255a697
     - os: freebsd
       compiler: clang
     - os: linux
@@ -62,7 +57,7 @@ matrix:
       env: CI_SCRIPT=ci/build-mingw64.sh TARGET=x86_64-w64-mingw32
   allow_failures:
     - os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.4
   fast_finish: true
 
 dist: focal
@@ -123,15 +118,14 @@ before_install:
         fi
   - |
         if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-            remove=$(brew list)
+            remove=$(brew list --formula)
             keep="gettext pcre2 git"
             install="autoconf automake pkg-config libtool python freetype fribidi little-cms2 luajit libass ffmpeg"
             for formula in ${keep[@]}; do remove=("${remove[@]/$formula}"); done
             for formula in ${install[@]}; do remove=("${remove[@]/$formula}"); done
             brew remove --force $remove --ignore-dependencies
-            if [[ "$TRAVIS_OSX_IMAGE" == "xcode9.2" ]]; then
-                brew untap caskroom/cask
-            fi
+            brew remove --cask $(brew list --cask)
+            brew untap homebrew/cask
             brew update
             if [[ -n "$CI_HOMEBREW_HASH" ]]; then
                 pushd "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core"

--- a/osdep/macos/libmpv_helper.swift
+++ b/osdep/macos/libmpv_helper.swift
@@ -47,23 +47,26 @@ class LibmpvHelper {
     }
 
     func initRender() {
-        var advanced: CInt = 1
+        let advanced: CInt = 1
         let api = UnsafeMutableRawPointer(mutating: (MPV_RENDER_API_TYPE_OPENGL as NSString).utf8String)
-        var pAddress = mpv_opengl_init_params(get_proc_address: getProcAddress,
+        let pAddress = mpv_opengl_init_params(get_proc_address: getProcAddress,
                                               get_proc_address_ctx: nil,
                                               extra_exts: nil)
-        var params: [mpv_render_param] = [
-            mpv_render_param(type: MPV_RENDER_PARAM_API_TYPE, data: api),
-            mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, data: &pAddress),
-            mpv_render_param(type: MPV_RENDER_PARAM_ADVANCED_CONTROL, data: &advanced),
-            mpv_render_param()
-        ]
 
-        if (mpv_render_context_create(&mpvRenderContext, mpvHandle, &params) < 0)
-        {
-            log.sendError("Render context init has failed.")
-            exit(1)
+        MPVHelper.withUnsafeMutableRawPointers([pAddress, advanced]) { (pointers: [UnsafeMutableRawPointer?]) in
+            var params: [mpv_render_param] = [
+                mpv_render_param(type: MPV_RENDER_PARAM_API_TYPE, data: api),
+                mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, data: pointers[0]),
+                mpv_render_param(type: MPV_RENDER_PARAM_ADVANCED_CONTROL, data: pointers[1]),
+                mpv_render_param()
+            ]
+
+            if (mpv_render_context_create(&mpvRenderContext, mpvHandle, &params) < 0) {
+                log.sendError("Render context init has failed.")
+                exit(1)
+            }
         }
+
     }
 
     let getProcAddress: (@convention(c) (UnsafeMutableRawPointer?, UnsafePointer<Int8>?)
@@ -119,26 +122,29 @@ class LibmpvHelper {
         deinitLock.lock()
         if mpvRenderContext != nil {
             var i: GLint = 0
-            var flip: CInt = 1
-            var skip: CInt = skip ? 1 : 0
-            var ditherDepth = depth
+            let flip: CInt = 1
+            let skip: CInt = skip ? 1 : 0
+            let ditherDepth = depth
             glGetIntegerv(GLenum(GL_DRAW_FRAMEBUFFER_BINDING), &i)
             // CAOpenGLLayer has ownership of FBO zero yet can return it to us,
             // so only utilize a newly received FBO ID if it is nonzero.
             fbo = i != 0 ? i : fbo
 
-            var data = mpv_opengl_fbo(fbo: Int32(fbo),
+            let data = mpv_opengl_fbo(fbo: Int32(fbo),
                                         w: Int32(surface.width),
                                         h: Int32(surface.height),
                           internal_format: 0)
-            var params: [mpv_render_param] = [
-                mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: &data),
-                mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: &flip),
-                mpv_render_param(type: MPV_RENDER_PARAM_DEPTH, data: &ditherDepth),
-                mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: &skip),
-                mpv_render_param()
-            ]
-            mpv_render_context_render(mpvRenderContext, &params);
+
+            MPVHelper.withUnsafeMutableRawPointers([data, flip, ditherDepth, skip]) { (pointers: [UnsafeMutableRawPointer?]) in
+                var params: [mpv_render_param] = [
+                    mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: pointers[0]),
+                    mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: pointers[1]),
+                    mpv_render_param(type: MPV_RENDER_PARAM_DEPTH, data: pointers[2]),
+                    mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: pointers[3]),
+                    mpv_render_param()
+                ]
+                mpv_render_context_render(mpvRenderContext, &params);
+            }
         } else {
             glClearColor(0, 0, 0, 1)
             glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
@@ -161,16 +167,20 @@ class LibmpvHelper {
             let u8Ptr = baseAddress.assumingMemoryBound(to: UInt8.self)
             let iccBstr = bstrdup(nil, bstr(start: u8Ptr, len: ptr.count))
             var icc = mpv_byte_array(data: iccBstr.start, size: iccBstr.len)
-            let params = mpv_render_param(type: MPV_RENDER_PARAM_ICC_PROFILE, data: &icc)
-            mpv_render_context_set_parameter(mpvRenderContext, params)
+            withUnsafeMutableBytes(of: &icc) { (ptr: UnsafeMutableRawBufferPointer) in
+                let params = mpv_render_param(type: MPV_RENDER_PARAM_ICC_PROFILE, data: ptr.baseAddress)
+                mpv_render_context_set_parameter(mpvRenderContext, params)
+            }
         }
     }
 
     func setRenderLux(_ lux: Int) {
         if mpvRenderContext == nil { return }
         var light = lux
-        let params = mpv_render_param(type: MPV_RENDER_PARAM_AMBIENT_LIGHT, data: &light)
-        mpv_render_context_set_parameter(mpvRenderContext, params)
+        withUnsafeMutableBytes(of: &light) { (ptr: UnsafeMutableRawBufferPointer) in
+            let params = mpv_render_param(type: MPV_RENDER_PARAM_AMBIENT_LIGHT, data: ptr.baseAddress)
+            mpv_render_context_set_parameter(mpvRenderContext, params)
+        }
     }
 
     func commandAsync(_ cmd: [String?], id: UInt64 = 1) {

--- a/osdep/macos/mpv_helper.swift
+++ b/osdep/macos/mpv_helper.swift
@@ -123,4 +123,22 @@ class MPVHelper {
     class func bridge<T: AnyObject>(ptr: UnsafeRawPointer) -> T {
         return Unmanaged<T>.fromOpaque(ptr).takeUnretainedValue()
     }
+
+    class func withUnsafeMutableRawPointers(_ arguments: [Any],
+                                               pointers: [UnsafeMutableRawPointer?] = [],
+                                                closure: (_ pointers: [UnsafeMutableRawPointer?]) -> Void) {
+        if arguments.count > 0 {
+            let args = Array(arguments.dropFirst(1))
+            var newPtrs = pointers
+            var firstArg = arguments.first
+            withUnsafeMutableBytes(of: &firstArg) { (ptr: UnsafeMutableRawBufferPointer) in
+                newPtrs.append(ptr.baseAddress)
+                withUnsafeMutableRawPointers(args, pointers: newPtrs, closure: closure)
+            }
+
+            return
+        }
+
+        closure(pointers)
+    }
 }

--- a/osdep/macos/mpv_helper.swift
+++ b/osdep/macos/mpv_helper.swift
@@ -86,17 +86,23 @@ class MPVHelper {
 
     func setOption(fullscreen: Bool) {
         optsPtr.pointee.fullscreen = fullscreen
-        m_config_cache_write_opt(optsCachePtr, UnsafeMutableRawPointer(&optsPtr.pointee.fullscreen))
+        _ = withUnsafeMutableBytes(of: &optsPtr.pointee.fullscreen) { (ptr: UnsafeMutableRawBufferPointer) in
+            m_config_cache_write_opt(optsCachePtr, ptr.baseAddress)
+        }
     }
 
     func setOption(minimized: Bool) {
         optsPtr.pointee.window_minimized = Int32(minimized)
-        m_config_cache_write_opt(optsCachePtr, UnsafeMutableRawPointer(&optsPtr.pointee.window_minimized))
+        _ = withUnsafeMutableBytes(of: &optsPtr.pointee.window_minimized) { (ptr: UnsafeMutableRawBufferPointer) in
+            m_config_cache_write_opt(optsCachePtr, ptr.baseAddress)
+        }
     }
 
     func setOption(maximized: Bool) {
         optsPtr.pointee.window_maximized = Int32(maximized)
-        m_config_cache_write_opt(optsCachePtr, UnsafeMutableRawPointer(&optsPtr.pointee.window_maximized))
+        _ = withUnsafeMutableBytes(of: &optsPtr.pointee.window_maximized) { (ptr: UnsafeMutableRawBufferPointer) in
+            m_config_cache_write_opt(optsCachePtr, ptr.baseAddress)
+        }
     }
 
     func setMacOptionCallback(_ callback: swift_wakeup_cb_fn, context object: AnyObject) {
@@ -140,5 +146,11 @@ class MPVHelper {
         }
 
         closure(pointers)
+    }
+
+    class func getPointer<T>(_ value: inout T) -> UnsafeMutableRawPointer? {
+        return withUnsafeMutableBytes(of: &value) { (ptr: UnsafeMutableRawBufferPointer) in
+            ptr.baseAddress
+        }
     }
 }

--- a/osdep/macos/swift_compat.swift
+++ b/osdep/macos/swift_compat.swift
@@ -33,7 +33,6 @@ extension String {
 #endif
 
 extension NSPasteboard.PasteboardType {
-
     static let fileURLCompat: NSPasteboard.PasteboardType = {
         if #available(OSX 10.13, *) {
             return .fileURL
@@ -53,7 +52,6 @@ extension NSPasteboard.PasteboardType {
 
 #if !swift(>=5.0)
 extension Data {
-
     mutating func withUnsafeMutableBytes<Type>(_ body: (UnsafeMutableRawBufferPointer) throws -> Type) rethrows -> Type {
         let dataCount = count
         return try withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) throws -> Type in
@@ -65,33 +63,8 @@ extension Data {
 
 #if !swift(>=4.2)
 extension NSDraggingInfo {
-
     var draggingPasteboard: NSPasteboard {
         get { return draggingPasteboard() }
     }
 }
 #endif
-
-#if !swift(>=4.1)
-extension Array {
-
-    func compactMap<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
-        return try self.flatMap(transform)
-    }
-}
-
-extension Array where Element == [CGLPixelFormatAttribute] {
-
-    func contains(_ obj: [CGLPixelFormatAttribute]) -> Bool {
-        return self.contains(where:{ $0 == obj })
-    }
-}
-
-extension NSWindow.Level {
-
-    static func +(left: NSWindow.Level, right: Int) -> NSWindow.Level {
-        return NSWindow.Level(left.rawValue + right)
-    }
-}
-#endif
-

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -531,42 +531,36 @@ class Common: NSObject {
             events.pointee |= Int32(checkEvents())
             return VO_TRUE
         case VOCTRL_VO_OPTS_CHANGED:
-            var o: UnsafeMutableRawPointer?
-            while mpv.nextChangedOption(property: &o) {
-                guard let opt = o else {
-                    log.sendError("No changed options was retrieved")
-                    return VO_TRUE
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.border) {
+            var opt: UnsafeMutableRawPointer?
+            while mpv.nextChangedOption(property: &opt) {
+                switch opt {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.border):
                     DispatchQueue.main.async {
                         self.window?.border = Bool(mpv.opts.border)
                     }
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.fullscreen) {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.fullscreen):
                     DispatchQueue.main.async {
                         self.window?.toggleFullScreen(nil)
                     }
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.ontop) ||
-                   opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.ontop_level) {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.ontop): fallthrough
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.ontop_level):
                     DispatchQueue.main.async {
                         self.window?.setOnTop(Bool(mpv.opts.ontop), Int(mpv.opts.ontop_level))
                     }
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.keepaspect_window) {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.keepaspect_window):
                     DispatchQueue.main.async {
                         self.window?.keepAspect = Bool(mpv.opts.keepaspect_window)
                     }
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.window_minimized) {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.window_minimized):
                     DispatchQueue.main.async {
                         self.window?.setMinimized(Bool(mpv.opts.window_minimized))
                     }
-                }
-                if opt == UnsafeMutableRawPointer(&mpv.optsPtr.pointee.window_maximized) {
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.window_maximized):
                     DispatchQueue.main.async {
                         self.window?.setMaximized(Bool(mpv.opts.window_maximized))
                     }
+                default:
+                    break
                 }
             }
             return VO_TRUE
@@ -676,19 +670,14 @@ class Common: NSObject {
             return
         }
 
-        var o: UnsafeMutableRawPointer?
-        while mpv.nextChangedMacOption(property: &o) {
-            guard let opt = o else {
-                log.sendWarning("Could not retrieve changed mac option")
-                return
-            }
-
+        var opt: UnsafeMutableRawPointer?
+        while mpv.nextChangedMacOption(property: &opt) {
             switch opt {
-            case UnsafeMutableRawPointer(&mpv.macOptsPtr.pointee.macos_title_bar_appearance):
+            case MPVHelper.getPointer(&mpv.macOptsPtr.pointee.macos_title_bar_appearance):
                 titleBar?.set(appearance: Int(mpv.macOpts.macos_title_bar_appearance))
-            case UnsafeMutableRawPointer(&mpv.macOptsPtr.pointee.macos_title_bar_material):
+            case MPVHelper.getPointer(&mpv.macOptsPtr.pointee.macos_title_bar_material):
                 titleBar?.set(material: Int(mpv.macOpts.macos_title_bar_material))
-            case UnsafeMutableRawPointer(&mpv.macOptsPtr.pointee.macos_title_bar_color):
+            case MPVHelper.getPointer(&mpv.macOptsPtr.pointee.macos_title_bar_color):
                 titleBar?.set(color: mpv.macOpts.macos_title_bar_color)
             default:
                 break

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -115,17 +115,19 @@ def check_cocoa(ctx, dependency_identifier):
 
     return res
 
-def check_swift(ctx, dependency_identifier):
-    minVer = StrictVersion("3.0.2")
-    if ctx.env.SWIFT_VERSION:
-        if StrictVersion(ctx.env.SWIFT_VERSION) >= minVer:
-            ctx.add_optional_message(dependency_identifier,
-                                     'version found: ' + str(ctx.env.SWIFT_VERSION))
-            return True
-    ctx.add_optional_message(dependency_identifier,
-                             "'swift >= " + str(minVer) + "' not found, found " +
-                             str(ctx.env.SWIFT_VERSION or None))
-    return False
+def check_swift(version):
+    def fn(ctx, dependency_identifier):
+        minVer = StrictVersion(version)
+        if ctx.env.SWIFT_VERSION:
+            if StrictVersion(ctx.env.SWIFT_VERSION) >= minVer:
+                ctx.add_optional_message(dependency_identifier,
+                                         'version found: ' + str(ctx.env.SWIFT_VERSION))
+                return True
+        ctx.add_optional_message(dependency_identifier,
+                                 "'swift >= " + str(minVer) + "' not found, found " +
+                                 str(ctx.env.SWIFT_VERSION or None))
+        return False
+    return fn
 
 def check_egl_provider(minVersion=None, name='egl', check=None):
     def fn(ctx, dependency_identifier, **kw):

--- a/wscript
+++ b/wscript
@@ -182,7 +182,7 @@ main_dependencies = [
         'name': '--swift',
         'desc': 'macOS Swift build tools',
         'deps': 'os-darwin',
-        'func': compose_checks(check_swift, check_macos_sdk('10.10')),
+        'func': compose_checks(check_swift('4.1'), check_macos_sdk('10.10')),
     }, {
         'name': '--uwp',
         'desc': 'Universal Windows Platform',


### PR DESCRIPTION
added a helper function to get pointers of several data at once. otherwise we would need to nest several withUnsafeBytes calls, which would make the whole code an indentation hell and hard to read. see: https://forums.swift.org/t/swift-5-2-pointers-and-coretext/34862

also dropped build support for swift <4.1 and with this support for xcode <= 9.2 and macOS 10.12.