### PR TITLE
stats.lua: include a filter's @label when displaying filters on stats page 1

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -426,6 +426,10 @@ local function append_filters(s, prop, prefix)
             n = n .. " (disabled)"
         end
 
+        if f.label ~= nil then
+            n = "@" .. f.label .. ":" .. n
+        end
+
         local p = {}
         for key,value in pairs(f.params) do
             p[#p+1] = key .. "=" .. value


### PR DESCRIPTION
This just tweaks the stats.lua script so that a filter's `@label` is also shown.  This is handy if you're also using the repl and want to know what label to `vf toggle @label`.  Screenshot included for reference

![image](https://user-images.githubusercontent.com/167585/111097465-cc5ae280-84fe-11eb-93f5-7343ba07e2f5.png)


Mentioning at @Argon- as the stats.lua creator!