### PR TITLE
video: Fix depth=0 on textures downloaded from ra

### DIFF
--- a/video/filter/vf_gpu.c
+++ b/video/filter/vf_gpu.c
@@ -196,6 +196,7 @@ static struct mp_image *gpu_render_frame(struct mp_filter *f, struct mp_image *i
             .downloadable = true,
             .w = w,
             .h = h,
+            .d = 1,
             .render_dst = true,
         };
 

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3481,6 +3481,7 @@ void gl_video_screenshot(struct gl_video *p, struct vo_frame *frame,
         .downloadable = true,
         .w = p->osd_rect.w,
         .h = p->osd_rect.h,
+        .d = 1,
         .render_dst = true,
     };
 


### PR DESCRIPTION
As per https://github.com/mpv-player/mpv/blob/master/video/out/gpu/ra.h#L130
Writing my own RA and I hit an issue by assuming depth couldn't be null.