### PR TITLE
osc: update chapter marker positions when duration changes

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -375,6 +375,15 @@ Configurable Options
 
     Set to ``yes`` to reduce festivity (i.e. disable santa hat in December.)
 
+``live_markers``
+    Default: yes
+
+    Updates the chapter indicator/marker positions on the seek bar when the
+    duration changes. This ensures the markers are accurate if chapters are
+    present on live streams. You may want to disable this on low-end systems
+    as this option reinitializes the OSC every time the duration changes when
+    there are chapters.
+
 Script Commands
 ~~~~~~~~~~~~~~~
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -48,6 +48,7 @@ local user_opts = {
     windowcontrols = "auto",    -- whether to show window controls
     windowcontrols_alignment = "right", -- which side to show window controls on
     greenandgrumpy = false,     -- disable santa hat
+    live_markers = true,        -- update seekbar chapter markers on duration change
 }
 
 -- read options from config and command-line
@@ -1688,6 +1689,7 @@ function update_options(list)
     validate_user_opts()
     request_tick()
     visibility_mode(user_opts.visibility, true)
+    update_duration_watch()
     request_init()
 end
 
@@ -2592,13 +2594,36 @@ function enable_osc(enable)
     end
 end
 
+-- request_init wrapped so that we can unobserve it on its own
+function on_duration() request_init() end
+
+local duration_watched = false
+function update_duration_watch()
+    local want_watch = user_opts.live_markers and
+                       (mp.get_property_number("chapters", 0) or 0) > 0 and
+                       true or false  -- ensure it's a boolean
+
+    if (want_watch ~= duration_watched) then
+        if want_watch then
+            mp.observe_property("duration", nil, on_duration)
+        else
+            mp.unobserve_property(on_duration)
+        end
+        duration_watched = want_watch
+    end
+end
+
 validate_user_opts()
+update_duration_watch()
 
 mp.register_event("shutdown", shutdown)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", nil, request_init)
 mp.observe_property("playlist", nil, request_init)
-mp.observe_property("chapter-list", nil, request_init)
+mp.observe_property("chapter-list", nil, function()
+    update_duration_watch()
+    request_init()
+end)
 
 mp.register_script_message("osc-message", show_message)
 mp.register_script_message("osc-chapterlist", function(dur)


### PR DESCRIPTION
Commit 6abb7e3 updates the markers when the chapters change, but it
doesn't update their relative position at the bar when the duration
changes.

This means that adding chapters to a live stream would result in
corresponding chapter markers which were static while the duration
changed and thus their positions became incorrect over time until the
OSC was reinitialized.

This is fixed by observing the `duration` property if chapters are present
and reinitializing the OSC when the duration changes.

The `live_markers` user option, which determines whether the `duration`
property is observed when there are chapters, has been added in order to
allow disabling this behaviour as calling `request_init()` frequently
might have some impact on low-end systems.

The impact of `request_init()` on `render()` was measured to increase from
1-1.5 ms to 2-3 ms on a 2010 MacBook Air, while the impact was neglible
on a 2016 Surface Book (increasing only to an average of 1.4 ms from
1.3 ms for n=1500 render cycles).

The `live_markers` option is enabled by default.