### PR TITLE
egl_helpers: remove EGL_OPENGL_ES3_BIT

### DIFF
--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -41,7 +41,6 @@
 #define EGL_CONTEXT_OPENGL_PROFILE_MASK         0x30FD
 #define EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT     0x00000001
 #define EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE   0x31B1
-#define EGL_OPENGL_ES3_BIT                      0x00000040
 typedef intptr_t EGLAttrib;
 #endif
 
@@ -117,7 +116,7 @@ static bool create_context(struct ra_ctx *ctx, EGLDisplay display,
         name = "Desktop OpenGL";
     } else {
         api = EGL_OPENGL_ES_API;
-        rend = EGL_OPENGL_ES2_BIT | EGL_OPENGL_ES3_BIT;
+        rend = EGL_OPENGL_ES2_BIT;
         name = "GLES 2.x +";
     }
 


### PR DESCRIPTION
d2e8bc449986e012f257249a996386bd323febd0 was the the commit that
originally introduced the usage of this bit. As the message states, the
purpose was to force creating GLES 3 contexts on drivers that do not
return a higher version context than what was requested. With the recent
opengl refactors, mpv's gl selection has already moved away from such
complicated queries. Perhaps when that commit was added things were
different, but nowadays it seems like Mesa simply returns the highest
driver version available that is compatibile with the request (i.e.
requesting GLES 2 returns a GLES 3 context on my machine). In that case,
let's just simply drop EGL_OPENGL_ES3_BIT altogether as it does break
GLES 2 only machines. Fixes #9431.