### PR TITLE
mac: fix screen selection edge case

### DIFF
--- a/TOOLS/macos-sdk-version.py
+++ b/TOOLS/macos-sdk-version.py
@@ -49,7 +49,7 @@ def find_macos_sdk():
         build_version = '10.' + str(major) + '.' + str(minor)
         # from 20 onwards macOS 11.0 starts
         if int(version_parts.group(1)) >= 20:
-            build_version = '11.' + str(minor)
+            build_version = str(major - 9) + '.' + str(minor)
 
     if not isinstance(sdk_version, str):
         sdk_version = '10.10.0'

--- a/osdep/macos/swift_extensions.swift
+++ b/osdep/macos/swift_extensions.swift
@@ -28,37 +28,6 @@ extension NSScreen {
             return deviceDescription[.screenNumber] as? CGDirectDisplayID ?? 0
         }
     }
-
-    public var displayName: String? {
-        get {
-            var name: String? = nil
-            var object: io_object_t
-            var iter = io_iterator_t()
-            let matching = IOServiceMatching("IODisplayConnect")
-            let result = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &iter)
-
-            if result != KERN_SUCCESS || iter == 0 { return nil }
-
-            repeat {
-                object = IOIteratorNext(iter)
-                if let info = IODisplayCreateInfoDictionary(object, IOOptionBits(kIODisplayOnlyPreferredName)).takeRetainedValue() as? [String:AnyObject],
-                    (info[kDisplayVendorID] as? UInt32 == CGDisplayVendorNumber(displayID) &&
-                    info[kDisplayProductID] as? UInt32 == CGDisplayModelNumber(displayID) &&
-                    info[kDisplaySerialNumber] as? UInt32 ?? 0 == CGDisplaySerialNumber(displayID))
-                {
-                    if let productNames = info["DisplayProductName"] as? [String:String],
-                       let productName = productNames.first?.value
-                    {
-                        name = productName
-                        break
-                    }
-                }
-            } while object != 0
-
-            IOObjectRelease(iter)
-            return name
-        }
-    }
 }
 
 extension NSColor {

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -395,6 +395,7 @@ class Common: NSObject {
     }
 
     func getScreenBy(name screenName: String?) -> NSScreen? {
+        if (screenName == nil) { return nil }
         for screen in NSScreen.screens {
             if screen.displayName == screenName {
                 return screen

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -397,7 +397,7 @@ class Common: NSObject {
     func getScreenBy(name screenName: String?) -> NSScreen? {
         if (screenName == nil) { return nil }
         for screen in NSScreen.screens {
-            if screen.displayName == screenName {
+            if screen.localizedName == screenName {
                 return screen
             }
         }
@@ -629,7 +629,7 @@ class Common: NSObject {
             let dnames = data!.assumingMemoryBound(to: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?.self)
             var array: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>? = nil
             var count: Int32 = 0
-            let displayName = getCurrentScreen()?.displayName ?? "Unknown"
+            let displayName = getCurrentScreen()?.localizedName ?? "Unknown"
 
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, nil)


### PR DESCRIPTION
For one of my monitors `NSScreen.displayName` was reporting `nil`. This lead to the following two issues.

* It was not possible to select the monitor by name, e.g. `--screen-name` or `--fs-screen-name`. This is addressed by an additional name check with the system provided `localizedName`.
* If no output monitor was specified, it would always default to this `nil`-monitor because there would be a match for `screen.displayName == screenName` thus returning this monitor, instead of returning `nil` (the default). This is addressed with a check for `nil`.