### PR TITLE
command: handle changes to image-display-duration

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6739,6 +6739,11 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 
     if (opt_ptr == &opts->vo->taskbar_progress)
         update_vo_playback_state(mpctx);
+
+    if (opt_ptr == &opts->image_display_duration && mpctx->vo_chain
+        && mpctx->vo_chain->is_sparse && !mpctx->ao_chain
+        && mpctx->video_status == STATUS_DRAINING)
+        mpctx->time_frame = opts->image_display_duration;
 }
 
 void mp_notify_property(struct MPContext *mpctx, const char *property)


### PR DESCRIPTION
When changing image-display-duration at runtime, make the new value take
effect immediately, rather than from the next playlist-position change.
This allows toggling the slideshow mode while viewing images (without
hacks like executing playlist-play-index current afterwards).

Changing image-display-duration, and thus mpctx->time_frame, while
playing videos doesn't cause any issue since the value is overwritten
immediately, with any --video-sync option value.