### PR TITLE
vo_gpu: opengl: try and create context at version 440 again

### DIFF
--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -23,6 +23,15 @@
 // 0-terminated list of desktop GL versions a backend should try to
 // initialize. Each entry is the minimum required version.
 const int mpgl_min_required_gl_versions[] = {
+    /*
+     * Nvidia drivers will not provide the highest supported version
+     * when 320 core is requested. Instead, it just returns 3.2. This
+     * would be bad, as we actually want compute shaders that require
+     * 4.2, so we have to request a sufficiently high version. We use
+     * 440 to maximise driver compatibility as we don't need anything
+     * from newer versions.
+     */
+    440,
     320,
     210,
     0


### PR DESCRIPTION
vo_gpu: opengl: try and create context at version 440 again

nvidia follow the OpenGL spec very strictly, with two particular
consequences:

* They will give you the exact context version that you ask for,
  rather than the highest possible version that meets your request.
* They will hide extensions that the specs say require a higher
  version than you request, even if it's technically possible to
  provide the extension at lower versions.

In our case, we really want a variety of extensions, particularly
compute shaders that are only available in 4.2 or higher. That means
that we must explicitly include a high enough version in our list of
versions to check for us to be able to get a 'good' enough context.

As for which version? We restore the 4.4 version that we had in the
old version selection logic. This is the highest version we ever asked
for, and we have separate logic that clamps the GLSL version to 4.4,
so anything newer wouldn't make a difference.