### PR TITLE
osc: fix cache displaying 60s in some cases

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2095,10 +2095,10 @@ function osc_init()
             dmx_cache = state.dmx_cache
         end
         local min = math.floor(dmx_cache / 60)
-        local sec = dmx_cache % 60
+        local sec = math.floor(dmx_cache % 60) -- don't round e.g. 59.9 to 60
         return "Cache: " .. (min > 0 and
             string.format("%sm%02.0fs", min, sec) or
-            string.format("%3.0fs", dmx_cache))
+            string.format("%3.0fs", sec))
     end
 
     -- volume


### PR DESCRIPTION
Previously, numbers like 59.9 could be stuck into the string.format method, resulting in lua rounding the number 59.9 to 60. A simple example that caused the bug: `string.format("%02.0f", 59.9)`.

Warning: This commit is untested.

Screenshot of bug:
![mpv_bug](https://user-images.githubusercontent.com/63090225/143610407-57161520-2436-4ccf-b875-2896d77af1f7.png)