### PR TITLE
stream_lavf: Add support for Gopher over TLS.

### DIFF
--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -413,7 +413,7 @@ const stream_info_t stream_info_ffmpeg = {
   .protocols = (const char *const[]){
      "rtmp", "rtsp", "rtsps", "http", "https", "mms", "mmst", "mmsh", "mmshttp",
      "rtp", "httpproxy", "rtmpe", "rtmps", "rtmpt", "rtmpte", "rtmpts", "srt",
-     "srtp", "gopher", "data",
+     "srtp", "gopher", "gophers", "data",
      NULL },
   .can_write = true,
   .stream_origin = STREAM_ORIGIN_NET,


### PR DESCRIPTION
Gopher over TLS (gophers) is a community-adopted protocol and has recently
been merged in:
 - curl (a1f06f32b8603427535fc21183a84ce92a9b96f7)
 - ffmpeg (51367267c8a9f1a840f5e810f8c788e6e03712a5)