### PR TITLE
wayland: force rerenders in certain cases

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -57,6 +57,7 @@ struct vo_wayland_state {
     bool activated;
     bool has_keyboard_input;
     bool focused;
+    bool force_render;
     bool frame_wait;
     bool hidden;
     bool scale_change;


### PR DESCRIPTION
~Apparently sometimes when the DPMS wakes up after some unspecified
amount of time, the compositor doesn't appear to send the initial frame
callback to mpv when the video is unpaused. This causes us to not
render and thus weird things happen (black screen, etc.). To work around
this, just force wl->hidden to false when setting the screensaver state.
In mpv's playloop, this step happens before the rendering starts up
again so the very next render is guarenteed to always happen. This has a
slight side effect of technically doing wasteful renders on
unpause if the window is hidden the entire time (sorry). Oh well. The
best fix is the proposed surface-suspension protocol which hopefully
would happen one day and solve this for good.~ Fixes #9016.