### PR TITLE
TOOLS\lua\autoload.lua: add m2ts video file extension

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -49,7 +49,7 @@ function SetUnion (a,b)
 end
 
 EXTENSIONS_VIDEO = Set {
-    'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp'
+    'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp', 'm2ts'
 }
 
 EXTENSIONS_AUDIO = Set {


### PR DESCRIPTION
Script will now add video files with the extension of 'm2ts' (BDMV) to playlist.