### PR TITLE
Drm HDR packet sender patch.

### DIFF
--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -24,6 +24,7 @@
 #include <xf86drmMode.h>
 
 #include "common/msg.h"
+#include "video/csputils.h"
 
 #define DRM_OPTS_PRIMARY_PLANE -1
 #define DRM_OPTS_OVERLAY_PLANE -2
@@ -69,6 +70,105 @@ struct drm_object {
     drmModePropertyRes **props_info;
 };
 
+#ifndef HAVE_HDR_OUTPUT_METADATA
+#define DRM_HAS_HDR_METADATA_INFOFFRAME
+#define DRM_HDMI_STATIC_METADATA_TYPE1 1
+/**
+ * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
+ *
+ * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
+ * to match exactly with the spec.
+ *
+ * Userspace is expected to pass the metadata information as per
+ * the format described in this structure.
+ */
+struct hdr_metadata_infoframe {
+	/**
+	 * @eotf: Electro-Optical Transfer Function (EOTF)
+	 * used in the stream.
+	 */
+	__u8 eotf;
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u8 metadata_type;
+	/**
+	 * @display_primaries: Color Primaries of the Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @display_primaries.x: X cordinate of color primary.
+	 * @display_primaries.y: Y cordinate of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} display_primaries[3];
+	/**
+	 * @white_point: White Point of Colorspace Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @white_point.x: X cordinate of whitepoint of color primary.
+	 * @white_point.y: Y cordinate of whitepoint of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} white_point;
+	/**
+	 * @max_display_mastering_luminance: Max Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_display_mastering_luminance;
+	/**
+	 * @min_display_mastering_luminance: Min Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of
+	 * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
+	 * represents 6.5535 cd/m2.
+	 */
+	__u16 min_display_mastering_luminance;
+	/**
+	 * @max_cll: Max Content Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_cll;
+	/**
+	 * @max_fall: Max Frame Average Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_fall;
+};
+
+/**
+ * struct hdr_output_metadata - HDR output metadata
+ *
+ * Metadata Information to be passed from userspace
+ */
+struct hdr_output_metadata {
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u32 metadata_type;
+	/**
+	 * @hdmi_metadata_type1: HDR Metadata Infoframe.
+	 */
+	union {
+		struct hdr_metadata_infoframe hdmi_metadata_type1;
+	};
+};
+
+#endif
+
+struct drm_hdr_metadata {
+#ifdef DRM_HAS_HDR_METADATA_INFOFFRAME
+    struct hdr_output_metadata data;
+    uint32_t blob_id;
+#endif
+};
+
+
 struct drm_atomic_context {
     int fd;
 
@@ -80,7 +180,10 @@ struct drm_atomic_context {
     drmModeAtomicReq *request;
 
     struct drm_atomic_state old_state;
+    
+    struct drm_hdr_metadata hdr_metadata;
 };
+
 
 
 int drm_object_create_properties(struct mp_log *log, int fd, struct drm_object *object);
@@ -100,5 +203,10 @@ bool drm_atomic_restore_old_state(drmModeAtomicReq *request, struct drm_atomic_c
 
 bool drm_mode_ensure_blob(int fd, struct drm_mode *mode);
 bool drm_mode_destroy_blob(int fd, struct drm_mode *mode);
+
+// append HDR blob to the connector properties
+void drm_send_hdrmeta(struct drm_atomic_context *ctx, struct mp_colorspace *color);
+void drm_destroy_hdrmeta(struct drm_atomic_context *ctx);
+
 
 #endif // MP_DRMATOMIC_H

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -92,6 +92,7 @@ const struct m_sub_options drm_conf = {
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},
         {"drm-video-plane-id", OPT_REPLACED("drm-drmprime-video-plane")},
         {"drm-osd-size", OPT_REPLACED("drm-draw-surface-size")},
+        {"drm-send-hdr-meta", OPT_CHOICE(drm_send_hdr_meta, {"no", 0}, {"auto", 1})},
         {0},
     },
     .defaults = &(const struct drm_opts) {
@@ -99,6 +100,7 @@ const struct m_sub_options drm_conf = {
         .drm_atomic = 1,
         .drm_draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drm_drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
+        .drm_send_hdr_meta = 0,
     },
     .size = sizeof(struct drm_opts),
 };
@@ -614,6 +616,7 @@ void kms_destroy(struct kms *kms)
 {
     if (!kms)
         return;
+    drm_destroy_hdrmeta(kms->atomic_context);
     drm_mode_destroy_blob(kms->fd, &kms->mode);
     if (kms->connector) {
         drmModeFreeConnector(kms->connector);

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -53,6 +53,7 @@ struct drm_opts {
     int drm_drmprime_video_plane;
     int drm_format;
     struct m_geometry drm_draw_surface_size;
+    int drm_send_hdr_meta;
 };
 
 struct drm_vsync_tuple {

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2521,7 +2521,7 @@ static void pass_scale_main(struct gl_video *p)
 // If OSD is true, ignore any changes that may have been made to the video
 // by previous passes (i.e. linear scaling)
 static void pass_colormanage(struct gl_video *p, struct mp_colorspace src,
-                             struct mp_colorspace fbo_csp, bool osd)
+                             struct mp_colorspace fbo_csp, struct mp_colorspace *out_color, bool osd)
 {
     struct ra *ra = p->ra;
 
@@ -2659,6 +2659,9 @@ static void pass_colormanage(struct gl_video *p, struct mp_colorspace src,
 
     // Adapt from src to dst as necessary
     pass_color_map(p->sc, p->use_linear && !osd, src, dst, &tone_map);
+
+    if(out_color)
+        *out_color = dst;
 
     if (p->use_lut_3d) {
         gl_sc_uniform_texture(p->sc, "lut_3d", p->lut_3d_texture);
@@ -2855,7 +2858,7 @@ static void pass_draw_osd(struct gl_video *p, int osd_flags, int frame_flags,
                 .light = MP_CSP_LIGHT_DISPLAY,
             };
 
-            pass_colormanage(p, csp_srgb, fbo.color_space, true);
+            pass_colormanage(p, csp_srgb, fbo.color_space, NULL, true);
         }
         mpgl_osd_draw_finish(p->osd, n, p->sc, fbo);
     }
@@ -2994,7 +2997,7 @@ static bool pass_render_frame(struct gl_video *p, struct mp_image *mpi,
     return true;
 }
 
-static void pass_draw_to_screen(struct gl_video *p, struct ra_fbo fbo)
+static void pass_draw_to_screen(struct gl_video *p, struct ra_fbo fbo, struct vo_frame *frame)
 {
     if (p->dumb_mode)
         pass_render_frame_dumb(p);
@@ -3006,7 +3009,7 @@ static void pass_draw_to_screen(struct gl_video *p, struct ra_fbo fbo)
         GLSL(color.rgb = pow(color.rgb, vec3(user_gamma));)
     }
 
-    pass_colormanage(p, p->image_params.color, fbo.color_space, false);
+    pass_colormanage(p, p->image_params.color, fbo.color_space, &frame->out_color, false);
 
     // Since finish_pass_fbo doesn't work with compute shaders, and neither
     // does the checkerboard/dither code, we may need an indirection via
@@ -3238,7 +3241,7 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
                  t->ideal_frame_duration, t->vsync_interval, mix);
         p->is_interpolated = true;
     }
-    pass_draw_to_screen(p, fbo);
+    pass_draw_to_screen(p, fbo, t);
 
     p->frames_drawn += 1;
 }
@@ -3324,7 +3327,7 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
                         p->output_tex_valid = true;
                     }
                 }
