### PR TITLE
stats.lua: replace deprecated "sans" with "sans-serif"

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -43,7 +43,7 @@ local o = {
     plot_color = "FFFFFF",
 
     -- Text style
-    font = "sans",
+    font = "sans-serif",
     font_mono = "monospace",   -- monospaced digits are sufficient
     font_size = 8,
     font_color = "FFFFFF",


### PR DESCRIPTION
fontconfig has a long standing, deprecated\[1\] alias for  "sans"  in  its
default "fonts.conf" file that  redirects  to  the  proper  "sans-serif"
family name, but the same fallback mechanic doesn't  happen  on  Windows
when using libass directwrite backend, which then picks whatever font is
specified by "osd-font" if any.

\[1\]: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/24330d27f88bbf387d92128d2c21e005f2563e93/fonts.conf.in