### PR TITLE
vo_rpi: fix DISPMANX_UPDATE_HANDLE_T leak

### DIFF
--- a/video/out/vo_rpi.c
+++ b/video/out/vo_rpi.c
@@ -804,6 +804,10 @@ static void destroy_dispmanx(struct vo *vo)
     disable_renderer(vo);
     destroy_overlays(vo);
 
+    if (p->update)
+        vc_dispmanx_update_submit_sync(p->update);
+    p->update = 0;
+
     if (p->display) {
         vc_dispmanx_vsync_callback(p->display, NULL, NULL);
         vc_dispmanx_display_close(p->display);
@@ -855,9 +859,6 @@ static void uninit(struct vo *vo)
     talloc_free(p->next_image);
 
     destroy_dispmanx(vo);
-
-    if (p->update)
-        vc_dispmanx_update_submit_sync(p->update);
 
     if (p->renderer)
         mmal_component_release(p->renderer);


### PR DESCRIPTION
Fixes handle leak that happened whenever tvservice callback was invoked.

Powering on the TV causes HDMI unplug and attached events to be sent to
the tvservice callback.

This meant you could only power on/off your TV a finite number of times
before you were unable to allocate additional resources from VideoCore
(usually resulting in a "Could not get DISPMANX objects." error).

Furthermore because the VideoCore kernel driver does not cleanup handles
when a process dies, the only way to recover from the leak was to reboot
the RPI.
