### PR TITLE
{wscript,demux_lavf}: clean up last bits of !FFMPEG_STRICT_ABI

### DIFF
--- a/wscript
+++ b/wscript
@@ -412,10 +412,14 @@ FFmpeg libraries. Git master is recommended."
         'desc': 'libavdevice',
         'func': check_pkg_config('libavdevice', '>= 57.0.0'),
     }, {
-        'name': '--ffmpeg-strict-abi',
-        'desc': 'Disable all known FFmpeg ABI violations',
-        'func': check_true,
-        'default': 'enable',
+        # The following should be removed in 2022 or if libavformat requirement
+        # is bumped to >= 59.8.100
+        'name': 'ffmpeg-aviocontext-bytes-read',
+        'desc': 'FFmpeg AVIOContext bytes_read statistic field',
+        'deps': 'ffmpeg',
+        'func': check_statement(['libavformat/avio.h'],
+                                '(struct AVIOContext){ 0 }.bytes_read = 7357',
+                                use=['ffmpeg']),
     }
 ]
 


### PR DESCRIPTION
The bytes_read struct member in AVIOContext is now officially public,
so its usage no longer has to be specified as non-compliance with
FFmpeg's ABI/API rules.

That said, unfortunately there was a short period of time between
August 2021 and October 2021 where the struct member did not exist
in FFmpeg's git master, so keep a feature check for it alive for
now to enable building with those versions. Thankfully, no release
version of FFmpeg will be without this field, so it should be
possible to drop this check with time.

Finally, simplify the function in case the struct member is not
found. After all, there is zero reason to iterate through the AVIO
contexts if we cannot get the information we require.