### PR TITLE
mp_image, f_decoder_wrapper: implement AV_FRAME_DATA_DISPLAYMATRIX

### DIFF
--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -594,12 +594,14 @@ static void fix_image_params(struct priv *p,
     if (m.p_w <= 0 || m.p_h <= 0)
         m.p_w = m.p_h = 1;
 
-    m.rotate = p->codec->rotate;
     m.stereo3d = p->codec->stereo_mode;
 
     if (opts->video_rotate < 0) {
         m.rotate = 0;
     } else {
+        // ffmpeg commit 535a835e51 says that frame rotate takes priority
+        if (!m.rotate)
+            m.rotate = p->codec->rotate;
         m.rotate = (m.rotate + opts->video_rotate) % 360;
     }
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -21,6 +21,7 @@
 
 #include <libavutil/mem.h>
 #include <libavutil/common.h>
+#include <libavutil/display.h>
 #include <libavutil/bswap.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/intreadwrite.h>
@@ -971,6 +972,13 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
         // Might be incorrect if colorspace changes.
         dst->params.color.light = p->color.light;
         dst->params.alpha = p->alpha;
+    }
+
+    sd = av_frame_get_side_data(src, AV_FRAME_DATA_DISPLAYMATRIX);
+    if (sd) {
+        double r = av_display_rotation_get((int32_t *)(sd->data));
+        if (!isnan(r))
+            dst->params.rotate = (((int)(-r) % 360) + 360) % 360;
     }
 
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_ICC_PROFILE);


### PR DESCRIPTION
fixes #9249 (JPEG orientation support) with ffmpeg commit [0].

[0] https://github.com/FFmpeg/FFmpeg/commit/e93c9986027d17917c3b4f533b28ee4a2ce7cd4c

tests:

- working with no/90/180/270 jpeg written by exiftool
- still working with h264 mp4 unrotated/rotated 90 degrees in container (plays rotated 90, not 180)
- still not working with rotated mkv (plays without rotation)
- still not working with h264_metadata=rotate=90 mp4 (plays without rotation)