### PR TITLE
build: remove aviocontext bytes_read check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: mingw_prefix/
-          key: "${{ matrix.target }}-1"
+          key: "${{ matrix.target }}-2"
 
       - name: Install dependencies
         run: |

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -261,9 +261,6 @@ typedef struct lavf_priv {
 
 static void update_read_stats(struct demuxer *demuxer)
 {
-#if !HAVE_FFMPEG_AVIOCONTEXT_BYTES_READ
-    return;
-#else
     lavf_priv_t *priv = demuxer->priv;
 
     for (int n = 0; n < priv->num_nested; n++) {
@@ -274,7 +271,6 @@ static void update_read_stats(struct demuxer *demuxer)
         nest->last_bytes = cur;
         demux_report_unbuffered_read_bytes(demuxer, new);
     }
-#endif
 }
 
 // At least mp4 has name="mov,mp4,m4a,3gp,3g2,mj2", so we split the name

--- a/meson.build
+++ b/meson.build
@@ -598,13 +598,6 @@ if darwin
 endif
 
 
-# The following should be removed in 2022 or if libavformat requirement
-# is bumped to >= 59.8.100
-aviocontext_bytes_read = cc.has_member('AVIOContext', 'bytes_read',
-                                       dependencies: ffmpeg['deps'][2], #libavformat
-                                       prefix: '#include <libavformat/avio.h>')
-
-
 # misc dependencies
 cdda_opt = get_option('cdda').require(
     get_option('gpl'),
@@ -1739,7 +1732,6 @@ conf_data.set10('HAVE_EGL_ANGLE_WIN32', egl_angle_win32.allowed())
 conf_data.set10('HAVE_EGL_DRM', egl_drm.allowed())
 conf_data.set10('HAVE_EGL_HELPERS', egl_helpers)
 conf_data.set10('HAVE_EGL_X11', egl_x11.allowed())
-conf_data.set10('HAVE_FFMPEG_AVIOCONTEXT_BYTES_READ', aviocontext_bytes_read)
 conf_data.set10('HAVE_GLIBC_THREAD_NAME', glibc_thread_name and posix)
 conf_data.set10('HAVE_GL', gl['use'])
 conf_data.set10('HAVE_GL_COCOA', gl_cocoa.allowed())

--- a/wscript
+++ b/wscript
@@ -411,15 +411,6 @@ FFmpeg libraries. Git master is recommended."
         'name': '--libavdevice',
         'desc': 'libavdevice',
         'func': check_pkg_config('libavdevice', '>= 57.0.0'),
-    }, {
-        # The following should be removed in 2022 or if libavformat requirement
-        # is bumped to >= 59.8.100
-        'name': 'ffmpeg-aviocontext-bytes-read',
-        'desc': 'FFmpeg AVIOContext bytes_read statistic field',
-        'deps': 'ffmpeg',
-        'func': check_statement(['libavformat/avio.h'],
-                                '(struct AVIOContext){ 0 }.bytes_read = 7357',
-                                use=['ffmpeg']),
     }
 ]
 


### PR DESCRIPTION
I'm not sure when we wanted to remove this check exactly, but maybe soon.