### PR TITLE
command: adds several commands/properties for secondary subs

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2632,11 +2632,17 @@ Property list
     subtitles, returns the first start time. If no current subtitle is present
     null is returned instead.
 
+``secondary-sub-start``
+    Same as ``sub-start``, but for the secondary subtitles.
+
 ``sub-end``
     The current subtitle end time (in seconds). If there's multiple current
     subtitles, return the last end time. If no current subtitle is present, or
     if it's present but has unknown or incorrect duration, null is returned
     instead.
+
+``secondary-sub-end``
+    Same as ``sub-end``, but for the secondary subtitles.
 
 ``playlist-pos`` (RW)
     Current position on playlist. The first entry is on position 0. Writing to

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -679,15 +679,29 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
     This works by unloading and re-adding the subtitle track.
 
-``sub-step <skip>``
+``sub-step <skip> <flags>``
     Change subtitle timing such, that the subtitle event after the next
     ``<skip>`` subtitle events is displayed. ``<skip>`` can be negative to step
     backwards.
 
-``sub-seek <skip>``
+    Secondary argument:
+
+    primary (default)
+        Steps through the primary subtitles.
+    secondary
+        Steps through the secondary subtitles.
+
+``sub-seek <skip> <flags>``
     Seek to the next (skip set to 1) or the previous (skip set to -1) subtitle.
     This is similar to ``sub-step``, except that it seeks video and audio
     instead of adjusting the subtitle delay.
+
+    Secondary argument:
+
+    primary (default)
+        Seeks through the primary subtitles.
+    secondary
+        Seeks through the secondary subtitles.
 
     For embedded subtitles (like with Matroska), this works only with subtitle
     events that have already been displayed, or are within a short prefetch

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2585,6 +2585,15 @@ Subtitles
     Can be used to disable display of subtitles, but still select and decode
     them.
 
+``--secondary-sub-visibility``, ``--no-secondary-sub-visibility``
+    Can be used to disable display of secondary subtitles, but still select and
+    decode them.
+
+    .. note::
+
+        If ``--sub-visibility=no``, secondary subtitles are hidden regardless of
+        ``--secondary-sub-visibility``.
+
 ``--sub-clear-on-seek``
     (Obscure, rarely useful.) Can be used to play broken mkv files with
     duplicate ReadOrder fields. ReadOrder is the first field in a

