### PR TITLE
autoload.lua: optional only add same series of videos

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -165,11 +165,14 @@ function find_and_add_entries()
             return false
         end
     if o.sameseries then
-        if mp.get_property("track-list/0/type") == "video" then
-            local name = string.sub(mp.get_property("filename/no-ext"), 1, 6)
-            local name0 = string.gsub(name, "%p", "%%%1")
-            if string.match(v, "^"..name0) == nil then
-            return false
+        local name = mp.get_property("filename")
+        local namepre = string.sub(name, 1, 6)
+        local namepre0 = string.gsub(namepre, "%p", "%%%1")
+        for vidext, _ in pairs(EXTENSIONS_VIDEO) do
+            if string.match(name, vidext.."$") ~= nil then
+                if string.match(v, "^"..namepre0) == nil then
+                return false
+                end
             end
         end
     end

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -164,7 +164,7 @@ function find_and_add_entries()
             return false
         end
     if o.sameseries then
-        if mp.get_property("current-tracks/video/albumart") ~= true then
+        if mp.get_property("current-tracks/video/albumart") == false then
             local name = string.sub(mp.get_property("filename/no-ext"), 1, 6)
             local name0 = string.gsub(name, "%p", "%%%1")
             if string.match(v, "^"..name0) == nil then

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -16,6 +16,7 @@ disabled=no
 images=no
 videos=yes
 audio=yes
+sameseries=yes
 
 --]]
 
@@ -164,7 +165,7 @@ function find_and_add_entries()
             return false
         end
     if o.sameseries then
-        if mp.get_property("current-tracks/video/albumart") == false then
+        if mp.get_property("track-list/0/type") == "video" then
             local name = string.sub(mp.get_property("filename/no-ext"), 1, 6)
             local name0 = string.gsub(name, "%p", "%%%1")
             if string.match(v, "^"..name0) == nil then
@@ -227,4 +228,4 @@ function find_and_add_entries()
     add_files_at(pl_current, append[-1])
 end
 
-mp.register_event("start-file", find_and_add_entries)
+mp.register_event("file-loaded", find_and_add_entries)

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -231,4 +231,4 @@ function find_and_add_entries()
     add_files_at(pl_current, append[-1])
 end
 
-mp.register_event("file-loaded", find_and_add_entries)
+mp.register_event("start-file", find_and_add_entries)

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -29,7 +29,8 @@ o = {
     disabled = false,
     images = true,
     videos = true,
-    audio = true
+    audio = true,
+    sameseries = true
 }
 options.read_options(o)
 
@@ -162,6 +163,15 @@ function find_and_add_entries()
         if ext == nil then
             return false
         end
+    if o.sameseries then
+        if mp.get_property("current-tracks/video/albumart") ~= true then
+            local name = string.sub(mp.get_property("filename/no-ext"), 1, 6)
+            local name0 = string.gsub(name, "%p", "%%%1")
+            if string.match(v, "^"..name0) == nil then
+            return false
+            end
+        end
+    end
         return EXTENSIONS[string.lower(ext)]
     end)
     table.sort(files, alnumcomp)


### PR DESCRIPTION
Sometimes we have temp directory containing various kinds of videos but only want to autoload related videos. Therefore I wrote a if case for such a simple purpose, with a option added together.