### PR TITLE
ytdl_hook.lua: improve check for sub language before inserting all-subs

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -762,7 +762,7 @@ function run_ytdl_hook(url)
         if (arg ~= "") then
             table.insert(command, arg)
         end
-        if (param == "sub-lang") and (arg ~= "") then
+        if (param == "sub-lang" or param == "sub-langs" or param == "srt-lang") and (arg ~= "") then
             allsubs = false
         elseif (param == "proxy") and (arg ~= "") then
             proxy = arg


### PR DESCRIPTION
`youtube-dl` and `yt-dlp` both support `--sub-langs` and `--srt-lang` in addition to `--sub-lang` for defining languages of subtitles.

This hook only checked for `sub-lang` in `--ytdl-raw-options` and inserted `--all-subs` in its absence.