### PR TITLE
win32: support the property 'focused'

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2502,8 +2502,7 @@ Property list
     ways. The property is unavailable if no video is active.
 
 ``focused``
-    Whether the window has focus. Currently works only on X11, Wayland and
-    macOS.
+    Whether the window has focus. Might not be supported by all VOs.
 
 ``display-names``
     Names of the displays that the mpv window covers. On X11, these


### PR DESCRIPTION
```
It seems that currently it's supported by all main VOs (x11, macOS,
wayland, Windows). TCT/sixel/caca probably not, and unknown with SDL.

Fixes #8868
```

@rossy should the WM_* handlers return `0` instead of doing `break` (which later ends up calling and returning `DefWindowProcW(...)`?

The MSDN docs states for both `WM_KILLFOCUS` and `WM_SETFOCUS`: "An application should return zero if it processes this message.", but I _think_ this is inconsistent in mpv handling of WM_* messages - and the WM_KILLFOCUS handler did not return 0 also before this commit.