### PR TITLE
waftools/features: add forgotten enable variants for enabled features

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ detect it, the file `build/config.log` may contain information about the
 reasons for the failure.
 
 NOTE: To avoid cluttering the output with unreadable spam, `--help` only shows
-one of the two switches for each option. If the option is autodetected by
-default, the `--disable-***` switch is printed; if the option is disabled by
-default, the `--enable-***` switch is printed. Either way, you can use
-`--enable-***` or `--disable-**` regardless of what is printed by `--help`.
+one of the two switches for each option. If the option is autodetected or
+enabled by default, the `--disable-***` switch is printed; if the option is
+disabled by default, the `--enable-***` switch is printed. Either way, you can
+use `--enable-***` or `--disable-**` regardless of what is printed by `--help`.
 
 To build the software you can use `./waf build`: the result of the compilation
 will be located in `build/mpv`. You can use `./waf install` to install mpv

--- a/waftools/features.py
+++ b/waftools/features.py
@@ -29,6 +29,7 @@ class Feature(object):
             ],
             'enable': [
                 {'state': 'disable', 'action': 'store_false', 'default': True},
+                {'state': 'enable',  'action': 'store_true',  'default': True},
             ],
         }[self.behaviour()]
 


### PR DESCRIPTION
This brings enabled features on the same level as disabled and
auto-detected features by having both alternatives available.

Looking at the commit message of 652895abdce4bc1ff2f00c7f21c0d0d722680806
this seems to have been the intent from the start, but this specific
definition was missing from the option creation in Features.