### PR TITLE
meson: remove unneccesary shaderc_static check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -997,7 +997,7 @@ if sdl2_video.allowed()
     sources += files('video/out/vo_sdl.c')
 endif
 
-shaderc = dependency('shaderc', 'shaderc_static', required: get_option('shaderc'))
+shaderc = dependency('shaderc', required: get_option('shaderc'))
 if shaderc.found()
     dependencies += shaderc
     features += shaderc.name()


### PR DESCRIPTION
shaderc is a special case dependency in meson. According to the
documentation*, it first checks for shaderc_shared and will fallback to
shaderc_combined (the order is reversed if the static keyword is true).
However, shaderc also has a third .pc file (shaderc_static) which should
be checked. The meson documentation doesn't indicate this, but it also
actually checks shaderc_shared*. shaderc_combined is first checked if
meson looks for static libs and if that is not found it tries
shaderc_shared. So this extra fallback check is not needed.

*: https://mesonbuild.com/Dependencies.html#shaderc
*: https://github.com/mesonbuild/meson/blob/a2934ca9d13ede4eb97b320bc768319ecad7b525/mesonbuild/dependencies/misc.py#L539