### PR TITLE
drm: add --drm-send-hdr-meta option to send HDR metadata

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -631,6 +631,13 @@ Available video output drivers are:
         Note: this option is only available with DRM atomic support.
         (default: display resolution)
 
+    ``--drm-send-hdr-meta=<no|auto>``
+        Send HDR metadata over the connector to indicate to the display that
+        a HDR EOTF curve should be used. Use together with ``--target-trc=hlg``
+        or ``--target-trc=pq`` to select the curve and use ``--target-peak=203``
+        to set the base white level.
+        (default: no)
+
 ``mediacodec_embed`` (Android)
     Renders ``IMGFMT_MEDIACODEC`` frames directly to an ``android.view.Surface``.
     Requires ``--hwdec=mediacodec`` for hardware decoding, along with

--- a/osdep/drm-hdr-metadata.h
+++ b/osdep/drm-hdr-metadata.h
@@ -1,0 +1,89 @@
+#pragma once
+
+/* Lifted verbatim from libdrm/drm_mode.h */
+
+/**
+ * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
+ *
+ * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
+ * to match exactly with the spec.
+ *
+ * Userspace is expected to pass the metadata information as per
+ * the format described in this structure.
+ */
+struct hdr_metadata_infoframe {
+	/**
+	 * @eotf: Electro-Optical Transfer Function (EOTF)
+	 * used in the stream.
+	 */
+	__u8 eotf;
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u8 metadata_type;
+	/**
+	 * @display_primaries: Color Primaries of the Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @display_primaries.x: X cordinate of color primary.
+	 * @display_primaries.y: Y cordinate of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} display_primaries[3];
+	/**
+	 * @white_point: White Point of Colorspace Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @white_point.x: X cordinate of whitepoint of color primary.
+	 * @white_point.y: Y cordinate of whitepoint of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} white_point;
+	/**
+	 * @max_display_mastering_luminance: Max Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_display_mastering_luminance;
+	/**
+	 * @min_display_mastering_luminance: Min Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of
+	 * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
+	 * represents 6.5535 cd/m2.
+	 */
+	__u16 min_display_mastering_luminance;
+	/**
+	 * @max_cll: Max Content Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_cll;
+	/**
+	 * @max_fall: Max Frame Average Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_fall;
+};
+
+/**
+ * struct hdr_output_metadata - HDR output metadata
+ *
+ * Metadata Information to be passed from userspace
+ */
+struct hdr_output_metadata {
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u32 metadata_type;
+	/**
+	 * @hdmi_metadata_type1: HDR Metadata Infoframe.
+	 */
+	union {
+		struct hdr_metadata_infoframe hdmi_metadata_type1;
+	};
+};

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -70,99 +70,17 @@ struct drm_object {
     drmModePropertyRes **props_info;
 };
 
-#ifndef HAVE_HDR_OUTPUT_METADATA
-#define DRM_HAS_HDR_METADATA_INFOFFRAME
-#define DRM_HDMI_STATIC_METADATA_TYPE1 1
-/**
- * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
- *
- * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
- * to match exactly with the spec.
- *
- * Userspace is expected to pass the metadata information as per
- * the format described in this structure.
- */
-struct hdr_metadata_infoframe {
-	/**
-	 * @eotf: Electro-Optical Transfer Function (EOTF)
-	 * used in the stream.
-	 */
-	__u8 eotf;
-	/**
-	 * @metadata_type: Static_Metadata_Descriptor_ID.
-	 */
-	__u8 metadata_type;
-	/**
-	 * @display_primaries: Color Primaries of the Data.
-	 * These are coded as unsigned 16-bit values in units of
-	 * 0.00002, where 0x0000 represents zero and 0xC350
-	 * represents 1.0000.
-	 * @display_primaries.x: X cordinate of color primary.
-	 * @display_primaries.y: Y cordinate of color primary.
-	 */
-	struct {
-		__u16 x, y;
-		} display_primaries[3];
-	/**
-	 * @white_point: White Point of Colorspace Data.
-	 * These are coded as unsigned 16-bit values in units of
-	 * 0.00002, where 0x0000 represents zero and 0xC350
-	 * represents 1.0000.
-	 * @white_point.x: X cordinate of whitepoint of color primary.
-	 * @white_point.y: Y cordinate of whitepoint of color primary.
-	 */
-	struct {
-		__u16 x, y;
-		} white_point;
-	/**
-	 * @max_display_mastering_luminance: Max Mastering Display Luminance.
-	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
-	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
-	 */
-	__u16 max_display_mastering_luminance;
-	/**
-	 * @min_display_mastering_luminance: Min Mastering Display Luminance.
-	 * This value is coded as an unsigned 16-bit value in units of
-	 * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
-	 * represents 6.5535 cd/m2.
-	 */
-	__u16 min_display_mastering_luminance;
-	/**
-	 * @max_cll: Max Content Light Level.
-	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
-	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
-	 */
-	__u16 max_cll;
-	/**
-	 * @max_fall: Max Frame Average Light Level.
-	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
-	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
-	 */
-	__u16 max_fall;
-};
+#define DRM_HAS_HDR_METADATA_INFOFRAME
+// https://lists.freedesktop.org/archives/dri-devel/2021-January/295187.html
+#define DRM_HDMI_STATIC_METADATA_TYPE1 0
 
-/**
- * struct hdr_output_metadata - HDR output metadata
- *
- * Metadata Information to be passed from userspace
- */
-struct hdr_output_metadata {
-	/**
-	 * @metadata_type: Static_Metadata_Descriptor_ID.
-	 */
-	__u32 metadata_type;
-	/**
-	 * @hdmi_metadata_type1: HDR Metadata Infoframe.
-	 */
-	union {
-		struct hdr_metadata_infoframe hdmi_metadata_type1;
-	};
-};
-
+#include "config.h"
+#if !HAVE_DRM_HDMI_HDR
+#include "osdep/drm-hdr-metadata.h"
 #endif
 
 struct drm_hdr_metadata {
-#ifdef DRM_HAS_HDR_METADATA_INFOFFRAME
+#ifdef DRM_HAS_HDR_METADATA_INFOFRAME
     struct hdr_output_metadata data;
     uint32_t blob_id;
 #endif

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -24,6 +24,7 @@
 #include <xf86drmMode.h>
 
 #include "common/msg.h"
+#include "video/csputils.h"
 
 #define DRM_OPTS_PRIMARY_PLANE -1
 #define DRM_OPTS_OVERLAY_PLANE -2
@@ -69,6 +70,105 @@ struct drm_object {
     drmModePropertyRes **props_info;
 };
 
+#ifndef HAVE_HDR_OUTPUT_METADATA
+#define DRM_HAS_HDR_METADATA_INFOFFRAME
+#define DRM_HDMI_STATIC_METADATA_TYPE1 1
+/**
+ * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
+ *
+ * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
+ * to match exactly with the spec.
+ *
+ * Userspace is expected to pass the metadata information as per
+ * the format described in this structure.
+ */
+struct hdr_metadata_infoframe {
+	/**
+	 * @eotf: Electro-Optical Transfer Function (EOTF)
+	 * used in the stream.
+	 */
+	__u8 eotf;
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u8 metadata_type;
+	/**
+	 * @display_primaries: Color Primaries of the Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @display_primaries.x: X cordinate of color primary.
+	 * @display_primaries.y: Y cordinate of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} display_primaries[3];
+	/**
+	 * @white_point: White Point of Colorspace Data.
+	 * These are coded as unsigned 16-bit values in units of
+	 * 0.00002, where 0x0000 represents zero and 0xC350
+	 * represents 1.0000.
+	 * @white_point.x: X cordinate of whitepoint of color primary.
+	 * @white_point.y: Y cordinate of whitepoint of color primary.
+	 */
+	struct {
+		__u16 x, y;
+		} white_point;
+	/**
+	 * @max_display_mastering_luminance: Max Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_display_mastering_luminance;
+	/**
+	 * @min_display_mastering_luminance: Min Mastering Display Luminance.
+	 * This value is coded as an unsigned 16-bit value in units of
+	 * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
+	 * represents 6.5535 cd/m2.
+	 */
+	__u16 min_display_mastering_luminance;
+	/**
+	 * @max_cll: Max Content Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_cll;
+	/**
+	 * @max_fall: Max Frame Average Light Level.
+	 * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+	 * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+	 */
+	__u16 max_fall;
+};
+
+/**
+ * struct hdr_output_metadata - HDR output metadata
+ *
+ * Metadata Information to be passed from userspace
+ */
+struct hdr_output_metadata {
+	/**
+	 * @metadata_type: Static_Metadata_Descriptor_ID.
+	 */
+	__u32 metadata_type;
+	/**
+	 * @hdmi_metadata_type1: HDR Metadata Infoframe.
+	 */
+	union {
+		struct hdr_metadata_infoframe hdmi_metadata_type1;
+	};
+};
+
+#endif
+
+struct drm_hdr_metadata {
+#ifdef DRM_HAS_HDR_METADATA_INFOFFRAME
+    struct hdr_output_metadata data;
+    uint32_t blob_id;
+#endif
+};
+
+
 struct drm_atomic_context {
     int fd;
 
@@ -80,7 +180,10 @@ struct drm_atomic_context {
     drmModeAtomicReq *request;
 
     struct drm_atomic_state old_state;
+    
+    struct drm_hdr_metadata hdr_metadata;
 };
+
 
 
 int drm_object_create_properties(struct mp_log *log, int fd, struct drm_object *object);
@@ -100,5 +203,10 @@ bool drm_atomic_restore_old_state(drmModeAtomicReq *request, struct drm_atomic_c
 
 bool drm_mode_ensure_blob(int fd, struct drm_mode *mode);
 bool drm_mode_destroy_blob(int fd, struct drm_mode *mode);
+
+// append HDR blob to the connector properties
+void drm_send_hdrmeta(struct drm_atomic_context *ctx, struct mp_colorspace *color);
+void drm_destroy_hdrmeta(struct drm_atomic_context *ctx);
+
 
 #endif // MP_DRMATOMIC_H

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -92,6 +92,7 @@ const struct m_sub_options drm_conf = {
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},
         {"drm-video-plane-id", OPT_REPLACED("drm-drmprime-video-plane")},
         {"drm-osd-size", OPT_REPLACED("drm-draw-surface-size")},
+        {"drm-send-hdr-meta", OPT_CHOICE(drm_send_hdr_meta, {"no", 0}, {"auto", 1})},
         {0},
     },
     .defaults = &(const struct drm_opts) {
@@ -99,6 +100,7 @@ const struct m_sub_options drm_conf = {
         .drm_atomic = 1,
         .drm_draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drm_drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
+        .drm_send_hdr_meta = 0,
     },
     .size = sizeof(struct drm_opts),
 };
@@ -614,6 +616,7 @@ void kms_destroy(struct kms *kms)
 {
     if (!kms)
         return;
+    drm_destroy_hdrmeta(kms->atomic_context);
     drm_mode_destroy_blob(kms->fd, &kms->mode);
     if (kms->connector) {
         drmModeFreeConnector(kms->connector);

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -53,6 +53,7 @@ struct drm_opts {
     int drm_drmprime_video_plane;
     int drm_format;
     struct m_geometry drm_draw_surface_size;
+    int drm_send_hdr_meta;
 };
 
 struct drm_vsync_tuple {

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -108,6 +108,8 @@ struct priv {
 
     struct mpv_opengl_drm_params_v2 drm_params;
     struct mpv_opengl_drm_draw_surface_size draw_surface_size;
+    
+    struct mp_colorspace out_color;
 };
 
 // Not general. Limited to only the formats being used in this module
@@ -466,7 +468,11 @@ static void queue_flip(struct ra_ctx *ctx, struct gbm_frame *frame)
     data->waiting_for_flip = &p->waiting_for_flip;
     data->log = ctx->log;
 
+
+
     if (atomic_ctx) {
+        if(ctx->vo->opts->drm_opts->drm_send_hdr_meta)
+              drm_send_hdrmeta(atomic_ctx, &p->out_color);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "FB_ID", p->fb->id);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "CRTC_ID", atomic_ctx->crtc->id);
         drm_object_set_property(atomic_ctx->request, atomic_ctx->draw_plane, "ZPOS", 1);
@@ -585,6 +591,8 @@ static bool drm_egl_submit_frame(struct ra_swapchain *sw, const struct vo_frame 
 
     p->still = frame->still;
 
+    p->out_color = frame->out_color;
+    
     return ra_gl_ctx_submit_frame(sw, frame);
 }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -242,6 +242,8 @@ struct vo_frame {
     // drops or reconfigs will keep the guarantee.
     // The ID is never 0 (unless num_frames==0). IDs are strictly monotonous.
     uint64_t frame_id;
+    // To hold colorspace data for HDR packets
+    struct mp_colorspace out_color;
 };
 
 // Presentation feedback. See get_vsync() for how backends should fill this

--- a/wscript
+++ b/wscript
@@ -480,6 +480,11 @@ video_output_features = [
         'deps': 'vt.h || consio.h',
         'func': check_pkg_config('libdrm', '>= 2.4.74'),
     }, {
+        'name': '--drm-hdmi-hdr',
+        'desc': 'DRM HDMI HDR metadata support',
+        'deps': 'drm',
+        'func': check_pkg_config('libdrm', '>= 2.4.104'),
+    }, {
         'name': '--gbm',
         'desc': 'GBM',
         'deps': 'gbm.h',


### PR DESCRIPTION
Based on the patch by medvedvvs. Changes to medvedevvs' patch:

- flattened to a single commit;
- splice out libdrm struct definitions to `osdep/drm-hdr-metadata.h` and make them conditional on the version of libdrm;
- calculate the peak level correctly;
- round and clamp the various metadata values properly;
- switch back to SDR on exit;
- add a man page entry;
- remove a potential resource leak in the error path;
- fix indentation.
