### PR TITLE
Update to libplacebo v3

### DIFF
--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -63,8 +63,6 @@ static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
         .d = 0,
         .format = ra_pl_fmt_get(format),
         .sampleable = true,
-        .sample_mode = format->linear_filter ? PL_TEX_SAMPLE_LINEAR
-                                             : PL_TEX_SAMPLE_NEAREST,
         .export_handle = p_owner->handle_type,
     };
 

--- a/video/out/hwdec/hwdec_vaapi_vk.c
+++ b/video/out/hwdec/hwdec_vaapi_vk.c
@@ -46,13 +46,8 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper, bool probing)
         uint32_t offset = p->desc.layers[n].offset[0];
         uint32_t pitch = p->desc.layers[n].pitch[0];
 
-#if PL_API_VER >= 88
         // AMD drivers do not return the size in the surface description, so we
-        // need to query it manually. The reason we guard this logic behind
-        // PL_API_VER >= 88 is that the same drivers also require DRM format
-        // modifier support in order to not produce corrupted textures, so
-        // having this #ifdef merely exists to protect users from combining
-        // too-new mpv with too-old libplacebo.
+        // need to query it manually.
         if (size == 0) {
             size = lseek(fd, 0, SEEK_END);
             if (size == -1) {
@@ -67,7 +62,6 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper, bool probing)
                 return false;
             }
         }
-#endif
 
         struct pl_tex_params tex_params = {
             .w = mp_image_plane_w(&p->layout, n),
@@ -82,12 +76,8 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper, bool probing)
                 },
                 .size = size,
                 .offset = offset,
-#if PL_API_VER >= 88
                 .drm_format_mod = p->desc.objects[id].drm_format_modifier,
-#endif
-#if PL_API_VER >= 106
                 .stride_w = pitch,
-#endif
             },
         };
 

--- a/video/out/hwdec/hwdec_vaapi_vk.c
+++ b/video/out/hwdec/hwdec_vaapi_vk.c
@@ -75,8 +75,6 @@ static bool vaapi_vk_map(struct ra_hwdec_mapper *mapper, bool probing)
             .d = 0,
             .format = format->priv,
             .sampleable = true,
-            .sample_mode = format->linear_filter ? PL_TEX_SAMPLE_LINEAR
-                                                 : PL_TEX_SAMPLE_NEAREST,
             .import_handle = PL_HANDLE_DMA_BUF,
             .shared_mem = (struct pl_shared_mem) {
                 .handle = {

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -235,7 +235,6 @@ static bool tex_upload_pl(struct ra *ra, const struct ra_tex_upload_params *para
         if (stride != params->stride) {
             // Fall back to uploading via a staging buffer prepared in CPU
             staging = pl_buf_create(gpu, &(struct pl_buf_params) {
-                .type = PL_BUF_TEX_TRANSFER,
                 .size = lines * stride,
                 .memory_type = PL_BUF_MEM_HOST,
                 .host_mapped = true,
@@ -293,16 +292,10 @@ static bool tex_download_pl(struct ra *ra, struct ra_tex_download_params *params
 static struct ra_buf *buf_create_pl(struct ra *ra,
                                     const struct ra_buf_params *params)
 {
-    static const enum pl_buf_type buf_type[] = {
-        [RA_BUF_TYPE_TEX_UPLOAD]     = PL_BUF_TEX_TRANSFER,
-        [RA_BUF_TYPE_SHADER_STORAGE] = PL_BUF_STORAGE,
-        [RA_BUF_TYPE_UNIFORM]        = PL_BUF_UNIFORM,
-        [RA_BUF_TYPE_SHARED_MEMORY]  = 0,
-    };
-
     const struct pl_buf *plbuf = pl_buf_create(get_gpu(ra), &(struct pl_buf_params) {
-        .type = buf_type[params->type],
         .size = params->size,
+        .uniform = params->type == RA_BUF_TYPE_UNIFORM,
+        .storable = params->type == RA_BUF_TYPE_SHADER_STORAGE,
         .host_mapped = params->host_mapped,
         .host_writable = params->host_mutable,
         .initial_data = params->initial_data,

--- a/video/out/placebo/utils.h
+++ b/video/out/placebo/utils.h
@@ -4,6 +4,7 @@
 #include "common/msg.h"
 
 #include <libplacebo/common.h>
+#include <libplacebo/context.h>
 
 void mppl_ctx_set_log(struct pl_context *ctx, struct mp_log *log, bool probing);
 

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -172,9 +172,7 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .async_compute = p->opts->async_compute,
         .queue_count = p->opts->queue_count,
         .device_name = p->opts->device,
-#if PL_API_VER >= 24
         .disable_events = p->opts->disable_events,
-#endif
     });
     if (!vk->vulkan)
         goto error;
@@ -189,11 +187,9 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .surface = vk->surface,
         .present_mode = preferred_mode,
         .swapchain_depth = ctx->vo->opts->swapchain_depth,
-#if PL_API_VER >= 29
         // mpv already handles resize events, so gracefully allow suboptimal
         // swapchains to exist in order to make resizing even smoother
         .allow_suboptimal = true,
-#endif
     };
 
     if (p->opts->swap_mode >= 0) // user override

--- a/wscript
+++ b/wscript
@@ -734,7 +734,7 @@ video_output_features = [
     }, {
         'name': '--libplacebo',
         'desc': 'libplacebo support',
-        'func': check_pkg_config('libplacebo >= 2.72.0'),
+        'func': check_pkg_config('libplacebo >= 3.104.0'),
     }, {
         'name': '--vulkan',
         'desc':  'Vulkan context support',


### PR DESCRIPTION
Bump minimum dependency and remove features that were deprecated starting with libplacebo v3, as these will be removed in libplacebo v4.