### PR TITLE
terminal-unix: identify and ignore unknown CSI sequences

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -221,6 +221,17 @@ static void process_input(struct input_ctx *input_ctx, bool timeout)
         if (!match) { // normal or unknown key
             int mods = 0;
             if (buf.b[0] == '\033') {
+                if (buf.len > 1 && buf.b[1] == '[') {
+                    // unknown CSI sequence. wait till it completes
+                    for (int i = 2; i < buf.len; i++) {
+                        if (buf.b[i] >= 0x40 && buf.b[i] <= 0x7E)  {
+                            skip_buf(&buf, i+1);
+                            continue;  // complete - throw it away
+                        }
+                    }
+                    goto read_more;  // not yet complete
+                }
+                // non-CSI esc sequence
                 skip_buf(&buf, 1);
                 if (buf.len > 0 && buf.b[0] > 0 && buf.b[0] < 127) {
                     // meta+normal key


### PR DESCRIPTION
Previously, if an unknown ESC sequence was detected where an ASCII
char `<X>` follows the ESC, mpv interpreted it as `ALT+<X>`, which is the
traditional terminal encoding of ALT+letter.

However, if `<X>` is '[' then it's a CSI sequence which continues after
the '[', possibly for quite a while, and has its own termination rules.

Previously, mpv interpreted unknown CSI sequences as ALT+[ and garbage
"keys" from the rest of the sequence.

In this commit, if a unknown CSI sequence is detected, mpv first waits
till it completes, and then throws away exactly the complete sequence.