### PR TITLE
Convert links to HTTPS

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -22,7 +22,7 @@ When cross-compiling, you have to run mpv's configure with these arguments:
 DEST_OS=win32 TARGET=i686-w64-mingw32 ./waf configure
 ```
 
-[MXE](http://mxe.cc) makes it very easy to bootstrap a complete MingGW-w64
+[MXE](https://mxe.cc) makes it very easy to bootstrap a complete MingGW-w64
 environment from a Linux machine. See a working example below.
 
 Alternatively, you can try [mingw-w64-cmake](https://github.com/lachs0r/mingw-w64-cmake),
@@ -38,7 +38,7 @@ Example with MXE
 #
 # Refer to
 #
-#    http://mxe.cc/#requirements
+#    https://mxe.cc/#requirements
 #
 # Scroll down for disto/OS-specific instructions to install them.
 

--- a/DOCS/man/af.rst
+++ b/DOCS/man/af.rst
@@ -198,7 +198,7 @@ Available filters are:
     for each option. The options are not documented here, because they are
     merely passed to librubberband. Look at the librubberband documentation
     to learn what each option does:
-    http://breakfastquay.com/rubberband/code-doc/classRubberBand_1_1RubberBandStretcher.html
+    https://breakfastquay.com/rubberband/code-doc/classRubberBand_1_1RubberBandStretcher.html
     (The mapping of the mpv rubberband filter sub-option names and values to
     those of librubberband follows a simple pattern: ``"Option" + Name + Value``.)
 

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -58,7 +58,7 @@ Language features - ECMAScript 5
 The scripting backend which mpv currently uses is MuJS - a compatible minimal
 ES5 interpreter. As such, ``String.substring`` is implemented for instance,
 while the common but non-standard ``String.substr`` is not. Please consult the
-MuJS pages on language features and platform support - http://mujs.com .
+MuJS pages on language features and platform support - https://mujs.com .
 
 Unsupported Lua APIs and their JS alternatives
 ----------------------------------------------

--- a/DOCS/man/libmpv.rst
+++ b/DOCS/man/libmpv.rst
@@ -10,9 +10,9 @@ Since libmpv merely allows access to underlying mechanisms that can control
 mpv, further documentation is spread over a few places:
 
 - https://github.com/mpv-player/mpv/blob/master/libmpv/client.h
-- http://mpv.io/manual/master/#options
-- http://mpv.io/manual/master/#list-of-input-commands
-- http://mpv.io/manual/master/#properties
+- https://mpv.io/manual/master/#options
+- https://mpv.io/manual/master/#list-of-input-commands
+- https://mpv.io/manual/master/#properties
 - https://github.com/mpv-player/mpv-examples/tree/master/libmpv
 
 C PLUGINS

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -480,7 +480,7 @@ The ``mp`` module is preloaded, although it can be loaded manually with
             the timer callback function fn is run).
 
     Note that these are methods, and you have to call them using ``:`` instead
-    of ``.`` (Refer to http://www.lua.org/manual/5.2/manual.html#3.4.9 .)
+    of ``.`` (Refer to https://www.lua.org/manual/5.2/manual.html#3.4.9 .)
 
     Example:
 

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -60,7 +60,7 @@ libavfilter bridge.
 .. note::
 
     To get a full list of available video filters, see ``--vf=help`` and
-    http://ffmpeg.org/ffmpeg-filters.html .
+    https://ffmpeg.org/ffmpeg-filters.html .
 
     Also, keep in mind that most actual filters are available via the ``lavfi``
     wrapper, which gives you access to most of libavfilter's filters. This
@@ -389,7 +389,7 @@ Available mpv-only filters are:
         option gives the flags which should be passed to libswscale. This
         option is numeric and takes a bit-wise combination of ``SWS_`` flags.
 
-        See ``http://git.videolan.org/?p=ffmpeg.git;a=blob;f=libswscale/swscale.h``.
+        See ``https://git.videolan.org/?p=ffmpeg.git;a=blob;f=libswscale/swscale.h``.
 
     ``<o>``
         Set AVFilterGraph options. These should be documented by FFmpeg.

--- a/DOCS/mplayer-changes.rst
+++ b/DOCS/mplayer-changes.rst
@@ -52,7 +52,7 @@ Input
 * Classic LIRC support was removed. Install remotes as input devices instead.
   This way they will send X11 key events to the mpv window, which can be bound
   using the normal ``input.conf``.
-  Also see: http://github.com/mpv-player/mpv/wiki/IR-remotes
+  Also see: https://github.com/mpv-player/mpv/wiki/IR-remotes
 * Joystick support was removed. It was considered useless and was the cause
   of some problems (e.g. a laptop's accelerator being recognized as joystick).
 * Support for relative seeking by percentage.

--- a/DOCS/waf-buildsystem.rst
+++ b/DOCS/waf-buildsystem.rst
@@ -46,7 +46,7 @@ mpv's custom configure step on top of waf
 
 To some extents mpv has a custom build system written on top of waf. This
 document will not go over the standard waf behaviour as that is documented in
-the `Waf book <http://docs.waf.googlecode.com/git/book_17/single.html>`_.
+the `Waf book <https://waf.io/book/>`_.
 
 All of the configuration process is handled with a declarative approach. Lists
 of dictionaries define the checks, and some custom Python code traverses these

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 * [Wiki](https://github.com/mpv-player/mpv/wiki)
 * [FAQ][FAQ]
-* [Manual](http://mpv.io/manual/master/)
+* [Manual](https://mpv.io/manual/master/)
 
 
 ## Overview
@@ -53,7 +53,7 @@ Releases can be found on the [release list][releases].
 
 
 For semi-official builds and third-party packages please see
-[mpv.io/installation](http://mpv.io/installation/).
+[mpv.io/installation](https://mpv.io/installation/).
 
 ## Changelog
 


### PR DESCRIPTION
Inspired by #8893 but done a bit more thoroughly. I used:
```
find . -type f \( -name '*.md' -o -name '*.rst' \)  -exec grep -n 'http://' {} +
```
to discover all of these links. The commits are:

- change mpv links to https
- change 3rd party links to https (after checking https is available)
- Change a dead link to the waf book to the current one

There were other dead links that I didn't touch
```
./DOCS/man/ao.rst:33:        You can also try `using the upmix plugin <http://git.io/vfuAy>`_.
./DOCS/man/input.rst:3068:    A list of tags can be found here: http://docs.aegisub.org/latest/ASS_Tags/
./DOCS/compile-windows.md:14:**Warning**: the original MinGW (http://www.mingw.org) is unsupported.
```
Also a link that did not have https
```
./DOCS/compile-windows.md:7:http://mingw-w64.sourceforge.net.
```

The rest were example links, e.g. `--ytdl-raw-options-append=proxy=http://127.0.0.1:3128`