### PR TITLE
context_drm_egl: allow autoprobe selection

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -726,11 +726,6 @@ static void drm_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 
 static bool drm_egl_init(struct ra_ctx *ctx)
 {
-    if (ctx->opts.probing) {
-        MP_VERBOSE(ctx, "DRM EGL backend can be activated only manually.\n");
-        return false;
-    }
-
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
     p->ev.version = DRM_EVENT_CONTEXT_VERSION;
     p->ev.page_flip_handler = &drm_pflip_cb;


### PR DESCRIPTION
Sometimes I use drm and I got annoyed by having to type --gpu-context=drm. The drm context has been explicitly coded to disallow the autoprobe almost its entire existence (since: https://github.com/mpv-player/mpv/commit/f757163058c2e5c7136213b0f79923fcea34b71a). @rr-: do you remember what the reason for that commit was?