### PR TITLE
manpage: fix PDF build

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -392,10 +392,12 @@ Playback Control
     difference between the two option is that this option performs a seek on
     loop, instead of reloading the file.
 
-    Note that ``--loop-file`` counts the number of times it causes the player to
-    seek to the beginning of the file, not the number of full playthroughs. This
-    means ``--loop-file=1`` will end up playing the file twice. Contrast with
-    ``--loop-playlist``, which counts the number of full playthroughs.
+    .. note::
+
+        ``--loop-file`` counts the number of times it causes the player to
+        seek to the beginning of the file, not the number of full playthroughs. This
+        means ``--loop-file=1`` will end up playing the file twice. Contrast with
+        ``--loop-playlist``, which counts the number of full playthroughs.
 
     ``--loop`` is an alias for this option.
 


### PR DESCRIPTION
Not clear what exactly makes it fail with this change, but making
the note paragraph added in d5ab5482a9 a note structure seems to fix it.