### PR TITLE
ao_opensles: add guards for sample rate to use

### DIFF
--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -111,6 +111,8 @@ static int init(struct ao *ao)
 
     // This AO only supports two channels at the moment
     mp_chmap_from_channels(&ao->channels, 2);
+    // Upstream "Wilhelm" supports only 8000 <= rate <= 192000
+    ao->samplerate = MPCLAMP(ao->samplerate, 8000, 192000);
 
     CHK(slCreateEngine(&p->sl, 0, NULL, 0, NULL, NULL));
     CHK((*p->sl)->Realize(p->sl, SL_BOOLEAN_FALSE));


### PR DESCRIPTION
Upstream "Wilhelm" (the Android OpenSLES implementation) supports only 8000 <= rate <= 192000. Make sure mpv resamples the audio when necessary.