-                pass_draw_to_screen(p, dest_fbo);
+                pass_draw_to_screen(p, dest_fbo, frame);
             }
 
             // "output tex valid" and "output tex needed" are equivalent

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -108,6 +108,8 @@ struct priv {
 
     struct mpv_opengl_drm_params_v2 drm_params;
     struct mpv_opengl_drm_draw_surface_size draw_surface_size;
+    
+    struct mp_colorspace out_color;
 };
 
 // Not general. Limited to only the formats being used in this module
@@ -466,7 +468,11 @@ static void queue_flip(struct ra_ctx *ctx, struct gbm_frame *frame)
     data->waiting_for_flip = &p->waiting_for_flip;
     data->log = ctx->log;
 
+
+
     if (atomic_ctx) {
+        if(ctx->vo->opts->drm_opts->drm_send_hdr_meta)
+              drm_send_hdrmeta(atomic_ctx, &p->out_color);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "FB_ID", p->fb->id);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "CRTC_ID", atomic_ctx->crtc->id);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "ZPOS", 1);
@@ -585,6 +591,8 @@ static bool drm_egl_submit_frame(struct ra_swapchain *sw, const struct vo_frame 
 
     p->still = frame->still;
 
+    p->out_color = frame->out_color;
+    
     return ra_gl_ctx_submit_frame(sw, frame);
 }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -242,6 +242,8 @@ struct vo_frame {
     // drops or reconfigs will keep the guarantee.
     // The ID is never 0 (unless num_frames==0). IDs are strictly monotonous.
     uint64_t frame_id;
+    // To hold colorspace data for HDR packets
+    struct mp_colorspace out_color;
 };
 
 // Presentation feedback. See get_vsync() for how backends should fill this


### PR DESCRIPTION
Experimental DRM/HDR patch.
Sends HDR metadata infoframes over HDMI in DRM EGL mode to make TV boxes happy with the HDR label at the corner.
New Mpv option: --drm-send-hdr-meta=no|auto (default no).
In 'auto' mode it will send meta info according to mpv's color conversion profile (really, only 3 HDR and 1 SDR profile are defined in the CTA-861-G standard).
Mpv makes a very nice color conversions, that are not available on small players and most of TVs. But, maybe, it is not bad to tell TV, that the content is HDR (LG monster shows HDR HLG label, for example).
Only EGL DRM console (tested on Linux > 5.4.26 kernel, but HDR meta in AMD/Intel/Nv drivers was available in 2019)  is supported (Xorg locks DRM Master).

Technical note: sending the HDR blob each plane flip is not good, maybe. But kernel ioctl checks for the blob to be different and makes commits on changes only. Standard says, that the blob can be sent in each HDMI video frame to maintain possible scene changes.