### PR TITLE
js: custom-init: use ~~/init.js, deprecate ~~/.init.js (dot)

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -47,6 +47,8 @@ Interface changes
       bindings during start-up (default: yes).
     - add ``track-list/N/image`` sub-property
     - remove `--opengl-restrict` option
+    - js custom-init: use filename ~~/init.js instead of ~~/.init.js (dot)
+
  --- mpv 0.33.0 ---
     - add `--d3d11-exclusive-fs` flag to enable D3D11 exclusive fullscreen mode
       when the player enters fullscreen.

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -336,7 +336,7 @@ Custom initialization
 ---------------------
 
 After mpv initializes the JavaScript environment for a script but before it
-loads the script - it tries to run the file ``.init.js`` at the root of the mpv
+loads the script - it tries to run the file ``init.js`` at the root of the mpv
 configuration directory. Code at this file can update the environment further
 for all scripts. E.g. if it contains ``mp.module_paths.push("/foo")`` then
 ``require`` at all scripts will search global module id's also at ``/foo``
@@ -344,6 +344,8 @@ for all scripts. E.g. if it contains ``mp.module_paths.push("/foo")`` then
 paths - like ``<script-dir>/modules`` for scripts which load from a directory).
 
 The custom-init file is ignored if mpv is invoked with ``--no-config``.
+
+Before mpv 0.34, the file name was ``.init.js`` (with dot) at the same dir.
 
 The event loop
 --------------

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -769,12 +769,16 @@ g.mp_event_loop = function mp_event_loop() {
     } while (mp.keep_running);
 };
 
-})(this)
 
 // let the user extend us, e.g. by adding items to mp.module_paths
-// (unlike e.g. read_file, file_info doesn't expand meta-paths)
-if (mp.get_property_bool("config") &&  // --no-config disables custom init
-    mp.utils.file_info(mp.utils.get_user_path("~~/.init.js")))
-{
-    require("~~/.init");
+if (mp.get_property_bool("config")) {  // --no-config disables custom init
+    // file_info doesn't expand meta-paths (other file functions do)
+    var file_info = mp.utils.file_info, user_path = mp.utils.get_user_path;
+
+    if (file_info(user_path("~~/init.js")))
+        require("~~/init");
+    else if (file_info(user_path("~~/.init.js")))
+        mp.msg.warn("Config file ~~/.init.js is ignored. Use ~~/init.js");
 }
+
+})(this)


### PR DESCRIPTION
mpv doesn't have other dot files in its config dir, and it also
shouldn't be "invisible".

The old name is still attempted (and loaded) if the new name doesn't
exist, but with a deprecation warning.
