### PR TITLE
Replace some deprecated av_init_packet() calls

### DIFF
--- a/audio/filter/af_lavcac3enc.c
+++ b/audio/filter/af_lavcac3enc.c
@@ -47,7 +47,7 @@
 #define AC3_MAX_CHANNELS 6
 #define AC3_MAX_CODED_FRAME_SIZE 3840
 #define AC3_FRAME_SIZE (6  * 256)
-const uint16_t ac3_bitrate_tab[19] = {
+const static uint16_t ac3_bitrate_tab[19] = {
     32, 40, 48, 56, 64, 80, 96, 112, 128,
     160, 192, 224, 256, 320, 384, 448, 512, 576, 640
 };
@@ -306,7 +306,7 @@ static struct mp_filter *af_lavcac3enc_create(struct mp_filter *parent,
     if (mp_set_avopts(f->log, s->lavc_actx, s->opts->avopts) < 0)
         goto error;
 
-    // For this one, we require the decoder to expert lists of all supported
+    // For this one, we require the decoder to export lists of all supported
     // parameters. (Not all decoders do that, but the ones we're interested
     // in do.)
     if (!s->lavc_acodec->sample_fmts ||
@@ -366,6 +366,7 @@ static struct mp_filter *af_lavcac3enc_create(struct mp_filter *parent,
 
 error:
     av_packet_free(&s->lavc_pkt);
+    avcodec_free_context(&s->lavc_actx);
     talloc_free(f);
     return NULL;
 }

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -731,6 +731,7 @@ static void encoder_destroy(void *ptr)
 {
     struct encoder_context *p = ptr;
 
+    av_packet_free(&p->pkt);
     avcodec_free_context(&p->encoder);
     free_stream(p->twopass_bytebuffer);
 }
@@ -910,6 +911,9 @@ bool encoder_init_codec_and_muxer(struct encoder_context *p,
     if (avcodec_parameters_from_context(p->info.codecpar, p->encoder) < 0)
         goto fail;
 
+    p->pkt = av_packet_alloc();
+    MP_HANDLE_OOM(p->pkt);
+
     encode_lavc_add_stream(p, p->encode_lavc_ctx, &p->info, on_ready, ctx);
     if (!p->mux_stream)
         goto fail;
@@ -930,11 +934,9 @@ bool encoder_encode(struct encoder_context *p, AVFrame *frame)
         goto fail;
     }
 
+    AVPacket *packet = p->pkt;
     for (;;) {
-        AVPacket packet = {0};
-        av_init_packet(&packet);
-
-        status = avcodec_receive_packet(p->encoder, &packet);
+        status = avcodec_receive_packet(p->encoder, packet);
         if (status == AVERROR(EAGAIN))
             break;
         if (status < 0 && status != AVERROR_EOF)
@@ -948,7 +950,7 @@ bool encoder_encode(struct encoder_context *p, AVFrame *frame)
         if (status == AVERROR_EOF)
             break;
 
-        encode_lavc_add_packet(p->mux_stream, &packet);
+        encode_lavc_add_packet(p->mux_stream, packet);
     }
 
     return true;

--- a/common/encode_lavc.h
+++ b/common/encode_lavc.h
@@ -83,7 +83,9 @@ struct encoder_context {
     AVCodecContext *encoder;
     struct mux_stream *mux_stream;
 
+    // (essentially private)
     struct stream *twopass_bytebuffer;
+    AVPacket *pkt;
 };
 
 // Free with talloc_free(). (Keep in mind actual deinitialization requires


### PR DESCRIPTION
This extracts the parts from #8698 that can be done without touching `mp_set_av_packet`. Made sure to include error handling and avoid repeated allocations this time.