### PR TITLE
Fix heap-buffer-overflow in mark_rect

### DIFF
--- a/sub/draw_bmp.c
+++ b/sub/draw_bmp.c
@@ -260,8 +260,8 @@ static void mark_rect(struct mp_draw_sub_cache *p, int x0, int y0, int x1, int y
     assert(x0 >= 0 && x0 <= x1 && x1 <= p->w);
     assert(y0 >= 0 && y0 <= y1 && y1 <= p->h);
 
-    int sx0 = x0 / SLICE_W;
-    int sx1 = x1 / SLICE_W;
+    const int sx0 = x0 / SLICE_W;
+    const int sx1 = MPMIN(x1 / SLICE_W, p->s_w - 1);
 
     for (int y = y0; y < y1; y++) {
         struct slice *line = &p->slices[y * p->s_w];
@@ -270,7 +270,7 @@ static void mark_rect(struct mp_draw_sub_cache *p, int x0, int y0, int x1, int y
         struct slice *s1 = &line[sx1];
 
         s0->x0 = MPMIN(s0->x0, x0 % SLICE_W);
-        s1->x1 = MPMAX(s1->x1, x1 % SLICE_W);
+        s1->x1 = MPMAX(s1->x1, ((x1 - 1) % SLICE_W) + 1);
 
         if (s0 != s1) {
             s0->x1 = SLICE_W;


### PR DESCRIPTION
Fix for the below encountered ASAN error:
```
==374192==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6280005e3992 at pc 0x555556335685 bp 0x7fff5e423890 sp 0x7fff5e423888
READ of size 2 at 0x6280005e3992 thread T25 (mpv/vo)
    #0 0x555556335684 in mark_rect ../sub/draw_bmp.c:273
    #1 0x555556338d28 in render_ass ../sub/draw_bmp.c:331
    #2 0x555556338d28 in render_sb ../sub/draw_bmp.c:463
    #3 0x555556344408 in mp_draw_sub_bitmaps ../sub/draw_bmp.c:857
    #4 0x555556358bb9 in osd_draw_on_image_p ../sub/osd.c:444
    #5 0x55555657ac45 in draw_image ../video/out/vo_x11.c:338
    #6 0x555556513a04 in render_frame ../video/out/vo.c:959
    #7 0x555556513a04 in vo_thread ../video/out/vo.c:1095
    #8 0x7ffff3ef5ea6 in start_thread nptl/pthread_create.c:477
    #9 0x7ffff34bbdee in __clone (/lib/x86_64-linux-gnu/libc.so.6+0xfddee)

0x6280005e3992 is located 2 bytes to the right of 14480-byte region [0x6280005e0100,0x6280005e3990)
allocated by thread T25 (mpv/vo) here:
    #0 0x7ffff7669037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x555556629047 in ta_zalloc_size ../ta/ta.c:158

Thread T25 (mpv/vo) created by T0 here:
    #0 0x7ffff76142a2 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x555556504595 in vo_create ../video/out/vo.c:332

SUMMARY: AddressSanitizer: heap-buffer-overflow ../sub/draw_bmp.c:273 in mark_rect
Shadow bytes around the buggy address:
  0x0c50800b46e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c50800b46f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c50800b4700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c50800b4710: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c50800b4720: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c50800b4730: 00 00[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c50800b4740: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c50800b4750: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c50800b4760: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c50800b4770: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c50800b4780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==374192==ABORTING
```