### PR TITLE
input: pass modifier state in set_mouse_pos

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -40,6 +40,7 @@ Interface changes
       `--tone-mapping-desaturate-exponent`.
     - add `dolbyvision` sub-parameter to `format` video filter
     - `--sub-visibility` no longer has any effect on secondary subtitles
+    - the MOUSE_MOVE input event can now be combined with modifiers
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -41,6 +41,7 @@ Interface changes
     - add `dolbyvision` sub-parameter to `format` video filter
     - `--sub-visibility` no longer has any effect on secondary subtitles
     - the MOUSE_MOVE input event can now be combined with modifiers
+    - modifiers can now be passed to the `mouse` input command
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -794,14 +794,15 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
         Do not clear the playlist.
 
 
-``mouse <x> <y> [<button> [<mode>]]``
+``mouse <x> <y> [<button> [<mode> [<modifiers>]]]``
     Send a mouse event with given coordinate (``<x>``, ``<y>``).
 
     Second argument:
 
     <button>
         The button number of clicked mouse button. This should be one of 0-19.
-        If ``<button>`` is omitted, only the position will be updated.
+        If ``<button>`` is omitted or the special value -1 is used, only the
+        position will be updated.
 
     Third argument:
 
@@ -810,6 +811,12 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
     <double>
         The mouse event represents double-click.
+
+    Fourth argument:
+
+    <modifiers>
+        Optional modifiers sent with the mouse event, using the form described
+        in `Key names`_.
 
 ``keypress <name>``
     Send a key event through mpv's input handler, triggering whatever

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -109,6 +109,7 @@ typedef struct mp_cmd {
     bool is_mouse_button : 1;
     bool repeated : 1;
     bool mouse_move : 1;
+    int mouse_move_mods;
     int mouse_x, mouse_y;
     struct mp_cmd *queue_next;
     double scale;               // for scaling numeric arguments

--- a/input/input.c
+++ b/input/input.c
@@ -862,12 +862,13 @@ void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y, int
         cmd->mouse_move = true;
         cmd->mouse_x = x;
         cmd->mouse_y = y;
+        cmd->mouse_move_mods = mods;
         if (should_drop_cmd(ictx, cmd)) {
             talloc_free(cmd);
         } else {
             // Coalesce with previous mouse move events (i.e. replace it)
             struct mp_cmd *tail = queue_peek_tail(&ictx->cmd_queue);
-            if (tail && tail->mouse_move) {
+            if (tail && tail->mouse_move && tail->mouse_move_mods == mods) {
                 queue_remove(&ictx->cmd_queue, tail);
                 talloc_free(tail);
             }

--- a/input/input.h
+++ b/input/input.h
@@ -94,10 +94,10 @@ void mp_input_put_key_utf8(struct input_ctx *ictx, int mods, struct bstr t);
 void mp_input_put_wheel(struct input_ctx *ictx, int direction, double value);
 
 // Update mouse position (in window coordinates).
-void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y);
+void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y, int mods);
 
 // Like mp_input_set_mouse_pos(), but ignore mouse disable option.
-void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y);
+void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y, int mods);
 
 void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y, int *hover);
 

--- a/input/keycodes.c
+++ b/input/keycodes.c
@@ -208,6 +208,31 @@ static const struct key_name modifier_names[] = {
     { 0 }
 };
 
