### PR TITLE
vo/gpu/opengl: try and make compute shaders work with GLES

### DIFF
--- a/video/out/gpu/error_diffusion.c
+++ b/video/out/gpu/error_diffusion.c
@@ -110,7 +110,7 @@ void pass_error_diffusion(struct gl_shader_cache *sc,
     // Initialize the ring buffer.
     GLSL("for (int i = int(gl_LocalInvocationIndex); i < %d; i += %d) ",
          ring_buffer_size, block_size);
-    GLSL("err_rgb8[i] = 0;\n");
+    GLSL("err_rgb8[i] = 0u;\n");
 
     GLSL("for (int block_id = 0; block_id < %d; ++block_id) {\n", blocks);
 
@@ -170,7 +170,7 @@ void pass_error_diffusion(struct gl_shader_cache *sc,
          "int((err_u32 >> %d) & 255u) - 128,"
          "int( err_u32        & 255u) - 128"
          ") / %d.0;\n", dither_quant, bitshift_r, bitshift_g, uint8_mul);
-    GLSL("err_rgb8[idx] = 0;\n");
+    GLSL("err_rgb8[idx] = 0u;\n");
 
     // Write the dithered pixel.
     GLSL("vec3 dithered = round(pix);\n");

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -783,8 +783,10 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
     if (glsl_es) {
         ADD(header, "#ifdef GL_FRAGMENT_PRECISION_HIGH\n");
         ADD(header, "precision highp float;\n");
+        ADD(header, "precision highp image2D;\n");
         ADD(header, "#else\n");
         ADD(header, "precision mediump float;\n");
+        ADD(header, "precision mediump image2D;\n");
         ADD(header, "#endif\n");
         
         ADD(header, "precision mediump sampler2D;\n");

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2698,9 +2698,12 @@ static void pass_dither(struct gl_video *p)
 
             struct image img = image_wrap(p->error_diffusion_tex[0], PLANE_RGB, p->components);
 
-            // 1024 is minimal required number of invocation allowed in single
-            // work group in OpenGL. Use it for maximal performance.
-            int block_size = MPMIN(1024, o_h);
+            // Ensure the block size doesn't exceed the minimum defined by the
+            // specification (1024 in desktop GL, 128 in GLES).
+            // TODO: Look up the actual maximum block size for the
+            // implementation using:
+            //     glGetIntegerv(MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &value);
+            int block_size = MPMIN(p->ra->glsl_es ? 128 : 1024, o_h);
 
             pass_describe(p, "dither=error-diffusion (kernel=%s, depth=%d)",
                              kernel->name, dst_depth);

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -609,7 +609,7 @@ static void hdr_update_peak(struct gl_shader_cache *sc,
     // pixel using shared memory first
     GLSLH(shared int wg_sum;)
     GLSLH(shared uint wg_max;)
-    GLSL(wg_sum = 0; wg_max = 0;)
+    GLSL(wg_sum = 0; wg_max = 0u;)
     GLSL(barrier();)
     GLSLF("float sig_log = log(max(sig_max, %f));\n", log_min);
     GLSLF("atomicAdd(wg_sum, int(sig_log * %f));\n", log_scale);
@@ -618,7 +618,7 @@ static void hdr_update_peak(struct gl_shader_cache *sc,
     // Have one thread per work group update the global atomics
     GLSL(memoryBarrierShared();)
     GLSL(barrier();)
-    GLSL(if (gl_LocalInvocationIndex == 0) {)
+    GLSL(if (gl_LocalInvocationIndex == 0u) {)
     GLSL(    int wg_avg = wg_sum / int(gl_WorkGroupSize.x * gl_WorkGroupSize.y);)
     GLSL(    atomicAdd(frame_sum, wg_avg);)
     GLSL(    atomicMax(frame_max, wg_max);)
@@ -628,8 +628,8 @@ static void hdr_update_peak(struct gl_shader_cache *sc,
 
     // Finally, to update the global state, we increment a counter per dispatch
     GLSL(uint num_wg = gl_NumWorkGroups.x * gl_NumWorkGroups.y;)
-    GLSL(if (gl_LocalInvocationIndex == 0 && atomicAdd(counter, 1) == num_wg - 1) {)
-    GLSL(    counter = 0;)
+    GLSL(if (gl_LocalInvocationIndex == 0u && atomicAdd(counter, 1u) == num_wg - 1u) {)
+    GLSL(    counter = 0u;)
     GLSL(    vec2 cur = vec2(float(frame_sum) / float(num_wg), frame_max);)
     GLSLF("  cur *= vec2(1.0/%f, 1.0/%f);\n", log_scale, sig_scale);
     GLSL(    cur.x = exp(cur.x);)
@@ -650,7 +650,7 @@ static void hdr_update_peak(struct gl_shader_cache *sc,
     GLSL(    average = mix(average, cur, weight);)
 
     // Reset SSBO state for the next frame
-    GLSL(    frame_sum = 0; frame_max = 0;)
+    GLSL(    frame_sum = 0; frame_max = 0u;)
     GLSL(    memoryBarrierBuffer();)
     GLSL(})
 }

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -308,6 +308,7 @@ static const struct gl_functions gl_functions[] = {
     },
     {
         .ver_core = 430,
+        .extension = "GL_ARB_invalidate_subdata",
         .functions = (const struct gl_function[]) {
             DEF_FN(InvalidateTexImage),
             {0}
@@ -339,8 +340,17 @@ static const struct gl_functions gl_functions[] = {
             {0}
         },
     },
+    // Equivalent extension for ES
+    {
+        .extension = "GL_EXT_buffer_storage",
+        .functions = (const struct gl_function[]) {
+            DEF_FN_NAME(BufferStorage, "glBufferStorageEXT"),
+            {0}
+        },
+    },
     {
         .ver_core = 420,
+        .ver_es_core = 310,
         .extension = "GL_ARB_shader_image_load_store",
         .functions = (const struct gl_function[]) {
             DEF_FN(BindImageTexture),
@@ -350,16 +360,19 @@ static const struct gl_functions gl_functions[] = {
     },
     {
         .ver_core = 310,
+        .ver_es_core = 300,
         .extension = "GL_ARB_uniform_buffer_object",
         .provides = MPGL_CAP_UBO,
     },
     {
         .ver_core = 430,
+        .ver_es_core = 310,
         .extension = "GL_ARB_shader_storage_buffer_object",
         .provides = MPGL_CAP_SSBO,
     },
     {
         .ver_core = 430,
+        .ver_es_core = 310,
         .extension = "GL_ARB_compute_shader",
         .functions = (const struct gl_function[]) {
             DEF_FN(DispatchCompute),
@@ -638,7 +651,7 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
         if (gl->es >= 200)
             gl->glsl_version = 100;
         if (gl->es >= 300)
-            gl->glsl_version = 300;
+            gl->glsl_version = gl->es;
     } else {
         gl->glsl_version = 120;
         int glsl_major = 0, glsl_minor = 0;


### PR DESCRIPTION
It's supposed to work with GLES >= 3.1 but we had all sorts of bad
assumptions in our version handling, and then our compute shader
isn't GLSL-ES compliant.

Still doesn't work. Fails with:

[vo/gpu/opengl] after dispatching compute shader: OpenGL error INVALID_OPERATION.