### PR TITLE
command: add display-width/display-height property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2529,6 +2529,11 @@ Property list
 ``vsync-jitter``
     Estimated deviation factor of the vsync duration.
 
+``display-width``, ``display-height``
+    The current display's horizontal and vertical resolution in pixels. Whether
+    or not these values update as the mpv window changes displays depends on
+    the windowing backend. It may not be available on all platforms.
+
 ``display-hidpi-scale``
     The HiDPI scale factor as reported by the windowing backend. If no VO is
     active, or if the VO does not report a value, this property is unavailable.

--- a/player/command.c
+++ b/player/command.c
@@ -2404,6 +2404,23 @@ static int mp_property_vsync_jitter(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, stddev);
 }
 
+static int mp_property_display_resolution(void *ctx, struct m_property *prop,
+                                          int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    struct vo *vo = mpctx->video_out;
+    if (!vo)
+        return M_PROPERTY_UNAVAILABLE;
+    int res[2];
+    if (vo_control(vo, VOCTRL_GET_DISPLAY_RES, &res) <= 0)
+        return M_PROPERTY_UNAVAILABLE;
+    if (strcmp(prop->name, "display-width") == 0) {
+        return m_property_int_ro(action, arg, res[0]);
+    } else {
+        return m_property_int_ro(action, arg, res[1]);
+    }
+}
+
 static int mp_property_hidpi_scale(void *ctx, struct m_property *prop,
                                    int action, void *arg)
 {
@@ -3519,6 +3536,8 @@ static const struct m_property mp_properties_base[] = {
     {"total-avsync-change", mp_property_total_avsync_change},
     {"mistimed-frame-count", mp_property_mistimed_frame_count},
     {"vsync-ratio", mp_property_vsync_ratio},
+    {"display-width", mp_property_display_resolution},
+    {"display-height", mp_property_display_resolution},
     {"decoder-frame-drop-count", mp_property_frame_drop_dec},
     {"frame-drop-count", mp_property_frame_drop_vo},
     {"vo-delayed-frame-count", mp_property_vo_delayed_frame_count},
@@ -3734,7 +3753,8 @@ static const char *const *const mp_event_property_change[] = {
       "demuxer-cache-state"),
     E(MP_EVENT_WIN_RESIZE, "current-window-scale", "osd-width", "osd-height",
       "osd-par", "osd-dimensions"),
-    E(MP_EVENT_WIN_STATE, "display-names", "display-fps"),
+    E(MP_EVENT_WIN_STATE, "display-names", "display-fps" "display-width",
+      "display-height"),
     E(MP_EVENT_WIN_STATE2, "display-hidpi-scale"),
     E(MP_EVENT_FOCUS, "focused"),
     E(MP_EVENT_CHANGE_PLAYLIST, "playlist", "playlist-pos", "playlist-pos-1",

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -438,27 +438,23 @@ class Common: NSObject {
                                     NSScreen.main
     }
 
-    func calculateRect(forScreen screen: NSScreen, visible: Bool) -> mp_rect {
+    func getWindowGeometry(forScreen screen: NSScreen,
+                           videoOut vo: UnsafeMutablePointer<vo>) -> NSRect {
         let r = screen.convertRectToBacking(screen.frame)
-        let targetFrame = visible ? screen.visibleFrame : screen.frame
+        let targetFrame = (mpv?.macOpts.macos_geometry_calculation ?? Int32(FRAME_VISIBLE)) == FRAME_VISIBLE
+            ? screen.visibleFrame : screen.frame
         let rv = screen.convertRectToBacking(targetFrame)
 
         // convert origin to be relative to target screen
         var originY = rv.origin.y - r.origin.y
-        var originX = rv.origin.x - r.origin.x
+        let originX = rv.origin.x - r.origin.x
         // flip the y origin, mp_rect expects the origin at the top-left
         // macOS' windowing system operates from the bottom-left
         originY = -(originY + rv.size.height)
-        return mp_rect(x0: Int32(originX),
-                       y0: Int32(originY),
-                       x1: Int32(originX + rv.size.width),
-                       y1: Int32(originY + rv.size.height))
-    }
-
-    func getWindowGeometry(forScreen screen: NSScreen,
-                           videoOut vo: UnsafeMutablePointer<vo>) -> NSRect {
-        let visible: Bool = (mpv?.macOpts.macos_geometry_calculation ?? Int32(FRAME_VISIBLE)) == FRAME_VISIBLE
-        var screenRC: mp_rect = calculateRect(forScreen: screen, visible: visible)
+        var screenRC: mp_rect = mp_rect(x0: Int32(originX),
+                                        y0: Int32(originY),
+                                        x1: Int32(originX + rv.size.width),
+                                        y1: Int32(originY + rv.size.height))
 
         var geo: vo_win_geometry = vo_win_geometry()
         vo_calc_window_geometry2(vo, &screenRC, Double(screen.backingScaleFactor), &geo)
@@ -652,6 +648,17 @@ class Common: NSObject {
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, nil)
             dnames.pointee = array
+            return VO_TRUE
+        case VOCTRL_GET_DISPLAY_RES:
+            guard let screen = getCurrentScreen() else {
+                log.sendWarning("No Screen available to retrieve frame")
+                return VO_NOTAVAIL
+            }
+            let sizeData = data.assumingMemoryBound(to: Int32.self)
+            let size = UnsafeMutableBufferPointer(start: sizeData, count: 2)
+            let frame = screen.convertRectToBacking(screen.frame)
+            size[0] = Int32(frame.size.width)
+            size[1] = Int32(frame.size.height)
             return VO_TRUE
         case VOCTRL_GET_FOCUSED:
             let focus = data.assumingMemoryBound(to: CBool.self)

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -880,6 +880,11 @@ static int drm_egl_control(struct ra_ctx *ctx, int *events, int request,
         *(double*)arg = fps;
         return VO_TRUE;
     }
+    case VOCTRL_GET_DISPLAY_RES: {
+        ((int *)arg)[0] = p->kms->mode.mode.hdisplay;
+        ((int *)arg)[1] = p->kms->mode.mode.vdisplay;
+        return VO_TRUE;
+    }
     case VOCTRL_PAUSE:
         ctx->vo->want_redraw = true;
         p->paused = true;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -120,6 +120,7 @@ enum mp_voctrl {
     VOCTRL_GET_AMBIENT_LUX,             // int*
     VOCTRL_GET_DISPLAY_FPS,             // double*
     VOCTRL_GET_HIDPI_SCALE,             // double*
+    VOCTRL_GET_DISPLAY_RES,             // int[2]
 
     /* private to vo_gpu */
     VOCTRL_EXTERNAL_RESIZE,

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -654,6 +654,11 @@ static int control(struct vo *vo, uint32_t request, void *arg)
         *(double*)arg = fps;
         return VO_TRUE;
     }
+    case VOCTRL_GET_DISPLAY_RES: {
+        ((int *)arg)[0] = p->kms->mode.mode.hdisplay;
+        ((int *)arg)[1] = p->kms->mode.mode.vdisplay;
+        return VO_TRUE;
+    }
     case VOCTRL_PAUSE:
         vo->want_redraw = true;
         p->paused = true;

--- a/video/out/vo_rpi.c
+++ b/video/out/vo_rpi.c
@@ -748,6 +748,10 @@ static int control(struct vo *vo, uint32_t request, void *data)
     case VOCTRL_GET_DISPLAY_FPS:
         *(double *)data = p->display_fps;
         return VO_TRUE;
+    case VOCTRL_GET_DISPLAY_RES:
+        ((int *)arg)[0] = p->w;
+        ((int *)arg)[1] = p->h;
+        return VO_TRUE;
     }
 
     return VO_NOTIMPL;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1768,6 +1768,11 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         update_display_info(w32);
         *(double*) arg = w32->display_fps;
         return VO_TRUE;
+    case VOCTRL_GET_DISPLAY_RES: ;
+        RECT r = get_screen_area(w32);
+        ((int *)arg)[0] = r.right;
+        ((int *)arg)[1] = r.bottom;
+        return VO_TRUE;
     case VOCTRL_GET_DISPLAY_NAMES:
         *(char ***)arg = get_disp_names(w32);
         return VO_TRUE;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1750,6 +1750,13 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         *(double *)arg = wl->current_output->refresh_rate;
         return VO_TRUE;
     }
+    case VOCTRL_GET_DISPLAY_RES: {
+        if (!wl->current_output)
+            return VO_NOTAVAIL;
+        ((int *)arg)[0] = wl->current_output->geometry.x1;
+        ((int *)arg)[1] = wl->current_output->geometry.y1;
+        return VO_TRUE;
+    }
     case VOCTRL_GET_HIDPI_SCALE: {
         if (!wl->scaling)
             return VO_NOTAVAIL;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1982,6 +1982,13 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
         *(double *)arg = fps;
         return VO_TRUE;
     }
+    case VOCTRL_GET_DISPLAY_RES: {
+        if (!x11->window || x11->parent)
+            return VO_NOTAVAIL;
+        ((int *)arg)[0] = x11->screenrc.x1;
+        ((int *)arg)[1] = x11->screenrc.y1;
+        return VO_TRUE;
+    }
     case VOCTRL_GET_HIDPI_SCALE:
         *(double *)arg = x11->dpi_scale;
         return VO_TRUE;


### PR DESCRIPTION
For some reason, this never existed before. Add VOCTRL_GET_DISPLAY_RES
and use it to obtain the current display's resolution from each
vo/windowing backend if applicable. Users can then access the current
display resolution as display-width and display-height as per the client
api. Note that macOS/cocoa was not attempted in this commit since the
author has no clue how to write swift.

Sidenote: I didn't test windows or rpi.

~Edit: Now this PR covers more video/display properties.~ Not anymore.