### PR TITLE
osc: re-initialize when chapter list changes

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2598,6 +2598,7 @@ mp.register_event("shutdown", shutdown)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", nil, request_init)
 mp.observe_property("playlist", nil, request_init)
+mp.observe_property("chapter-list", nil, request_init)
 
 mp.register_script_message("osc-message", show_message)
 mp.register_script_message("osc-chapterlist", function(dur)


### PR DESCRIPTION
When the OSC initializes, it checks whether the current video has chapters, and if it does not, it disables its chapter functionality (chapter buttons are grayed out and unusable, chapter indicators don't show on the seek bar). If another script¹ changes the chapter list after the video has loaded, those changes will be ignored by the OSC until some other event causes it to re-initialize, because it does not observe the chapter list property. This is fixed by simply adding observation of `chapter-list` alongside the other properties that trigger re-initialization.

¹ For example, [this SponsorBlock script](https://github.com/po5/mpv_sponsorblock), with the local database disabled, loads segments asynchronously, creating chapters a short time after playback starts. These chapters don't appear on the OSC unless another event (such as resizing the window) causes it to re-initialize.