+int mp_input_get_modifiers_combo_from_name(const char *name)
+{
+    bstr cur = bstr0(name);
+    if (cur.len == 0)
+        return 0;
+    int modifiers = 0;
+    while (true) {
+        for (const struct key_name *m = modifier_names; m->name; m++) {
+            bstr mod_name = bstr0(m->name);
+            if (!bstrcasecmp(mod_name, bstr_splice(cur, 0, mod_name.len))) {
+                modifiers |= m->key;
+                cur = bstr_cut(cur, mod_name.len);
+                goto found;
+            }
+        }
+        return -1;
+found:
+        if (cur.len == 0)
+            return modifiers;
+        if (cur.start[0] != '+')
+            return -1;
+        cur = bstr_cut(cur, 1);
+    }
+}
+
 int mp_input_get_key_from_name(const char *name)
 {
     int modifiers = 0;

--- a/input/keycodes.h
+++ b/input/keycodes.h
@@ -238,6 +238,10 @@
 // Makes adjustments like turning "shift+z" into "Z"
 int mp_normalize_keycode(int keycode);
 
+// Parse modifier string (such as "ctrl+alt") and return modifier mask
+// or -1 on invalid input
+int mp_input_get_modifiers_combo_from_name(const char *name);
+
 // Get input key from its name.
 int mp_input_get_key_from_name(const char *name);
 

--- a/osdep/macos/mpv_helper.swift
+++ b/osdep/macos/mpv_helper.swift
@@ -73,7 +73,7 @@ class MPVHelper {
     }
 
     func setMousePosition(_ pos: NSPoint) {
-        mp_input_set_mouse_pos(input, Int32(pos.x), Int32(pos.y))
+        mp_input_set_mouse_pos(input, Int32(pos.x), Int32(pos.y), 0)
     }
 
     func putAxis(_ mpkey: Int32, delta: Double) {

--- a/player/command.c
+++ b/player/command.c
@@ -5833,11 +5833,17 @@ static void cmd_mouse(void *p)
         if (vo_res.w && vo_res.h && hover != oldhover)
             pre_key = hover ? MP_KEY_MOUSE_ENTER : MP_KEY_MOUSE_LEAVE;
     }
+    int mods = mp_input_get_modifiers_combo_from_name(cmd->args[4].v.s);
+    if (mods == -1) {
+        MP_ERR(mpctx, "%s is not a valid modifier.\n", cmd->args[4].v.s);
+        cmd->success = false;
+        return;
+    }
 
     if (button == -1) {// no button
         if (pre_key)
             mp_input_put_key_artificial(mpctx->input, pre_key);
-        mp_input_set_mouse_pos_artificial(mpctx->input, x, y, 0);
+        mp_input_set_mouse_pos_artificial(mpctx->input, x, y, mods);
         return;
     }
     if (button < 0 || button >= MP_KEY_MOUSE_BTN_COUNT) {// invalid button
@@ -5852,11 +5858,12 @@ static void cmd_mouse(void *p)
         cmd->success = false;
         return;
     }
+
     button += dbc ? MP_MBTN_DBL_BASE : MP_MBTN_BASE;
     if (pre_key)
         mp_input_put_key_artificial(mpctx->input, pre_key);
-    mp_input_set_mouse_pos_artificial(mpctx->input, x, y, 0);
-    mp_input_put_key_artificial(mpctx->input, button);
+    mp_input_set_mouse_pos_artificial(mpctx->input, x, y, mods);
+    mp_input_put_key_artificial(mpctx->input, button | mods);
 }
 
 static void cmd_key(void *p)
@@ -6411,6 +6418,8 @@ const struct mp_cmd_def mp_cmds[] = {
                             {"button", OPT_INT(v.i), OPTDEF_INT(-1)},
                             {"mode", OPT_CHOICE(v.i,
                                 {"single", 0}, {"double", 1}),
+                                .flags = MP_CMD_OPT_ARG},
+                            {"modifiers", OPT_STRING(v.s),
                                 .flags = MP_CMD_OPT_ARG}}},
     { "keybind", cmd_key_bind, { {"name", OPT_STRING(v.s)},
                                  {"cmd", OPT_STRING(v.s)} }},

--- a/player/command.c
+++ b/player/command.c
@@ -5837,7 +5837,7 @@ static void cmd_mouse(void *p)
     if (button == -1) {// no button
         if (pre_key)
             mp_input_put_key_artificial(mpctx->input, pre_key);
-        mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
+        mp_input_set_mouse_pos_artificial(mpctx->input, x, y, 0);
         return;
     }
     if (button < 0 || button >= MP_KEY_MOUSE_BTN_COUNT) {// invalid button
@@ -5855,7 +5855,7 @@ static void cmd_mouse(void *p)
     button += dbc ? MP_MBTN_DBL_BASE : MP_MBTN_BASE;
     if (pre_key)
         mp_input_put_key_artificial(mpctx->input, pre_key);
-    mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
+    mp_input_set_mouse_pos_artificial(mpctx->input, x, y, 0);
     mp_input_put_key_artificial(mpctx->input, button);
 }
 

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -976,7 +976,7 @@ int vo_cocoa_control(struct vo *vo, int *events, int request, void *arg)
 {
     [self recalcMovableByWindowBackground:point];
     if (!self.vout->cocoa->window_is_dragged)
-        mp_input_set_mouse_pos(self.vout->input_ctx, point.x, point.y);
+        mp_input_set_mouse_pos(self.vout->input_ctx, point.x, point.y, 0);
 }
 
 - (void)putKey:(int)mpkey withModifiers:(int)modifiers

