### PR TITLE
TOOLS/autocrop.lua: improve cover art detection

### DIFF
--- a/TOOLS/lua/autocrop.lua
+++ b/TOOLS/lua/autocrop.lua
@@ -102,12 +102,13 @@ function is_enough_time(seconds)
 end
 
 function is_cropable()
-    local vid = mp.get_property_native("vid")
-    local is_album = vid and mp.get_property_native(
-        string.format("track-list/%d/albumart", vid)
-    ) or false
+    for _, track in pairs(mp.get_property_native('track-list')) do
+        if track.type == 'video' and track.selected then
+            return not track.albumart
+        end
+    end
 
-    return vid and not is_album
+    return false
 end
 
 function remove_filter(label)


### PR DESCRIPTION
Checks for the albumart flag on the video track that is actually being
used rather than the one with the same index as vid, which can be wrong.
If there is a subtitle stream, track-list/0 is the audio, track-list/1
is the subtitles, and track-list/2 is the video, even though vid is 1.
There can also be multiple audio tracks.

Also makes videos with lavfi-complex cropable.