### PR TITLE
player: if media-title was set return that in playlist/N/title

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2954,13 +2954,20 @@ static int get_playlist_entry(int item, int action, void *arg, void *ctx)
     if (!e)
         return M_PROPERTY_ERROR;
 
+    const char *entry_title = e->title;
+    for (int i = 0; i < e->num_params; i++) {
+        struct playlist_param p = e->params[i];
+        if (!bstrcmp0(p.name, "media-title"))
+            entry_title = bstrto0(NULL, p.value);
+    }
+
     bool current = mpctx->playlist->current == e;
     bool playing = mpctx->playing == e;
     struct m_sub_property props[] = {
         {"filename",    SUB_PROP_STR(e->filename)},
         {"current",     SUB_PROP_FLAG(1), .unavailable = !current},
         {"playing",     SUB_PROP_FLAG(1), .unavailable = !playing},
-        {"title",       SUB_PROP_STR(e->title), .unavailable = !e->title},
+        {"title",       SUB_PROP_STR(entry_title), .unavailable = !entry_title},
         {"id",          SUB_PROP_INT64(e->id)},
         {0}
     };


### PR DESCRIPTION
The `loadfile` command can be passed a list of optional per-file options as the third argument which are associated with the loaded file. If the `media-title` is set using `loadfile`, it takes precedence over the default
title tag in the UI. It is also possible to retrieve the `media-title` using the `media-title` property. Unfortunately, this approach only works for the currently playing file. Presently, there seems to be no way to retrieve the media-title for a given playlist entry. This commit changes `playlist/N/title` to return the media-title, if it is not set it falls back  to the title tag which is conceptually similar to how the media-title property itself works currently.

Alternative designs:

1. Add a specific `playlist/N/media-title` subproperty.
2. Implement some generic command to to retrieve arbitrary per-file options for a given playlist entry.

If a different design is desired let me know. I am personally not familiar with the mpv code base but I would appreciate it if some way of accessing these per-file options for a given playlist entry using the IPC protocol would be implemented.