### PR TITLE
vo_gpu: use interpolation-threshold on integer multiples

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,6 +27,10 @@ Interface changes
 ::
 
  --- mpv 0.35.0 ---
+    - `--interpolation-threshold` now applies as long as the display hz is
+      an integer multiple of the video fps instead of only being limited to
+      if the display hz and video fps were almost the same (i.e. an integer
+      multiple of 1).
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,
       `--interpolation-preserve` `--lut`, `--lut-type`, `--image-lut`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5242,12 +5242,15 @@ them.
 
 ``--interpolation-threshold=<0..1,-1>``
     Threshold below which frame ratio interpolation gets disabled (default:
-    ``0.01``). This is calculated as ``abs(disphz/vfps - 1) < threshold``,
-    where ``vfps`` is the speed-adjusted video FPS, and ``disphz`` the
-    display refresh rate. (The speed-adjusted video FPS is roughly equal to
-    the normal video FPS, but with slowdown and speedup applied. This matters
-    if you use ``--video-sync=display-resample`` to make video run synchronously
-    to the display FPS, or if you change the ``speed`` property.)
+    ``0.01``). This is calculated as ``abs(disphz/vfps - round(disphz/vfps))
+    < threshold``, where ``vfps`` is the speed-adjusted video FPS, and ``disphz``
+    the display refresh rate. ``round`` takes the ``disphz/vfps`` ratio to the
+    nearest integer so the threshold also operates if the display refresh rate
+    is an integer multiple of the video FPS (i.e. a 30 FPS video on a 60 Hz
+    display). The speed-adjusted video FPS is roughly equal to the normal video
+    FPS, but with slowdown and speedup applied. This matters if you use
+    ``--video-sync=display-resample`` to make video run synchronously to the
+    display FPS, or if you change the ``speed`` property.
 
     The default is intended to enable interpolation in scenarios where
     retiming with the ``--video-sync=display-*`` cannot adjust the speed of

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3277,7 +3277,8 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
                            (p->frames_drawn || !frame->still);
         if (interpolate) {
             double ratio = frame->ideal_frame_duration / frame->vsync_interval;
-            if (fabs(ratio - 1.0) < p->opts.interpolation_threshold)
+            int rounded_ratio = round(ratio);
+            if (fabs(ratio - rounded_ratio) < p->opts.interpolation_threshold)
                 interpolate = false;
         }
 


### PR DESCRIPTION
Currently, the --interpolation-threshold option only ever applies if the
vsync ratio is close to 1 (i.e. 60fps video on a 60hz display). This
changes the logic of interpolation-threshold to instead apply to the
nearest integer of the vsync ratio (i.e. 30fps video on a 60hz display
would disable the use of interpolation by default). -1 still disables
this threshold and always enables interpolation like before.

Alternative approach to #8934.

Edit: was suggested in IRC to use `abs(ratio - round(ratio) / ratio` instead. I'll update this later.