### PR TITLE
Meson CI updates/cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./bootstrap.py
-          # TODO: switch back to zypper when OpenSuse updates Meson
-          # zypper -n install meson
-          zypper -n install python3-pip
-          pip install --no-input meson ninja
+          zypper -n install meson
 
       - name: Build with meson
         run: |
@@ -166,6 +163,7 @@ jobs:
                 libplacebo \
                 libxkbcommon \
                 luajit \
+                meson \
                 openal-soft \
                 pkgconf \
                 python3 \
@@ -190,8 +188,5 @@ jobs:
                 uchardet \
                 v4l_compat \
                 #
-            # Meson from pkg is too old
-            python3 -m ensurepip
-            pip3 install --no-input meson ninja
         run: |
           ./ci/build-freebsd.sh

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('mpv',
         'c',
         license: ['GPL2+', 'LGPL2.1+'],
         version: files('./VERSION'),
-        meson_version: '>=0.60.0',
+        meson_version: '>=0.60.3',
         default_options: [
             'buildtype=debugoptimized',
             'b_lundef=false',
@@ -639,15 +639,7 @@ if dvdnav.found() and dvdread.found()
     sources += files('stream/stream_dvdnav.c')
 endif
 
-#TODO: remove this crap one day.
-#Freebsd requires 0.60.2 or up to work without specifying the method.
-#Windows breaks on exactly 0.60.2 (will have to wait for 0.60.3).
-if host_machine.system() == 'freebsd' or host_machine.system() == 'windows'
-    iconv_method = 'system'
-else
-    iconv_method = 'auto'
-endif
-iconv = dependency('iconv', method: iconv_method, required: get_option('iconv'))
+iconv = dependency('iconv', required: get_option('iconv'))
 if iconv.found()
     dependencies += iconv
     features += 'iconv'


### PR DESCRIPTION
I happened to look around at some distros and it looks like a lot of people are up to date on meson versions now which is good. The first commit drops some pip3 calls in the github workflows and instead just uses the OS package manager to fetch meson since it's now new enough. The second commit removes some iconv workaround crap and as a result updates the required meson version to 0.60.3. I know bumping the required version to something that came out a little more than two weeks ago doesn't look nice, but for whatever reason, more distros are on 0.60.3 now than were on 0.60.0 when meson support was initially merged. I don't anticipate bumping the required meson version anytime in the near future, so I think 0.60.3 will be the requirement for a very long time.

Edit: Looks like opensuse's mirrors haven't synced yet. I'll give it a few hours.