### PR TITLE
af_scaletempo2: use gcc vectors to speed up inner loop

### DIFF
--- a/wscript
+++ b/wscript
@@ -117,6 +117,10 @@ build_options = [
         'default': 'enable',
         'func': check_true,
     }, {
+        'name': '--vector',
+        'desc': 'GCC vector instructions',
+        'func': check_statement([], 'float v __attribute__((vector_size(32)))'),
+    }, {
         'name': '--clang-database',
         'desc': 'generate a clang compilation database',
         'func': check_true,


### PR DESCRIPTION
This brings my scaletempo2 benchmark down from ~22s to ~8s on my machine
(-march=native), and down to ~11s with a generic compile.

Closes #8848

TODO:
- [x] figure out why I get the following warning:

```
./audio/filter/af_scaletempo2_internals.c: In function ‘hsum8’:
../audio/filter/af_scaletempo2_internals.c:111:21: note: the ABI for passing parameters with 32-byte alignment has changed in GCC 4.6
  111 | static inline float hsum8(v8sf v8)
      |                     ^~~~~
```