### PR TITLE
demux: add support for XSPF playlist files

### DIFF
--- a/wscript
+++ b/wscript
@@ -387,6 +387,10 @@ iconv support use --disable-iconv.",
         'desc': 'SDL2 gamepad input',
         'deps': 'sdl2',
         'func': check_true,
+    }, {
+        'name': '--libxml2',
+        'desc': 'libxml2 for XSPF support',
+        'func': check_pkg_config('libxml-2.0'),
     }
 ]
 


### PR DESCRIPTION
This adds support for the playlist format XSPF ([website](xspf.org)). It is used by various music players, maybe most notably it is the default for exporting playlists in VLC. 

As XSPF is an XML format, I used the libxml2 library in implementation. This would add a new dependency, although libxml2 is already a dependency of ffmpeg and probably present on most systems. I have added an appropriate entry to the `wscript`, mostly so that it compiles. I have no experience with WAF, so it is very probable that this part needs to be changed in order to comply with best practices. 

Line 227 assumes that p->real_stream->path is always set. Is that the case? If not an alternative way would be to load the entire file into memory and then use `xmlParseMemory()` instead. 