### PR TITLE
[BSD] Fix cplugins/libdl existence check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -336,14 +336,15 @@ if get_option('ta-leak-report')
     features += 'ta-leak-report'
 endif
 
-libdl = cc.find_library('libdl', required: false)
-if libdl.found()
-    dependencies += libdl
+libdl_dep = cc.find_library('libdl', required: false)
+libdl = cc.has_function('dlopen', dependencies: libdl_dep, prefix: '#include <dlfcn.h>')
+if libdl
+    dependencies += libdl_dep
     features += 'libdl'
 endif
 
 cplugins = get_option('cplugins').require(
-    libdl.found() and not win32 and cc.has_link_argument('-rdynamic'),
+    libdl and not win32 and cc.has_link_argument('-rdynamic'),
     error_message: 'cplugins not supported by the os or compiler!',
 )
 if cplugins.allowed()
@@ -1425,7 +1426,7 @@ vaapi = {
     'name': 'vaapi',
     'deps': dependency('libva', version: '>= 1.1.0', required: get_option('vaapi')),
 }
-vaapi += {'use': vaapi['deps'].found() and libdl.found() and
+vaapi += {'use': vaapi['deps'].found() and libdl and
           (x11['use'] or wayland['use'] or egl_drm.allowed())}
 if vaapi['use']
     dependencies += vaapi['deps']
@@ -1751,7 +1752,7 @@ conf_data.set10('HAVE_JPEG', jpeg.found())
 conf_data.set10('HAVE_LCMS2', lcms2.found())
 conf_data.set10('HAVE_LIBARCHIVE', libarchive.found())
 conf_data.set10('HAVE_LIBAVDEVICE', libavdevice.found())
-conf_data.set10('HAVE_LIBDL', libdl.found())
+conf_data.set10('HAVE_LIBDL', libdl)
 conf_data.set10('HAVE_LIBBLURAY', libbluray.found())
 conf_data.set10('HAVE_LIBPLACEBO_V4', libplacebo_v4)
 conf_data.set10('HAVE_LINUX_FSTATFS', linux_fstatfs)


### PR DESCRIPTION
There is no libdl library in the *BSD family of operating systems; all required functions (dl{open,close,sym,...}) are in libc and available for every dynamic executable. [1]

Therefore, current check for libdl existence is incorrect. As a consequence, building cplugins is forcibly disabled on the bsd systems, which is wrong, since nothing prevents successful building/working.

In the patch I create 5 logical variables similar to `darwin`, `win32` or `posix`. Of course, I could make just one variable `bsd` and set it to `true` in a loop iterating over a list of 4 bsd systems [2]  or match the OS names with a regular expression, but:
* there is a noticeable non-zero chance that sooner or later we will find a feature that is specific to only one of the BSD family of OSes, not all, and one variable will not be enough.
* I want to affect the configuration of the builds of only four specific OSes, and not affect all kinds of custom distributions, which, for example, may contain 'bsd' in the name (yes, I understand that it is possible to make a more strict regular expression).

So I think that in this case a simple and explicit solution is preferable.

[1]
> Other ELF platforms require linking with library "libdl" to provide
> dlopen() and other	functions.  FreeBSD does not require linking with the
> library, but supports it for compatibility.
([source](https://www.freebsd.org/cgi/man.cgi?query=dlopen&sektion=3&manpath=freebsd-release-ports))

> (These functions are not in a library.  They are included in every dynam-
> ically linked program automatically.)
(sources: [netbsd](https://man.netbsd.org/dlopen.3), [dragonflybsd](https://leaf.dragonflybsd.org/cgi/web-man?command=dlopen&section=ANY)).

> Remove libdl, support is in libc since a long time already.
([source](https://www.openbsd.org/plus32.html))

[2] Something like that:
```
bsd = false
foreach bsd_os: ['dragonflybsd', 'freebsd', 'netbsd', 'openbsd']
    bsd = host_machine.system() == bsd_os
    if bsd
        break
    endif
endforeach
```
