### PR TITLE
manpage: fix watch-later-options examples

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -867,9 +867,10 @@ Program Behavior
 
         - ``--watch-later-options-remove=fullscreen``
           Resuming a file won't restore the fullscreen state.
-        - ``--watch-later-options-remove=volume,mute``
+        - ``--watch-later-options-remove=volume``
+          ``--watch-later-options-remove=mute``
           Resuming a file won't restore the volume or mute state.
-        - ``--watch-later-options=``
+        - ``--watch-later-options-clr``
           Resuming a file won't restore any option except the starting
           position.
 

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -249,9 +249,7 @@ bool m_config_watch_later_backup_opt_changed(struct m_config *config,
 {
     struct m_config_option *co = m_config_get_co(config, bstr0(opt_name));
     if (!co) {
-        // --watch-later-options= makes the first list item an empty string.
-        if (strcmp(opt_name, "") != 0)
-            MP_ERR(config, "Option %s not found.\n", opt_name);
+        MP_ERR(config, "Option %s not found.\n", opt_name);
         return false;
     }
 


### PR DESCRIPTION
--watch-later-options-remove doesn't accept multiple options, so split
the example.

Also suggest the more correct -clr to empty the list, and remove the
workaround to not print an error with --watch-later-options=