### PR TITLE
dylib-unhell.py: fix building with brotli

### DIFF
--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -10,11 +10,13 @@ from functools import partial
 sys_re = re.compile("^/System")
 usr_re = re.compile("^/usr/lib/")
 exe_re = re.compile("@executable_path")
+loader_re = re.compile("@loader_path")
 
 def is_user_lib(objfile, libname):
     return not sys_re.match(libname) and \
            not usr_re.match(libname) and \
            not exe_re.match(libname) and \
+           not loader_re.match(libname) and \
            not "libobjc." in libname and \
            not "libSystem." in libname and \
            not "libc." in libname and \


### PR DESCRIPTION
I notice this issue when run `brew update && brew upgrade && brew install mpv --HEAD`

Since [recent change](https://github.com/Homebrew/homebrew-core/commit/093d8417e3fd32137e878dce7cb1f92d6df3fcb7) from homebrew, `jpeg-xl` becomes one of dependencies of `aom`, `ffmpeg`, `mpv`, and since `brotli` is part of `jpeg-xl`, so I notice this issue during building `mpv`

The error during building `mpv` is
```
error: /Library/Developer/CommandLineTools/usr/bin/otool-classic: can't open file: @loader_path/libbrotlicommon.1.dylib (No such file or directory)
```
so I dig into the building script itself, and it seems this PR can fix the issue.

test with `brew install mpv --HEAD`, no more building issue, and `mpv` works fine



