### PR TITLE
sub: show subs without duration on vid change

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -288,7 +288,7 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
     }
 
     reset_video_state(mpctx);
-    reset_subtitle_state(mpctx);
+    term_osd_set_subs(mpctx, NULL);
 
     return;
 


### PR DESCRIPTION
When changing video track with subtitles with unknown duration, they
aren't shown until you seek, cycle sub back and forth, or apply a video
filter. This is caused by reinit_video_chain_src() calling
reset_subtitle_state() -> sub/sd_ass.c:reset() -> ass_flush_events()
when ctx->duration_unknown is true.

The ass_flush_events() call was added in a714f8e928 so subs with unknown
duration wouldn't multiply on seek, i.e. when reset_subtitle_state() is
called from reset_playback_state(). Therefore, this commit adds an
argument to reset_subtitle_state() that determines whether to call
ass_flush_events().

Alternatively, replacing `reset_subtitle_state()` in `reinit_video_chain_src()` with just `term_osd_set_subs(mpctx, NULL)`, which clears any subtitles printed to the terminal when switching to a video track, fixes the bug. The `reset_subtitle_state()` call was added in c1ac97b99b to "reset the state correctly when switching between video/no-video", but with it removed I no longer notice any issue doing that.

Trying to reinitialize subs after switching video track in `property_switch_track()` by calling `uninit_sub_all(); reinit_sub_all(); mp_force_video_refresh()` does not fix the issue.