### PR TITLE
macos: add default handler function

### DIFF
--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -21,7 +21,7 @@
 #import "macosx_menubar_objc.h"
 #import "osdep/macosx_application_objc.h"
 #include "osdep/macosx_compat.h"
-#import <CoreServices/CoreServices.h>
+#include <ApplicationServices/ApplicationServices.h>
 
 @implementation MenuBar
 {

--- a/osdep/macosx_menubar.m
+++ b/osdep/macosx_menubar.m
@@ -21,6 +21,7 @@
 #import "macosx_menubar_objc.h"
 #import "osdep/macosx_application_objc.h"
 #include "osdep/macosx_compat.h"
+#import <CoreServices/CoreServices.h>
 
 @implementation MenuBar
 {
@@ -48,7 +49,12 @@
                         @"key"        : @"",
                         @"target"     : self
                     }],
-                    @{ @"name": @"separator" },
+                    [NSMutableDictionary dictionaryWithDictionary:@{
+                        @"name"       : @"Set as default handler",
+                        @"action"     : @"defaultHandler:",
+                        @"key"        : @"",
+                        @"target"     : self
+                    }],
                     [NSMutableDictionary dictionaryWithDictionary:@{
                         @"name"       : @"Preferences…",
                         @"action"     : @"preferences:",
@@ -766,6 +772,23 @@
         [(Application *)NSApp openFiles:url];
     }
 }
+
+- (void)defaultHandler:(NSMenuItem *)menuItem
+{
+    NSArray *extensions = @[@"webm",@"mkv",@"mov",@"mp4",@"avi"];
+    for (NSString *extension in extensions) {
+        for (UTType *type in [UTType typesWithTag: extension
+                                        tagClass: kUTTagClassFilenameExtension
+                                conformingToType: nil])
+        {
+            if ([type identifier]) {
+                NSLog(@"%@ -> %@", extension, type);
+                LSSetDefaultRoleHandlerForContentType([type identifier], kLSRolesAll, @"io.mpv");
+            }
+        }
+    }
+}
+
 
 - (void)cmd:(NSMenuItem *)menuItem
 {

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -98,7 +98,7 @@ def check_cocoa(ctx, dependency_identifier):
     fn = check_cc(
         fragment         = load_fragment('cocoa.m'),
         compile_filename = 'test.m',
-        framework_name   = ['Cocoa', 'IOKit', 'OpenGL', 'QuartzCore'],
+        framework_name   = ['Cocoa', 'IOKit', 'OpenGL', 'QuartzCore', 'CoreServices'],
         includes         = [ctx.srcnode.abspath()],
         linkflags        = '-fobjc-arc')
 

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -98,7 +98,7 @@ def check_cocoa(ctx, dependency_identifier):
     fn = check_cc(
         fragment         = load_fragment('cocoa.m'),
         compile_filename = 'test.m',
-        framework_name   = ['Cocoa', 'IOKit', 'OpenGL', 'QuartzCore', 'CoreServices'],
+        framework_name   = ['Cocoa', 'IOKit', 'OpenGL', 'QuartzCore', 'ApplicationServices'],
         includes         = [ctx.srcnode.abspath()],
         linkflags        = '-fobjc-arc')
 


### PR DESCRIPTION
Kinda WIP and taking suggestions on best way to get extensions. Would be nice to be able to set the default handler from within mpv i.e. without duti which is kinda broken on arm64