### PR TITLE
audio: prevent uninit_audio_out during encoding

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -516,7 +516,8 @@ void reinit_audio_chain(struct MPContext *mpctx)
     struct track *track = NULL;
     track = mpctx->current_track[0][STREAM_AUDIO];
     if (!track || !track->stream) {
-        uninit_audio_out(mpctx);
+        if (!mpctx->encode_lavc_ctx)
+            uninit_audio_out(mpctx);
         error_on_track(mpctx, track);
         return;
     }


### PR DESCRIPTION
There was a simple oversight that meant audio outputs were
uninitialized during an encoding, which is not allowed, the encoding
would stop with numerous errors.
I added a single line to prevent the call of uninit_audio_out in
reinit_audio_chain if the encoder was active and this appears to have
fixed the problem without breaking anything else.

Fixes #8568