### PR TITLE
Docs: mark --vo=libmpv as supported with --hwdec=vaapi (fix #8045)

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1201,7 +1201,7 @@ Video
     :auto-copy: enable best hw decoder with copy-back (see below)
     :vdpau:     requires ``--vo=gpu`` with X11, or ``--vo=vdpau`` (Linux only)
     :vdpau-copy: copies video back into system RAM (Linux with some GPUs only)
-    :vaapi:     requires ``--vo=gpu`` or ``--vo=vaapi`` (Linux only)
+    :vaapi:     requires ``--vo=gpu``, ``--vo=vaapi`` or ``--vo=libmpv`` (Linux only)
     :vaapi-copy: copies video back into system RAM (Linux with some GPUs only)
     :videotoolbox: requires ``--vo=gpu`` (macOS 10.8 and up),
                    or ``--vo=libmpv`` (iOS 9.0 and up)


### PR DESCRIPTION
`DOCS/man/options.rst` [said](https://github.com/mpv-player/mpv/blob/478d39c57492107ce8d5a33e80d5624db330ceab/DOCS/man/options.rst#video):
> #### `--hwdec=<api>`
> `<api>` can be one of the following:
> vaapi: | requires --vo=gpu or --vo=vaapi (Linux only)
> -- | --

But I think this is not the case, from my experience it looks like it also works when embedding mpv in other application using libmpv (and the `libmpv` video output driver).