### PR TITLE
Update drm_atomic.h

### DIFF
--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -24,6 +24,7 @@
 #include <xf86drmMode.h>
 
 #include "common/msg.h"
+#include "video/csputils.h"
 
 #define DRM_OPTS_PRIMARY_PLANE -1
 #define DRM_OPTS_OVERLAY_PLANE -2
@@ -69,6 +70,105 @@ struct drm_object {
     drmModePropertyRes **props_info;
 };
 
+#ifndef HAVE_HDR_OUTPUT_METADATA
+#define DRM_HAS_HDR_METADATA_INFOFFRAME
+#define DRM_HDMI_STATIC_METADATA_TYPE1 1
+/**
+ * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
+ *
+ * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
+ * to match exactly with the spec.
+ *
+ * Userspace is expected to pass the metadata information as per
+ * the format described in this structure.
+ */
+struct hdr_metadata_infoframe {
+	/**
+	 * @eotf: Electro-Optical Transfer Function (EOTF)
+	 * used in the stream.
+	 */
+	__u8 eotf;
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u8 metadata_type;
+	/**
+	 * @display_primaries: Color Primaries of the Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @display_primaries.x: X cordinate of color primary.
+	 * @display_primaries.y: Y cordinate of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} display_primaries[3];
+	/**
+	 * @white_point: White Point of Colorspace Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @white_point.x: X cordinate of whitepoint of color primary.
+	 * @white_point.y: Y cordinate of whitepoint of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} white_point;
+	/**
+	 * @max_display_mastering_luminance: Max Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_display_mastering_luminance;
+	/**
+	 * @min_display_mastering_luminance: Min Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of
+	 * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
+	 * represents 6.5535 cd/m2.
+	 */
+	__u16 min_display_mastering_luminance;
+	/**
+	 * @max_cll: Max Content Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_cll;
+	/**
+	 * @max_fall: Max Frame Average Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_fall;
+};
+
+/**
+ * struct hdr_output_metadata - HDR output metadata
+ *
+ * Metadata Information to be passed from userspace
+ */
+struct hdr_output_metadata {
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u32 metadata_type;
+	/**
+	 * @hdmi_metadata_type1: HDR Metadata Infoframe.
+	 */
+	union {
+		struct hdr_metadata_infoframe hdmi_metadata_type1;
+	};
+};
+
+#endif
+
+struct drm_hdr_metadata {
+#ifdef DRM_HAS_HDR_METADATA_INFOFFRAME
+    struct hdr_output_metadata data;
+    uint32_t blob_id;
+#endif
+};
+
+
 struct drm_atomic_context {
     int fd;
 
@@ -80,7 +180,10 @@ struct drm_atomic_context {
     drmModeAtomicReq *request;
 
     struct drm_atomic_state old_state;
+    
+    struct drm_hdr_metadata hdr_metadata;
 };
+
 
 
 int drm_object_create_properties(struct mp_log *log, int fd, struct drm_object *object);
@@ -100,5 +203,10 @@ bool drm_atomic_restore_old_state(drmModeAtomicReq *request, struct drm_atomic_c
 
 bool drm_mode_ensure_blob(int fd, struct drm_mode *mode);
 bool drm_mode_destroy_blob(int fd, struct drm_mode *mode);
+
+// append HDR blob to the connector properties
+void drm_send_hdrmeta(struct drm_atomic_context *ctx, struct mp_colorspace *color);
+void drm_destroy_hdrmeta(struct drm_atomic_context *ctx);
+
 
 #endif // MP_DRMATOMIC_H


### PR DESCRIPTION
Experimental DRM/HDR patch 4/7.
Sending HDR metadata infoframes over HDMI in DRM EGL mode to make TV boxes happy with the HDR label at the corner.
HDR structure is taken from drm includes. Libdrm is old in repositories. But Linux includes are OK.
