### PR TITLE
vo_gpu/vo_gpu_next: create wait_for_frame function

### DIFF
--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -78,6 +78,11 @@ struct ra_swapchain_fns {
     // Gets the current framebuffer depth in bits (0 if unknown). Optional.
     int (*color_depth)(struct ra_swapchain *sw);
 
+    // Certain platforms may want to setup/check some things before actually
+    // drawing the next frame. If this exists and returns false, then subsequent
+    // start frame call will be skipped and the next frame will not be drawn.
+    bool (*wait_for_frame)(struct ra_swapchain *sw);
+
     // Called when rendering starts. Returns NULL on failure. This must be
     // followed by submit_frame, to submit the rendered frame. This function
     // can also fail sporadically, and such errors should be ignored unless

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -211,6 +211,15 @@ int ra_gl_ctx_color_depth(struct ra_swapchain *sw)
     return depth_g;
 }
 
+static bool ra_gl_ctx_wait_for_frame(struct ra_swapchain *sw)
+{
+    struct priv *p = sw->priv;
+    bool should_draw = true;
+    if (p->params.wait_for_frame)
+        should_draw = p->params.wait_for_frame(sw->ctx);
+    return should_draw;
+}
+
 bool ra_gl_ctx_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
@@ -303,9 +312,10 @@ static void ra_gl_ctx_get_vsync(struct ra_swapchain *sw,
 }
 
 static const struct ra_swapchain_fns ra_gl_swapchain_fns = {
-    .color_depth   = ra_gl_ctx_color_depth,
-    .start_frame   = ra_gl_ctx_start_frame,
-    .submit_frame  = ra_gl_ctx_submit_frame,
-    .swap_buffers  = ra_gl_ctx_swap_buffers,
-    .get_vsync     = ra_gl_ctx_get_vsync,
+    .color_depth    = ra_gl_ctx_color_depth,
+    .wait_for_frame = ra_gl_ctx_wait_for_frame,
+    .start_frame    = ra_gl_ctx_start_frame,
+    .submit_frame   = ra_gl_ctx_submit_frame,
+    .swap_buffers   = ra_gl_ctx_swap_buffers,
+    .get_vsync      = ra_gl_ctx_get_vsync,
 };

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -30,6 +30,9 @@ struct ra_gl_ctx_params {
     // See ra_swapchain_fns.get_vsync.
     void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
 
+    // See ra_swapchain_fns.wait_for_frame. Called before start_frame.
+    bool (*wait_for_frame)(struct ra_ctx *ctx);
+
     // Set to false if the implementation follows normal GL semantics, which is
     // upside down. Set to true if it does *not*, i.e. if rendering is right
     // side up

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -54,19 +54,17 @@ static void resize(struct ra_ctx *ctx)
     wl->vo->dheight = height;
 }
 
-static bool wayland_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
+static bool wayland_egl_wait_for_frame(struct ra_ctx *ctx)
 {
-    struct ra_ctx *ctx = sw->ctx;
     struct vo_wayland_state *wl = ctx->vo->wl;
     bool render = !wl->hidden || wl->opts->disable_vsync;
     wl->frame_wait = true;
 
-    return render ? ra_gl_ctx_start_frame(sw, out_fbo) : false;
+    return render;
 }
 
-static void wayland_egl_swap_buffers(struct ra_swapchain *sw)
+static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 {
-    struct ra_ctx *ctx = sw->ctx;
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
@@ -78,11 +76,6 @@ static void wayland_egl_swap_buffers(struct ra_swapchain *sw)
     if (wl->presentation)
         vo_wayland_sync_swap(wl);
 }
-
-static const struct ra_swapchain_fns wayland_egl_swapchain = {
-    .start_frame  = wayland_egl_start_frame,
-    .swap_buffers = wayland_egl_swap_buffers,
-};
 
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
@@ -116,8 +109,9 @@ static bool egl_create_context(struct ra_ctx *ctx)
     mpegl_load_functions(&p->gl, wl->log);
 
     struct ra_gl_ctx_params params = {
-        .external_swapchain = &wayland_egl_swapchain,
-        .get_vsync          = &wayland_egl_get_vsync,
+        .wait_for_frame = wayland_egl_wait_for_frame,
+        .swap_buffers   = wayland_egl_swap_buffers,
+        .get_vsync      = wayland_egl_get_vsync,
     };
 
     if (!ra_gl_ctx_init(ctx, &p->gl, params))

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -74,10 +74,24 @@ static void resize(struct vo *vo)
     vo->want_redraw = true;
 }
 
+static bool wait_for_frame(struct vo *vo)
+{
+    struct gpu_priv *p = vo->priv;
+    struct ra_swapchain *sw = p->ctx->swapchain;
+    bool should_draw = true;
+    if (sw->fns->wait_for_frame)
+        should_draw = sw->fns->wait_for_frame(sw);
+    return should_draw;
+}
+
 static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct gpu_priv *p = vo->priv;
     struct ra_swapchain *sw = p->ctx->swapchain;
