### PR TITLE
osxbundle: use python3

### DIFF
--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import os

--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 import os
 import shutil
 import sys


### PR DESCRIPTION
It seems `osxbundle` will execute `dylib-unhell` with python2, fixed in this pr