### PR TITLE
DOCS: fix typo in options_subtitles

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2747,7 +2747,7 @@ Subtitles
 ``--sub-justify=<auto|left|center|right>``
     Control how multi line subs are justified irrespective of where they
     are aligned (default: ``auto`` which justifies as defined by
-    ``--sub-align-y``).
+    ``--sub-align-x``).
     Left justification is recommended to make the subs easier to read
     as it is easier for the eyes.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2681,12 +2681,6 @@ Subtitles
 ``--sub-border-color=<color>``
     See ``--sub-color``. Color used for the sub font border.
 
-    .. note::
-
-        ignored when ``--sub-back-color`` is
-        specified (or more exactly: when that option is not set to completely
-        transparent).
-
 ``--sub-border-size=<size>``
     Size of the sub font border in scaled pixels (see ``--sub-font-size``
     for details). A value of 0 disables borders.
@@ -2764,6 +2758,12 @@ Subtitles
 
 ``--sub-shadow-color=<color>``
     See ``--sub-color``. Color used for sub text shadow.
+
+    .. note::
+
+        ignored when ``--sub-back-color`` is
+        specified (or more exactly: when that option is not set to completely
+        transparent).
 
 ``--sub-shadow-offset=<size>``
     Displacement of the sub text shadow in scaled pixels (see


### PR DESCRIPTION
move the incorrect description of --sub-border-color to --sub-shadow-color
a tiny fix typo in --sub-justify