### PR TITLE
remove VOCTRL_GET_UNFS_WINDOW_SIZE and improve osd message printing

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2349,19 +2349,16 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
         return M_PROPERTY_OK;
     case M_PROPERTY_GET_TYPE:
     case M_PROPERTY_GET: ;
+        struct mp_osd_res vo_res = osd_get_vo_res(mpctx->osd);
+        if (!mpctx->video_out || !mpctx->video_out->config_ok)
+            return M_PROPERTY_UNAVAILABLE;
         struct mp_image_params params = get_video_out_params(mpctx);
         int vid_w, vid_h;
         mp_image_params_get_dsize(&params, &vid_w, &vid_h);
         if (vid_w < 1 || vid_h < 1)
             return M_PROPERTY_UNAVAILABLE;
-
-        int s[2];
-        if (vo_control(vo, VOCTRL_GET_UNFS_WINDOW_SIZE, s) <= 0 ||
-            s[0] < 1 || s[1] < 1)
-            return M_PROPERTY_UNAVAILABLE;
-
-        double xs = (double)s[0] / vid_w;
-        double ys = (double)s[1] / vid_h;
+        double xs = (double)vo_res.w / vid_w;
+        double ys = (double)vo_res.h / vid_h;
         return m_property_double_ro(action, arg, (xs + ys) / 2);
     }
     return M_PROPERTY_NOT_IMPLEMENTED;

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -869,16 +869,6 @@ static int vo_cocoa_control_on_main_thread(struct vo *vo, int request, void *arg
     struct vo_cocoa_state *s = vo->cocoa;
 
     switch (request) {
-    case VOCTRL_GET_UNFS_WINDOW_SIZE: {
-        int *sz = arg;
-        NSRect rect = (s->fullscreen || vo->opts->fullscreen) ?
-                       s->unfs_window : [s->view frame];
-        if(!vo->opts->hidpi_window_scale)
-            rect = [s->current_screen convertRectToBacking:rect];
-        sz[0] = rect.size.width;
-        sz[1] = rect.size.height;
-        return VO_TRUE;
-    }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
         int *sz = arg;
         NSRect r = NSMakeRect(0, 0, sz[0], sz[1]);

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -617,17 +617,6 @@ class Common: NSObject {
                 return VO_TRUE;
             }
             return VO_NOTIMPL
-        case VOCTRL_GET_UNFS_WINDOW_SIZE:
-            let sizeData = data.assumingMemoryBound(to: Int32.self)
-            let size = UnsafeMutableBufferPointer(start: sizeData, count: 2)
-            var rect = window?.unfsContentFrame ?? NSRect(x: 0, y: 0, width: 1280, height: 720)
-            if let screen = window?.currentScreen, !Bool(mpv.opts.hidpi_window_scale) {
-                rect = screen.convertRectToBacking(rect)
-            }
-
-            size[0] = Int32(rect.size.width)
-            size[1] = Int32(rect.size.height)
-            return VO_TRUE
         case VOCTRL_SET_UNFS_WINDOW_SIZE:
             let sizeData = data.assumingMemoryBound(to: Int32.self)
             let size = UnsafeBufferPointer(start: sizeData, count: 2)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -95,9 +95,8 @@ enum mp_voctrl {
     VOCTRL_KILL_SCREENSAVER,
     VOCTRL_RESTORE_SCREENSAVER,
 
-    // Return or set window size (not-fullscreen mode only - if fullscreened,
-    // these must access the not-fullscreened window size only).
-    VOCTRL_GET_UNFS_WINDOW_SIZE,        // int[2] (w/h)
+    // Set window size (not-fullscreen mode only - if fullscreened,
+    // this must access the not-fullscreened window size only).
     VOCTRL_SET_UNFS_WINDOW_SIZE,        // int[2] (w/h)
 
     VOCTRL_GET_FOCUSED,                 // bool*

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1715,17 +1715,6 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 
         return VO_TRUE;
     }
-    case VOCTRL_GET_UNFS_WINDOW_SIZE: {
-        int *s = arg;
-
-        if (!w32->window_bounds_initialized)
-            return VO_FALSE;
-
-        RECT *rc = w32->current_fs ? &w32->prev_windowrc : &w32->windowrc;
-        s[0] = rect_w(*rc);
-        s[1] = rect_h(*rc);
-        return VO_TRUE;
-    }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
         int *s = arg;
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1597,12 +1597,6 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         *(char ***)arg = get_displays_spanned(wl);
         return VO_TRUE;
     }
-    case VOCTRL_GET_UNFS_WINDOW_SIZE: {
-        int *s = arg;
-        s[0] = mp_rect_w(wl->geometry) * wl->scaling;
-        s[1] = mp_rect_h(wl->geometry) * wl->scaling;
-        return VO_TRUE;
-    }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
         int *s = arg;
         wl->window_size.x0 = 0;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1895,14 +1895,6 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
         }
         return VO_TRUE;
     }
-    case VOCTRL_GET_UNFS_WINDOW_SIZE: {
-        int *s = arg;
-        if (!x11->window || x11->parent)
-            return VO_FALSE;
-        s[0] = (x11->fs ? RC_W(x11->nofsrc) : RC_W(x11->winrc)) / x11->dpi_scale;
-        s[1] = (x11->fs ? RC_H(x11->nofsrc) : RC_H(x11->winrc)) / x11->dpi_scale;
-        return VO_TRUE;
-    }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
         int *s = arg;
         if (!x11->window || x11->parent)


### PR DESCRIPTION
There's two different but slightly related commits here.

1. Get rid of `VOCTRL_GET_UNFS_WINDOW_SIZE`. This VOCTRL goes to every windowing backend to get the size of the window and is only used for obtaining the `current-window-scale` property. However, this isn't needed at all. mpv's vo core is perfectly capable of getting the window size without needing any special platform-specific code. `osd-dimensions` already does this so just copy how that is done and then do the math necessary to return the scale of the window. Since `VOCTRL_GET_UNFS_WINDOW_SIZE` is no longer used in `command.c`, we can just delete all this code from every special windowing backend that implemented it. In theory, any platform should be able to get the `current-window-scale` property as long as `osd_get_vo_res` returns something.
2. This behavior was made more obvious by the first commit, but it actually always existed (example: the `edition` property). By default, changing a property prints an osd message. The format is just `property_name: ${property_name}` where the latter is the expanded property value. This works fine when getting a property, but when setting it, there could be a mismatch. That's because the actual value of the property, `${property_name}`, may not be what the user is trying to set. This can be most easily seen when setting `current-window-scale` while in fullscreen. The mpv window will, of course, not change size so the value displayed is whatever the actual scale of the window is. It's unintuitive. To fix that, we can simply carry around an extra `const char` argument and pass it down to the osd printing functions. If that char is available, use that when constructing the message to print instead of just always expanding the property.