### PR TITLE
player: fix segfault

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -224,10 +224,9 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
             (type != STREAM_VIDEO || (fuzz != 1 && bstrcmp(dename, f_fname) != 0)))
             prio |= 32; // exact movie name match
 
+        bstr lang = {0};
         if (type == STREAM_VIDEO)
             goto cover_art;
-
-        bstr lang = {0};
         if (bstr_startswith(tmp_fname_trim, f_fname_trim)) {
             int start = 0;
             lang = guess_lang_from_filename(tmp_fname_trim, &start);

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -221,7 +221,7 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
         int prio = 0;
 
         if (bstrcmp(tmp_fname_trim, f_fname_trim) == 0 &&
-            (type != STREAM_VIDEO || (fuzz != 1 && bstrcmp(dename, f_fname) != 0)))
+            (type != STREAM_VIDEO || fuzz != 1))
             prio |= 32; // exact movie name match
 
         bstr lang = {0};


### PR DESCRIPTION
Removes the goto which caused lang to be used in the sub->lang
assignment without being initialized when adding cover art. lang is
normally initialized to a garbage value like {start = 0x0, len =
94415366337024}, and so sub->lang was assigned nullptr whether lang was
initialized on not due to safety checks in bstrdup0's internals
(ta_strndup checks if the pointer is null first), but a segfault happens
only on Windows 8 on certain builds of GCC 10.2 with optimization,
assumedly because lang.start is initialized to a non-null value which
bstrdup0 tries to use.

Also remove the check that the external filename is not the same as the
currently playing one, preventing mpv from loading images again as
external cover art, which isn't necessary because cover art is only
added when playing standalone audio. I had only added that check because
I would otherwise get a segfault only when compiling with GCC 10.2 with
optimize and changing position within a playlist of multiple images, but
this was also caused by the uninitialized lang which is now fixed.

Fixes #8922.