### PR TITLE
vo_gpu_next: Initialize `pl_frame_mix`

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -679,7 +679,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         tbits->sample_depth = opts->dither_depth;
     }
 
-    struct pl_frame_mix mix;
+    struct pl_frame_mix mix = {0};
     if (frame->current) {
         // Update queue state
         struct pl_queue_params qparams = {


### PR DESCRIPTION
Without initializing, the random data causes the `pl_render_image_mix`
function to abort with a SIGSEGV.

I found that the crash was the easiest to reproduce with `--force-window=immediate`, but is not exclusive to that option.