### PR TITLE
Fix initial seek (--start) causing  MMAL to freeze

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -715,7 +715,7 @@ static void reset_avctx(struct mp_filter *vd)
 {
     vd_ffmpeg_ctx *ctx = vd->priv;
 
-    if (ctx->avctx && avcodec_is_open(ctx->avctx))
+    if (ctx->avctx && avcodec_is_open(ctx->avctx) && ctx->state.packets_sent)
         avcodec_flush_buffers(ctx->avctx);
     ctx->flushing = false;
     ctx->hwdec_request_reinit = false;


### PR DESCRIPTION
`mpv --start=10 --hwdec=mmal --no-audio --vo=null --vd-lavc-software-fallback=no test.mp4`

will cause MMAL to not output any frames:

```
[ffmpeg/video] h264_mmal: Did not get output frame from MMAL.
[vd] Error while decoding frame (hardware decoding)!
```
MMAL freezes if avcodec_flush_buffers is called before any packets are sent. 