### PR TITLE
vo_gpu_next: implement HDR passthrough

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -31,6 +31,7 @@ Interface changes
       `--allow-delayed-peak-detect`, `--builtin-scalers`,
       `--interpolation-preserve` `--lut`, `--lut-type`, `--image-lut`,
       `--image-lut-type` and `--target-lut` along with it.
+    - add `--target-colorspace-hint`
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6172,6 +6172,11 @@ them.
         Fully replaces the color decoding. A LUT of this type should ingest the
         image's native colorspace and output normalized non-linear RGB.
 
+``--target-colorspace-hint```
+    Automatically configure the output colorspace of the display to pass
+    through the input values of the stream (e.g. for HDR passthrough), if
+    possible. Requires a supporting driver and ``--vo=gpu-next``.
+
 ``--target-prim=<value>``
     Specifies the primaries of the display. Video colors will be adapted to
     this colorspace when ICC color management is not being used. Valid values


### PR DESCRIPTION
Completely untested, since Linux still can't into HDR in 2021. Somebody
please make sure it works.

Technically covers #8219, since gpu-context=drm can be combined with
vo=gpu-next.