### PR TITLE
[RFC] path: support looking up config files via XDG_CONFIG_DIRS

### DIFF
--- a/osdep/path-unix.c
+++ b/osdep/path-unix.c
@@ -32,6 +32,7 @@ static void path_init(void)
 {
     char *home = getenv("HOME");
     char *xdg_dir = getenv("XDG_CONFIG_HOME");
+    char *xdg_config_dirs = getenv("XDG_CONFIG_DIRS");
 
     if (xdg_dir && xdg_dir[0]) {
         snprintf(mpv_home, sizeof(mpv_home), "%s/mpv", xdg_dir);
@@ -48,6 +49,44 @@ static void path_init(void)
     if (mp_path_exists(old_home) && !mp_path_exists(mpv_home)) {
         snprintf(mpv_home, sizeof(mpv_home), "%s", old_home);
         old_home[0] = '\0';
+        return;
+    }
+
+    // no previous mpv_home was found so continue searching through XDG_CONFIG_DIRS
+    if (!mp_path_exists(mpv_home)) {
+        char tmp[512];
+        char *token;
+        char *buf;
+        char *original_buf;
+        if (!xdg_config_dirs || !xdg_config_dirs[0]) {
+            // If the XDG_CONFIG_DIRS variable is empty or unset default to
+            // /etc/xdg as per spec.
+            xdg_config_dirs = "/etc/xdg";
+        }
+
+        // create a copy of the xdg_config_dirs var as strsep is mutating the original value
+        buf = original_buf = strdup(xdg_config_dirs);
+        if (buf == NULL)
+            return;
+
+        // For each colon (:) delimited path in the variable search for an mpv directory.
+        // The first directory that was found is set as mpv_home.
+        while ((token = strsep(&buf, ":"))) {
+            if (snprintf(tmp, sizeof(tmp), "%s/mpv", token) >= sizeof(tmp)) {
+                // new path doesn't fit in the buffer, use previous match
+                break;
+            }
+
+            if (mp_path_exists(tmp)) {
+                // copy to the destination buffer, we don't have to
+                // care about the return value of snprintf as the size
+                // has already been checked above.
+                (void) snprintf(mpv_home, sizeof(mpv_home), "%s", tmp);
+                break;
+            }
+        }
+
+        free(original_buf);
     }
 }
 


### PR DESCRIPTION
This adds a fallback to XDG_CONFIG_DIRS if neither ~/.config/mpv nor
~/.mpv exist.

XDG_CONFIG_DIRS is a colon (:) separated list of paths just like PATH
where the first entry in the list has the highest priority. We append
`/mpv` to each of these directories and set mpv_home to that value, if
it exists.

If none of the XDG_CONFIG_DIRS exist the previous default is used.

----

I was motivated to write this patch as I wanted to pre-configure mpv default system wide. The options to customise the situation weren't great as I'd either have to change packaging of mpv or touch each and every users home directory (while creating them).

Since `XDG_CONFIG_DIRS` already contain all the relevant paths (in correct order of priority) i decided to implement this in MPV.

With this commit I can now use my system defined default MPV configuration without ever having to touch user configuration or the packaging on MPV on the distribution. I can now put configuration files into `/etc/xdg/mpv` and it just works 🥳.

I do not have a bunch of state or previous MPV configuration on my systems so I didn't really test that case extensively. I noticed that mpv was still preferring ~/.config/mpv (as it should be) so that backwards compatibility is still there.