### PR TITLE
stats: remove some script-opts key bindings

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -52,13 +52,6 @@ option. The configuration syntax is described in `ON SCREEN CONTROLLER`_.
 Configurable Options
 ~~~~~~~~~~~~~~~~~~~~
 
-``key_oneshot``
-    Default: i
-``key_toggle``
-    Default: I
-
-    Key bindings to display stats.
-
 ``key_page_1``
     Default: 1
 ``key_page_2``
@@ -174,14 +167,12 @@ Note: colors are given as hexadecimal values and use ASS tag order: BBGGRR
 Different key bindings
 ~~~~~~~~~~~~~~~~~~~~~~
 
-A different key binding can be defined with the aforementioned options
-``key_oneshot`` and ``key_toggle`` but also with commands in ``input.conf``,
-for example::
+Additional keys can be configured in ``input.conf`` to display the stats::
 
     e script-binding stats/display-stats
     E script-binding stats/display-stats-toggle
 
-Using ``input.conf``, it is also possible to directly display a certain page::
+And to display a certain page directly::
 
     i script-binding stats/display-page-1
     e script-binding stats/display-page-2

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -13,8 +13,6 @@ local utils = require 'mp.utils'
 -- Options
 local o = {
     -- Default key bindings
-    key_oneshot = "i",
-    key_toggle = "I",
     key_page_1 = "1",
     key_page_2 = "2",
     key_page_3 = "3",
@@ -1125,11 +1123,11 @@ display_timer = mp.add_periodic_timer(o.duration,
 display_timer:kill()
 
 -- Single invocation key binding
-mp.add_key_binding(o.key_oneshot, "display-stats", function() process_key_binding(true) end,
+mp.add_key_binding(nil, "display-stats", function() process_key_binding(true) end,
     {repeatable=true})
 
 -- Toggling key binding
-mp.add_key_binding(o.key_toggle, "display-stats-toggle", function() process_key_binding(false) end,
+mp.add_key_binding(nil, "display-stats-toggle", function() process_key_binding(false) end,
     {repeatable=false})
 
 -- Single invocation bindings without key, can be used in input.conf to create


### PR DESCRIPTION
Only allow changing the key bindings to display and toggle stats in
input.conf, like with Del for the OSC and ` for the console.

The comments for script-binding stats/display-stats and script-binding
stats/display-stats-toggle in etc/input.conf will now be shown in the
keybinding stats page. Before, the versions of those keybindings defined
in stats.lua without comments were taking precedence.