### PR TITLE
player: add thd (TrueHD) to whitelist of audio extensions

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -39,7 +39,7 @@ static const char *const sub_exts[] = {"utf", "utf8", "utf-8", "idx", "sub",
 
 static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",
                                          "ogg", "m4a", "ac3", "opus", "wav",
-                                         "wv", "eac3",
+                                         "wv", "eac3", "thd",
                                          NULL};
 
 static const char *const image_exts[] = {"jpg", "jpeg", "png", "gif", "bmp",


### PR DESCRIPTION
mpv works fine with such audio when extension is changed to something already supported like "ac3".