### PR TITLE
egl_helpers: fix create_context fallback behavior

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -486,6 +486,26 @@ static const struct gl_functions gl_functions[] = {
 #undef DEF_FN
 #undef DEF_FN_NAME
 
+void mpgl_check_version(GL *gl, void *(*get_fn)(void *ctx, const char *n),
+                        void *fn_ctx)
+{
+    gl->GetString = get_fn(fn_ctx, "glGetString");
+    if (!gl->GetString) {
+        gl->version = 0;
+        return;
+    }
+    const char *version_string = gl->GetString(GL_VERSION);
+    if (!version_string) {
+        gl->version = 0;
+        return;
+    }
+    int major = 0, minor = 0;
+    if (sscanf(version_string, "%d.%d", &major, &minor) < 2) {
+        gl->version = 0;
+        return;
+    }
+    gl->version = MPGL_VER(major, minor);
+}
 
 // Fill the GL struct with function pointers and extensions from the current
 // GL context. Called by the backend.

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -70,6 +70,8 @@ enum {
 
 #define MPGL_VER_P(ver) MPGL_VER_GET_MAJOR(ver), MPGL_VER_GET_MINOR(ver)
 
+void mpgl_check_version(GL *gl, void *(*get_fn)(void *ctx, const char *n),
+                        void *fn_ctx);
 void mpgl_load_functions(GL *gl, void *(*getProcAddress)(const GLubyte *),
                          const char *ext2, struct mp_log *log);
 void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),


### PR DESCRIPTION
The EGL stuff is really complicated because of historical reasons
(tl;dr: blame EGL). There was one edge case with EGL context creation
that lead to incorrect behavior. EGL_KHR_create_context was created with
EGL 1.4 (which mpv does support) but it is still possible for an EGL 1.4
device to not implement this extension. That means that none of the EGL
attrs that pass a specific opengl version work. So for this obscure
case, there is a fallback context creation at the very end which simply
creates an EGLContext without passing any special attrs.

This has another problem however. mpv has a hard requirement on at least
desktop opengl 2.1 or opengl ES 2.0 to function (we're not asking for
much here). Since the fallback EGL context creation has no version
checking, it is entirely possible to create an EGL context with a
desktop opengl version under 2.1. As you get further along in the code,
the user will encounter the hard opengl version check and then error
out. However, we're supposed to also actually check if GLES works
(that's what the opengl-es=auto option is for) so this is a bug.

The fix is to do a bit of code duplication and make a mpgl_check_version
specifically for if we hit the edge case of needing to create an EGL
context without the EGL_KHR_create_context extension. Grab the version
with the function pointer, check if it's under 210, if so destroy the
EGL context and set it to NULL. After that, if the user has set
opengl-es to auto, mpv will try GLES next. If it is set to no, then mpv
will simply fail as desired. Fixes #5915.

Sidenote: the ra_gl_ctx_test_version originally testing 140 doesn't make
any sense. Passing the version number in that function only does
something if the user has set opengl-restrict. What we need to do is to
pass the version of the created context to that function. If the version
is higher than the opengl-restrict option, then make this a failure.