### PR TITLE
stream_lavf: add --icy-codepage option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -37,6 +37,8 @@ Interface changes
     - add an additional optional `albumart` argument to the `video-add` command,
       which tells mpv to load the given video as album art.
     - undeprecate `--cache-secs` option
+    - add `--icy-codepage` option to allow choosing which codepage is used for
+      decoding icy stream metadata.
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4780,6 +4780,30 @@ Network
     are not used for https URLs. Setting this option does not try to make the
     ytdl script use the proxy.
 
+``--icy-codepage=<codepage>``
+    Codepage to use for decoding icy-title metadata. uchardet will be
+    used to guess the charset. (If mpv was not compiled with uchardet, then
+    ``utf-8`` is the effective default.)
+
+    The default value for this option is ``auto``, which enables autodetection.
+
+    The following steps are taken to determine the final codepage, in order:
+
+    - if the specific codepage has a ``+``, use that codepage
+    - if the data looks like UTF-8, assume it is UTF-8
+    - if ``--icy-codepage`` is set to a specific codepage, use that
+    - run uchardet, and if successful, use that
+    - otherwise, use ``UTF-8-BROKEN``
+
+    .. admonition:: Examples
+
+        - ``--icy-codepage=latin2`` Use Latin 2 if input is not UTF-8.
+        - ``--icy-codepage=+cp1250`` Always force recoding to cp1250.
+
+    The pseudo codepage ``UTF-8-BROKEN`` is used internally. If it's set,
+    the icy-title is interpreted as UTF-8 with "Latin 1" as fallback for bytes
+    which are not valid UTF-8 sequences. iconv is never involved in this mode.
+
 ``--tls-ca-file=<filename>``
     Certificate authority database file for use with TLS. (Silently fails with
     older FFmpeg or Libav versions.)


### PR DESCRIPTION
This adds an option to mpv to set the codepage that should be used for decoding the icy-title metadata. By default, "auto" is chosen, which uses uchardet for guessing if mpv was built with support for it, and otherwise effectively uses utf-8.

Fixes #8844.

Somebody check this for memory leaks and whatnot, I have no clue how to use C because I am a big dumb baby who has never bothered to learn it properly.