### PR TITLE
sub: fix subs/lyrics on music files with sub-past-video-end=no

### DIFF
--- a/player/sub.c
+++ b/player/sub.c
@@ -115,7 +115,9 @@ static bool update_subtitle(struct MPContext *mpctx, double video_pts,
     // quite different, because normally subtitles are redrawn on new video
     // frames, using the video frames' timestamps.
     if (mpctx->video_out && mpctx->video_status == STATUS_EOF &&
-        mpctx->opts->subs_rend->sub_past_video_end) {
+        (mpctx->opts->subs_rend->sub_past_video_end ||
+         !mpctx->current_track[0][STREAM_VIDEO] ||
+         mpctx->current_track[0][STREAM_VIDEO]->attached_picture)) {
         if (osd_get_force_video_pts(mpctx->osd) != video_pts) {
             osd_set_force_video_pts(mpctx->osd, video_pts);
             osd_query_and_reset_want_redraw(mpctx->osd);


### PR DESCRIPTION
Default regressed on this case in 11423acf3

Reported in https://github.com/mpv-player/mpv/pull/8420#issuecomment-868987385