### PR TITLE
Fix typos

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -326,7 +326,7 @@ Interface changes
       (such as "sub-file"), deprecated in mpv 0.26.0
     - deprecate the old command based hook API, and introduce a proper C API
       (the high level Lua API for this does not change)
-    - rename the the lua-settings/ config directory to script-opts/
+    - rename the lua-settings/ config directory to script-opts/
     - the way the player waits for scripts getting loaded changes slightly. Now
       scripts are loaded in parallel, and block the player from continuing
       playback only in the player initialization phase. It could change again in

--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -119,5 +119,5 @@ You can encode files from one format/codec to another using this facility.
     .. admonition:: Example
 
         "``--oremove-metadata=comment,genre``"
-            excludes copying of the the comment and genre tags to the output
+            excludes copying of the comment and genre tags to the output
             file.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -531,7 +531,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
 ``subprocess``
     Similar to ``run``, but gives more control about process execution to the
-    caller, and does does not detach the process.
+    caller, and does not detach the process.
 
     You can avoid blocking until the process terminates by running this command
     asynchronously. (For example ``mp.command_native_async()`` in Lua scripting.)
@@ -1636,7 +1636,7 @@ The following hooks are currently defined:
     Ordered after ``start-file`` and before ``playback-restart``.
 
 ``on_load_fail``
-    Called after after a file has been opened, but failed to. This can be
+    Called after a file has been opened, but failed to. This can be
     used to provide a fallback in case native demuxers failed to recognize
     the file, instead of always running before the native demuxers like
     ``on_load``. Demux will only be retried if ``stream-open-filename``

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -529,7 +529,7 @@ Suffix        Meaning
 -clr          Clear the option (remove all items)
 -remove       Delete item if present (does not interpret escapes)
 -del          Delete 1 or more items by integer index (deprecated)
--toggle       Append an item, or remove if if it already exists (no escapes)
+-toggle       Append an item, or remove it if it already exists (no escapes)
 ============= ===============================================
 
 ``-append`` is meant as a simple way to append a single item without having
@@ -580,7 +580,7 @@ Suffix        Meaning
 -clr          Clear the option (remove all filters)
 -remove       Delete filter if present
 -del          Delete 1 or more filters by integer index or filter label (deprecated)
--toggle       Append a filter, or remove if if it already exists
+-toggle       Append a filter, or remove it if it already exists
 -help         Pseudo operation that prints a help text to the terminal
 ============= ===============================================
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1532,7 +1532,7 @@ Video
     video will be either cut off, or black bars are added.
 
     This value is multiplied with the value derived from ``--video-zoom`` and
-    the normal video aspect aspect ratio. This option is disabled if the
+    the normal video aspect ratio. This option is disabled if the
     ``--no-keepaspect`` option is used.
 
 ``--video-align-x=<-1-1>``, ``--video-align-y=<-1-1>``
@@ -4423,7 +4423,7 @@ Software Scaler
         a and b are the bicubic b and c parameters.
 
 ``--zimg-scaler-chroma=...``
-    Same as ``--zimg-scaler``, for for chroma interpolation (default: bilinear).
+    Same as ``--zimg-scaler``, for chroma interpolation (default: bilinear).
 
 ``--zimg-scaler-chroma-param-a``, ``--zimg-scaler-chroma-param-b``
     Same as ``--zimg-scaler-param-a`` / ``--zimg-scaler-param-b``, for chroma.
@@ -4484,7 +4484,7 @@ It also sets the defaults for the ``lavrresample`` audio filter.
 
 ``--audio-resample-max-output-size=<length>``
     Limit maximum size of audio frames filtered at once, in ms (default: 40).
-    The output size size is limited in order to make resample speed changes
+    The output size is limited in order to make resample speed changes
     react faster. This is necessary especially if decoders or filters output
     very large frame sizes (like some lossless codecs or some DRC filters).
     This option does not affect the resampling algorithm in any way.
@@ -6027,7 +6027,7 @@ them.
 
 ``--macos-geometry-calculation=<visible|whole>``
     This changes the rectangle which is used to calculate the screen position
-    and size of the window (default: visible). ``visible`` takes the the menu
+    and size of the window (default: visible). ``visible`` takes the menu
     bar and Dock into account and the window is only positioned/sized within the
     visible screen frame rectangle, ``whole`` takes the whole screen frame
     rectangle and ignores the menu bar and Dock. Other previous restrictions

--- a/DOCS/tech-overview.txt
+++ b/DOCS/tech-overview.txt
@@ -377,7 +377,7 @@ without causing conflicts with other library users in the same process. To any
 piece of code, a "safe" library's API can simply be used, without having to
 worry about other API users that may be around somewhere.
 
-Libraries are often not library safe, because they they use global mutable state
+Libraries are often not library safe, because they use global mutable state
 or other "global" resources. Typical examples include use of signals, simple
 global variables (like hsearch() in libc), or internal caches not protected by
 locks.
@@ -481,7 +481,7 @@ VOs, AOs, demuxers, and more. The frontend usually calls "down" the usage
 hierarchy: mpctx almost on top, then things like vo/ao, and utility code on the
 very bottom.
 