--- a/video/out/vo_caca.c
+++ b/video/out/vo_caca.c
@@ -180,7 +180,7 @@ static void check_events(struct vo *vo)
             mp_input_put_key(vo->input_ctx, MP_KEY_CLOSE_WIN);
             break;
         case CACA_EVENT_MOUSE_MOTION:
-            mp_input_set_mouse_pos(vo->input_ctx, cev.data.mouse.x, cev.data.mouse.y);
+            mp_input_set_mouse_pos(vo->input_ctx, cev.data.mouse.x, cev.data.mouse.y, 0);
             break;
         case CACA_EVENT_MOUSE_PRESS:
             mp_input_put_key(vo->input_ctx,

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -605,9 +605,11 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
             }
             break;
         }
-        case SDL_MOUSEMOTION:
-            mp_input_set_mouse_pos(vo->input_ctx, ev.motion.x, ev.motion.y);
+        case SDL_MOUSEMOTION: {
+            int mods = sdl_mod_to_mpv_mod(SDL_GetModState());
+            mp_input_set_mouse_pos(vo->input_ctx, ev.motion.x, ev.motion.y, mods);
             break;
+        }
         case SDL_MOUSEBUTTONDOWN: {
             int mods = sdl_mod_to_mpv_mod(SDL_GetModState());
             int i;

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -521,6 +521,20 @@ static void wakeup(struct vo *vo)
     SDL_PushEvent(&event);
 }
 
+static int sdl_mod_to_mpv_mod(int sdl_mod)
+{
+    int mpv_mod = 0;
+    if (sdl_mod & (KMOD_LSHIFT | KMOD_RSHIFT))
+        mpv_mod |= MP_KEY_MODIFIER_SHIFT;
+    if (sdl_mod & (KMOD_LCTRL | KMOD_RCTRL))
+        mpv_mod |= MP_KEY_MODIFIER_CTRL;
+    if (sdl_mod & (KMOD_LALT | KMOD_RALT))
+        mpv_mod |= MP_KEY_MODIFIER_ALT;
+    if (sdl_mod & (KMOD_LGUI | KMOD_RGUI))
+        mpv_mod |= MP_KEY_MODIFIER_META;
+    return mpv_mod;
+}
+
 static void wait_events(struct vo *vo, int64_t until_time_us)
 {
     int64_t wait_us = until_time_us - mp_time_us();
@@ -586,14 +600,7 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
                     break;
                 }
             if (keycode) {
-                if (ev.key.keysym.mod & (KMOD_LSHIFT | KMOD_RSHIFT))
-                    keycode |= MP_KEY_MODIFIER_SHIFT;
-                if (ev.key.keysym.mod & (KMOD_LCTRL | KMOD_RCTRL))
-                    keycode |= MP_KEY_MODIFIER_CTRL;
-                if (ev.key.keysym.mod & (KMOD_LALT | KMOD_RALT))
-                    keycode |= MP_KEY_MODIFIER_ALT;
-                if (ev.key.keysym.mod & (KMOD_LGUI | KMOD_RGUI))
-                    keycode |= MP_KEY_MODIFIER_META;
+                keycode |= sdl_mod_to_mpv_mod(ev.key.keysym.mod);
                 mp_input_put_key(vo->input_ctx, keycode);
             }
             break;
