### PR TITLE
vo_gpu: add interpolation-allow-multiple, defaulting on

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5200,6 +5200,12 @@ The following video options are currently all specific to ``--vo=gpu`` and
 
     Set this to ``-1`` to disable this logic.
 
+``--interpolation-allow-multiple=<yes|no>``
+    Whether or not to count multiples (or factors) of the video frame rate as equivalent
+    to it for the `--interpolation-threshold` calculation. Default: yes.
+    This disables interpolation when playing e.g. 24fps content on a 48Hz display,
+    or vice versa.
+
 ``--opengl-pbo``
     Enable use of PBOs. On some drivers this can be faster, especially if the
     source video size is huge (e.g. so called "4K" video). On other drivers it

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -318,6 +318,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .scaler_resizes_only = 1,
     .scaler_lut_size = 6,
     .interpolation_threshold = 0.01,
+    .interpolation_allow_multiple = 1,
     .alpha_mode = ALPHA_BLEND_TILES,
     .background = {0, 0, 0, 255},
     .gamma = 1.0f,
@@ -439,6 +440,7 @@ const struct m_sub_options gl_video_conf = {
         {"background", OPT_COLOR(background)},
         {"interpolation", OPT_FLAG(interpolation)},
         {"interpolation-threshold", OPT_FLOAT(interpolation_threshold)},
+        {"interpolation-allow-multiple", OPT_FLAG(interpolation_allow_multiple)},
         {"blend-subtitles", OPT_CHOICE(blend_subs,
             {"no", BLEND_SUBS_NO},
             {"yes", BLEND_SUBS_YES},
@@ -3275,9 +3277,11 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
     if (has_frame) {
         bool interpolate = p->opts.interpolation && frame->display_synced &&
                            (p->frames_drawn || !frame->still);
-        if (interpolate) {
+        if (interpolate && p->opts.interpolation_threshold >= 0.) {
             double ratio = frame->ideal_frame_duration / frame->vsync_interval;
-            if (fabs(ratio - 1.0) < p->opts.interpolation_threshold)
+            if (ratio < 1. && ratio > 0.)
+                ratio = 1. / ratio;
+            if (fabs(ratio - (p->opts.interpolation_allow_multiple ? round(ratio) : 1.0)) < p->opts.interpolation_threshold)
                 interpolate = false;
         }
 

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -141,6 +141,7 @@ struct gl_video_opts {
     struct m_color background;
     int interpolation;
     float interpolation_threshold;
+    int interpolation_allow_multiple;
     int blend_subs;
     char **user_shaders;
     int deband;


### PR DESCRIPTION
This prevents interpolation from kicking in for e.g. 24fps content on 48Hz displays