### PR TITLE
DOCS/input: update osd-ass-cc documentation

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3057,13 +3057,14 @@ Property list
 
     .. admonition:: Example
 
-        - ``--osd-status-msg='This is ${osd-ass-cc/0}{\\b1}bold text'``
-        - ``show-text "This is ${osd-ass-cc/0}{\b1}bold text"``
+        - ``--osd-msg3='This is ${osd-ass-cc/0}{\\b1}bold text'``
+        - ``show-text "This is ${osd-ass-cc/0}{\\b1}bold text"``
 
     Any ASS override tags as understood by libass can be used.
 
     Note that you need to escape the ``\`` character, because the string is
-    processed for C escape sequences before passing it to the OSD code.
+    processed for C escape sequences before passing it to the OSD code. See
+    `Flat command syntax`_ for details.
 
     A list of tags can be found here: http://docs.aegisub.org/latest/ASS_Tags/
 


### PR DESCRIPTION
- Replace the legacy --osd-status-msg with the newer --osd-msg3.
- Use single quotes in
  show-text "This is ${osd-ass-cc/0}{\b1}bold text", which is wrong
  because \b is interpreted as an escape sequence. You need to use \\\\b
  or single quotes.
- Update the escaping notice, since you can now use single and custom
  quotes which don't interpret escape sequences.