### PR TITLE
command: fix OSD displaying wrong edition title

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -1048,7 +1048,7 @@ static int mp_property_edition(void *ctx, struct m_property *prop,
     if (!demuxer)
         return mp_property_generic_option(mpctx, prop, action, arg);
 
-    int ed = demuxer->edition;
+    int ed = ((demuxer->edition + 1) % demuxer->num_editions);
 
     if (demuxer->num_editions <= 1)
         return M_PROPERTY_UNAVAILABLE;


### PR DESCRIPTION
When cycling editions, the OSD would display the title of the previous edition, instead of the current one. This commit adds one to the index of the edition title to retrieve and wraps it by the number of editions.
Fixes #8656.