### PR TITLE
drm: context_drm_egl: reinstal DRM master handling

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -44,8 +44,6 @@
 #define EGL_PLATFORM_GBM_KHR 0x31D7
 #endif
 
-#define USE_MASTER 0
-
 #ifndef EGL_EXT_platform_base
 typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC)
     (EGLenum platform, void *native_display, const EGLint *attrib_list);
@@ -423,15 +421,11 @@ static void release_vt(void *data)
     struct ra_ctx *ctx = data;
     MP_VERBOSE(ctx->vo, "Releasing VT\n");
     crtc_release(ctx);
-    if (USE_MASTER) {
-        //this function enables support for switching to x, weston etc.
-        //however, for whatever reason, it can be called only by root users.
-        //until things change, this is commented.
-        struct priv *p = ctx->priv;
-        if (drmDropMaster(p->kms->fd)) {
-            MP_WARN(ctx->vo, "Failed to drop DRM master: %s\n",
-                    mp_strerror(errno));
-        }
+
+    const struct priv *p = ctx->priv;
+    if (drmDropMaster(p->kms->fd)) {
+        MP_WARN(ctx->vo, "Failed to drop DRM master: %s\n",
+                mp_strerror(errno));
     }
 }
 
@@ -439,12 +433,11 @@ static void acquire_vt(void *data)
 {
     struct ra_ctx *ctx = data;
     MP_VERBOSE(ctx->vo, "Acquiring VT\n");
-    if (USE_MASTER) {
-        struct priv *p = ctx->priv;
-        if (drmSetMaster(p->kms->fd)) {
-            MP_WARN(ctx->vo, "Failed to acquire DRM master: %s\n",
-                    mp_strerror(errno));
-        }
+
+    const struct priv *p = ctx->priv;
+    if (drmSetMaster(p->kms->fd)) {
+        MP_WARN(ctx->vo, "Failed to acquire DRM master: %s\n",
+                mp_strerror(errno));
     }
 
     crtc_setup(ctx);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -45,7 +45,6 @@
 
 #define BYTES_PER_PIXEL 4
 #define BITS_PER_PIXEL 32
-#define USE_MASTER 0
 
 struct framebuffer {
     uint32_t width;
@@ -255,25 +254,19 @@ static void release_vt(void *data)
 {
     struct vo *vo = data;
     crtc_release(vo);
-    if (USE_MASTER) {
-        //this function enables support for switching to x, weston etc.
-        //however, for whatever reason, it can be called only by root users.
-        //until things change, this is commented.
-        struct priv *p = vo->priv;
-        if (drmDropMaster(p->kms->fd)) {
-            MP_WARN(vo, "Failed to drop DRM master: %s\n", mp_strerror(errno));
-        }
+
+    const struct priv *p = vo->priv;
+    if (drmDropMaster(p->kms->fd)) {
+        MP_WARN(vo, "Failed to drop DRM master: %s\n", mp_strerror(errno));
     }
 }
 
 static void acquire_vt(void *data)
 {
     struct vo *vo = data;
-    if (USE_MASTER) {
-        struct priv *p = vo->priv;
-        if (drmSetMaster(p->kms->fd)) {
-            MP_WARN(vo, "Failed to acquire DRM master: %s\n", mp_strerror(errno));
-        }
+    const struct priv *p = vo->priv;
+    if (drmSetMaster(p->kms->fd)) {
+        MP_WARN(vo, "Failed to acquire DRM master: %s\n", mp_strerror(errno));
     }
 
     crtc_setup(vo);


### PR DESCRIPTION
Traditionally any DRM application needed to be CAP_SYS_ADMIN to drop and regain the DRM master.

Since mpv is a media player, it understandably lacked the capability bit. Thus the code handling the capability would fail and was disabled.

The need to CAP_SYS_ADMIN has been relaxed with 5.10, released late last year, so let's re-enable the code. This allows mpv to be a good citizen when used alongside other DRM/bare-metal apps.

If for any reason this causes problems, please open an issue and @- me so that I can fix the underlying issue.