### PR TITLE
audio: set audio chain ao on reinit

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -568,8 +568,10 @@ void reinit_audio_chain_src(struct MPContext *mpctx, struct track *track)
     if (recreate_audio_filters(mpctx) < 0)
         goto init_error;
 
-    if (mpctx->ao)
+    if (mpctx->ao) {
+        ao_chain_set_ao(ao_c, mpctx->ao);
         audio_update_volume(mpctx);
+    }
 
     mp_wakeup_core(mpctx);
     return;


### PR DESCRIPTION
Seems to be a slight corner case with the audio API rewrite. When
switching from one file to another one, the volume of the ao would never
be set because the audio chain's ao wasn't set. This caused a bug with
the reset-set-on-file option. The volume/property would be correctly set
internally, but the gain was not actually set when the file switched.
Fixes #8287.

If someone that actually knows how the audio code works can double check to make sure I'm not doing something retarded here, that'd be great.