### PR TITLE
w32_common: fixes minimized window being focused on launch

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -962,7 +962,7 @@ static void update_window_state(struct vo_w32_state *w32)
     // Show the window if it's not yet visible
     if (!is_visible(w32->window)) {
         if (w32->opts->window_minimized) {
-            ShowWindow(w32->window, SW_SHOWMINIMIZED);
+            ShowWindow(w32->window, SW_SHOWMINNOACTIVE);
             update_maximized_state(w32); // Set the WPF_RESTORETOMAXIMIZED flag
         } else if (w32->opts->window_maximized) {
             ShowWindow(w32->window, SW_SHOWMAXIMIZED);


### PR DESCRIPTION
Currently on Windows, mpv is taking focus when launched with `--window-minimized=yes`.  This commit stops Windows from focusing the minimized window, which is consistent with what happens when the window is manually minimized.

Resolves: #9641