### PR TITLE
Clears stdout when mpv begins encoding piped output

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -685,6 +685,8 @@ void mp_msg_force_stderr(struct mpv_global *global, bool force_stderr)
     pthread_mutex_lock(&root->lock);
     root->force_stderr = force_stderr;
     pthread_mutex_unlock(&root->lock);
+    if (force_stderr)
+        fflush(stdout);
 }
 
 // Only to be called from the main thread.


### PR DESCRIPTION
Fixes a problem whereby warnings or messages output prior to encoding
would appear at the beginning of the encoded output stream,
rendering it unreadable to any media decoder.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.