### PR TITLE
github/workflows: disable seccomp for linux native CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
     runs-on: "ubuntu-20.04"
     container:
       image: "registry.cirno.systems/kiwi/containers/mpv-ci:stable-deps"
+      # Disable seccomp until a container manager in GitHub recognizes
+      # clone3() syscall,
+      # <https://github.com/actions/virtual-environments/issues/3812>.
+      options: --security-opt seccomp=unconfined
       env:
         CC: "${{ matrix.cc }}"
     strategy:


### PR DESCRIPTION
This CI builder bases on openSUSE Tumbleweed, and recently had
its glibc updated. This led to new syscalls such as 'clone3' not
being allowed through the security layer.

Can be reverted after Github Actions updates their security policy.

actions/virtual-environments#3812