### PR TITLE
sub: render subtitles when playing only audio

### DIFF
--- a/player/sub.c
+++ b/player/sub.c
@@ -114,8 +114,10 @@ static bool update_subtitle(struct MPContext *mpctx, double video_pts,
     // Handle displaying subtitles on VO with no video being played. This is
     // quite different, because normally subtitles are redrawn on new video
     // frames, using the video frames' timestamps.
+    struct track *vtrack = mpctx->current_track[0][STREAM_VIDEO];
     if (mpctx->video_out && mpctx->video_status == STATUS_EOF &&
-        mpctx->opts->subs_rend->sub_past_video_end) {
+        (!vtrack || vtrack->attached_picture ||
+         mpctx->opts->subs_rend->sub_past_video_end)) {
         if (osd_get_force_video_pts(mpctx->osd) != video_pts) {
             osd_set_force_video_pts(mpctx->osd, video_pts);
             osd_query_and_reset_want_redraw(mpctx->osd);


### PR DESCRIPTION
Fixes the regression caused by commit 11423ac for which when playing
audio with cover art, or with --force-window and no cover art, subs
would not be rendered unless --sub-past-video-end is used.