### PR TITLE
wayland: support extra mouse buttons

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -205,25 +205,29 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
     state = state == WL_POINTER_BUTTON_STATE_PRESSED ? MP_KEY_STATE_DOWN
                                                      : MP_KEY_STATE_UP;
 
-    switch (button) {
-    case BTN_LEFT:
-        button = MP_MBTN_LEFT;
-        break;
-    case BTN_MIDDLE:
-        button = MP_MBTN_MID;
-        break;
-    case BTN_RIGHT:
-        button = MP_MBTN_RIGHT;
-        break;
-    case BTN_SIDE:
-        button = MP_MBTN_BACK;
-        break;
-    case BTN_EXTRA:
-        button = MP_MBTN_FORWARD;
-        break;
-    default:
+    if (button >= BTN_MOUSE && button < BTN_JOYSTICK) {
+        switch (button) {
+        case BTN_LEFT:
+            button = MP_MBTN_LEFT;
+            break;
+        case BTN_MIDDLE:
+            button = MP_MBTN_MID;
+            break;
+        case BTN_RIGHT:
+            button = MP_MBTN_RIGHT;
+            break;
+        case BTN_SIDE:
+            button = MP_MBTN_BACK;
+            break;
+        case BTN_EXTRA:
+            button = MP_MBTN_FORWARD;
+            break;
+        default:
+            button += MP_MBTN9 - BTN_FORWARD;
+            break;
+        }
+    } else {
         button = 0;
-        break;
     }
 
     if (wl->keyboard)


### PR DESCRIPTION
Mouse button event codes above `BTN_EXTRA` (the ones currently defined
in `input-event-codes.h` are `BTN_FORWARD`, `BTN_BACK`, and `BTN_TASK`)
are mapped to `MP_MBTN9` and up. (Reminder that due to historical
reasons, the names `BTN_FORWARD` and `BTN_BACK` are completely
misleading; the real forward and back buttons are `BTN_SIDE` and
`BTN_EXTRA` and are already mapped correctly by mpv.)

This functionality is analogous to what the X11 backend supports in
`video/out/x11_common.c` and what the Cocoa backend supports in
`video/out/cocoa/events_view.m`.