### PR TITLE
build: add xcode project for debugging and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 /old_build
 /Makefile
+
+/mpv.xcodeproj/project.xcworkspace/xcuserdata
+/mpv.xcodeproj/xcuserdata

--- a/TOOLS/sort-xcode-project-file
+++ b/TOOLS/sort-xcode-project-file
@@ -1,0 +1,183 @@
+#!/usr/bin/env perl
+
+# Copyright (C) 2007, 2008, 2009, 2010 Apple Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer. 
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution. 
+# 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission. 
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Script to sort "children" and "files" sections in Xcode project.pbxproj files
+
+use strict;
+use warnings;
+
+use File::Basename;
+use File::Spec;
+use File::Temp qw(tempfile);
+use Getopt::Long;
+
+sub sortChildrenByFileName($$);
+sub sortFilesByFileName($$);
+
+# Files (or products) without extensions
+my %isFile = map { $_ => 1 } qw(
+    create_hash_table
+    jsc
+    minidom
+    testapi
+    testjsglue
+);
+
+my $printWarnings = 1;
+my $showHelp;
+
+my $getOptionsResult = GetOptions(
+    'h|help'         => \$showHelp,
+    'w|warnings!'    => \$printWarnings,
+);
+
+if (scalar(@ARGV) == 0 && !$showHelp) {
+    print STDERR "ERROR: No Xcode project files (project.pbxproj) listed on command-line.\n";
+    undef $getOptionsResult;
+}
+
+if (!$getOptionsResult || $showHelp) {
+    print STDERR <<__END__;
+Usage: @{[ basename($0) ]} [options] path/to/project.pbxproj [path/to/project.pbxproj ...]
+  -h|--help           show this help message
+  -w|--[no-]warnings  show or suppress warnings (default: show warnings)
+__END__
+    exit 1;
+}
+
+for my $projectFile (@ARGV) {
+    if (basename($projectFile) =~ /\.xcodeproj$/) {
+        $projectFile = File::Spec->catfile($projectFile, "project.pbxproj");
+    }
+
+    if (basename($projectFile) ne "project.pbxproj") {
+        print STDERR "WARNING: Not an Xcode project file: $projectFile\n" if $printWarnings;
+        next;
+    }
+
+    # Grab the mainGroup for the project file.
+    my $mainGroup = "";
+    open(IN, "< $projectFile") || die "Could not open $projectFile: $!";
+    while (my $line = <IN>) {
+        $mainGroup = $2 if $line =~ m#^(\s*)mainGroup = ([0-9A-F]{24}( /\* .+ \*/)?);$#;
+    }
+    close(IN);
+
+    my ($OUT, $tempFileName) = tempfile(
+        basename($projectFile) . "-XXXXXXXX",
+        DIR => dirname($projectFile),
+        UNLINK => 0,
+    );
+
+    # Clean up temp file in case of die()
+    $SIG{__DIE__} = sub {
+        close(IN);
+        close($OUT);
+        unlink($tempFileName);
+    };
+
+    my @lastTwo = ();
+    open(IN, "< $projectFile") || die "Could not open $projectFile: $!";
+    while (my $line = <IN>) {
+        if ($line =~ /^(\s*)files = \(\s*$/) {
+            print $OUT $line;
+            my $endMarker = $1 . ");";
+            my @files;
+            while (my $fileLine = <IN>) {
+                if ($fileLine =~ /^\Q$endMarker\E\s*$/) {
+                    $endMarker = $fileLine;
+                    last;
+                }
+                push @files, $fileLine;
+            }
+            print $OUT sort sortFilesByFileName @files;
+            print $OUT $endMarker;
+        } elsif ($line =~ /^(\s*)children = \(\s*$/) {
+            print $OUT $line;
+            my $endMarker = $1 . ");";
+            my @children;
+            while (my $childLine = <IN>) {
+                if ($childLine =~ /^\Q$endMarker\E\s*$/) {
+                    $endMarker = $childLine;
+                    last;
+                }
+                push @children, $childLine;
+            }
+            if ($lastTwo[0] =~ m#^\s+\Q$mainGroup\E = \{$#) {
+                # Don't sort mainGroup
+                print $OUT @children;
+            } else {
+                print $OUT sort sortChildrenByFileName @children;
+            }
+            print $OUT $endMarker;
+        } else {
+            print $OUT $line;
+        }
+
+        push @lastTwo, $line;
+        shift @lastTwo if scalar(@lastTwo) > 2;
+    }
+    close(IN);
+    close($OUT);
+
+    unlink($projectFile) || die "Could not delete $projectFile: $!";
+    rename($tempFileName, $projectFile) || die "Could not rename $tempFileName to $projectFile: $!";
+}
+
+exit 0;
+
+sub sortChildrenByFileName($$)
+{
+    my ($a, $b) = @_;
+    my $aFileName = $1 if $a =~ /^\s*[A-Z0-9]{24} \/\* (.+) \*\/,$/;
+    my $bFileName = $1 if $b =~ /^\s*[A-Z0-9]{24} \/\* (.+) \*\/,$/;
+    my $aSuffix = $1 if $aFileName =~ m/\.([^.]+)$/;
+    my $bSuffix = $1 if $bFileName =~ m/\.([^.]+)$/;
+    if ((!$aSuffix && !$isFile{$aFileName} && $bSuffix) || ($aSuffix && !$bSuffix && !$isFile{$bFileName})) {
+        return !$aSuffix ? -1 : 1;
+    }
+    if ($aFileName =~ /^UnifiedSource\d+/ && $bFileName =~ /^UnifiedSource\d+/) {
+        my $aNumber = $1 if $aFileName =~ /^UnifiedSource(\d+)/;
+        my $bNumber = $1 if $bFileName =~ /^UnifiedSource(\d+)/;
+        return $aNumber <=> $bNumber;
+    }
+    return lc($aFileName) cmp lc($bFileName);
+}
+
+sub sortFilesByFileName($$)
+{
+    my ($a, $b) = @_;
+    my $aFileName = $1 if $a =~ /^\s*[A-Z0-9]{24} \/\* (.+) in /;
+    my $bFileName = $1 if $b =~ /^\s*[A-Z0-9]{24} \/\* (.+) in /;
+    if ($aFileName =~ /^UnifiedSource\d+/ && $bFileName =~ /^UnifiedSource\d+/) {
+        my $aNumber = $1 if $aFileName =~ /^UnifiedSource(\d+)/;
+        my $bNumber = $1 if $bFileName =~ /^UnifiedSource(\d+)/;
+        return $aNumber <=> $bNumber;
+    }
+    return lc($aFileName) cmp lc($bFileName);
+}

--- a/mpv.xcodeproj/project.pbxproj
+++ b/mpv.xcodeproj/project.pbxproj
@@ -1,0 +1,2948 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D7A49550265980C300214818 /* stream_cdda.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A491FD265980C000214818 /* stream_cdda.c */; };
+		D7A49551265980C300214818 /* stream_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A491FE265980C000214818 /* stream_memory.c */; };
+		D7A49552265980C300214818 /* stream_dvb.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A491FF265980C000214818 /* stream_dvb.c */; };
+		D7A49553265980C300214818 /* stream_dvdnav.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49201265980C000214818 /* stream_dvdnav.c */; };
+		D7A49554265980C300214818 /* stream_avdevice.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49202265980C000214818 /* stream_avdevice.c */; };
+		D7A49555265980C300214818 /* stream_slice.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49203265980C000214818 /* stream_slice.c */; };
+		D7A49556265980C300214818 /* stream_edl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49206265980C000214818 /* stream_edl.c */; };
+		D7A49557265980C300214818 /* cookies.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49207265980C000214818 /* cookies.c */; };
+		D7A49558265980C300214818 /* stream_cb.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49209265980C000214818 /* stream_cb.c */; };
+		D7A49559265980C300214818 /* stream_bluray.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4920A265980C000214818 /* stream_bluray.c */; };
+		D7A4955A265980C300214818 /* stream_lavf.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4920B265980C000214818 /* stream_lavf.c */; };
+		D7A4955B265980C300214818 /* stream_null.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4920D265980C000214818 /* stream_null.c */; };
+		D7A4955C265980C300214818 /* stream_concat.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4920E265980C000214818 /* stream_concat.c */; };
+		D7A4955D265980C300214818 /* stream_file.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4920F265980C000214818 /* stream_file.c */; };
+		D7A4955E265980C300214818 /* dvb_tune.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49210265980C000214818 /* dvb_tune.c */; };
+		D7A4955F265980C300214818 /* stream_libarchive.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49211265980C000214818 /* stream_libarchive.c */; };
+		D7A49560265980C300214818 /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49212265980C000214818 /* stream.c */; };
+		D7A49561265980C300214818 /* stream_mf.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49213265980C000214818 /* stream_mf.c */; };
+		D7A49562265980C300214818 /* f_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49216265980C000214818 /* f_utils.c */; };
+		D7A49563265980C300214818 /* f_async_queue.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49217265980C000214818 /* f_async_queue.c */; };
+		D7A49564265980C300214818 /* f_auto_filters.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49218265980C000214818 /* f_auto_filters.c */; };
+		D7A49565265980C300214818 /* f_hwtransfer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4921A265980C000214818 /* f_hwtransfer.c */; };
+		D7A49566265980C300214818 /* f_lavfi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4921C265980C000214818 /* f_lavfi.c */; };
+		D7A49567265980C300214818 /* f_swscale.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49221265980C000214818 /* f_swscale.c */; };
+		D7A49568265980C300214818 /* f_output_chain.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49222265980C000214818 /* f_output_chain.c */; };
+		D7A49569265980C300214818 /* filter.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49223265980C000214818 /* filter.c */; };
+		D7A4956A265980C300214818 /* f_autoconvert.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49225265980C000214818 /* f_autoconvert.c */; };
+		D7A4956B265980C300214818 /* f_decoder_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49228265980C000214818 /* f_decoder_wrapper.c */; };
+		D7A4956C265980C300214818 /* f_demux_in.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4922A265980C000214818 /* f_demux_in.c */; };
+		D7A4956D265980C300214818 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4922C265980C000214818 /* frame.c */; };
+		D7A4956E265980C300214818 /* f_swresample.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4922D265980C000214818 /* f_swresample.c */; };
+		D7A4956F265980C300214818 /* user_filters.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4922E265980C000214818 /* user_filters.c */; };
+		D7A49571265980C300214818 /* m_config_core.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4923A265980C000214818 /* m_config_core.c */; };
+		D7A49572265980C300214818 /* parse_commandline.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4923C265980C000214818 /* parse_commandline.c */; };
+		D7A49573265980C300214818 /* m_option.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4923F265980C000214818 /* m_option.c */; };
+		D7A49574265980C300214818 /* m_property.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49240265980C000214818 /* m_property.c */; };
+		D7A49575265980C300214818 /* path.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49242265980C000214818 /* path.c */; };
+		D7A49576265980C300214818 /* parse_configfile.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49243265980C000214818 /* parse_configfile.c */; };
+		D7A49577265980C300214818 /* m_config_frontend.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49245265980C000214818 /* m_config_frontend.c */; };
+		D7A49578265980C300214818 /* options.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49246265980C000214818 /* options.c */; };
+		D7A4958B265980C300214818 /* aframe.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4925C265980C000214818 /* aframe.c */; };
+		D7A4958C265980C300214818 /* ao_null.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4925E265980C000214818 /* ao_null.c */; };
+		D7A4958D265980C300214818 /* ao_coreaudio_exclusive.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4925F265980C000214818 /* ao_coreaudio_exclusive.c */; };
+		D7A4958E265980C300214818 /* ao_wasapi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49260265980C000214818 /* ao_wasapi.c */; };
+		D7A4958F265980C300214818 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49261265980C000214818 /* buffer.c */; };
+		D7A49590265980C300214818 /* ao_audiounit.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A49263265980C000214818 /* ao_audiounit.m */; };
+		D7A49591265980C300214818 /* ao_wasapi_changenotify.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49265265980C000214818 /* ao_wasapi_changenotify.c */; };
+		D7A49592265980C300214818 /* ao_pulse.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49267265980C000214818 /* ao_pulse.c */; };
+		D7A49593265980C300214818 /* ao_coreaudio.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49268265980C000214818 /* ao_coreaudio.c */; };
+		D7A49594265980C300214818 /* ao_oss.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49269265980C000214818 /* ao_oss.c */; };
+		D7A49595265980C300214818 /* ao_coreaudio_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4926B265980C000214818 /* ao_coreaudio_utils.c */; };
+		D7A49596265980C300214818 /* ao_opensles.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4926C265980C000214818 /* ao_opensles.c */; };
+		D7A49597265980C300214818 /* ao_sdl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4926E265980C000214818 /* ao_sdl.c */; };
+		D7A49598265980C300214818 /* ao_alsa.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4926F265980C000214818 /* ao_alsa.c */; };
+		D7A49599265980C300214818 /* ao_wasapi_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49270265980C000214818 /* ao_wasapi_utils.c */; };
+		D7A4959A265980C300214818 /* ao_openal.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49271265980C000214818 /* ao_openal.c */; };
+		D7A4959B265980C300214818 /* ao.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49272265980C000214818 /* ao.c */; };
+		D7A4959C265980C300214818 /* ao_pcm.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49273265980C000214818 /* ao_pcm.c */; };
+		D7A4959D265980C300214818 /* ao_coreaudio_chmap.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49274265980C000214818 /* ao_coreaudio_chmap.c */; };
+		D7A4959E265980C300214818 /* ao_jack.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49275265980C000214818 /* ao_jack.c */; };
+		D7A4959F265980C300214818 /* ao_coreaudio_properties.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49276265980C000214818 /* ao_coreaudio_properties.c */; };
+		D7A495A0265980C300214818 /* ao_audiotrack.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49277265980C000214818 /* ao_audiotrack.c */; };
+		D7A495A1265980C300214818 /* ao_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49278265980C000214818 /* ao_lavc.c */; };
+		D7A495A2265980C300214818 /* chmap.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4927A265980C000214818 /* chmap.c */; };
+		D7A495A3265980C300214818 /* format.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4927B265980C000214818 /* format.c */; };
+		D7A495A4265980C300214818 /* fmt-conversion.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4927C265980C000214818 /* fmt-conversion.c */; };
+		D7A495A5265980C300214818 /* ad_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4927F265980C000214818 /* ad_lavc.c */; };
+		D7A495A6265980C300214818 /* ad_spdif.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49280265980C000214818 /* ad_spdif.c */; };
+		D7A495A7265980C300214818 /* af_lavcac3enc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49284265980C000214818 /* af_lavcac3enc.c */; };
+		D7A495A8265980C300214818 /* af_format.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49285265980C000214818 /* af_format.c */; };
+		D7A495A9265980C300214818 /* af_scaletempo.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49286265980C000214818 /* af_scaletempo.c */; };
+		D7A495AA265980C300214818 /* af_drop.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49287265980C000214818 /* af_drop.c */; };
+		D7A495AB265980C300214818 /* af_scaletempo2_internals.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49288265980C000214818 /* af_scaletempo2_internals.c */; };
+		D7A495AC265980C300214818 /* af_scaletempo2.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49289265980C000214818 /* af_scaletempo2.c */; };
+		D7A495AD265980C300214818 /* af_rubberband.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4928A265980C000214818 /* af_rubberband.c */; };
+		D7A495AE265980C300214818 /* chmap_sel.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4928C265980C000214818 /* chmap_sel.c */; };
+		D7A495B0265980C300214818 /* codecs.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49291265980C000214818 /* codecs.c */; };
+		D7A495B1265980C300214818 /* common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49292265980C000214818 /* common.c */; };
+		D7A495B2265980C300214818 /* msg.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49294265980C000214818 /* msg.c */; };
+		D7A495B3265980C300214818 /* recorder.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49295265980C000214818 /* recorder.c */; };
+		D7A495B4265980C300214818 /* tags.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49297265980C000214818 /* tags.c */; };
+		D7A495B5265980C300214818 /* playlist.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49299265980C000214818 /* playlist.c */; };
+		D7A495B6265980C300214818 /* stats.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4929A265980C000214818 /* stats.c */; };
+		D7A495B7265980C300214818 /* av_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4929E265980C000214818 /* av_common.c */; };
+		D7A495B8265980C300214818 /* version.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492A2265980C000214818 /* version.c */; };
+		D7A495B9265980C300214818 /* encode_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492A3265980C000214818 /* encode_lavc.c */; };
+		D7A495BA265980C300214818 /* av_log.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492A6265980C000214818 /* av_log.c */; };
+		D7A495BD265980C300214818 /* repack.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492AC265980C000214818 /* repack.c */; };
+		D7A495BE265980C300214818 /* img_format.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492AF265980C000214818 /* img_format.c */; };
+		D7A495BF265980C300214818 /* mp_image_pool.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492B2265980C000214818 /* mp_image_pool.c */; };
+		D7A495C0265980C300214818 /* vo_xv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492B7265980C000214818 /* vo_xv.c */; };
+		D7A495C1265980C300214818 /* drm_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492B9265980C000214818 /* drm_common.c */; };
+		D7A495C2265980C300214818 /* error_diffusion.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492BD265980C000214818 /* error_diffusion.c */; };
+		D7A495C3265980C300214818 /* d3d11_helpers.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C0265980C000214818 /* d3d11_helpers.c */; };
+		D7A495C4265980C300214818 /* video.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C2265980C000214818 /* video.c */; };
+		D7A495C5265980C300214818 /* spirv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C3265980C000214818 /* spirv.c */; };
+		D7A495C6265980C300214818 /* osd.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C4265980C000214818 /* osd.c */; };
+		D7A495C7265980C300214818 /* user_shaders.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C5265980C000214818 /* user_shaders.c */; };
+		D7A495C8265980C300214818 /* spirv_shaderc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C6265980C000214818 /* spirv_shaderc.c */; };
+		D7A495C9265980C300214818 /* libmpv_gpu.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C8265980C000214818 /* libmpv_gpu.c */; };
+		D7A495CA265980C300214818 /* lcms.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492C9265980C000214818 /* lcms.c */; };
+		D7A495CB265980C300214818 /* video_shaders.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492CB265980C000214818 /* video_shaders.c */; };
+		D7A495CC265980C300214818 /* shader_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492CC265980C000214818 /* shader_cache.c */; };
+		D7A495CD265980C300214818 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492CE265980C000214818 /* utils.c */; };
+		D7A495CE265980C300214818 /* hwdec.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492D1265980C000214818 /* hwdec.c */; };
+		D7A495CF265980C300214818 /* context.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492D3265980C000214818 /* context.c */; };
+		D7A495D0265980C300214818 /* ra.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492D6265980C000214818 /* ra.c */; };
+		D7A495D1265980C300214818 /* aspect.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492DA265980C000214818 /* aspect.c */; };
+		D7A495D2265980C300214818 /* vo_vdpau.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492DB265980C000214818 /* vo_vdpau.c */; };
+		D7A495D3265980C300214818 /* vo_sdl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492DE265980C000214818 /* vo_sdl.c */; };
+		D7A495D4265980C300214818 /* filter_kernels.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492DF265980C000214818 /* filter_kernels.c */; };
+		D7A495D5265980C300214818 /* dr_helper.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E0265980C000214818 /* dr_helper.c */; };
+		D7A495D6265980C300214818 /* libmpv_sw.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E1265980C000214818 /* libmpv_sw.c */; };
+		D7A495D7265980C300214818 /* ra_d3d11.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E4265980C000214818 /* ra_d3d11.c */; };
+		D7A495D8265980C300214818 /* hwdec_d3d11va.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E5265980C000214818 /* hwdec_d3d11va.c */; };
+		D7A495D9265980C300214818 /* hwdec_dxva2dxgi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E6265980C000214818 /* hwdec_dxva2dxgi.c */; };
+		D7A495DA265980C300214818 /* context.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E7265980C000214818 /* context.c */; };
+		D7A495DB265980C300214818 /* vo_vaapi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E8265980C000214818 /* vo_vaapi.c */; };
+		D7A495DC265980C300214818 /* vo_x11.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492E9265980C000214818 /* vo_x11.c */; };
+		D7A495DD265980C300214818 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492ED265980C100214818 /* utils.c */; };
+		D7A495DE265980C300214818 /* ra_pl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492EE265980C100214818 /* ra_pl.c */; };
+		D7A495DF265980C300214818 /* android_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492EF265980C100214818 /* android_common.c */; };
+		D7A495E0265980C300214818 /* vo_sixel.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F0265980C100214818 /* vo_sixel.c */; };
+		D7A495E1265980C300214818 /* cocoa_common.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F1265980C100214818 /* cocoa_common.m */; };
+		D7A495E2265980C300214818 /* vo_gpu.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F2265980C100214818 /* vo_gpu.c */; };
+		D7A495E3265980C300214818 /* vo_null.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F4265980C100214818 /* vo_null.c */; };
+		D7A495E4265980C300214818 /* vo_wlshm.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F5265980C100214818 /* vo_wlshm.c */; };
+		D7A495E5265980C300214818 /* vo_caca.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F6265980C100214818 /* vo_caca.c */; };
+		D7A495E6265980C300214818 /* drm_atomic.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F7265980C100214818 /* drm_atomic.c */; };
+		D7A495E7265980C300214818 /* vo_rpi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492F8265980C100214818 /* vo_rpi.c */; };
+		D7A495E8265980C300214818 /* hwdec_vaapi_vk.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492FD265980C100214818 /* hwdec_vaapi_vk.c */; };
+		D7A495E9265980C300214818 /* hwdec_cuda_gl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A492FE265980C100214818 /* hwdec_cuda_gl.c */; };
+		D7A495EA265980C300214818 /* hwdec_vaapi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49300265980C100214818 /* hwdec_vaapi.c */; };
+		D7A495EB265980C300214818 /* hwdec_cuda.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49301265980C100214818 /* hwdec_cuda.c */; };
+		D7A495EC265980C300214818 /* hwdec_cuda_vk.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49302265980C100214818 /* hwdec_cuda_vk.c */; };
+		D7A495ED265980C300214818 /* hwdec_vaapi_gl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49303265980C100214818 /* hwdec_vaapi_gl.c */; };
+		D7A495EE265980C300214818 /* wayland_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49305265980C100214818 /* wayland_common.c */; };
+		D7A495EF265980C300214818 /* bitmap_packer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49306265980C100214818 /* bitmap_packer.c */; };
+		D7A495F0265980C300214818 /* x11_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49307265980C100214818 /* x11_common.c */; };
+		D7A495F1265980C300214818 /* view.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A49309265980C100214818 /* view.swift */; };
+		D7A495F2265980C300214818 /* common.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4930A265980C100214818 /* common.swift */; };
+		D7A495F3265980C300214818 /* title_bar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4930B265980C100214818 /* title_bar.swift */; };
+		D7A495F4265980C300214818 /* window.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4930C265980C100214818 /* window.swift */; };
+		D7A495F5265980C300214818 /* gl_layer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4930D265980C100214818 /* gl_layer.swift */; };
+		D7A495F6265980C300214818 /* video_view.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A4930F265980C100214818 /* video_view.m */; };
+		D7A495F7265980C300214818 /* events_view.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A49311265980C100214818 /* events_view.m */; };
+		D7A495F8265980C300214818 /* window.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A49314265980C100214818 /* window.m */; };
+		D7A495F9265980C300214818 /* drm_prime.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49316265980C100214818 /* drm_prime.c */; };
+		D7A495FA265980C300214818 /* vo_direct3d.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49317265980C100214818 /* vo_direct3d.c */; };
+		D7A495FB265980C300214818 /* context_xlib.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4931B265980C100214818 /* context_xlib.c */; };
+		D7A495FC265980C300214818 /* context_android.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4931C265980C100214818 /* context_android.c */; };
+		D7A495FD265980C300214818 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4931E265980C100214818 /* utils.c */; };
+		D7A495FE265980C300214818 /* context.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49320265980C100214818 /* context.c */; };
+		D7A495FF265980C300214818 /* context_win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49321265980C100214818 /* context_win.c */; };
+		D7A49600265980C300214818 /* context_wayland.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49322265980C100214818 /* context_wayland.c */; };
+		D7A49601265980C300214818 /* vo_drm.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49324265980C100214818 /* vo_drm.c */; };
+		D7A49602265980C300214818 /* dither.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49325265980C100214818 /* dither.c */; };
+		D7A49603265980C300214818 /* vo_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49327265980C100214818 /* vo_lavc.c */; };
+		D7A49604265980C300214818 /* vo.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49328265980C100214818 /* vo.c */; };
+		D7A49605265980C300214818 /* droptarget.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4932E265980C100214818 /* droptarget.c */; };
+		D7A49606265980C300214818 /* displayconfig.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4932F265980C100214818 /* displayconfig.c */; };
+		D7A49607265980C300214818 /* vo_tct.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49330265980C100214818 /* vo_tct.c */; };
+		D7A49608265980C300214818 /* cocoa_cb_common.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A49331265980C100214818 /* cocoa_cb_common.swift */; };
+		D7A49609265980C300214818 /* vo_mediacodec_embed.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49332265980C100214818 /* vo_mediacodec_embed.c */; };
+		D7A4960A265980C300214818 /* vo_image.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49333265980C100214818 /* vo_image.c */; };
+		D7A4960B265980C300214818 /* vo_libmpv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49335265980C100214818 /* vo_libmpv.c */; };
+		D7A4960C265980C300214818 /* win_state.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49336265980C100214818 /* win_state.c */; };
+		D7A4960D265980C300214818 /* w32_common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49337265980C100214818 /* w32_common.c */; };
+		D7A4960E265980C300214818 /* hwdec_rpi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49339265980C100214818 /* hwdec_rpi.c */; };
+		D7A4960F265980C300214818 /* hwdec_d3d11egl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4933A265980C100214818 /* hwdec_d3d11egl.c */; };
+		D7A49610265980C300214818 /* context_dxinterop.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4933B265980C100214818 /* context_dxinterop.c */; };
+		D7A49611265980C300214818 /* common.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4933C265980C100214818 /* common.c */; };
+		D7A49612265980C300214818 /* egl_helpers.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4933E265980C100214818 /* egl_helpers.c */; };
+		D7A49613265980C300214818 /* angle_dynamic.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49340265980C100214818 /* angle_dynamic.c */; };
+		D7A49614265980C300214818 /* context_cocoa.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49342265980C100214818 /* context_cocoa.c */; };
+		D7A49615265980C300214818 /* context_android.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49343265980C100214818 /* context_android.c */; };
+		D7A49616265980C300214818 /* hwdec_osx.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49344265980C100214818 /* hwdec_osx.c */; };
+		D7A49617265980C300214818 /* oml_sync.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49346265980C100214818 /* oml_sync.c */; };
+		D7A49618265980C300214818 /* hwdec_drmprime_drm.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49348265980C100214818 /* hwdec_drmprime_drm.c */; };
+		D7A49619265980C300214818 /* hwdec_vdpau.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49349265980C100214818 /* hwdec_vdpau.c */; };
+		D7A4961A265980C300214818 /* context_drm_egl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4934A265980C100214818 /* context_drm_egl.c */; };
+		D7A4961B265980C300214818 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4934B265980C100214818 /* utils.c */; };
+		D7A4961C265980C300214818 /* context_x11egl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4934D265980C100214818 /* context_x11egl.c */; };
+		D7A4961D265980C300214818 /* hwdec_dxva2egl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4934E265980C100214818 /* hwdec_dxva2egl.c */; };
+		D7A4961E265980C300214818 /* hwdec_ios.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A4934F265980C100214818 /* hwdec_ios.m */; };
+		D7A4961F265980C300214818 /* ra_gl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49351265980C100214818 /* ra_gl.c */; };
+		D7A49620265980C300214818 /* context_rpi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49352265980C100214818 /* context_rpi.c */; };
+		D7A49621265980C300214818 /* formats.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49353265980C100214818 /* formats.c */; };
+		D7A49622265980C300214818 /* context.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49354265980C100214818 /* context.c */; };
+		D7A49623265980C300214818 /* hwdec_dxva2gldx.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49355265980C100214818 /* hwdec_dxva2gldx.c */; };
+		D7A49624265980C300214818 /* libmpv_gl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49356265980C100214818 /* libmpv_gl.c */; };
+		D7A49625265980C300214818 /* context_glx.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49357265980C100214818 /* context_glx.c */; };
+		D7A49626265980C300214818 /* context_angle.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49358265980C100214818 /* context_angle.c */; };
+		D7A49627265980C300214818 /* context_win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4935A265980C100214818 /* context_win.c */; };
+		D7A49628265980C300214818 /* context_wayland.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4935B265980C100214818 /* context_wayland.c */; };
+		D7A49629265980C300214818 /* cuda.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4935D265980C100214818 /* cuda.c */; };
+		D7A4962A265980C300214818 /* mp_image.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4935E265980C100214818 /* mp_image.c */; };
+		D7A4962B265980C300214818 /* vdpau_mixer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4935F265980C100214818 /* vdpau_mixer.c */; };
+		D7A4962C265980C300214818 /* fmt-conversion.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49360265980C100214818 /* fmt-conversion.c */; };
+		D7A4962D265980C300214818 /* sws_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49364265980C100214818 /* sws_utils.c */; };
+		D7A4962E265980C300214818 /* image_loader.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49365265980C100214818 /* image_loader.c */; };
+		D7A4962F265980C300214818 /* vd_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49367265980C100214818 /* vd_lavc.c */; };
+		D7A49630265980C300214818 /* vaapi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49369265980C100214818 /* vaapi.c */; };
+		D7A49631265980C300214818 /* vdpau_functions.inc in Sources */ = {isa = PBXBuildFile; fileRef = D7A4936A265980C100214818 /* vdpau_functions.inc */; };
+		D7A49632265980C300214818 /* image_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4936C265980C100214818 /* image_writer.c */; };
+		D7A49633265980C300214818 /* vdpau.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4936D265980C100214818 /* vdpau.c */; };
+		D7A49634265980C300214818 /* hwdec.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4936F265980C100214818 /* hwdec.c */; };
+		D7A49635265980C300214818 /* zimg.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49370265980C100214818 /* zimg.c */; };
+		D7A49636265980C300214818 /* vf_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49373265980C100214818 /* vf_sub.c */; };
+		D7A49637265980C300214818 /* vf_vdpaupp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49375265980C100214818 /* vf_vdpaupp.c */; };
+		D7A49638265980C300214818 /* vf_d3d11vpp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49376265980C100214818 /* vf_d3d11vpp.c */; };
+		D7A49639265980C300214818 /* vf_vapoursynth.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49377265980C100214818 /* vf_vapoursynth.c */; };
+		D7A4963A265980C300214818 /* refqueue.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49378265980C100214818 /* refqueue.c */; };
+		D7A4963B265980C300214818 /* vf_fingerprint.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49379265980C100214818 /* vf_fingerprint.c */; };
+		D7A4963C265980C300214818 /* vf_format.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4937A265980C100214818 /* vf_format.c */; };
+		D7A4963D265980C300214818 /* vf_vavpp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4937B265980C100214818 /* vf_vavpp.c */; };
+		D7A4963E265980C300214818 /* vf_gpu.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4937C265980C100214818 /* vf_gpu.c */; };
+		D7A4963F265980C300214818 /* csputils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4937F265980C100214818 /* csputils.c */; };
+		D7A49640265980C300214818 /* d3d.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49380265980C100214818 /* d3d.c */; };
+		D7A49641265980C300214818 /* javascript.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49382265980C100214818 /* javascript.c */; };
+		D7A49642265980C300214818 /* video.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49387265980C100214818 /* video.c */; };
+		D7A49643265980C300214818 /* playloop.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49388265980C100214818 /* playloop.c */; };
+		D7A49644265980C300214818 /* osd.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49389265980C100214818 /* osd.c */; };
+		D7A49645265980C300214818 /* loadfile.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4938A265980C100214818 /* loadfile.c */; };
+		D7A49646265980C300214818 /* lua.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4938B265980C100214818 /* lua.c */; };
+		D7A49647265980C300214818 /* command.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4938C265980C100214818 /* command.c */; };
+		D7A49650265980C300214818 /* client.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49396265980C100214818 /* client.c */; };
+		D7A49651265980C300214818 /* configfiles.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49397265980C100214818 /* configfiles.c */; };
+		D7A49652265980C300214818 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49398265980C100214818 /* main.c */; };
+		D7A49653265980C300214818 /* screenshot.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49399265980C100214818 /* screenshot.c */; };
+		D7A49654265980C300214818 /* external_files.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4939A265980C100214818 /* external_files.c */; };
+		D7A49655265980C300214818 /* sub.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4939C265980C100214818 /* sub.c */; };
+		D7A49657265980C300214818 /* misc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4939F265980C100214818 /* misc.c */; };
+		D7A49658265980C300214818 /* scripting.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A493A0265980C100214818 /* scripting.c */; };
+		D7A49659265980C300214818 /* audio.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A493A1265980C100214818 /* audio.c */; };
+		D7A4965B265980C300214818 /* ta.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A493A4265980C100214818 /* ta.c */; };
+		D7A4965C265980C300214818 /* ta_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A493A5265980C100214818 /* ta_utils.c */; };
+		D7A4965D265980C300214818 /* ta_talloc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A493A6265980C100214818 /* ta_talloc.c */; };
+		D7A496B4265980C400214818 /* gl_video.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49406265980C100214818 /* gl_video.c */; };
+		D7A496B5265980C400214818 /* json.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49407265980C100214818 /* json.c */; };
+		D7A496B6265980C400214818 /* repack.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49408265980C100214818 /* repack.c */; };
+		D7A496BD265980C400214818 /* img_format.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49410265980C100214818 /* img_format.c */; };
+		D7A496BE265980C400214818 /* paths.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49412265980C100214818 /* paths.c */; };
+		D7A496BF265980C400214818 /* chmap.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49414265980C100214818 /* chmap.c */; };
+		D7A496C0265980C400214818 /* scale_sws.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49415265980C100214818 /* scale_sws.c */; };
+		D7A496C1265980C400214818 /* linked_list.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49416265980C100214818 /* linked_list.c */; };
+		D7A496C2265980C400214818 /* tests.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49417265980C100214818 /* tests.c */; };
+		D7A496C4265980C400214818 /* scale_zimg.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49419265980C100214818 /* scale_zimg.c */; };
+		D7A496C5265980C400214818 /* scale_test.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4941A265980C100214818 /* scale_test.c */; };
+		D7A496C9265980C400214818 /* subprocess-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49425265980C100214818 /* subprocess-win.c */; };
+		D7A496CA265980C400214818 /* subprocess-dummy.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49427265980C100214818 /* subprocess-dummy.c */; };
+		D7A496CB265980C400214818 /* main-fn-unix.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49428265980C100214818 /* main-fn-unix.c */; };
+		D7A496CC265980C400214818 /* path-unix.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49429265980C100214818 /* path-unix.c */; };
+		D7A496CD265980C400214818 /* terminal-unix.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4942A265980C100214818 /* terminal-unix.c */; };
+		D7A496CE265980C400214818 /* timer.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4942B265980C100214818 /* timer.c */; };
+		D7A496CF265980C400214818 /* remote_command_center.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4942D265980C100214818 /* remote_command_center.swift */; };
+		D7A496D0265980C400214818 /* log_helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4942E265980C100214818 /* log_helper.swift */; };
+		D7A496D1265980C400214818 /* libmpv_helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4942F265980C100214818 /* libmpv_helper.swift */; };
+		D7A496D2265980C400214818 /* swift_compat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A49430265980C100214818 /* swift_compat.swift */; };
+		D7A496D3265980C400214818 /* mpv_helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A49431265980C100214818 /* mpv_helper.swift */; };
+		D7A496D4265980C400214818 /* swift_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A49432265980C100214818 /* swift_extensions.swift */; };
+		D7A496D6265980C400214818 /* w32_keyboard.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49436265980C100214818 /* w32_keyboard.c */; };
+		D7A496D7265980C400214818 /* main-fn-cocoa.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49437265980C100214818 /* main-fn-cocoa.c */; };
+		D7A496D8265980C400214818 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49438265980C100214818 /* io.c */; };
+		D7A496D9265980C400214818 /* windows_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4943C265980C100214818 /* windows_utils.c */; };
+		D7A496DA265980C400214818 /* subprocess-posix.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4943F265980C100214818 /* subprocess-posix.c */; };
+		D7A496DB265980C400214818 /* terminal-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49442265980C100214818 /* terminal-win.c */; };
+		D7A496DC265980C400214818 /* terminal-dummy.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49444265980C100214818 /* terminal-dummy.c */; };
+		D7A496DD265980C400214818 /* subprocess.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49446265980C100214818 /* subprocess.c */; };
+		D7A496DE265980C400214818 /* timer-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49448265980C100214818 /* timer-linux.c */; };
+		D7A496E0265980C400214818 /* glob-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4944B265980C100214818 /* glob-win.c */; };
+		D7A496E1265980C400214818 /* timer-darwin.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4944C265980C100214818 /* timer-darwin.c */; };
+		D7A496E2265980C400214818 /* path-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4944E265980C100214818 /* path-win.c */; };
+		D7A496E3265980C400214818 /* strnlen.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49450265980C100214818 /* strnlen.c */; };
+		D7A496E4265980C400214818 /* win32-console-wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49454265980C100214818 /* win32-console-wrapper.c */; };
+		D7A496E5265980C400214818 /* macosx_menubar.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A49458265980C100214818 /* macosx_menubar.m */; };
+		D7A496E6265980C400214818 /* path-uwp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49459265980C100214818 /* path-uwp.c */; };
+		D7A496E7265980C400214818 /* macosx_events.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A4945B265980C100214818 /* macosx_events.m */; };
+		D7A496E8265980C400214818 /* path-macosx.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A4945D265980C100214818 /* path-macosx.m */; };
+		D7A496E9265980C400214818 /* pthread.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49461265980C100214818 /* pthread.c */; };
+		D7A496EA265980C400214818 /* macosx_touchbar.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A49465265980C100214818 /* macosx_touchbar.m */; };
+		D7A496EB265980C400214818 /* timer-win2.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49467265980C100214818 /* timer-win2.c */; };
+		D7A496EC265980C400214818 /* main-fn-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49468265980C100214818 /* main-fn-win.c */; };
+		D7A496ED265980C400214818 /* threads.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49469265980C100214818 /* threads.c */; };
+		D7A496EE265980C400214818 /* macosx_application.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A4946A265980C100214818 /* macosx_application.m */; };
+		D7A496EF265980C400214818 /* semaphore_osx.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4946B265980C100214818 /* semaphore_osx.c */; };
+		D7A496F0265980C400214818 /* polldev.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4946C265980C100214818 /* polldev.c */; };
+		D7A496F1265980C400214818 /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49471265980C200214818 /* demux.c */; };
+		D7A496F2265980C400214818 /* demux_timeline.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49472265980C200214818 /* demux_timeline.c */; };
+		D7A496F3265980C400214818 /* demux_mkv_timeline.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49473265980C200214818 /* demux_mkv_timeline.c */; };
+		D7A496F4265980C400214818 /* demux_mf.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49474265980C200214818 /* demux_mf.c */; };
+		D7A496F5265980C400214818 /* demux_playlist.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49476265980C200214818 /* demux_playlist.c */; };
+		D7A496F6265980C400214818 /* demux_mkv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49477265980C200214818 /* demux_mkv.c */; };
+		D7A496F7265980C400214818 /* demux_edl.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49478265980C200214818 /* demux_edl.c */; };
+		D7A496F8265980C400214818 /* packet.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49479265980C200214818 /* packet.c */; };
+		D7A496F9265980C400214818 /* codec_tags.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4947B265980C200214818 /* codec_tags.c */; };
+		D7A496FA265980C400214818 /* demux_lavf.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4947C265980C200214818 /* demux_lavf.c */; };
+		D7A496FB265980C400214818 /* demux_null.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4947D265980C200214818 /* demux_null.c */; };
+		D7A496FC265980C400214818 /* timeline.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4947E265980C200214818 /* timeline.c */; };
+		D7A496FD265980C400214818 /* demux_raw.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4947F265980C200214818 /* demux_raw.c */; };
+		D7A496FE265980C400214818 /* ebml.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49481265980C200214818 /* ebml.c */; };
+		D7A496FF265980C400214818 /* cue.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49483265980C200214818 /* cue.c */; };
+		D7A49700265980C400214818 /* demux_libarchive.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49484265980C200214818 /* demux_libarchive.c */; };
+		D7A49701265980C400214818 /* cache.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49485265980C200214818 /* cache.c */; };
+		D7A49702265980C400214818 /* demux_disc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49487265980C200214818 /* demux_disc.c */; };
+		D7A49703265980C400214818 /* demux_cue.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49489265980C200214818 /* demux_cue.c */; };
+		D7A49706265980C400214818 /* json.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4948F265980C200214818 /* json.c */; };
+		D7A49707265980C400214818 /* jni.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49490265980C200214818 /* jni.c */; };
+		D7A49708265980C400214818 /* dispatch.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49491265980C200214818 /* dispatch.c */; };
+		D7A49709265980C400214818 /* rendezvous.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49492265980C200214818 /* rendezvous.c */; };
+		D7A4970A265980C400214818 /* bstr.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49495265980C200214818 /* bstr.c */; };
+		D7A4970B265980C400214818 /* thread_tools.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4949D265980C200214818 /* thread_tools.c */; };
+		D7A4970C265980C400214818 /* natural_sort.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494A1265980C200214818 /* natural_sort.c */; };
+		D7A4970D265980C400214818 /* thread_pool.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494A2265980C200214818 /* thread_pool.c */; };
+		D7A4970E265980C400214818 /* charset_conv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494A3265980C200214818 /* charset_conv.c */; };
+		D7A4970F265980C400214818 /* node.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494A4265980C200214818 /* node.c */; };
+		D7A4972E265980C400214818 /* iconv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494C7265980C200214818 /* iconv.c */; };
+		D7A4972F265980C400214818 /* coreaudio.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494C8265980C200214818 /* coreaudio.c */; };
+		D7A49730265980C400214818 /* touchbar.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A494C9265980C200214818 /* touchbar.m */; };
+		D7A49731265980C400214818 /* audiounit.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CA265980C200214818 /* audiounit.c */; };
+		D7A49732265980C400214818 /* sse.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CB265980C200214818 /* sse.c */; };
+		D7A49733265980C400214818 /* pthreads.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CC265980C200214818 /* pthreads.c */; };
+		D7A49734265980C400214818 /* wasapi.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CD265980C200214818 /* wasapi.c */; };
+		D7A49735265980C400214818 /* cocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CE265980C200214818 /* cocoa.m */; };
+		D7A49736265980C400214818 /* gl_x11.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A494CF265980C200214818 /* gl_x11.c */; };
+		D7A4978D265980C400214818 /* ass_mp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4952F265980C200214818 /* ass_mp.c */; };
+		D7A4978E265980C400214818 /* osd_libass.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49530265980C200214818 /* osd_libass.c */; };
+		D7A4978F265980C400214818 /* osd.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49531265980C200214818 /* osd.c */; };
+		D7A49790265980C400214818 /* img_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49532265980C200214818 /* img_convert.c */; };
+		D7A49791265980C400214818 /* draw_bmp.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49533265980C200214818 /* draw_bmp.c */; };
+		D7A49792265980C400214818 /* sd_ass.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49534265980C200214818 /* sd_ass.c */; };
+		D7A49793265980C400214818 /* sd_lavc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49535265980C200214818 /* sd_lavc.c */; };
+		D7A49794265980C400214818 /* filter_regex.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49536265980C200214818 /* filter_regex.c */; };
+		D7A49795265980C400214818 /* lavc_conv.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49538265980C200214818 /* lavc_conv.c */; };
+		D7A49796265980C400214818 /* dec_sub.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49539265980C200214818 /* dec_sub.c */; };
+		D7A49797265980C400214818 /* filter_sdh.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4953E265980C200214818 /* filter_sdh.c */; };
+		D7A49799265980C400214818 /* ipc-dummy.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49542265980C200214818 /* ipc-dummy.c */; };
+		D7A4979A265980C400214818 /* ipc-win.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49543265980C200214818 /* ipc-win.c */; };
+		D7A4979B265980C400214818 /* cmd.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49547265980C200214818 /* cmd.c */; };
+		D7A4979C265980C400214818 /* input.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49548265980C200214818 /* input.c */; };
+		D7A4979D265980C400214818 /* event.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A49549265980C200214818 /* event.c */; };
+		D7A4979E265980C400214818 /* keycodes.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4954A265980C200214818 /* keycodes.c */; };
+		D7A4979F265980C400214818 /* ipc.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4954B265980C200214818 /* ipc.c */; };
+		D7A497A0265980C400214818 /* ipc-unix.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4954D265980C200214818 /* ipc-unix.c */; };
+		D7A497A1265980C400214818 /* sdl_gamepad.c in Sources */ = {isa = PBXBuildFile; fileRef = D7A4954E265980C200214818 /* sdl_gamepad.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		D7A491FB265980C000214818 /* Copyright */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Copyright; sourceTree = "<group>"; };
+		D7A491FD265980C000214818 /* stream_cdda.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_cdda.c; sourceTree = "<group>"; };
+		D7A491FE265980C000214818 /* stream_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_memory.c; sourceTree = "<group>"; };
+		D7A491FF265980C000214818 /* stream_dvb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_dvb.c; sourceTree = "<group>"; };
+		D7A49200265980C000214818 /* dvbin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dvbin.h; sourceTree = "<group>"; };
+		D7A49201265980C000214818 /* stream_dvdnav.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_dvdnav.c; sourceTree = "<group>"; };
+		D7A49202265980C000214818 /* stream_avdevice.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_avdevice.c; sourceTree = "<group>"; };
+		D7A49203265980C000214818 /* stream_slice.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_slice.c; sourceTree = "<group>"; };
+		D7A49204265980C000214818 /* stream_libarchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream_libarchive.h; sourceTree = "<group>"; };
+		D7A49205265980C000214818 /* dvb_tune.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dvb_tune.h; sourceTree = "<group>"; };
+		D7A49206265980C000214818 /* stream_edl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_edl.c; sourceTree = "<group>"; };
+		D7A49207265980C000214818 /* cookies.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cookies.c; sourceTree = "<group>"; };
+		D7A49208265980C000214818 /* stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream.h; sourceTree = "<group>"; };
+		D7A49209265980C000214818 /* stream_cb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_cb.c; sourceTree = "<group>"; };
+		D7A4920A265980C000214818 /* stream_bluray.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_bluray.c; sourceTree = "<group>"; };
+		D7A4920B265980C000214818 /* stream_lavf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_lavf.c; sourceTree = "<group>"; };
+		D7A4920C265980C000214818 /* cookies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cookies.h; sourceTree = "<group>"; };
+		D7A4920D265980C000214818 /* stream_null.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_null.c; sourceTree = "<group>"; };
+		D7A4920E265980C000214818 /* stream_concat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_concat.c; sourceTree = "<group>"; };
+		D7A4920F265980C000214818 /* stream_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_file.c; sourceTree = "<group>"; };
+		D7A49210265980C000214818 /* dvb_tune.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dvb_tune.c; sourceTree = "<group>"; };
+		D7A49211265980C000214818 /* stream_libarchive.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_libarchive.c; sourceTree = "<group>"; };
+		D7A49212265980C000214818 /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
+		D7A49213265980C000214818 /* stream_mf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream_mf.c; sourceTree = "<group>"; };
+		D7A49215265980C000214818 /* f_decoder_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_decoder_wrapper.h; sourceTree = "<group>"; };
+		D7A49216265980C000214818 /* f_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_utils.c; sourceTree = "<group>"; };
+		D7A49217265980C000214818 /* f_async_queue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_async_queue.c; sourceTree = "<group>"; };
+		D7A49218265980C000214818 /* f_auto_filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_auto_filters.c; sourceTree = "<group>"; };
+		D7A49219265980C000214818 /* f_autoconvert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_autoconvert.h; sourceTree = "<group>"; };
+		D7A4921A265980C000214818 /* f_hwtransfer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_hwtransfer.c; sourceTree = "<group>"; };
+		D7A4921B265980C000214818 /* f_demux_in.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_demux_in.h; sourceTree = "<group>"; };
+		D7A4921C265980C000214818 /* f_lavfi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_lavfi.c; sourceTree = "<group>"; };
+		D7A4921D265980C000214818 /* user_filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = user_filters.h; sourceTree = "<group>"; };
+		D7A4921E265980C000214818 /* f_swresample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_swresample.h; sourceTree = "<group>"; };
+		D7A4921F265980C000214818 /* frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame.h; sourceTree = "<group>"; };
+		D7A49220265980C000214818 /* filter_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter_internal.h; sourceTree = "<group>"; };
+		D7A49221265980C000214818 /* f_swscale.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_swscale.c; sourceTree = "<group>"; };
+		D7A49222265980C000214818 /* f_output_chain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_output_chain.c; sourceTree = "<group>"; };
+		D7A49223265980C000214818 /* filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter.c; sourceTree = "<group>"; };
+		D7A49224265980C000214818 /* f_auto_filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_auto_filters.h; sourceTree = "<group>"; };
+		D7A49225265980C000214818 /* f_autoconvert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_autoconvert.c; sourceTree = "<group>"; };
+		D7A49226265980C000214818 /* f_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_utils.h; sourceTree = "<group>"; };
+		D7A49227265980C000214818 /* f_async_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_async_queue.h; sourceTree = "<group>"; };
+		D7A49228265980C000214818 /* f_decoder_wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_decoder_wrapper.c; sourceTree = "<group>"; };
+		D7A49229265980C000214818 /* f_lavfi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_lavfi.h; sourceTree = "<group>"; };
+		D7A4922A265980C000214818 /* f_demux_in.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_demux_in.c; sourceTree = "<group>"; };
+		D7A4922B265980C000214818 /* f_hwtransfer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_hwtransfer.h; sourceTree = "<group>"; };
+		D7A4922C265980C000214818 /* frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
+		D7A4922D265980C000214818 /* f_swresample.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = f_swresample.c; sourceTree = "<group>"; };
+		D7A4922E265980C000214818 /* user_filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = user_filters.c; sourceTree = "<group>"; };
+		D7A4922F265980C000214818 /* filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter.h; sourceTree = "<group>"; };
+		D7A49230265980C000214818 /* f_output_chain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_output_chain.h; sourceTree = "<group>"; };
+		D7A49231265980C000214818 /* f_swscale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = f_swscale.h; sourceTree = "<group>"; };
+		D7A49232265980C000214818 /* appveyor.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = appveyor.yml; sourceTree = "<group>"; };
+		D7A49237265980C000214818 /* m_property.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = m_property.h; sourceTree = "<group>"; };
+		D7A49238265980C000214818 /* m_option.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = m_option.h; sourceTree = "<group>"; };
+		D7A49239265980C000214818 /* parse_configfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parse_configfile.h; sourceTree = "<group>"; };
+		D7A4923A265980C000214818 /* m_config_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_config_core.c; sourceTree = "<group>"; };
+		D7A4923B265980C000214818 /* path.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = path.h; sourceTree = "<group>"; };
+		D7A4923C265980C000214818 /* parse_commandline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = parse_commandline.c; sourceTree = "<group>"; };
+		D7A4923D265980C000214818 /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = options.h; sourceTree = "<group>"; };
+		D7A4923E265980C000214818 /* m_config_frontend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = m_config_frontend.h; sourceTree = "<group>"; };
+		D7A4923F265980C000214818 /* m_option.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_option.c; sourceTree = "<group>"; };
+		D7A49240265980C000214818 /* m_property.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_property.c; sourceTree = "<group>"; };
+		D7A49241265980C000214818 /* m_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = m_config.h; sourceTree = "<group>"; };
+		D7A49242265980C000214818 /* path.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = path.c; sourceTree = "<group>"; };
+		D7A49243265980C000214818 /* parse_configfile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = parse_configfile.c; sourceTree = "<group>"; };
+		D7A49244265980C000214818 /* m_config_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = m_config_core.h; sourceTree = "<group>"; };
+		D7A49245265980C000214818 /* m_config_frontend.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = m_config_frontend.c; sourceTree = "<group>"; };
+		D7A49246265980C000214818 /* options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = options.c; sourceTree = "<group>"; };
+		D7A49247265980C000214818 /* parse_commandline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parse_commandline.h; sourceTree = "<group>"; };
+		D7A49248265980C000214818 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VERSION; sourceTree = "<group>"; };
+		D7A4924A265980C000214818 /* mpv-icon-8bit-16x16.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "mpv-icon-8bit-16x16.png"; sourceTree = "<group>"; };
+		D7A4924B265980C000214818 /* mpv.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.conf; sourceTree = "<group>"; };
+		D7A4924C265980C000214818 /* mpv.desktop */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.desktop; sourceTree = "<group>"; };
+		D7A4924D265980C000214818 /* input.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = input.conf; sourceTree = "<group>"; };
+		D7A4924E265980C000214818 /* encoding-profiles.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "encoding-profiles.conf"; sourceTree = "<group>"; };
+		D7A4924F265980C000214818 /* mpv.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = mpv.svg; sourceTree = "<group>"; };
+		D7A49250265980C000214818 /* mpv.bash-completion */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "mpv.bash-completion"; sourceTree = "<group>"; };
+		D7A49251265980C000214818 /* builtin.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = builtin.conf; sourceTree = "<group>"; };
+		D7A49252265980C000214818 /* _mpv.zsh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = _mpv.zsh; sourceTree = "<group>"; };
+		D7A49253265980C000214818 /* restore-old-bindings.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "restore-old-bindings.conf"; sourceTree = "<group>"; };
+		D7A49254265980C000214818 /* mpv-icon-8bit-128x128.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "mpv-icon-8bit-128x128.png"; sourceTree = "<group>"; };
+		D7A49255265980C000214818 /* mpv-gradient.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "mpv-gradient.svg"; sourceTree = "<group>"; };
+		D7A49256265980C000214818 /* mplayer-input.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "mplayer-input.conf"; sourceTree = "<group>"; };
+		D7A49257265980C000214818 /* mpv-icon-8bit-64x64.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "mpv-icon-8bit-64x64.png"; sourceTree = "<group>"; };
+		D7A49258265980C000214818 /* mpv-icon.ico */ = {isa = PBXFileReference; lastKnownFileType = image.ico; path = "mpv-icon.ico"; sourceTree = "<group>"; };
+		D7A49259265980C000214818 /* mpv-symbolic.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "mpv-symbolic.svg"; sourceTree = "<group>"; };
+		D7A4925A265980C000214818 /* mpv-icon-8bit-32x32.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "mpv-icon-8bit-32x32.png"; sourceTree = "<group>"; };
+		D7A4925C265980C000214818 /* aframe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aframe.c; sourceTree = "<group>"; };
+		D7A4925E265980C000214818 /* ao_null.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_null.c; sourceTree = "<group>"; };
+		D7A4925F265980C000214818 /* ao_coreaudio_exclusive.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_coreaudio_exclusive.c; sourceTree = "<group>"; };
+		D7A49260265980C000214818 /* ao_wasapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_wasapi.c; sourceTree = "<group>"; };
+		D7A49261265980C000214818 /* buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
+		D7A49262265980C000214818 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		D7A49263265980C000214818 /* ao_audiounit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ao_audiounit.m; sourceTree = "<group>"; };
+		D7A49264265980C000214818 /* ao_coreaudio_chmap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ao_coreaudio_chmap.h; sourceTree = "<group>"; };
+		D7A49265265980C000214818 /* ao_wasapi_changenotify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_wasapi_changenotify.c; sourceTree = "<group>"; };
+		D7A49266265980C000214818 /* ao.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ao.h; sourceTree = "<group>"; };
+		D7A49267265980C000214818 /* ao_pulse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_pulse.c; sourceTree = "<group>"; };
+		D7A49268265980C000214818 /* ao_coreaudio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_coreaudio.c; sourceTree = "<group>"; };
+		D7A49269265980C000214818 /* ao_oss.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_oss.c; sourceTree = "<group>"; };
+		D7A4926A265980C000214818 /* ao_coreaudio_properties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ao_coreaudio_properties.h; sourceTree = "<group>"; };
+		D7A4926B265980C000214818 /* ao_coreaudio_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_coreaudio_utils.c; sourceTree = "<group>"; };
+		D7A4926C265980C000214818 /* ao_opensles.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_opensles.c; sourceTree = "<group>"; };
+		D7A4926D265980C000214818 /* ao_wasapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ao_wasapi.h; sourceTree = "<group>"; };
+		D7A4926E265980C000214818 /* ao_sdl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_sdl.c; sourceTree = "<group>"; };
+		D7A4926F265980C000214818 /* ao_alsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_alsa.c; sourceTree = "<group>"; };
+		D7A49270265980C000214818 /* ao_wasapi_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_wasapi_utils.c; sourceTree = "<group>"; };
+		D7A49271265980C000214818 /* ao_openal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_openal.c; sourceTree = "<group>"; };
+		D7A49272265980C000214818 /* ao.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao.c; sourceTree = "<group>"; };
+		D7A49273265980C000214818 /* ao_pcm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_pcm.c; sourceTree = "<group>"; };
+		D7A49274265980C000214818 /* ao_coreaudio_chmap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_coreaudio_chmap.c; sourceTree = "<group>"; };
+		D7A49275265980C000214818 /* ao_jack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_jack.c; sourceTree = "<group>"; };
+		D7A49276265980C000214818 /* ao_coreaudio_properties.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_coreaudio_properties.c; sourceTree = "<group>"; };
+		D7A49277265980C000214818 /* ao_audiotrack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_audiotrack.c; sourceTree = "<group>"; };
+		D7A49278265980C000214818 /* ao_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ao_lavc.c; sourceTree = "<group>"; };
+		D7A49279265980C000214818 /* ao_coreaudio_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ao_coreaudio_utils.h; sourceTree = "<group>"; };
+		D7A4927A265980C000214818 /* chmap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chmap.c; sourceTree = "<group>"; };
+		D7A4927B265980C000214818 /* format.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = format.c; sourceTree = "<group>"; };
+		D7A4927C265980C000214818 /* fmt-conversion.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "fmt-conversion.c"; sourceTree = "<group>"; };
+		D7A4927D265980C000214818 /* chmap_sel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chmap_sel.h; sourceTree = "<group>"; };
+		D7A4927F265980C000214818 /* ad_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ad_lavc.c; sourceTree = "<group>"; };
+		D7A49280265980C000214818 /* ad_spdif.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ad_spdif.c; sourceTree = "<group>"; };
+		D7A49281265980C000214818 /* aframe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aframe.h; sourceTree = "<group>"; };
+		D7A49282265980C000214818 /* fmt-conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "fmt-conversion.h"; sourceTree = "<group>"; };
+		D7A49284265980C000214818 /* af_lavcac3enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_lavcac3enc.c; sourceTree = "<group>"; };
+		D7A49285265980C000214818 /* af_format.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_format.c; sourceTree = "<group>"; };
+		D7A49286265980C000214818 /* af_scaletempo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_scaletempo.c; sourceTree = "<group>"; };
+		D7A49287265980C000214818 /* af_drop.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_drop.c; sourceTree = "<group>"; };
+		D7A49288265980C000214818 /* af_scaletempo2_internals.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_scaletempo2_internals.c; sourceTree = "<group>"; };
+		D7A49289265980C000214818 /* af_scaletempo2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_scaletempo2.c; sourceTree = "<group>"; };
+		D7A4928A265980C000214818 /* af_rubberband.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = af_rubberband.c; sourceTree = "<group>"; };
+		D7A4928B265980C000214818 /* af_scaletempo2_internals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = af_scaletempo2_internals.h; sourceTree = "<group>"; };
+		D7A4928C265980C000214818 /* chmap_sel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chmap_sel.c; sourceTree = "<group>"; };
+		D7A4928D265980C000214818 /* format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = format.h; sourceTree = "<group>"; };
+		D7A4928E265980C000214818 /* chmap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chmap.h; sourceTree = "<group>"; };
+		D7A4928F265980C000214818 /* wscript */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wscript; sourceTree = "<group>"; };
+		D7A49291265980C000214818 /* codecs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = codecs.c; sourceTree = "<group>"; };
+		D7A49292265980C000214818 /* common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common.c; sourceTree = "<group>"; };
+		D7A49293265980C000214818 /* av_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = av_common.h; sourceTree = "<group>"; };
+		D7A49294265980C000214818 /* msg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = msg.c; sourceTree = "<group>"; };
+		D7A49295265980C000214818 /* recorder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = recorder.c; sourceTree = "<group>"; };
+		D7A49296265980C000214818 /* encode_lavc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode_lavc.h; sourceTree = "<group>"; };
+		D7A49297265980C000214818 /* tags.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tags.c; sourceTree = "<group>"; };
+		D7A49298265980C000214818 /* global.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = global.h; sourceTree = "<group>"; };
+		D7A49299265980C000214818 /* playlist.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = playlist.c; sourceTree = "<group>"; };
+		D7A4929A265980C000214818 /* stats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stats.c; sourceTree = "<group>"; };
+		D7A4929B265980C000214818 /* av_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = av_log.h; sourceTree = "<group>"; };
+		D7A4929C265980C000214818 /* msg_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = msg_control.h; sourceTree = "<group>"; };
+		D7A4929D265980C000214818 /* recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recorder.h; sourceTree = "<group>"; };
+		D7A4929E265980C000214818 /* av_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = av_common.c; sourceTree = "<group>"; };
+		D7A4929F265980C000214818 /* msg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = msg.h; sourceTree = "<group>"; };
+		D7A492A0265980C000214818 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		D7A492A1265980C000214818 /* codecs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codecs.h; sourceTree = "<group>"; };
+		D7A492A2265980C000214818 /* version.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = version.c; sourceTree = "<group>"; };
+		D7A492A3265980C000214818 /* encode_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encode_lavc.c; sourceTree = "<group>"; };
+		D7A492A4265980C000214818 /* tags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tags.h; sourceTree = "<group>"; };
+		D7A492A5265980C000214818 /* stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stats.h; sourceTree = "<group>"; };
+		D7A492A6265980C000214818 /* av_log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = av_log.c; sourceTree = "<group>"; };
+		D7A492A7265980C000214818 /* encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode.h; sourceTree = "<group>"; };
+		D7A492A8265980C000214818 /* playlist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playlist.h; sourceTree = "<group>"; };
+		D7A492A9265980C000214818 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		D7A492AA265980C000214818 /* bootstrap.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = bootstrap.py; sourceTree = "<group>"; };
+		D7A492AC265980C000214818 /* repack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = repack.c; sourceTree = "<group>"; };
+		D7A492AD265980C000214818 /* image_loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = image_loader.h; sourceTree = "<group>"; };
+		D7A492AE265980C000214818 /* sws_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sws_utils.h; sourceTree = "<group>"; };
+		D7A492AF265980C000214818 /* img_format.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = img_format.c; sourceTree = "<group>"; };
+		D7A492B0265980C000214818 /* vdpau.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vdpau.h; sourceTree = "<group>"; };
+		D7A492B1265980C000214818 /* hwdec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hwdec.h; sourceTree = "<group>"; };
+		D7A492B2265980C000214818 /* mp_image_pool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mp_image_pool.c; sourceTree = "<group>"; };
+		D7A492B3265980C000214818 /* image_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = image_writer.h; sourceTree = "<group>"; };
+		D7A492B4265980C000214818 /* vaapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vaapi.h; sourceTree = "<group>"; };
+		D7A492B6265980C000214818 /* drm_prime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = drm_prime.h; sourceTree = "<group>"; };
+		D7A492B7265980C000214818 /* vo_xv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_xv.c; sourceTree = "<group>"; };
+		D7A492B8265980C000214818 /* x11_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x11_common.h; sourceTree = "<group>"; };
+		D7A492B9265980C000214818 /* drm_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = drm_common.c; sourceTree = "<group>"; };
+		D7A492BA265980C000214818 /* bitmap_packer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitmap_packer.h; sourceTree = "<group>"; };
+		D7A492BB265980C000214818 /* wayland_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wayland_common.h; sourceTree = "<group>"; };
+		D7A492BD265980C000214818 /* error_diffusion.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = error_diffusion.c; sourceTree = "<group>"; };
+		D7A492BE265980C000214818 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		D7A492BF265980C000214818 /* shader_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shader_cache.h; sourceTree = "<group>"; };
+		D7A492C0265980C000214818 /* d3d11_helpers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = d3d11_helpers.c; sourceTree = "<group>"; };
+		D7A492C1265980C000214818 /* hwdec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hwdec.h; sourceTree = "<group>"; };
+		D7A492C2265980C000214818 /* video.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = video.c; sourceTree = "<group>"; };
+		D7A492C3265980C000214818 /* spirv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spirv.c; sourceTree = "<group>"; };
+		D7A492C4265980C000214818 /* osd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = osd.c; sourceTree = "<group>"; };
+		D7A492C5265980C000214818 /* user_shaders.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = user_shaders.c; sourceTree = "<group>"; };
+		D7A492C6265980C000214818 /* spirv_shaderc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spirv_shaderc.c; sourceTree = "<group>"; };
+		D7A492C7265980C000214818 /* ra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ra.h; sourceTree = "<group>"; };
+		D7A492C8265980C000214818 /* libmpv_gpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = libmpv_gpu.c; sourceTree = "<group>"; };
+		D7A492C9265980C000214818 /* lcms.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcms.c; sourceTree = "<group>"; };
+		D7A492CA265980C000214818 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		D7A492CB265980C000214818 /* video_shaders.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = video_shaders.c; sourceTree = "<group>"; };
+		D7A492CC265980C000214818 /* shader_cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shader_cache.c; sourceTree = "<group>"; };
+		D7A492CD265980C000214818 /* error_diffusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error_diffusion.h; sourceTree = "<group>"; };
+		D7A492CE265980C000214818 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
+		D7A492CF265980C000214818 /* spirv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv.h; sourceTree = "<group>"; };
+		D7A492D0265980C000214818 /* video.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video.h; sourceTree = "<group>"; };
+		D7A492D1265980C000214818 /* hwdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec.c; sourceTree = "<group>"; };
+		D7A492D2265980C000214818 /* d3d11_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = d3d11_helpers.h; sourceTree = "<group>"; };
+		D7A492D3265980C000214818 /* context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context.c; sourceTree = "<group>"; };
+		D7A492D4265980C000214818 /* libmpv_gpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libmpv_gpu.h; sourceTree = "<group>"; };
+		D7A492D5265980C000214818 /* lcms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcms.h; sourceTree = "<group>"; };
+		D7A492D6265980C000214818 /* ra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ra.c; sourceTree = "<group>"; };
+		D7A492D7265980C000214818 /* user_shaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = user_shaders.h; sourceTree = "<group>"; };
+		D7A492D8265980C000214818 /* osd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = osd.h; sourceTree = "<group>"; };
+		D7A492D9265980C000214818 /* video_shaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_shaders.h; sourceTree = "<group>"; };
+		D7A492DA265980C000214818 /* aspect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aspect.c; sourceTree = "<group>"; };
+		D7A492DB265980C000214818 /* vo_vdpau.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_vdpau.c; sourceTree = "<group>"; };
+		D7A492DC265980C000214818 /* dither.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dither.h; sourceTree = "<group>"; };
+		D7A492DD265980C000214818 /* libmpv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libmpv.h; sourceTree = "<group>"; };
+		D7A492DE265980C000214818 /* vo_sdl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_sdl.c; sourceTree = "<group>"; };
+		D7A492DF265980C000214818 /* filter_kernels.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_kernels.c; sourceTree = "<group>"; };
+		D7A492E0265980C000214818 /* dr_helper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dr_helper.c; sourceTree = "<group>"; };
+		D7A492E1265980C000214818 /* libmpv_sw.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = libmpv_sw.c; sourceTree = "<group>"; };
+		D7A492E3265980C000214818 /* ra_d3d11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ra_d3d11.h; sourceTree = "<group>"; };
+		D7A492E4265980C000214818 /* ra_d3d11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ra_d3d11.c; sourceTree = "<group>"; };
+		D7A492E5265980C000214818 /* hwdec_d3d11va.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_d3d11va.c; sourceTree = "<group>"; };
+		D7A492E6265980C000214818 /* hwdec_dxva2dxgi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_dxva2dxgi.c; sourceTree = "<group>"; };
+		D7A492E7265980C000214818 /* context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context.c; sourceTree = "<group>"; };
+		D7A492E8265980C000214818 /* vo_vaapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_vaapi.c; sourceTree = "<group>"; };
+		D7A492E9265980C000214818 /* vo_x11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_x11.c; sourceTree = "<group>"; };
+		D7A492EB265980C000214818 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		D7A492EC265980C000214818 /* ra_pl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ra_pl.h; sourceTree = "<group>"; };
+		D7A492ED265980C100214818 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
+		D7A492EE265980C100214818 /* ra_pl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ra_pl.c; sourceTree = "<group>"; };
+		D7A492EF265980C100214818 /* android_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = android_common.c; sourceTree = "<group>"; };
+		D7A492F0265980C100214818 /* vo_sixel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_sixel.c; sourceTree = "<group>"; };
+		D7A492F1265980C100214818 /* cocoa_common.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa_common.m; sourceTree = "<group>"; };
+		D7A492F2265980C100214818 /* vo_gpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_gpu.c; sourceTree = "<group>"; };
+		D7A492F3265980C100214818 /* vo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vo.h; sourceTree = "<group>"; };
+		D7A492F4265980C100214818 /* vo_null.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_null.c; sourceTree = "<group>"; };
+		D7A492F5265980C100214818 /* vo_wlshm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_wlshm.c; sourceTree = "<group>"; };
+		D7A492F6265980C100214818 /* vo_caca.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_caca.c; sourceTree = "<group>"; };
+		D7A492F7265980C100214818 /* drm_atomic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = drm_atomic.c; sourceTree = "<group>"; };
+		D7A492F8265980C100214818 /* vo_rpi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_rpi.c; sourceTree = "<group>"; };
+		D7A492F9265980C100214818 /* win_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = win_state.h; sourceTree = "<group>"; };
+		D7A492FA265980C100214818 /* w32_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = w32_common.h; sourceTree = "<group>"; };
+		D7A492FC265980C100214818 /* hwdec_vaapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hwdec_vaapi.h; sourceTree = "<group>"; };
+		D7A492FD265980C100214818 /* hwdec_vaapi_vk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_vaapi_vk.c; sourceTree = "<group>"; };
+		D7A492FE265980C100214818 /* hwdec_cuda_gl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_cuda_gl.c; sourceTree = "<group>"; };
+		D7A492FF265980C100214818 /* hwdec_cuda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hwdec_cuda.h; sourceTree = "<group>"; };
+		D7A49300265980C100214818 /* hwdec_vaapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_vaapi.c; sourceTree = "<group>"; };
+		D7A49301265980C100214818 /* hwdec_cuda.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_cuda.c; sourceTree = "<group>"; };
+		D7A49302265980C100214818 /* hwdec_cuda_vk.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_cuda_vk.c; sourceTree = "<group>"; };
+		D7A49303265980C100214818 /* hwdec_vaapi_gl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_vaapi_gl.c; sourceTree = "<group>"; };
+		D7A49304265980C100214818 /* drm_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = drm_common.h; sourceTree = "<group>"; };
+		D7A49305265980C100214818 /* wayland_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wayland_common.c; sourceTree = "<group>"; };
+		D7A49306265980C100214818 /* bitmap_packer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bitmap_packer.c; sourceTree = "<group>"; };
+		D7A49307265980C100214818 /* x11_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x11_common.c; sourceTree = "<group>"; };
+		D7A49309265980C100214818 /* view.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = view.swift; sourceTree = "<group>"; };
+		D7A4930A265980C100214818 /* common.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = common.swift; sourceTree = "<group>"; };
+		D7A4930B265980C100214818 /* title_bar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = title_bar.swift; sourceTree = "<group>"; };
+		D7A4930C265980C100214818 /* window.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = window.swift; sourceTree = "<group>"; };
+		D7A4930D265980C100214818 /* gl_layer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = gl_layer.swift; sourceTree = "<group>"; };
+		D7A4930F265980C100214818 /* video_view.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = video_view.m; sourceTree = "<group>"; };
+		D7A49310265980C100214818 /* window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = window.h; sourceTree = "<group>"; };
+		D7A49311265980C100214818 /* events_view.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = events_view.m; sourceTree = "<group>"; };
+		D7A49312265980C100214818 /* mpvadapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpvadapter.h; sourceTree = "<group>"; };
+		D7A49313265980C100214818 /* video_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_view.h; sourceTree = "<group>"; };
+		D7A49314265980C100214818 /* window.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = window.m; sourceTree = "<group>"; };
+		D7A49315265980C100214818 /* events_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = events_view.h; sourceTree = "<group>"; };
+		D7A49316265980C100214818 /* drm_prime.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = drm_prime.c; sourceTree = "<group>"; };
+		D7A49317265980C100214818 /* vo_direct3d.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_direct3d.c; sourceTree = "<group>"; };
+		D7A49318265980C100214818 /* dr_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dr_helper.h; sourceTree = "<group>"; };
+		D7A4931A265980C100214818 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		D7A4931B265980C100214818 /* context_xlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_xlib.c; sourceTree = "<group>"; };
+		D7A4931C265980C100214818 /* context_android.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_android.c; sourceTree = "<group>"; };
+		D7A4931D265980C100214818 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		D7A4931E265980C100214818 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
+		D7A4931F265980C100214818 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		D7A49320265980C100214818 /* context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context.c; sourceTree = "<group>"; };
+		D7A49321265980C100214818 /* context_win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_win.c; sourceTree = "<group>"; };
+		D7A49322265980C100214818 /* context_wayland.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_wayland.c; sourceTree = "<group>"; };
+		D7A49323265980C100214818 /* filter_kernels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter_kernels.h; sourceTree = "<group>"; };
+		D7A49324265980C100214818 /* vo_drm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_drm.c; sourceTree = "<group>"; };
+		D7A49325265980C100214818 /* dither.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dither.c; sourceTree = "<group>"; };
+		D7A49326265980C100214818 /* aspect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aspect.h; sourceTree = "<group>"; };
+		D7A49327265980C100214818 /* vo_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_lavc.c; sourceTree = "<group>"; };
+		D7A49328265980C100214818 /* vo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo.c; sourceTree = "<group>"; };
+		D7A49329265980C100214818 /* cocoa_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cocoa_common.h; sourceTree = "<group>"; };
+		D7A4932A265980C100214818 /* android_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = android_common.h; sourceTree = "<group>"; };
+		D7A4932C265980C100214818 /* droptarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = droptarget.h; sourceTree = "<group>"; };
+		D7A4932D265980C100214818 /* displayconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = displayconfig.h; sourceTree = "<group>"; };
+		D7A4932E265980C100214818 /* droptarget.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = droptarget.c; sourceTree = "<group>"; };
+		D7A4932F265980C100214818 /* displayconfig.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = displayconfig.c; sourceTree = "<group>"; };
+		D7A49330265980C100214818 /* vo_tct.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_tct.c; sourceTree = "<group>"; };
+		D7A49331265980C100214818 /* cocoa_cb_common.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = cocoa_cb_common.swift; sourceTree = "<group>"; };
+		D7A49332265980C100214818 /* vo_mediacodec_embed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_mediacodec_embed.c; sourceTree = "<group>"; };
+		D7A49333265980C100214818 /* vo_image.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_image.c; sourceTree = "<group>"; };
+		D7A49334265980C100214818 /* drm_atomic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = drm_atomic.h; sourceTree = "<group>"; };
+		D7A49335265980C100214818 /* vo_libmpv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vo_libmpv.c; sourceTree = "<group>"; };
+		D7A49336265980C100214818 /* win_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = win_state.c; sourceTree = "<group>"; };
+		D7A49337265980C100214818 /* w32_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = w32_common.c; sourceTree = "<group>"; };
+		D7A49339265980C100214818 /* hwdec_rpi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_rpi.c; sourceTree = "<group>"; };
+		D7A4933A265980C100214818 /* hwdec_d3d11egl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_d3d11egl.c; sourceTree = "<group>"; };
+		D7A4933B265980C100214818 /* context_dxinterop.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_dxinterop.c; sourceTree = "<group>"; };
+		D7A4933C265980C100214818 /* common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common.c; sourceTree = "<group>"; };
+		D7A4933D265980C100214818 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		D7A4933E265980C100214818 /* egl_helpers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = egl_helpers.c; sourceTree = "<group>"; };
+		D7A4933F265980C100214818 /* formats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = formats.h; sourceTree = "<group>"; };
+		D7A49340265980C100214818 /* angle_dynamic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = angle_dynamic.c; sourceTree = "<group>"; };
+		D7A49341265980C100214818 /* ra_gl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ra_gl.h; sourceTree = "<group>"; };
+		D7A49342265980C100214818 /* context_cocoa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_cocoa.c; sourceTree = "<group>"; };
+		D7A49343265980C100214818 /* context_android.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_android.c; sourceTree = "<group>"; };
+		D7A49344265980C100214818 /* hwdec_osx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_osx.c; sourceTree = "<group>"; };
+		D7A49345265980C100214818 /* context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = context.h; sourceTree = "<group>"; };
+		D7A49346265980C100214818 /* oml_sync.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = oml_sync.c; sourceTree = "<group>"; };
+		D7A49347265980C100214818 /* egl_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = egl_helpers.h; sourceTree = "<group>"; };
+		D7A49348265980C100214818 /* hwdec_drmprime_drm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_drmprime_drm.c; sourceTree = "<group>"; };
+		D7A49349265980C100214818 /* hwdec_vdpau.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_vdpau.c; sourceTree = "<group>"; };
+		D7A4934A265980C100214818 /* context_drm_egl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_drm_egl.c; sourceTree = "<group>"; };
+		D7A4934B265980C100214818 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
+		D7A4934C265980C100214818 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		D7A4934D265980C100214818 /* context_x11egl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_x11egl.c; sourceTree = "<group>"; };
+		D7A4934E265980C100214818 /* hwdec_dxva2egl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_dxva2egl.c; sourceTree = "<group>"; };
+		D7A4934F265980C100214818 /* hwdec_ios.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = hwdec_ios.m; sourceTree = "<group>"; };
+		D7A49350265980C100214818 /* angle_dynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = angle_dynamic.h; sourceTree = "<group>"; };
+		D7A49351265980C100214818 /* ra_gl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ra_gl.c; sourceTree = "<group>"; };
+		D7A49352265980C100214818 /* context_rpi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_rpi.c; sourceTree = "<group>"; };
+		D7A49353265980C100214818 /* formats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = formats.c; sourceTree = "<group>"; };
+		D7A49354265980C100214818 /* context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context.c; sourceTree = "<group>"; };
+		D7A49355265980C100214818 /* hwdec_dxva2gldx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec_dxva2gldx.c; sourceTree = "<group>"; };
+		D7A49356265980C100214818 /* libmpv_gl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = libmpv_gl.c; sourceTree = "<group>"; };
+		D7A49357265980C100214818 /* context_glx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_glx.c; sourceTree = "<group>"; };
+		D7A49358265980C100214818 /* context_angle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_angle.c; sourceTree = "<group>"; };
+		D7A49359265980C100214818 /* gl_headers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_headers.h; sourceTree = "<group>"; };
+		D7A4935A265980C100214818 /* context_win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_win.c; sourceTree = "<group>"; };
+		D7A4935B265980C100214818 /* context_wayland.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = context_wayland.c; sourceTree = "<group>"; };
+		D7A4935C265980C100214818 /* oml_sync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = oml_sync.h; sourceTree = "<group>"; };
+		D7A4935D265980C100214818 /* cuda.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cuda.c; sourceTree = "<group>"; };
+		D7A4935E265980C100214818 /* mp_image.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mp_image.c; sourceTree = "<group>"; };
+		D7A4935F265980C100214818 /* vdpau_mixer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vdpau_mixer.c; sourceTree = "<group>"; };
+		D7A49360265980C100214818 /* fmt-conversion.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "fmt-conversion.c"; sourceTree = "<group>"; };
+		D7A49361265980C100214818 /* zimg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zimg.h; sourceTree = "<group>"; };
+		D7A49362265980C100214818 /* d3d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = d3d.h; sourceTree = "<group>"; };
+		D7A49363265980C100214818 /* csputils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = csputils.h; sourceTree = "<group>"; };
+		D7A49364265980C100214818 /* sws_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sws_utils.c; sourceTree = "<group>"; };
+		D7A49365265980C100214818 /* image_loader.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = image_loader.c; sourceTree = "<group>"; };
+		D7A49367265980C100214818 /* vd_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vd_lavc.c; sourceTree = "<group>"; };
+		D7A49368265980C100214818 /* repack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = repack.h; sourceTree = "<group>"; };
+		D7A49369265980C100214818 /* vaapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vaapi.c; sourceTree = "<group>"; };
+		D7A4936A265980C100214818 /* vdpau_functions.inc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.pascal; path = vdpau_functions.inc; sourceTree = "<group>"; };
+		D7A4936B265980C100214818 /* mp_image_pool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mp_image_pool.h; sourceTree = "<group>"; };
+		D7A4936C265980C100214818 /* image_writer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = image_writer.c; sourceTree = "<group>"; };
+		D7A4936D265980C100214818 /* vdpau.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vdpau.c; sourceTree = "<group>"; };
+		D7A4936E265980C100214818 /* img_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = img_format.h; sourceTree = "<group>"; };
+		D7A4936F265980C100214818 /* hwdec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hwdec.c; sourceTree = "<group>"; };
+		D7A49370265980C100214818 /* zimg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = zimg.c; sourceTree = "<group>"; };
+		D7A49371265980C100214818 /* fmt-conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "fmt-conversion.h"; sourceTree = "<group>"; };
+		D7A49373265980C100214818 /* vf_sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_sub.c; sourceTree = "<group>"; };
+		D7A49374265980C100214818 /* refqueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = refqueue.h; sourceTree = "<group>"; };
+		D7A49375265980C100214818 /* vf_vdpaupp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_vdpaupp.c; sourceTree = "<group>"; };
+		D7A49376265980C100214818 /* vf_d3d11vpp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_d3d11vpp.c; sourceTree = "<group>"; };
+		D7A49377265980C100214818 /* vf_vapoursynth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_vapoursynth.c; sourceTree = "<group>"; };
+		D7A49378265980C100214818 /* refqueue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = refqueue.c; sourceTree = "<group>"; };
+		D7A49379265980C100214818 /* vf_fingerprint.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_fingerprint.c; sourceTree = "<group>"; };
+		D7A4937A265980C100214818 /* vf_format.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_format.c; sourceTree = "<group>"; };
+		D7A4937B265980C100214818 /* vf_vavpp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_vavpp.c; sourceTree = "<group>"; };
+		D7A4937C265980C100214818 /* vf_gpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vf_gpu.c; sourceTree = "<group>"; };
+		D7A4937D265980C100214818 /* vdpau_mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vdpau_mixer.h; sourceTree = "<group>"; };
+		D7A4937E265980C100214818 /* mp_image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mp_image.h; sourceTree = "<group>"; };
+		D7A4937F265980C100214818 /* csputils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = csputils.c; sourceTree = "<group>"; };
+		D7A49380265980C100214818 /* d3d.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = d3d.c; sourceTree = "<group>"; };
+		D7A49382265980C100214818 /* javascript.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = javascript.c; sourceTree = "<group>"; };
+		D7A49383265980C100214818 /* core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = core.h; sourceTree = "<group>"; };
+		D7A49384265980C100214818 /* client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = client.h; sourceTree = "<group>"; };
+		D7A49385265980C100214818 /* external_files.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = external_files.h; sourceTree = "<group>"; };
+		D7A49386265980C100214818 /* screenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = screenshot.h; sourceTree = "<group>"; };
+		D7A49387265980C100214818 /* video.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = video.c; sourceTree = "<group>"; };
+		D7A49388265980C100214818 /* playloop.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = playloop.c; sourceTree = "<group>"; };
+		D7A49389265980C100214818 /* osd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = osd.c; sourceTree = "<group>"; };
+		D7A4938A265980C100214818 /* loadfile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadfile.c; sourceTree = "<group>"; };
+		D7A4938B265980C100214818 /* lua.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lua.c; sourceTree = "<group>"; };
+		D7A4938C265980C100214818 /* command.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = command.c; sourceTree = "<group>"; };
+		D7A4938E265980C100214818 /* osc.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = osc.lua; sourceTree = "<group>"; };
+		D7A4938F265980C100214818 /* auto_profiles.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = auto_profiles.lua; sourceTree = "<group>"; };
+		D7A49390265980C100214818 /* assdraw.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = assdraw.lua; sourceTree = "<group>"; };
+		D7A49391265980C100214818 /* stats.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = stats.lua; sourceTree = "<group>"; };
+		D7A49392265980C100214818 /* console.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = console.lua; sourceTree = "<group>"; };
+		D7A49393265980C100214818 /* options.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = options.lua; sourceTree = "<group>"; };
+		D7A49394265980C100214818 /* defaults.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = defaults.lua; sourceTree = "<group>"; };
+		D7A49395265980C100214818 /* ytdl_hook.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ytdl_hook.lua; sourceTree = "<group>"; };
+		D7A49396265980C100214818 /* client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = client.c; sourceTree = "<group>"; };
+		D7A49397265980C100214818 /* configfiles.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = configfiles.c; sourceTree = "<group>"; };
+		D7A49398265980C100214818 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		D7A49399265980C100214818 /* screenshot.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = screenshot.c; sourceTree = "<group>"; };
+		D7A4939A265980C100214818 /* external_files.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = external_files.c; sourceTree = "<group>"; };
+		D7A4939B265980C100214818 /* command.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = command.h; sourceTree = "<group>"; };
+		D7A4939C265980C100214818 /* sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sub.c; sourceTree = "<group>"; };
+		D7A4939E265980C100214818 /* defaults.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = defaults.js; sourceTree = "<group>"; };
+		D7A4939F265980C100214818 /* misc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = misc.c; sourceTree = "<group>"; };
+		D7A493A0265980C100214818 /* scripting.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scripting.c; sourceTree = "<group>"; };
+		D7A493A1265980C100214818 /* audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = audio.c; sourceTree = "<group>"; };
+		D7A493A2265980C100214818 /* wscript_build.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = wscript_build.py; sourceTree = "<group>"; };
+		D7A493A4265980C100214818 /* ta.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ta.c; sourceTree = "<group>"; };
+		D7A493A5265980C100214818 /* ta_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ta_utils.c; sourceTree = "<group>"; };
+		D7A493A6265980C100214818 /* ta_talloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ta_talloc.c; sourceTree = "<group>"; };
+		D7A493A7265980C100214818 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		D7A493A8265980C100214818 /* ta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ta.h; sourceTree = "<group>"; };
+		D7A493A9265980C100214818 /* ta_talloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ta_talloc.h; sourceTree = "<group>"; };
+		D7A493AB265980C100214818 /* build-mingw64.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-mingw64.sh"; sourceTree = "<group>"; };
+		D7A493AC265980C100214818 /* build-macos.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-macos.sh"; sourceTree = "<group>"; };
+		D7A493AD265980C100214818 /* build-freebsd.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-freebsd.sh"; sourceTree = "<group>"; };
+		D7A493AE265980C100214818 /* build-tumbleweed.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "build-tumbleweed.sh"; sourceTree = "<group>"; };
+		D7A493B0265980C100214818 /* uncrustify.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uncrustify.cfg; sourceTree = "<group>"; };
+		D7A493B1265980C100214818 /* umpv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = umpv; sourceTree = "<group>"; };
+		D7A493B2265980C100214818 /* appveyor-build.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "appveyor-build.sh"; sourceTree = "<group>"; };
+		D7A493B3265980C100214818 /* mpv_identify.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = mpv_identify.sh; sourceTree = "<group>"; };
+		D7A493B4265980C100214818 /* matroska.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = matroska.py; sourceTree = "<group>"; };
+		D7A493B5265980C100214818 /* stats-conv.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "stats-conv.py"; sourceTree = "<group>"; };
+		D7A493B6265980C100214818 /* file2string.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = file2string.py; sourceTree = "<group>"; };
+		D7A493B7265980C100214818 /* sort-xcode-project-file */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sort-xcode-project-file"; sourceTree = "<group>"; };
+		D7A493B8265980C100214818 /* travis-rebuild-website */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "travis-rebuild-website"; sourceTree = "<group>"; };
+		D7A493BA265980C100214818 /* mpv.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = mpv.app; sourceTree = "<group>"; };
+		D7A493BC265980C100214818 /* appveyor-install.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "appveyor-install.sh"; sourceTree = "<group>"; };
+		D7A493BD265980C100214818 /* dylib-unhell.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "dylib-unhell.py"; sourceTree = "<group>"; };
+		D7A493BE265980C100214818 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		D7A493CA265980C100214818 /* autoload.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = autoload.lua; sourceTree = "<group>"; };
+		D7A493CB265980C100214818 /* osd-test.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "osd-test.lua"; sourceTree = "<group>"; };
+		D7A493CC265980C100214818 /* cycle-deinterlace-pullup.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "cycle-deinterlace-pullup.lua"; sourceTree = "<group>"; };
+		D7A493CD265980C100214818 /* ontop-playback.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "ontop-playback.lua"; sourceTree = "<group>"; };
+		D7A493CE265980C100214818 /* observe-all.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "observe-all.lua"; sourceTree = "<group>"; };
+		D7A493CF265980C100214818 /* autocrop.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = autocrop.lua; sourceTree = "<group>"; };
+		D7A493D0265980C100214818 /* pause-when-minimize.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "pause-when-minimize.lua"; sourceTree = "<group>"; };
+		D7A493D1265980C100214818 /* status-line.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "status-line.lua"; sourceTree = "<group>"; };
+		D7A493D2265980C100214818 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		D7A493D3265980C100214818 /* audio-hotplug-test.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "audio-hotplug-test.lua"; sourceTree = "<group>"; };
+		D7A493D4265980C100214818 /* test-hooks.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "test-hooks.lua"; sourceTree = "<group>"; };
+		D7A493D5265980C100214818 /* acompressor.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = acompressor.lua; sourceTree = "<group>"; };
+		D7A493D6265980C100214818 /* skip-logo.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "skip-logo.lua"; sourceTree = "<group>"; };
+		D7A493D7265980C100214818 /* autodeint.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = autodeint.lua; sourceTree = "<group>"; };
+		D7A493D8265980C100214818 /* ao-null-reload.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "ao-null-reload.lua"; sourceTree = "<group>"; };
+		D7A493D9265980C100214818 /* command-test.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "command-test.lua"; sourceTree = "<group>"; };
+		D7A493DA265980C100214818 /* nan-test.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "nan-test.lua"; sourceTree = "<group>"; };
+		D7A493DB265980C100214818 /* travis-deps */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = "travis-deps"; sourceTree = "<group>"; };
+		D7A493DD265980C100214818 /* uniE007.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE007.glyph; sourceTree = "<group>"; };
+		D7A493DE265980C100214818 /* uniE101.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE101.glyph; sourceTree = "<group>"; };
+		D7A493DF265980C100214818 /* uniE005.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE005.glyph; sourceTree = "<group>"; };
+		D7A493E0265980C100214818 /* uniE001.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE001.glyph; sourceTree = "<group>"; };
+		D7A493E1265980C100214818 /* uniE105.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE105.glyph; sourceTree = "<group>"; };
+		D7A493E2265980C100214818 /* uniE107.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE107.glyph; sourceTree = "<group>"; };
+		D7A493E3265980C100214818 /* uniE003.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE003.glyph; sourceTree = "<group>"; };
+		D7A493E4265980C100214818 /* font.props */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = font.props; sourceTree = "<group>"; };
+		D7A493E5265980C100214818 /* uniE004.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE004.glyph; sourceTree = "<group>"; };
+		D7A493E6265980C100214818 /* uniE006.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE006.glyph; sourceTree = "<group>"; };
+		D7A493E7265980C100214818 /* .notdef.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .notdef.glyph; sourceTree = "<group>"; };
+		D7A493E8265980C100214818 /* uniE106.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE106.glyph; sourceTree = "<group>"; };
+		D7A493E9265980C100214818 /* uniE002.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE002.glyph; sourceTree = "<group>"; };
+		D7A493EA265980C100214818 /* uniE104.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE104.glyph; sourceTree = "<group>"; };
+		D7A493EB265980C100214818 /* uniE108.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE108.glyph; sourceTree = "<group>"; };
+		D7A493EC265980C100214818 /* uniE111.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE111.glyph; sourceTree = "<group>"; };
+		D7A493ED265980C100214818 /* uniE113.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE113.glyph; sourceTree = "<group>"; };
+		D7A493EE265980C100214818 /* uniE00A.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE00A.glyph; sourceTree = "<group>"; };
+		D7A493EF265980C100214818 /* uniE10E.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE10E.glyph; sourceTree = "<group>"; };
+		D7A493F0265980C100214818 /* uniE013.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE013.glyph; sourceTree = "<group>"; };
+		D7A493F1265980C100214818 /* uniE10A.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE10A.glyph; sourceTree = "<group>"; };
+		D7A493F2265980C100214818 /* uniE115.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE115.glyph; sourceTree = "<group>"; };
+		D7A493F3265980C100214818 /* uniE008.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE008.glyph; sourceTree = "<group>"; };
+		D7A493F4265980C100214818 /* uniE10C.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE10C.glyph; sourceTree = "<group>"; };
+		D7A493F5265980C100214818 /* uniE011.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE011.glyph; sourceTree = "<group>"; };
+		D7A493F6265980C100214818 /* uniE112.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE112.glyph; sourceTree = "<group>"; };
+		D7A493F7265980C100214818 /* uniE10D.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE10D.glyph; sourceTree = "<group>"; };
+		D7A493F8265980C100214818 /* uniE109.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE109.glyph; sourceTree = "<group>"; };
+		D7A493F9265980C100214818 /* uniE110.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE110.glyph; sourceTree = "<group>"; };
+		D7A493FA265980C100214818 /* uniE00B.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE00B.glyph; sourceTree = "<group>"; };
+		D7A493FB265980C100214818 /* uniE009.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE009.glyph; sourceTree = "<group>"; };
+		D7A493FC265980C100214818 /* uniE114.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE114.glyph; sourceTree = "<group>"; };
+		D7A493FD265980C100214818 /* uniE010.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE010.glyph; sourceTree = "<group>"; };
+		D7A493FE265980C100214818 /* uniE10B.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE10B.glyph; sourceTree = "<group>"; };
+		D7A493FF265980C100214818 /* uniE012.glyph */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = uniE012.glyph; sourceTree = "<group>"; };
+		D7A49401265980C100214818 /* gen-osd-font.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "gen-osd-font.sh"; sourceTree = "<group>"; };
+		D7A49402265980C100214818 /* osxbundle.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = osxbundle.py; sourceTree = "<group>"; };
+		D7A49403265980C100214818 /* file2string.pyc */ = {isa = PBXFileReference; lastKnownFileType = file; path = file2string.pyc; sourceTree = "<group>"; };
+		D7A49404265980C100214818 /* idet.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = idet.sh; sourceTree = "<group>"; };
+		D7A49406265980C100214818 /* gl_video.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_video.c; sourceTree = "<group>"; };
+		D7A49407265980C100214818 /* json.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = json.c; sourceTree = "<group>"; };
+		D7A49408265980C100214818 /* repack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = repack.c; sourceTree = "<group>"; };
+		D7A4940A265980C100214818 /* repack_zimg.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = repack_zimg.log; sourceTree = "<group>"; };
+		D7A4940B265980C100214818 /* repack.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = repack.txt; sourceTree = "<group>"; };
+		D7A4940C265980C100214818 /* zimg_formats.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = zimg_formats.txt; sourceTree = "<group>"; };
+		D7A4940D265980C100214818 /* repack_sws.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = repack_sws.log; sourceTree = "<group>"; };
+		D7A4940E265980C100214818 /* img_formats.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = img_formats.txt; sourceTree = "<group>"; };
+		D7A4940F265980C100214818 /* draw_bmp.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = draw_bmp.txt; sourceTree = "<group>"; };
+		D7A49410265980C100214818 /* img_format.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = img_format.c; sourceTree = "<group>"; };
+		D7A49411265980C100214818 /* scale_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scale_test.h; sourceTree = "<group>"; };
+		D7A49412265980C100214818 /* paths.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = paths.c; sourceTree = "<group>"; };
+		D7A49413265980C100214818 /* tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tests.h; sourceTree = "<group>"; };
+		D7A49414265980C100214818 /* chmap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chmap.c; sourceTree = "<group>"; };
+		D7A49415265980C100214818 /* scale_sws.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scale_sws.c; sourceTree = "<group>"; };
+		D7A49416265980C100214818 /* linked_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linked_list.c; sourceTree = "<group>"; };
+		D7A49417265980C100214818 /* tests.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tests.c; sourceTree = "<group>"; };
+		D7A49418265980C100214818 /* subtimes.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = subtimes.js; sourceTree = "<group>"; };
+		D7A49419265980C100214818 /* scale_zimg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scale_zimg.c; sourceTree = "<group>"; };
+		D7A4941A265980C100214818 /* scale_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scale_test.c; sourceTree = "<group>"; };
+		D7A4941B265980C100214818 /* input-gamepad.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "input-gamepad.conf"; sourceTree = "<group>"; };
+		D7A4941D265980C100214818 /* client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = client.h; sourceTree = "<group>"; };
+		D7A4941E265980C100214818 /* stream_cb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream_cb.h; sourceTree = "<group>"; };
+		D7A4941F265980C100214818 /* render_gl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = render_gl.h; sourceTree = "<group>"; };
+		D7A49420265980C100214818 /* mpv.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.def; sourceTree = "<group>"; };
+		D7A49421265980C100214818 /* mpv.pc.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.pc.in; sourceTree = "<group>"; };
+		D7A49422265980C100214818 /* opengl_cb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opengl_cb.h; sourceTree = "<group>"; };
+		D7A49423265980C100214818 /* render.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = render.h; sourceTree = "<group>"; };
+		D7A49425265980C100214818 /* subprocess-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "subprocess-win.c"; sourceTree = "<group>"; };
+		D7A49426265980C100214818 /* semaphore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = semaphore.h; sourceTree = "<group>"; };
+		D7A49427265980C100214818 /* subprocess-dummy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "subprocess-dummy.c"; sourceTree = "<group>"; };
+		D7A49428265980C100214818 /* main-fn-unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-fn-unix.c"; sourceTree = "<group>"; };
+		D7A49429265980C100214818 /* path-unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "path-unix.c"; sourceTree = "<group>"; };
+		D7A4942A265980C100214818 /* terminal-unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "terminal-unix.c"; sourceTree = "<group>"; };
+		D7A4942B265980C100214818 /* timer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = timer.c; sourceTree = "<group>"; };
+		D7A4942D265980C100214818 /* remote_command_center.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = remote_command_center.swift; sourceTree = "<group>"; };
+		D7A4942E265980C100214818 /* log_helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = log_helper.swift; sourceTree = "<group>"; };
+		D7A4942F265980C100214818 /* libmpv_helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = libmpv_helper.swift; sourceTree = "<group>"; };
+		D7A49430265980C100214818 /* swift_compat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = swift_compat.swift; sourceTree = "<group>"; };
+		D7A49431265980C100214818 /* mpv_helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = mpv_helper.swift; sourceTree = "<group>"; };
+		D7A49432265980C100214818 /* swift_extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = swift_extensions.swift; sourceTree = "<group>"; };
+		D7A49433265980C100214818 /* mpv.exe.manifest */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = mpv.exe.manifest; sourceTree = "<group>"; };
+		D7A49434265980C100214818 /* getpid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getpid.h; sourceTree = "<group>"; };
+		D7A49435265980C100214818 /* compiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compiler.h; sourceTree = "<group>"; };
+		D7A49436265980C100214818 /* w32_keyboard.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = w32_keyboard.c; sourceTree = "<group>"; };
+		D7A49437265980C100214818 /* main-fn-cocoa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-fn-cocoa.c"; sourceTree = "<group>"; };
+		D7A49438265980C100214818 /* io.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = io.c; sourceTree = "<group>"; };
+		D7A49439265980C100214818 /* path.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = path.h; sourceTree = "<group>"; };
+		D7A4943A265980C100214818 /* endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endian.h; sourceTree = "<group>"; };
+		D7A4943B265980C100214818 /* macosx_touchbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_touchbar.h; sourceTree = "<group>"; };
+		D7A4943C265980C100214818 /* windows_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = windows_utils.c; sourceTree = "<group>"; };
+		D7A4943D265980C100214818 /* macosx_events.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_events.h; sourceTree = "<group>"; };
+		D7A4943E265980C100214818 /* macosx_menubar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_menubar.h; sourceTree = "<group>"; };
+		D7A4943F265980C100214818 /* subprocess-posix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "subprocess-posix.c"; sourceTree = "<group>"; };
+		D7A49440265980C100214818 /* polldev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = polldev.h; sourceTree = "<group>"; };
+		D7A49441265980C100214818 /* macosx_application.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_application.h; sourceTree = "<group>"; };
+		D7A49442265980C100214818 /* terminal-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "terminal-win.c"; sourceTree = "<group>"; };
+		D7A49443265980C100214818 /* threads.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = threads.h; sourceTree = "<group>"; };
+		D7A49444265980C100214818 /* terminal-dummy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "terminal-dummy.c"; sourceTree = "<group>"; };
+		D7A49445265980C100214818 /* macOS_swift_bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macOS_swift_bridge.h; sourceTree = "<group>"; };
+		D7A49446265980C100214818 /* subprocess.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = subprocess.c; sourceTree = "<group>"; };
+		D7A49447265980C100214818 /* timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timer.h; sourceTree = "<group>"; };
+		D7A49448265980C100214818 /* timer-linux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "timer-linux.c"; sourceTree = "<group>"; };
+		D7A49449265980C100214818 /* macosx_versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_versions.h; sourceTree = "<group>"; };
+		D7A4944A265980C100214818 /* mpv.rc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.rc; sourceTree = "<group>"; };
+		D7A4944B265980C100214818 /* glob-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "glob-win.c"; sourceTree = "<group>"; };
+		D7A4944C265980C100214818 /* timer-darwin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "timer-darwin.c"; sourceTree = "<group>"; };
+		D7A4944D265980C100214818 /* io.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = io.h; sourceTree = "<group>"; };
+		D7A4944E265980C100214818 /* path-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "path-win.c"; sourceTree = "<group>"; };
+		D7A49450265980C100214818 /* strnlen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strnlen.c; sourceTree = "<group>"; };
+		D7A49451265980C100214818 /* strnlen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strnlen.h; sourceTree = "<group>"; };
+		D7A49452265980C100214818 /* terminal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = terminal.h; sourceTree = "<group>"; };
+		D7A49453265980C100214818 /* macosx_compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_compat.h; sourceTree = "<group>"; };
+		D7A49454265980C100214818 /* win32-console-wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "win32-console-wrapper.c"; sourceTree = "<group>"; };
+		D7A49455265980C100214818 /* w32_keyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = w32_keyboard.h; sourceTree = "<group>"; };
+		D7A49456265980C100214818 /* macosx_menubar_objc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_menubar_objc.h; sourceTree = "<group>"; };
+		D7A49457265980C100214818 /* macosx_events_objc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_events_objc.h; sourceTree = "<group>"; };
+		D7A49458265980C100214818 /* macosx_menubar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = macosx_menubar.m; sourceTree = "<group>"; };
+		D7A49459265980C100214818 /* path-uwp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "path-uwp.c"; sourceTree = "<group>"; };
+		D7A4945A265980C100214818 /* windows_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = windows_utils.h; sourceTree = "<group>"; };
+		D7A4945B265980C100214818 /* macosx_events.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = macosx_events.m; sourceTree = "<group>"; };
+		D7A4945C265980C100214818 /* macosx_application_objc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macosx_application_objc.h; sourceTree = "<group>"; };
+		D7A4945D265980C100214818 /* path-macosx.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "path-macosx.m"; sourceTree = "<group>"; };
+		D7A4945E265980C100214818 /* strnlen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strnlen.h; sourceTree = "<group>"; };
+		D7A4945F265980C100214818 /* main-fn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "main-fn.h"; sourceTree = "<group>"; };
+		D7A49461265980C100214818 /* pthread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pthread.c; sourceTree = "<group>"; };
+		D7A49463265980C100214818 /* semaphore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = semaphore.h; sourceTree = "<group>"; };
+		D7A49464265980C100214818 /* pthread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pthread.h; sourceTree = "<group>"; };
+		D7A49465265980C100214818 /* macosx_touchbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = macosx_touchbar.m; sourceTree = "<group>"; };
+		D7A49466265980C100214818 /* subprocess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = subprocess.h; sourceTree = "<group>"; };
+		D7A49467265980C100214818 /* timer-win2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "timer-win2.c"; sourceTree = "<group>"; };
+		D7A49468265980C100214818 /* main-fn-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-fn-win.c"; sourceTree = "<group>"; };
+		D7A49469265980C100214818 /* threads.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = threads.c; sourceTree = "<group>"; };
+		D7A4946A265980C100214818 /* macosx_application.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = macosx_application.m; sourceTree = "<group>"; };
+		D7A4946B265980C100214818 /* semaphore_osx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = semaphore_osx.c; sourceTree = "<group>"; };
+		D7A4946C265980C100214818 /* polldev.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = polldev.c; sourceTree = "<group>"; };
+		D7A4946D265980C100214818 /* atomic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = atomic.h; sourceTree = "<group>"; };
+		D7A4946F265980C200214818 /* ebml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ebml.h; sourceTree = "<group>"; };
+		D7A49470265980C200214818 /* stheader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stheader.h; sourceTree = "<group>"; };
+		D7A49471265980C200214818 /* demux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux.c; sourceTree = "<group>"; };
+		D7A49472265980C200214818 /* demux_timeline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_timeline.c; sourceTree = "<group>"; };
+		D7A49473265980C200214818 /* demux_mkv_timeline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_mkv_timeline.c; sourceTree = "<group>"; };
+		D7A49474265980C200214818 /* demux_mf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_mf.c; sourceTree = "<group>"; };
+		D7A49475265980C200214818 /* cue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cue.h; sourceTree = "<group>"; };
+		D7A49476265980C200214818 /* demux_playlist.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_playlist.c; sourceTree = "<group>"; };
+		D7A49477265980C200214818 /* demux_mkv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_mkv.c; sourceTree = "<group>"; };
+		D7A49478265980C200214818 /* demux_edl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_edl.c; sourceTree = "<group>"; };
+		D7A49479265980C200214818 /* packet.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = packet.c; sourceTree = "<group>"; };
+		D7A4947A265980C200214818 /* cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cache.h; sourceTree = "<group>"; };
+		D7A4947B265980C200214818 /* codec_tags.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = codec_tags.c; sourceTree = "<group>"; };
+		D7A4947C265980C200214818 /* demux_lavf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_lavf.c; sourceTree = "<group>"; };
+		D7A4947D265980C200214818 /* demux_null.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_null.c; sourceTree = "<group>"; };
+		D7A4947E265980C200214818 /* timeline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = timeline.c; sourceTree = "<group>"; };
+		D7A4947F265980C200214818 /* demux_raw.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_raw.c; sourceTree = "<group>"; };
+		D7A49480265980C200214818 /* demux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = demux.h; sourceTree = "<group>"; };
+		D7A49481265980C200214818 /* ebml.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ebml.c; sourceTree = "<group>"; };
+		D7A49482265980C200214818 /* packet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet.h; sourceTree = "<group>"; };
+		D7A49483265980C200214818 /* cue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cue.c; sourceTree = "<group>"; };
+		D7A49484265980C200214818 /* demux_libarchive.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_libarchive.c; sourceTree = "<group>"; };
+		D7A49485265980C200214818 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
+		D7A49486265980C200214818 /* matroska.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matroska.h; sourceTree = "<group>"; };
+		D7A49487265980C200214818 /* demux_disc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_disc.c; sourceTree = "<group>"; };
+		D7A49488265980C200214818 /* timeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timeline.h; sourceTree = "<group>"; };
+		D7A49489265980C200214818 /* demux_cue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux_cue.c; sourceTree = "<group>"; };
+		D7A4948A265980C200214818 /* codec_tags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codec_tags.h; sourceTree = "<group>"; };
+		D7A4948B265980C200214818 /* RELEASE_NOTES */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RELEASE_NOTES; sourceTree = "<group>"; };
+		D7A4948C265980C200214818 /* mpv_talloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mpv_talloc.h; sourceTree = "<group>"; };
+		D7A4948D265980C200214818 /* LICENSE.LGPL */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.LGPL; sourceTree = "<group>"; };
+		D7A4948F265980C200214818 /* json.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = json.c; sourceTree = "<group>"; };
+		D7A49490265980C200214818 /* jni.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = jni.c; sourceTree = "<group>"; };
+		D7A49491265980C200214818 /* dispatch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dispatch.c; sourceTree = "<group>"; };
+		D7A49492265980C200214818 /* rendezvous.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rendezvous.c; sourceTree = "<group>"; };
+		D7A49493265980C200214818 /* thread_tools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_tools.h; sourceTree = "<group>"; };
+		D7A49494265980C200214818 /* linked_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linked_list.h; sourceTree = "<group>"; };
+		D7A49495265980C200214818 /* bstr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bstr.c; sourceTree = "<group>"; };
+		D7A49496265980C200214818 /* natural_sort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = natural_sort.h; sourceTree = "<group>"; };
+		D7A49497265980C200214818 /* node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = node.h; sourceTree = "<group>"; };
+		D7A49498265980C200214818 /* charset_conv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charset_conv.h; sourceTree = "<group>"; };
+		D7A49499265980C200214818 /* thread_pool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_pool.h; sourceTree = "<group>"; };
+		D7A4949A265980C200214818 /* jni.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jni.h; sourceTree = "<group>"; };
+		D7A4949B265980C200214818 /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
+		D7A4949C265980C200214818 /* ctype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ctype.h; sourceTree = "<group>"; };
+		D7A4949D265980C200214818 /* thread_tools.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread_tools.c; sourceTree = "<group>"; };
+		D7A4949E265980C200214818 /* rendezvous.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rendezvous.h; sourceTree = "<group>"; };
+		D7A4949F265980C200214818 /* dispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dispatch.h; sourceTree = "<group>"; };
+		D7A494A0265980C200214818 /* bstr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bstr.h; sourceTree = "<group>"; };
+		D7A494A1265980C200214818 /* natural_sort.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = natural_sort.c; sourceTree = "<group>"; };
+		D7A494A2265980C200214818 /* thread_pool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread_pool.c; sourceTree = "<group>"; };
+		D7A494A3265980C200214818 /* charset_conv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = charset_conv.c; sourceTree = "<group>"; };
+		D7A494A4265980C200214818 /* node.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = node.c; sourceTree = "<group>"; };
+		D7A494A5265980C200214818 /* LICENSE.GPL */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.GPL; sourceTree = "<group>"; };
+		D7A494A6265980C200214818 /* version.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = version.sh; sourceTree = "<group>"; };
+		D7A494A9265980C200214818 /* vo.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = vo.rst; sourceTree = "<group>"; };
+		D7A494AA265980C200214818 /* af.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = af.rst; sourceTree = "<group>"; };
+		D7A494AB265980C200214818 /* osc.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = osc.rst; sourceTree = "<group>"; };
+		D7A494AC265980C200214818 /* lua.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = lua.rst; sourceTree = "<group>"; };
+		D7A494AD265980C200214818 /* encode.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = encode.rst; sourceTree = "<group>"; };
+		D7A494AE265980C200214818 /* javascript.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = javascript.rst; sourceTree = "<group>"; };
+		D7A494AF265980C200214818 /* libmpv.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = libmpv.rst; sourceTree = "<group>"; };
+		D7A494B0265980C200214818 /* options.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = options.rst; sourceTree = "<group>"; };
+		D7A494B1265980C200214818 /* stats.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = stats.rst; sourceTree = "<group>"; };
+		D7A494B2265980C200214818 /* console.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = console.rst; sourceTree = "<group>"; };
+		D7A494B3265980C200214818 /* mpv.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mpv.rst; sourceTree = "<group>"; };
+		D7A494B4265980C200214818 /* changes.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = changes.rst; sourceTree = "<group>"; };
+		D7A494B5265980C200214818 /* input.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = input.rst; sourceTree = "<group>"; };
+		D7A494B6265980C200214818 /* vf.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = vf.rst; sourceTree = "<group>"; };
+		D7A494B7265980C200214818 /* ao.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ao.rst; sourceTree = "<group>"; };
+		D7A494B8265980C200214818 /* ipc.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ipc.rst; sourceTree = "<group>"; };
+		D7A494B9265980C200214818 /* compile-windows.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = "compile-windows.md"; sourceTree = "<group>"; };
+		D7A494BA265980C200214818 /* mplayer-changes.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "mplayer-changes.rst"; sourceTree = "<group>"; };
+		D7A494BB265980C200214818 /* encoding.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = encoding.rst; sourceTree = "<group>"; };
+		D7A494BC265980C200214818 /* tech-overview.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "tech-overview.txt"; sourceTree = "<group>"; };
+		D7A494BD265980C200214818 /* edl-mpv.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "edl-mpv.rst"; sourceTree = "<group>"; };
+		D7A494BE265980C200214818 /* contribute.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = contribute.md; sourceTree = "<group>"; };
+		D7A494BF265980C200214818 /* interface-changes.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "interface-changes.rst"; sourceTree = "<group>"; };
+		D7A494C0265980C200214818 /* release-policy.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = "release-policy.md"; sourceTree = "<group>"; };
+		D7A494C1265980C200214818 /* waf-buildsystem.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "waf-buildsystem.rst"; sourceTree = "<group>"; };
+		D7A494C2265980C200214818 /* client-api-changes.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "client-api-changes.rst"; sourceTree = "<group>"; };
+		D7A494C3265980C200214818 /* compatibility.rst */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = compatibility.rst; sourceTree = "<group>"; };
+		D7A494C5265980C200214818 /* deps_parser.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = deps_parser.py; sourceTree = "<group>"; };
+		D7A494C7265980C200214818 /* iconv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = iconv.c; sourceTree = "<group>"; };
+		D7A494C8265980C200214818 /* coreaudio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = coreaudio.c; sourceTree = "<group>"; };
+		D7A494C9265980C200214818 /* touchbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = touchbar.m; sourceTree = "<group>"; };
+		D7A494CA265980C200214818 /* audiounit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = audiounit.c; sourceTree = "<group>"; };
+		D7A494CB265980C200214818 /* sse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sse.c; sourceTree = "<group>"; };
+		D7A494CC265980C200214818 /* pthreads.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pthreads.c; sourceTree = "<group>"; };
+		D7A494CD265980C200214818 /* wasapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wasapi.c; sourceTree = "<group>"; };
+		D7A494CE265980C200214818 /* cocoa.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa.m; sourceTree = "<group>"; };
+		D7A494CF265980C200214818 /* gl_x11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_x11.c; sourceTree = "<group>"; };
+		D7A494D2265980C200214818 /* waf_customizations.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = waf_customizations.py; sourceTree = "<group>"; };
+		D7A494D3265980C200214818 /* clang_compilation_database.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = clang_compilation_database.py; sourceTree = "<group>"; };
+		D7A494D6265980C200214818 /* custom.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = custom.py; sourceTree = "<group>"; };
+		D7A494D7265980C200214818 /* generic.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = generic.py; sourceTree = "<group>"; };
+		D7A494D8265980C200214818 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		D7A494E6265980C200214818 /* inflector.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = inflector.py; sourceTree = "<group>"; };
+		D7A494E7265980C200214818 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		D7A494E8265980C200214818 /* features.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = features.py; sourceTree = "<group>"; };
+		D7A494FF265980C200214818 /* syms.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = syms.py; sourceTree = "<group>"; };
+		D7A49501265980C200214818 /* compiler.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = compiler.py; sourceTree = "<group>"; };
+		D7A49502265980C200214818 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		D7A49512265980C200214818 /* compiler_swift.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = compiler_swift.py; sourceTree = "<group>"; };
+		D7A49514265980C200214818 /* devices.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = devices.py; sourceTree = "<group>"; };
+		D7A4951B265980C200214818 /* __init__.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		D7A49526265980C200214818 /* sources.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = sources.py; sourceTree = "<group>"; };
+		D7A49528265980C200214818 /* headers.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = headers.py; sourceTree = "<group>"; };
+		D7A4952B265980C200214818 /* dependencies.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = dependencies.py; sourceTree = "<group>"; };
+		D7A4952D265980C200214818 /* osd_font.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = osd_font.otf; sourceTree = "<group>"; };
+		D7A4952E265980C200214818 /* dec_sub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dec_sub.h; sourceTree = "<group>"; };
+		D7A4952F265980C200214818 /* ass_mp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ass_mp.c; sourceTree = "<group>"; };
+		D7A49530265980C200214818 /* osd_libass.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = osd_libass.c; sourceTree = "<group>"; };
+		D7A49531265980C200214818 /* osd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = osd.c; sourceTree = "<group>"; };
+		D7A49532265980C200214818 /* img_convert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = img_convert.c; sourceTree = "<group>"; };
+		D7A49533265980C200214818 /* draw_bmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = draw_bmp.c; sourceTree = "<group>"; };
+		D7A49534265980C200214818 /* sd_ass.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sd_ass.c; sourceTree = "<group>"; };
+		D7A49535265980C200214818 /* sd_lavc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sd_lavc.c; sourceTree = "<group>"; };
+		D7A49536265980C200214818 /* filter_regex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_regex.c; sourceTree = "<group>"; };
+		D7A49537265980C200214818 /* ass_mp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ass_mp.h; sourceTree = "<group>"; };
+		D7A49538265980C200214818 /* lavc_conv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lavc_conv.c; sourceTree = "<group>"; };
+		D7A49539265980C200214818 /* dec_sub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_sub.c; sourceTree = "<group>"; };
+		D7A4953A265980C200214818 /* sd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sd.h; sourceTree = "<group>"; };
+		D7A4953B265980C200214818 /* osd_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = osd_state.h; sourceTree = "<group>"; };
+		D7A4953C265980C200214818 /* img_convert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = img_convert.h; sourceTree = "<group>"; };
+		D7A4953D265980C200214818 /* osd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = osd.h; sourceTree = "<group>"; };
+		D7A4953E265980C200214818 /* filter_sdh.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_sdh.c; sourceTree = "<group>"; };
+		D7A4953F265980C200214818 /* draw_bmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = draw_bmp.h; sourceTree = "<group>"; };
+		D7A49542265980C200214818 /* ipc-dummy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ipc-dummy.c"; sourceTree = "<group>"; };
+		D7A49543265980C200214818 /* ipc-win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ipc-win.c"; sourceTree = "<group>"; };
+		D7A49544265980C200214818 /* input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = input.h; sourceTree = "<group>"; };
+		D7A49545265980C200214818 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event.h; sourceTree = "<group>"; };
+		D7A49546265980C200214818 /* keycodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keycodes.h; sourceTree = "<group>"; };
+		D7A49547265980C200214818 /* cmd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd.c; sourceTree = "<group>"; };
+		D7A49548265980C200214818 /* input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = input.c; sourceTree = "<group>"; };
+		D7A49549265980C200214818 /* event.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = event.c; sourceTree = "<group>"; };
+		D7A4954A265980C200214818 /* keycodes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = keycodes.c; sourceTree = "<group>"; };
+		D7A4954B265980C200214818 /* ipc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ipc.c; sourceTree = "<group>"; };
+		D7A4954C265980C200214818 /* cmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd.h; sourceTree = "<group>"; };
+		D7A4954D265980C200214818 /* ipc-unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ipc-unix.c"; sourceTree = "<group>"; };
+		D7A4954E265980C200214818 /* sdl_gamepad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sdl_gamepad.c; sourceTree = "<group>"; };
+		D7A497A9265984E300214818 /* mpv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = mpv.app; path = /Users/Akemi/Repositories/mpv/build/Debug/mpv.app; sourceTree = "<absolute>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D7A491D426597FE500214818 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D74FE378265929FB008536C6 = {
+			isa = PBXGroup;
+			children = (
+				D7A49232265980C000214818 /* appveyor.yml */,
+				D7A4925B265980C000214818 /* audio */,
+				D7A492AA265980C000214818 /* bootstrap.py */,
+				D7A493AA265980C100214818 /* ci */,
+				D7A49290265980C000214818 /* common */,
+				D7A491FB265980C000214818 /* Copyright */,
+				D7A4946E265980C200214818 /* demux */,
+				D7A494A7265980C200214818 /* DOCS */,
+				D7A49249265980C000214818 /* etc */,
+				D7A49214265980C000214818 /* filters */,
+				D7A49541265980C200214818 /* input */,
+				D7A4941C265980C100214818 /* libmpv */,
+				D7A494A5265980C200214818 /* LICENSE.GPL */,
+				D7A4948D265980C200214818 /* LICENSE.LGPL */,
+				D7A4948E265980C200214818 /* misc */,
+				D7A4948C265980C200214818 /* mpv_talloc.h */,
+				D7A49236265980C000214818 /* options */,
+				D7A49424265980C100214818 /* osdep */,
+				D7A49381265980C100214818 /* player */,
+				D7A492A9265980C000214818 /* README.md */,
+				D7A4948B265980C200214818 /* RELEASE_NOTES */,
+				D7A491FC265980C000214818 /* stream */,
+				D7A4952C265980C200214818 /* sub */,
+				D7A493A3265980C100214818 /* ta */,
+				D7A49405265980C100214818 /* test */,
+				D7A493AF265980C100214818 /* TOOLS */,
+				D7A49248265980C000214818 /* VERSION */,
+				D7A494A6265980C200214818 /* version.sh */,
+				D7A492AB265980C000214818 /* video */,
+				D7A494C4265980C200214818 /* waftools */,
+				D7A4928F265980C000214818 /* wscript */,
+				D7A493A2265980C100214818 /* wscript_build.py */,
+			);
+			sourceTree = "<group>";
+		};
+		D7A491FC265980C000214818 /* stream */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49207265980C000214818 /* cookies.c */,
+				D7A4920C265980C000214818 /* cookies.h */,
+				D7A49210265980C000214818 /* dvb_tune.c */,
+				D7A49205265980C000214818 /* dvb_tune.h */,
+				D7A49200265980C000214818 /* dvbin.h */,
+				D7A49212265980C000214818 /* stream.c */,
+				D7A49208265980C000214818 /* stream.h */,
+				D7A49202265980C000214818 /* stream_avdevice.c */,
+				D7A4920A265980C000214818 /* stream_bluray.c */,
+				D7A49209265980C000214818 /* stream_cb.c */,
+				D7A491FD265980C000214818 /* stream_cdda.c */,
+				D7A4920E265980C000214818 /* stream_concat.c */,
+				D7A491FF265980C000214818 /* stream_dvb.c */,
+				D7A49201265980C000214818 /* stream_dvdnav.c */,
+				D7A49206265980C000214818 /* stream_edl.c */,
+				D7A4920F265980C000214818 /* stream_file.c */,
+				D7A4920B265980C000214818 /* stream_lavf.c */,
+				D7A49211265980C000214818 /* stream_libarchive.c */,
+				D7A49204265980C000214818 /* stream_libarchive.h */,
+				D7A491FE265980C000214818 /* stream_memory.c */,
+				D7A49213265980C000214818 /* stream_mf.c */,
+				D7A4920D265980C000214818 /* stream_null.c */,
+				D7A49203265980C000214818 /* stream_slice.c */,
+			);
+			path = stream;
+			sourceTree = "<group>";
+		};
+		D7A49214265980C000214818 /* filters */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49217265980C000214818 /* f_async_queue.c */,
+				D7A49227265980C000214818 /* f_async_queue.h */,
+				D7A49218265980C000214818 /* f_auto_filters.c */,
+				D7A49224265980C000214818 /* f_auto_filters.h */,
+				D7A49225265980C000214818 /* f_autoconvert.c */,
+				D7A49219265980C000214818 /* f_autoconvert.h */,
+				D7A49228265980C000214818 /* f_decoder_wrapper.c */,
+				D7A49215265980C000214818 /* f_decoder_wrapper.h */,
+				D7A4922A265980C000214818 /* f_demux_in.c */,
+				D7A4921B265980C000214818 /* f_demux_in.h */,
+				D7A4921A265980C000214818 /* f_hwtransfer.c */,
+				D7A4922B265980C000214818 /* f_hwtransfer.h */,
+				D7A4921C265980C000214818 /* f_lavfi.c */,
+				D7A49229265980C000214818 /* f_lavfi.h */,
+				D7A49222265980C000214818 /* f_output_chain.c */,
+				D7A49230265980C000214818 /* f_output_chain.h */,
+				D7A4922D265980C000214818 /* f_swresample.c */,
+				D7A4921E265980C000214818 /* f_swresample.h */,
+				D7A49221265980C000214818 /* f_swscale.c */,
+				D7A49231265980C000214818 /* f_swscale.h */,
+				D7A49216265980C000214818 /* f_utils.c */,
+				D7A49226265980C000214818 /* f_utils.h */,
+				D7A49223265980C000214818 /* filter.c */,
+				D7A4922F265980C000214818 /* filter.h */,
+				D7A49220265980C000214818 /* filter_internal.h */,
+				D7A4922C265980C000214818 /* frame.c */,
+				D7A4921F265980C000214818 /* frame.h */,
+				D7A4922E265980C000214818 /* user_filters.c */,
+				D7A4921D265980C000214818 /* user_filters.h */,
+			);
+			path = filters;
+			sourceTree = "<group>";
+		};
+		D7A49236265980C000214818 /* options */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49241265980C000214818 /* m_config.h */,
+				D7A4923A265980C000214818 /* m_config_core.c */,
+				D7A49244265980C000214818 /* m_config_core.h */,
+				D7A49245265980C000214818 /* m_config_frontend.c */,
+				D7A4923E265980C000214818 /* m_config_frontend.h */,
+				D7A4923F265980C000214818 /* m_option.c */,
+				D7A49238265980C000214818 /* m_option.h */,
+				D7A49240265980C000214818 /* m_property.c */,
+				D7A49237265980C000214818 /* m_property.h */,
+				D7A49246265980C000214818 /* options.c */,
+				D7A4923D265980C000214818 /* options.h */,
+				D7A4923C265980C000214818 /* parse_commandline.c */,
+				D7A49247265980C000214818 /* parse_commandline.h */,
+				D7A49243265980C000214818 /* parse_configfile.c */,
+				D7A49239265980C000214818 /* parse_configfile.h */,
+				D7A49242265980C000214818 /* path.c */,
+				D7A4923B265980C000214818 /* path.h */,
+			);
+			path = options;
+			sourceTree = "<group>";
+		};
+		D7A49249265980C000214818 /* etc */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49252265980C000214818 /* _mpv.zsh */,
+				D7A49251265980C000214818 /* builtin.conf */,
+				D7A4924E265980C000214818 /* encoding-profiles.conf */,
+				D7A4924D265980C000214818 /* input.conf */,
+				D7A49256265980C000214818 /* mplayer-input.conf */,
+				D7A49255265980C000214818 /* mpv-gradient.svg */,
+				D7A49254265980C000214818 /* mpv-icon-8bit-128x128.png */,
+				D7A4924A265980C000214818 /* mpv-icon-8bit-16x16.png */,
+				D7A4925A265980C000214818 /* mpv-icon-8bit-32x32.png */,
+				D7A49257265980C000214818 /* mpv-icon-8bit-64x64.png */,
+				D7A49258265980C000214818 /* mpv-icon.ico */,
+				D7A49259265980C000214818 /* mpv-symbolic.svg */,
+				D7A49250265980C000214818 /* mpv.bash-completion */,
+				D7A4924B265980C000214818 /* mpv.conf */,
+				D7A4924C265980C000214818 /* mpv.desktop */,
+				D7A4924F265980C000214818 /* mpv.svg */,
+				D7A49253265980C000214818 /* restore-old-bindings.conf */,
+			);
+			path = etc;
+			sourceTree = "<group>";
+		};
+		D7A4925B265980C000214818 /* audio */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4927E265980C000214818 /* decode */,
+				D7A49283265980C000214818 /* filter */,
+				D7A4925D265980C000214818 /* out */,
+				D7A4925C265980C000214818 /* aframe.c */,
+				D7A49281265980C000214818 /* aframe.h */,
+				D7A4927A265980C000214818 /* chmap.c */,
+				D7A4928E265980C000214818 /* chmap.h */,
+				D7A4928C265980C000214818 /* chmap_sel.c */,
+				D7A4927D265980C000214818 /* chmap_sel.h */,
+				D7A4927C265980C000214818 /* fmt-conversion.c */,
+				D7A49282265980C000214818 /* fmt-conversion.h */,
+				D7A4927B265980C000214818 /* format.c */,
+				D7A4928D265980C000214818 /* format.h */,
+			);
+			path = audio;
+			sourceTree = "<group>";
+		};
+		D7A4925D265980C000214818 /* out */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49272265980C000214818 /* ao.c */,
+				D7A49266265980C000214818 /* ao.h */,
+				D7A4926F265980C000214818 /* ao_alsa.c */,
+				D7A49277265980C000214818 /* ao_audiotrack.c */,
+				D7A49263265980C000214818 /* ao_audiounit.m */,
+				D7A49268265980C000214818 /* ao_coreaudio.c */,
+				D7A49274265980C000214818 /* ao_coreaudio_chmap.c */,
+				D7A49264265980C000214818 /* ao_coreaudio_chmap.h */,
+				D7A4925F265980C000214818 /* ao_coreaudio_exclusive.c */,
+				D7A49276265980C000214818 /* ao_coreaudio_properties.c */,
+				D7A4926A265980C000214818 /* ao_coreaudio_properties.h */,
+				D7A4926B265980C000214818 /* ao_coreaudio_utils.c */,
+				D7A49279265980C000214818 /* ao_coreaudio_utils.h */,
+				D7A49275265980C000214818 /* ao_jack.c */,
+				D7A49278265980C000214818 /* ao_lavc.c */,
+				D7A4925E265980C000214818 /* ao_null.c */,
+				D7A49271265980C000214818 /* ao_openal.c */,
+				D7A4926C265980C000214818 /* ao_opensles.c */,
+				D7A49269265980C000214818 /* ao_oss.c */,
+				D7A49273265980C000214818 /* ao_pcm.c */,
+				D7A49267265980C000214818 /* ao_pulse.c */,
+				D7A4926E265980C000214818 /* ao_sdl.c */,
+				D7A49260265980C000214818 /* ao_wasapi.c */,
+				D7A4926D265980C000214818 /* ao_wasapi.h */,
+				D7A49265265980C000214818 /* ao_wasapi_changenotify.c */,
+				D7A49270265980C000214818 /* ao_wasapi_utils.c */,
+				D7A49261265980C000214818 /* buffer.c */,
+				D7A49262265980C000214818 /* internal.h */,
+			);
+			path = out;
+			sourceTree = "<group>";
+		};
+		D7A4927E265980C000214818 /* decode */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4927F265980C000214818 /* ad_lavc.c */,
+				D7A49280265980C000214818 /* ad_spdif.c */,
+			);
+			path = decode;
+			sourceTree = "<group>";
+		};
+		D7A49283265980C000214818 /* filter */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49287265980C000214818 /* af_drop.c */,
+				D7A49285265980C000214818 /* af_format.c */,
+				D7A49284265980C000214818 /* af_lavcac3enc.c */,
+				D7A4928A265980C000214818 /* af_rubberband.c */,
+				D7A49286265980C000214818 /* af_scaletempo.c */,
+				D7A49289265980C000214818 /* af_scaletempo2.c */,
+				D7A49288265980C000214818 /* af_scaletempo2_internals.c */,
+				D7A4928B265980C000214818 /* af_scaletempo2_internals.h */,
+			);
+			path = filter;
+			sourceTree = "<group>";
+		};
+		D7A49290265980C000214818 /* common */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4929E265980C000214818 /* av_common.c */,
+				D7A49293265980C000214818 /* av_common.h */,
+				D7A492A6265980C000214818 /* av_log.c */,
+				D7A4929B265980C000214818 /* av_log.h */,
+				D7A49291265980C000214818 /* codecs.c */,
+				D7A492A1265980C000214818 /* codecs.h */,
+				D7A49292265980C000214818 /* common.c */,
+				D7A492A0265980C000214818 /* common.h */,
+				D7A492A7265980C000214818 /* encode.h */,
+				D7A492A3265980C000214818 /* encode_lavc.c */,
+				D7A49296265980C000214818 /* encode_lavc.h */,
+				D7A49298265980C000214818 /* global.h */,
+				D7A49294265980C000214818 /* msg.c */,
+				D7A4929F265980C000214818 /* msg.h */,
+				D7A4929C265980C000214818 /* msg_control.h */,
+				D7A49299265980C000214818 /* playlist.c */,
+				D7A492A8265980C000214818 /* playlist.h */,
+				D7A49295265980C000214818 /* recorder.c */,
+				D7A4929D265980C000214818 /* recorder.h */,
+				D7A4929A265980C000214818 /* stats.c */,
+				D7A492A5265980C000214818 /* stats.h */,
+				D7A49297265980C000214818 /* tags.c */,
+				D7A492A4265980C000214818 /* tags.h */,
+				D7A492A2265980C000214818 /* version.c */,
+			);
+			path = common;
+			sourceTree = "<group>";
+		};
+		D7A492AB265980C000214818 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49366265980C100214818 /* decode */,
+				D7A49372265980C100214818 /* filter */,
+				D7A492B5265980C000214818 /* out */,
+				D7A4937F265980C100214818 /* csputils.c */,
+				D7A49363265980C100214818 /* csputils.h */,
+				D7A4935D265980C100214818 /* cuda.c */,
+				D7A49380265980C100214818 /* d3d.c */,
+				D7A49362265980C100214818 /* d3d.h */,
+				D7A49360265980C100214818 /* fmt-conversion.c */,
+				D7A49371265980C100214818 /* fmt-conversion.h */,
+				D7A4936F265980C100214818 /* hwdec.c */,
+				D7A492B1265980C000214818 /* hwdec.h */,
+				D7A49365265980C100214818 /* image_loader.c */,
+				D7A492AD265980C000214818 /* image_loader.h */,
+				D7A4936C265980C100214818 /* image_writer.c */,
+				D7A492B3265980C000214818 /* image_writer.h */,
+				D7A492AF265980C000214818 /* img_format.c */,
+				D7A4936E265980C100214818 /* img_format.h */,
+				D7A4935E265980C100214818 /* mp_image.c */,
+				D7A4937E265980C100214818 /* mp_image.h */,
+				D7A492B2265980C000214818 /* mp_image_pool.c */,
+				D7A4936B265980C100214818 /* mp_image_pool.h */,
+				D7A492AC265980C000214818 /* repack.c */,
+				D7A49368265980C100214818 /* repack.h */,
+				D7A49364265980C100214818 /* sws_utils.c */,
+				D7A492AE265980C000214818 /* sws_utils.h */,
+				D7A49369265980C100214818 /* vaapi.c */,
+				D7A492B4265980C000214818 /* vaapi.h */,
+				D7A4936D265980C100214818 /* vdpau.c */,
+				D7A492B0265980C000214818 /* vdpau.h */,
+				D7A4936A265980C100214818 /* vdpau_functions.inc */,
+				D7A4935F265980C100214818 /* vdpau_mixer.c */,
+				D7A4937D265980C100214818 /* vdpau_mixer.h */,
+				D7A49370265980C100214818 /* zimg.c */,
+				D7A49361265980C100214818 /* zimg.h */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+		D7A492B5265980C000214818 /* out */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4930E265980C100214818 /* cocoa */,
+				D7A492E2265980C000214818 /* d3d11 */,
+				D7A492BC265980C000214818 /* gpu */,
+				D7A492FB265980C100214818 /* hwdec */,
+				D7A49308265980C100214818 /* mac */,
+				D7A49338265980C100214818 /* opengl */,
+				D7A492EA265980C000214818 /* placebo */,
+				D7A49319265980C100214818 /* vulkan */,
+				D7A4932B265980C100214818 /* win32 */,
+				D7A492EF265980C100214818 /* android_common.c */,
+				D7A4932A265980C100214818 /* android_common.h */,
+				D7A492DA265980C000214818 /* aspect.c */,
+				D7A49326265980C100214818 /* aspect.h */,
+				D7A49306265980C100214818 /* bitmap_packer.c */,
+				D7A492BA265980C000214818 /* bitmap_packer.h */,
+				D7A49331265980C100214818 /* cocoa_cb_common.swift */,
+				D7A49329265980C100214818 /* cocoa_common.h */,
+				D7A492F1265980C100214818 /* cocoa_common.m */,
+				D7A49325265980C100214818 /* dither.c */,
+				D7A492DC265980C000214818 /* dither.h */,
+				D7A492E0265980C000214818 /* dr_helper.c */,
+				D7A49318265980C100214818 /* dr_helper.h */,
+				D7A492F7265980C100214818 /* drm_atomic.c */,
+				D7A49334265980C100214818 /* drm_atomic.h */,
+				D7A492B9265980C000214818 /* drm_common.c */,
+				D7A49304265980C100214818 /* drm_common.h */,
+				D7A49316265980C100214818 /* drm_prime.c */,
+				D7A492B6265980C000214818 /* drm_prime.h */,
+				D7A492DF265980C000214818 /* filter_kernels.c */,
+				D7A49323265980C100214818 /* filter_kernels.h */,
+				D7A492DD265980C000214818 /* libmpv.h */,
+				D7A492E1265980C000214818 /* libmpv_sw.c */,
+				D7A49328265980C100214818 /* vo.c */,
+				D7A492F3265980C100214818 /* vo.h */,
+				D7A492F6265980C100214818 /* vo_caca.c */,
+				D7A49317265980C100214818 /* vo_direct3d.c */,
+				D7A49324265980C100214818 /* vo_drm.c */,
+				D7A492F2265980C100214818 /* vo_gpu.c */,
+				D7A49333265980C100214818 /* vo_image.c */,
+				D7A49327265980C100214818 /* vo_lavc.c */,
+				D7A49335265980C100214818 /* vo_libmpv.c */,
+				D7A49332265980C100214818 /* vo_mediacodec_embed.c */,
+				D7A492F4265980C100214818 /* vo_null.c */,
+				D7A492F8265980C100214818 /* vo_rpi.c */,
+				D7A492DE265980C000214818 /* vo_sdl.c */,
+				D7A492F0265980C100214818 /* vo_sixel.c */,
+				D7A49330265980C100214818 /* vo_tct.c */,
+				D7A492E8265980C000214818 /* vo_vaapi.c */,
+				D7A492DB265980C000214818 /* vo_vdpau.c */,
+				D7A492F5265980C100214818 /* vo_wlshm.c */,
+				D7A492E9265980C000214818 /* vo_x11.c */,
+				D7A492B7265980C000214818 /* vo_xv.c */,
+				D7A49337265980C100214818 /* w32_common.c */,
+				D7A492FA265980C100214818 /* w32_common.h */,
+				D7A49305265980C100214818 /* wayland_common.c */,
+				D7A492BB265980C000214818 /* wayland_common.h */,
+				D7A49336265980C100214818 /* win_state.c */,
+				D7A492F9265980C100214818 /* win_state.h */,
+				D7A49307265980C100214818 /* x11_common.c */,
+				D7A492B8265980C000214818 /* x11_common.h */,
+			);
+			path = out;
+			sourceTree = "<group>";
+		};
+		D7A492BC265980C000214818 /* gpu */ = {
+			isa = PBXGroup;
+			children = (
+				D7A492D3265980C000214818 /* context.c */,
+				D7A492CA265980C000214818 /* context.h */,
+				D7A492C0265980C000214818 /* d3d11_helpers.c */,
+				D7A492D2265980C000214818 /* d3d11_helpers.h */,
+				D7A492BD265980C000214818 /* error_diffusion.c */,
+				D7A492CD265980C000214818 /* error_diffusion.h */,
+				D7A492D1265980C000214818 /* hwdec.c */,
+				D7A492C1265980C000214818 /* hwdec.h */,
+				D7A492C9265980C000214818 /* lcms.c */,
+				D7A492D5265980C000214818 /* lcms.h */,
+				D7A492C8265980C000214818 /* libmpv_gpu.c */,
+				D7A492D4265980C000214818 /* libmpv_gpu.h */,
+				D7A492C4265980C000214818 /* osd.c */,
+				D7A492D8265980C000214818 /* osd.h */,
+				D7A492D6265980C000214818 /* ra.c */,
+				D7A492C7265980C000214818 /* ra.h */,
+				D7A492CC265980C000214818 /* shader_cache.c */,
+				D7A492BF265980C000214818 /* shader_cache.h */,
+				D7A492C3265980C000214818 /* spirv.c */,
+				D7A492CF265980C000214818 /* spirv.h */,
+				D7A492C6265980C000214818 /* spirv_shaderc.c */,
+				D7A492C5265980C000214818 /* user_shaders.c */,
+				D7A492D7265980C000214818 /* user_shaders.h */,
+				D7A492CE265980C000214818 /* utils.c */,
+				D7A492BE265980C000214818 /* utils.h */,
+				D7A492C2265980C000214818 /* video.c */,
+				D7A492D0265980C000214818 /* video.h */,
+				D7A492CB265980C000214818 /* video_shaders.c */,
+				D7A492D9265980C000214818 /* video_shaders.h */,
+			);
+			path = gpu;
+			sourceTree = "<group>";
+		};
+		D7A492E2265980C000214818 /* d3d11 */ = {
+			isa = PBXGroup;
+			children = (
+				D7A492E7265980C000214818 /* context.c */,
+				D7A492E5265980C000214818 /* hwdec_d3d11va.c */,
+				D7A492E6265980C000214818 /* hwdec_dxva2dxgi.c */,
+				D7A492E4265980C000214818 /* ra_d3d11.c */,
+				D7A492E3265980C000214818 /* ra_d3d11.h */,
+			);
+			path = d3d11;
+			sourceTree = "<group>";
+		};
+		D7A492EA265980C000214818 /* placebo */ = {
+			isa = PBXGroup;
+			children = (
+				D7A492EE265980C100214818 /* ra_pl.c */,
+				D7A492EC265980C000214818 /* ra_pl.h */,
+				D7A492ED265980C100214818 /* utils.c */,
+				D7A492EB265980C000214818 /* utils.h */,
+			);
+			path = placebo;
+			sourceTree = "<group>";
+		};
+		D7A492FB265980C100214818 /* hwdec */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49301265980C100214818 /* hwdec_cuda.c */,
+				D7A492FF265980C100214818 /* hwdec_cuda.h */,
+				D7A492FE265980C100214818 /* hwdec_cuda_gl.c */,
+				D7A49302265980C100214818 /* hwdec_cuda_vk.c */,
+				D7A49300265980C100214818 /* hwdec_vaapi.c */,
+				D7A492FC265980C100214818 /* hwdec_vaapi.h */,
+				D7A49303265980C100214818 /* hwdec_vaapi_gl.c */,
+				D7A492FD265980C100214818 /* hwdec_vaapi_vk.c */,
+			);
+			path = hwdec;
+			sourceTree = "<group>";
+		};
+		D7A49308265980C100214818 /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4930A265980C100214818 /* common.swift */,
+				D7A4930D265980C100214818 /* gl_layer.swift */,
+				D7A4930B265980C100214818 /* title_bar.swift */,
+				D7A49309265980C100214818 /* view.swift */,
+				D7A4930C265980C100214818 /* window.swift */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
+		D7A4930E265980C100214818 /* cocoa */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49315265980C100214818 /* events_view.h */,
+				D7A49311265980C100214818 /* events_view.m */,
+				D7A49312265980C100214818 /* mpvadapter.h */,
+				D7A49313265980C100214818 /* video_view.h */,
+				D7A4930F265980C100214818 /* video_view.m */,
+				D7A49310265980C100214818 /* window.h */,
+				D7A49314265980C100214818 /* window.m */,
+			);
+			path = cocoa;
+			sourceTree = "<group>";
+		};
+		D7A49319265980C100214818 /* vulkan */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4931F265980C100214818 /* common.h */,
+				D7A49320265980C100214818 /* context.c */,
+				D7A4931D265980C100214818 /* context.h */,
+				D7A4931C265980C100214818 /* context_android.c */,
+				D7A49322265980C100214818 /* context_wayland.c */,
+				D7A49321265980C100214818 /* context_win.c */,
+				D7A4931B265980C100214818 /* context_xlib.c */,
+				D7A4931E265980C100214818 /* utils.c */,
+				D7A4931A265980C100214818 /* utils.h */,
+			);
+			path = vulkan;
+			sourceTree = "<group>";
+		};
+		D7A4932B265980C100214818 /* win32 */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4932F265980C100214818 /* displayconfig.c */,
+				D7A4932D265980C100214818 /* displayconfig.h */,
+				D7A4932E265980C100214818 /* droptarget.c */,
+				D7A4932C265980C100214818 /* droptarget.h */,
+			);
+			path = win32;
+			sourceTree = "<group>";
+		};
+		D7A49338265980C100214818 /* opengl */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49340265980C100214818 /* angle_dynamic.c */,
+				D7A49350265980C100214818 /* angle_dynamic.h */,
+				D7A4933C265980C100214818 /* common.c */,
+				D7A4934C265980C100214818 /* common.h */,
+				D7A49354265980C100214818 /* context.c */,
+				D7A49345265980C100214818 /* context.h */,
+				D7A49343265980C100214818 /* context_android.c */,
+				D7A49358265980C100214818 /* context_angle.c */,
+				D7A49342265980C100214818 /* context_cocoa.c */,
+				D7A4934A265980C100214818 /* context_drm_egl.c */,
+				D7A4933B265980C100214818 /* context_dxinterop.c */,
+				D7A49357265980C100214818 /* context_glx.c */,
+				D7A49352265980C100214818 /* context_rpi.c */,
+				D7A4935B265980C100214818 /* context_wayland.c */,
+				D7A4935A265980C100214818 /* context_win.c */,
+				D7A4934D265980C100214818 /* context_x11egl.c */,
+				D7A4933E265980C100214818 /* egl_helpers.c */,
+				D7A49347265980C100214818 /* egl_helpers.h */,
+				D7A49353265980C100214818 /* formats.c */,
+				D7A4933F265980C100214818 /* formats.h */,
+				D7A49359265980C100214818 /* gl_headers.h */,
+				D7A4933A265980C100214818 /* hwdec_d3d11egl.c */,
+				D7A49348265980C100214818 /* hwdec_drmprime_drm.c */,
+				D7A4934E265980C100214818 /* hwdec_dxva2egl.c */,
+				D7A49355265980C100214818 /* hwdec_dxva2gldx.c */,
+				D7A4934F265980C100214818 /* hwdec_ios.m */,
+				D7A49344265980C100214818 /* hwdec_osx.c */,
+				D7A49339265980C100214818 /* hwdec_rpi.c */,
+				D7A49349265980C100214818 /* hwdec_vdpau.c */,
+				D7A49356265980C100214818 /* libmpv_gl.c */,
+				D7A49346265980C100214818 /* oml_sync.c */,
+				D7A4935C265980C100214818 /* oml_sync.h */,
+				D7A49351265980C100214818 /* ra_gl.c */,
+				D7A49341265980C100214818 /* ra_gl.h */,
+				D7A4934B265980C100214818 /* utils.c */,
+				D7A4933D265980C100214818 /* utils.h */,
+			);
+			path = opengl;
+			sourceTree = "<group>";
+		};
+		D7A49366265980C100214818 /* decode */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49367265980C100214818 /* vd_lavc.c */,
+			);
+			path = decode;
+			sourceTree = "<group>";
+		};
+		D7A49372265980C100214818 /* filter */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49378265980C100214818 /* refqueue.c */,
+				D7A49374265980C100214818 /* refqueue.h */,
+				D7A49376265980C100214818 /* vf_d3d11vpp.c */,
+				D7A49379265980C100214818 /* vf_fingerprint.c */,
+				D7A4937A265980C100214818 /* vf_format.c */,
+				D7A4937C265980C100214818 /* vf_gpu.c */,
+				D7A49373265980C100214818 /* vf_sub.c */,
+				D7A49377265980C100214818 /* vf_vapoursynth.c */,
+				D7A4937B265980C100214818 /* vf_vavpp.c */,
+				D7A49375265980C100214818 /* vf_vdpaupp.c */,
+			);
+			path = filter;
+			sourceTree = "<group>";
+		};
+		D7A49381265980C100214818 /* player */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4939D265980C100214818 /* javascript */,
+				D7A4938D265980C100214818 /* lua */,
+				D7A493A1265980C100214818 /* audio.c */,
+				D7A49396265980C100214818 /* client.c */,
+				D7A49384265980C100214818 /* client.h */,
+				D7A4938C265980C100214818 /* command.c */,
+				D7A4939B265980C100214818 /* command.h */,
+				D7A49397265980C100214818 /* configfiles.c */,
+				D7A49383265980C100214818 /* core.h */,
+				D7A4939A265980C100214818 /* external_files.c */,
+				D7A49385265980C100214818 /* external_files.h */,
+				D7A49382265980C100214818 /* javascript.c */,
+				D7A4938A265980C100214818 /* loadfile.c */,
+				D7A4938B265980C100214818 /* lua.c */,
+				D7A49398265980C100214818 /* main.c */,
+				D7A4939F265980C100214818 /* misc.c */,
+				D7A49389265980C100214818 /* osd.c */,
+				D7A49388265980C100214818 /* playloop.c */,
+				D7A49399265980C100214818 /* screenshot.c */,
+				D7A49386265980C100214818 /* screenshot.h */,
+				D7A493A0265980C100214818 /* scripting.c */,
+				D7A4939C265980C100214818 /* sub.c */,
+				D7A49387265980C100214818 /* video.c */,
+			);
+			path = player;
+			sourceTree = "<group>";
+		};
+		D7A4938D265980C100214818 /* lua */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49390265980C100214818 /* assdraw.lua */,
+				D7A4938F265980C100214818 /* auto_profiles.lua */,
+				D7A49392265980C100214818 /* console.lua */,
+				D7A49394265980C100214818 /* defaults.lua */,
+				D7A49393265980C100214818 /* options.lua */,
+				D7A4938E265980C100214818 /* osc.lua */,
+				D7A49391265980C100214818 /* stats.lua */,
+				D7A49395265980C100214818 /* ytdl_hook.lua */,
+			);
+			path = lua;
+			sourceTree = "<group>";
+		};
+		D7A4939D265980C100214818 /* javascript */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4939E265980C100214818 /* defaults.js */,
+			);
+			path = javascript;
+			sourceTree = "<group>";
+		};
+		D7A493A3265980C100214818 /* ta */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493A7265980C100214818 /* README */,
+				D7A493A4265980C100214818 /* ta.c */,
+				D7A493A8265980C100214818 /* ta.h */,
+				D7A493A6265980C100214818 /* ta_talloc.c */,
+				D7A493A9265980C100214818 /* ta_talloc.h */,
+				D7A493A5265980C100214818 /* ta_utils.c */,
+			);
+			path = ta;
+			sourceTree = "<group>";
+		};
+		D7A493AA265980C100214818 /* ci */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493AD265980C100214818 /* build-freebsd.sh */,
+				D7A493AC265980C100214818 /* build-macos.sh */,
+				D7A493AB265980C100214818 /* build-mingw64.sh */,
+				D7A493AE265980C100214818 /* build-tumbleweed.sh */,
+			);
+			path = ci;
+			sourceTree = "<group>";
+		};
+		D7A493AF265980C100214818 /* TOOLS */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493C9265980C100214818 /* lua */,
+				D7A493B9265980C100214818 /* osxbundle */,
+				D7A493B7265980C100214818 /* sort-xcode-project-file */,
+				D7A493DB265980C100214818 /* travis-deps */,
+				D7A493B8265980C100214818 /* travis-rebuild-website */,
+				D7A493B1265980C100214818 /* umpv */,
+				D7A493BE265980C100214818 /* __init__.py */,
+				D7A493B2265980C100214818 /* appveyor-build.sh */,
+				D7A493BC265980C100214818 /* appveyor-install.sh */,
+				D7A493BD265980C100214818 /* dylib-unhell.py */,
+				D7A493B6265980C100214818 /* file2string.py */,
+				D7A49403265980C100214818 /* file2string.pyc */,
+				D7A49401265980C100214818 /* gen-osd-font.sh */,
+				D7A49404265980C100214818 /* idet.sh */,
+				D7A493B4265980C100214818 /* matroska.py */,
+				D7A493DC265980C100214818 /* mpv-osd-symbols.sfdir */,
+				D7A493B3265980C100214818 /* mpv_identify.sh */,
+				D7A49402265980C100214818 /* osxbundle.py */,
+				D7A493B5265980C100214818 /* stats-conv.py */,
+				D7A493B0265980C100214818 /* uncrustify.cfg */,
+			);
+			path = TOOLS;
+			sourceTree = "<group>";
+		};
+		D7A493B9265980C100214818 /* osxbundle */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493BA265980C100214818 /* mpv.app */,
+			);
+			path = osxbundle;
+			sourceTree = "<group>";
+		};
+		D7A493C9265980C100214818 /* lua */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493D5265980C100214818 /* acompressor.lua */,
+				D7A493D8265980C100214818 /* ao-null-reload.lua */,
+				D7A493D3265980C100214818 /* audio-hotplug-test.lua */,
+				D7A493CF265980C100214818 /* autocrop.lua */,
+				D7A493D7265980C100214818 /* autodeint.lua */,
+				D7A493CA265980C100214818 /* autoload.lua */,
+				D7A493D9265980C100214818 /* command-test.lua */,
+				D7A493CC265980C100214818 /* cycle-deinterlace-pullup.lua */,
+				D7A493DA265980C100214818 /* nan-test.lua */,
+				D7A493CE265980C100214818 /* observe-all.lua */,
+				D7A493CD265980C100214818 /* ontop-playback.lua */,
+				D7A493CB265980C100214818 /* osd-test.lua */,
+				D7A493D0265980C100214818 /* pause-when-minimize.lua */,
+				D7A493D2265980C100214818 /* README.md */,
+				D7A493D6265980C100214818 /* skip-logo.lua */,
+				D7A493D1265980C100214818 /* status-line.lua */,
+				D7A493D4265980C100214818 /* test-hooks.lua */,
+			);
+			path = lua;
+			sourceTree = "<group>";
+		};
+		D7A493DC265980C100214818 /* mpv-osd-symbols.sfdir */ = {
+			isa = PBXGroup;
+			children = (
+				D7A493E7265980C100214818 /* .notdef.glyph */,
+				D7A493E4265980C100214818 /* font.props */,
+				D7A493E0265980C100214818 /* uniE001.glyph */,
+				D7A493E9265980C100214818 /* uniE002.glyph */,
+				D7A493E3265980C100214818 /* uniE003.glyph */,
+				D7A493E5265980C100214818 /* uniE004.glyph */,
+				D7A493DF265980C100214818 /* uniE005.glyph */,
+				D7A493E6265980C100214818 /* uniE006.glyph */,
+				D7A493DD265980C100214818 /* uniE007.glyph */,
+				D7A493F3265980C100214818 /* uniE008.glyph */,
+				D7A493FB265980C100214818 /* uniE009.glyph */,
+				D7A493EE265980C100214818 /* uniE00A.glyph */,
+				D7A493FA265980C100214818 /* uniE00B.glyph */,
+				D7A493FD265980C100214818 /* uniE010.glyph */,
+				D7A493F5265980C100214818 /* uniE011.glyph */,
+				D7A493FF265980C100214818 /* uniE012.glyph */,
+				D7A493F0265980C100214818 /* uniE013.glyph */,
+				D7A493DE265980C100214818 /* uniE101.glyph */,
+				D7A493EA265980C100214818 /* uniE104.glyph */,
+				D7A493E1265980C100214818 /* uniE105.glyph */,
+				D7A493E8265980C100214818 /* uniE106.glyph */,
+				D7A493E2265980C100214818 /* uniE107.glyph */,
+				D7A493EB265980C100214818 /* uniE108.glyph */,
+				D7A493F8265980C100214818 /* uniE109.glyph */,
+				D7A493F1265980C100214818 /* uniE10A.glyph */,
+				D7A493FE265980C100214818 /* uniE10B.glyph */,
+				D7A493F4265980C100214818 /* uniE10C.glyph */,
+				D7A493F7265980C100214818 /* uniE10D.glyph */,
+				D7A493EF265980C100214818 /* uniE10E.glyph */,
+				D7A493F9265980C100214818 /* uniE110.glyph */,
+				D7A493EC265980C100214818 /* uniE111.glyph */,
+				D7A493F6265980C100214818 /* uniE112.glyph */,
+				D7A493ED265980C100214818 /* uniE113.glyph */,
+				D7A493FC265980C100214818 /* uniE114.glyph */,
+				D7A493F2265980C100214818 /* uniE115.glyph */,
+			);
+			path = "mpv-osd-symbols.sfdir";
+			sourceTree = "<group>";
+		};
+		D7A49405265980C100214818 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49409265980C100214818 /* ref */,
+				D7A49414265980C100214818 /* chmap.c */,
+				D7A49406265980C100214818 /* gl_video.c */,
+				D7A49410265980C100214818 /* img_format.c */,
+				D7A4941B265980C100214818 /* input-gamepad.conf */,
+				D7A49407265980C100214818 /* json.c */,
+				D7A49416265980C100214818 /* linked_list.c */,
+				D7A49412265980C100214818 /* paths.c */,
+				D7A49408265980C100214818 /* repack.c */,
+				D7A49415265980C100214818 /* scale_sws.c */,
+				D7A4941A265980C100214818 /* scale_test.c */,
+				D7A49411265980C100214818 /* scale_test.h */,
+				D7A49419265980C100214818 /* scale_zimg.c */,
+				D7A49418265980C100214818 /* subtimes.js */,
+				D7A49417265980C100214818 /* tests.c */,
+				D7A49413265980C100214818 /* tests.h */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		D7A49409265980C100214818 /* ref */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4940F265980C100214818 /* draw_bmp.txt */,
+				D7A4940E265980C100214818 /* img_formats.txt */,
+				D7A4940B265980C100214818 /* repack.txt */,
+				D7A4940D265980C100214818 /* repack_sws.log */,
+				D7A4940A265980C100214818 /* repack_zimg.log */,
+				D7A4940C265980C100214818 /* zimg_formats.txt */,
+			);
+			path = ref;
+			sourceTree = "<group>";
+		};
+		D7A4941C265980C100214818 /* libmpv */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4941D265980C100214818 /* client.h */,
+				D7A49420265980C100214818 /* mpv.def */,
+				D7A49421265980C100214818 /* mpv.pc.in */,
+				D7A49422265980C100214818 /* opengl_cb.h */,
+				D7A49423265980C100214818 /* render.h */,
+				D7A4941F265980C100214818 /* render_gl.h */,
+				D7A4941E265980C100214818 /* stream_cb.h */,
+			);
+			path = libmpv;
+			sourceTree = "<group>";
+		};
+		D7A49424265980C100214818 /* osdep */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4944F265980C100214818 /* android */,
+				D7A4942C265980C100214818 /* macos */,
+				D7A49460265980C100214818 /* win32 */,
+				D7A4946D265980C100214818 /* atomic.h */,
+				D7A49435265980C100214818 /* compiler.h */,
+				D7A4943A265980C100214818 /* endian.h */,
+				D7A49434265980C100214818 /* getpid.h */,
+				D7A4944B265980C100214818 /* glob-win.c */,
+				D7A49438265980C100214818 /* io.c */,
+				D7A4944D265980C100214818 /* io.h */,
+				D7A49445265980C100214818 /* macOS_swift_bridge.h */,
+				D7A49441265980C100214818 /* macosx_application.h */,
+				D7A4946A265980C100214818 /* macosx_application.m */,
+				D7A4945C265980C100214818 /* macosx_application_objc.h */,
+				D7A49453265980C100214818 /* macosx_compat.h */,
+				D7A4943D265980C100214818 /* macosx_events.h */,
+				D7A4945B265980C100214818 /* macosx_events.m */,
+				D7A49457265980C100214818 /* macosx_events_objc.h */,
+				D7A4943E265980C100214818 /* macosx_menubar.h */,
+				D7A49458265980C100214818 /* macosx_menubar.m */,
+				D7A49456265980C100214818 /* macosx_menubar_objc.h */,
+				D7A4943B265980C100214818 /* macosx_touchbar.h */,
+				D7A49465265980C100214818 /* macosx_touchbar.m */,
+				D7A49449265980C100214818 /* macosx_versions.h */,
+				D7A49437265980C100214818 /* main-fn-cocoa.c */,
+				D7A49428265980C100214818 /* main-fn-unix.c */,
+				D7A49468265980C100214818 /* main-fn-win.c */,
+				D7A4945F265980C100214818 /* main-fn.h */,
+				D7A49433265980C100214818 /* mpv.exe.manifest */,
+				D7A4944A265980C100214818 /* mpv.rc */,
+				D7A4945D265980C100214818 /* path-macosx.m */,
+				D7A49429265980C100214818 /* path-unix.c */,
+				D7A49459265980C100214818 /* path-uwp.c */,
+				D7A4944E265980C100214818 /* path-win.c */,
+				D7A49439265980C100214818 /* path.h */,
+				D7A4946C265980C100214818 /* polldev.c */,
+				D7A49440265980C100214818 /* polldev.h */,
+				D7A49426265980C100214818 /* semaphore.h */,
+				D7A4946B265980C100214818 /* semaphore_osx.c */,
+				D7A4945E265980C100214818 /* strnlen.h */,
+				D7A49427265980C100214818 /* subprocess-dummy.c */,
+				D7A4943F265980C100214818 /* subprocess-posix.c */,
+				D7A49425265980C100214818 /* subprocess-win.c */,
+				D7A49446265980C100214818 /* subprocess.c */,
+				D7A49466265980C100214818 /* subprocess.h */,
+				D7A49444265980C100214818 /* terminal-dummy.c */,
+				D7A4942A265980C100214818 /* terminal-unix.c */,
+				D7A49442265980C100214818 /* terminal-win.c */,
+				D7A49452265980C100214818 /* terminal.h */,
+				D7A49469265980C100214818 /* threads.c */,
+				D7A49443265980C100214818 /* threads.h */,
+				D7A4944C265980C100214818 /* timer-darwin.c */,
+				D7A49448265980C100214818 /* timer-linux.c */,
+				D7A49467265980C100214818 /* timer-win2.c */,
+				D7A4942B265980C100214818 /* timer.c */,
+				D7A49447265980C100214818 /* timer.h */,
+				D7A49436265980C100214818 /* w32_keyboard.c */,
+				D7A49455265980C100214818 /* w32_keyboard.h */,
+				D7A49454265980C100214818 /* win32-console-wrapper.c */,
+				D7A4943C265980C100214818 /* windows_utils.c */,
+				D7A4945A265980C100214818 /* windows_utils.h */,
+			);
+			path = osdep;
+			sourceTree = "<group>";
+		};
+		D7A4942C265980C100214818 /* macos */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4942F265980C100214818 /* libmpv_helper.swift */,
+				D7A4942E265980C100214818 /* log_helper.swift */,
+				D7A49431265980C100214818 /* mpv_helper.swift */,
+				D7A4942D265980C100214818 /* remote_command_center.swift */,
+				D7A49430265980C100214818 /* swift_compat.swift */,
+				D7A49432265980C100214818 /* swift_extensions.swift */,
+			);
+			path = macos;
+			sourceTree = "<group>";
+		};
+		D7A4944F265980C100214818 /* android */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49450265980C100214818 /* strnlen.c */,
+				D7A49451265980C100214818 /* strnlen.h */,
+			);
+			path = android;
+			sourceTree = "<group>";
+		};
+		D7A49460265980C100214818 /* win32 */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49462265980C100214818 /* include */,
+				D7A49461265980C100214818 /* pthread.c */,
+			);
+			path = win32;
+			sourceTree = "<group>";
+		};
+		D7A49462265980C100214818 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49464265980C100214818 /* pthread.h */,
+				D7A49463265980C100214818 /* semaphore.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		D7A4946E265980C200214818 /* demux */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49485265980C200214818 /* cache.c */,
+				D7A4947A265980C200214818 /* cache.h */,
+				D7A4947B265980C200214818 /* codec_tags.c */,
+				D7A4948A265980C200214818 /* codec_tags.h */,
+				D7A49483265980C200214818 /* cue.c */,
+				D7A49475265980C200214818 /* cue.h */,
+				D7A49471265980C200214818 /* demux.c */,
+				D7A49480265980C200214818 /* demux.h */,
+				D7A49489265980C200214818 /* demux_cue.c */,
+				D7A49487265980C200214818 /* demux_disc.c */,
+				D7A49478265980C200214818 /* demux_edl.c */,
+				D7A4947C265980C200214818 /* demux_lavf.c */,
+				D7A49484265980C200214818 /* demux_libarchive.c */,
+				D7A49474265980C200214818 /* demux_mf.c */,
+				D7A49477265980C200214818 /* demux_mkv.c */,
+				D7A49473265980C200214818 /* demux_mkv_timeline.c */,
+				D7A4947D265980C200214818 /* demux_null.c */,
+				D7A49476265980C200214818 /* demux_playlist.c */,
+				D7A4947F265980C200214818 /* demux_raw.c */,
+				D7A49472265980C200214818 /* demux_timeline.c */,
+				D7A49481265980C200214818 /* ebml.c */,
+				D7A4946F265980C200214818 /* ebml.h */,
+				D7A49486265980C200214818 /* matroska.h */,
+				D7A49479265980C200214818 /* packet.c */,
+				D7A49482265980C200214818 /* packet.h */,
+				D7A49470265980C200214818 /* stheader.h */,
+				D7A4947E265980C200214818 /* timeline.c */,
+				D7A49488265980C200214818 /* timeline.h */,
+			);
+			path = demux;
+			sourceTree = "<group>";
+		};
+		D7A4948E265980C200214818 /* misc */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49495265980C200214818 /* bstr.c */,
+				D7A494A0265980C200214818 /* bstr.h */,
+				D7A494A3265980C200214818 /* charset_conv.c */,
+				D7A49498265980C200214818 /* charset_conv.h */,
+				D7A4949C265980C200214818 /* ctype.h */,
+				D7A49491265980C200214818 /* dispatch.c */,
+				D7A4949F265980C200214818 /* dispatch.h */,
+				D7A49490265980C200214818 /* jni.c */,
+				D7A4949A265980C200214818 /* jni.h */,
+				D7A4948F265980C200214818 /* json.c */,
+				D7A4949B265980C200214818 /* json.h */,
+				D7A49494265980C200214818 /* linked_list.h */,
+				D7A494A1265980C200214818 /* natural_sort.c */,
+				D7A49496265980C200214818 /* natural_sort.h */,
+				D7A494A4265980C200214818 /* node.c */,
+				D7A49497265980C200214818 /* node.h */,
+				D7A49492265980C200214818 /* rendezvous.c */,
+				D7A4949E265980C200214818 /* rendezvous.h */,
+				D7A494A2265980C200214818 /* thread_pool.c */,
+				D7A49499265980C200214818 /* thread_pool.h */,
+				D7A4949D265980C200214818 /* thread_tools.c */,
+				D7A49493265980C200214818 /* thread_tools.h */,
+			);
+			path = misc;
+			sourceTree = "<group>";
+		};
+		D7A494A7265980C200214818 /* DOCS */ = {
+			isa = PBXGroup;
+			children = (
+				D7A494A8265980C200214818 /* man */,
+				D7A494C2265980C200214818 /* client-api-changes.rst */,
+				D7A494C3265980C200214818 /* compatibility.rst */,
+				D7A494B9265980C200214818 /* compile-windows.md */,
+				D7A494BE265980C200214818 /* contribute.md */,
+				D7A494BD265980C200214818 /* edl-mpv.rst */,
+				D7A494BB265980C200214818 /* encoding.rst */,
+				D7A494BF265980C200214818 /* interface-changes.rst */,
+				D7A494BA265980C200214818 /* mplayer-changes.rst */,
+				D7A494C0265980C200214818 /* release-policy.md */,
+				D7A494BC265980C200214818 /* tech-overview.txt */,
+				D7A494C1265980C200214818 /* waf-buildsystem.rst */,
+			);
+			path = DOCS;
+			sourceTree = "<group>";
+		};
+		D7A494A8265980C200214818 /* man */ = {
+			isa = PBXGroup;
+			children = (
+				D7A494AA265980C200214818 /* af.rst */,
+				D7A494B7265980C200214818 /* ao.rst */,
+				D7A494B4265980C200214818 /* changes.rst */,
+				D7A494B2265980C200214818 /* console.rst */,
+				D7A494AD265980C200214818 /* encode.rst */,
+				D7A494B5265980C200214818 /* input.rst */,
+				D7A494B8265980C200214818 /* ipc.rst */,
+				D7A494AE265980C200214818 /* javascript.rst */,
+				D7A494AF265980C200214818 /* libmpv.rst */,
+				D7A494AC265980C200214818 /* lua.rst */,
+				D7A494B3265980C200214818 /* mpv.rst */,
+				D7A494B0265980C200214818 /* options.rst */,
+				D7A494AB265980C200214818 /* osc.rst */,
+				D7A494B1265980C200214818 /* stats.rst */,
+				D7A494B6265980C200214818 /* vf.rst */,
+				D7A494A9265980C200214818 /* vo.rst */,
+			);
+			path = man;
+			sourceTree = "<group>";
+		};
+		D7A494C4265980C200214818 /* waftools */ = {
+			isa = PBXGroup;
+			children = (
+				D7A494D4265980C200214818 /* checks */,
+				D7A49500265980C200214818 /* detections */,
+				D7A494C6265980C200214818 /* fragments */,
+				D7A49518265980C200214818 /* generators */,
+				D7A494E7265980C200214818 /* __init__.py */,
+				D7A494D3265980C200214818 /* clang_compilation_database.py */,
+				D7A4952B265980C200214818 /* dependencies.py */,
+				D7A494C5265980C200214818 /* deps_parser.py */,
+				D7A494E8265980C200214818 /* features.py */,
+				D7A494E6265980C200214818 /* inflector.py */,
+				D7A494FF265980C200214818 /* syms.py */,
+				D7A494D2265980C200214818 /* waf_customizations.py */,
+			);
+			path = waftools;
+			sourceTree = "<group>";
+		};
+		D7A494C6265980C200214818 /* fragments */ = {
+			isa = PBXGroup;
+			children = (
+				D7A494CA265980C200214818 /* audiounit.c */,
+				D7A494CE265980C200214818 /* cocoa.m */,
+				D7A494C8265980C200214818 /* coreaudio.c */,
+				D7A494CF265980C200214818 /* gl_x11.c */,
+				D7A494C7265980C200214818 /* iconv.c */,
+				D7A494CC265980C200214818 /* pthreads.c */,
+				D7A494CB265980C200214818 /* sse.c */,
+				D7A494C9265980C200214818 /* touchbar.m */,
+				D7A494CD265980C200214818 /* wasapi.c */,
+			);
+			path = fragments;
+			sourceTree = "<group>";
+		};
+		D7A494D4265980C200214818 /* checks */ = {
+			isa = PBXGroup;
+			children = (
+				D7A494D8265980C200214818 /* __init__.py */,
+				D7A494D6265980C200214818 /* custom.py */,
+				D7A494D7265980C200214818 /* generic.py */,
+			);
+			path = checks;
+			sourceTree = "<group>";
+		};
+		D7A49500265980C200214818 /* detections */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49502265980C200214818 /* __init__.py */,
+				D7A49501265980C200214818 /* compiler.py */,
+				D7A49512265980C200214818 /* compiler_swift.py */,
+				D7A49514265980C200214818 /* devices.py */,
+			);
+			path = detections;
+			sourceTree = "<group>";
+		};
+		D7A49518265980C200214818 /* generators */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4951B265980C200214818 /* __init__.py */,
+				D7A49528265980C200214818 /* headers.py */,
+				D7A49526265980C200214818 /* sources.py */,
+			);
+			path = generators;
+			sourceTree = "<group>";
+		};
+		D7A4952C265980C200214818 /* sub */ = {
+			isa = PBXGroup;
+			children = (
+				D7A4952F265980C200214818 /* ass_mp.c */,
+				D7A49537265980C200214818 /* ass_mp.h */,
+				D7A49539265980C200214818 /* dec_sub.c */,
+				D7A4952E265980C200214818 /* dec_sub.h */,
+				D7A49533265980C200214818 /* draw_bmp.c */,
+				D7A4953F265980C200214818 /* draw_bmp.h */,
+				D7A49536265980C200214818 /* filter_regex.c */,
+				D7A4953E265980C200214818 /* filter_sdh.c */,
+				D7A49532265980C200214818 /* img_convert.c */,
+				D7A4953C265980C200214818 /* img_convert.h */,
+				D7A49538265980C200214818 /* lavc_conv.c */,
+				D7A49531265980C200214818 /* osd.c */,
+				D7A4953D265980C200214818 /* osd.h */,
+				D7A4952D265980C200214818 /* osd_font.otf */,
+				D7A49530265980C200214818 /* osd_libass.c */,
+				D7A4953B265980C200214818 /* osd_state.h */,
+				D7A4953A265980C200214818 /* sd.h */,
+				D7A49534265980C200214818 /* sd_ass.c */,
+				D7A49535265980C200214818 /* sd_lavc.c */,
+			);
+			path = sub;
+			sourceTree = "<group>";
+		};
+		D7A49541265980C200214818 /* input */ = {
+			isa = PBXGroup;
+			children = (
+				D7A49547265980C200214818 /* cmd.c */,
+				D7A4954C265980C200214818 /* cmd.h */,
+				D7A49549265980C200214818 /* event.c */,
+				D7A49545265980C200214818 /* event.h */,
+				D7A49548265980C200214818 /* input.c */,
+				D7A49544265980C200214818 /* input.h */,
+				D7A49542265980C200214818 /* ipc-dummy.c */,
+				D7A4954D265980C200214818 /* ipc-unix.c */,
+				D7A49543265980C200214818 /* ipc-win.c */,
+				D7A4954B265980C200214818 /* ipc.c */,
+				D7A4954A265980C200214818 /* keycodes.c */,
+				D7A49546265980C200214818 /* keycodes.h */,
+				D7A4954E265980C200214818 /* sdl_gamepad.c */,
+			);
+			path = input;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXLegacyTarget section */
+		D74FE37D265929FB008536C6 /* mpv build */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "build  $(ACTION)";
+			buildConfigurationList = D74FE380265929FB008536C6 /* Build configuration list for PBXLegacyTarget "mpv build" */;
+			buildPhases = (
+			);
+			buildToolPath = ./waf;
+			buildWorkingDirectory = .;
+			dependencies = (
+			);
+			name = "mpv build";
+			passBuildSettingsInEnvironment = 1;
+			productName = mpv;
+		};
+		D77688832659560800FFDF2E /* mpv configure build */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "configure build $(ACTION)";
+			buildConfigurationList = D77688862659560800FFDF2E /* Build configuration list for PBXLegacyTarget "mpv configure build" */;
+			buildPhases = (
+			);
+			buildToolPath = ./waf;
+			buildWorkingDirectory = .;
+			dependencies = (
+			);
+			name = "mpv configure build";
+			passBuildSettingsInEnvironment = 1;
+			productName = "configure build";
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXNativeTarget section */
+		D7A491D626597FE500214818 /* mpv */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D7A491E826597FE600214818 /* Build configuration list for PBXNativeTarget "mpv" */;
+			buildPhases = (
+				D7A491D326597FE500214818 /* Sources */,
+				D7A491D426597FE500214818 /* Frameworks */,
+				D7A491D526597FE500214818 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = mpv;
+			productName = mpv;
+			productReference = D7A497A9265984E300214818 /* mpv.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D74FE379265929FB008536C6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1120;
+				ORGANIZATIONNAME = Akemi;
+				TargetAttributes = {
+					D74FE37D265929FB008536C6 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+					D77688832659560800FFDF2E = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+					D7A491D626597FE500214818 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+				};
+			};
+			buildConfigurationList = D74FE37C265929FB008536C6 /* Build configuration list for PBXProject "mpv" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D74FE378265929FB008536C6;
+			productRefGroup = D74FE378265929FB008536C6;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D74FE37D265929FB008536C6 /* mpv build */,
+				D77688832659560800FFDF2E /* mpv configure build */,
+				D7A491D626597FE500214818 /* mpv */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D7A491D526597FE500214818 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D7A491D326597FE500214818 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D7A495A5265980C300214818 /* ad_lavc.c in Sources */,
+				D7A495A6265980C300214818 /* ad_spdif.c in Sources */,
+				D7A495AA265980C300214818 /* af_drop.c in Sources */,
+				D7A495A8265980C300214818 /* af_format.c in Sources */,
+				D7A495A7265980C300214818 /* af_lavcac3enc.c in Sources */,
+				D7A495AD265980C300214818 /* af_rubberband.c in Sources */,
+				D7A495A9265980C300214818 /* af_scaletempo.c in Sources */,
+				D7A495AC265980C300214818 /* af_scaletempo2.c in Sources */,
+				D7A495AB265980C300214818 /* af_scaletempo2_internals.c in Sources */,
+				D7A4958B265980C300214818 /* aframe.c in Sources */,
+				D7A495DF265980C300214818 /* android_common.c in Sources */,
+				D7A49613265980C300214818 /* angle_dynamic.c in Sources */,
+				D7A4959B265980C300214818 /* ao.c in Sources */,
+				D7A49598265980C300214818 /* ao_alsa.c in Sources */,
+				D7A495A0265980C300214818 /* ao_audiotrack.c in Sources */,
+				D7A49590265980C300214818 /* ao_audiounit.m in Sources */,
+				D7A49593265980C300214818 /* ao_coreaudio.c in Sources */,
+				D7A4959D265980C300214818 /* ao_coreaudio_chmap.c in Sources */,
+				D7A4958D265980C300214818 /* ao_coreaudio_exclusive.c in Sources */,
+				D7A4959F265980C300214818 /* ao_coreaudio_properties.c in Sources */,
+				D7A49595265980C300214818 /* ao_coreaudio_utils.c in Sources */,
+				D7A4959E265980C300214818 /* ao_jack.c in Sources */,
+				D7A495A1265980C300214818 /* ao_lavc.c in Sources */,
+				D7A4958C265980C300214818 /* ao_null.c in Sources */,
+				D7A4959A265980C300214818 /* ao_openal.c in Sources */,
+				D7A49596265980C300214818 /* ao_opensles.c in Sources */,
+				D7A49594265980C300214818 /* ao_oss.c in Sources */,
+				D7A4959C265980C300214818 /* ao_pcm.c in Sources */,
+				D7A49592265980C300214818 /* ao_pulse.c in Sources */,
+				D7A49597265980C300214818 /* ao_sdl.c in Sources */,
+				D7A4958E265980C300214818 /* ao_wasapi.c in Sources */,
+				D7A49591265980C300214818 /* ao_wasapi_changenotify.c in Sources */,
+				D7A49599265980C300214818 /* ao_wasapi_utils.c in Sources */,
+				D7A495D1265980C300214818 /* aspect.c in Sources */,
+				D7A4978D265980C400214818 /* ass_mp.c in Sources */,
+				D7A49659265980C300214818 /* audio.c in Sources */,
+				D7A49731265980C400214818 /* audiounit.c in Sources */,
+				D7A495B7265980C300214818 /* av_common.c in Sources */,
+				D7A495BA265980C300214818 /* av_log.c in Sources */,
+				D7A495EF265980C300214818 /* bitmap_packer.c in Sources */,
+				D7A4970A265980C400214818 /* bstr.c in Sources */,
+				D7A4958F265980C300214818 /* buffer.c in Sources */,
+				D7A49701265980C400214818 /* cache.c in Sources */,
+				D7A4970E265980C400214818 /* charset_conv.c in Sources */,
+				D7A496BF265980C400214818 /* chmap.c in Sources */,
+				D7A495A2265980C300214818 /* chmap.c in Sources */,
+				D7A495AE265980C300214818 /* chmap_sel.c in Sources */,
+				D7A49650265980C300214818 /* client.c in Sources */,
+				D7A4979B265980C400214818 /* cmd.c in Sources */,
+				D7A49735265980C400214818 /* cocoa.m in Sources */,
+				D7A49608265980C300214818 /* cocoa_cb_common.swift in Sources */,
+				D7A495E1265980C300214818 /* cocoa_common.m in Sources */,
+				D7A496F9265980C400214818 /* codec_tags.c in Sources */,
+				D7A495B0265980C300214818 /* codecs.c in Sources */,
+				D7A49647265980C300214818 /* command.c in Sources */,
+				D7A49611265980C300214818 /* common.c in Sources */,
+				D7A495B1265980C300214818 /* common.c in Sources */,
+				D7A495F2265980C300214818 /* common.swift in Sources */,
+				D7A49651265980C300214818 /* configfiles.c in Sources */,
+				D7A495CF265980C300214818 /* context.c in Sources */,
+				D7A495FE265980C300214818 /* context.c in Sources */,
+				D7A49622265980C300214818 /* context.c in Sources */,
+				D7A495DA265980C300214818 /* context.c in Sources */,
+				D7A495FC265980C300214818 /* context_android.c in Sources */,
+				D7A49615265980C300214818 /* context_android.c in Sources */,
+				D7A49626265980C300214818 /* context_angle.c in Sources */,
+				D7A49614265980C300214818 /* context_cocoa.c in Sources */,
+				D7A4961A265980C300214818 /* context_drm_egl.c in Sources */,
+				D7A49610265980C300214818 /* context_dxinterop.c in Sources */,
+				D7A49625265980C300214818 /* context_glx.c in Sources */,
+				D7A49620265980C300214818 /* context_rpi.c in Sources */,
+				D7A49600265980C300214818 /* context_wayland.c in Sources */,
+				D7A49628265980C300214818 /* context_wayland.c in Sources */,
+				D7A49627265980C300214818 /* context_win.c in Sources */,
+				D7A495FF265980C300214818 /* context_win.c in Sources */,
+				D7A4961C265980C300214818 /* context_x11egl.c in Sources */,
+				D7A495FB265980C300214818 /* context_xlib.c in Sources */,
+				D7A49557265980C300214818 /* cookies.c in Sources */,
+				D7A4972F265980C400214818 /* coreaudio.c in Sources */,
+				D7A4963F265980C300214818 /* csputils.c in Sources */,
+				D7A49629265980C300214818 /* cuda.c in Sources */,
+				D7A496FF265980C400214818 /* cue.c in Sources */,
+				D7A49640265980C300214818 /* d3d.c in Sources */,
+				D7A495C3265980C300214818 /* d3d11_helpers.c in Sources */,
+				D7A49796265980C400214818 /* dec_sub.c in Sources */,
+				D7A496F1265980C400214818 /* demux.c in Sources */,
+				D7A49703265980C400214818 /* demux_cue.c in Sources */,
+				D7A49702265980C400214818 /* demux_disc.c in Sources */,
+				D7A496F7265980C400214818 /* demux_edl.c in Sources */,
+				D7A496FA265980C400214818 /* demux_lavf.c in Sources */,
+				D7A49700265980C400214818 /* demux_libarchive.c in Sources */,
+				D7A496F4265980C400214818 /* demux_mf.c in Sources */,
+				D7A496F6265980C400214818 /* demux_mkv.c in Sources */,
+				D7A496F3265980C400214818 /* demux_mkv_timeline.c in Sources */,
+				D7A496FB265980C400214818 /* demux_null.c in Sources */,
+				D7A496F5265980C400214818 /* demux_playlist.c in Sources */,
+				D7A496FD265980C400214818 /* demux_raw.c in Sources */,
+				D7A496F2265980C400214818 /* demux_timeline.c in Sources */,
+				D7A49708265980C400214818 /* dispatch.c in Sources */,
+				D7A49606265980C300214818 /* displayconfig.c in Sources */,
+				D7A49602265980C300214818 /* dither.c in Sources */,
+				D7A495D5265980C300214818 /* dr_helper.c in Sources */,
+				D7A49791265980C400214818 /* draw_bmp.c in Sources */,
+				D7A495E6265980C300214818 /* drm_atomic.c in Sources */,
+				D7A495C1265980C300214818 /* drm_common.c in Sources */,
+				D7A495F9265980C300214818 /* drm_prime.c in Sources */,
+				D7A49605265980C300214818 /* droptarget.c in Sources */,
+				D7A4955E265980C300214818 /* dvb_tune.c in Sources */,
+				D7A496FE265980C400214818 /* ebml.c in Sources */,
+				D7A49612265980C300214818 /* egl_helpers.c in Sources */,
+				D7A495B9265980C300214818 /* encode_lavc.c in Sources */,
+				D7A495C2265980C300214818 /* error_diffusion.c in Sources */,
+				D7A4979D265980C400214818 /* event.c in Sources */,
+				D7A495F7265980C300214818 /* events_view.m in Sources */,
+				D7A49654265980C300214818 /* external_files.c in Sources */,
+				D7A49563265980C300214818 /* f_async_queue.c in Sources */,
+				D7A49564265980C300214818 /* f_auto_filters.c in Sources */,
+				D7A4956A265980C300214818 /* f_autoconvert.c in Sources */,
+				D7A4956B265980C300214818 /* f_decoder_wrapper.c in Sources */,
+				D7A4956C265980C300214818 /* f_demux_in.c in Sources */,
+				D7A49565265980C300214818 /* f_hwtransfer.c in Sources */,
+				D7A49566265980C300214818 /* f_lavfi.c in Sources */,
+				D7A49568265980C300214818 /* f_output_chain.c in Sources */,
+				D7A4956E265980C300214818 /* f_swresample.c in Sources */,
+				D7A49567265980C300214818 /* f_swscale.c in Sources */,
+				D7A49562265980C300214818 /* f_utils.c in Sources */,
+				D7A49569265980C300214818 /* filter.c in Sources */,
+				D7A495D4265980C300214818 /* filter_kernels.c in Sources */,
+				D7A49794265980C400214818 /* filter_regex.c in Sources */,
+				D7A49797265980C400214818 /* filter_sdh.c in Sources */,
+				D7A4962C265980C300214818 /* fmt-conversion.c in Sources */,
+				D7A495A4265980C300214818 /* fmt-conversion.c in Sources */,
+				D7A495A3265980C300214818 /* format.c in Sources */,
+				D7A49621265980C300214818 /* formats.c in Sources */,
+				D7A4956D265980C300214818 /* frame.c in Sources */,
+				D7A495F5265980C300214818 /* gl_layer.swift in Sources */,
+				D7A496B4265980C400214818 /* gl_video.c in Sources */,
+				D7A49736265980C400214818 /* gl_x11.c in Sources */,
+				D7A496E0265980C400214818 /* glob-win.c in Sources */,
+				D7A49634265980C300214818 /* hwdec.c in Sources */,
+				D7A495CE265980C300214818 /* hwdec.c in Sources */,
+				D7A495EB265980C300214818 /* hwdec_cuda.c in Sources */,
+				D7A495E9265980C300214818 /* hwdec_cuda_gl.c in Sources */,
+				D7A495EC265980C300214818 /* hwdec_cuda_vk.c in Sources */,
+				D7A4960F265980C300214818 /* hwdec_d3d11egl.c in Sources */,
+				D7A495D8265980C300214818 /* hwdec_d3d11va.c in Sources */,
+				D7A49618265980C300214818 /* hwdec_drmprime_drm.c in Sources */,
+				D7A495D9265980C300214818 /* hwdec_dxva2dxgi.c in Sources */,
+				D7A4961D265980C300214818 /* hwdec_dxva2egl.c in Sources */,
+				D7A49623265980C300214818 /* hwdec_dxva2gldx.c in Sources */,
+				D7A4961E265980C300214818 /* hwdec_ios.m in Sources */,
+				D7A49616265980C300214818 /* hwdec_osx.c in Sources */,
+				D7A4960E265980C300214818 /* hwdec_rpi.c in Sources */,
+				D7A495EA265980C300214818 /* hwdec_vaapi.c in Sources */,
+				D7A495ED265980C300214818 /* hwdec_vaapi_gl.c in Sources */,
+				D7A495E8265980C300214818 /* hwdec_vaapi_vk.c in Sources */,
+				D7A49619265980C300214818 /* hwdec_vdpau.c in Sources */,
+				D7A4972E265980C400214818 /* iconv.c in Sources */,
+				D7A4962E265980C300214818 /* image_loader.c in Sources */,
+				D7A49632265980C300214818 /* image_writer.c in Sources */,
+				D7A49790265980C400214818 /* img_convert.c in Sources */,
+				D7A496BD265980C400214818 /* img_format.c in Sources */,
+				D7A495BE265980C300214818 /* img_format.c in Sources */,
+				D7A4979C265980C400214818 /* input.c in Sources */,
+				D7A496D8265980C400214818 /* io.c in Sources */,
+				D7A49799265980C400214818 /* ipc-dummy.c in Sources */,
+				D7A497A0265980C400214818 /* ipc-unix.c in Sources */,
+				D7A4979A265980C400214818 /* ipc-win.c in Sources */,
+				D7A4979F265980C400214818 /* ipc.c in Sources */,
+				D7A49641265980C300214818 /* javascript.c in Sources */,
+				D7A49707265980C400214818 /* jni.c in Sources */,
+				D7A496B5265980C400214818 /* json.c in Sources */,
+				D7A49706265980C400214818 /* json.c in Sources */,
+				D7A4979E265980C400214818 /* keycodes.c in Sources */,
+				D7A49795265980C400214818 /* lavc_conv.c in Sources */,
+				D7A495CA265980C300214818 /* lcms.c in Sources */,
+				D7A49624265980C300214818 /* libmpv_gl.c in Sources */,
+				D7A495C9265980C300214818 /* libmpv_gpu.c in Sources */,
+				D7A496D1265980C400214818 /* libmpv_helper.swift in Sources */,
+				D7A495D6265980C300214818 /* libmpv_sw.c in Sources */,
+				D7A496C1265980C400214818 /* linked_list.c in Sources */,
+				D7A49645265980C300214818 /* loadfile.c in Sources */,
+				D7A496D0265980C400214818 /* log_helper.swift in Sources */,
+				D7A49646265980C300214818 /* lua.c in Sources */,
+				D7A49571265980C300214818 /* m_config_core.c in Sources */,
+				D7A49577265980C300214818 /* m_config_frontend.c in Sources */,
+				D7A49573265980C300214818 /* m_option.c in Sources */,
+				D7A49574265980C300214818 /* m_property.c in Sources */,
+				D7A496EE265980C400214818 /* macosx_application.m in Sources */,
+				D7A496E7265980C400214818 /* macosx_events.m in Sources */,
+				D7A496E5265980C400214818 /* macosx_menubar.m in Sources */,
+				D7A496EA265980C400214818 /* macosx_touchbar.m in Sources */,
+				D7A496D7265980C400214818 /* main-fn-cocoa.c in Sources */,
+				D7A496CB265980C400214818 /* main-fn-unix.c in Sources */,
+				D7A496EC265980C400214818 /* main-fn-win.c in Sources */,
+				D7A49652265980C300214818 /* main.c in Sources */,
+				D7A49657265980C300214818 /* misc.c in Sources */,
+				D7A4962A265980C300214818 /* mp_image.c in Sources */,
+				D7A495BF265980C300214818 /* mp_image_pool.c in Sources */,
+				D7A496D3265980C400214818 /* mpv_helper.swift in Sources */,
+				D7A495B2265980C300214818 /* msg.c in Sources */,
+				D7A4970C265980C400214818 /* natural_sort.c in Sources */,
+				D7A4970F265980C400214818 /* node.c in Sources */,
+				D7A49617265980C300214818 /* oml_sync.c in Sources */,
+				D7A49578265980C300214818 /* options.c in Sources */,
+				D7A49644265980C300214818 /* osd.c in Sources */,
+				D7A495C6265980C300214818 /* osd.c in Sources */,
+				D7A4978F265980C400214818 /* osd.c in Sources */,
+				D7A4978E265980C400214818 /* osd_libass.c in Sources */,
+				D7A496F8265980C400214818 /* packet.c in Sources */,
+				D7A49572265980C300214818 /* parse_commandline.c in Sources */,
+				D7A49576265980C300214818 /* parse_configfile.c in Sources */,
+				D7A496E8265980C400214818 /* path-macosx.m in Sources */,
+				D7A496CC265980C400214818 /* path-unix.c in Sources */,
+				D7A496E6265980C400214818 /* path-uwp.c in Sources */,
+				D7A496E2265980C400214818 /* path-win.c in Sources */,
+				D7A49575265980C300214818 /* path.c in Sources */,
+				D7A496BE265980C400214818 /* paths.c in Sources */,
+				D7A495B5265980C300214818 /* playlist.c in Sources */,
+				D7A49643265980C300214818 /* playloop.c in Sources */,
+				D7A496F0265980C400214818 /* polldev.c in Sources */,
+				D7A496E9265980C400214818 /* pthread.c in Sources */,
+				D7A49733265980C400214818 /* pthreads.c in Sources */,
+				D7A495D0265980C300214818 /* ra.c in Sources */,
+				D7A495D7265980C300214818 /* ra_d3d11.c in Sources */,
+				D7A4961F265980C300214818 /* ra_gl.c in Sources */,
+				D7A495DE265980C300214818 /* ra_pl.c in Sources */,
+				D7A495B3265980C300214818 /* recorder.c in Sources */,
+				D7A4963A265980C300214818 /* refqueue.c in Sources */,
+				D7A496CF265980C400214818 /* remote_command_center.swift in Sources */,
+				D7A49709265980C400214818 /* rendezvous.c in Sources */,
+				D7A495BD265980C300214818 /* repack.c in Sources */,
+				D7A496B6265980C400214818 /* repack.c in Sources */,
+				D7A496C0265980C400214818 /* scale_sws.c in Sources */,
+				D7A496C5265980C400214818 /* scale_test.c in Sources */,
+				D7A496C4265980C400214818 /* scale_zimg.c in Sources */,
+				D7A49653265980C300214818 /* screenshot.c in Sources */,
+				D7A49658265980C300214818 /* scripting.c in Sources */,
+				D7A49792265980C400214818 /* sd_ass.c in Sources */,
+				D7A49793265980C400214818 /* sd_lavc.c in Sources */,
+				D7A497A1265980C400214818 /* sdl_gamepad.c in Sources */,
+				D7A496EF265980C400214818 /* semaphore_osx.c in Sources */,
+				D7A495CC265980C300214818 /* shader_cache.c in Sources */,
+				D7A495C5265980C300214818 /* spirv.c in Sources */,
+				D7A495C8265980C300214818 /* spirv_shaderc.c in Sources */,
+				D7A49732265980C400214818 /* sse.c in Sources */,
+				D7A495B6265980C300214818 /* stats.c in Sources */,
+				D7A49560265980C300214818 /* stream.c in Sources */,
+				D7A49554265980C300214818 /* stream_avdevice.c in Sources */,
+				D7A49559265980C300214818 /* stream_bluray.c in Sources */,
+				D7A49558265980C300214818 /* stream_cb.c in Sources */,
+				D7A49550265980C300214818 /* stream_cdda.c in Sources */,
+				D7A4955C265980C300214818 /* stream_concat.c in Sources */,
+				D7A49552265980C300214818 /* stream_dvb.c in Sources */,
+				D7A49553265980C300214818 /* stream_dvdnav.c in Sources */,
+				D7A49556265980C300214818 /* stream_edl.c in Sources */,
+				D7A4955D265980C300214818 /* stream_file.c in Sources */,
+				D7A4955A265980C300214818 /* stream_lavf.c in Sources */,
+				D7A4955F265980C300214818 /* stream_libarchive.c in Sources */,
+				D7A49551265980C300214818 /* stream_memory.c in Sources */,
+				D7A49561265980C300214818 /* stream_mf.c in Sources */,
+				D7A4955B265980C300214818 /* stream_null.c in Sources */,
+				D7A49555265980C300214818 /* stream_slice.c in Sources */,
+				D7A496E3265980C400214818 /* strnlen.c in Sources */,
+				D7A49655265980C300214818 /* sub.c in Sources */,
+				D7A496CA265980C400214818 /* subprocess-dummy.c in Sources */,
+				D7A496DA265980C400214818 /* subprocess-posix.c in Sources */,
+				D7A496C9265980C400214818 /* subprocess-win.c in Sources */,
+				D7A496DD265980C400214818 /* subprocess.c in Sources */,
+				D7A496D2265980C400214818 /* swift_compat.swift in Sources */,
+				D7A496D4265980C400214818 /* swift_extensions.swift in Sources */,
+				D7A4962D265980C300214818 /* sws_utils.c in Sources */,
+				D7A4965B265980C300214818 /* ta.c in Sources */,
+				D7A4965D265980C300214818 /* ta_talloc.c in Sources */,
+				D7A4965C265980C300214818 /* ta_utils.c in Sources */,
+				D7A495B4265980C300214818 /* tags.c in Sources */,
+				D7A496DC265980C400214818 /* terminal-dummy.c in Sources */,
+				D7A496CD265980C400214818 /* terminal-unix.c in Sources */,
+				D7A496DB265980C400214818 /* terminal-win.c in Sources */,
+				D7A496C2265980C400214818 /* tests.c in Sources */,
+				D7A4970D265980C400214818 /* thread_pool.c in Sources */,
+				D7A4970B265980C400214818 /* thread_tools.c in Sources */,
+				D7A496ED265980C400214818 /* threads.c in Sources */,
+				D7A496FC265980C400214818 /* timeline.c in Sources */,
+				D7A496E1265980C400214818 /* timer-darwin.c in Sources */,
+				D7A496DE265980C400214818 /* timer-linux.c in Sources */,
+				D7A496EB265980C400214818 /* timer-win2.c in Sources */,
+				D7A496CE265980C400214818 /* timer.c in Sources */,
+				D7A495F3265980C300214818 /* title_bar.swift in Sources */,
+				D7A49730265980C400214818 /* touchbar.m in Sources */,
+				D7A4956F265980C300214818 /* user_filters.c in Sources */,
+				D7A495C7265980C300214818 /* user_shaders.c in Sources */,
+				D7A495FD265980C300214818 /* utils.c in Sources */,
+				D7A495CD265980C300214818 /* utils.c in Sources */,
+				D7A4961B265980C300214818 /* utils.c in Sources */,
+				D7A495DD265980C300214818 /* utils.c in Sources */,
+				D7A49630265980C300214818 /* vaapi.c in Sources */,
+				D7A4962F265980C300214818 /* vd_lavc.c in Sources */,
+				D7A49633265980C300214818 /* vdpau.c in Sources */,
+				D7A49631265980C300214818 /* vdpau_functions.inc in Sources */,
+				D7A4962B265980C300214818 /* vdpau_mixer.c in Sources */,
+				D7A495B8265980C300214818 /* version.c in Sources */,
+				D7A49638265980C300214818 /* vf_d3d11vpp.c in Sources */,
+				D7A4963B265980C300214818 /* vf_fingerprint.c in Sources */,
+				D7A4963C265980C300214818 /* vf_format.c in Sources */,
+				D7A4963E265980C300214818 /* vf_gpu.c in Sources */,
+				D7A49636265980C300214818 /* vf_sub.c in Sources */,
+				D7A49639265980C300214818 /* vf_vapoursynth.c in Sources */,
+				D7A4963D265980C300214818 /* vf_vavpp.c in Sources */,
+				D7A49637265980C300214818 /* vf_vdpaupp.c in Sources */,
+				D7A49642265980C300214818 /* video.c in Sources */,
+				D7A495C4265980C300214818 /* video.c in Sources */,
+				D7A495CB265980C300214818 /* video_shaders.c in Sources */,
+				D7A495F6265980C300214818 /* video_view.m in Sources */,
+				D7A495F1265980C300214818 /* view.swift in Sources */,
+				D7A49604265980C300214818 /* vo.c in Sources */,
+				D7A495E5265980C300214818 /* vo_caca.c in Sources */,
+				D7A495FA265980C300214818 /* vo_direct3d.c in Sources */,
+				D7A49601265980C300214818 /* vo_drm.c in Sources */,
+				D7A495E2265980C300214818 /* vo_gpu.c in Sources */,
+				D7A4960A265980C300214818 /* vo_image.c in Sources */,
+				D7A49603265980C300214818 /* vo_lavc.c in Sources */,
+				D7A4960B265980C300214818 /* vo_libmpv.c in Sources */,
+				D7A49609265980C300214818 /* vo_mediacodec_embed.c in Sources */,
+				D7A495E3265980C300214818 /* vo_null.c in Sources */,
+				D7A495E7265980C300214818 /* vo_rpi.c in Sources */,
+				D7A495D3265980C300214818 /* vo_sdl.c in Sources */,
+				D7A495E0265980C300214818 /* vo_sixel.c in Sources */,
+				D7A49607265980C300214818 /* vo_tct.c in Sources */,
+				D7A495DB265980C300214818 /* vo_vaapi.c in Sources */,
+				D7A495D2265980C300214818 /* vo_vdpau.c in Sources */,
+				D7A495E4265980C300214818 /* vo_wlshm.c in Sources */,
+				D7A495DC265980C300214818 /* vo_x11.c in Sources */,
+				D7A495C0265980C300214818 /* vo_xv.c in Sources */,
+				D7A4960D265980C300214818 /* w32_common.c in Sources */,
+				D7A496D6265980C400214818 /* w32_keyboard.c in Sources */,
+				D7A49734265980C400214818 /* wasapi.c in Sources */,
+				D7A495EE265980C300214818 /* wayland_common.c in Sources */,
+				D7A496E4265980C400214818 /* win32-console-wrapper.c in Sources */,
+				D7A4960C265980C300214818 /* win_state.c in Sources */,
+				D7A495F8265980C300214818 /* window.m in Sources */,
+				D7A495F4265980C300214818 /* window.swift in Sources */,
+				D7A496D9265980C400214818 /* windows_utils.c in Sources */,
+				D7A495F0265980C300214818 /* x11_common.c in Sources */,
+				D7A49635265980C300214818 /* zimg.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		D74FE37E265929FB008536C6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		D74FE37F265929FB008536C6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+			};
+			name = Release;
+		};
+		D74FE381265929FB008536C6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUGGING_SYMBOLS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = "";
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "mpv/mpv build-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		D74FE382265929FB008536C6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = "";
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "mpv/mpv build-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		D77688842659560800FFDF2E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUGGING_SYMBOLS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "mpv/mpv configure build-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		D77688852659560800FFDF2E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "mpv/mpv configure build-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		D7A491E926597FE600214818 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)\"/**";
+				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = io.mpv;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = osdep/macOS_swift_bridge.h;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		D7A491EA26597FE600214818 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)\"/**";
+				INFOPLIST_FILE = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = io.mpv;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = osdep/macOS_swift_bridge.h;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D74FE37C265929FB008536C6 /* Build configuration list for PBXProject "mpv" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D74FE37E265929FB008536C6 /* Debug */,
+				D74FE37F265929FB008536C6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D74FE380265929FB008536C6 /* Build configuration list for PBXLegacyTarget "mpv build" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D74FE381265929FB008536C6 /* Debug */,
+				D74FE382265929FB008536C6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D77688862659560800FFDF2E /* Build configuration list for PBXLegacyTarget "mpv configure build" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D77688842659560800FFDF2E /* Debug */,
+				D77688852659560800FFDF2E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D7A491E826597FE600214818 /* Build configuration list for PBXNativeTarget "mpv" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D7A491E926597FE600214818 /* Debug */,
+				D7A491EA26597FE600214818 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D74FE379265929FB008536C6 /* Project object */;
+}

