### PR TITLE
m_config: replace several mp_read_option_raw calls

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -40,6 +40,8 @@ Interface changes
     - remove `--icc-contrast` and introduce `--icc-force-contrast`. The latter
       defaults to the equivalent of the old `--icc-contrast=inf`, and can
       instead be used to specifically set the contrast to any value.
+    - deprecate --cdrom-device, instead use --cdda-device which behaves exactly
+      the same
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1145,7 +1145,7 @@ PROTOCOLS
 
     Play a series of images as video.
 
-``cdda://[device]`` ``--cdrom-device=PATH`` ``--cdda-...``
+``cdda://[device]`` ``--cdda-device=PATH`` ``--cdda-...``
 
     Play CD.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3286,7 +3286,7 @@ Disc Devices
 ------------
 
 ``--cdrom-device=<path>``
-    Specify the CD-ROM device (default: ``/dev/cdrom``).
+    Deprecated, use ``--cdda-device`` instead.
 
 ``--dvd-device=<path>``
     Specify the DVD device or .iso filename (default: ``/dev/dvd``). You can
@@ -3308,6 +3308,9 @@ Disc Devices
 
 ``--cdda-...``
     These options can be used to tune the CD Audio reading feature of mpv.
+
+``--cdda-device=<path>``
+    Specify the CD-ROM device.
 
 ``--cdda-speed=<value>``
     Set CD spin speed.

