### PR TITLE
lua: do not set metatable for empty arrays/maps

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -874,8 +874,10 @@ static void pushnode(lua_State *L, mpv_node *node)
         break;
     case MPV_FORMAT_NODE_ARRAY:
         lua_newtable(L); // table
-        lua_getfield(L, LUA_REGISTRYINDEX, "ARRAY"); // table mt
-        lua_setmetatable(L, -2); // table
+        if (node->u.list->num) {
+            lua_getfield(L, LUA_REGISTRYINDEX, "ARRAY"); // table mt
+            lua_setmetatable(L, -2); // table
+        }
         for (int n = 0; n < node->u.list->num; n++) {
             pushnode(L, &node->u.list->values[n]); // table value
             lua_rawseti(L, -2, n + 1); // table
@@ -883,8 +885,10 @@ static void pushnode(lua_State *L, mpv_node *node)
         break;
     case MPV_FORMAT_NODE_MAP:
         lua_newtable(L); // table
-        lua_getfield(L, LUA_REGISTRYINDEX, "MAP"); // table mt
-        lua_setmetatable(L, -2); // table
+        if (node->u.list->num) {
+            lua_getfield(L, LUA_REGISTRYINDEX, "MAP"); // table mt
+            lua_setmetatable(L, -2); // table
+        }
         for (int n = 0; n < node->u.list->num; n++) {
             lua_pushstring(L, node->u.list->keys[n]); // table key
             pushnode(L, &node->u.list->values[n]); // table key value


### PR DESCRIPTION
```
Lua has only tables, which function as arrays and maps. In makenode(), mpv has
to probe the tables and decide whether it is an MPV_FORMAT_ARRAY or MPV_FORMAT_MAP.
In case of an empty table, array is assumed. Alternatively, if the table has
been assigned one of mpv's format metatables, as in pushnode(), the probe can
be skipped.

A bug appears. If the user modifies tables mpv has returned in a manner that
doesn't fit the assigned array/map and passes them back to mpv, an array-table
will have its non-index keys ignored. Map-tables are not particularly affected,
since non-string map keys are already illegal and raise an error.
Easy way to trip into this is to serialize an empty table with utils.format_json()
into assumed "[]", and later parsing that into a table. The table is now tagged as
an array, and modifications to its fields are ignored if again serialized.

This commit has pushnode() only setting the metatable for non-empty arrays/maps,
resolving the empty-array lock-in.
It is still possible to err and misuse the tagged tables (say, clearing an
array-table and attempting to reuse it as a map), but that should be much
more rare, and we can still get a small performance benefit in the cases
where data is passed back and forth between Lua and mpv.

Fixes #9655
```

Omitting the metatable is also a possibility, but as noted in commit, we can get some performance gain by using it.
Ignoring the metatable in `makenode()` is technically another possible action, but there's little point in having the metatable set and not using it on mpv side - Lua scripts won't benefit from it, as inspection is rarely necessary. We have documentation for the command results, and for specifics, the source code, so knowing whether that empty table is *really* an array or a map doesn't matter. Table's a table.