### PR TITLE
vd_lavc: add VP8 to the default allowed hwdec codec list

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1606,7 +1606,7 @@ Video
     You can get the list of allowed codecs with ``mpv --vd=help``. Remove the
     prefix, e.g. instead of ``lavc:h264`` use ``h264``.
 
-    By default, this is set to ``h264,vc1,hevc,vp9,av1``. Note that
+    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1``. Note that
     the hardware acceleration special codecs like ``h264_vdpau`` are not
     relevant anymore, and in fact have been removed from Libav in this form.
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -135,7 +135,7 @@ const struct m_sub_options vd_lavc_conf = {
         .framedrop = AVDISCARD_NONREF,
         .dr = 1,
         .hwdec_api = "no",
-        .hwdec_codecs = "h264,vc1,hevc,vp9,av1",
+        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;
         // for example, if vo_gpu increases the number of reference surfaces for


### PR DESCRIPTION
It is supported at least on Intel, from gen8 to gen12, and still gives a pretty welcome reduction of CPU usage on my gen9.