### PR TITLE
demux_mkv: fix correct start pts for eac3

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1742,6 +1742,8 @@ static int demux_mkv_open_audio(demuxer_t *demuxer, mkv_track_t *track)
         !strcmp(codec, "truehd") || !strcmp(codec, "eac3"))
     {
         track->parse = true;
+        if (!strcmp(codec, "eac3"))
+            track->parse_timebase = AV_TIME_BASE;
     } else if (!strcmp(codec, "flac")) {
         unsigned char *ptr = extradata;
         unsigned int size = extradata_len;


### PR DESCRIPTION
eac3 audio gets pts of following demuxer audio packet resulting
in not starting with correct pts. This is probably due to
audio parser buffering data and not outputting audio packet
before it is fed next packet. To fix this let the audio parser
set pts instead of mkv internal mkv demuxer.

In my tests with a video with eac3 audio I get pts of the first two
audio frames as:
0.032000
0.064000
after the patch I get:
0.000000
0.032000

I have also tested by disabling the internal mkv demuxer so the ffmpeg
mkv demuxer is used instead. That also results in first audio packet having
0.000000 as pts.
ffprobe also says first packet should have pts 0
I have not tested if other audio formats that also need an audio parser
have the same problem.