### PR TITLE
options: Make validation and help possible for all option types

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2827,7 +2827,7 @@ done:
     return out_pkt;
 }
 
-void demuxer_help(struct mp_log *log)
+int demuxer_help(struct mp_log *log, const m_option_t *opt, struct bstr name)
 {
     int i;
 
@@ -2837,6 +2837,9 @@ void demuxer_help(struct mp_log *log)
         mp_info(log, "%10s  %s\n",
                 demuxer_list[i]->name, demuxer_list[i]->desc);
     }
+    mp_info(log, "\n");
+
+    return M_OPT_EXIT;
 }
 
 static const char *d_level(enum demux_check level)

--- a/demux/demux.h
+++ b/demux/demux.h
@@ -293,7 +293,7 @@ void demuxer_select_track(struct demuxer *demuxer, struct sh_stream *stream,
 void demuxer_refresh_track(struct demuxer *demuxer, struct sh_stream *stream,
                            double ref_pts);
 
-void demuxer_help(struct mp_log *log);
+int demuxer_help(struct mp_log *log, const m_option_t *opt, struct bstr name);
 
 int demuxer_add_attachment(struct demuxer *demuxer, char *name,
                            char *type, void *data, size_t data_size);

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -110,16 +110,19 @@ struct dec_wrapper_opts {
     int64_t audio_reverse_size;
 };
 
-static int decoder_list_opt(struct mp_log *log, const m_option_t *opt,
-                            struct bstr name, struct bstr param);
+static int decoder_list_help(struct mp_log *log, const m_option_t *opt,
+                            struct bstr name);
 
 const struct m_sub_options dec_wrapper_conf = {
     .opts = (const struct m_option[]){
         {"correct-pts", OPT_FLAG(correct_pts)},
         {"fps", OPT_DOUBLE(force_fps), M_RANGE(0, DBL_MAX)},
-        {"ad", OPT_STRING_VALIDATE(audio_decoders, decoder_list_opt)},
-        {"vd", OPT_STRING_VALIDATE(video_decoders, decoder_list_opt)},
-        {"audio-spdif", OPT_STRING_VALIDATE(audio_spdif, decoder_list_opt)},
+        {"ad", OPT_STRING(audio_decoders),
+            .help = decoder_list_help},
+        {"vd", OPT_STRING(video_decoders),
+            .help = decoder_list_help},
+        {"audio-spdif", OPT_STRING(audio_spdif),
+            .help = decoder_list_help},
         {"video-rotate", OPT_CHOICE(video_rotate, {"no", -1}),
             .flags = UPDATE_IMGPAR, M_RANGE(0, 359)},
         {"video-aspect-override", OPT_ASPECT(movie_aspect),
@@ -232,11 +235,9 @@ struct priv {
     int dropped_frames; // total frames _probably_ dropped
 };
 
-static int decoder_list_opt(struct mp_log *log, const m_option_t *opt,
-                            struct bstr name, struct bstr param)
+static int decoder_list_help(struct mp_log *log, const m_option_t *opt,
+                            struct bstr name)
 {
-    if (!bstr_equals0(param, "help"))
-        return 1;
     if (strcmp(opt->name, "ad") == 0) {
         struct mp_decoder_list *list = audio_decoder_list();
         mp_print_decoders(log, MSGL_INFO, "Audio decoders:", list);

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -189,9 +189,12 @@ struct m_opt_choice_alternatives {
 const char *m_opt_choice_str(const struct m_opt_choice_alternatives *choices,
                              int value);
 
-// For OPT_STRING_VALIDATE(). Behaves like m_option_type.parse().
+// Validator function signatures. Required to properly type the param value.
+typedef int (*m_opt_generic_validate_fn)(struct mp_log *log, const m_option_t *opt,
+                                         struct bstr name, void *value);
+
 typedef int (*m_opt_string_validate_fn)(struct mp_log *log, const m_option_t *opt,
-                                        struct bstr name, struct bstr param);
+                                        struct bstr name, const char **value);
 
 // m_option.priv points to this if OPT_SUBSTRUCT is used
 struct m_sub_options {
@@ -384,6 +387,12 @@ struct m_option {
     // Print a warning when this option is used (for options with no direct
     // replacement.)
     const char *deprecation_message;
+
+    // Optional function that validates a param value for this option.
+    m_opt_generic_validate_fn validate;
+
+    // Optional function that displays help. Will replace type-specific help.
+    int (*help)(struct mp_log *log, const m_option_t *opt, struct bstr name);
 };
 
 char *format_file_size(int64_t size);
@@ -491,11 +500,8 @@ char *format_file_size(int64_t size);
 char *m_option_strerror(int code);
 
 // Helper to parse options, see \ref m_option_type::parse.
-static inline int m_option_parse(struct mp_log *log, const m_option_t *opt,
-                                 struct bstr name, struct bstr param, void *dst)
-{
-    return opt->type->parse(log, opt, name, param, dst);
-}
+int m_option_parse(struct mp_log *log, const m_option_t *opt,
+                   struct bstr name, struct bstr param, void *dst);
 
 // Helper to print options, see \ref m_option_type::print.
 static inline char *m_option_print(const m_option_t *opt, const void *val_ptr)
@@ -663,7 +669,8 @@ extern const char m_option_path_separator;
 
 #define OPT_STRING_VALIDATE(field, validate_fn) \
     OPT_TYPED_FIELD(m_option_type_string, char*, field), \
-    .priv = MP_EXPECT_TYPE(m_opt_string_validate_fn, validate_fn)
+    .validate = (m_opt_generic_validate_fn) \
+        MP_EXPECT_TYPE(m_opt_string_validate_fn, validate_fn)
 
 #define M_CHOICES(...) \
     .priv = (void *)&(const struct m_opt_choice_alternatives[]){ __VA_ARGS__, {0}}

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -195,6 +195,9 @@ typedef int (*m_opt_generic_validate_fn)(struct mp_log *log, const m_option_t *o
 
 typedef int (*m_opt_string_validate_fn)(struct mp_log *log, const m_option_t *opt,
                                         struct bstr name, const char **value);
+typedef int (*m_opt_int_validate_fn)(struct mp_log *log, const m_option_t *opt,
+                                     struct bstr name, const int *value);
+
 
 // m_option.priv points to this if OPT_SUBSTRUCT is used
 struct m_sub_options {
@@ -666,6 +669,11 @@ extern const char m_option_path_separator;
 
 #define OPT_CHANNELS(field) \
     OPT_TYPED_FIELD(m_option_type_channels, struct m_channels, field)
+
+#define OPT_INT_VALIDATE(field, validate_fn) \
+    OPT_TYPED_FIELD(m_option_type_int, int, field), \
+    .validate = (m_opt_generic_validate_fn) \
+        MP_EXPECT_TYPE(m_opt_int_validate_fn, validate_fn)
 
 #define OPT_STRING_VALIDATE(field, validate_fn) \
     OPT_TYPED_FIELD(m_option_type_string, char*, field), \

--- a/options/options.c
+++ b/options/options.c
@@ -46,6 +46,7 @@
 #include "player/core.h"
 #include "player/command.h"
 #include "stream/stream.h"
+#include "demux/demux.h"
 
 #if HAVE_DRM
 #include "video/out/drm_common.h"
@@ -514,9 +515,9 @@ static const m_option_t mp_opts[] = {
 #endif
 
     // demuxer.c - select audio/sub file/demuxer
-    {"demuxer", OPT_STRING(demuxer_name)},
-    {"audio-demuxer", OPT_STRING(audio_demuxer_name)},
-    {"sub-demuxer", OPT_STRING(sub_demuxer_name)},
+    {"demuxer", OPT_STRING(demuxer_name), .help = demuxer_help},
+    {"audio-demuxer", OPT_STRING(audio_demuxer_name), .help = demuxer_help},
+    {"sub-demuxer", OPT_STRING(sub_demuxer_name), .help = demuxer_help},
     {"demuxer-thread", OPT_FLAG(demuxer_thread)},
     {"demuxer-termination-timeout", OPT_DOUBLE(demux_termination_timeout)},
     {"demuxer-cache-wait", OPT_FLAG(demuxer_cache_wait)},

--- a/player/main.c
+++ b/player/main.c
@@ -54,7 +54,6 @@
 #include "input/input.h"
 
 #include "audio/out/ao.h"
-#include "demux/demux.h"
 #include "misc/thread_tools.h"
 #include "sub/osd.h"
 #include "test/tests.h"
@@ -202,13 +201,6 @@ static bool handle_help_options(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
     struct mp_log *log = mpctx->log;
-    if ((opts->demuxer_name && strcmp(opts->demuxer_name, "help") == 0) ||
-        (opts->audio_demuxer_name && strcmp(opts->audio_demuxer_name, "help") == 0) ||
-        (opts->sub_demuxer_name && strcmp(opts->sub_demuxer_name, "help") == 0)) {
-        demuxer_help(log);
-        MP_INFO(mpctx, "\n");
-        return true;
-    }
     if (opts->ao_opts->audio_device &&
         strcmp(opts->ao_opts->audio_device, "help") == 0)
     {

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -28,7 +28,7 @@
 
 static int d3d11_validate_adapter(struct mp_log *log,
                                   const struct m_option *opt,
-                                  struct bstr name, struct bstr param);
+                                  struct bstr name, const char **value);
 
 struct d3d11_opts {
     int feature_level;
@@ -111,8 +111,9 @@ struct priv {
 
 static int d3d11_validate_adapter(struct mp_log *log,
                                   const struct m_option *opt,
-                                  struct bstr name, struct bstr param)
+                                  struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     bool help = bstr_equals0(param, "help");
     bool adapter_matched = false;
     struct bstr listing = { 0 };

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -110,16 +110,20 @@ static const struct ra_ctx_fns *contexts[] = {
 #endif
 };
 
-int ra_ctx_validate_api(struct mp_log *log, const struct m_option *opt,
-                        struct bstr name, struct bstr param)
+int ra_ctx_api_help(struct mp_log *log, const struct m_option *opt,
+                    struct bstr name)
 {
-    if (bstr_equals0(param, "help")) {
-        mp_info(log, "GPU APIs (contexts):\n");
-        mp_info(log, "    auto (autodetect)\n");
-        for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
-            mp_info(log, "    %s (%s)\n", contexts[n]->type, contexts[n]->name);
-        return M_OPT_EXIT;
-    }
+    mp_info(log, "GPU APIs (contexts):\n");
+    mp_info(log, "    auto (autodetect)\n");
+    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
+        mp_info(log, "    %s (%s)\n", contexts[n]->type, contexts[n]->name);
+    return M_OPT_EXIT;
+}
+
+int ra_ctx_validate_api(struct mp_log *log, const struct m_option *opt,
+                        struct bstr name, const char **value)
+{
+    struct bstr param = bstr0(*value);
     if (bstr_equals0(param, "auto"))
         return 1;
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
@@ -129,16 +133,20 @@ int ra_ctx_validate_api(struct mp_log *log, const struct m_option *opt,
     return M_OPT_INVALID;
 }
 
-int ra_ctx_validate_context(struct mp_log *log, const struct m_option *opt,
-                            struct bstr name, struct bstr param)
+int ra_ctx_context_help(struct mp_log *log, const struct m_option *opt,
+                        struct bstr name)
 {
-    if (bstr_equals0(param, "help")) {
-        mp_info(log, "GPU contexts (APIs):\n");
-        mp_info(log, "    auto (autodetect)\n");
-        for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
-            mp_info(log, "    %s (%s)\n", contexts[n]->name, contexts[n]->type);
-        return M_OPT_EXIT;
-    }
+    mp_info(log, "GPU contexts (APIs):\n");
+    mp_info(log, "    auto (autodetect)\n");
+    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
+        mp_info(log, "    %s (%s)\n", contexts[n]->name, contexts[n]->type);
+    return M_OPT_EXIT;
+}
+
+int ra_ctx_validate_context(struct mp_log *log, const struct m_option *opt,
+                            struct bstr name, const char **value)
+{
+    struct bstr param = bstr0(*value);
     if (bstr_equals0(param, "auto"))
         return 1;
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -100,7 +100,11 @@ struct ra_ctx *ra_ctx_create(struct vo *vo, const char *context_type,
 void ra_ctx_destroy(struct ra_ctx **ctx);
 
 struct m_option;
+int ra_ctx_api_help(struct mp_log *log, const struct m_option *opt,
+                    struct bstr name);
 int ra_ctx_validate_api(struct mp_log *log, const struct m_option *opt,
-                        struct bstr name, struct bstr param);
+                        struct bstr name, const char **value);
+int ra_ctx_context_help(struct mp_log *log, const struct m_option *opt,
+                        struct bstr name);
 int ra_ctx_validate_context(struct mp_log *log, const struct m_option *opt,
-                            struct bstr name, struct bstr param);
+                            struct bstr name, const char **value);

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -106,8 +106,9 @@ struct ra_hwdec *ra_hwdec_load_driver(struct ra *ra, struct mp_log *log,
 }
 
 int ra_hwdec_validate_opt(struct mp_log *log, const m_option_t *opt,
-                          struct bstr name, struct bstr param)
+                          struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     bool help = bstr_equals0(param, "help");
     if (help)
         mp_info(log, "Available hwdecs:\n");

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -109,7 +109,7 @@ struct ra_hwdec *ra_hwdec_load_driver(struct ra *ra, struct mp_log *log,
                                       bool is_auto);
 
 int ra_hwdec_validate_opt(struct mp_log *log, const m_option_t *opt,
-                          struct bstr name, struct bstr param);
+                          struct bstr name, const char **value);
 
 void ra_hwdec_uninit(struct ra_hwdec *hwdec);
 

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -67,8 +67,9 @@ static bool parse_3dlut_size(const char *arg, int *p1, int *p2, int *p3)
 }
 
 static int validate_3dlut_size_opt(struct mp_log *log, const m_option_t *opt,
-                                   struct bstr name, struct bstr param)
+                                   struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     int p1, p2, p3;
     char s[20];
     snprintf(s, sizeof(s), "%.*s", BSTR_P(param));

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -337,13 +337,13 @@ static const struct gl_video_opts gl_video_opts_def = {
 };
 
 static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
-                               struct bstr name, struct bstr param);
+                               struct bstr name, const char **value);
 
 static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
-                               struct bstr name, struct bstr param);
+                               struct bstr name, const char **value);
 
 static int validate_error_diffusion_opt(struct mp_log *log, const m_option_t *opt,
-                                        struct bstr name, struct bstr param);
+                                        struct bstr name, const char **value);
 
 #define OPT_BASE_STRUCT struct gl_video_opts
 
@@ -4089,8 +4089,9 @@ void gl_video_configure_queue(struct gl_video *p, struct vo *vo)
 }
 
 static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
-                               struct bstr name, struct bstr param)
+                               struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     char s[20] = {0};
     int r = 1;
     bool tscale = bstr_equals0(name, "tscale");
@@ -4121,8 +4122,9 @@ static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
 }
 
 static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
-                               struct bstr name, struct bstr param)
+                               struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     char s[20] = {0};
     int r = 1;
     if (bstr_equals0(param, "help")) {
@@ -4146,8 +4148,9 @@ static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
 }
 
 static int validate_error_diffusion_opt(struct mp_log *log, const m_option_t *opt,
-                                        struct bstr name, struct bstr param)
+                                        struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     char s[20] = {0};
     int r = 1;
     if (bstr_equals0(param, "help")) {

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -321,8 +321,12 @@ err_out:
 
 #define OPT_BASE_STRUCT struct gpu_priv
 static const m_option_t options[] = {
-    {"gpu-context", OPT_STRING_VALIDATE(context_name, ra_ctx_validate_context)},
-    {"gpu-api", OPT_STRING_VALIDATE(context_type, ra_ctx_validate_api)},
+    {"gpu-context",
+        OPT_STRING_VALIDATE(context_name, ra_ctx_validate_context),
+        .help = ra_ctx_context_help},
+    {"gpu-api",
+        OPT_STRING_VALIDATE(context_type, ra_ctx_validate_api),
+        .help = ra_ctx_api_help},
     {"gpu-debug", OPT_FLAG(opts.debug)},
     {"gpu-sw", OPT_FLAG(opts.allow_sw)},
     {0}

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -31,8 +31,9 @@ struct vulkan_opts {
 };
 
 static int vk_validate_dev(struct mp_log *log, const struct m_option *opt,
-                           struct bstr name, struct bstr param)
+                           struct bstr name, const char **value)
 {
+    struct bstr param = bstr0(*value);
     int ret = M_OPT_INVALID;
     VkResult res;
 


### PR DESCRIPTION
Today, validation is only possible for string type options. But there's
no particular reason why it needs to be restricted in this way, and
there are potential uses, to allow other options to be validated
without forcing the option to have to reimplement parsing from
scratch.

The first part, simply making the validation function an explicit
field instead of overloading priv is simple enough. But if we only do
that, then the validation function still needs to deal with the raw
pre-parsed string. Instead, we want to allow the value to be parsed
before it is validated. This generates a fair amount of fallout in the
existing code, as the current validators have to be adjusted to work
with regular c strings instead of bstrs.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.