### PR TITLE
opengl: Support DebugMessageCallback on ES

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -454,6 +454,17 @@ static const struct gl_functions gl_functions[] = {
             {0}
         },
     },
+    // ES version uses a different extension.
+    {
+        .ver_es_core = 320,
+        .extension = "GL_KHR_debug",
+        .provides = MPGL_CAP_DEBUG,
+        .functions = (const struct gl_function[]) {
+            // (only functions needed by us)
+            DEF_FN(DebugMessageCallback),
+            {0}
+        },
+    },
     // These don't exist - they are for the sake of mpv internals, and libmpv
     // interaction (see libmpv/opengl_cb.h).
     // This is not used by the render API, only the deprecated opengl-cb API.


### PR DESCRIPTION
This function is provided by a different extension on OpenGL ES so we
add a separate gl_functions.

ref: https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt tested locally on nvidia drivers. I'm not totally sure if this is the accepted way to handle functions with different extensions between gl and gles but it seems correct.

Signed-off-by: Kurt Kartaltepe <kkartaltepe@gmail.com>