### PR TITLE
TOOLS/lua/autoload: add ignore_hidden option

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -157,7 +157,9 @@ function find_and_add_entries()
         return
     end
     table.filter(files, function (v, k)
-        if (o.ignore_hidden and string.match(v, "^%.")) then
+        -- The current file could be a hidden file, ignoring it doesn't load other
+        -- files from the current directory.
+        if (o.ignore_hidden and not (v == filename) and string.match(v, "^%.")) then
             return false
         end
         local ext = get_extension(v)

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -16,6 +16,7 @@ disabled=no
 images=no
 videos=yes
 audio=yes
+ignore_hidden=yes
 
 --]]
 
@@ -29,7 +30,8 @@ o = {
     disabled = false,
     images = true,
     videos = true,
-    audio = true
+    audio = true,
+    ignore_hidden = true
 }
 options.read_options(o)
 
@@ -155,7 +157,7 @@ function find_and_add_entries()
         return
     end
     table.filter(files, function (v, k)
-        if string.match(v, "^%.") then
+        if (o.ignore_hidden and string.match(v, "^%.")) then
             return false
         end
         local ext = get_extension(v)


### PR DESCRIPTION
See commit for logic. Basically ignoring hidden files is probably what 90% of users want, but 10% of users will get annoyed by. Might as well give them an option to allow for hidden files now that extensions are explicitly whitelisted.