### PR TITLE
Appveyor: Use latest build image for fixed MSYS2 installation.

### DIFF
--- a/TOOLS/appveyor-install.sh
+++ b/TOOLS/appveyor-install.sh
@@ -24,6 +24,7 @@ pacman -S --noconfirm --needed \
     $MINGW_PACKAGE_PREFIX-ninja \
     $MINGW_PACKAGE_PREFIX-rubberband \
     $MINGW_PACKAGE_PREFIX-shaderc \
+    $MINGW_PACKAGE_PREFIX-spirv-cross \
     $MINGW_PACKAGE_PREFIX-uchardet \
     $MINGW_PACKAGE_PREFIX-vulkan
 
@@ -50,13 +51,4 @@ pacman -Sc --noconfirm
         --enable-dxva2 \
         --enable-schannel
     make -j4 install
-)
-
-# Compile SPIRV-Cross
-(
-    git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Cross && cd SPIRV-Cross
-
-    mkdir build && cd build
-    cmake -GNinja -DSPIRV_CROSS_SHARED=ON -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX ..
-    ninja install
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2019
+
 branches:
   only:
     - master
@@ -15,18 +17,8 @@ shallow_clone: true
 test: off
 
 install:
-  # Work around age/brokenness of Appveyor's msys2 by adding the new
-  # maintainer's keyring.
-  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-  - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-  - bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
-  # Support for Ada and Objective-C was removed from MSYS2. GCC won't update if
-  # these packages are installed.
-  - >-
-    C:\msys64\usr\bin\pacman -R --noconfirm --noprogressbar
-    mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-objc mingw-w64-x86_64-gcc-ada
-    mingw-w64-x86_64-gcc-objc
+  # Disable checking disk space to speed up install time
+  - C:\msys64\usr\bin\sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
   # Update core packages
   - C:\msys64\usr\bin\pacman -Syyuu --noconfirm --noprogressbar --ask=20
   # Explicitly kill any remaining msys2 processes after core update


### PR DESCRIPTION
As MSYS2 installer issues are fixed, remove the workaround from previous commits b8104a013d958e3f177891b22949fc2e66eab955 and ea91162802432aabc8a86216d56223f690e49a67