### PR TITLE
hwdec/d3d11va: Fix a possible memory leak

### DIFF
--- a/video/out/d3d11/hwdec_d3d11va.c
+++ b/video/out/d3d11/hwdec_d3d11va.c
@@ -67,6 +67,7 @@ static void uninit(struct ra_hwdec *hw)
 {
     struct priv_owner *p = hw->priv;
     hwdec_devices_remove(hw->devs, &p->hwctx);
+    av_buffer_unref(&p->hwctx.av_device_ref);
     SAFE_RELEASE(p->device);
     SAFE_RELEASE(p->device1);
 }


### PR DESCRIPTION
I use mpv in unity3d. 
When launched with --vo=gpu --gpu-api=d3d11 --gpu-context=d3d11  --hwdec=d3d11va, switching next video caused Mpv memory leak.
I tried to solve it and found the problem in the d3d11va.