### PR TITLE
demux: also read "CUESHEET" tag from stream metadata

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3167,19 +3167,26 @@ void demux_update(demuxer_t *demuxer, double pts)
 
 static void demux_init_cuesheet(struct demuxer *demuxer)
 {
+    if (demuxer->num_chapters)
+        return;
+
+    struct sh_stream *sh = demuxer->in->metadata_stream;
     char *cue = mp_tags_get_str(demuxer->metadata, "cuesheet");
-    if (cue && !demuxer->num_chapters) {
-        struct cue_file *f = mp_parse_cue(bstr0(cue));
-        if (f) {
-            if (mp_check_embedded_cue(f) < 0) {
-                MP_WARN(demuxer, "Embedded cue sheet references more than one file. "
-                        "Ignoring it.\n");
-            } else {
-                for (int n = 0; n < f->num_tracks; n++) {
-                    struct cue_track *t = &f->tracks[n];
-                    int idx = demuxer_add_chapter(demuxer, "", t->start, -1);
-                    mp_tags_merge(demuxer->chapters[idx].metadata, t->tags);
-                }
+    if (!cue && sh)
+        cue = mp_tags_get_str(sh->tags, "cuesheet");
+    if (!cue)
+        return;
+
+    struct cue_file *f = mp_parse_cue(bstr0(cue));
+    if (f) {
+        if (mp_check_embedded_cue(f) < 0) {
+            MP_WARN(demuxer, "Embedded cue sheet references more than one file. "
+                    "Ignoring it.\n");
+        } else {
+            for (int n = 0; n < f->num_tracks; n++) {
+                struct cue_track *t = &f->tracks[n];
+                int idx = demuxer_add_chapter(demuxer, "", t->start, -1);
+                mp_tags_merge(demuxer->chapters[idx].metadata, t->tags);
             }
         }
         talloc_free(f);


### PR DESCRIPTION
After transcoding an mp3 file with an embedded cue sheet to opus, I discovered, that mpv only reads the "CUESHEET" tag from format-level metadata. With this PR, `demux_init_cuesheet` also reads a stream-level "CUESHEET" tag, if the former read fails.

I have zero familiarity with the mpv code base, and while this works, someone should verify, that reading from field `.metadata_stream` in `struct demux_internal` is the correct fix.

------------

Read embedded cue sheets from stream-level metadata, in addition to
format-level metadata.

Fixes missing chapters in opus files with "CUESHEET" tags.
