### PR TITLE
bash completion: Allow completions to work without external functions

### DIFF
--- a/etc/mpv.bash-completion
+++ b/etc/mpv.bash-completion
@@ -34,13 +34,12 @@ _mpv_get_args()
   declare -a candidates
   case $type in
     String)
-      echo "$doc" | grep -q '\[file\]'
-      if [ $? -eq 0 ]; then
+      if echo "$doc" | grep -q '\[file\]' ; then
         if [ "$cur" = '=' ]; then
           # Without this, _filedir will try and complete files starting with '='
           cur=""
         fi
-        _filedir
+        _filedir 2>/dev/null || COMPREPLY=($(compgen -f))
         return 0
       else
         candidates=($(mpv $1=help | grep -v ':' | awk '{print $1;}'))
@@ -106,7 +105,7 @@ _mpv()
         fi
         ;;
       *)
-        _filedir
+        _filedir 2>/dev/null || COMPREPLY=($(compgen -f))
         ;;
     esac
   fi


### PR DESCRIPTION
If bash_completion wasn't installed, _filedir wouldn't be defined which
led to all filename-based completions to error out. Specifically
autocompletion would fail when a filename was expected and when
bash_completion wasn't installed. Now we fall back to `compgen -f` if
_filedir fails. According to _filedir's comments, compgen doesn't
handle files with spaces well, but it is still better to complete most
files than none.