### PR TITLE
sub: add --sub-fonts-dir and --osd-fonts-dir options

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1572,11 +1572,8 @@ For Windows-specifics, see `FILES ON WINDOWS`_ section.
     fallback subtitle font
 
 ``~/.config/mpv/fonts/``
-    Font files in this directory are used by mpv/libass for subtitles. Useful
-    if you do not want to install fonts to your system. Note that files in this
-    directory are loaded into memory before being used by mpv. If you have a
-    lot of fonts, consider using fonts.conf (see above) to include additional
-    fonts, which is more memory-efficient.
+    Default location for ``--sub-fonts-dir`` (see `Subtitles`_) and
+    ``--osd-fonts-dir`` (see `OSD`_).
 
 ``~/.config/mpv/scripts/``
     All files in this directory are loaded as if they were passed to the

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2904,6 +2904,15 @@ Subtitles
     name does not match, it may prefer not to render any text that uses the
     missing font.)
 
+``--sub-fonts-dir=<path>``
+    Font files in this directory are used by mpv/libass for subtitles. Useful
+    if you do not want to install fonts to your system. Note that files in this
+    directory are loaded into memory before being used by mpv. If you have a
+    lot of fonts, consider using fonts.conf (see `FILES`_ section) to include
+    additional mpv user settings.
+
+    If this option is not specified, ``~~/fonts`` will be used by default.
+
 Window
 ------
 
@@ -4255,6 +4264,9 @@ OSD
 ``--osd-font-provider=<...>``
     See ``--sub-font-provider`` for details and accepted values. Note that
     unlike subtitles, OSD never uses embedded fonts from media files.
+
+``--osd-fonts-dir=<path>``
+    See ``--sub-fonts-dir`` for details.  Defaults to ``~~/fonts``.
 
 Screenshot
 ----------

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -132,9 +132,12 @@ static void message_callback(int level, const char *format, va_list va, void *ct
     mp_msg(log, level, "\n");
 }
 
-ASS_Library *mp_ass_init(struct mpv_global *global, struct mp_log *log)
+ASS_Library *mp_ass_init(struct mpv_global *global,
+                         struct osd_style_opts *opts, struct mp_log *log)
 {
-    char *path = mp_find_config_file(NULL, global, "fonts");
+    char *path = opts->fonts_dir && opts->fonts_dir[0] ?
+                 mp_get_user_path(NULL, global, opts->fonts_dir) :
+                 mp_find_config_file(NULL, global, "fonts");
     mp_dbg(log, "ASS library version: 0x%x (runtime 0x%x)\n",
            (unsigned)LIBASS_VERSION, ass_library_version());
     ASS_Library *priv = ass_library_init();

--- a/sub/ass_mp.h
+++ b/sub/ass_mp.h
@@ -47,7 +47,8 @@ void mp_ass_set_style(ASS_Style *style, double res_y,
 
 void mp_ass_configure_fonts(ASS_Renderer *priv, struct osd_style_opts *opts,
                             struct mpv_global *global, struct mp_log *log);
-ASS_Library *mp_ass_init(struct mpv_global *global, struct mp_log *log);
+ASS_Library *mp_ass_init(struct mpv_global *global,
+                         struct osd_style_opts *opts, struct mp_log *log);
 
 struct sub_bitmaps;
 struct mp_ass_packer;

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -67,6 +67,8 @@ static const m_option_t style_opts[] = {
         {"auto", 0}, {"left", 1}, {"center", 2}, {"right", 3})},
     {"font-provider", OPT_CHOICE(font_provider,
         {"auto", 0}, {"none", 1}, {"fontconfig", 2}), .flags = UPDATE_SUB_HARD},
+    {"fonts-dir", OPT_STRING(fonts_dir),
+        .flags = M_OPT_FILE | UPDATE_SUB_HARD},
     {0}
 };
 

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -157,6 +157,7 @@ struct osd_style_opts {
     bool italic;
     int justify;
     int font_provider;
+    char *fonts_dir;
 };
 
 extern const struct m_sub_options osd_style_conf;

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -51,7 +51,7 @@ static void create_ass_renderer(struct osd_state *osd, struct ass_state *ass)
         return;
 
     ass->log = mp_log_new(NULL, osd->log, "libass");
-    ass->library = mp_ass_init(osd->global, ass->log);
+    ass->library = mp_ass_init(osd->global, osd->opts->osd_style, ass->log);
     ass_add_font(ass->library, "mpv-osd-symbols", (void *)osd_font_pfb,
                  sizeof(osd_font_pfb) - 1);
 

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -206,7 +206,7 @@ static void assobjects_init(struct sd *sd)
     struct sd_ass_priv *ctx = sd->priv;
     struct mp_subtitle_opts *opts = sd->opts;
 
-    ctx->ass_library = mp_ass_init(sd->global, sd->log);
+    ctx->ass_library = mp_ass_init(sd->global, sd->opts->sub_style, sd->log);
     ass_set_extract_fonts(ctx->ass_library, opts->use_embedded_fonts);
 
     add_subtitle_fonts(sd);


### PR DESCRIPTION
These options make it possible to specify the directory that will be
passed to `ass_set_fonts_dir()`, akin to VLC's `--ssa-fontsdir` and
FFmpeg's `fontsdir`.

Fixes #8338