### PR TITLE
scaletempo2: don't needlessly memset/write to heap

### DIFF
--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -116,13 +116,14 @@ static void multi_channel_dot_product(
     assert(frame_offset_a >= 0);
     assert(frame_offset_b >= 0);
 
-    memset(dot_product, 0, sizeof(*dot_product) * channels);
     for (int k = 0; k < channels; ++k) {
         const float* ch_a = a[k] + frame_offset_a;
         const float* ch_b = b[k] + frame_offset_b;
+        float dp = 0;
         for (int n = 0; n < num_frames; ++n) {
-            dot_product[k] += *ch_a++ * *ch_b++;
+            dp += *ch_a++ * *ch_b++;
         }
+        dot_product[k] = dp;
     }
 }
 


### PR DESCRIPTION
multi_channel_dot_product would previously write to dot_product[k]
with each iteration, and initialised it to set it all to 0.

This isn't required. Just use a stack variable that's set to 0 as
an accumulator and then write to dot_product[k] once we're done.

Addresses #8848.