### PR TITLE
ao/pulse: signal the mainloop when ops are done

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -712,7 +712,7 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
             if (!waitop(priv, pa_context_set_sink_input_volume(priv->context,
                                                                stream_index,
                                                                &volume,
-                                                               NULL, NULL))) {
+                                                               &context_success_cb, ao))) {
                 GENERIC_ERR_MSG("pa_context_set_sink_input_volume() failed");
                 return CONTROL_ERROR;
             }
@@ -721,7 +721,7 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
             if (!waitop(priv, pa_context_set_sink_input_mute(priv->context,
                                                              stream_index,
                                                              *mute,
-                                                             NULL, NULL))) {
+                                                             &context_success_cb, ao))) {
                 GENERIC_ERR_MSG("pa_context_set_sink_input_mute() failed");
                 return CONTROL_ERROR;
             }


### PR DESCRIPTION
See #8633

Without the explicit singal the call to pa_threaded_mainloop_wait()
will not return as soon as possible.

@jeeb  This fixes the issues identifier in #8633