### PR TITLE
win32: apply geometry position to content instead of window

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1419,8 +1419,13 @@ static void gui_thread_reconfig(void *ptr)
     struct vo *vo = w32->vo;
 
     RECT r = get_working_area(w32);
-    if (!w32->current_fs && !IsMaximized(w32->window) && w32->opts->border)
+    // for normal window which is auto-positioned (centered), center the window
+    // rather than the content (by subtracting the borders from the work area)
+    if (!w32->current_fs && !IsMaximized(w32->window) && w32->opts->border &&
+        !w32->opts->geometry.xy_valid /* specific position not requested */)
+    {
         subtract_window_borders(w32, w32->window, &r);
+    }
     struct mp_rect screen = { r.left, r.top, r.right, r.bottom };
     struct vo_win_geometry geo;
 


### PR DESCRIPTION
The docs specify that the +-X+-Y geometry values position the content.
This used to work worrectly but got broken at 8fb4fd9a .
Geometry size is unaffected - this only concerns position.

Commit 8fb4fd9a made it center the window rather than the content by
taking the borders into account during positioning, but forgot to make
an exception when a position is specified explicitly.

This commit adds this exception, and now if a specific position is
requested then the borders are ignored, and the content is positioned
correctly.