-"Callback hell" is when when components call both up and down the hierarchy,
+"Callback hell" is when components call both up and down the hierarchy,
 which for example leads to accidentally recursion, reentrancy problems, or
 locking nightmares. This is avoided by (mostly) calling only down the hierarchy.
 Basically the call graph forms a DAG. The other direction is handled by event

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -1803,7 +1803,7 @@ MPV_EXPORT int mpv_hook_add(mpv_handle *ctx, uint64_t reply_userdata,
  * Respond to a MPV_EVENT_HOOK event. You must call this after you have handled
  * the event. There is no way to "cancel" or "stop" the hook.
  *
- * Calling this will will typically unblock the player for whatever the hook
+ * Calling this will typically unblock the player for whatever the hook
  * is responsible for (e.g. for the "on_load" hook it lets it continue
  * playback).
  *

--- a/options/parse_configfile.c
+++ b/options/parse_configfile.c
@@ -179,7 +179,7 @@ static bstr read_file(struct mp_log *log, const char *filename)
     MP_ASSERT_UNREACHABLE();
 }
 
-// Load options and profiles from from a config file.
+// Load options and profiles from a config file.
 //  conffile: path to the config file
 //  initial_section: default section where to add normal options
 //  flags: M_SETOPT_* bits

--- a/player/lua.c
+++ b/player/lua.c
@@ -345,7 +345,7 @@ static void fuck_lua(lua_State *L, const char *search_path, const char *extra)
     // Unbelievable but true: Lua loads .lua files AND dynamic libraries from
     // the working directory. This is highly security relevant.
     // Lua scripts are still supposed to load globally installed libraries, so
-    // try to get by by filtering out any relative paths.
+    // try to get them by filtering out any relative paths.
     while (path.len) {
         bstr item;
         bstr_split_tok(path, ";", &item, &path);

--- a/test/gl_video.c
+++ b/test/gl_video.c
@@ -17,7 +17,7 @@ static void run(struct test_ctx *ctx)
     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 0.0);
     assert_float_equal(x, 2.40f, FLT_EPSILON);
 
-    // 32 corresponds to the the midpoint after converting lux to the log10 scale
+    // 32 corresponds to the midpoint after converting lux to the log10 scale
     x = gl_video_scale_ambient_lux(16.0, 64.0, 2.40, 1.961, 32.0);
     float mid_gamma = (2.40 - 1.961) / 2 + 1.961;
     assert_float_equal(x, mid_gamma, FLT_EPSILON);

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -57,7 +57,7 @@ struct ra_hwdec_mapper_driver {
     void (*uninit)(struct ra_hwdec_mapper *mapper);
 
     // Map mapper->src as texture, and set mapper->frame to textures using it.
-    // It is expected that that the textures remain valid until the next unmap
+    // It is expected that the textures remain valid until the next unmap
     // or uninit call.
     // The function is allowed to unref mapper->src if it's not needed (i.e.
     // this function creates a copy).

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1171,7 +1171,7 @@ static void pass_is_compute(struct gl_video *p, int bw, int bh, bool flexible)
 }
 
 // w/h: the width/height of the compute shader's operating domain (e.g. the
-// target target that needs to be written, or the source texture that needs to
+// target that needs to be written, or the source texture that needs to
 // be reduced)
 static void dispatch_compute(struct gl_video *p, int w, int h,
                              struct compute_info info)
@@ -3195,7 +3195,7 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
         }
 
         if (oversample) {
-            // Oversample uses the frame area as mix ratio, not the the vsync
+            // Oversample uses the frame area as mix ratio, not the vsync
             // position itself
             double vsync_dist = t->vsync_interval / t->ideal_frame_duration,
                    threshold = tscale->conf.kernel.params[0];

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -392,7 +392,7 @@ void pass_linearize(struct gl_shader_cache *sc, enum mp_csp_trc trc)
               "             / (vec3(%f) - vec3(%f) * color.rgb);\n",
               PQ_C1, PQ_C2, PQ_C3);
         GLSLF("color.rgb = pow(color.rgb, vec3(%f));\n", 1.0 / PQ_M1);
-        // PQ's output range is 0-10000, but we need it to be relative to to
+        // PQ's output range is 0-10000, but we need it to be relative to
         // MP_REF_WHITE instead, so rescale
         GLSLF("color.rgb *= vec3(%f);\n", 10000 / MP_REF_WHITE);
         break;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2068,7 +2068,7 @@ static void set_screensaver(struct vo_x11_state *x11, bool enabled)
         CARD16 state;
         DPMSInfo(mDisplay, &state, &onoff);
         if (!x11->dpms_touched && enabled)
-            return; // enable DPMS only we we disabled it before
+            return; // enable DPMS only if we disabled it before
         if (enabled != !!onoff) {
             MP_VERBOSE(x11, "Setting DMPS: %s.\n", enabled ? "on" : "off");
             if (enabled) {


### PR DESCRIPTION
After noticing repeated words in the manual, I used the following command to track down similar typos.

``` sh
rg --pcre2 '\b(\w+) \1\b'
```