### PR TITLE
editorconfig: add initial file/config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# To use this config on you editor, follow the instructions at:
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
The mpv project uses fairly consistent 4 space indentation rules,
alongside 80 column line width and trailing newline at the end of the
file.

From a quick look these cover the C, python, lua, js, RST and others.

Add a trivial .editorconfig file in-tree to help maintain the style.
Practically every editor out there has built-in or plugin support for
it - see https://editorconfig.org/ for more.

For example: my setup us in vim, where the plugin automatically picks
the style and applies it as I'm writing. No setup needed - it just works

While working on https://github.com/mpv-player/mpv/pull/9268 far too many tab snuck-in.
So might as well have this in-tree - since it automates the less interesting parts of coding.

@Dudemanguy @avih 