### PR TITLE
[RFC] wayland: add support for xdg_toplevel.configure_bounds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1035,7 +1035,7 @@ wayland = {
     'name': 'wayland',
     'deps': [dependency('wayland-client', version: '>= 1.15.0', required: get_option('wayland')),
              dependency('wayland-cursor', version: '>= 1.15.0', required: get_option('wayland')),
-             dependency('wayland-protocols', required: get_option('wayland')),
+             dependency('wayland-protocols', version: '>= 1.25', required: get_option('wayland')),
              dependency('xkbcommon', version: '>= 0.3.0', required: get_option('wayland'))],
     'header': cc.check_header('linux/input-event-codes.h', required: get_option('wayland')),
     'scanner': find_program('wayland-scanner', required: get_option('wayland')),

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -52,6 +52,10 @@ struct vo_wayland_state {
     int reduced_width;
     int toplevel_width;
     int toplevel_height;
+    int bounds_width;
+    int bounds_height;
+    int pending_bounds_width;
+    int pending_bounds_height;
 
     /* State */
     bool activated;

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -102,7 +102,7 @@ def check_lua(ctx, dependency_identifier):
 
 def check_wl_protocols(ctx, dependency_identifier):
     def fn(ctx, dependency_identifier):
-        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.15")
+        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.25")
         ret = ret(ctx, dependency_identifier)
         if ret != None:
             ctx.env.WL_PROTO_DIR = ret.split()[0]


### PR DESCRIPTION
With the xdg_toplevel.configure_bounds event, the compositor can tell
the client the maximum recommended window size. The configure bounds can
correspond to the work area size or a tile size, etc.

The xdg_toplevel.configure_bounds event is sent prior to the
xdg_toplevel.configure event, and it is optional. For example, kwin
would send it only if the xdg_toplevel.configure has 0x0 size.

https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/41