### PR TITLE
encode_lavc: additional 'oforce-key-frames' option

### DIFF
--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -93,6 +93,16 @@ You can encode files from one format/codec to another using this facility.
     and all pts are passed through as-is. Never seek backwards or use multiple
     input files in this mode!
 
+``--oforce-key-frames=<value>``
+    Replicates FFmpeg argument -force_key_frames for output.
+    Useful for maintaining a regular keyframe interval ragrdless of frame rate.
+    Only allows value with the prefix 'expr:'
+
+    .. admonition:: Example
+
+        "``--oforce-key-frames=expr:gte(t,n_forced*2)``"
+            Forces a keyframe once every 2 seconds.
+
 ``--no-ocopy-metadata``
     Turns off copying of metadata from input files to output files when
     encoding (which is enabled by default).

--- a/common/encode.h
+++ b/common/encode.h
@@ -44,6 +44,7 @@ struct encode_opts {
     int video_first;
     int audio_first;
     int copy_metadata;
+    char *forced_keyframes;
     char **set_metadata;
     char **remove_metadata;
 };

--- a/common/encode_lavc.h
+++ b/common/encode_lavc.h
@@ -27,6 +27,7 @@
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avstring.h>
+#include <libavutil/eval.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/opt.h>
 #include <libavutil/mathematics.h>
@@ -52,6 +53,18 @@ struct encode_lavc_context {
     // anti discontinuity mode
     double next_in_pts;
     double discontinuity_pts_offset;
+    
+    AVExpr *forced_keyframes_pexpr;
+    double forced_keyframes_expr_const_values[5];
+};
+
+enum forced_keyframes_const {
+    FKF_N,
+    FKF_N_FORCED,
+    FKF_PREV_FORCED_N,
+    FKF_PREV_FORCED_T,
+    FKF_T,
+    FKF_NB
 };
 
 // --- interface for vo/ao drivers
@@ -104,6 +117,9 @@ bool encoder_init_codec_and_muxer(struct encoder_context *p,
 
 // Encode the frame and write the packet. frame is ref'ed as need.
 bool encoder_encode(struct encoder_context *p, AVFrame *frame);
+
+// Determine if frame is keyframe if --oforce-key-frames is used.
+enum AVPictureType encoder_get_pict_type(struct encode_lavc_context *enc, double outpts);
 
 // Return muxer timebase (only available after on_ready() has been called).
 // Caller needs to acquire encode_lavc_context.lock (or call it from on_ready).

--- a/video/out/vo_lavc.c
+++ b/video/out/vo_lavc.c
@@ -221,7 +221,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *voframe)
         abort();
 
     frame->pts = rint(outpts * av_q2d(av_inv_q(avc->time_base)));
-    frame->pict_type = 0; // keep this at unknown/undefined
+    frame->pict_type = encoder_get_pict_type(ectx, outpts);
     frame->quality = avc->global_quality;
     encoder_encode(enc, frame);
     av_frame_free(&frame);


### PR DESCRIPTION
I've added an option to parse an AVExpr to allow greater control
over keyframe intervals on output streams.
This essentially replicates FFmpeg's -force_key_frames argument, which
is particularly useful for maintaining regular keyframe intervals
according to time, not frame rate - a common practice that is
recommended when encoding for live streaming services.

Implements feature requested in #8557