### PR TITLE
audio: stop corrupting audio on underreads

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -162,7 +162,8 @@ static int read_buffer(struct ao *ao, void **data, int samples, bool *eof)
 
     // pad with silence (underflow/paused/eof)
     for (int n = 0; n < ao->num_planes; n++) {
-        af_fill_silence((char *)data[n] + pos, (samples - pos) * ao->sstride,
+        af_fill_silence((char *)data[n] + pos * ao->sstride,
+                        (samples - pos) * ao->sstride,
                         ao->format);
     }
 


### PR DESCRIPTION
regression introduced in b74c09efbf7c6969fc053265f72cc0501b840ce1:

https://github.com/mpv-player/mpv/blob/e095bdb5f56c1f78c47d1e7583ebc95fc20ba16e/audio/out/buffer.c#L163-L166

this is obviously wrong, as you can compare to a memcpy just a few lines before in the same function:

https://github.com/mpv-player/mpv/blob/e095bdb5f56c1f78c47d1e7583ebc95fc20ba16e/audio/out/buffer.c#L145-L147

here's the original version pre-refactor:

https://github.com/mpv-player/mpv/blob/3a8abbee2fd25f9d137098cd4ed9f7cedf478fbd/audio/out/pull.c#L183-L185

probable root cause of #8381. maybe related to #9472 

this was most likely to cause issues when viewing live/network streams where audio data might not be readily available on every read, causing the underflow code to kick in. it sounds like crackling and popping when it happens since silence is randomly being overwritten onto valid audio data.