### PR TITLE
Lua: refine timers and idle observers

### DIFF
--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -528,8 +528,17 @@ function mp.dispatch_events(allow_wait)
         if not more_events then
             wait = process_timers() or 1e20 -- infinity for all practical purposes
             if wait ~= 0 then
+                local idle_called = nil
                 for _, handler in ipairs(idle_handlers) do
+                    idle_called = true
                     handler()
+                end
+                if idle_called then
+                    -- handlers don't complete in 0 time, and may modify timers
+                    wait = mp.get_next_timeout() or 1e20
+                    if wait < 0 then
+                        wait = 0
+                    end
                 end
             end
             -- Resume playloop - important especially if an error happened while

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -333,6 +333,7 @@ end
 -- Run timers that have met their deadline.
 -- Return: next absolute time a timer expires as number, or nil if no timers
 local function process_timers()
+    local t0 = nil
     while true do
         local timer = get_next_timer()
         if not timer then
@@ -343,6 +344,14 @@ local function process_timers()
         if wait > 0 then
             return wait
         else
+            if not t0 then
+                t0 = now  -- first due callback: always executes, remember t0
+            elseif timer.next_deadline > t0 then
+                -- don't block forever with slow callbacks and endless timers.
+                -- we'll continue right after checking mpv events.
+                return 0
+            end
+
             if timer.oneshot then
                 timer:kill()
             else
@@ -518,8 +527,10 @@ function mp.dispatch_events(allow_wait)
         local wait = 0
         if not more_events then
             wait = process_timers() or 1e20 -- infinity for all practical purposes
-            for _, handler in ipairs(idle_handlers) do
-                handler()
+            if wait ~= 0 then
+                for _, handler in ipairs(idle_handlers) do
+                    handler()
+                end
             end
             -- Resume playloop - important especially if an error happened while
             -- suspended, and the error was handled, but no resume was done.


### PR DESCRIPTION
Two commits:
- Don't allow slow timer callbacks to block script event handling (including quit).
- Timers added from idle observers could fire long after they're due.

More details and example at the commit messages.