### PR TITLE
img_format: guard against segfault on undefined pixdesc name

### DIFF
--- a/video/img_format.c
+++ b/video/img_format.c
@@ -428,7 +428,7 @@ static bool mp_imgfmt_get_desc_from_pixdesc(int mpfmt, struct mp_imgfmt_desc *ou
         desc.flags |= MP_IMGFLAG_TYPE_HW;
 
     // Pixdesc does not provide a flag for XYZ, so this is the best we can do.
-    if (strncmp(pd->name, "xyz", 3) == 0) {
+    if (pd->name != NULL && strncmp(pd->name, "xyz", 3) == 0) {
         desc.flags |= MP_IMGFLAG_COLOR_XYZ;
     } else if (pd->flags & AV_PIX_FMT_FLAG_RGB) {
         desc.flags |= MP_IMGFLAG_COLOR_RGB;


### PR DESCRIPTION
had mpv segfaulting on startup - only a quick fix by guarding against comparing with `null` in `strncmp()` , but tested and seems to work fine so far

this happened with mpv:head on sway1.5 / wayland running on arm64 / rpi4
```
vo=gpu
gpu-context=wayland
hwdec=mmal
```
using drm instead of wayland worked fine on the same system


I hope someone with knowledge of mpv likes to have a closer look at the problem since I don't have any clue what `mp_imgfmt_get_desc_from_pixdesc` does and only a vague undestanding what the whole `img_format.c` is about -> fix works fine for me but just guarding against null might only hide the problem ..

anyways, will open an issue and attach a stacktrace from gdb later