### PR TITLE
stream_dvb: Add missing mutex unlock.

### DIFF
--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -1045,6 +1045,7 @@ static int dvb_open(stream_t *stream)
     }
 
     if (!dvb_parse_path(stream)) {
+        pthread_mutex_unlock(&global_dvb_state_lock);
         goto err_out;
     }
 


### PR DESCRIPTION
This deadlock was not triggered in real use since configuration
validity does not change at runtime.

closes #9459
