### PR TITLE
vo_gpu_next: remove vsync_offset usage

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -644,7 +644,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     if (!pl_swapchain_start_frame(p->sw, &swframe)) {
         // Advance the queue state to the current PTS to discard unused frames
         pl_queue_update(p->queue, NULL, &(struct pl_queue_params) {
-            .pts = frame->current->pts + frame->vsync_offset,
+            .pts = frame->current->pts,
             .radius = pl_frame_mix_radius(&p->params),
         });
         return;
@@ -684,7 +684,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     if (frame->current) {
         // Update queue state
         struct pl_queue_params qparams = {
-            .pts = frame->current->pts + frame->vsync_offset,
+            .pts = frame->current->pts,
             .radius = pl_frame_mix_radius(&p->params),
             .vsync_duration = frame->vsync_interval,
             .frame_duration = frame->ideal_frame_duration,


### PR DESCRIPTION
With a configuration that looks something like this:
```
vo=gpu-next
profile=gpu-hq
video-sync=display-resample
deband-iterations=10
```
start up mpv and you should be able to notice some dropped/delayed frames at the beginning. If you let it play for about 8-10 seconds it will "correct" itself and playback will be smooth. The stats will note something like 20-30 mistimed/delayed frames. The results may vary depending on your hardware of course and you may need to increase/decrease deband-iterations to see it. With vo=gpu, this behavior doesn't occur. There's the normal slight startup mistimings (like 4-5 frames) that are basically imperceptible.

I did some digging around, and I found that by simply removing this value, it fixes it. vo=gpu-next behaves exactly like vo=gpu does. I couldn't explain to you the technical reason why this works (beyond speculation), but vo_gpu_next is the only thing that uses `vsync_offset` in this manner so maybe it's better to just ignore it.
