### PR TITLE
Refine arguments quoting #2

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -162,7 +162,7 @@ a number of other places.
 
 |
 | ``<command>  ::= [<prefixes>] <command_name> (<argument>)*``
-| ``<argument> ::= (<unquoted> | " <double_quoted> " | !X <custom_quoted> X!)``
+| ``<argument> ::= (<unquoted> | " <double_quoted> " | `X <custom_quoted> X`)``
 
 ``command_name`` is an unquoted string with the command name itself. See
 `List of Input Commands`_ for a list.
@@ -171,10 +171,10 @@ Arguments are separated by whitespaces even if the command expects only one
 argument. Arguments with whitespaces or other special characters must be quoted,
 or the command cannot be parsed correctly.
 
-Double quoted arguments start and end with ``"``. Custom quotes start with ``!``
-(exclamation mark) followed by any ASCII character, and end in the same pair in
-reverse order, e.g. ``!'foo'!`` or ``!-bar-!``. The final pair sequence is not
-allowed inside the string - in these examples ``'!`` and ``-!`` respectively.
+Double quoted arguments start and end with ``"``. Custom quotes start with `````
+(back-quote) followed by any ASCII character, and end in the same pair in
+reverse order, e.g. ```-foo-``` or ````bar````. The final pair sequence is not
+allowed inside the string - in these examples ``-``` and `````` respectively.
 
 Custom quotes take their content literally, while inside double quotes
 JSON/C-style escaping can be used. JSON escapes according to RFC 8259, minus

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -162,7 +162,7 @@ a number of other places.
 
 |
 | ``<command>  ::= [<prefixes>] <command_name> (<argument>)*``
-| ``<argument> ::= (<unquoted> | " <double_quoted> " | `X <custom_quoted> X`)``
+| ``<argument> ::= (<unquoted> | " <double_quoted> " | ' <single_quoted> ' | `X <custom_quoted> X`)``
 
 ``command_name`` is an unquoted string with the command name itself. See
 `List of Input Commands`_ for a list.
@@ -171,14 +171,21 @@ Arguments are separated by whitespaces even if the command expects only one
 argument. Arguments with whitespaces or other special characters must be quoted,
 or the command cannot be parsed correctly.
 
-Double quoted arguments start and end with ``"``. Custom quotes start with `````
-(back-quote) followed by any ASCII character, and end in the same pair in
-reverse order, e.g. ```-foo-``` or ````bar````. The final pair sequence is not
-allowed inside the string - in these examples ``-``` and `````` respectively.
+Double quotes interpret JSON/C-style escaping, like ``\t`` or ``\"`` or ``\\``.
+JSON escapes according to RFC 8259, minus surrogate pair escapes. This is the
+only form which allows newlines at the value - as ``\n``.
 
-Custom quotes take their content literally, while inside double quotes
-JSON/C-style escaping can be used. JSON escapes according to RFC 8259, minus
-surrogate pair escapes, should be a safe subset that can be used.
+Single quotes take the content literally, and cannot include the single-quote
+character at the value.
+
+Custom quotes also take the content literally, but are more flexible than single
+quotes. They start with ````` (back-quote) followed by any ASCII character,
+and end at the first occurance of the same pair in reverse order, e.g.
+```-foo-``` or ````bar````. The final pair sequence is not allowed at the
+value - in these examples ``-``` and `````` respectively. In the second
+example the last character of the value also can't be a back-quote.
+
+Mixed quoting at the same argument, like ``'foo'"bar"``, is not supported.
 
 Note that argument parsing and property expansion happen at different stages.
 First, arguments are determined as described above, and then, where applicable,

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -336,9 +336,19 @@ static int pctx_read_token(struct parse_ctx *ctx, bstr *out)
             return -1;
         }
         if (!bstr_eatstart0(&ctx->str, "\"")) {
-            MP_ERR(ctx, "Unterminated quotes: ...>%.*s<.\n", BSTR_P(start));
+            MP_ERR(ctx, "Unterminated double quote: ...>%.*s<.\n", BSTR_P(start));
             return -1;
         }
+        return 1;
+    }
+    if (bstr_eatstart0(&ctx->str, "'")) {
+        int next = bstrchr(ctx->str, '\'');
+        if (next < 0) {
+            MP_ERR(ctx, "Unterminated single quote: ...>%.*s<.\n", BSTR_P(start));
+            return -1;
+        }
+        *out = bstr_splice(ctx->str, 0, next);
+        ctx->str = bstr_cut(ctx->str, next+1);
         return 1;
     }
     if (ctx->start.len > 1 && bstr_eatstart0(&ctx->str, "`")) {

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -341,8 +341,8 @@ static int pctx_read_token(struct parse_ctx *ctx, bstr *out)
         }
         return 1;
     }
-    if (ctx->start.len > 1 && bstr_eatstart0(&ctx->str, "!")) {
-        char endquote[2] = {ctx->str.start[0], '!'};
+    if (ctx->start.len > 1 && bstr_eatstart0(&ctx->str, "`")) {
+        char endquote[2] = {ctx->str.start[0], '`'};
         ctx->str = bstr_cut(ctx->str, 1);
         int next = bstr_find(ctx->str, (bstr){endquote, 2});
         if (next < 0) {

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -386,10 +386,10 @@ local name_prefixes = {
 -- It's decent in practice, and worst case is "incorrect" subject.
 local function cmd_subject(cmd)
     cmd = cmd:gsub(";.*", ""):gsub("%-", "_")  -- only first cmd, s/-/_/
-    local TOKEN = '^%s*"?([%w_!]*)'  -- captures+ends before a (maybe) final "
+    local TOKEN = '^%s*["\']?([%w_!]*)'  -- captures+ends before (maybe) final "
     local tok, sname, subw
 
-    repeat tok, cmd = cmd:match(TOKEN .. '"?(.*)')
+    repeat tok, cmd = cmd:match(TOKEN .. '["\']?(.*)')
     until not cmd_prefixes[tok]
     -- tok is the 1st non-generic command/property name token, cmd is the rest
 


### PR DESCRIPTION
- Change custom quotes start-char from `!` (exclamation-mark) to \` (back quote/tick).
- Support single quotes, and refine the docs now that we have 3 types of quotes.
- Detect single quotes in stats.lua page 4 (key bindings).

Main reason for changing `!` to \` is that we have ` cycle-values !reverse ...` which required quoting as `cycle-values "!reverse" ...` after custom quotes were added, but doesn't anymore because `!` is no longer special.

This breaks backward compatibility for anyone who's already using custom quotes at their `input.conf`, however, we didn't make a release yet since custom quotes were added, and it's trivial to use the new char instead.

Supporting single quotes is useful, simple, and technically unrelated to the custom quotes change, but I prefer to have them presented together.

@jeeb @sfan5 and anyone else who has a preference on custom-quotes character choice, I'd appreciate your feedback. Maybe specifically - is it likely for unquoted arguments at `input.conf` to begin with \` ? (I'd think no).

The previous choice of `!` failed to take `!reverse` into consideration, in part due to almost no feedback at the time.