### PR TITLE
sub/lavc_conv: only set subtitle text format when required

### DIFF
--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -83,7 +83,10 @@ struct lavc_conv *lavc_conv_create(struct mp_log *log, const char *codec_name,
         goto error;
     if (mp_lavc_set_extradata(avctx, extradata, extradata_len) < 0)
         goto error;
+
+#if LIBAVCODEC_VERSION_MAJOR < 59
     av_dict_set(&opts, "sub_text_format", "ass", 0);
+#endif
     av_dict_set(&opts, "flags2", "+ass_ro_flush_noop", 0);
     if (strcmp(codec_name, "eia_608") == 0)
         av_dict_set(&opts, "real_time", "1", 0);


### PR DESCRIPTION
Since libavcodec major version 59, the requested "ass" format became
the default as the old timing-included format was disabled starting
with that version. Additionally, this option by itself has since
been deprecated as it no longer serves any purpose.

References:
FFmpeg/FFmpeg@1f63665ca567fbc49fa80166d468a822c2999efa
FFmpeg/FFmpeg@176b8d785bf7531b6eb8e3d6e8c03f75cb29de1e

Fixes #9413