### PR TITLE
wayland: simplify render loop 

### DIFF
--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -218,11 +218,14 @@ static void draw_image(struct vo *vo, struct mp_image *src)
     struct priv *p = vo->priv;
     struct vo_wayland_state *wl = vo->wl;
     struct buffer *buf;
+    bool callback = true;
 
-    if (wl->hidden)
-        return;
+    if (!wl->opts->disable_vsync)
+        callback = vo_wayland_wait_frame(wl);
 
     wl->frame_wait = true;
+    if (!callback)
+        return;
 
     buf = p->free_buffers;
     if (buf) {
@@ -273,9 +276,6 @@ static void flip_page(struct vo *vo)
     wl_surface_damage(wl->surface, 0, 0, mp_rect_w(wl->geometry),
                       mp_rect_h(wl->geometry));
     wl_surface_commit(wl->surface);
-
-    if (!wl->opts->disable_vsync)
-        vo_wayland_wait_frame(wl);
 
     if (wl->presentation)
         wayland_sync_swap(wl);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -32,25 +32,18 @@ struct priv {
 static bool wayland_vk_start_frame(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
+    bool render = true;
 
-    bool render = !wl->hidden || wl->opts->disable_vsync;
+    if (!wl->opts->disable_vsync)
+        render = vo_wayland_wait_frame(wl);
 
-    if (wl->frame_wait && wl->presentation)
-        vo_wayland_sync_clear(wl);
-
-    if (render)
-        wl->frame_wait = true;
-
+    wl->frame_wait = true;
     return render;
 }
 
 static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-
-    if (!wl->opts->disable_vsync)
-        vo_wayland_wait_frame(wl);
-
     if (wl->presentation)
         wayland_sync_swap(wl);
 }

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -79,7 +79,6 @@ struct vo_wayland_state {
     bool activated;
     bool has_keyboard_input;
     bool focused;
-    bool hidden;
     int timeout_count;
     int wakeup_pipe[2];
     int pending_vo_events;
@@ -153,9 +152,8 @@ int last_available_sync(struct vo_wayland_state *wl);
 void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wakeup(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);
-void vo_wayland_wait_frame(struct vo_wayland_state *wl);
+bool vo_wayland_wait_frame(struct vo_wayland_state *wl);
 void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);
-void vo_wayland_sync_clear(struct vo_wayland_state *wl);
 void wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_sync_shift(struct vo_wayland_state *wl);
 void queue_new_sync(struct vo_wayland_state *wl);


### PR DESCRIPTION
Check the commit message if you want my full blog entry. ~~Basically what this does is add an optional VOCTRL_WAIT_CALLBACK event to the main render loop (specifically in `render_frame`). Like the name implies, a vo/backend can implement a wait function here for blocking purposes right before the succeeding `draw_frame` call. If the vo/backend doesn't need this, then it just instantly returns true and nothing changes. Of course, the target here is wayland and its frame callback but in theory any other vo/backend could leverage this mechanism if it was advantageous.~~ Actually, I just refactored/changed the wayland render loop a bit.

Using this approach greatly simplifies a lot of the wayland logic (a bunch of crap can be deleted) and finally achieves my goal of not having to use `wl_display_roundtrip` on every single frame (don't let wayland developers read that or they might have a heart attack). It seems to work as I hoped so far. Need to do some more testing.