### PR TITLE
wayland_egl: don't unconditionally submit a frame

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -64,6 +64,15 @@ static bool wayland_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_
     return render ? ra_gl_ctx_start_frame(sw, out_fbo) : false;
 }
 
+static bool wayland_egl_submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
+{
+    struct ra_ctx *ctx = sw->ctx;
+    struct vo_wayland_state *wl = ctx->vo->wl;
+    bool render = !wl->hidden || wl->opts->disable_vsync;
+
+    return render ? ra_gl_ctx_submit_frame(sw, frame): false;
+}
+
 static void wayland_egl_swap_buffers(struct ra_swapchain *sw)
 {
     struct ra_ctx *ctx = sw->ctx;
@@ -81,6 +90,7 @@ static void wayland_egl_swap_buffers(struct ra_swapchain *sw)
 
 static const struct ra_swapchain_fns wayland_egl_swapchain = {
     .start_frame  = wayland_egl_start_frame,
+    .submit_frame = wayland_egl_submit_frame,
     .swap_buffers = wayland_egl_swap_buffers,
 };
 


### PR DESCRIPTION
The wayland egl context works using an external swapchain. This defined
both the start_frame and swap_buffers part of the mechanism, but
submit_frame was left out. This meant that ra_gl_ctx_submit_frame was
always executed even in cases where we were skipping rendering. Fix this
by simply checking if the surface is hidden and using that to determine
whether or not the submit the next frame.

@mahkoh: Does this fix the first bug in #9813?