### PR TITLE
options: Add watch_later_effective_path

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -763,6 +763,10 @@ Program Behavior
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
+``--watch-later-effective-path=<string>``
+    Use the specified string instead of the current file name for saving
+    and resuming.
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/options/options.c
+++ b/options/options.c
@@ -698,6 +698,7 @@ static const m_option_t mp_opts[] = {
         OPT_FLAG(ignore_path_in_watch_later_config)},
     {"watch-later-directory", OPT_STRING(watch_later_directory),
         .flags = M_OPT_FILE},
+    {"watch-later-effective-path", OPT_STRING(watch_later_effective_path)},
     {"watch-later-options", OPT_STRINGLIST(watch_later_options)},
 
     {"ordered-chapters", OPT_FLAG(ordered_chapters)},

--- a/options/options.h
+++ b/options/options.h
@@ -254,6 +254,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
+    char *watch_later_effective_path;
     char **watch_later_options;
     int pause;
     int keep_open;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -201,7 +201,9 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     void *tmp = talloc_new(NULL);
     const char *realpath = fname;
     bstr bfname = bstr0(fname);
-    if (!mp_is_url(bfname)) {
+    if(mpctx->opts->watch_later_effective_path) {
+        realpath = mpctx->opts->watch_later_effective_path;
+    } else if (!mp_is_url(bfname)) {
         if (opts->ignore_path_in_watch_later_config) {
             realpath = mp_basename(fname);
         } else {


### PR DESCRIPTION
A new option has been added to override the filename in
mp_get_playback_resume_config_filename. This allows streams to be
resumed when the underlying url changes.

Closes: #9346

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.