### PR TITLE
context_drm_egl: Use gbm_surface_create_with_modifiers

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -90,7 +90,9 @@ const struct m_sub_options drm_conf = {
             M_RANGE(0, INT_MAX)},
         {"drm-format", OPT_CHOICE(drm_format,
             {"xrgb8888",    DRM_OPTS_FORMAT_XRGB8888},
-            {"xrgb2101010", DRM_OPTS_FORMAT_XRGB2101010})},
+            {"xrgb2101010", DRM_OPTS_FORMAT_XRGB2101010},
+            {"xbgr8888",    DRM_OPTS_FORMAT_XBGR8888},
+            {"xbgr2101010", DRM_OPTS_FORMAT_XBGR2101010})},
         {"drm-draw-surface-size", OPT_SIZE_BOX(drm_draw_surface_size)},
 
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -26,6 +26,8 @@
 
 #define DRM_OPTS_FORMAT_XRGB8888    0
 #define DRM_OPTS_FORMAT_XRGB2101010 1
+#define DRM_OPTS_FORMAT_XBGR8888    2
+#define DRM_OPTS_FORMAT_XBGR2101010 3
 
 struct kms {
     struct mp_log *log;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -119,10 +119,18 @@ static const char *gbm_format_to_string(uint32_t format)
         return "GBM_FORMAT_XRGB8888";
     case GBM_FORMAT_ARGB8888:
         return "GBM_FORMAT_ARGB8888";
+    case GBM_FORMAT_XBGR8888:
+        return "GBM_FORMAT_XBGR8888";
+    case GBM_FORMAT_ABGR8888:
+        return "GBM_FORMAT_ABGR8888";
     case GBM_FORMAT_XRGB2101010:
         return "GBM_FORMAT_XRGB2101010";
     case GBM_FORMAT_ARGB2101010:
         return "GBM_FORMAT_ARGB2101010";
+    case GBM_FORMAT_XBGR2101010:
+        return "GBM_FORMAT_XBGR2101010";
+    case GBM_FORMAT_ABGR2101010:
+        return "GBM_FORMAT_ABGR2101010";
     default:
         return "UNKNOWN";
     }
@@ -139,10 +147,18 @@ static uint32_t fallback_format_for(uint32_t format)
         return GBM_FORMAT_ARGB8888;
     case GBM_FORMAT_ARGB8888:
         return GBM_FORMAT_XRGB8888;
+    case GBM_FORMAT_XBGR8888:
+        return GBM_FORMAT_ABGR8888;
+    case GBM_FORMAT_ABGR8888:
+        return GBM_FORMAT_XBGR8888;
     case GBM_FORMAT_XRGB2101010:
         return GBM_FORMAT_ARGB2101010;
     case GBM_FORMAT_ARGB2101010:
         return GBM_FORMAT_XRGB2101010;
+    case GBM_FORMAT_XBGR2101010:
+        return GBM_FORMAT_ABGR2101010;
+    case GBM_FORMAT_ABGR2101010:
+        return GBM_FORMAT_XBGR2101010;
     default:
         return 0;
     }
@@ -840,12 +856,23 @@ static bool drm_egl_init(struct ra_ctx *ctx)
 
     uint32_t argb_format;
     uint32_t xrgb_format;
-    if (DRM_OPTS_FORMAT_XRGB2101010 == ctx->vo->opts->drm_opts->drm_format) {
+    switch (ctx->vo->opts->drm_opts->drm_format) {
+    case DRM_OPTS_FORMAT_XRGB2101010:
         argb_format = GBM_FORMAT_ARGB2101010;
         xrgb_format = GBM_FORMAT_XRGB2101010;
-    } else {
+        break;
+    case DRM_OPTS_FORMAT_XBGR2101010:
+        argb_format = GBM_FORMAT_ABGR2101010;
+        xrgb_format = GBM_FORMAT_XBGR2101010;
+        break;
+    case DRM_OPTS_FORMAT_XBGR8888:
+        argb_format = GBM_FORMAT_ABGR8888;
+        xrgb_format = GBM_FORMAT_XBGR8888;
+        break;
+    default:
         argb_format = GBM_FORMAT_ARGB8888;
         xrgb_format = GBM_FORMAT_XRGB8888;
+        break;
     }
 
     if (!probe_gbm_format(ctx, argb_format, xrgb_format)) {

--- a/wscript
+++ b/wscript
@@ -496,7 +496,7 @@ video_output_features = [
         'name': '--gbm',
         'desc': 'GBM',
         'deps': 'gbm.h',
-        'func': check_pkg_config('gbm'),
+        'func': check_pkg_config('gbm', '>= 17.1.0'),
     } , {
         'name': '--wayland-scanner',
         'desc': 'wayland-scanner',


### PR DESCRIPTION
The GBM supporting nvidia driver doesn't support creating surfaces
without modifiers and using modifiers is more and more recommended as
the right way to do this.

Enumerating modifiers is painfully verbose, but necessary if we are to
allow the driver to pick the best possible one.

Finally, I added support for [A|X]BGR2101010 because nvidia supports
that instead of RGB. Of course, their EGL doesn't support 10bit formats
so you still can't actually use a 10bit DRM format.