### PR TITLE
osc.lua: avoid infinite ticks loop on idle 

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -132,6 +132,12 @@ local is_december = os.date("*t").month == 12
 -- Helperfunctions
 --
 
+function kill_animation()
+    state.anistart = nil
+    state.animation = nil
+    state.anitype =  nil
+end
+
 function set_osd(res_x, res_y, text)
     if state.osd.res_x == res_x and
        state.osd.res_y == res_y and
@@ -2339,14 +2345,10 @@ function render()
             if (state.anitype == "out") then
                 osc_visible(false)
             end
-            state.anistart = nil
-            state.animation = nil
-            state.anitype =  nil
+            kill_animation()
         end
     else
-        state.anistart = nil
-        state.animation = nil
-        state.anitype =  nil
+        kill_animation()
     end
 
     --mouse show/hide area

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2609,7 +2609,17 @@ function tick()
     state.tick_last_time = mp.get_time()
 
     if state.anitype ~= nil then
-        request_tick()
+        -- state.anistart can be nil - animation should now start, or it can
+        -- be a timestamp when it started. state.idle has no animation.
+        if not state.idle and
+           (not state.anistart or
+            mp.get_time() < 1 + state.anistart + user_opts.fadeduration/1000)
+        then
+            -- animating or starting, or still within 1s past the deadline
+            request_tick()
+        else
+            kill_animation()
+        end
     end
 end
 


### PR DESCRIPTION
Infinite repeating ticks on idle happened before this commit whenever mpv is in idle state and a tick is triggered (mouse move, property change, etc). Once it started - it never stopped ticking.

These commits fix that.