### PR TITLE
wayland: use the surface-suspension-v1 protocol

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -58,10 +58,9 @@ static bool wayland_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_
 {
     struct ra_ctx *ctx = sw->ctx;
     struct vo_wayland_state *wl = ctx->vo->wl;
-    bool render = !wl->hidden || wl->opts->disable_vsync;
     wl->frame_wait = true;
 
-    return render ? ra_gl_ctx_start_frame(sw, out_fbo) : false;
+    return !wl->suspended ? ra_gl_ctx_start_frame(sw, out_fbo) : false;
 }
 
 static void wayland_egl_swap_buffers(struct ra_swapchain *sw)

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -218,10 +218,9 @@ static void draw_image(struct vo *vo, struct mp_image *src)
     struct priv *p = vo->priv;
     struct vo_wayland_state *wl = vo->wl;
     struct buffer *buf;
-    bool render = !wl->hidden || wl->opts->disable_vsync;
     wl->frame_wait = true;
 
-    if (!render)
+    if (wl->suspended)
         return;
 
     buf = p->free_buffers;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -29,10 +29,8 @@ struct priv {
 static bool wayland_vk_start_frame(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    bool render = !wl->hidden || wl->opts->disable_vsync;
     wl->frame_wait = true;
-
-    return render;
+    return !wl->suspended;
 }
 
 static void wayland_vk_swap_buffers(struct ra_ctx *ctx)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -58,9 +58,9 @@ struct vo_wayland_state {
     bool has_keyboard_input;
     bool focused;
     bool frame_wait;
-    bool hidden;
     bool scale_change;
     bool state_change;
+    bool suspended;
     bool toplevel_configured;
     int display_fd;
     int mouse_unscaled_x;
@@ -69,13 +69,16 @@ struct vo_wayland_state {
     int mouse_y;
     int pending_vo_events;
     int scaling;
-    int timeout_count;
     int touch_entries;
     int wakeup_pipe[2];
 
     /* idle-inhibit */
     struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager;
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
+
+    /* surface-suspension */
+    struct wp_surface_suspension_manager_v1 *surface_suspension_manager;
+    struct wp_surface_suspension_v1 *surface_suspension;
 
     /* xdg-decoration */
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;

--- a/wscript
+++ b/wscript
@@ -498,6 +498,7 @@ video_output_features = [
         'desc': 'wayland-scanner',
         'func': check_program('wayland-scanner', 'WAYSCAN')
     } , {
+        #TODO: add a version check here for whenever the protocol gets merged
         'name': '--wayland-protocols',
         'desc': 'wayland-protocols',
         'func': check_wl_protocols

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -110,6 +110,12 @@ def build(ctx):
             protocol  = "stable/xdg-shell/xdg-shell",
             target    = "generated/wayland/xdg-shell.h")
         ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/surface-suspension/surface-suspension-v1",
+            target    = "generated/wayland/surface-suspension.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/surface-suspension/surface-suspension-v1",
+            target    = "generated/wayland/surface-suspension.h")
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
             protocol  = "unstable/idle-inhibit/idle-inhibit-unstable-v1",
             target    = "generated/wayland/idle-inhibit-unstable-v1.c")
         ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
@@ -515,6 +521,7 @@ def build(ctx):
         ( "video/out/w32_common.c",              "win32-desktop" ),
         ( "generated/wayland/idle-inhibit-unstable-v1.c", "wayland" ),
         ( "generated/wayland/presentation-time.c", "wayland" ),
+        ( "generated/wayland/surface-suspension.c", "wayland" ),
         ( "generated/wayland/xdg-decoration-unstable-v1.c", "wayland" ),
         ( "generated/wayland/xdg-shell.c",       "wayland" ),
         ( "video/out/wayland_common.c",          "wayland" ),


### PR DESCRIPTION
An implementation of the surface-suspension-v1 protocol for mpv wayland. See the upstream discussion [here](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/99). Everyone seems to like it, so hopefully the protocol won't sit in wayland-protocols forever. I plan to merge this after the protocol gets upstreamed with a new release.

You can test this by using: https://github.com/swaywm/sway/pull/6336