### PR TITLE
vo_gpu: hwdec_vaapi: Don't probe formats for irrelevant endpoints

### DIFF
--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -362,6 +362,10 @@ static void determine_working_formats(struct ra_hwdec *hw)
 
     for (int n = 0; n < num_profiles; n++) {
         VAProfile profile = profiles[n];
+        if (profile == VAProfileNone) {
+            // We don't use the None profile.
+            continue;
+        }
         int num_ep = 0;
         status = vaQueryConfigEntrypoints(p->display, profile, entrypoints,
                                           &num_ep);
@@ -371,6 +375,10 @@ static void determine_working_formats(struct ra_hwdec *hw)
             continue;
         }
         for (int ep = 0; ep < num_ep; ep++) {
+            if (entrypoints[ep] != VAEntrypointVLD) {
+                // We are only interested in decoding entrypoints.
+                continue;
+            }
             VAConfigID config = VA_INVALID_ID;
             status = vaCreateConfig(p->display, profile, entrypoints[ep],
                                     NULL, 0, &config);


### PR DESCRIPTION
While testing support for the exotic formats used by Intel vaapi for
4:2:2 and 4:4:4 surfaces, I realised that we were enumerating all
endpoints and checking formats for them. The problem with this is
that decoding (VLD) endpoints are only a subset of what vaapi exposes.

All the encoding endpoints are there too, and there is also the
None profile that we don't care about, but which generates ffmpeg
warnings if you try and examine it.

So, let's only look at VLD endpoints. This will speed things up a
little bit and make the logging less noisy.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.