### PR TITLE
command: don't hardcode commands list to be repeatable

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1702,7 +1702,9 @@ prefixes can be specified. They are separated by whitespace.
     This is the default for ``input.conf`` commands.
 ``repeatable``
     For some commands, keeping a key pressed doesn't run the command repeatedly.
-    This prefix forces enabling key repeat in any case.
+    This prefix forces enabling key repeat in any case. For a list of commands:
+    the first command determines the repeatability of the whole list (up to and
+    including version 0.33 - a list was always repeatable).
 ``async``
     Allow asynchronous execution (if possible). Note that only a few commands
     will support this (usually this is explicitly documented). Some commands

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -608,8 +608,10 @@ void mp_cmd_dump(struct mp_log *log, int msgl, char *header, struct mp_cmd *cmd)
 
 bool mp_input_is_repeatable_cmd(struct mp_cmd *cmd)
 {
-    return (cmd->def->allow_auto_repeat) || cmd->def == &mp_cmd_list ||
-           (cmd->flags & MP_ALLOW_REPEAT);
+    if (cmd->def == &mp_cmd_list && cmd->args[0].v.p)
+        cmd = cmd->args[0].v.p;  // list - only 1st cmd is considered
+
+    return (cmd->def->allow_auto_repeat) || (cmd->flags & MP_ALLOW_REPEAT);
 }
 
 bool mp_input_is_scalable_cmd(struct mp_cmd *cmd)


### PR DESCRIPTION
Previously, a list of commands was always considered repeatable.

This behavior was added at 6710527a (and moved around since then),
in order to fix #807 (impossible to make a repeatable list).

The problem was that a list doesn't have the normal repeatability
flags and so it was never repeatable, so it was hardcoded to be
repeatable instead. Presumably it was deemed good enough.

However, this made it impossible to have a non-repeatable list.

This commit changes the behavior so that a list repeatability is
that of the first command at the list.

This way, any list can be made either repeatable or non-repeatable
using the following idiom (e.g. at input.conf), based on the fact
that the "ignore" command is not repeatable by default:

  x            ignore; cmd1...; cmd2...   # non-repeatable
  y repeatable ignore; cmd1...; cmd2...   # repeatable

Fixes #7841
