### PR TITLE
osxbundle: fix slow and wasteful memory allocation

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -188,6 +188,11 @@
     <string>${VERSION}</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>LSEnvironment</key>
+    <dict>
+      <key>MallocNanoZone</key>
+      <string>0</string>
+    </dict>
     <key>CFBundleURLTypes</key>
     <array>
       <dict>


### PR DESCRIPTION
see the description of the commit for some explanation.

the behaviour can be forced by setting the following environment variable on the terminal:
```
MallocNanoZone="1" mpv PATH/TO/FILE.mkv
```

make sure to call following to the app info.plist cache, otherwise it might take the cached old plist.
```
/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f PATH/TO/mpv.app
```

additional to the reproductions steps from issue #8820 and #7405 and comment(s) here https://github.com/mpv-player/mpv/issues/7405#issuecomment-835799610.

TL;DR the problem is a slow and wasteful memory allocation policy that is only activated when launched from the finder, eg launchd. the environment variable has to be set before/with the launch. setting it in the main method is already too late.

some additional info and related issues:
https://opensource.apple.com/source/libmalloc/libmalloc-317.40.8/src/nano_malloc_common.c.auto.html
https://chromium.googlesource.com/chromium/src.git/+/b32a54d5896276f5f7be79e120e410e1e2537c63
https://shapeof.com/archives/2015/10/mallocnanozone.html

i bet it's related to issue #5511 too and in combination with #8266 it will also be fixed.

thanks again to @ePirat for his insight and help solving this problem.