--- a/player/command.c
+++ b/player/command.c
@@ -2873,7 +2873,8 @@ static struct sd_times get_times(void *ctx, struct m_property *prop,
 {
     struct sd_times res = { .start = MP_NOPTS_VALUE, .end = MP_NOPTS_VALUE };
     MPContext *mpctx = ctx;
-    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    int track_ind = *(int *)prop->priv;
+    struct track *track = mpctx->current_track[track_ind][STREAM_SUB];
     struct dec_sub *sub = track ? track->d_sub : NULL;
     double pts = mpctx->playback_pts;
     if (!sub || pts == MP_NOPTS_VALUE)
@@ -3674,8 +3675,14 @@ static const struct m_property mp_properties_base[] = {
         .priv = (void *)&(const int){SD_TEXT_TYPE_PLAIN}},
     {"sub-text-ass", mp_property_sub_text,
         .priv = (void *)&(const int){SD_TEXT_TYPE_ASS}},
-    {"sub-start", mp_property_sub_start},
-    {"sub-end", mp_property_sub_end},
+    {"sub-start", mp_property_sub_start,
+        .priv = (void *)&(const int){0}},
+    {"secondary-sub-start", mp_property_sub_start, 
+        .priv = (void *)&(const int){1}},
+    {"sub-end", mp_property_sub_end,
+        .priv = (void *)&(const int){0}},
+    {"secondary-sub-end", mp_property_sub_end, 
+        .priv = (void *)&(const int){1}},
 
     {"vf", mp_property_vf},
     {"af", mp_property_af},
@@ -3755,7 +3762,7 @@ static const char *const *const mp_event_property_change[] = {
       "estimated-display-fps", "vsync-jitter", "sub-text", "secondary-sub-text",
       "audio-bitrate", "video-bitrate", "sub-bitrate", "decoder-frame-drop-count",
       "frame-drop-count", "video-frame-info", "vf-metadata", "af-metadata",
-      "sub-start", "sub-end"),
+      "sub-start", "sub-end", "secondary-sub-start", "secondary-sub-end"),
     E(MP_EVENT_DURATION_UPDATE, "duration"),
     E(MPV_EVENT_VIDEO_RECONFIG, "video-out-params", "video-params",
       "video-format", "video-codec", "video-bitrate", "dwidth", "dheight",

--- a/player/command.c
+++ b/player/command.c
@@ -3677,11 +3677,11 @@ static const struct m_property mp_properties_base[] = {
         .priv = (void *)&(const int){SD_TEXT_TYPE_ASS}},
     {"sub-start", mp_property_sub_start,
         .priv = (void *)&(const int){0}},
-    {"secondary-sub-start", mp_property_sub_start, 
+    {"secondary-sub-start", mp_property_sub_start,
         .priv = (void *)&(const int){1}},
     {"sub-end", mp_property_sub_end,
         .priv = (void *)&(const int){0}},
-    {"secondary-sub-end", mp_property_sub_end, 
+    {"secondary-sub-end", mp_property_sub_end,
         .priv = (void *)&(const int){1}},
 
     {"vf", mp_property_vf},
@@ -5035,13 +5035,14 @@ static void cmd_sub_step_seek(void *p)
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
     bool step = *(bool *)cmd->priv;
+    int track_ind = cmd->args[1].v.i;
 
     if (!mpctx->playback_initialized) {
         cmd->success = false;
         return;
     }
 
-    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    struct track *track = mpctx->current_track[track_ind][STREAM_SUB];
     struct dec_sub *sub = track ? track->d_sub : NULL;
     double refpts = get_current_time(mpctx);
     if (sub && refpts != MP_NOPTS_VALUE) {
@@ -6073,10 +6074,28 @@ const struct mp_cmd_def mp_cmds[] = {
     },
     { "playlist-shuffle", cmd_playlist_shuffle, },
     { "playlist-unshuffle", cmd_playlist_unshuffle, },
-    { "sub-step", cmd_sub_step_seek, { {"skip", OPT_INT(v.i)} },
-        .allow_auto_repeat = true, .priv = &(const bool){true} },
-    { "sub-seek", cmd_sub_step_seek, { {"skip", OPT_INT(v.i)} },
-        .allow_auto_repeat = true, .priv = &(const bool){false} },
+    { "sub-step", cmd_sub_step_seek,
+        {
+            {"skip", OPT_INT(v.i)},
+            {"flags", OPT_CHOICE(v.i,
+                {"primary", 0},
+                {"secondary", 1}),
+                OPTDEF_INT(0)},
+        },
+        .allow_auto_repeat = true,
+        .priv = &(const bool){true}
+    },
+    { "sub-seek", cmd_sub_step_seek,
+        {
+            {"skip", OPT_INT(v.i)},
+            {"flags", OPT_CHOICE(v.i,
+                {"primary", 0},
+                {"secondary", 1}),
+                OPTDEF_INT(0)},
+        },
+        .allow_auto_repeat = true,
+        .priv = &(const bool){false}
+    },
     { "print-text", cmd_print_text, { {"text", OPT_STRING(v.s)} },
         .is_noisy = true, .allow_auto_repeat = true },
     { "show-text", cmd_show_text,

--- a/test/subtimes.js
+++ b/test/subtimes.js
@@ -5,3 +5,11 @@ function subtimes() {
 }
 
 mp.add_key_binding("t", "subtimes", subtimes);
+
+function secondary_subtimes() {
+  mp.msg.info("secondary-sub-start: " + mp.get_property_number("secondary-sub-start"));
+  mp.msg.info("secondary-sub-end: " + mp.get_property_number("secondary-sub-end"));
+  mp.msg.info("secondary-sub-text: " + mp.get_property_native("secondary-sub-text"));
+}
+
+mp.add_key_binding("T", "secondary_subtimes", secondary_subtimes);


### PR DESCRIPTION
* ~~Adds ```--secondary-sub-delay=<sec>``` as an option and makes it so ```--sub-delay=<sec>``` only affects the primary subtitle.~~
* Adds ```secondary-sub-start``` and ```secondary-sub-end``` properties. Closes #8343.
* Adds a secondary argument to ```sub-seek``` and ```sub-step``` for choosing which subtitle track to seek/step through. The primary subtitle is the default so as not to break compatibility with anything that depended on the old versions.
* Adds documentation for ``secondary-sub-visibility``.