### PR TITLE
vo_gpu_next: don't crash if ctx->ra_ctx is NULL

### DIFF
--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -129,7 +129,7 @@ void gpu_ctx_destroy(struct gpu_ctx **ctxp)
     struct priv *p = ctx->priv;
 
 #if HAVE_GL && defined(PL_HAVE_OPENGL)
-    if (ra_is_gl(ctx->ra_ctx->ra)) {
+    if (ctx->ra_ctx && ra_is_gl(ctx->ra_ctx->ra)) {
         pl_swapchain_destroy(&ctx->swapchain);
         pl_opengl_destroy(&p->opengl);
         pl_log_destroy(&ctx->pllog);


### PR DESCRIPTION
This can happen if we bail out of gpu_ctx_create before ra_ctx was
created.