### PR TITLE
use lua 5.1 on macos and cleanup meson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 luajit libass ffmpeg meson
+          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 lua@5.1 libass ffmpeg meson
 
       - name: Build with meson
         run: |

--- a/meson.build
+++ b/meson.build
@@ -717,20 +717,8 @@ if lua_opt != 'disabled'
     endforeach
 endif
 
-# Dumb hack for macOS if we're using luajit so the shared libary compiles.
-# The partial dependency is only used for libmpv and not mpv itself.
-# https://github.com/Homebrew/homebrew-core/issues/37169
-luajit_full = dependency('', required: false)
-luajit_partial = dependency('', required: false)
 if lua['use']
-    if darwin and lua['deps'].name() == 'luajit'
-        luajit_full = lua['deps']
-        luajit_partial = lua['deps'].partial_dependency(compile_args: true, link_args: false,
-                                                        links: true, includes: true, sources: true)
-    else
-        dependencies += lua['deps']
-    endif
-
+    dependencies += lua['deps']
     features += lua['deps'].name()
     sources += files('player/lua.c')
     subdir(join_paths('generated', 'player', 'lua'))
@@ -1837,9 +1825,8 @@ if get_option('libmpv')
     minor = client_h_define.split('|')[1].strip('() ')
     client_api_version = major + '.' + minor + '.0'
 
-    libmpv = library('mpv', sources, dependencies: [dependencies, luajit_partial],
-                     gnu_symbol_visibility: 'hidden', version: client_api_version,
-                     include_directories: includedir, install: true)
+    libmpv = library('mpv', sources, dependencies: dependencies, gnu_symbol_visibility: 'hidden',
+                     version: client_api_version, include_directories: includedir, install: true)
     pkg = import('pkgconfig')
     pkg.generate(libmpv, version: client_api_version,
                  description: 'mpv media player client library')
@@ -1876,6 +1863,6 @@ if get_option('cplayer')
                  rename: 'mpv.svg')
     install_data('etc/mpv-symbolic.svg', install_dir: join_paths(hicolor_dir, 'symbolic', 'apps'))
 
-    executable('mpv', sources, dependencies: [dependencies, luajit_full],
+    executable('mpv', sources, dependencies: dependencies,
                include_directories: includedir, install: true)
 endif


### PR DESCRIPTION
See the commit messages for full details. The tl;dr is that luajit 2.0 is broken and shouldn't be used on macos and yet the CI pulled it in anyway. When I originally made the meson build, I did some hacks to workaround this behavior (otherwise the build will fail), but really this shouldn't be supported at all since luajit 2.0 is known to have issues on some versions of macos (https://github.com/mpv-player/mpv/issues/7512). This just makes the CI use lua 5.1 instead and the special logic in meson is removed.

I dunno if we want to add any hard errors or warnings if a user tries to build with luajit 2.0 on mac? It seems like a similar change (https://github.com/mpv-player/mpv/pull/7574) was rejected previously so perhaps not.