### PR TITLE
player: add --input-cursor-passthrough option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -80,6 +80,8 @@ Interface changes
     - add `--corner-rounding` option
     - change `--subs-with-matching-audio` default from `yes` to `no`
     - change `--slang` default from blank to `auto`
+    - add `--input-cursor-passthrough` option to allow pointer events to completely
+      passthrough the mpv window
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4060,6 +4060,12 @@ Input
     driver. Necessary to use the OSC, or to select the buttons in DVD menus.
     Support depends on the VO in use.
 
+``--input-cursor-passthrough``, ``--no-input-cursor-passthrough``
+    (X11 and Wayland only)
+    Tell the backend windowing system to allow pointer events to passthrough
+    the mpv window. This allows windows under mpv to instead receive pointer
+    events as if the mpv window was never there.
+
 ``--input-media-keys=<yes|no>``
     On systems where mpv can choose between receiving media keys or letting
     the system handle them - this option controls whether mpv should receive

--- a/options/options.c
+++ b/options/options.c
@@ -135,6 +135,7 @@ static const m_option_t mp_vo_opt_list[] = {
         M_RANGE(1.0/32.0, 32.0)},
     {"fullscreen", OPT_BOOL(fullscreen)},
     {"fs", OPT_ALIAS("fullscreen")},
+    {"input-cursor-passthrough", OPT_BOOL(cursor_passthrough)},
     {"native-keyrepeat", OPT_BOOL(native_keyrepeat)},
     {"panscan", OPT_FLOAT(panscan), M_RANGE(0.0, 1.0)},
     {"video-zoom", OPT_FLOAT(zoom), M_RANGE(-20.0, 20.0)},

--- a/options/options.h
+++ b/options/options.h
@@ -32,6 +32,7 @@ typedef struct mp_vo_opts {
     int x11_netwm;
     int x11_bypass_compositor;
     int x11_present;
+    bool cursor_passthrough;
     bool native_keyrepeat;
 
     float panscan;


### PR DESCRIPTION
See #8938.

Add an option for allowing pointer events to pass through the mpv
window. This could be useful in cases where a user wants to display
transparent images/video with mpv and interact with applications beneath
the window. This commit implements this functionality for x11 and
wayland. Note that whether or not this actually works likely depends on
your window manager and/or compositor. E.g. sway ignores pointer events
but does not send the events to the window below (no clue if intentional
or a bug). Weston behaves as expected.

As an aside, the APIs do allow for specifying a region of any arbitrary size for a passthrough. I did not think such granularity would have any practical use. Most likely, you either would want mouse events on the entire window (vast majority of cases) or none at all, so I just left this as a yes/no option. This could be changed if someone really wants specific rectangular region control with this option.