### PR TITLE
DOCS: fix typo on seekbarkeyframes

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -180,12 +180,12 @@ Configurable Options
 ``seekbarkeyframes``
     Default: yes
 
-    Controls the mode used to seek when dragging the seekbar (default: true). If
-    set to true, default seeking mode is used (usually keyframes, but player
-    defaults and heuristics can change it to exact). If set to false, exact
-    seeking on mouse drags will be used instead. Keyframes are preferred, but
-    exact seeks may be useful in cases where keyframes cannot be found. Note
-    that using exact seeks can potentially make mouse dragging much slower.
+    Controls the mode used to seek when dragging the seekbar. If set to ``yes``,
+    default seeking mode is used (usually keyframes, but player defaults and
+    heuristics can change it to exact). If set to ``no``, exact seeking on
+    mouse drags will be used instead. Keyframes are preferred, but exact seeks
+    may be useful in cases where keyframes cannot be found. Note that using
+    exact seeks can potentially make mouse dragging much slower.
 
 ``seekrangestyle``
     Default: inverted


### PR DESCRIPTION
fix the tiny typo about `seekbarkeyframes`
`true` or `false` cannot be read from conf file. 
So change them to `yes` or `no`.