### PR TITLE
Update drm_common.c

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -92,6 +92,7 @@ const struct m_sub_options drm_conf = {
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},
         {"drm-video-plane-id", OPT_REPLACED("drm-drmprime-video-plane")},
         {"drm-osd-size", OPT_REPLACED("drm-draw-surface-size")},
+        {"drm-send-hdr-meta", OPT_CHOICE(drm_send_hdr_meta, {"no", 0}, {"auto", 1})},
         {0},
     },
     .defaults = &(const struct drm_opts) {
@@ -99,6 +100,7 @@ const struct m_sub_options drm_conf = {
         .drm_atomic = 1,
         .drm_draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drm_drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
+        .drm_send_hdr_meta = 0,
     },
     .size = sizeof(struct drm_opts),
 };
@@ -614,6 +616,7 @@ void kms_destroy(struct kms *kms)
 {
     if (!kms)
         return;
+    drm_destroy_hdrmeta(kms->atomic_context);
     drm_mode_destroy_blob(kms->fd, &kms->mode);
     if (kms->connector) {
         drmModeFreeConnector(kms->connector);


### PR DESCRIPTION
Experimental DRM/HDR patch 5/7.
Sending HDR metadata infoframes over HDMI in DRM EGL mode to make TV boxes happy with the HDR label at the corner.
Here, only new MPV option: --drm-send-hdr-meta (no/auto, default no).
