### PR TITLE
stats.lua: add keybindings info page

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -43,6 +43,9 @@ The following listings are not necessarily complete. See ``etc/input.conf`` for
 a list of default bindings. User ``input.conf`` files and Lua scripts can
 define additional key bindings.
 
+See also `--input-test`_ for interactive binding details by key, and the
+`stats`_ built-in script for key bindings list (including print to terminal).
+
 Keyboard Control
 ----------------
 

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -24,7 +24,7 @@ stats:
 1      Show usual stats
 2      Show frame timings (scroll)
 3      Input cache stats
-4      Internal stuff (scroll)
+0      Internal stuff (scroll)
 ====   ==================
 
 On pages which support scroll, these key bindings are also active:
@@ -64,8 +64,8 @@ Configurable Options
     Default: 2
 ``key_page_3``
     Default: 3
-``key_page_4``
-    Default: 4
+``key_page_0``
+    Default: 0
 
     Key bindings for page switching while stats are displayed.
 

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -197,6 +197,12 @@ The keys are grouped automatically using a simple analysis of the command
 string, and one should not expect documentation-level grouping accuracy,
 however, it should still be reasonably useful.
 
+Using ``--idle --script-opts=stats-bindlist=yes`` will print the list to the
+terminal and quit immediately. By default long lines are shortened to 79 chars,
+and terminal escape sequences are enabled. A different length limit can be
+set by changing ``yes`` to a number (at least 40), and escape sequences can be
+disabled by adding ``-`` before the value, e.g. ``...=-yes`` or ``...=-120``.
+
 Like with ``--input-test``, the list includes bindings from ``input.conf`` and
 from user scripts. Use `--no-config`` to list only built-in bindings.
 

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -24,6 +24,7 @@ stats:
 1      Show usual stats
 2      Show frame timings (scroll)
 3      Input cache stats
+4      Active key bindings (scroll)
 0      Internal stuff (scroll)
 ====   ==================
 
@@ -64,6 +65,8 @@ Configurable Options
     Default: 2
 ``key_page_3``
     Default: 3
+``key_page_4``
+    Default: 4
 ``key_page_0``
     Default: 0
 
@@ -182,6 +185,20 @@ Using ``input.conf``, it is also possible to directly display a certain page::
 
     i script-binding stats/display-page-1
     e script-binding stats/display-page-2
+
+Active key bindings page
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lists the active key bindings and the commands they're bound to, excluding the
+interactive keys of the stats script itself. See also `--input-test`_ for more
+detailed view of each binding.
+
+The keys are grouped automatically using a simple analysis of the command
+string, and one should not expect documentation-level grouping accuracy,
+however, it should still be reasonably useful.
+
+Like with ``--input-test``, the list includes bindings from ``input.conf`` and
+from user scripts. Use `--no-config`` to list only built-in bindings.
 
 Internal stuff page
 ~~~~~~~~~~~~~~~~~~~

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -18,7 +18,7 @@ local o = {
     key_page_1 = "1",
     key_page_2 = "2",
     key_page_3 = "3",
-    key_page_4 = "4",
+    key_page_0 = "0",
     -- For pages which support scrolling
     key_scroll_up = "UP",
     key_scroll_down = "DOWN",
@@ -669,7 +669,7 @@ local function perf_stats()
     local stats = {}
     eval_ass_formatting()
     add_header(stats)
-    local page = pages[o.key_page_4]
+    local page = pages[o.key_page_0]
     append(stats, "", {prefix=o.nl .. o.nl .. page.desc .. ":", nl="", indent=""})
     page.offset = append_general_perfdata(stats, page.offset)
     return table.concat(stats)
@@ -800,7 +800,7 @@ pages = {
     [o.key_page_1] = { f = default_stats, desc = "Default" },
     [o.key_page_2] = { f = vo_stats, desc = "Extended Frame Timings", scroll = true },
     [o.key_page_3] = { f = cache_stats, desc = "Cache Statistics" },
-    [o.key_page_4] = { f = perf_stats, desc = "Internal performance info", scroll = true },
+    [o.key_page_0] = { f = perf_stats, desc = "Internal performance info", scroll = true },
 }
 
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -838,11 +838,12 @@ local function record_data(skip)
 end
 
 -- Call the function for `page` and print it to OSD
-local function print_page(page)
+local function print_page(page, after_scroll)
     if o.persistent_overlay then
-        mp.set_osd_ass(0, 0, pages[page].f())
+        mp.set_osd_ass(0, 0, pages[page].f(after_scroll))
     else
-        mp.osd_message(pages[page].f(), display_timer.oneshot and o.duration or o.redraw_delay + 1)
+        mp.osd_message(pages[page].f(after_scroll),
+                       display_timer.oneshot and o.duration or o.redraw_delay + 1)
     end
 end
 
@@ -854,7 +855,7 @@ end
 local function scroll_delta(d)
     if display_timer.oneshot then display_timer:kill() ; display_timer:resume() end
     pages[curr_page].offset = (pages[curr_page].offset or 1) + d
-    print_page(curr_page)
+    print_page(curr_page, true)
 end
 local function scroll_up() scroll_delta(-o.scroll_lines) end
 local function scroll_down() scroll_delta(o.scroll_lines) end


### PR DESCRIPTION
- Move the internal performance info from page 4 to page 0.
- Add key-bindings list at page 4.
- Support help-like printout of the whole list to the terminal.

The alignment/grouping style is heavily inspired by @medhefgo's #8924 but otherwise it's an independent implementation.

<details>
  <summary>Inside: terminal output listing for --no-config</summary>

By default the key names and section titles are in bold, but using `-yes` instead of `yes` disables the terminal escape sequences. The interactive video-window (libass) output is similar in style.

```
$ mpv --idle --no-config --script-opts=stats-help-keys=-yes
Active key bindings:
  
                    audio 
             SHARP  cycle audio
            Ctrl++  add audio-delay 0.100
            Ctrl+-  add audio-delay -0.100
  
                    brightness 
                 3  add brightness -1
                 4  add brightness 1
  
                    chapter 
                 !  add chapter -1
                 @  add chapter 1
              PGUP  add chapter 1
             PGDWN  add chapter -1
  
                    contrast 
                 1  add contrast -1
                 2  add contrast 1
  
                    deinterlace 
                 d  cycle deinterlace
  
                    edition 
                 E  cycle edition
  
                    frame 
                 ,  frame-back-step
                 .  frame-step
  
                    fullscreen 
                 f  cycle fullscreen
               ESC  set fullscreen no
     MBTN_LEFT_DBL  cycle fullscreen
  
                    gamma 
                 5  add gamma -1
                 6  add gamma 1
  
                    hwdec 
            Ctrl+h  cycle-values hwdec "auto" "no"
  
                    loop 
                 l  ab-loop
                 L  cycle-values loop-file "inf" "no"
  
                    mute 
                 m  cycle mute
              MUTE  cycle mute
  
                    ontop 
                 T  cycle ontop
  
                    osd 
                 O  no-osd cycle-values osd-level 3 1
  
                    panscan 
                 e  add panscan +0.1
                 w  add panscan -0.1
                 W  add panscan +0.1
  
                    pause 
                 p  cycle pause
              PLAY  cycle pause
             PAUSE  cycle pause
             SPACE  cycle pause
          PLAYONLY  set pause no
         PAUSEONLY  set pause yes
         PLAYPAUSE  cycle pause
        MBTN_RIGHT  cycle pause
  
                    playlist 
                 <  playlist-prev
                 >  playlist-next
              NEXT  playlist-next
              PREV  playlist-prev
             ENTER  playlist-next
         MBTN_BACK  playlist-prev
      MBTN_FORWARD  playlist-next
  
                    quit 
                 q  quit
                 Q  quit-watch-later
              STOP  quit
             POWER  quit
         CLOSE_WIN  quit
            Ctrl+c  quit 4
            Ctrl+w  quit
  
                    saturation 
                 7  add saturation -1
                 8  add saturation 1
  
                    screenshot 
                 s  screenshot
                 S  screenshot video
             Alt+s  screenshot each-frame
            Ctrl+s  screenshot window
  
                    script: console 
                 `  script-binding console/enable
  
                    script: osc 
               DEL  script-binding osc/visibility
  
                    seek 
                UP  seek  60
              DOWN  seek -60
              LEFT  seek -5
             RIGHT  seek  5
            REWIND  seek -60
           FORWARD  seek 60
          WHEEL_UP  seek 10
        WHEEL_DOWN  seek -10
          Shift+BS  revert-seek
          Shift+UP  no-osd seek  5 exact
        Shift+DOWN  no-osd seek -5 exact
        Shift+LEFT  no-osd seek -1 exact
        Shift+PGUP  seek 600
       Shift+PGDWN  seek -600
       Shift+RIGHT  no-osd seek  1 exact
     Shift+Ctrl+BS  revert-seek mark
  
                    show 
                 o  show-progress
                 P  show-progress
                F8  show_text ${playlist}
                F9  show_text ${track-list}
  
                    speed 
                 [  multiply speed 1/1.1
                 ]  multiply speed 1.1
                 {  multiply speed 0.5
                 }  multiply speed 2.0
                BS  set speed 1.0
  
                    sub 
                 F  add sub-scale -0.1
                 G  add sub-scale +0.1
                 j  cycle sub
                 J  cycle sub down
                 r  add sub-pos -1
                 R  add sub-pos +1
                 t  add sub-pos +1
                 u  cycle-values sub-ass-override "force" "no"
                 v  cycle sub-visibility
                 V  cycle sub-ass-vsfilter-aspect-compat
                 x  add sub-delay +0.1
                 z  add sub-delay -0.1
                 Z  add sub-delay +0.1
             Alt+v  cycle secondary-sub-visibility
         Ctrl+LEFT  no-osd sub-seek -1
        Ctrl+RIGHT  no-osd sub-seek  1
   Shift+Ctrl+LEFT  sub-step -1
  Shift+Ctrl+RIGHT  sub-step 1
  
                    video 
                 _  cycle video
                 A  cycle-values video-aspect-override "16:9" "4:3" "2.35:1"...
             Alt++  add video-zoom   0.1
             Alt+-  add video-zoom  -0.1
            Alt+BS  set video-zoom 0 ; set video-pan-x 0 ; set video-pan-y 0
            Alt+UP  add video-pan-y  0.1
          Alt+DOWN  add video-pan-y -0.1
          Alt+LEFT  add video-pan-x  0.1
         Alt+RIGHT  add video-pan-x -0.1
  
                    volume 
                 *  add volume 2
                 /  add volume -2
                 0  add volume 2
                 9  add volume -2
         VOLUME_UP  add volume 2
        WHEEL_LEFT  add volume -2
       VOLUME_DOWN  add volume -2
       WHEEL_RIGHT  add volume 2
  
                    window 
             Alt+0  set window-scale 0.5
             Alt+1  set window-scale 1.0
             Alt+2  set window-scale 2.0
```
</details>