### PR TITLE
wayland: report correct window size when maximized

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1602,8 +1602,13 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
     }
     case VOCTRL_GET_UNFS_WINDOW_SIZE: {
         int *s = arg;
-        s[0] = mp_rect_w(wl->window_size) * wl->scaling;
-        s[1] = mp_rect_h(wl->window_size) * wl->scaling;
+        if (wl->vo_opts->window_maximized) {
+            s[0] = mp_rect_w(wl->geometry) * wl->scaling;
+            s[1] = mp_rect_h(wl->geometry) * wl->scaling;
+        } else {
+            s[0] = mp_rect_w(wl->window_size) * wl->scaling;
+            s[1] = mp_rect_h(wl->window_size) * wl->scaling;
+        }
         return VO_TRUE;
     }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {


### PR DESCRIPTION
In wayland_common, wl->window_size keeps track of the window's size when
it is not in the fullscreen or maximized state. GET_UNFS_WINDOW_SIZE is
meant to report the size except for when it is fullscreen (hence UNFS).
However, the actual function was merely returning the wl->window_size so
it was wrong for maximized windows. Workaround this by returning
wl->geometry instead when we have the maximized case. Fixes #9207.