### PR TITLE
options: don't always set set-locally to true

### DIFF
--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -283,8 +283,7 @@ void m_config_backup_all_opts(struct m_config *config)
 void m_config_backup_watch_later_opts(struct m_config *config)
 {
     for (int n = 0; n < config->num_opts; n++)
-        ensure_backup(&config->watch_later_backup_opts, BACKUP_LOCAL,
-                      &config->opts[n]);
+        ensure_backup(&config->watch_later_backup_opts, 0, &config->opts[n]);
 }
 
 struct m_config_option *m_config_get_co_raw(const struct m_config *config,


### PR DESCRIPTION
Since 1d1d1fbff9 option-info/\<name>/set-locally was being set to true
for every option. This broke setting start from ytdl-hook, which doesn't
overwrite start if it was set-locally. Fix this so that only adding an
option to reset-on-next-file or setting file-local-options/\<name> make
set-locally true like before.

However, it's arguable whether just adding an option to
reset-on-next-file without ever changing it should make set-locally
true, so that e.g.
--reset-on-next-file=start 'https://www.youtube.com/watch?v=LXb3EKWsInQ&t=1m30s'
doesn't start at 90, though it probably should.

Fixes #9081.