### PR TITLE
w32_common: fix bad window style for no-border window

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,7 @@
 name: build
 
 on:
-  push:
-    branches:
-      - master
-      - ci
-      - 'release/**'
-  pull_request:
-    branches: [master]
+  workflow_dispatch:
 
 jobs:
   mingw:

--- a/my
+++ b/my
@@ -1,0 +1,1 @@
+meson build --wipe --reconfigure && meson compile -C build


### PR DESCRIPTION
Currently on Windows, the no-border window (`--no-border`) has window style `WS_OVERLAPPED | WS_MINIMIZEBOX`. According to [Microsoft doc](https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles#ws_minimizebox), when `WS_MINIMIZEBOX` is specified, `WS_SYSMENU` must also be specified.

The inconsistency causes some apps relying on the correct combination of flags to miss, e.g. https://github.com/valinet/ExplorerPatcher/issues/161.

This small change adds `WS_SYSMENU` to the no-border window style, making it exactly the same as the fullscreen window style.

Locally built and tested that the two functionalities originated the [previous change](https://github.com/mpv-player/mpv/commit/bf5727a60fbae12510238c23a38b89822b128baa) still exist:

1) Clicking taskbar minimizes the window;
2) Win+Down arrow minimizes the window.