### PR TITLE
demux_playlist: extend maximum line size (again) to 2M

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -50,7 +50,7 @@ static bool check_mimetype(struct stream *s, const char *const *list)
 struct pl_parser {
     struct mp_log *log;
     struct stream *s;
-    char buffer[512 * 1024];
+    char buffer[2 * 1024 * 1024];
     int utf16;
     struct playlist *pl;
     bool error;


### PR DESCRIPTION
Last time it was extended was de3ecc60 from 8K to 512K two years ago.

The issue currently is that youtube EDL files can get very big.
Size of about 520K (one line), was observed, at the time of writing:
  mpv https://youtube.com/watch?v=DBzFQgSMHdQ --ytdl-format=299

ytdl_hook.lua is unaffected by this because EDL lists don't go through
the file reader at demux_playlist.c (where each line was limited to
512K before this commit), however, EDL files on disk which are
loaded with --playlist=file.edl do.

Increase the limit to 2M so that such EDL files can also be loaded
from disk.