--- a/mpv.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/mpv.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:mpv.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/mpv.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/mpv.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/mpv.xcodeproj/xcshareddata/xcschemes/mpv build.xcscheme
+++ b/mpv.xcodeproj/xcshareddata/xcschemes/mpv build.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "exec &gt; &quot;${PROJECT_DIR}/build/xcode-prebuild.log&quot; 2&gt;&amp;1&#10;echo &quot;Start of xcode prebuild log:&quot;&#10;&#10;perl &quot;${PROJECT_DIR}/TOOLS/sort-xcode-project-file&quot; &quot;${PROJECT_FILE_PATH}/project.pbxproj&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D74FE37D265929FB008536C6"
+                     BuildableName = "mpv build"
+                     BlueprintName = "mpv build"
+                     ReferencedContainer = "container:mpv.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D74FE37D265929FB008536C6"
+               BuildableName = "mpv build"
+               BlueprintName = "mpv build"
+               ReferencedContainer = "container:mpv.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Users/Akemi/Repositories/mpv/build/mpv">
+      </PathRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D74FE37D265929FB008536C6"
+            BuildableName = "mpv build"
+            BlueprintName = "mpv build"
+            ReferencedContainer = "container:mpv.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/mpv.xcodeproj/xcshareddata/xcschemes/mpv configure build.xcscheme
+++ b/mpv.xcodeproj/xcshareddata/xcschemes/mpv configure build.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "exec &gt; &quot;${PROJECT_DIR}/build/xcode-prebuild.log&quot; 2&gt;&amp;1&#10;echo &quot;Start of xcode prebuild log:&quot;&#10;&#10;perl &quot;${PROJECT_DIR}/TOOLS/sort-xcode-project-file&quot; &quot;${PROJECT_FILE_PATH}/project.pbxproj&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D77688832659560800FFDF2E"
+                     BuildableName = "mpv configure build"
+                     BlueprintName = "mpv configure build"
+                     ReferencedContainer = "container:mpv.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D77688832659560800FFDF2E"
+               BuildableName = "mpv configure build"
+               BlueprintName = "mpv configure build"
+               ReferencedContainer = "container:mpv.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Users/Akemi/Repositories/mpv/build/mpv">
+      </PathRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D77688832659560800FFDF2E"
+            BuildableName = "mpv configure build"
+            BlueprintName = "mpv configure build"
+            ReferencedContainer = "container:mpv.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
i am not sure if we actually want this in our project? i personally started to like code completion and jumping to function/class/etc definition right from my editor/IDE. sometimes it's also a good addition to the incomplete or bad online only documentation. though for swift/obj-c there isn't much besides Xcode or AppCode and both need an Xcode project file. which is frankly a bit of a pain, since the project is not synced with the folder/file structure and the Xcode project file keeps its own lists. so new files need to be added to it manually. making this file a source of 'constant' updates, at least for the editor part and debugging. mpv can still be build without those files and debugging works for the files already included. see my commits on the commit itself for some more info.

