### PR TITLE
vo_gpu_next: initial attempt at adding d3d11 support

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -262,7 +262,7 @@ Available video output drivers are:
     the same set of features as ``--vo=gpu``. See `GPU renderer options`_ for a
     list.
 
-    Currently, this only supports Vulkan, OpenGL and no hardware
+    Currently, this only supports Vulkan, OpenGL, D3D11 and no hardware
     decoding. Unlike ``--vo=gpu``, the FBO formats are not tunable, but you can
     still set ``--gpu-dumb-mode=yes`` to forcibly disable their use.
 

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -199,6 +199,9 @@ static bool d3d11_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
 
+    if (!out_fbo)
+        return true;
+
     if (!p->backbuffer)
         return false;
 

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -24,6 +24,7 @@
 #include "video/out/gpu/d3d11_helpers.h"
 #include "video/out/gpu/spirv.h"
 #include "video/out/w32_common.h"
+#include "context.h"
 #include "ra_d3d11.h"
 
 static int d3d11_validate_adapter(struct mp_log *log,
@@ -524,6 +525,18 @@ static bool d3d11_init(struct ra_ctx *ctx)
 error:
     d3d11_uninit(ctx);
     return false;
+}
+
+IDXGISwapChain *ra_d3d11_ctx_get_swapchain(struct ra_ctx *ra)
+{
+    if (ra->swapchain->fns != &d3d11_swapchain)
+        return NULL;
+
+    struct priv *p = ra->priv;
+
+    IDXGISwapChain_AddRef(p->swapchain);
+
+    return p->swapchain;
 }
 
 const struct ra_ctx_fns ra_ctx_d3d11 = {

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -492,6 +492,13 @@ static bool d3d11_init(struct ra_ctx *ctx)
     if (!vo_w32_init(ctx->vo))
         goto error;
 
+    UINT usage = DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_SHADER_INPUT;
+    if (ID3D11Device_GetFeatureLevel(p->device) >= D3D_FEATURE_LEVEL_11_0 &&
+        p->opts->output_format != DXGI_FORMAT_B8G8R8A8_UNORM)
+    {
+        usage |= DXGI_USAGE_UNORDERED_ACCESS;
+    }
+
     struct d3d11_swapchain_opts scopts = {
         .window = vo_w32_hwnd(ctx->vo),
         .width = ctx->vo->dwidth,
@@ -503,7 +510,7 @@ static bool d3d11_init(struct ra_ctx *ctx)
         // Add one frame for the backbuffer and one frame of "slack" to reduce
         // contention with the window manager when acquiring the backbuffer
         .length = ctx->vo->opts->swapchain_depth + 2,
-        .usage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        .usage = usage,
     };
     if (!mp_d3d11_create_swapchain(p->device, ctx->log, &scopts, &p->swapchain))
         goto error;

--- a/video/out/d3d11/context.h
+++ b/video/out/d3d11/context.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <dxgi.h>
+
+#include "video/out/gpu/context.h"
+
+// Get the underlying D3D11 swap chain from an RA context. The returned swap chain is
+// refcounted and must be released by the caller.
+IDXGISwapChain *ra_d3d11_ctx_get_swapchain(struct ra_ctx *ra);

--- a/wscript
+++ b/wscript
@@ -741,9 +741,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 3.104.0'),
     }, {
         'name': 'libplacebo-v4',
-        'desc': 'libplacebo v4.170+, needed for vo_gpu_next',
+        'desc': 'libplacebo v4.190+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 170',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 190',
                                    use='libplacebo'),
     }, {
         'name': '--vulkan',


### PR DESCRIPTION
1. Handle lack of output fbo in D3D11's `start_frame`.
2. Add an API to get the d3d11 swap chain from the RA context.
3. Minor rework of the `gpu-next` context code to make more non-Vulkan use cases share at least some common code.
4. Do initial plugging in of d3d11 shenanigans.

Now locally I see d3d11 working by default, as well as `--gpu-api=vulkan` working. So I haven't broken Vulkan, at least :) .

**Known issues**:

`--d3d11-output-csp=pq` -> the swap chain gets configured properly, but the color space is not propagated to libplacebo so basically you get a very red colored image (since I don't think this is reverse tone mapping :) ) 🔴
