### PR TITLE
mac: use custom touch bar item and slider instead of a touch bar slider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,13 +118,21 @@ before_install:
         fi
   - |
         if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-            remove=$(brew list --formula)
+            if [[ "$TRAVIS_OSX_IMAGE" == "xcode12.2" ]]; then
+                remove=$(brew list --formula)
+            else
+                remove=$(brew list)
+            fi
             keep="gettext pcre2 git"
             install="autoconf automake pkg-config libtool python freetype fribidi little-cms2 luajit libass ffmpeg"
             for formula in ${keep[@]}; do remove=("${remove[@]/$formula}"); done
             for formula in ${install[@]}; do remove=("${remove[@]/$formula}"); done
             brew remove --force $remove --ignore-dependencies
-            brew remove --cask $(brew list --cask)
+            if [[ "$TRAVIS_OSX_IMAGE" == "xcode12.2" ]]; then
+                brew remove $(brew list --cask)
+            else
+                brew cask remove $(brew cask list)
+            fi
             brew untap homebrew/cask
             brew update
             if [[ -n "$CI_HOMEBREW_HASH" ]]; then

--- a/osdep/macosx_touchbar.h
+++ b/osdep/macosx_touchbar.h
@@ -41,5 +41,6 @@ struct mpv_event;
 @property(nonatomic, retain) NSDictionary *touchbarItems;
 @property(nonatomic, assign) double duration;
 @property(nonatomic, assign) double position;
+@property(nonatomic, assign) int pause;
 
 @end

--- a/osdep/macosx_touchbar.m
+++ b/osdep/macosx_touchbar.m
@@ -131,13 +131,13 @@
                 makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([self.touchbarItems[identifier][@"type"] isEqualToString:@"slider"]) {
-        NSSliderTouchBarItem *tbItem = [[NSSliderTouchBarItem alloc] initWithIdentifier:identifier];
-        tbItem.slider.minValue = 0.0f;
-        tbItem.slider.maxValue = 100.0f;
-        tbItem.target = self;
-        tbItem.action = @selector(seekbarChanged:);
+        NSCustomTouchBarItem *tbItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSSlider *slider = [NSSlider sliderWithTarget:self action:@selector(seekbarChanged:)];
+        slider.minValue = 0.0f;
+        slider.maxValue = 100.0f;
+        tbItem.view = slider;
         tbItem.customizationLabel = self.touchbarItems[identifier][@"name"];
-        [self.touchbarItems[identifier] setObject:tbItem.slider forKey:@"view"];
+        [self.touchbarItems[identifier] setObject:slider forKey:@"view"];
         return tbItem;
     } else if ([self.touchbarItems[identifier][@"type"] isEqualToString:@"button"]) {
         NSCustomTouchBarItem *tbItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
@@ -261,11 +261,11 @@
     [self.app queueCommand:(char *)[self.touchbarItems[identifier][@"cmd"] UTF8String]];
 }
 
-- (void)seekbarChanged:(NSSliderTouchBarItem *)sender
+- (void)seekbarChanged:(NSSlider *)slider
 {
-    NSString *identifier = [self getIdentifierFromView:sender.slider];
+    NSString *identifier = [self getIdentifierFromView:slider];
     NSString *seek = [NSString stringWithFormat:
-        self.touchbarItems[identifier][@"cmd"], sender.slider.doubleValue];
+        self.touchbarItems[identifier][@"cmd"], slider.doubleValue];
     [self.app queueCommand:(char *)[seek UTF8String]];
 }
 


### PR DESCRIPTION
replaces the broken NSSliderTouchBarItem with a NSCustomTouchBarItem + NSSlider, which are basically identically.

also only update the touch bar items when necessary, eg touch bar and the affected item is visible.

fixes a constraint warning (#7047) and hopefully also at least one performance regression (#8477).