### PR TITLE
player: fix property name

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -270,7 +270,7 @@ static const char *const backup_properties[] = {
     "sub-use-margins",
     "sub-ass-force-margins",
     "sub-ass-vsfilter-aspect-compat",
-    "sub-style-override",
+    "sub-ass-override",
     "ab-loop-a",
     "ab-loop-b",
     "options/video-aspect-override",


### PR DESCRIPTION
Commits 4d1ffec and 6e481d0 renamed sub-ass-style-override to
sub-ass-override. But in commit bd603c2, when renaming it in
quit-watch-later's backup_properties, which determines which properties
are saved by quit-watch-later/write-watch-later-config, it was
incorrectly renamed to sub-style-override instead, and thus never got
saved even if modified at runtime. Instead mpv attempted to save the
non-existing property "sub-style-override", but since no error is raised
when saving non-existing properties with quit-watch-later, no one
noticed it. This commit renames the saved property to the correct new
name "sub-ass-override" so that it does get saved.