### PR TITLE
command: cycle: respect the prefix "repeatable"

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -344,6 +344,10 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     the minimum, on underflow set it to the maximum. If ``up`` or ``down`` is
     omitted, assume ``up``.
 
+    Whether or not key-repeat is enabled by default depends on the property.
+    Currently properties with continuous values are repeatable by default (like
+    ``volume``), while discrete values are not (like ``osd-level``).
+
 ``multiply <name> <value>``
     Similar to ``add``, but multiplies the property or option with the numeric
     value.

--- a/player/command.c
+++ b/player/command.c
@@ -4921,7 +4921,9 @@ static void cmd_add_cycle(void *p)
     bool is_cycle = !!cmd->priv;
 
     char *property = cmd->args[0].v.s;
-    if (cmd->cmd->repeated && !check_property_autorepeat(property, mpctx)) {
+    if (cmd->cmd->repeated && !check_property_autorepeat(property, mpctx) &&
+        !(cmd->cmd->flags & MP_ALLOW_REPEAT)  /* "repeatable" prefix */ )
+    {
         MP_VERBOSE(mpctx, "Dropping command '%s' from auto-repeated key.\n",
                    cmd->cmd->original);
         return;


### PR DESCRIPTION
The "cycle" command _declaration_ enables repeatability by default,
however, the command handler applies additional logic to augment it,
based on the property which is being cycled - using some guesswork.

Specifically, properties with discrete values are not repeatable
(like sub or osd-level), while continuous properties are repeatable
(like volume).

Previously, the "repeatable" prefix could not override this additional
logic.

This commit changes the behavior so that the logic affects only the
default repeatability (still based on the property like before),
however, the "repeatable" prefix is now allowed to override it.