### PR TITLE
Hide terminal cursor

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -40,6 +40,7 @@ Interface changes
     - remove `--icc-contrast` and introduce `--icc-force-contrast`. The latter
       defaults to the equivalent of the old `--icc-contrast=inf`, and can
       instead be used to specifically set the contrast to any value.
+    - Add --term-cursor-hide to hide the terminal cursor.
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4510,6 +4510,10 @@ Terminal
         Only show warnings or worse, and let the ao_alsa output show errors
         only.
 
+``--term-cursor-hide``, ``--no-term-cursor-hide``
+    Hide the terminal cursor with VT220 escape sequences.
+    (Disabled by default.)
+
 ``--term-osd=<auto|no|force>``
     Control whether OSD messages are shown on the console when no video output
     is available (default: auto).

--- a/options/options.c
+++ b/options/options.c
@@ -730,6 +730,7 @@ static const m_option_t mp_opts[] = {
     {"hr-seek-framedrop", OPT_FLAG(hr_seek_framedrop)},
     {"autosync", OPT_CHOICE(autosync, {"no", -1}), M_RANGE(0, 10000)},
 
+    {"term-cursor-hide", OPT_BOOL(term_cursor_hide), .flags = UPDATE_OSD},
     {"term-osd", OPT_CHOICE(term_osd,
         {"force", 1}, {"auto", 2}, {"no", 0}), .flags = UPDATE_OSD},
 

--- a/options/options.h
+++ b/options/options.h
@@ -225,6 +225,7 @@ typedef struct MPOpts {
     int autosync;
     int frame_dropping;
     int video_latency_hacks;
+    bool term_cursor_hide;
     int term_osd;
     int term_osd_bar;
     char *term_osd_bar_chars;

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -33,3 +33,7 @@ bool terminal_try_attach(void)
 {
     return false;
 }
+
+void terminal_show_cursor(bool)
+{
+}

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -4,7 +4,7 @@ void terminal_init(void)
 {
 }
 
-void terminal_setup_getch(struct input_ctx *ictx)
+void terminal_setup(struct input_ctx *ictx, bool hide_cursor)
 {
 }
 

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -33,7 +33,3 @@ bool terminal_try_attach(void)
 {
     return false;
 }
-
-void terminal_show_cursor(bool)
-{
-}

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -352,6 +352,7 @@ static void getch2_poll(void)
 
 static void stop_sighandler(int signum)
 {
+    terminal_show_cursor(true);
     do_deactivate_getch2();
 
     // note: for this signal, we use SA_RESETHAND but do NOT mask signals
@@ -361,6 +362,8 @@ static void stop_sighandler(int signum)
 
 static void continue_sighandler(int signum)
 {
+    terminal_show_cursor(false);
+
     // SA_RESETHAND has reset SIGTSTP, so we need to restore it here
     setsigaction(SIGTSTP, stop_sighandler, SA_RESETHAND, false);
 
@@ -390,6 +393,7 @@ static void close_tty(void)
 
 static void quit_request_sighandler(int signum)
 {
+    terminal_show_cursor(true);
     do_deactivate_getch2();
 
     (void)write(death_pipe[1], &(char){1}, 1);
@@ -512,6 +516,15 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
     *cols = ws.ws_col;
     *px_width = ws.ws_xpixel;
     *px_height = ws.ws_ypixel;
+}
+
+void terminal_show_cursor(bool visible)
+{
+    if (visible)
+        printf("\e[?25h");
+    else
+        printf("\e[?25l");
+    fflush(stdout);
 }
 
 void terminal_init(void)

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -520,11 +520,7 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
 
 void terminal_show_cursor(bool visible)
 {
-    if (visible)
-        printf("\e[?25h");
-    else
-        printf("\e[?25l");
-    fflush(stdout);
+    write(STDOUT_FILENO, (visible ? "\e[?25h" : "\e[?25l"), 6);
 }
 
 void terminal_init(void)

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -55,7 +55,9 @@
 
 static volatile struct termios tio_orig;
 static volatile int tio_orig_set;
+
 static int send_cursor_esc = 0;
+void terminal_show_cursor(bool);
 
 static int tty_in = -1, tty_out = -1;
 

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -55,6 +55,7 @@
 
 static volatile struct termios tio_orig;
 static volatile int tio_orig_set;
+static int send_cursor_esc = 0;
 
 static int tty_in = -1, tty_out = -1;
 
@@ -435,8 +436,11 @@ static void *terminal_thread(void *ptr)
     return NULL;
 }
 
-void terminal_setup_getch(struct input_ctx *ictx)
+void terminal_setup(struct input_ctx *ictx, bool hide_cursor)
 {
+    send_cursor_esc = hide_cursor;
+    terminal_show_cursor(false);
+
     if (!getch2_enabled || input_ctx)
         return;
 
@@ -464,6 +468,8 @@ void terminal_setup_getch(struct input_ctx *ictx)
 
 void terminal_uninit(void)
 {
+    terminal_show_cursor(true);
+
     if (!getch2_enabled)
         return;
 
@@ -520,7 +526,8 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
 
 void terminal_show_cursor(bool visible)
 {
-    write(STDOUT_FILENO, (visible ? "\e[?25h" : "\e[?25l"), 6);
+    if (send_cursor_esc)
+        write(STDOUT_FILENO, (visible ? "\e[?25h" : "\e[?25l"), 6);
 }
 
 void terminal_init(void)

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -414,11 +414,6 @@ bool terminal_try_attach(void)
     return true;
 }
 
-void terminal_show_cursor(bool)
-{
-	// Don't do anything on Windows.
-}
-
 void terminal_init(void)
 {
     CONSOLE_SCREEN_BUFFER_INFO cinfo;

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -174,7 +174,7 @@ static void *input_thread_fn(void *ptr)
     return NULL;
 }
 
-void terminal_setup_getch(struct input_ctx *ictx)
+void terminal_setup(struct input_ctx *ictx, bool hide_cursor)
 {
     if (running)
         return;

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -414,6 +414,11 @@ bool terminal_try_attach(void)
     return true;
 }
 
+void terminal_show_cursor(bool)
+{
+	// Don't do anything on Windows.
+}
+
 void terminal_init(void)
 {
     CONSOLE_SCREEN_BUFFER_INFO cinfo;

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -49,4 +49,7 @@ void mp_write_console_ansi(void *wstream, char *buf);
 /* Windows-only function to attach to the parent process's console */
 bool terminal_try_attach(void);
 
+/* Show and hide cursor. */
+void terminal_show_cursor(bool);
+
 #endif /* MPLAYER_GETCH2_H */

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -29,9 +29,9 @@ struct input_ctx;
 void terminal_init(void);
 
 /* Setup ictx to read keys from the terminal */
-void terminal_setup_getch(struct input_ctx *ictx);
+void terminal_setup(struct input_ctx *ictx, bool hide_cursor);
 
-/* Undo terminal_init(), and also terminal_setup_getch() */
+/* Undo terminal_init(), and also terminal_setup() */
 void terminal_uninit(void);
 
 /* Return whether the process has been backgrounded. */
@@ -49,7 +49,7 @@ void mp_write_console_ansi(void *wstream, char *buf);
 /* Windows-only function to attach to the parent process's console */
 bool terminal_try_attach(void);
 
-/* Show and hide cursor. */
+/* Unix only: show and hide cursor. */
 void terminal_show_cursor(bool);
 
 #endif /* MPLAYER_GETCH2_H */

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -49,7 +49,4 @@ void mp_write_console_ansi(void *wstream, char *buf);
 /* Windows-only function to attach to the parent process's console */
 bool terminal_try_attach(void);
 
-/* Unix only: show and hide cursor. */
-void terminal_show_cursor(bool);
-
 #endif /* MPLAYER_GETCH2_H */

--- a/player/main.c
+++ b/player/main.c
@@ -136,7 +136,7 @@ void mp_update_logging(struct MPContext *mpctx, bool preinit)
         mp_print_version(mpctx->log, false); // for log-file=... in config files
 
     if (enabled && !preinit && mpctx->opts->consolecontrols)
-        terminal_setup_getch(mpctx->input);
+        terminal_setup(mpctx->input, mpctx->opts->term_cursor_hide);
 }
 
 void mp_print_version(struct mp_log *log, int always)
@@ -420,7 +420,6 @@ int mpv_main(int argc, char *argv[])
         return 1;
 
     mpctx->is_cli = true;
-    terminal_show_cursor(false);
 
     char **options = argv && argv[0] ? argv + 1 : NULL; // skips program name
     int r = mp_initialize(mpctx, options);
@@ -459,6 +458,5 @@ int mpv_main(int argc, char *argv[])
         rc = mpctx->quit_custom_rc;
 
     mp_destroy(mpctx);
-    terminal_show_cursor(true);
     return rc;
 }

--- a/player/main.c
+++ b/player/main.c
@@ -420,6 +420,7 @@ int mpv_main(int argc, char *argv[])
         return 1;
 
     mpctx->is_cli = true;
+    terminal_show_cursor(false);
 
     char **options = argv && argv[0] ? argv + 1 : NULL; // skips program name
     int r = mp_initialize(mpctx, options);
@@ -458,5 +459,6 @@ int mpv_main(int argc, char *argv[])
         rc = mpctx->quit_custom_rc;
 
     mp_destroy(mpctx);
+    terminal_show_cursor(true);
     return rc;
 }


### PR DESCRIPTION
This hides the terminal cursor on startup.

IMHO it doesn't look very nice in the terminal output:

![screenshot_2021-07-11-13-08-06_border](https://user-images.githubusercontent.com/1032692/125183990-fde57f80-e24c-11eb-981d-7e2a1827a1d5.png)

Especially with `--term-osd-bar` it looks pretty meh:

![screenshot_2021-07-11-13-08-43_border](https://user-images.githubusercontent.com/1032692/125183991-ffaf4300-e24c-11eb-88c2-5ae401bca3e9.png)

And even more so if you use something like `--term-osd-bar-chars=┣━╉─┤`:

![screenshot_2021-07-11-13-09-49_border](https://user-images.githubusercontent.com/1032692/125183992-0047d980-e24d-11eb-9477-97dcf08c8408.png)

Not sure if:

1. This is really the best location? 
2. There should be an option for this?
3. How well this works on Windows? I just have a Linux laptop, so I
   can't really test Windows, so I just added a no-op for it.