### PR TITLE
command: with lavfi-complex, make current-tracks return the first one

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2971,15 +2971,8 @@ Property list
     For example, ``current-tracks/audio/lang`` returns the current audio track's
     language field (the same value as ``track-list/N/lang``).
 
-    A sub-entry is accessible only if a track of that type is actually selected.
-    Tracks selected via ``--lavfi-complex`` never appear under this property.
-    ``current-tracks`` and ``current-tracks/`` are currently not accessible, and
-    will not return anything.
-
-    Scripts etc. should not use this. They should use ``track-list``, loop over
-    all tracks, and inspect the ``selected`` field to test whether a track is
-    selected (or compare the ``id`` field to the ``video`` / ``audio`` etc.
-    options).
+    If tracks of the requested type are selected via ``--lavfi-complex``, the
+    first one is returned.
 
 ``chapter-list``
     List of chapters, current entry marked. Currently, the raw property value

--- a/player/command.c
+++ b/player/command.c
@@ -2075,6 +2075,16 @@ static int property_current_tracks(void *ctx, struct m_property *prop,
         return M_PROPERTY_UNKNOWN;
 
     struct track *t = mpctx->current_track[order][type];
+
+    if (!t && mpctx->lavfi) {
+        for (int n = 0; n < mpctx->num_tracks; n++) {
+            if (mpctx->tracks[n]->type == type && mpctx->tracks[n]->selected) {
+                t = mpctx->tracks[n];
+                break;
+            }
+        }
+    }
+
     if (!t)
         return M_PROPERTY_UNAVAILABLE;
 


### PR DESCRIPTION
This behavior is more convenient and allows profile conditions like:

[video]
profile-cond=get('current-tracks/video/image') == false

[image]
profile-cond=get('current-tracks/video/image')

Otherwise, these profiles have to be manually applied and restored in a
script.

The note about discouraging the use of current-tracks in scripts is
removed, because it makes people avoid using this convenient property.
It was added in 720bcd79d03 without leaving an explanation of why you
shouldn't use it, and the only reason seems to be that it doesn't work
with lavfi-complex, but this commit changes that.