### PR TITLE
player: fixed external video add attached_picture

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -801,8 +801,13 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 ``audio-reload [<id>]``
     Reload the given audio tracks. See ``sub-reload`` command.
 
-``video-add <url> [<flags> [<title> [<lang>]]]``
+``video-add <url> [<flags> [<title> [<lang> [<extra>]]]]``
     Load the given video file. See ``sub-add`` command.
+    
+    ``extra`` flags:
+
+    <albumart>
+        Sets the video track's ``albumart`` value to true.
 
 ``video-remove [<id>]``
     Remove the given video track. See ``sub-remove`` command.

--- a/player/command.c
+++ b/player/command.c
@@ -5282,6 +5282,9 @@ static void cmd_track_add(void *p)
         char *lang = cmd->args[3].v.s;
         if (lang && lang[0])
             t->lang = talloc_strdup(t, lang);
+        int extra = cmd->args[4].v.i;
+        int is_albumart = extra & 1;
+        t->attached_picture = t->type == STREAM_VIDEO && is_albumart;
     }
 
     if (mpctx->playback_initialized)
@@ -5322,8 +5325,10 @@ static void cmd_track_reload(void *p)
 
     if (t && t->is_external && t->external_filename) {
         char *filename = talloc_strdup(NULL, t->external_filename);
+        bool is_coverart = t->attached_picture;
         mp_remove_track(mpctx, t);
         nt_num = mp_add_external_file(mpctx, filename, type, cmd->abort->cancel);
+        t->attached_picture = is_coverart;
         talloc_free(filename);
     }
 
@@ -6070,6 +6075,8 @@ const struct mp_cmd_def mp_cmds[] = {
                 .flags = MP_CMD_OPT_ARG},
             {"title", OPT_STRING(v.s), .flags = MP_CMD_OPT_ARG},
             {"lang", OPT_STRING(v.s), .flags = MP_CMD_OPT_ARG},
+            {"extra", OPT_CHOICE(v.i,
+                {"albumart", 1}), .flags = MP_CMD_OPT_ARG},
         },
         .priv = &(const int){STREAM_VIDEO},
         .spawn_thread = true,

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -832,8 +832,6 @@ int mp_add_external_file(struct MPContext *mpctx, char *filename,
         t->external_filename = talloc_strdup(t, filename);
         t->no_default = sh->type != filter;
         t->no_auto_select = t->no_default;
-        // filter==STREAM_VIDEO always means cover art.
-        t->attached_picture = t->type == STREAM_VIDEO && filter == STREAM_VIDEO;
         if (first_num < 0 && (filter == STREAM_TYPE_COUNT || sh->type == filter))
             first_num = mpctx->num_tracks - 1;
     }
@@ -1376,7 +1374,10 @@ static void load_external_opts_thread(void *p)
     load_chapters(mpctx);
     open_external_files(mpctx, mpctx->opts->audio_files, STREAM_AUDIO);
     open_external_files(mpctx, mpctx->opts->sub_name, STREAM_SUB);
+    int n = mpctx->num_tracks;
     open_external_files(mpctx, mpctx->opts->coverart_files, STREAM_VIDEO);
+    for (; n < mpctx->num_tracks; n++)
+        mpctx->tracks[n]->attached_picture = true;
     open_external_files(mpctx, mpctx->opts->external_files, STREAM_TYPE_COUNT);
     autoload_external_files(mpctx, mpctx->playback_abort);
 


### PR DESCRIPTION
Fixes bug introduced in commit 55d7f9d
Player assumed all external video tracks added were artwork
(video_track->attached_picture=true), but this is rarely the case when
using the command 'video-add'.
This had the added side effect of only playing the first frame of
dynamically added video tracks.

There was a fundamental problem in assuming all additional
externally loaded video was coverart. To overcome this I've added
an extra argument to mp_add_external_file, mp_add_external_files
and the video-add command to specify if the file is artwork.
It only applies to video tracks and is ignored otherwise.

Now attached_picture will only equal true if the file was explicitly
loaded within autoload_external_files, passed as argument in
--cover-art-files or --cover-art-file, or via the command video-add with
the new extra flag.

Fixes #8358