### PR TITLE
docs: fix an old style parameter reference

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -310,7 +310,7 @@ Available mpv-only filters are:
 
     ``<stereo-in>``
         Set the stereo mode the video is assumed to be encoded in. Use
-        ``--vf format:stereo-in=help`` to list all available modes. Check with
+        ``--vf=format:stereo-in=help`` to list all available modes. Check with
         the ``stereo3d`` filter documentation to see what the names mean.
 
     ``<stereo-out>``


### PR DESCRIPTION
`--vf format:stereo-in=help` no longer works.  It now must be `--vf=format:stereo-in=help`
After noticing this I regex searched the other man pages and this was the only usage of this old style I could find.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.