### PR TITLE
wayland: avoid doing unneccesary window resizes

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -649,9 +649,6 @@ static void output_handle_done(void* data, struct wl_output *wl_output)
         set_surface_scaling(wl);
         spawn_cursor(wl);
         set_geometry(wl);
-        wl->window_size = wl->vdparams;
-        if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
-            wl->geometry = wl->window_size;
         wl->pending_vo_events |= VO_EVENT_DPI;
         wl->pending_vo_events |= VO_EVENT_RESIZE;
     }
@@ -707,12 +704,8 @@ static void surface_handle_enter(void *data, struct wl_surface *wl_surface,
 
     if (!mp_rect_equals(&old_output_geometry, &wl->current_output->geometry)) {
         set_geometry(wl);
-        wl->window_size = wl->vdparams;
         force_resize = true;
     }
-
-    if (!wl->vo_opts->fullscreen && !wl->vo_opts->window_maximized)
-        wl->geometry = wl->window_size;
 
     if (!mp_rect_equals(&old_geometry, &wl->geometry) || force_resize)
         wl->pending_vo_events |= VO_EVENT_RESIZE;


### PR DESCRIPTION
Commits 04018c306196888861775b248a8596ae494f122b
cd7a7a1de8d8bffa05170befef25b251711c994a introduced behavior that
updated window geometry during wayland events (specifically surface and
output). This is good but they also are too aggressive with
automatically resizing. For example, if a window is manually resized by
the user and then dragged to a different monitor with different geometry
than the initial monitor, mpv will automatically resize itself to the
window's resolution. The initial thought behind this logic was for
autofit to automatically readjust itself on a new monitor, but doing
that breaks other common use cases. An attempt could be made to
distinguish between autofit and a manual resize but that introduces a
lot of complexity for an edge case. It's better to simply not change the
window geometry here. Internal values are recalculated and scaled of
course, but wl->window_size and wl->geometry should not change.

Fixes #9599.