### PR TITLE
options: audio-display determines cover priority

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2806,7 +2806,8 @@ Property list
     ``track-list/N/albumart``
         ``yes``/true if this is a video track that consists of a single
         picture, ``no``/false or unavailable otherwise. This is used for video
-        tracks that are really attached pictures in audio files.
+        tracks that are really images embedded in audio files and for external
+        cover art.
 
     ``track-list/N/default``
         ``yes``/true if the track has the default flag set in the file,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2036,14 +2036,17 @@ Audio
         want. For example, most A/V receivers connected via HDMI and that can
         do 7.1 would  be served by: ``--audio-channels=7.1,5.1,stereo``
 
-``--audio-display=<no|attachment>``
-    Setting this option to ``attachment`` (default) will display image
-    attachments (e.g. album cover art) when playing audio files. It will
-    display the first image found, and additional images are available as
-    video tracks.
+``--audio-display=<no|embedded-first|external-first>``
+    Determines whether to display cover art when playing audio files and with
+    what priority. It will display the first image found, and additional images
+    are available as video tracks.
 
-    Setting this option to ``no`` disables display of video entirely when
-    playing audio files.
+    :no:             Disable display of video entirely when playing audio
+                     files.
+    :embedded-first: Display embedded images and external cover art, giving
+                     priority to embedded images (default).
+    :external-first: Display embedded images and external cover art, giving
+                     priority to external files.
 
     This option has no influence on files with normal video tracks.
 

--- a/options/options.c
+++ b/options/options.c
@@ -508,7 +508,8 @@ static const m_option_t mp_opts[] = {
 
     {"lavfi-complex", OPT_STRING(lavfi_complex), .flags = UPDATE_LAVFI_COMPLEX},
 
-    {"audio-display", OPT_CHOICE(audio_display, {"no", 0}, {"attachment", 1})},
+    {"audio-display", OPT_CHOICE(audio_display, {"no", 0},
+        {"embedded-first", 1}, {"external-first", 2})},
 
     {"hls-bitrate", OPT_CHOICE(hls_bitrate,
         {"no", -1}, {"min", 0}, {"max", INT_MAX}), M_RANGE(0, INT_MAX)},

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -476,8 +476,12 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs,
         return !t1->is_external;
     bool ext1 = t1->is_external && !t1->no_default;
     bool ext2 = t2->is_external && !t2->no_default;
-    if (ext1 != ext2)
+    if (ext1 != ext2) {
+        if (t1->attached_picture && t2->attached_picture
+            && opts->audio_display == 1)
+            return !ext1;
         return ext1;
+    }
     if (t1->auto_loaded != t2->auto_loaded)
         return !t1->auto_loaded;
     int l1 = match_lang(langs, t1->lang), l2 = match_lang(langs, t2->lang);
@@ -1619,7 +1623,7 @@ static void play_current_file(struct MPContext *mpctx)
 
     if (mpctx->vo_chain && mpctx->vo_chain->is_coverart) {
         MP_INFO(mpctx,
-            "Displaying attached picture. Use --no-audio-display to prevent this.\n");
+            "Displaying cover art. Use --no-audio-display to prevent this.\n");
     }
 
     if (!mpctx->vo_chain)


### PR DESCRIPTION
Let audio-display determine whether attached pictures or external cover
art tracks should be selected when both are present.

Attached pictures are given priority by default as requested in #8539.

Also updates references to attached pictures in the log and manpage to
refer to cover art as well.

Closes #8539.

Reusing `audio-display` to set the priority instead of adding another option is nice, but it may be better to decide whether the priority of external sub and audio files should be configurable, and if so implement it consistently for sub, audio and cover art, like --{sub,audio-file,cover-art}-auto-select=[no,yes]. I don't know if someone actually needs those though. See #3777.