### PR TITLE
Don't create DXGI_USAGE_UNORDERED_ACCESS backbuffers in Windows 7

### DIFF
--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -630,6 +630,16 @@ static HRESULT create_swapchain_1_2(ID3D11Device *dev, IDXGIFactory2 *factory,
     };
 
     if (flip) {
+        // UNORDERED_ACCESS with FLIP_SEQUENTIAL seems to be buggy with
+        // Windows 7 drivers
+        if ((desc.BufferUsage & DXGI_USAGE_UNORDERED_ACCESS) &&
+            !IsWindows8OrGreater())
+        {
+            mp_verbose(log, "Disabling UNORDERED_ACCESS for flip-model "
+                            "swapchain backbuffers in Windows 7\n");
+            desc.BufferUsage &= ~DXGI_USAGE_UNORDERED_ACCESS;
+        }
+
         desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
         desc.BufferCount = opts->length;
     } else {


### PR DESCRIPTION
This is to fix a bug where adding the `DXGI_USAGE_UNORDERED_ACCESS` flag breaks rendering in Windows 7.

It feels like a bit of a special case, and it's not clear if the breakage in Windows 7 is due to the OS itself, or bad drivers, but flip-model swapchains in Windows 7 (Platform Update) have been notoriously buggy, so it might be the best solution to just remove `UNORDERED_ACCESS` there.