### PR TITLE
auto_profiles.lua: no longer attempts to restore profiles by default

### DIFF
--- a/player/lua/auto_profiles.lua
+++ b/player/lua/auto_profiles.lua
@@ -163,7 +163,7 @@ local function load_profiles()
                 properties = {},
                 status = nil,
                 dirty = true, -- need re-evaluate
-                has_restore_opt = v["profile-restore"] ~= "default"
+                has_restore_opt = v["profile-restore"] and v["profile-restore"] ~= "default"
             }
             profiles[#profiles + 1] = profile
             have_dirty_profiles = true


### PR DESCRIPTION
No longer attempts to restore profiles that do not have
profile-restore set to a valid value. Note that this
restore fails due to the lack of any saved restore data.
This patch hence does not change the behaviour of any
conditional auto-profiles, but it does prevent warning
messages from being triggered unnecessarily.

When parsing the `profile-list` property, treat a missing
`profile-restore` field the same as `profile-restore=default`.
Before any value other than `default` would attempt a restore.

For some reason the `profile-restore` field in the `profile-list`
property is only set when the value
is `copy` or `copy-equal`. This means profiles without
`profile-restore`, or ones where `profile-restore=default`
would always attempt to restore the profile, resulting in
warning messages.

This behaviour seems to have been present since `profile-restore` was
implemented, and can be alternatively fixed by changing the option code
to set the profile-restore field to default if no other option has been
set. However, this extremely simple patch in `auto_profiles.lua`
accomplishes the same task.

The current behaviour means we don't actually need to check if the
restore field is set to `default` at all, since it never will be.
However, keeping that extra check provides a failsafe if the behaviour
of the field ever changes to include explicit declarations of the
`default` option.