### PR TITLE
build: enable strict FFmpeg ABI compatibility by default

### DIFF
--- a/wscript
+++ b/wscript
@@ -415,7 +415,7 @@ FFmpeg libraries. Git master is recommended."
         'name': '--ffmpeg-strict-abi',
         'desc': 'Disable all known FFmpeg ABI violations',
         'func': check_true,
-        'default': 'disable',
+        'default': 'enable',
     }
 ]
 


### PR DESCRIPTION
Its define (HAVE_FFMPEG_STRICT_ABI) is now utilized in a single
location, where an internal libavformat struct member is utilized.
This struct member is now (after around 10 years) finally removed
from public visibility in FFmpeg's master.

After a review of functionality, the information in bytes_read is
passed onto the demuxer layer, and then utilized for
{cache,hack}_unbuffered_read_bytes. This information is then utilized
for:

1. Calculation of bytes_per_second in demux/demux.c::update_cache,
   which fills the information for properties "cache-speed" as well as
   "raw-input-rate" (of which stats.lua is the most prominent user).
2. bytes_per_second also affects how often update_cache is called in
   addition to the two locations it is called unconditionally in
   (read_packet, demux_update).

In other words, the information provided does not appear to control
crucial mpv functionality, but rather its lack would seem to mostly
affect the speed of certain properties updating, or having valid
values. For the former, stream size as well as timed metadata get
updated in update_cache - although the demux layer does throttle
the update of certain things to once per second in that function.
For the latter, "cache-speed" and "raw-input-rate" lose read data
statistics from AVIOContexts opened by the opened FFmpeg AVFormatContext
itself, as opposed to the primary one - which goes through mpv's
stream reading implementation.

By enabling this feature, and disabling this abuse of private API
lets users build mpv by default with the latest master FFmpeg, thus
giving us the breathing room to look into some of the details of
this case, and either decide to:

1. Post a patch to add this information back to FFmpeg proper.
2. Remove or replace this functionality in another manner.

End user impact:
Any IO not handled by mpv itself - but rather by IO contexts newly
opened by the input format - is not visible through the properties
"cache-speed" and "raw-input-rate". Examples of such input formats
are the HLS and DASH readers in FFmpeg.

Historical git references:
- Addition of unbuffered_read_bytes: 4dfaa37
- Rework to have the reporting function: ebf183e

Fixes #9159