### PR TITLE
wayland: ignore toplevel listener if geometry is 0

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1121,6 +1121,10 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
     struct mp_vo_opts *vo_opts = wl->vo_opts;
     struct mp_rect old_geometry = wl->geometry;
 
+    /* Don't do anything here if we haven't finished setting geometry. */
+    if (mp_rect_w(wl->geometry) == 0 || mp_rect_h(wl->geometry) == 0)
+        return;
+
     bool is_maximized = false;
     bool is_fullscreen = false;
     bool is_activated = false;


### PR DESCRIPTION
It turns out that if a user specifies fullscreen=yes and a width/height
in an autoprofile, the compositor can execute its toplevel listener
event. This can happen before we have any mpv window rendered at all so
we end up performing a bunch of geometry operations and state checks
when we shouldn't. It subtly messes up a lot of things like state
detection. Just return from this function if the geometry has no width
or height yet.

@laichiaheng: Does this commit fix your issue?