### PR TITLE
ci/build-freebsd: enable sndio ao during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
                 pkgconf \
                 python3 \
                 sdl2 \
+                sndio \
                 vulkan-headers \
                 wayland-protocols \
                 #

--- a/ci/build-freebsd.sh
+++ b/ci/build-freebsd.sh
@@ -11,6 +11,7 @@ meson build \
     -Degl-drm=enabled \
     -Dopenal=enabled \
     -Dsdl2=enabled \
+    -Dsndio=enabled \
     -Dvaapi-wayland=enabled \
     -Dvdpau=enabled \
     -Dvulkan=enabled \
@@ -33,6 +34,7 @@ python3 ./waf configure \
     --enable-egl-drm \
     --enable-openal \
     --enable-sdl2 \
+    --enable-sndio \
     --enable-vaapi-wayland \
     --enable-vdpau \
     --enable-vulkan \


### PR DESCRIPTION
We have this ao again since #9298 so let's run it through the CI.