### PR TITLE
window-scale fixes

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2333,6 +2333,12 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
     if (params.rotate % 180 == 90 && (vo->driver->caps & VO_CAP_ROTATE90))
         MPSWAP(int, vid_w, vid_h);
 
+    if (vo->monitor_par < 1) {
+        vid_h = MPCLAMP(vid_h / vo->monitor_par, 1, 16000);
+    } else {
+        vid_w = MPCLAMP(vid_w * vo->monitor_par, 1, 16000);
+    }
+
     if (action == M_PROPERTY_SET) {
         // Also called by update_window_scale as a NULL property.
         double scale = *(double *)arg;

--- a/player/command.c
+++ b/player/command.c
@@ -2330,6 +2330,9 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
     if (vid_w < 1 || vid_h < 1)
         return M_PROPERTY_UNAVAILABLE;
 
+    if (params.rotate % 180 == 90 && (vo->driver->caps & VO_CAP_ROTATE90))
+        MPSWAP(int, vid_w, vid_h);
+
     if (action == M_PROPERTY_SET) {
         // Also called by update_window_scale as a NULL property.
         double scale = *(double *)arg;

--- a/player/command.c
+++ b/player/command.c
@@ -2331,6 +2331,7 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
         return M_PROPERTY_UNAVAILABLE;
 
     if (action == M_PROPERTY_SET) {
+        // Also called by update_window_scale as a NULL property.
         double scale = *(double *)arg;
         int s[2] = {vid_w * scale, vid_h * scale};
         if (s[0] <= 0 || s[1] <= 0)
@@ -2351,20 +2352,9 @@ static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
 
 static void update_window_scale(struct MPContext *mpctx)
 {
-    struct vo *vo = mpctx->video_out;
-    if (!vo)
-        return;
-
-    struct mp_image_params params = get_video_out_params(mpctx);
-    int vid_w, vid_h;
-    mp_image_params_get_dsize(&params, &vid_w, &vid_h);
-    if (vid_w < 1 || vid_h < 1)
-        return;
-
     double scale = mpctx->opts->vo->window_scale;
-    int s[2] = {vid_w * scale, vid_h * scale};
-    if (s[0] > 0 && s[1] > 0)
-        vo_control(vo, VOCTRL_SET_UNFS_WINDOW_SIZE, s);
+    mp_property_current_window_scale(mpctx, (struct m_property *)NULL,
+                                     M_PROPERTY_SET, (void*)&scale);
 }
 
 static int mp_property_display_fps(void *ctx, struct m_property *prop,


### PR DESCRIPTION
The vo currently handles rotations in 90 degree steps and some VOs set
this via VO_CAP_ROTATE90. When the rotation exactly hits either 90 or
270 degrees, this causes the values of dwidth and dheight to perfectly
swap like one would expect. However, the mp_image_params_get_dsize
function call in both of the window scale functions do not take this
special case into account. So the width/height values returned will be
incorrectly flipped in the 90 and 270 degree cases if the vo driver does
implement VO_CAP_ROTATE90 (like vo=gpu). Fortunately, the
mp_image_params struct keeps track of the rotation for us. So all we
need to do is check if the image is rotated at 90 or 270 degrees and
check that the current vo driver supports VO_CAP_ROTATE90. If so, then
swap vid_w and vid_h to their true, correct values.