### PR TITLE
stream_file: add new identifier for macOS FUSE filesystems

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -176,7 +176,7 @@ static bool check_stream_network(int fd)
 {
     struct statfs fs;
     const char *stypes[] = { "afpfs", "nfs", "smbfs", "webdav", "osxfusefs",
-                             "fuse", "fusefs.sshfs", NULL };
+                             "fuse", "fusefs.sshfs", "macfuse", NULL };
     if (fstatfs(fd, &fs) == 0)
         for (int i=0; stypes[i]; i++)
             if (strcmp(stypes[i], fs.f_fstypename) == 0)


### PR DESCRIPTION
i tested tuxera ntfs first since it is the commercial version of macfuse/ntfs-3g and would use the same f_fstypename, but it doesn't. so i added it to the list too.

the new f_fstypename for osxfusefs is macfuse, though we will still keep the old name.

was requested on this clossed issue: https://github.com/mpv-player/mpv/issues/634#issuecomment-821959432