### PR TITLE
wayland: Check for egl 1.5 KHR platforms first

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -99,10 +99,13 @@ static bool egl_create_context(struct ra_ctx *ctx)
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
     struct vo_wayland_state *wl = ctx->vo->wl;
 
-    if (!(p->egl_display = mpegl_get_display(EGL_PLATFORM_WAYLAND_EXT,
-                                             "EGL_EXT_platform_wayland",
+    if (!(p->egl_display = mpegl_get_display(EGL_PLATFORM_WAYLAND_KHR,
+                                             "EGL_KHR_platform_wayland",
                                              wl->display)))
-        return false;
+        if (!(p->egl_display = mpegl_get_display(EGL_PLATFORM_WAYLAND_EXT,
+                                                 "EGL_EXT_platform_wayland",
+                                                 wl->display)))
+            return false;
 
     if (eglInitialize(p->egl_display, NULL, NULL) != EGL_TRUE)
         return false;

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -324,6 +324,8 @@ EGLDisplay mpegl_get_display(EGLenum platform, const char *platform_ext_name,
         return EGL_NO_DISPLAY;
 
     // Before we go through the EGL 1.4 BS, try if we can use native EGL 1.5
+    // only *_KHR platforms are defined for 1.5, but some drivers like mesa still work.
+    // However on platforms where this is broken they do not return an error either.
     if (is_egl15()) {
         // This is EGL 1.5. It must support querying standard functions through
         // eglGetProcAddress(). Note that on EGL 1.4, even if the function is


### PR DESCRIPTION
The existing mpegl_create_platform calls mix egl 1.5 KHR functions with
egl 1.4 EXT extensions platforms which can result in some drivers
getting confused and failing to attach pixel buffers to the window.

To avoid rewriting this to make it explicit which extension is being
used this change attempts to use the egl 1.5 extension first in
context_wayland.c which matches the priorities in egl_helpers.c and the
note about calling twice for the different platforms.

This resolves windows being black on wayland on nividia proprietary
drivers.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.