### PR TITLE
vo_gpu_next: refactor subtitle rendering

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -965,14 +965,14 @@ if libplacebo.found()
     sources += files('video/out/placebo/ra_pl.c',
                      'video/out/placebo/utils.c')
     pl_api_ver = libplacebo.version().split('.')[1]
-    if pl_api_ver.version_compare('>=190')
+    if pl_api_ver.version_compare('>=197')
         features += 'libplacebo-next'
         libplacebo_next = true
-        message('libplacebo v4.190+ found! Enabling vo_gpu_next.')
+        message('libplacebo v4.197+ found! Enabling vo_gpu_next.')
         sources += files('video/out/vo_gpu_next.c',
                          'video/out/gpu_next/context.c')
     else
-        message('libplacebo v4.190+ not found! Disabling vo_gpu_next.')
+        message('libplacebo v4.197+ not found! Disabling vo_gpu_next.')
     endif
 endif
 

--- a/player/command.c
+++ b/player/command.c
@@ -6619,6 +6619,8 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
             }
         }
         osd_changed(mpctx->osd);
+        if (mpctx->video_out)
+            vo_control_async(mpctx->video_out, VOCTRL_OSD_CHANGED, NULL);
         if (flags & (UPDATE_SUB_FILT | UPDATE_SUB_HARD))
             mp_force_video_refresh(mpctx);
         mp_wakeup_core(mpctx);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -678,6 +678,7 @@ void vo_control_async(struct vo *vo, int request, void *data)
         break;
     case VOCTRL_KILL_SCREENSAVER:
     case VOCTRL_RESTORE_SCREENSAVER:
+    case VOCTRL_OSD_CHANGED:
         break;
     default:
         abort(); // requires explicit support

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -72,6 +72,9 @@ enum mp_voctrl {
     // you could install your own listener.
     VOCTRL_VO_OPTS_CHANGED,
 
+    // Triggered by any change to the OSD (e.g. OSD style changes)
+    VOCTRL_OSD_CHANGED,
+
     /* private to vo_gpu */
     VOCTRL_LOAD_HWDEC_API,
 

--- a/wscript
+++ b/wscript
@@ -741,9 +741,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 4.157.0'),
     }, {
         'name': 'libplacebo-next',
-        'desc': 'libplacebo v4.190+, needed for vo_gpu_next',
+        'desc': 'libplacebo v4.197+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 190',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 197',
                                    use='libplacebo'),
     }, {
         'name': '--vulkan',


### PR DESCRIPTION
Render subs at the video resolution, rather than the overlay resolution.
Uses the new APIs found in libplacebo 196+, to allow controlling the OSD
resolution even for image-attached overlays.

Also fixes an issue where the overlay state did not get correctly
updated while paused. To avoid regenerating the OSD / flushing the cache
constantly, we keep track of OSD changes and only regenerate the OSD
when the OSD state is expected to change in some way (e.g. resolution
change). This requires introducing a new VOCTRL to inform the VO when
the UPDATE_OSD-tagged options have changed.

Fixes #9744, #9524, #9399 and #9398.

TODO:
- [x] video-rotate etc. breaks subtitles entirely
- [x] test to see if it interacts as expected with sub-use-margins?
- [x] should we support `--blend-subtitles=video` still? (it won't blend it onto the video, though, just generate it at video res - with bilinear scaling...)

(*should* subtitles be rotated along with the video, or not?)

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.