### PR TITLE
 vo_gpu_next: fix resource exhaustion on minimized windows 

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -414,9 +414,7 @@ static bool map_frame(pl_gpu gpu, pl_tex *tex, const struct pl_source_frame *src
             .data = mpi->icc_profile ? mpi->icc_profile->data : NULL,
             .len = mpi->icc_profile ? mpi->icc_profile->size : 0,
         },
-#if PL_API_VER >= 162
         .rotation = mpi->params.rotate / 90,
-#endif
     };
 
     enum pl_chroma_location chroma = mp_chroma_to_pl(mpi->params.chroma_location);
@@ -668,13 +666,11 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
                 p->src.x0, p->src.y0, p->src.x1, p->src.y1,
             };
 
-#if PL_API_VER >= 162
             // mpv gives us transposed rects, libplacebo expects untransposed
             if (img->rotation % PL_ROTATION_180) {
                 MPSWAP(float, img->crop.x0, img->crop.y0);
                 MPSWAP(float, img->crop.x1, img->crop.y1);
             }
-#endif
         }
     }
 
@@ -1153,9 +1149,7 @@ static void update_render_options(struct priv *p)
     p->params.skip_anti_aliasing = !opts->correct_downscaling;
     p->params.disable_linear_scaling = !opts->linear_downscaling && !opts->linear_upscaling;
     p->params.disable_fbos = opts->dumb_mode == 1;
-#if PL_API_VER >= 164
     p->params.blend_against_tiles = opts->alpha_mode == ALPHA_BLEND_TILES;
-#endif
 
     // Map scaler options as best we can
     p->params.upscaler = map_scaler(p, SCALER_SCALE);
@@ -1242,9 +1236,7 @@ const struct m_opt_choice_alternatives lut_types[] = {
 const struct vo_driver video_out_gpu_next = {
     .description = "Video output based on libplacebo",
     .name = "gpu-next",
-#if PL_API_VER >= 162
     .caps = VO_CAP_ROTATE90,
-#endif
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -584,8 +584,14 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         return;
 
     struct pl_swapchain_frame swframe;
-    if (!pl_swapchain_start_frame(p->sw, &swframe))
+    if (!pl_swapchain_start_frame(p->sw, &swframe)) {
+        // Advance the queue state to the current PTS to discard unused frames
+        pl_queue_update(p->queue, NULL, &(struct pl_queue_params) {
+            .pts = frame->current->pts + frame->vsync_offset,
+            .radius = pl_frame_mix_radius(&p->params),
+        });
         return;
+    }
 
     bool valid = false;
     p->is_interpolated = false;
@@ -612,7 +618,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     if (opts->target_peak)
         target.color.sig_peak = opts->target_peak;
 
-    struct pl_frame_mix mix = {0};
+    struct pl_frame_mix mix;
     if (frame->current) {
         // Update queue state
         struct pl_queue_params qparams = {

--- a/wscript
+++ b/wscript
@@ -741,9 +741,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 3.104.0'),
     }, {
         'name': 'libplacebo-v4',
-        'desc': 'libplacebo v4.157+, needed for vo_gpu_next',
+        'desc': 'libplacebo v4.170+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 157',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 170',
                                    use='libplacebo'),
     }, {
         'name': '--vulkan',


### PR DESCRIPTION
This required an upstream API change to implement in a way that doesn't
unnecessarily re-push or upload frames that won't be used. I consider
this a big enough bug to justify bumping the minimum version for it.

Closes #9401