### PR TITLE
options: adds primary-only and secondary-only choices to --sub-visibility

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -39,6 +39,8 @@ Interface changes
     - add `--tone-mapping-mode`, replacing `--tone-mapping-desaturate` and
       `--tone-mapping-desaturate-exponent`.
     - add `dolbyvision` sub-parameter to `format` video filter
+    - remove `--secondary-sub-visibility` and introduces
+      `--sub-visibility=primary-only` and `--sub-visibility=secondary-only`
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2607,18 +2607,9 @@ Subtitles
 
     This is a path list option. See `List Options`_ for details.
 
-``--sub-visibility``, ``--no-sub-visibility``
+``--sub-visibility=<no|yes|primary-only|secondary-only>``, ``--no-sub-visibility``
     Can be used to disable display of subtitles, but still select and decode
     them.
-
-``--secondary-sub-visibility``, ``--no-secondary-sub-visibility``
-    Can be used to disable display of secondary subtitles, but still select and
-    decode them.
-
-    .. note::
-
-        If ``--sub-visibility=no``, secondary subtitles are hidden regardless of
-        ``--secondary-sub-visibility``.
 
 ``--sub-clear-on-seek``
     (Obscure, rarely useful.) Can be used to play broken mkv files with

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -121,7 +121,6 @@
 #R add sub-pos +1                       # move subtitles down
 #t add sub-pos +1                       # move subtitles down
 #v cycle sub-visibility                 # hide or show the subtitles
-#Alt+v cycle secondary-sub-visibility   # hide or show the secondary subtitles
 #V cycle sub-ass-vsfilter-aspect-compat # toggle stretching SSA/ASS subtitles with anamorphic videos to match the historical renderer
 #u cycle-values sub-ass-override "force" "no" # toggle overriding SSA/ASS subtitle styles with the normal styles
 #j cycle sub                            # switch subtitle track

--- a/options/options.c
+++ b/options/options.c
@@ -240,8 +240,9 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-delay", OPT_FLOAT(sub_delay)},
         {"sub-fps", OPT_FLOAT(sub_fps)},
         {"sub-speed", OPT_FLOAT(sub_speed)},
-        {"sub-visibility", OPT_FLAG(sub_visibility)},
-        {"secondary-sub-visibility", OPT_FLAG(sec_sub_visibility)},
+        {"sub-visibility", OPT_CHOICE(sub_visibility,
+            {"no", 0}, {"yes", 1}, {"primary-only", 2}, {"secondary-only", 3})
+        },
         {"sub-forced-only", OPT_CHOICE(forced_subs_only,
             {"auto", -1}, {"no", 0}, {"yes", 1})},
         {"stretch-dvd-subs", OPT_FLAG(stretch_dvd_subs)},
