### PR TITLE
DOCS: fix manual compiling warnings

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -43,7 +43,7 @@ The following listings are not necessarily complete. See ``etc/input.conf`` for
 a list of default bindings. User ``input.conf`` files and Lua scripts can
 define additional key bindings.
 
-See also `--input-test`_ for interactive binding details by key, and the
+See also ``--input-test`` for interactive binding details by key, and the
 `stats`_ built-in script for key bindings list (including print to terminal).
 
 Keyboard Control

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -181,7 +181,7 @@ Active key bindings page
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Lists the active key bindings and the commands they're bound to, excluding the
-interactive keys of the stats script itself. See also `--input-test`_ for more
+interactive keys of the stats script itself. See also ``--input-test`` for more
 detailed view of each binding.
 
 The keys are grouped automatically using a simple analysis of the command


### PR DESCRIPTION
This fix the two warnings shown below when trying to compile any 
of the three renditions of the manual:

```
DOCS/man/mpv.rst:46: (ERROR/3) Unknown target name: "--input-test".
DOCS/man/stats.rst:183: (ERROR/3) Unknown target name: "--input-test".
```
