### PR TITLE
sub/osd: add keybinding to toggle secondary subtitles

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -127,6 +127,7 @@
 #R add sub-pos +1                       #                down
 #t add sub-pos +1                       # same as previous binding (discouraged)
 #v cycle sub-visibility
+#Alt+v cycle secondary-sub-visibility
 # stretch SSA/ASS subtitles with anamorphic videos to match historical
 #V cycle sub-ass-vsfilter-aspect-compat
 # switch between applying no style overrides to SSA/ASS subtitles, and

--- a/options/options.c
+++ b/options/options.c
@@ -236,6 +236,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-fps", OPT_FLOAT(sub_fps)},
         {"sub-speed", OPT_FLOAT(sub_speed)},
         {"sub-visibility", OPT_FLAG(sub_visibility)},
+        {"secondary-sub-visibility", OPT_FLAG(sec_sub_visibility)},
         {"sub-forced-only", OPT_CHOICE(forced_subs_only,
             {"auto", -1}, {"no", 0}, {"yes", 1})},
         {"stretch-dvd-subs", OPT_FLAG(stretch_dvd_subs)},
@@ -278,6 +279,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
     .size = sizeof(OPT_BASE_STRUCT),
     .defaults = &(OPT_BASE_STRUCT){
         .sub_visibility = 1,
+        .sec_sub_visibility = 1,
         .forced_subs_only = -1,
         .sub_pos = 100,
         .sub_speed = 1.0,

--- a/options/options.h
+++ b/options/options.h
@@ -73,6 +73,7 @@ typedef struct mp_vo_opts {
 // Subtitle options needed by the subtitle decoders/renderers.
 struct mp_subtitle_opts {
     int sub_visibility;
+    int sec_sub_visibility;
     int sub_pos;
     float sub_delay;
     float sub_fps;

--- a/player/command.c
+++ b/player/command.c
@@ -3965,6 +3965,9 @@ static const struct property_osd_display {
     {"sub-visibility",
      .msg = "Subtitles ${!sub-visibility==yes:hidden}"
       "${?sub-visibility==yes:visible${?sub==no: (but no subtitles selected)}}"},
+    {"secondary-sub-visibility",
+     .msg = "Secondary Subtitles ${!secondary-sub-visibility==yes:hidden}"
+      "${?secondary-sub-visibility==yes:visible${?secondary-sid==no: (but no secondary subtitles selected)}}"},
     {"sub-forced-only", "Forced sub only"},
     {"sub-scale", "Sub Scale"},
     {"sub-ass-vsfilter-aspect-compat", "Subtitle VSFilter aspect compat"},

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -449,3 +449,8 @@ void sub_set_play_dir(struct dec_sub *sub, int dir)
     sub->play_dir = dir;
     pthread_mutex_unlock(&sub->lock);
 }
+
+bool sub_is_secondary_visible(struct dec_sub *sub)
+{
+    return !!sub->opts->sec_sub_visibility;
+}

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -10,7 +10,6 @@ struct sh_stream;
 struct mpv_global;
 struct demux_packet;
 struct mp_recorder_sink;
-
 struct dec_sub;
 struct sd;
 
@@ -52,6 +51,7 @@ void sub_reset(struct dec_sub *sub);
 void sub_select(struct dec_sub *sub, bool selected);
 void sub_set_recorder_sink(struct dec_sub *sub, struct mp_recorder_sink *sink);
 void sub_set_play_dir(struct dec_sub *sub, int dir);
+bool sub_is_secondary_visible(struct dec_sub *sub);
 
 int sub_control(struct dec_sub *sub, enum sd_ctrl cmd, void *arg);
 

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -290,8 +290,11 @@ static struct sub_bitmaps *render_object(struct osd_state *osd,
 
     check_obj_resize(osd, osdres, obj);
 
-    if (obj->type == OSDTYPE_SUB || obj->type == OSDTYPE_SUB2) {
+    if (obj->type == OSDTYPE_SUB) {
         if (obj->sub)
+            res = sub_get_bitmaps(obj->sub, obj->vo_res, format, video_pts);
+    } else if (obj->type == OSDTYPE_SUB2) {
+        if (obj->sub && sub_is_secondary_visible(obj->sub))
             res = sub_get_bitmaps(obj->sub, obj->vo_res, format, video_pts);
     } else if (obj->type == OSDTYPE_EXTERNAL2) {
         if (obj->external2 && obj->external2->format) {


### PR DESCRIPTION
Closes issue #8243
Adds a new option `secondary-sub-visibility` which toggles the visibility of the secondary subtitle. The default keybind for toggling the secondary subtitles is `Alt+v`.