### PR TITLE
osc: expose osc-visibility via shared-script-properties

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2803,6 +2803,7 @@ function visibility_mode(mode, no_osd)
     end
 
     user_opts.visibility = mode
+    utils.shared_script_property_set("osc-visibility", mode)
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC visibility: " .. mode)


### PR DESCRIPTION
osc-visibility can already be changed at runtime via script-message
or other means, but until now there was no way to tell what the
current state is.

Now shared-script-properties/osc-visibility reflects this state.
It's output-only by the osc - changing it does not affect the osc.

Useful if a script wants to change osc-visibility temporarily, and
later restore to its original state.

There's no way to coordinate if more than one script wants to change
it, but that would be a hard problem to solve anyway, even if the
osc itself tried to coordinate such requests from different sources.