--- a/demux/demux.h
+++ b/demux/demux.h
@@ -205,6 +205,8 @@ typedef struct demuxer {
     int stream_origin; // any STREAM_ORIGIN_* (set from source stream)
     bool access_references; // allow opening other files/URLs
 
+    struct demux_shared_opts *shared_opts;
+
     // Bitmask of DEMUX_EVENT_*
     int events;
 

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -48,6 +48,7 @@
 #include "stheader.h"
 #include "options/m_config.h"
 #include "options/m_option.h"
+#include "options/options.h"
 #include "options/path.h"
 
 #ifndef AV_DISPOSITION_TIMED_THUMBNAILS
@@ -237,7 +238,6 @@ typedef struct lavf_priv {
     double seek_delay;
 
     struct demux_lavf_opts *opts;
-    double mf_fps;
 
     bool pcm_seek_hack_disabled;
     AVStream *pcm_seek_hack;
@@ -715,7 +715,7 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
         if (st->avg_frame_rate.num)
             sh->codec->fps = av_q2d(st->avg_frame_rate);
         if (priv->format_hack.image_format)
-            sh->codec->fps = priv->mf_fps;
+            sh->codec->fps = demuxer->shared_opts->mf_fps;
         sh->codec->par_w = st->sample_aspect_ratio.num;
         sh->codec->par_h = st->sample_aspect_ratio.den;
 
@@ -930,12 +930,6 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
     priv->opts = mp_get_config_group(priv, demuxer->global, &demux_lavf_conf);
     struct demux_lavf_opts *lavfdopts = priv->opts;
 
-    int index_mode;
-    mp_read_option_raw(demuxer->global, "index", &m_option_type_choice,
-                       &index_mode);
-    mp_read_option_raw(demuxer->global, "mf-fps", &m_option_type_double,
-                       &priv->mf_fps);
-
     if (lavf_check_file(demuxer, check) < 0)
         return -1;
 
@@ -943,7 +937,7 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
     if (!avfc)
         return -1;
 
-    if (index_mode != 1)
+    if (demuxer->shared_opts->index_mode != 1)
         avfc->flags |= AVFMT_FLAG_IGNIDX;
 
     if (lavfdopts->probesize) {

--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -27,8 +27,8 @@
 
 #include "mpv_talloc.h"
 #include "common/msg.h"
-#include "options/options.h"
 #include "options/m_config.h"
+#include "options/options.h"
 #include "options/path.h"
 #include "misc/ctype.h"
 
@@ -365,11 +365,7 @@ static int demux_open_mf(demuxer_t *demuxer, enum demux_check check)
     if (!mf || mf->nr_of_files < 1)
         goto error;
 
-    double mf_fps;
-    char *mf_type;
-    mp_read_option_raw(demuxer->global, "mf-fps", &m_option_type_double, &mf_fps);
-    mp_read_option_raw(demuxer->global, "mf-type", &m_option_type_string, &mf_type);
-
+    char *mf_type = demuxer->shared_opts->mf_type;
     const char *codec = mp_map_mimetype_to_video_codec(demuxer->stream->mime_type);
     if (!codec || (mf_type && mf_type[0]))
         codec = probe_format(mf, mf_type, check);
@@ -386,7 +382,7 @@ static int demux_open_mf(demuxer_t *demuxer, enum demux_check check)
     c->codec = codec;
     c->disp_w = 0;
     c->disp_h = 0;
-    c->fps = mf_fps;
+    c->fps = demuxer->shared_opts->mf_fps;
     c->reliable_fps = true;
 
     demux_add_sh_stream(demuxer, sh);

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -46,6 +46,7 @@
 #include "common/av_common.h"
 #include "options/m_config.h"
 #include "options/m_option.h"
+#include "options/options.h"
 #include "misc/bstr.h"
 #include "stream/stream.h"
 #include "video/csputils.h"
@@ -2020,10 +2021,9 @@ static int demux_mkv_open(demuxer_t *demuxer, enum demux_check check)
     mkv_d->segment_start = stream_tell(s);
     mkv_d->segment_end = end_pos;
 
-    mp_read_option_raw(demuxer->global, "index", &m_option_type_choice,
-                       &mkv_d->index_mode);
     mp_read_option_raw(demuxer->global, "edition", &m_option_type_choice,
                        &mkv_d->edition_id);
+    mkv_d->index_mode = demuxer->shared_opts->index_mode;
     mkv_d->opts = mp_get_config_group(mkv_d, demuxer->global, &demux_mkv_conf);
 
     if (demuxer->params && demuxer->params->matroska_was_valid)

--- a/options/options.h
+++ b/options/options.h
@@ -281,8 +281,6 @@ typedef struct MPOpts {
     char *screenshot_directory;
     bool screenshot_sw;
 
-    int index_mode;
-
     struct m_channels audio_output_channels;
     int audio_output_format;
     int force_srate;
@@ -305,15 +303,10 @@ typedef struct MPOpts {
 
     int w32_priority;
 
+    struct bluray_params *stream_bluray_opts;
     struct cdda_params *stream_cdda_opts;
     struct dvb_params *stream_dvb_opts;
     struct stream_lavf_params *stream_lavf_opts;
-
-    char *cdrom_device;
-    char *bluray_device;
-
-    double mf_fps;
-    char *mf_type;
 
     struct demux_rawaudio_opts *demux_rawaudio;
     struct demux_rawvideo_opts *demux_rawvideo;
@@ -336,8 +329,6 @@ typedef struct MPOpts {
     char *ipc_path;
     char *ipc_client;
 
-    int wingl_dwm_flush;
-
     struct mp_resample_opts *resample_opts;
 
     struct gl_video_opts *gl_video_opts;
@@ -350,13 +341,27 @@ typedef struct MPOpts {
     struct cocoa_opts *cocoa_opts;
     struct macos_opts *macos_opts;
     struct wayland_opts *wayland_opts;
+    struct wingl_opts *wingl_opts;
+    struct cuda_opts *cuda_opts;
+    struct demux_shared_opts *demux_shared_opts;
     struct dvd_opts *dvd_opts;
     struct vaapi_opts *vaapi_opts;
     struct sws_opts *sws_opts;
     struct zimg_opts *zimg_opts;
 
-    int cuda_device;
 } MPOpts;
+
+struct cuda_opts {
+    int cuda_device;
+};
+
+struct demux_shared_opts {
+    int access_references;
+    int edition_id;
+    int index_mode;
+    double mf_fps;
+    char *mf_type;
+};
 
 struct dvd_opts {
     int angle;
@@ -369,6 +374,8 @@ struct filter_opts {
 };
 
 extern const struct m_sub_options vo_sub_opts;
+extern const struct m_sub_options cuda_conf;
+extern const struct m_sub_options demux_shared_conf;
 extern const struct m_sub_options dvd_conf;
 extern const struct m_sub_options mp_subtitle_sub_opts;
 extern const struct m_sub_options mp_sub_filter_opts;

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -354,9 +354,10 @@ static int stream_create_instance(const stream_info_t *sinfo,
     if (flags & STREAM_LESS_NOISE)
         mp_msg_set_max_level(s->log, MSGL_WARN);
 
-    int opt;
-    mp_read_option_raw(s->global, "access-references", &m_option_type_flag, &opt);
-    s->access_references = opt;
+    struct demux_shared_opts *shared_opts =
+        mp_get_config_group(s, s->global, &demux_shared_conf);
+    s->access_references = shared_opts->access_references;
+    talloc_free(shared_opts);
 
     MP_VERBOSE(s, "Opening %s\n", url);
 

--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -61,6 +61,7 @@ typedef struct cdda_params {
     size_t data_pos;
 
     // options
+    char *cdrom_device;
     int speed;
     int paranoia_mode;
     int sector_size;
@@ -76,6 +77,7 @@ typedef struct cdda_params {
 #define OPT_BASE_STRUCT struct cdda_params
 const struct m_sub_options stream_cdda_conf = {
     .opts = (const m_option_t[]) {
+        {"device", OPT_STRING(cdrom_device), .flags = M_OPT_FILE},
         {"speed", OPT_INT(speed), M_RANGE(1, 100)},
         {"paranoia", OPT_INT(paranoia_mode), M_RANGE(0, 2)},
         {"sector-size", OPT_INT(sector_size), M_RANGE(1, 100)},
@@ -287,15 +289,10 @@ static int open_cdda(stream_t *st)
     cdrom_drive_t *cdd = NULL;
     int last_track;
 
-    char *global_device;
-    mp_read_option_raw(st->global, "cdrom-device", &m_option_type_string,
-                       &global_device);
-    talloc_steal(st, global_device);
-
     if (st->path[0]) {
         p->device = st->path;
-    } else if (global_device && global_device[0]) {
-        p->device = global_device;
+    } else if (p->cdrom_device && p->cdrom_device[0]) {
+        p->device = p->cdrom_device;
     } else {
         p->device = DEFAULT_CDROM_DEVICE;
     }

--- a/video/cuda.c
+++ b/video/cuda.c
@@ -19,15 +19,18 @@
 
 #include "hwdec.h"
 #include "options/m_config.h"
+#include "options/options.h"
 
 #include <libavutil/hwcontext.h>
 
 static struct AVBufferRef *cuda_create_standalone(struct mpv_global *global,
         struct mp_log *log, struct hwcontext_create_dev_params *params)
 {
-    int decode_dev_idx;
-    mp_read_option_raw(global, "cuda-decode-device", &m_option_type_choice,
-                       &decode_dev_idx);
+    void *tmp = talloc_new(NULL);
+    struct cuda_opts *opts =
+        mp_get_config_group(tmp, global, &cuda_conf);
+    int decode_dev_idx = opts->cuda_device;
+    talloc_free(tmp);
 
     char *decode_dev = NULL;
     if (decode_dev_idx != -1) {

--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -29,6 +29,8 @@ struct cuda_hw_priv {
     CUcontext display_ctx;
     CUcontext decode_ctx;
 
+    struct cuda_opts *opts;
+
     // Stored as int to avoid depending on libplacebo enum
     int handle_type;
 

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "hwdec_cuda.h"
 #include "options/m_config.h"
+#include "options/options.h"
 #include "video/out/opengl/formats.h"
 #include "video/out/opengl/ra_gl.h"
 
@@ -136,9 +137,12 @@ bool cuda_gl_init(const struct ra_hwdec *hw) {
 
     p->decode_ctx = p->display_ctx;
 
-    int decode_dev_idx = -1;
-    mp_read_option_raw(hw->global, "cuda-decode-device", &m_option_type_choice,
-                       &decode_dev_idx);
+
+    void *tmp = talloc_new(NULL);
+    struct cuda_opts *opts =
+        mp_get_config_group(tmp, hw->global, &cuda_conf);
+    int decode_dev_idx = opts->cuda_device;
+    talloc_free(tmp);
 
     if (decode_dev_idx > -1) {
         CUcontext dummy;

--- a/video/out/opengl/context_win.c
+++ b/video/out/opengl/context_win.c
@@ -37,6 +37,20 @@
 #define WGL_CONTEXT_CORE_PROFILE_BIT_ARB   0x00000001
 #endif
 
+struct wingl_opts {
+    int wingl_dwm_flush;
+};
+
+#define OPT_BASE_STRUCT struct wingl_opts
+const struct m_sub_options wingl_conf = {
+    .opts = (const struct m_option[]) {
+        {"opengl-dwmflush", OPT_CHOICE(wingl_dwm_flush,
+            {"no", -1}, {"auto", 0}, {"windowed", 1}, {"yes", 2})},
+        {0}
+    },
+    .size = sizeof(struct wingl_opts),
+};
+
 struct priv {
     GL gl;
 
@@ -247,9 +261,10 @@ static void wgl_swap_buffers(struct ra_ctx *ctx)
     // default if we don't DwmFLush
     int new_swapinterval = p->opt_swapinterval;
 
-    int dwm_flush_opt;
-    mp_read_option_raw(ctx->global, "opengl-dwmflush", &m_option_type_choice,
-                       &dwm_flush_opt);
+    struct wingl_opts *opts =
+        mp_get_config_group(ctx, ctx->global, &wingl_conf);
+    int dwm_flush_opt = opts->wingl_dwm_flush;
+    talloc_free(opts);
 
     if (dwm_flush_opt >= 0) {
         if ((dwm_flush_opt == 1 && !ctx->vo->opts->fullscreen) ||


### PR DESCRIPTION
wm4 mentioned that he did not like this function, and it's forbidden in
new code. There are still several uses of this function in mpv. This
commit does not remove all of them (the solution for those would be a
bit more convoluted), but just low-hanging fruit that can easily be
fixed. Note that one side-effect of this is that cdrom-device gets
deprecated in favor of cdda-device (due it being moved to cdda_params).