### PR TITLE
w32: fix --monitoraspect application and improve initial fit

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1422,10 +1422,13 @@ static void gui_thread_reconfig(void *ptr)
     struct mp_rect screen = { r.left, r.top, r.right, r.bottom };
     struct vo_win_geometry geo;
 
+    RECT monrc = get_monitor_info(w32).rcMonitor;
+    struct mp_rect mon = { monrc.left, monrc.top, monrc.right, monrc.bottom };
+
     if (w32->dpi_scale == 0)
         force_update_display_info(w32);
 
-    vo_calc_window_geometry2(vo, &screen, w32->dpi_scale, &geo);
+    vo_calc_window_geometry3(vo, &screen, &mon, w32->dpi_scale, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     bool reset_size = w32->o_dwidth != vo->dwidth ||

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1419,6 +1419,8 @@ static void gui_thread_reconfig(void *ptr)
     struct vo *vo = w32->vo;
 
     RECT r = get_working_area(w32);
+    if (!w32->current_fs && !IsMaximized(w32->window) && w32->opts->border)
+        subtract_window_borders(w32, w32->window, &r);
     struct mp_rect screen = { r.left, r.top, r.right, r.bottom };
     struct vo_win_geometry geo;
 

--- a/video/out/win_state.c
+++ b/video/out/win_state.c
@@ -67,8 +67,9 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 // Compute the "suggested" window size and position and return it in *out_geo.
 // screen is the bounding box of the current screen within the virtual desktop.
 // Does not change *vo.
-//  screen: position of the screen on virtual desktop on which the window
-//          should be placed
+//  screen: position of the area on virtual desktop on which the video-content
+//          should be placed (maybe after excluding decorations, taskbars, etc)
+//  monitor: position of the monitor on virtual desktop (used for pixelaspect).
 //  dpi_scale: the DPI multiplier to get from virtual to real coordinates
 //             (>1 for "hidpi")
 // Use vo_apply_window_geometry() to copy the result into the vo.
@@ -76,7 +77,8 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 //       geometry additional to this code. This is to deal with initial window
 //       placement, fullscreen handling, avoiding resize on reconfig() with no
 //       size change, multi-monitor stuff, and possibly more.
-void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
+void vo_calc_window_geometry3(struct vo *vo, const struct mp_rect *screen,
+                              const struct mp_rect *monitor,
                               double dpi_scale, struct vo_win_geometry *out_geo)
 {
     struct mp_vo_opts *opts = vo->opts;
@@ -103,9 +105,13 @@ void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
     int scr_w = screen->x1 - screen->x0;
     int scr_h = screen->y1 - screen->y0;
 
-    MP_DBG(vo, "screen size: %dx%d\n", scr_w, scr_h);
+    int mon_w = monitor->x1 - monitor->x0;
+    int mon_h = monitor->y1 - monitor->y0;
 
-    calc_monitor_aspect(opts, scr_w, scr_h, &out_geo->monitor_par, &d_w, &d_h);
+    MP_DBG(vo, "max content size: %dx%d\n", scr_w, scr_h);
+    MP_DBG(vo, "monitor size: %dx%d\n", mon_w, mon_h);
+
+    calc_monitor_aspect(opts, mon_w, mon_h, &out_geo->monitor_par, &d_w, &d_h);
 
     apply_autofit(&d_w, &d_h, scr_w, scr_h, &opts->autofit, true, true);
     apply_autofit(&d_w, &d_h, scr_w, scr_h, &opts->autofit_smaller, true, false);
@@ -123,6 +129,13 @@ void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
 
     if (opts->geometry.xy_valid || opts->force_window_position)
         out_geo->flags |= VO_WIN_FORCE_POS;
+}
+
+// same as vo_calc_window_geometry3 with monitor assumed same as screen
+void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
+                              double dpi_scale, struct vo_win_geometry *out_geo)
+{
+    vo_calc_window_geometry3(vo, screen, screen, dpi_scale, out_geo);
 }
 
 void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,

--- a/video/out/win_state.h
+++ b/video/out/win_state.h
@@ -27,6 +27,9 @@ void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
                              struct vo_win_geometry *out_geo);
 void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
                               double dpi_scale, struct vo_win_geometry *out_geo);
+void vo_calc_window_geometry3(struct vo *vo, const struct mp_rect *screen,
+                              const struct mp_rect *monitor,
+                              double dpi_scale, struct vo_win_geometry *out_geo);
 void vo_apply_window_geometry(struct vo *vo, const struct vo_win_geometry *geo);
 
 #endif


### PR DESCRIPTION
- First two commits separate the general screen fit calculation from the monitor aspect calculation, and then use this separate calculation from the win32 vo.
- Third commit does the initial fit/center including the border instead of the content. This only affects initial positioning and not the initial size.