### PR TITLE
macOS AV: handle deprecated APIs in macOS 12

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -28,6 +28,10 @@
 #include "ao_coreaudio_properties.h"
 #include "ao_coreaudio_utils.h"
 
+#if !HAVE_MACOS_12_0_FEATURES
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 struct priv {
     AudioDeviceID device;
     AudioUnit audio_unit;
@@ -370,7 +374,7 @@ static int hotplug_init(struct ao *ao)
         AudioObjectPropertyAddress addr = {
             hotplug_properties[i],
             kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
+            kAudioObjectPropertyElementMain
         };
         err = AudioObjectAddPropertyListener(
             kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);
@@ -395,7 +399,7 @@ static void hotplug_uninit(struct ao *ao)
         AudioObjectPropertyAddress addr = {
             hotplug_properties[i],
             kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
+            kAudioObjectPropertyElementMain
         };
         err = AudioObjectRemovePropertyListener(
             kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -51,6 +51,10 @@
 #include "audio/out/ao_coreaudio_properties.h"
 #include "audio/out/ao_coreaudio_utils.h"
 
+#if !HAVE_MACOS_12_0_FEATURES
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 struct priv {
     AudioDeviceID device;   // selected device
 
@@ -120,7 +124,7 @@ static OSStatus enable_property_listener(struct ao *ao, bool enabled)
     for (int n = 0; n < MP_ARRAY_SIZE(devs); n++) {
         AudioObjectPropertyAddress addr = {
             .mScope    = kAudioObjectPropertyScopeGlobal,
-            .mElement  = kAudioObjectPropertyElementMaster,
+            .mElement  = kAudioObjectPropertyElementMain,
             .mSelector = selectors[n],
         };
         AudioDeviceID device = devs[n];

--- a/audio/out/ao_coreaudio_properties.c
+++ b/audio/out/ao_coreaudio_properties.c
@@ -23,13 +23,17 @@
 #include "audio/out/ao_coreaudio_utils.h"
 #include "mpv_talloc.h"
 
+#if !HAVE_MACOS_12_0_FEATURES
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 OSStatus ca_get(AudioObjectID id, ca_scope scope, ca_sel selector,
                 uint32_t size, void *data)
 {
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectGetPropertyData(id, &p_addr, 0, NULL, &size, data);
@@ -41,7 +45,7 @@ OSStatus ca_set(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectSetPropertyData(id, &p_addr, 0, NULL, size, data);
@@ -56,7 +60,7 @@ OSStatus ca_get_ary(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     err = AudioObjectGetPropertyDataSize(id, &p_addr, 0, NULL, &p_size);
@@ -95,7 +99,7 @@ Boolean ca_settable(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectIsPropertySettable(id, &p_addr, data);

--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -35,6 +35,10 @@
 #include <mach/mach_time.h>
 #endif
 
+#if !HAVE_MACOS_12_0_FEATURES
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 CFStringRef cfstr_from_cstr(char *str)
 {
     return CFStringCreateWithCString(NULL, str, CA_CFSTR_ENCODING);
@@ -113,7 +117,7 @@ OSStatus ca_select_device(struct ao *ao, char* name, AudioDeviceID *device)
         AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
             .mSelector = kAudioHardwarePropertyDeviceForUID,
             .mScope    = kAudioObjectPropertyScopeGlobal,
-            .mElement  = kAudioObjectPropertyElementMaster,
+            .mElement  = kAudioObjectPropertyElementMain,
         };
         err = AudioObjectGetPropertyData(
             kAudioObjectSystemObject, &p_addr, 0, 0, &size, &v);
@@ -392,7 +396,7 @@ static OSStatus ca_change_mixing(struct ao *ao, AudioDeviceID device,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = kAudioDevicePropertySupportsMixing,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     if (AudioObjectHasProperty(device, &p_addr)) {
@@ -493,7 +497,7 @@ bool ca_change_physical_format_sync(struct ao *ao, AudioStreamID stream,
     AudioObjectPropertyAddress p_addr = {
         .mSelector = kAudioStreamPropertyPhysicalFormat,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     err = AudioObjectAddPropertyListener(stream, &p_addr,

--- a/osdep/macos/swift_extensions.swift
+++ b/osdep/macos/swift_extensions.swift
@@ -35,8 +35,11 @@ extension NSScreen {
             var object: io_object_t
             var iter = io_iterator_t()
             let matching = IOServiceMatching("IODisplayConnect")
+            #if HAVE_MACOS_12_0_FEATURES
+            let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter)
+            #else
             let result = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &iter)
-
+            #endif
             if result != KERN_SUCCESS || iter == 0 { return nil }
 
             repeat {

--- a/osdep/macosx_compat.h
+++ b/osdep/macosx_compat.h
@@ -24,6 +24,11 @@
 #import <Cocoa/Cocoa.h>
 #include "osdep/macosx_versions.h"
 
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0)
+#define kIOMainPortDefault kIOMasterPortDefault
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 #if (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_12)
 
 @interface NSWindow (macOS10_12_SDK)

--- a/osdep/macosx_versions.h
+++ b/osdep/macosx_versions.h
@@ -30,4 +30,8 @@
 #    define MAC_OS_X_VERSION_10_12 101200
 #endif
 
+#if !defined(MAC_OS_VERSION_12_0)
+#    define MAC_OS_VERSION_12_0 120000
+#endif
+
 #endif /* MPV_MACOSX_VERSIONS */

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -227,14 +227,14 @@ static void cocoa_init_light_sensor(struct vo *vo)
     run_on_main_thread(vo, ^{
         struct vo_cocoa_state *s = vo->cocoa;
         io_service_t srv = IOServiceGetMatchingService(
-                kIOMasterPortDefault, IOServiceMatching("AppleLMUController"));
+                kIOMainPortDefault, IOServiceMatching("AppleLMUController"));
         if (srv == IO_OBJECT_NULL) {
             MP_VERBOSE(vo, "can't find an ambient light sensor\n");
             return;
         }
 
         // subscribe to notifications from the light sensor driver
-        s->light_sensor_io_port = IONotificationPortCreate(kIOMasterPortDefault);
+        s->light_sensor_io_port = IONotificationPortCreate(kIOMainPortDefault);
         IONotificationPortSetDispatchQueue(
             s->light_sensor_io_port, dispatch_get_main_queue());
 

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -304,13 +304,21 @@ class Common: NSObject {
     }
 
     func initLightSensor() {
+        #if HAVE_MACOS_12_0_FEATURES
+        let srv = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleLMUController"))
+        #else
         let srv = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("AppleLMUController"))
+        #endif
         if srv == IO_OBJECT_NULL {
             log.sendVerbose("Can't find an ambient light sensor")
             return
         }
 
+        #if HAVE_MACOS_12_0_FEATURES
+        lightSensorIOPort = IONotificationPortCreate(kIOMainPortDefault)
+        #else
         lightSensorIOPort = IONotificationPortCreate(kIOMasterPortDefault)
+        #endif
         IONotificationPortSetDispatchQueue(lightSensorIOPort, queue)
         var n = io_object_t()
         IOServiceAddInterestNotification(lightSensorIOPort, srv, kIOGeneralInterest, lightSensorCallback, MPVHelper.bridge(obj: self), &n)

--- a/wscript
+++ b/wscript
@@ -837,7 +837,12 @@ standalone_features = [
         'desc': 'macOS 10.14 SDK Features',
         'deps': 'cocoa',
         'func': check_macos_sdk('10.14')
-    },{
+    }, {
+        'name': '--macos-12-0-features',
+        'desc': 'macOS 12.0 SDK Features',
+        'deps': 'cocoa',
+        'func': check_macos_sdk('12.0')
+    }, {
         'name': '--macos-media-player',
         'desc': 'macOS Media Player support',
         'deps': 'macos-10-12-2-features && swift',


### PR DESCRIPTION
Deprecated: [kAudioObjectPropertyElementMaster](https://developer.apple.com/documentation/coreaudio/kaudioobjectpropertyelementmaster)
replacement in macOS 12: [kAudioObjectPropertyElementMain](https://developer.apple.com/documentation/coreaudio/kaudioobjectpropertyelementmain)

Deprecated: [kIOMasterPortDefault](https://developer.apple.com/documentation/iokit/kiomasterportdefault)
replacement in macOS 12: [kIOMainPortDefault](https://developer.apple.com/documentation/iokit/kiomainportdefault)
