### PR TITLE
path: search relative to current dir for subs when streaming

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2593,8 +2593,8 @@ Subtitles
     Multiple directories can be separated by ":" (";" on Windows).
     Paths can be relative or absolute. Relative paths are interpreted relative
     to video file directory.
-    If the file is a URL, only absolute paths and ``sub`` configuration
-    subdirectory will be scanned.
+    If the file is a URL, relative paths are interpreted relative to the current
+    directory.
 
     .. admonition:: Example
 

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -317,9 +317,12 @@ static void load_paths(struct mpv_global *global, struct MPOpts *opts,
 {
     for (int i = 0; paths && paths[i]; i++) {
         char *expanded_path = mp_get_user_path(NULL, global, paths[i]);
-        char *path = mp_path_join_bstr(
-            *slist, mp_dirname(fname),
-            bstr0(expanded_path ? expanded_path : paths[i]));
+        char *effective_path = expanded_path ? expanded_path : paths[i];
+
+        char *path = !mp_path_is_absolute(bstr0(effective_path)) &&
+                      mp_is_url(mp_dirname(fname)) ? effective_path :
+                      mp_path_join_bstr(*slist, mp_dirname(fname),
+                                        bstr0(effective_path));
         append_dir_subtitles(global, opts, slist, nsubs, bstr0(path),
                              fname, 0, type);
         talloc_free(expanded_path);


### PR DESCRIPTION
Previously, relative subtitle paths weren't processed when dealing with
remote files since normally paths are relative to the directory of the
target file. Now relative paths are interpreted with respect to the
current directory.

This makes it a tad more convenient when streaming remote media and the
subs have already been downloaded. Assuming sub files are in the current
directory,
`mpv --sub-file-paths=$PWD` becomes `mpv --sub-file-paths=.`
which seems more natural.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.