### PR TITLE
build: lua 5.1/5.2: use generic version names 

### DIFF
--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -58,15 +58,28 @@ def check_iconv(ctx, dependency_identifier):
     return check_libs(libs, checkfn)(ctx, dependency_identifier)
 
 def check_lua(ctx, dependency_identifier):
+    # mainline lua 5.1/5.2 doesn't have a .pc file, so each distro chooses
+    # a different name, either non-versioned (lua.pc) or lua5x/lua5.x/lua-5.x
+    # and we need to check them all. luadef* are the non-versioned .pc files,
+    # and the rest represent the .pc file exactly e.g. --lua=lua-5.1
+    # The non lua* names are legacy in mpv configure, and kept for compat.
     lua_versions = [
+        ( 'luadef52','lua >= 5.2.0 lua < 5.3.0' ), # package "lua"
         ( '52',     'lua >= 5.2.0 lua < 5.3.0' ),
+        ( 'lua52',  'lua52 >= 5.2.0'),
         ( '52arch', 'lua52 >= 5.2.0'), # Arch
+        ( 'lua5.2', 'lua5.2 >= 5.2.0'),
         ( '52deb',  'lua5.2 >= 5.2.0'), # debian
+        ( 'lua-5.2','lua-5.2 >= 5.2.0'),
         ( '52fbsd', 'lua-5.2 >= 5.2.0'), # FreeBSD
         ( 'luajit', 'luajit >= 2.0.0' ),
+        ( 'luadef51','lua >= 5.1.0 lua < 5.2.0'), # package "lua"
         ( '51',     'lua >= 5.1.0 lua < 5.2.0'),
+        ( 'lua51',  'lua51 >= 5.1.0'),
         ( '51obsd', 'lua51 >= 5.1.0'), # OpenBSD
+        ( 'lua5.1', 'lua5.1 >= 5.1.0'),
         ( '51deb',  'lua5.1 >= 5.1.0'), # debian
+        ( 'lua-5.1','lua-5.1 >= 5.1.0'),
         ( '51fbsd', 'lua-5.1 >= 5.1.0'), # FreeBSD
     ]
 

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -75,13 +75,15 @@ def check_lua(ctx, dependency_identifier):
             [lv for lv in lua_versions if lv[0] == ctx.options.LUA_VER]
 
     for lua_version, pkgconfig_query in lua_versions:
+        display_version = lua_version
+        lua_version = inflector.sanitize_id(lua_version)
         if check_pkg_config(pkgconfig_query, uselib_store=lua_version) \
             (ctx, dependency_identifier):
             # XXX: this is a bit of a hack, ask waf developers if I can copy
             # the uselib_store to 'lua'
             ctx.mark_satisfied(lua_version)
             ctx.add_optional_message(dependency_identifier,
-                                     'version found: ' + lua_version)
+                                     'version found: ' + display_version)
             return True
     return False
 

--- a/waftools/inflector.py
+++ b/waftools/inflector.py
@@ -1,6 +1,6 @@
 import re
 
-def _underscore(word):
+def sanitize_id(word):
     """ Converts a word "into_it_s_underscored_version"
     Convert any "CamelCased" or "ordinary Word" into an
     "underscored_word"."""
@@ -10,7 +10,7 @@ def _underscore(word):
             re.sub('([A-Z]+)([A-Z][a-z])', '\\1_\\2', re.sub('::', '/', word)))).lower()
 
 def storage_key(dep):
-    return _underscore(dep)
+    return sanitize_id(dep)
 
 def define_key(dep):
     return ("have_" + storage_key(dep)).upper()

--- a/wscript
+++ b/wscript
@@ -907,7 +907,7 @@ def options(opt):
     group.add_option('--lua',
         type    = 'string',
         dest    = 'LUA_VER',
-        help    = "select Lua package which should be autodetected. Choices: 51 51deb 51obsd 51fbsd 52 52deb 52arch 52fbsd luajit")
+        help    = "select Lua package to autodetect. Choices (x is 1 or 2): luadef5x, lua5x, lua5.x, lua-5.x, luajit (luadef5x is for pkg-config name 'lua', the rest are exact pkg-config names)")
     group.add_option('--swift-flags',
         type    = 'string',
         dest    = 'SWIFT_FLAGS',


### PR DESCRIPTION
This allows using the (pkg-config) package name to choose a specific lua version e.g. `--lua=lua52` or `--lua=lua-5.1` etc.

The same generic names are also autodetected instead of the previous distro-specific names (51deb, 52arch, etc).

The legacy names are still supported, but not documented anymore, and are shadowed by the generic names during autodetection.

Maybe todo in the future:
- The name which shows at the output of `mpv -v` has underscores, e.g. `--lua=lua-5.1` shows as `lua_5_1`. It would be nicer if it would be same as the requested name. mpv doesn't use any of these names (it detects the version using the lua C headers).
- During autodetection, until a package is found, pkg-config is invoked twice than required (both for the generic name and for the legacy name which refer to the same package). We could try to map the the legacy names to the generic names and avoid some invocations of pkg-config.