another pain is that the binary has to be specified for debugging and the path can't be relative to the project root but needs to be absolute. otherwise it will lead to an assert and Xcode will just crash.

https://github.com/Akemi/mpv/commit/0e729fd96b3b2825391944eb7da1c2d6ddde8496#diff-e129a10694648ac8b9c9e8472d58c2d97a380c299ae89d5d33a1e89d64699758R63

when adding files to Xcode they will be out of order completely. so i had to add a sorting script that is automatically called on build to order the files within the project file alphabetically. Xcode doesn't provide a built in function to sort the whole project structure and it also seems to be the preferred way of Apple (the script comes directly from Apple).
https://github.com/WebKit/WebKit/blob/main/Tools/Scripts/sort-Xcode-project-file
hope this doesn't conflict in any way with our license?

when adding new files one needs to make sure to add them to the "mpv" target too. there are two different build targets. one to configure + build and one to only build mpv. both use our waf build system. for debugging one has to adjust the binary path in Product > Scheme > Edit Scheme for both build schemes under Run > Run.

added the user related project settings to the .gitignore, since they are not necessary.

i thought it might be a good idea to add this project file, since i already did the work of configuring everything and it was quite helpful for me for debugging and information resources. though i can totally understand if we don't want this in our project. i first wanted to add a definition to generate an Xcode project via [XcodeGen](https://github.com/yonaskolb/XcodeGen), [xcake](https://github.com/igor-makarov/xcake) or similar, but they don't provide everything we need for a setup we have to use, eg a config for an external build system.