### PR TITLE
ytdl_hook: fix crash on missing track bitrate

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -507,7 +507,7 @@ local function add_single_video(json)
 
         if requested_formats then
             for _, track in pairs(requested_formats) do
-                max_bitrate = track.tbr > max_bitrate and
+                max_bitrate = (track.tbr and track.tbr > max_bitrate) and
                     track.tbr or max_bitrate
             end
         elseif json.tbr then


### PR DESCRIPTION
Some tracks happen to lack bitrate information (ie. no tbr value).
In that case, just ignore the track while computing the max bitrate.

For an example, this is a stream in which all audio tracks
have no bitrate: https://www.raiplay.it/dirette/rai1