### PR TITLE
DOCS/stats.rst: remove remaining references to 'Source Sans Pro'

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -39,8 +39,9 @@ Font
 ~~~~
 
 For optimal visual experience, a font with support for many font weights and
-monospaced digits is recommended. By default, the open source font
-`Source Sans Pro <https://github.com/adobe-fonts/source-sans-pro>`_ is used.
+monospaced digits is recommended. The open source font
+`Source Sans Pro <https://github.com/adobe-fonts/source-sans-pro>`_ is an
+example of such font.
 
 Configuration
 -------------
@@ -110,15 +111,15 @@ Configurable Options
     Clear data buffers used for drawing graphs when toggling.
 
 ``font``
-    Default: Source Sans Pro
+    Default: sans-serif
 
-    Font name. Should support as many font weights as possible for optimal
+    Font name or family. Should support as many font weights as possible for optimal
     visual experience.
 
 ``font_mono``
-    Default: Source Sans Pro
+    Default: monospace
 
-    Font name for parts where monospaced characters are necessary to align
+    Font name or family for parts where monospaced characters are necessary to align
     text. Currently, monospaced digits are sufficient.
 
 ``font_size``


### PR DESCRIPTION
Commit cb51dfa76a8760fc0d67de9ee90f692ee02fc247 removed 'Source Sans Pro'
as the default 'stats.lua' font of choice, but the documentation for the
script was not updated accordingly. Replace all mentions of 'Source
Sans Pro' in the manual with generic font-familiy names.