### PR TITLE
Fix Address Sanitizer reported error and Thread Sanitizer reported data race

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -4137,9 +4137,9 @@ static void update_cache(struct demux_internal *in)
         stream_control(stream, STREAM_CTRL_GET_METADATA, &stream_metadata);
     }
 
-    update_bytes_read(in);
-
     pthread_mutex_lock(&in->lock);
+
+    update_bytes_read(in);
 
     if (do_update)
         in->stream_size = stream_size;


### PR DESCRIPTION
Heap use after free error reported by Address Sanitizer in case of audio init failure. 

Thread sanitizer reported data race for the variable `in->byte_level_seeks` which is written without acquiring the lock inside `update_bytes_read` and simultaneously being read in `demux_get_reader_state` with lock acquired.