### PR TITLE
context_wayland: prefer es context over core

### DIFF
--- a/video/filter/vf_gpu.c
+++ b/video/filter/vf_gpu.c
@@ -88,7 +88,8 @@ static struct offscreen_ctx *gl_offscreen_ctx_create(struct mpv_global *global,
         .global = global,
     };
     EGLConfig config;
-    if (!mpegl_create_context(&ractx, gl->egl_display, &gl->egl_context, &config))
+    if (!mpegl_create_context(&ractx, gl->egl_display, &gl->egl_context, &config,
+                              false))
     {
         MP_ERR(ctx, "Could not create EGL context.\n");
         goto error;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -216,8 +216,7 @@ static bool init_egl(struct ra_ctx *ctx)
     if (!mpegl_create_context_cb(ctx,
                                  p->egl.display,
                                  (struct mpegl_cb){match_config_to_visual, ctx},
-                                 &p->egl.context,
-                                 &config))
+                                 &p->egl.context, &config, false))
         return false;
     MP_VERBOSE(ctx, "Initializing EGL surface\n");
     p->egl.surface

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -118,8 +118,9 @@ static bool egl_create_context(struct ra_ctx *ctx)
     if (eglInitialize(p->egl_display, NULL, NULL) != EGL_TRUE)
         return false;
 
+    // Prefer ES context over Core.
     if (!mpegl_create_context(ctx, p->egl_display, &p->egl_context,
-                              &p->egl_config))
+                              &p->egl_config, true))
         return false;
 
     eglMakeCurrent(p->egl_display, NULL, NULL, p->egl_context);

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -120,7 +120,8 @@ static bool mpegl_init(struct ra_ctx *ctx)
         ctx->opts.want_alpha = 0;
 
     EGLConfig config;
-    if (!mpegl_create_context_cb(ctx, p->egl_display, cb, &p->egl_context, &config))
+    if (!mpegl_create_context_cb(ctx, p->egl_display, cb, &p->egl_context, &config,
+                                 false))
         goto uninit;
 
     int cid, vID, n;

--- a/video/out/opengl/egl_helpers.h
+++ b/video/out/opengl/egl_helpers.h
@@ -11,7 +11,8 @@
 struct mp_log;
 
 bool mpegl_create_context(struct ra_ctx *ctx, EGLDisplay display,
-                          EGLContext *out_context, EGLConfig *out_config);
+                          EGLContext *out_context, EGLConfig *out_config,
+                          bool prefer_es);
 
 struct mpegl_cb {
     // if set, pick the desired config from the given list and return its index
@@ -24,7 +25,7 @@ struct mpegl_cb {
 
 bool mpegl_create_context_cb(struct ra_ctx *ctx, EGLDisplay display,
                              struct mpegl_cb cb, EGLContext *out_context,
-                             EGLConfig *out_config);
+                             EGLConfig *out_config, bool prefer_es);
 
 struct GL;
 void mpegl_load_functions(struct GL *gl, struct mp_log *log);


### PR DESCRIPTION
Fixes black picture when using `gpu` video output
on wayland sessions with EGLStreams backend.

Backward compatible with previous implementation.

Works on Gnome/KDE/Sway with GBM(Intel, AMD) and EGLStreams(NVidia)
wayland backend combinations.
