### PR TITLE
github/workflows: use xcode 13.1 if image defaults to xcode 13.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Override Xcode 13.0 if it's the default toolchain
+        run: |
+          XCODE_PATH="$(xcode-select -p)"
+          case "${XCODE_PATH}" in
+            *Xcode_13.0*)
+              sudo xcode-select -s "/Applications/Xcode_13.1.app"
+              echo "Updated Xcode path ${XCODE_PATH} -> $(xcode-select -p)"
+              ;;
+          esac
+
       - name: Install dependencies
         run: |
           brew update


### PR DESCRIPTION
I find it both hilarious and sad that Github decided that defaulting
to XCode 13.0 was a good idea... At least they added 13.1 quickly.

Ref actions/virtual-environments#4180
Ref actions/virtual-environments#4300