### PR TITLE
Osc hoverinfo

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -43,7 +43,8 @@ pl next
     =============   ================================================
 
 title
-    | Displays current media-title, filename, or custom title
+    | Displays current media-title, filename, custom title, or target chapter
+      name while hovering the seekbar.
 
     =============   ================================================
     left-click      show playlist position and length and full title


### PR DESCRIPTION
Three commits:
- Add `hoverinfo` framework - "status" at the osc title while hovering some osc elements.
- Add static info text for most buttons.
- Add dynamic seekbar info with target chapter.

The framework allows either static or dynamic text per element (or none). Info for disabled elements does show up - to allow discoverability, but it's grayed-out like the disabled element itself.

The second commit (static buttons text) is open to bikeshedding about format/texts and whether or not we want it also for trivial buttons (e.g. the play/pause button currently does have hoverinfo), but I suggest not to dwell on it too much because it's trivial to change at any time.

Personally I don't have a strong opinion on what the info texts should be exactly, other than it should be useful.

The third commit adds one dynamic info (the seekbar), but we can also consider dynamic info for simple buttons, for instance we could do this for the play/pause button:
```lua
ne.hoverinfo = function()
    return mp.get_property_native("pause") and "play" or "pause"
end
```

and similar for mute/unmute, enter/exit fullscreen, etc, though again, it's trivial to change the actual infos at any time.

If anyone wants to test it locally, this is `osc.lua` in mpv master with the 3 commits applied: https://0x0.st/-9Ae.lua  (`curl https://0x0.st/-9Ae.lua > ./osc.lua && mpv --no-osc --script=./osc.lua myclip.mkv`)