### PR TITLE
ytdl_hook.lua: search for yt-dlp by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -995,9 +995,11 @@ Program Behavior
         no). It's disabled ("no") by default for performance reasons.
 
     ``ytdl_path=youtube-dl``
-        Configure path to youtube-dl executable or a compatible fork's.
-        The default "youtube-dl" looks for the executable in PATH. In a Windows
-        environment the suffix extension ".exe" is always appended.
+        Configure paths to youtube-dl's executable or a compatible fork's. The
+        paths should be separated by : on Unix and ; on Windows. mpv looks in
+        order for the configured paths in PATH and in mpv's config directory.
+        The defaults are "yt-dlp", "yt-dlp_x86" and "youtube-dl". On Windows
+        the suffix extension ".exe" is always appended.
 
     .. admonition:: Why do the option names mix ``_`` and ``-``?
 


### PR DESCRIPTION
Because youtube-dl is inactive and the yt-dlp fork is becoming more
popular, make mpv use yt-dlp without any extra configuration.

yt-dlp is ordered before youtube-dl because it's more obscure, so users
who have yt-dlp installed are more likely to want to use it rather than
youtube-dl.

io.open and os.getenv('PATH') are not used because they don't handle
UTF-8 on Windows 7 and 8.

exists_in_path is based on
https://github.com/TheAMM/mpv_script_libs/blob/master/helpers.lua

Fixes #9208.