### PR TITLE
stream/dvbin: remove "full-featured" API includes

### DIFF
--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -22,8 +22,6 @@
 #include <inttypes.h>
 #include <linux/dvb/dmx.h>
 #include <linux/dvb/frontend.h>
-#include <linux/dvb/video.h>
-#include <linux/dvb/audio.h>
 #include <linux/dvb/version.h>
 
 #define MAX_ADAPTERS 16


### PR DESCRIPTION
We do not actually use this, and it's in a state of maybe-removal from the kernel as of Linux 5.14. Get rid of it; mpv still builds fine without it, so it wasn't needed anyways.

Fixes #9233.