### PR TITLE
Introducing osc keyboard control.

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -375,6 +375,12 @@ Configurable Options
 
     Set to ``yes`` to reduce festivity (i.e. disable santa hat in December.)
 
+``controlkbd``
+    Default: yes
+
+    Deliver control of some keys for the osc to handle, making possible to
+    eg. disable osd-on-seek and use the osc bar for it.
+
 Script Commands
 ~~~~~~~~~~~~~~~
 

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -79,7 +79,7 @@ local default_section = "input_dispatch_" .. mp.script_name
 -- Note: the bindings are not active by default. Use enable_key_bindings().
 --
 -- list is an array of key bindings, where each entry is an array as follow:
---      {key, callback_press, callback_down, callback_up}
+--      {key, callback_press/callback_repeat, callback_down, callback_up}
 -- key is the key string as used in input.conf, like "ctrl+a"
 --
 -- callback can be a string too, in which case the following will be added like
@@ -99,10 +99,10 @@ function mp.set_key_bindings(list, section, flags)
                 local event = state:sub(1, 1)
                 local is_mouse = state:sub(2, 2) == "m"
                 local def = (is_mouse and "u") or "d"
-                if event == "r" then
-                    return
-                end
-                if event == "p" and cb then
+                --if event == "r" then
+                --    return
+                --end
+                if event == "p" or event == "r" and cb then
                     cb()
                 elseif event == "d" and cb_down then
                     cb_down()

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -48,6 +48,7 @@ local user_opts = {
     windowcontrols = "auto",    -- whether to show window controls
     windowcontrols_alignment = "right", -- which side to show window controls on
     greenandgrumpy = false,     -- disable santa hat
+    controlkbd = true,          -- take control of some keyboard keys(eg. seek keys)
 }
 
 -- read options from config and command-line
@@ -2481,6 +2482,25 @@ function process_event(source, what)
     end
 end
 
+--process events from the keyboard
+--generally this is supposed to immitate mpv's own behaviour on the osc
+function process_event_key(key)
+    show_osc()
+    if key == "right" then
+        mp.command("seek 5")
+    end
+    if key == "left" then
+        mp.command("seek -5")
+    end
+    if key == "up" then
+        mp.command("seek 60")
+    end
+    if key == "down" then
+        mp.command("seek -60")
+    end
+    request_tick()
+end
+
 
 local logo_lines = {
     -- White border
@@ -2664,6 +2684,20 @@ mp.set_key_bindings({
 }, "showhide_wc", "force")
 do_enable_keybindings()
 
+--keyboard bindings
+if user_opts.controlkbd then
+    mp.set_key_bindings({
+        {"right",               function(e) process_event_key("right") end,
+                                function(e) process_event_key("right") end},
+        {"left",                function(e) process_event_key("left") end,
+                                function(e) process_event_key("left") end},
+        {"up",                  function(e) process_event_key("up") end,
+                                function(e) process_event_key("up") end},
+        {"down",                function(e) process_event_key("down") end,
+                                function(e) process_event_key("down") end},
+    }, "osc-kbd", "force")
+    mp.enable_key_bindings("osc-kbd")
+end
 --mouse input bindings
 mp.set_key_bindings({
     {"mbtn_left",           function(e) process_event("mbtn_left", "up") end,


### PR DESCRIPTION
Giving control of some keyboard keys to the osc makes possible for us
to show the changes being made without resorting always to the osd,
which makes the player appearance somewhat weird, for example, when
seeking, the only available behavior was either disabling
osd-on-seek and having absolutely no visual feedback of the seeking or
accepting the other indicator(osd) that would appear on top of the
osc(which clearly makes no sense).
The only thing bad I could think about with this new default behavior
is if the user does not want the osc to mess with the keyboard (eg.
because he already has some script that changes those same keys), for
this case theres a new option that can be called with
--script-opts=osc-controlkbd=no which makes the osc not ever touch any
keyboard key, thus bringing back the old behaviour.