@@ -285,7 +286,6 @@ const struct m_sub_options mp_subtitle_sub_opts = {
     .size = sizeof(OPT_BASE_STRUCT),
     .defaults = &(OPT_BASE_STRUCT){
         .sub_visibility = 1,
-        .sec_sub_visibility = 1,
         .forced_subs_only = -1,
         .sub_pos = 100,
         .sub_speed = 1.0,
@@ -880,6 +880,8 @@ static const m_option_t mp_opts[] = {
     {"pphelp", OPT_REMOVED(NULL)},
     {"rawaudio", OPT_REMOVED("use --demuxer-rawaudio-...")},
     {"rawvideo", OPT_REMOVED("use --demuxer-rawvideo-...")},
+    {"secondary-sub-visibility", OPT_REMOVED(
+        "use --sub-visibility=primary-only/yes")},
     {"spugauss", OPT_REPLACED("sub-gauss")},
     {"srate", OPT_REPLACED("audio-samplerate")},
     {"ss", OPT_REPLACED("start")},

--- a/options/options.h
+++ b/options/options.h
@@ -73,7 +73,6 @@ typedef struct mp_vo_opts {
 // Subtitle options needed by the subtitle decoders/renderers.
 struct mp_subtitle_opts {
     int sub_visibility;
-    int sec_sub_visibility;
     int sub_pos;
     float sub_delay;
     float sub_fps;

--- a/player/command.c
+++ b/player/command.c
@@ -4003,11 +4003,13 @@ static const struct property_osd_display {
     {"sub-delay", "Sub delay"},
     {"sub-speed", "Sub speed"},
     {"sub-visibility",
-     .msg = "Subtitles ${!sub-visibility==yes:hidden}"
-      "${?sub-visibility==yes:visible${?sub==no: (but no subtitles selected)}}"},
-    {"secondary-sub-visibility",
-     .msg = "Secondary Subtitles ${!secondary-sub-visibility==yes:hidden}"
-      "${?secondary-sub-visibility==yes:visible${?secondary-sid==no: (but no secondary subtitles selected)}}"},
+        .msg = "Subtitles ${?sub-visibility==no:hidden}"
+            "${?sub-visibility==yes:visible}"
+            "${?sub-visibility==primary-only:visible (primary only"
+                "${?sid==no: but no subtitles selected})}"
+            "${?sub-visibility==secondary-only:visible (secondary only"
+                "${?secondary-sid==no: but no subtitles selected})}"
+    },
     {"sub-forced-only", "Forced sub only"},
     {"sub-scale", "Sub Scale"},
     {"sub-ass-vsfilter-aspect-compat", "Subtitle VSFilter aspect compat"},

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -453,7 +453,12 @@ void sub_set_play_dir(struct dec_sub *sub, int dir)
     pthread_mutex_unlock(&sub->lock);
 }
 
+bool sub_is_primary_visible(struct dec_sub *sub)
+{
+    return sub->opts->sub_visibility == 1 || sub->opts->sub_visibility == 2;
+}
+
 bool sub_is_secondary_visible(struct dec_sub *sub)
 {
-    return !!sub->opts->sec_sub_visibility;
+    return sub->opts->sub_visibility == 1 || sub->opts->sub_visibility == 3;
 }

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -51,6 +51,7 @@ void sub_reset(struct dec_sub *sub);
 void sub_select(struct dec_sub *sub, bool selected);
 void sub_set_recorder_sink(struct dec_sub *sub, struct mp_recorder_sink *sink);
 void sub_set_play_dir(struct dec_sub *sub, int dir);
+bool sub_is_primary_visible(struct dec_sub *sub);
 bool sub_is_secondary_visible(struct dec_sub *sub);
 
 int sub_control(struct dec_sub *sub, enum sd_ctrl cmd, void *arg);

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -291,7 +291,7 @@ static struct sub_bitmaps *render_object(struct osd_state *osd,
     check_obj_resize(osd, osdres, obj);
 
     if (obj->type == OSDTYPE_SUB) {
-        if (obj->sub)
+        if (obj->sub && sub_is_primary_visible(obj->sub))
             res = sub_get_bitmaps(obj->sub, obj->vo_res, format, video_pts);
     } else if (obj->type == OSDTYPE_SUB2) {
         if (obj->sub && sub_is_secondary_visible(obj->sub))


### PR DESCRIPTION
- Changes `--sub-visibility` from a flag option to a choice option, adding `primary-only` and `secondary-only` choices for displaying only the primary subtitle track and secondary subtitle track respectively
- Removes `--secondary-sub-visibility` and displays a message telling the user to use `--sub-visibility=primary-only` instead
- Removes `Alt+v` as a bind for cycling through `--secondary-sub-visibility`
- ~~Adds `--primary-sub-visibility` option for toggling the visibility of the primary subtitle track independent of `--secondary-sub-visibility`~~
- ~~Adds `Alt+V` shortcut for cycling through `primary-sub-visibility`~~

**Use Case**
I maintain a video player using libmpv that renders primary subtitles outside of mpv by observing the `sub-text` property. I would like to make it so that I can use mpv to render the secondary subtitle track while my player renders the primary subtitle track. Currently that is not possible using `secondary-sub-visibility` and `sub-visibility` because `secondary-sub-visibility` cannot be toggled independently of `sub-visibility`. This means that if secondary subtitles are visible, the primary subtitle track must also be visible. This leads to an issue where the primary subtitle track ends up being rendered twice in my player if the user wants to enable secondary subtitles.
![image](https://user-images.githubusercontent.com/72582120/141527206-fb0194b3-6d0e-434d-8ee6-877a269485c6.png)
