### PR TITLE
docs: fix reference to the now defunct --video-sync-adrop-size

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6567,11 +6567,10 @@ Miscellaneous
                         video. (Although it should have the same effects as
                         ``audio``, the implementation is very different.)
     :display-adrop:     Drop or repeat audio data to compensate desyncing
-                        video. See ``--video-sync-adrop-size``. This mode will
-                        cause severe audio artifacts if the real monitor
-                        refresh rate is too different from the reported or
-                        forced rate. Since mpv 0.33.0, this acts on entire audio
-                        frames, instead of single samples.
+                        video. This mode will cause severe audio artifacts if
+                        the real monitor refresh rate is too different from
+                        the reported or forced rate. Since mpv 0.33.0, this
+                        acts on entire audio frames, instead of single samples.
     :display-desync:    Sync video to display, and let audio play on its own.
     :desync:            Sync video according to system clock, and let audio play
                         on its own.


### PR DESCRIPTION
docs: fix reference to the now defunct --video-sync-adrop-size

This is a follow up to 502e7987d8d85cb1d9eb3b3d1af38a1a92cc04e8
