### PR TITLE
meson: look for rst2man.py as well as rst2man

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1631,7 +1631,7 @@ endif
 
 # manpages
 manpage = 'DOCS/man/mpv.rst'
-rst2man = find_program('rst2man', required: get_option('manpage-build'))
+rst2man = find_program('rst2man', 'rst2man.py', required: get_option('manpage-build'))
 if rst2man.found()
     features += 'manpage-build'
     mandir = get_option('mandir')


### PR DESCRIPTION
If you install docutils with pip in the default way, you will get a
script called `rst2man.py` rather than `rst2man`, so look for both
names.