### PR TITLE
options: only apply sub-visibility to primary subs

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -39,6 +39,7 @@ Interface changes
     - add `--tone-mapping-mode`, replacing `--tone-mapping-desaturate` and
       `--tone-mapping-desaturate-exponent`.
     - add `dolbyvision` sub-parameter to `format` video filter
+    - `--sub-visibility` no longer has any effect on secondary subtitles
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2615,11 +2615,6 @@ Subtitles
     Can be used to disable display of secondary subtitles, but still select and
     decode them.
 
-    .. note::
-
-        If ``--sub-visibility=no``, secondary subtitles are hidden regardless of
-        ``--secondary-sub-visibility``.
-
 ``--sub-clear-on-seek``
     (Obscure, rarely useful.) Can be used to play broken mkv files with
     duplicate ReadOrder fields. ReadOrder is the first field in a

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -334,8 +334,6 @@ struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
 {
     pthread_mutex_lock(&sub->lock);
 
-    struct mp_subtitle_opts *opts = sub->opts;
-
     pts = pts_to_subtitle(sub, pts);
 
     sub->last_vo_pts = pts;
@@ -344,7 +342,7 @@ struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
     struct sub_bitmaps *res = NULL;
 
     if (!(sub->end != MP_NOPTS_VALUE && pts >= sub->end) &&
-        opts->sub_visibility && sub->sd->driver->get_bitmaps)
+        sub->sd->driver->get_bitmaps)
         res = sub->sd->driver->get_bitmaps(sub->sd, dim, format, pts);
 
     pthread_mutex_unlock(&sub->lock);
@@ -451,6 +449,11 @@ void sub_set_play_dir(struct dec_sub *sub, int dir)
     pthread_mutex_lock(&sub->lock);
     sub->play_dir = dir;
     pthread_mutex_unlock(&sub->lock);
+}
+
+bool sub_is_primary_visible(struct dec_sub *sub)
+{
+    return !!sub->opts->sub_visibility;
 }
 
 bool sub_is_secondary_visible(struct dec_sub *sub)

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -51,6 +51,7 @@ void sub_reset(struct dec_sub *sub);
 void sub_select(struct dec_sub *sub, bool selected);
 void sub_set_recorder_sink(struct dec_sub *sub, struct mp_recorder_sink *sink);
 void sub_set_play_dir(struct dec_sub *sub, int dir);
+bool sub_is_primary_visible(struct dec_sub *sub);
 bool sub_is_secondary_visible(struct dec_sub *sub);
 
 int sub_control(struct dec_sub *sub, enum sd_ctrl cmd, void *arg);

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -291,7 +291,7 @@ static struct sub_bitmaps *render_object(struct osd_state *osd,
     check_obj_resize(osd, osdres, obj);
 
     if (obj->type == OSDTYPE_SUB) {
-        if (obj->sub)
+        if (obj->sub && sub_is_primary_visible(obj->sub))
             res = sub_get_bitmaps(obj->sub, obj->vo_res, format, video_pts);
     } else if (obj->type == OSDTYPE_SUB2) {
         if (obj->sub && sub_is_secondary_visible(obj->sub))


### PR DESCRIPTION
Reverts 928668e and instead adds this functionality by modifying `sub-visibility` to only affect primary subs.

Edit: Rebased on master.