### PR TITLE
wayland: ensure read and draw buffers are assigned

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -143,6 +143,7 @@ static const struct gl_functions gl_functions[] = {
         .ver_core = 210,
         .provides = MPGL_CAP_ROW_LENGTH | MPGL_CAP_1D_TEX,
         .functions = (const struct gl_function[]) {
+            DEF_FN(DrawBuffer),
             DEF_FN(GetTexLevelParameteriv),
             DEF_FN(ReadBuffer),
             DEF_FN(TexImage1D),

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -111,6 +111,7 @@ struct GL {
     void (GLAPIENTRY *ReadPixels)(GLint, GLint, GLsizei, GLsizei, GLenum,
                                   GLenum, GLvoid *);
     void (GLAPIENTRY *ReadBuffer)(GLenum);
+    void (GLAPIENTRY *DrawBuffer)(GLenum);
     void (GLAPIENTRY *DrawArrays)(GLenum, GLint, GLsizei);
     GLenum (GLAPIENTRY *GetError)(void);
     void (GLAPIENTRY *GetTexLevelParameteriv)(GLenum, GLint, GLenum, GLint *);

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -144,6 +144,13 @@ static void egl_create_window(struct ra_ctx *ctx)
     }
 
     eglMakeCurrent(p->egl_display, p->egl_surface, p->egl_surface, p->egl_context);
+    // eglMakeCurrent may not configure the draw or read buffers if the context
+    // has been made current previously. On nvidia GL_NONE is bound because EGL_NO_SURFACE
+    // is used initially and we must bind the read and draw buffers here.
+    if(!p->gl.es) {
+        p->gl.ReadBuffer(GL_BACK);
+        p->gl.DrawBuffer(GL_BACK);
+    }
 
     eglSwapInterval(p->egl_display, 0);
 }


### PR DESCRIPTION
This is a workaround for nvidia proprietary drivers. The authors of
those drivers interpret the spec such that eglMakeCurrent will not
reconfigure the read and draw buffers. Thus windows wont display
anything drawn by opengl. nvidia authors refer to
https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_no_config_context.txt
specifically Issues 2/3 which reference eglMakeCurrent.

On mesa this is a non-issue and the read/draw targets are assigned with
eglMakeCurrent.

The context must be made current in order to query OpenGL strings. An
earlier proposal to create the wayland window surface similarly to X11
during init was deemed inappropriate so instead we manually set the
targets once we have created a window surface.

I'm not very familiar with the opengl layer in mpv, so if there is a better 
place to add these gl specific calls at that layer instead of in the egl layer
that would be good too. Nvidia has provided patches related to this behavior
issue in [firefox](https://hg.mozilla.org/mozilla-central/rev/c2191ee9cb65) and [kwin](https://invent.kde.org/plasma/kwin/-/commit/d257850bd1815aae4d985fb0e24f8f10851c42da) for reference.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.