### PR TITLE
wayland: cleanup handle_toplevel_config

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -50,8 +50,6 @@ struct vo_wayland_state {
     int gcd;
     int reduced_height;
     int reduced_width;
-    int toplevel_width;
-    int toplevel_height;
 
     /* State */
     bool activated;


### PR DESCRIPTION
Need to actually test some other compositors but probably they work fine since Sway has by far the most complicated geometry handling of the group.