### PR TITLE
filter_kernels: implementation of Hpl_2007_179 (not finished)

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5156,7 +5156,7 @@ them.
     Defaults to the filter's preferred window if unset. Use
     ``--scale-window=help`` to get a list of supported windowing functions.
 
-``--scale-wparam=<window>``, ``--cscale-wparam=<window>``, ``--cscale-wparam=<window>``, ``--tscale-wparam=<window>``
+``--scale-wparam1=<window>``, ``--scale-wparam2=<window>``, ``--cscale-wparam1=<window>``, ``--cscale-wparam2=<window>``, ``--dscale-wparam1=<window>``, ``--dscale-wparam2=<window>``, ``--tscale-wparam1=<window>``, ``--tscale-wparam2=<window>``
     (Advanced users only) Configure the parameter for the window function given
     by ``--scale-window`` etc. By default, these are set to the special string
     ``default``, which maps to a window-specific default value. Ignored if the
@@ -5170,6 +5170,8 @@ them.
     gaussian
         Scale parameter (t). Increasing this makes the window wider. Defaults
         to 1.
+    hpl_2007_197
+        Window parameters (chi) and (eta). Defaults to 0.414 and 0.61.
 
 ``--scaler-lut-size=<4..10>``
     Set the size of the lookup texture for scaler kernels (default: 6). The

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -316,6 +316,18 @@ static double gaussian(params *p, double x)
     return exp(-2.0 * x * x / p->params[0]);
 }
 
+static double hpl_2007_179(params *p, double x)
+{
+    //fix me: if radius is set to 4 by user or defaults,
+    //x here have to stay x and not x/4
+    x *= user_set_or_defualt_scale_radius;
+    double chi = p->params[0],
+           eta = p->params[1];
+    double n = M_PI * chi * x / (2.0 - eta);
+    n *= n;
+    return cosh(sqrt(2.0 * eta) * M_PI * chi * x / (2.0 - eta)) * pow(M_E, -n);
+}
+
 static double sinc(params *p, double x)
 {
     if (fabs(x) < 1e-8)
@@ -353,6 +365,7 @@ const struct filter_window mp_filter_windows[] = {
     {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
     {"blackman",       1,   blackman, .params = {0.16, NAN} },
     {"gaussian",       2,   gaussian, .params = {1.00, NAN} },
+    {"hpl_2007_179",   1,   hpl_2007_179, .params = {0.414, 0.61} },
     {"sinc",           1,   sinc},
     {"jinc",           1.2196698912665045, jinc},
     {"sphinx",         1.4302966531242027, sphinx},

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -357,7 +357,8 @@ static int validate_error_diffusion_opt(struct mp_log *log, const m_option_t *op
     {n"-blur",   OPT_FLOAT(scaler[i].kernel.blur)},                        \
     {n"-cutoff", OPT_FLOAT(scaler[i].cutoff), M_RANGE(0.0, 1.0)},          \
     {n"-taper",  OPT_FLOAT(scaler[i].kernel.taper), M_RANGE(0.0, 1.0)},    \
-    {n"-wparam", OPT_FLOATDEF(scaler[i].window.params[0])},                \
+    {n"-wparam1", OPT_FLOATDEF(scaler[i].window.params[0])},               \
+    {n"-wparam2", OPT_FLOATDEF(scaler[i].window.params[1])},               \
     {n"-wblur",  OPT_FLOAT(scaler[i].window.blur)},                        \
     {n"-wtaper", OPT_FLOAT(scaler[i].window.taper), M_RANGE(0.0, 1.0)},    \
     {n"-clamp",  OPT_FLOAT(scaler[i].clamp), M_RANGE(0.0, 1.0)},           \


### PR DESCRIPTION
https://www.hpl.hp.com/techreports/2007/HPL-2007-179.pdf

As mentioned in the code x has to stay x and not x/radius. Now I don't know an elegant solution to this problem.

I tested the implementation and replicating existing kernels as mentioned in the paper yields close dssim results. On top of that the filter can be fine tuned to perform even better, as mentioned in the paper. 

Sorry for unfinished code, had no luck getting help on irc.