### PR TITLE
manpage: clarify watch-later-options examples

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -866,12 +866,12 @@ Program Behavior
     .. admonition:: Examples
 
         - ``--watch-later-options-remove=fullscreen``
-          Resuming a file won't restore the fullscreen state.
+          The fullscreen state won't be saved to watch later files.
         - ``--watch-later-options-remove=volume``
           ``--watch-later-options-remove=mute``
-          Resuming a file won't restore the volume or mute state.
+          The volume and mute state won't be saved to watch later files.
         - ``--watch-later-options-clr``
-          Resuming a file won't restore any option except the starting
+          No option will be saved to watch later files except the starting
           position.
 
 ``--write-filename-in-watch-later-config``


### PR DESCRIPTION
Make it clearer that watch-later-options controls which are options are
not saved and not which ones are restored.