### PR TITLE
vo_gpu: hwdec: load hwdec interops on-demand by default

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -431,7 +431,8 @@ static AVBufferRef *hwdec_create_dev(struct mp_filter *vd,
             return ref;
         }
     } else if (ctx->hwdec_devs) {
-        hwdec_devices_request_all(ctx->hwdec_devs);
+        hwdec_devices_request_for_img_fmt(ctx->hwdec_devs,
+                                          pixfmt2imgfmt(hwdec->pix_fmt));
         return hwdec_devices_get_lavc(ctx->hwdec_devs, hwdec->lavc_device);
     }
 
@@ -510,7 +511,8 @@ static void select_and_set_hwdec(struct mp_filter *vd)
                 // Most likely METHOD_INTERNAL, which often use delay-loaded
                 // VO support as well.
                 if (ctx->hwdec_devs)
-                    hwdec_devices_request_all(ctx->hwdec_devs);
+                    hwdec_devices_request_for_img_fmt(
+                        ctx->hwdec_devs, pixfmt2imgfmt(hwdec->pix_fmt));
             }
 
             ctx->use_hwdec = true;

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -428,7 +428,7 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
     if (!info || !info->hwdec_devs)
         goto fail;
 
-    hwdec_devices_request_all(info->hwdec_devs);
+    hwdec_devices_request_for_img_fmt(info->hwdec_devs, IMGFMT_D3D11);
 
     struct mp_hwdec_ctx *hwctx =
         hwdec_devices_get_by_lavc(info->hwdec_devs, AV_HWDEVICE_TYPE_D3D11VA);

--- a/video/hwdec.c
+++ b/video/hwdec.c
@@ -13,7 +13,7 @@ struct mp_hwdec_devices {
     struct mp_hwdec_ctx **hwctxs;
     int num_hwctxs;
 
-    void (*load_api)(void *ctx);
+    void (*load_api)(void *ctx, int imgfmt);
     void *load_api_ctx;
 };
 
@@ -95,16 +95,16 @@ void hwdec_devices_remove(struct mp_hwdec_devices *devs, struct mp_hwdec_ctx *ct
 }
 
 void hwdec_devices_set_loader(struct mp_hwdec_devices *devs,
-    void (*load_api)(void *ctx), void *load_api_ctx)
+    void (*load_api)(void *ctx, int imgfmt), void *load_api_ctx)
 {
     devs->load_api = load_api;
     devs->load_api_ctx = load_api_ctx;
 }
 
-void hwdec_devices_request_all(struct mp_hwdec_devices *devs)
+void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs, int imgfmt)
 {
     if (devs->load_api && !hwdec_devices_get_first(devs))
-        devs->load_api(devs->load_api_ctx);
+        devs->load_api(devs->load_api_ctx, imgfmt);
 }
 
 char *hwdec_devices_get_names(struct mp_hwdec_devices *devs)

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -55,11 +55,12 @@ void hwdec_devices_remove(struct mp_hwdec_devices *devs, struct mp_hwdec_ctx *ct
 // If used at all, this must be set/unset during initialization/uninitialization,
 // as concurrent use with hwdec_devices_request() is a race condition.
 void hwdec_devices_set_loader(struct mp_hwdec_devices *devs,
-    void (*load_api)(void *ctx), void *load_api_ctx);
+    void (*load_api)(void *ctx, int imgfmt), void *load_api_ctx);
 
-// Cause VO to lazily load all devices, and will block until this is done (even
-// if not available).
-void hwdec_devices_request_all(struct mp_hwdec_devices *devs);
+// Cause VO to lazily load all devices for a specified img format, and will
+// block until this is done (even if not available). Pass IMGFMT_NONE to load
+// all available devices.
+void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs, int imgfmt);
 
 // Return "," concatenated list (for introspection/debugging). Use talloc_free().
 char *hwdec_devices_get_names(struct mp_hwdec_devices *devs);

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -220,7 +220,8 @@ bool gl_video_showing_interpolated_frame(struct gl_video *p);
 struct mp_hwdec_devices;
 void gl_video_load_hwdecs(struct gl_video *p, struct mp_hwdec_devices *devs,
                           bool load_all_by_default);
-void gl_video_load_hwdecs_all(struct gl_video *p, struct mp_hwdec_devices *devs);
+void gl_video_load_hwdecs_for_img_fmt(struct gl_video *p, struct mp_hwdec_devices *devs,
+                                      int imgfmt);
 
 struct vo;
 void gl_video_configure_queue(struct gl_video *p, struct vo *vo);

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -126,18 +126,19 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     return 0;
 }
 
-static void request_hwdec_api(struct vo *vo)
+static void request_hwdec_api(struct vo *vo, void *data)
 {
     struct gpu_priv *p = vo->priv;
+    int imgfmt = (intptr_t)data;
 
-    gl_video_load_hwdecs_all(p->renderer, vo->hwdec_devs);
+    gl_video_load_hwdecs_for_img_fmt(p->renderer, vo->hwdec_devs, imgfmt);
 }
 
-static void call_request_hwdec_api(void *ctx)
+static void call_request_hwdec_api(void *ctx, int imgfmt)
 {
     // Roundabout way to run hwdec loading on the VO thread.
     // Redirects to request_hwdec_api().
-    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, NULL);
+    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, (void *)(intptr_t)imgfmt);
 }
 
 static void get_and_update_icc_profile(struct gpu_priv *p)
@@ -200,7 +201,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
         return true;
     }
     case VOCTRL_LOAD_HWDEC_API:
-        request_hwdec_api(vo);
+        request_hwdec_api(vo, data);
         return true;
     case VOCTRL_UPDATE_RENDER_OPTS: {
         update_ra_ctx_options(vo);


### PR DESCRIPTION
Historically, we have treated hwdec interop loading as a completely
separate step from loading the hwdecs themselves. Some hwdecs need an
interop, and some don't, and users generally configure the exact
hwdec they want, so interops that aren't relevant for that hwdec
shouldn't be loaded to save time and avoid warning/error spam.

The basic approach here is to recognise that interops are tied to
hwdecs by imgfmt. The hwdec outputs some format, and an interop is
needed to get that format to the vo without read back.

So, when we try to load an hwdec, instead of just blindly loading all
interops as we do today, let's pass the imgfmt in and only load
interops that work for that format. If more than one interop is
available for the format, the existing logic (whatever it is) will
continue to be used to pick one.

We also have one callsite in filters where we seem to pre-emptively
load all the interops. It's probably possible to trace down a specific
format but for now I'm just letting it keep loading all of them; it's
no worse than before.

You may notice there is no documentation update - and that's because
the current docs say that when the interop mode is `auto`, the interop
is loaded on demand. So reality now reflects the docs. How nice.

Fixes #8765
Fixes #9691 