+
+    bool should_draw = wait_for_frame(vo);
+    if (!should_draw)
+        return;
 
     struct ra_fbo fbo;
     if (!sw->fns->start_frame(sw, &fbo))

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -524,6 +524,16 @@ static void info_callback(void *priv, const struct pl_render_info *info)
     frame->count = index + 1;
 }
 
+static bool wait_for_frame(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+    struct ra_swapchain *sw = p->ra_ctx->swapchain;
+    bool should_draw = true;
+    if (sw->fns->wait_for_frame)
+        should_draw = sw->fns->wait_for_frame(sw);
+    return should_draw;
+}
+
 static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *p = vo->priv;
@@ -576,6 +586,10 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
 
         p->last_id = id;
     }
+
+    bool should_draw = wait_for_frame(vo);
+    if (!should_draw)
+        return;
 
     struct pl_swapchain_frame swframe;
     if (!pl_swapchain_start_frame(p->sw, &swframe))

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -235,15 +235,19 @@ static int color_depth(struct ra_swapchain *sw)
     return 0; // TODO: implement this somehow?
 }
 
+static bool wait_for_frame(struct ra_swapchain *sw)
+{
+    struct priv *p = sw->priv;
+    bool should_draw = true;
+    if (p->params.wait_for_frame)
+        should_draw = p->params.wait_for_frame(sw->ctx);
+    return should_draw;
+}
+
 static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
     struct pl_swapchain_frame frame;
-    bool start = true;
-    if (p->params.start_frame)
-        start = p->params.start_frame(sw->ctx);
-    if (!start)
-        return false;
     if (!pl_swapchain_start_frame(p->vk->swapchain, &frame))
         return false;
     if (!mppl_wrap_tex(sw->ctx->ra, frame.fbo, &p->proxy_tex))
@@ -280,9 +284,10 @@ static void get_vsync(struct ra_swapchain *sw,
 }
 
 static const struct ra_swapchain_fns vulkan_swapchain = {
-    .color_depth   = color_depth,
-    .start_frame   = start_frame,
-    .submit_frame  = submit_frame,
-    .swap_buffers  = swap_buffers,
-    .get_vsync     = get_vsync,
+    .color_depth    = color_depth,
+    .wait_for_frame = wait_for_frame,
+    .start_frame    = start_frame,
+    .submit_frame   = submit_frame,
+    .swap_buffers   = swap_buffers,
+    .get_vsync      = get_vsync,
 };

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -7,8 +7,8 @@ struct ra_vk_ctx_params {
     // See ra_swapchain_fns.get_vsync.
     void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
 
-    // In case something special needs to be done when starting a frame.
-    bool (*start_frame)(struct ra_ctx *ctx);
+    // See ra_swapchain_fns.wait_for_frame. Called before start_frame.
+    bool (*wait_for_frame)(struct ra_ctx *ctx);
 
     // In case something special needs to be done on the buffer swap.
     void (*swap_buffers)(struct ra_ctx *ctx);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -26,7 +26,7 @@ struct priv {
     struct mpvk_ctx vk;
 };
 
-static bool wayland_vk_start_frame(struct ra_ctx *ctx)
+static bool wayland_vk_wait_for_frame(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
     bool render = !wl->hidden || wl->opts->disable_vsync;
@@ -84,7 +84,7 @@ static bool wayland_vk_init(struct ra_ctx *ctx)
     };
 
     struct ra_vk_ctx_params params = {
-        .start_frame = wayland_vk_start_frame,
+        .wait_for_frame = wayland_vk_wait_for_frame,
         .swap_buffers = wayland_vk_swap_buffers,
         .get_vsync = wayland_vk_get_vsync,
     };


### PR DESCRIPTION
Because wayland is a special snowflake, its rendering loop has a special
param which is used by vo_gpu to interface with wayland's frame callback
and all that jazz. The way this is currently implemented (in EGL and
Vulkan) is not exactly the same and also vo_gpu_next cannot easily take
advantage of it. Let's change the semantics of this a bit by creating a
new wait_for_frame function in vo_gpu and vo_gpu_next and defining it as
a function pointer in gpu's context.h. The workflow will simply be that
wait_for_frame will calldown into the specific backend, ask if it is
okay to render, and then return the value to draw_frame. If we get
false, then just skip drawing for this frame. After that, plugging this
new framework into the wayland contexts is pretty trivial.

This fixes `display-resample` in gpu-next on wayland while also unifying the way this special case was treated in the mpv code. I originally had this as separate commits but the actual wayland-specific changes were pretty trivial so I just merged it here.