### PR TITLE
osc improvement: shows osc topbar in fullscreen

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -429,7 +429,11 @@ end
 function window_controls_enabled()
     val = user_opts.windowcontrols
     if val == "auto" then
-        return not state.border
+        if state.fullscreen then
+           return val ~= "no"
+        else
+           return not state.border
+        end
     else
         return val ~= "no"
     end


### PR DESCRIPTION
Previously, the osc topbar was imited to users who have disabled border.
This removes that limitation when in fullscreen state, because fullscreen state does not have borders;
which makes the osc topbar usefulness available to everyone after losing the border topbar.