@@ -602,19 +609,23 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
             mp_input_set_mouse_pos(vo->input_ctx, ev.motion.x, ev.motion.y);
             break;
         case SDL_MOUSEBUTTONDOWN: {
+            int mods = sdl_mod_to_mpv_mod(SDL_GetModState());
             int i;
             for (i = 0; i < sizeof(mousebtns) / sizeof(mousebtns[0]); ++i)
                 if (mousebtns[i].sdl == ev.button.button) {
-                    mp_input_put_key(vo->input_ctx, mousebtns[i].mpv | MP_KEY_STATE_DOWN);
+                    mp_input_put_key(vo->input_ctx,
+                                     mousebtns[i].mpv | MP_KEY_STATE_DOWN | mods);
                     break;
                 }
             break;
         }
         case SDL_MOUSEBUTTONUP: {
+            int mods = sdl_mod_to_mpv_mod(SDL_GetModState());
             int i;
             for (i = 0; i < sizeof(mousebtns) / sizeof(mousebtns[0]); ++i)
                 if (mousebtns[i].sdl == ev.button.button) {
-                    mp_input_put_key(vo->input_ctx, mousebtns[i].mpv | MP_KEY_STATE_UP);
+                    mp_input_put_key(vo->input_ctx,
+                                     mousebtns[i].mpv | MP_KEY_STATE_UP | mods);
                     break;
                 }
             break;
@@ -625,10 +636,11 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
 #else
             double multiplier = 0.1;
 #endif
+            int mpmod = sdl_mod_to_mpv_mod(SDL_GetModState());
             int y_code = ev.wheel.y > 0 ? MP_WHEEL_UP : MP_WHEEL_DOWN;
-            mp_input_put_wheel(vo->input_ctx, y_code, abs(ev.wheel.y) * multiplier);
+            mp_input_put_wheel(vo->input_ctx, y_code | mpmod, abs(ev.wheel.y) * multiplier);
             int x_code = ev.wheel.x > 0 ? MP_WHEEL_RIGHT : MP_WHEEL_LEFT;
-            mp_input_put_wheel(vo->input_ctx, x_code, abs(ev.wheel.x) * multiplier);
+            mp_input_put_wheel(vo->input_ctx, x_code | mpmod, abs(ev.wheel.x) * multiplier);
             break;
         }
         }

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1247,7 +1247,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         if (x != w32->mouse_x || y != w32->mouse_y) {
             w32->mouse_x = x;
             w32->mouse_y = y;
-            mp_input_set_mouse_pos(w32->input_ctx, x, y);
+            mp_input_set_mouse_pos(w32->input_ctx, x, y, mod_state(w32));
         }
         break;
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -190,8 +190,9 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
     wl->mouse_unscaled_x = sx;
     wl->mouse_unscaled_y = sy;
 
+    int mods = get_mods(wl);
     if (!wl->toplevel_configured)
-        mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+        mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y, mods);
     wl->toplevel_configured = false;
 }
 
@@ -288,7 +289,8 @@ static void touch_handle_down(void *data, struct wl_touch *wl_touch,
     wl->mouse_x = wl_fixed_to_int(x_w) * wl->scaling;
     wl->mouse_y = wl_fixed_to_int(y_w) * wl->scaling;
 
-    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+    int mods = get_mods(wl);
+    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y, mods);
     mp_input_put_key(wl->vo->input_ctx, MP_MBTN_LEFT | MP_KEY_STATE_DOWN);
 
     enum xdg_toplevel_resize_edge edge;
@@ -314,7 +316,8 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
     wl->mouse_x = wl_fixed_to_int(x_w) * wl->scaling;
     wl->mouse_y = wl_fixed_to_int(y_w) * wl->scaling;
 
-    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+    int mods = get_mods(wl);
+    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y, mods);
 }
 
 static void touch_handle_frame(void *data, struct wl_touch *wl_touch)

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1178,8 +1178,10 @@ void vo_x11_check_events(struct vo *vo)
                 };
                 x11_send_ewmh_msg(x11, "_NET_WM_MOVERESIZE", params);
             } else {
+                int mods = get_mods(Event.xmotion.state);
                 mp_input_set_mouse_pos(x11->input_ctx, Event.xmotion.x,
-                                                       Event.xmotion.y);
+                                                       Event.xmotion.y,
+                                                       mods);
             }
             x11->win_drag_button1_down = false;
             break;


### PR DESCRIPTION
This makes it possible to use CTRL+MOUSE_MOVE and similar bindings

Tested on x11 and wayland. 

For win32 I made the change 'blind', as in I couldn't compile or test it. For cocoa I could not figure how to retrieve the modifiers, so currently they are not passed.

I wasn't sure from reading `client-api-changes.rst` if this change should be mentioned, should it?

Motivation for this change: I have a plugin where the user can draw rectangles on the video with the mouse. I would like to make it similar to other programs (like inkscape), where CTRL can be held to preserve the aspect ratio, or SHIFT to preserve the center (or both)