### PR TITLE
msg: fix really-quiet option to only affect terminal output

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -126,6 +126,8 @@ static void update_loglevel(struct mp_log *log)
     struct mp_log_root *root = log->root;
     pthread_mutex_lock(&root->lock);
     log->level = MSGL_STATUS + root->verbose; // default log level
+    if (root->really_quiet)
+        log->level = -1;
     for (int n = 0; root->msg_levels && root->msg_levels[n * 2 + 0]; n++) {
         if (match_mod(log->verbose_prefix, root->msg_levels[n * 2 + 0]))
             log->level = mp_msg_find_level(root->msg_levels[n * 2 + 1]);
@@ -143,8 +145,6 @@ static void update_loglevel(struct mp_log *log)
     if (log->root->stats_file)
         log->level = MPMAX(log->level, MSGL_STATS);
     log->level = MPMIN(log->level, log->max_level);
-    if (root->really_quiet)
-        log->level = -1;
     atomic_store(&log->reload_counter, atomic_load(&log->root->reload_counter));
     pthread_mutex_unlock(&root->lock);
 }


### PR DESCRIPTION
this change is up for discussion. i think it doesn't make sense for `log-file` to produce a (half) empty file if `really-quiet` is set. we want to at least have a log of `-v -v` verbosity.

introduced by a600d152d21ef398eb72b008ee3fe266696eb638, since the log level is overwritten after the log level was actually found by mp_msg_find_level.

we had that problem on #8581