### PR TITLE
osdep/terminal: allow binding ^Z

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -235,7 +235,8 @@ static void process_input(struct input_ctx *input_ctx, bool timeout)
             unsigned char c = buf.b[0];
             skip_buf(&buf, 1);
             if (c < 32) {
-                c = c <= 25 ? (c + 'a' - 1) : (c - 25 + '2' - 1);
+                // 1..26 is ^A..^Z, and 27..31 is ^3..^7
+                c = c <= 26 ? (c + 'a' - 1) : (c + '3' - 27);
                 mods |= MP_KEY_MODIFIER_CTRL;
             }
             mp_input_put_key(input_ctx, c | mods);


### PR DESCRIPTION
If you use "stty susp ''" to disable sending the TSTP signal with ^Z,
then mpv won't recognize this ^Z in the terminal:

	[input] No key binding found for key 'Ctrl+2'.

Adjust 25 to 26 so ^Z works as well.

This was added in f250c29 for #8072; I think there's no real reason to stop at
Y? As far as I can see this has no downsides: All ^ keys work fine,
including ^Z if you don't disable it with stty.