### PR TITLE
vo_gpu_next: call start_frame in vulkan/context.c

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -577,6 +577,12 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         p->last_id = id;
     }
 
+    // Doesn't draw anything. Only checks for visibility.
+    struct ra_swapchain *sw = p->ra_ctx->swapchain;
+    bool should_draw = sw->fns->start_frame(sw, NULL);
+    if (!should_draw)
+        return;
+
     struct pl_swapchain_frame swframe;
     if (!pl_swapchain_start_frame(p->sw, &swframe))
         return;

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -239,11 +239,15 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
     struct pl_swapchain_frame frame;
+
     bool visible = true;
     if (p->params.check_visible)
         visible = p->params.check_visible(sw->ctx);
-    if (!visible)
-        return false;
+
+    // If out_fbo is NULL, this was called from vo_gpu_next. Bail out.
+    if (out_fbo == NULL || !visible)
+        return visible;
+
     if (!pl_swapchain_start_frame(p->vk->swapchain, &frame))
         return false;
     if (!mppl_wrap_tex(sw->ctx->ra, frame.fbo, &p->proxy_tex))

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -239,10 +239,10 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
     struct pl_swapchain_frame frame;
-    bool start = true;
-    if (p->params.start_frame)
-        start = p->params.start_frame(sw->ctx);
-    if (!start)
+    bool visible = true;
+    if (p->params.check_visible)
+        visible = p->params.check_visible(sw->ctx);
+    if (!visible)
         return false;
     if (!pl_swapchain_start_frame(p->vk->swapchain, &frame))
         return false;

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -7,8 +7,9 @@ struct ra_vk_ctx_params {
     // See ra_swapchain_fns.get_vsync.
     void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
 
-    // In case something special needs to be done when starting a frame.
-    bool (*start_frame)(struct ra_ctx *ctx);
+    // For special contexts (i.e. wayland) that want to check visibility
+    // before drawing a frame.
+    bool (*check_visible)(struct ra_ctx *ctx);
 
     // In case something special needs to be done on the buffer swap.
     void (*swap_buffers)(struct ra_ctx *ctx);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -26,7 +26,7 @@ struct priv {
     struct mpvk_ctx vk;
 };
 
-static bool wayland_vk_start_frame(struct ra_ctx *ctx)
+static bool wayland_vk_check_visible(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
     bool render = !wl->hidden || wl->opts->disable_vsync;
@@ -84,7 +84,7 @@ static bool wayland_vk_init(struct ra_ctx *ctx)
     };
 
     struct ra_vk_ctx_params params = {
-        .start_frame = wayland_vk_start_frame,
+        .check_visible = wayland_vk_check_visible,
         .swap_buffers = wayland_vk_swap_buffers,
         .get_vsync = wayland_vk_get_vsync,
     };


### PR DESCRIPTION
Alternative to #9392. It's way simpler (the first commit is purely cosmetic) so this is probably better. I'm assuming here that the `ra_fbo` is never `NULL` normally which I think is fine. Basically, we're just cannibalizing vulkan/context.c a little bit more.