### PR TITLE
sub: support --sub-filter-jsre (js regex)

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2826,6 +2826,11 @@ Subtitles
         include replacing the regexes with a very primitive and small subset of
         sed, or some method to control case-sensitivity.
 
+``--sub-filter-jsre-...=...``
+    Same as ``--sub-filter-regex`` but with JavaScript regular expressions.
+    Shares/affected-by all ``--sub-filter-regex-*`` control options (see below),
+    and also experimental. Requires only JavaScript support.
+
 ``--sub-filter-regex-warn=<yes|no>``
     Log dropped lines with warning log level, instead of verbose (default: no).
     Helpful for testing.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2804,7 +2804,7 @@ Subtitles
 
     List items are matched in order. If a regular expression matches, the
     process is stopped, and the subtitle line is discarded. The text matched
-    against is, currently, always the ``Text`` field of ASS events (if the
+    against is, by default, the ``Text`` field of ASS events (if the
     subtitle format is different, it is always converted). This may include
     formatting tags. Matching is case-insensitive, but how this is done depends
     on the libc, and most likely works in ASCII only. It does not work on
@@ -2830,6 +2830,12 @@ Subtitles
     Same as ``--sub-filter-regex`` but with JavaScript regular expressions.
     Shares/affected-by all ``--sub-filter-regex-*`` control options (see below),
     and also experimental. Requires only JavaScript support.
+
+``--sub-filter-regex-plain=<yes|no>``
+    Whether to first convert the ASS "Text" field to plain-text (default: no).
+    This strips ASS tags and applies ASS directives, like ``\N`` to new-line.
+    If the result is multi-line then the regexp anchors ``^`` and ``$`` match
+    each line, but still any match discards all lines.
 
 ``--sub-filter-regex-warn=<yes|no>``
     Log dropped lines with warning log level, instead of verbose (default: no).

--- a/options/options.c
+++ b/options/options.c
@@ -218,6 +218,7 @@ const struct m_sub_options mp_sub_filter_opts = {
         {"sub-filter-sdh", OPT_FLAG(sub_filter_SDH)},
         {"sub-filter-sdh-harder", OPT_FLAG(sub_filter_SDH_harder)},
         {"sub-filter-regex-enable", OPT_FLAG(rf_enable)},
+        {"sub-filter-regex-plain", OPT_FLAG(rf_plain)},
         {"sub-filter-regex", OPT_STRINGLIST(rf_items)},
         {"sub-filter-jsre", OPT_STRINGLIST(jsre_items)},
         {"sub-filter-regex-warn", OPT_FLAG(rf_warn)},

--- a/options/options.c
+++ b/options/options.c
@@ -219,6 +219,7 @@ const struct m_sub_options mp_sub_filter_opts = {
         {"sub-filter-sdh-harder", OPT_FLAG(sub_filter_SDH_harder)},
         {"sub-filter-regex-enable", OPT_FLAG(rf_enable)},
         {"sub-filter-regex", OPT_STRINGLIST(rf_items)},
+        {"sub-filter-jsre", OPT_STRINGLIST(jsre_items)},
         {"sub-filter-regex-warn", OPT_FLAG(rf_warn)},
         {0}
     },

--- a/options/options.h
+++ b/options/options.h
@@ -114,6 +114,7 @@ struct mp_sub_filter_opts {
     int sub_filter_SDH;
     int sub_filter_SDH_harder;
     int rf_enable;
+    int rf_plain;
     char **rf_items;
     char **jsre_items;
     int rf_warn;

--- a/options/options.h
+++ b/options/options.h
@@ -115,6 +115,7 @@ struct mp_sub_filter_opts {
     int sub_filter_SDH_harder;
     int rf_enable;
     char **rf_items;
+    char **jsre_items;
     int rf_warn;
 };
 

--- a/sub/filter_jsre.c
+++ b/sub/filter_jsre.c
@@ -1,0 +1,134 @@
+#include <stdio.h>
+#include <sys/types.h>
+
+#include <mujs.h>
+
+#include "common/common.h"
+#include "common/msg.h"
+#include "misc/bstr.h"
+#include "options/options.h"
+#include "sd.h"
+
+
+// p_NAME are protected functions (never throw) which interact with the JS VM.
+// return 0 on successful interaction, not-0 on (caught) js-error.
+// on error: stack is the same as on entry + an error value
+
+// js: global[n] = new RegExp(str, flags)
+static int p_regcomp(js_State *J, int n, const char *str, int flags)
+{
+    if (js_try(J))
+        return 1;
+
+    js_pushnumber(J, n);  // n
+    js_newregexp(J, str, flags);  // n regex
+    js_setglobal(J, js_tostring(J, -2));  // n  (and global[n] is the regex)
+    js_pop(J, 1);
+
+    js_endtry(J);
+    return 0;
+}
+
+// js: found = global[n].test(text)
+static int p_regexec(js_State *J, int n, const char *text, int *found)
+{
+    if (js_try(J))
+        return 1;
+
+    js_pushnumber(J, n);  // n
+    js_getglobal(J, js_tostring(J, -1));  // n global[n]
+    js_getproperty(J, -1, "test");  // n global[n] global[n].test
+    js_rot2(J);  // n global[n].test global[n]   (n, test(), and its `this')
+    js_pushstring(J, text); // n global[n].test global[n] text
+    js_call(J, 1);  // n test-result
+    *found = js_toboolean(J, -1);
+    js_pop(J, 2);  // the result and n
+
+    js_endtry(J);
+    return 0;
+}
+
+// protected. caller should pop the error after using the result string.
+static const char *get_err(js_State *J)
+{
+    return js_trystring(J, -1, "unknown error");
+}
+
+
+struct priv {
+    js_State *J;
+    int num_regexes;
+    int offset;
+};
+
+static void destruct_priv(void *p)
+{
+    js_freestate(((struct priv *)p)->J);
+}
+
+static bool jsre_init(struct sd_filter *ft)
+{
+    if (strcmp(ft->codec, "ass") != 0)
+        return false;
+
+    if (!ft->opts->rf_enable)
+        return false;
+
+    struct priv *p = talloc_zero(ft, struct priv);
+    ft->priv = p;
+
+    p->J = js_newstate(0, 0, JS_STRICT);
+    if (!p->J) {
+        MP_ERR(ft, "jsre: VM init error\n");
+        return false;
+    }
+    talloc_set_destructor(p, destruct_priv);
+
+    for (int n = 0; ft->opts->jsre_items && ft->opts->jsre_items[n]; n++) {
+        char *item = ft->opts->jsre_items[n];
+
+        int err = p_regcomp(p->J, p->num_regexes, item, JS_REGEXP_I);
+        if (err) {
+            MP_ERR(ft, "jsre: %s -- '%s'\n", get_err(p->J), item);
+            js_pop(p->J, 1);
+            continue;
+        }
+
+        p->num_regexes += 1;
+    }
+
+    if (!p->num_regexes)
+        return false;
+
+    p->offset = sd_ass_fmt_offset(ft->event_format);
+    return true;
+}
+
+static struct demux_packet *jsre_filter(struct sd_filter *ft,
+                                      struct demux_packet *pkt)
+{
+    struct priv *p = ft->priv;
+    char *text = bstrto0(NULL, sd_ass_pkt_text(ft, pkt, p->offset));
+    bool drop = false;
+
+    for (int n = 0; n < p->num_regexes; n++) {
+        int found, err = p_regexec(p->J, n, text, &found);
+        if (err == 0 && found) {
+            int level = ft->opts->rf_warn ? MSGL_WARN : MSGL_V;
+            MP_MSG(ft, level, "jsre: regex %d => drop: '%s'\n", n, text);
+            drop = true;
+            break;
+        } else if (err) {
+            MP_WARN(ft, "jsre: test regex %d: %s.\n", n, get_err(p->J));
+            js_pop(p->J, 1);
+        }
+    }
+
+    talloc_free(text);
+    return drop ? NULL : pkt;
+}
+
+const struct sd_filter_functions sd_filter_jsre = {
+    .init   = jsre_init,
+    .filter = jsre_filter,
+};

--- a/sub/filter_jsre.c
+++ b/sub/filter_jsre.c
@@ -87,7 +87,7 @@ static bool jsre_init(struct sd_filter *ft)
     for (int n = 0; ft->opts->jsre_items && ft->opts->jsre_items[n]; n++) {
         char *item = ft->opts->jsre_items[n];
 
-        int err = p_regcomp(p->J, p->num_regexes, item, JS_REGEXP_I);
+        int err = p_regcomp(p->J, p->num_regexes, item, JS_REGEXP_I | JS_REGEXP_M);
         if (err) {
             MP_ERR(ft, "jsre: %s -- '%s'\n", get_err(p->J), item);
             js_pop(p->J, 1);
@@ -110,6 +110,9 @@ static struct demux_packet *jsre_filter(struct sd_filter *ft,
     struct priv *p = ft->priv;
     char *text = bstrto0(NULL, sd_ass_pkt_text(ft, pkt, p->offset));
     bool drop = false;
+
+    if (ft->opts->rf_plain)
+        sd_ass_to_plaintext(text, strlen(text), text);
 
     for (int n = 0; n < p->num_regexes; n++) {
         int found, err = p_regexec(p->J, n, text, &found);

--- a/sub/filter_regex.c
+++ b/sub/filter_regex.c
@@ -30,7 +30,7 @@ static bool rf_init(struct sd_filter *ft)
         MP_TARRAY_GROW(p, p->regexes, p->num_regexes);
         regex_t *preg = &p->regexes[p->num_regexes];
 
-        int err = regcomp(preg, item, REG_ICASE | REG_EXTENDED | REG_NOSUB);
+        int err = regcomp(preg, item, REG_ICASE | REG_EXTENDED | REG_NOSUB | REG_NEWLINE);
         if (err) {
             char errbuf[512];
             regerror(err, preg, errbuf, sizeof(errbuf));
@@ -62,6 +62,9 @@ static struct demux_packet *rf_filter(struct sd_filter *ft,
     struct priv *p = ft->priv;
     char *text = bstrto0(NULL, sd_ass_pkt_text(ft, pkt, p->offset));
     bool drop = false;
+
+    if (ft->opts->rf_plain)
+        sd_ass_to_plaintext(text, strlen(text), text);
 
     for (int n = 0; n < p->num_regexes; n++) {
         int err = regexec(&p->regexes[n], text, 0, NULL, 0);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -89,4 +89,15 @@ struct sd_filter_functions {
 extern const struct sd_filter_functions sd_filter_sdh;
 extern const struct sd_filter_functions sd_filter_regex;
 
+
+// convenience utils for filters with ass codec
+
+// num commas to skip at an ass-event before the "Text" field (always last)
+// (doesn't change, can be retrieved once on filter init)
+int sd_ass_fmt_offset(const char *event_format);
+
+// the event (pkt->buffer) "Text" content according to the calculated offset.
+// on malformed event: warns and returns (bstr){NULL,0}
+bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset);
+
 #endif

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -101,4 +101,9 @@ int sd_ass_fmt_offset(const char *event_format);
 // on malformed event: warns and returns (bstr){NULL,0}
 bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset);
 
+// convert \0-terminated "Text" (ass) content to plaintext, possibly in-place.
+// result.start is out, result.len is MIN(out_siz, strlen(in)) or smaller.
+// if there's room: out[result.len] is set to \0. out == in is allowed.
+bstr sd_ass_to_plaintext(char *out, size_t out_siz, const char *in);
+
 #endif

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -88,6 +88,7 @@ struct sd_filter_functions {
 
 extern const struct sd_filter_functions sd_filter_sdh;
 extern const struct sd_filter_functions sd_filter_regex;
+extern const struct sd_filter_functions sd_filter_jsre;
 
 
 // convenience utils for filters with ass codec

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -68,6 +68,9 @@ static const struct sd_filter_functions *const filters[] = {
 #if HAVE_POSIX
     &sd_filter_regex,
 #endif
+#if HAVE_JAVASCRIPT
+    &sd_filter_jsre,
+#endif
     NULL,
 };
 

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -973,3 +973,12 @@ bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset)
     }
     return txt;
 }
+
+bstr sd_ass_to_plaintext(char *out, size_t out_siz, const char *in)
+{
+    struct buf b = {out, out_siz, 0};
+    ass_to_plaintext(&b, in);
+    if (b.len < out_siz)
+        out[b.len] = 0;
+    return (bstr){out, b.len};
+}

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -376,6 +376,7 @@ def build(ctx):
         ( "sub/dec_sub.c" ),
         ( "sub/draw_bmp.c" ),
         ( "sub/filter_regex.c",                  "posix" ),
+        ( "sub/filter_jsre.c",                   "javascript" ),
         ( "sub/filter_sdh.c" ),
         ( "sub/img_convert.c" ),
         ( "sub/lavc_conv.c" ),


### PR DESCRIPTION
The core of this patch set is adding a js-based regex filter, pretty much the same as `--js-filter-regex` but with JS regex syntax, and also sharing its control options.

Main reason for adding it is that the regex filter doesn't work on Windows due to missing regex POSIX APIs, but JS support in mpv can, and usually is enabed in Windows builds.

However, while adding it I noticed that there's some duplicated code where ASS sub filters need to extract the text fom the demuxed packet, which is annoying to reinvent/duplicate.

So the first commit adds the text extraction code as utilities for ASS filters, and uses it from the regex filter. The following two commits make use of these utils for the SDH filter.

The 4th commit finally adds the jsre filter which also makes use of these utils.

Then, the last (5th) commit adds support for converting the ASS "Text" event to plaintext before doing the match (both regex and jsre, disabled by default). The functionality already existed in mpv and using it from the regex and jsre filters was rather trivial.