### PR TITLE
options: add always to stop-screensaver

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3255,10 +3255,12 @@ Window
     1). A value of 1 means square pixels (correct for (almost?) all LCDs). See
     also ``--monitoraspect`` and ``--video-aspect-override``.
 
-``--stop-screensaver``, ``--no-stop-screensaver``
+``--stop-screensaver=<yes|no|always>``
     Turns off the screensaver (or screen blanker and similar mechanisms) at
-    startup and turns it on again on exit (default: yes). The screensaver is
-    always re-enabled when the player is paused.
+    startup and turns it on again on exit (default: yes). When using ``yes``,
+    the screensaver will re-enable when playback is not active. ``always`` will
+    always disable the screensaver. Note that stopping the screensaver is only
+    possible if a video output is available (i.e. there is an open mpv window).
 
     This is not supported on all video outputs or platforms. Sometimes it is
     implemented, but does not work (especially with Linux "desktops"). Read the

--- a/options/options.c
+++ b/options/options.c
@@ -648,7 +648,11 @@ static const m_option_t mp_opts[] = {
     {"cursor-autohide", OPT_CHOICE(cursor_autohide_delay,
         {"no", -1}, {"always", -2}), M_RANGE(0, 30000)},
     {"cursor-autohide-fs-only", OPT_FLAG(cursor_autohide_fs)},
-    {"stop-screensaver", OPT_FLAG(stop_screensaver), .flags = UPDATE_SCREENSAVER},
+    {"stop-screensaver", OPT_CHOICE(stop_screensaver,
+        {"no", 0},
+        {"yes", 1},
+        {"always", 2}),
+        .flags = UPDATE_SCREENSAVER},
 
     {"", OPT_SUBSTRUCT(video_equalizer, mp_csp_equalizer_conf)},
 

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -197,7 +197,8 @@ void update_screensaver_state(struct MPContext *mpctx)
     if (!mpctx->video_out)
         return;
 
-    bool saver_state = !mpctx->playback_active || !mpctx->opts->stop_screensaver;
+    bool saver_state = (!mpctx->playback_active || !mpctx->opts->stop_screensaver) &&
+                       mpctx->opts->stop_screensaver != 2;
     vo_control_async(mpctx->video_out, saver_state ? VOCTRL_RESTORE_SCREENSAVER
                                                    : VOCTRL_KILL_SCREENSAVER, NULL);
 }


### PR DESCRIPTION
The stop-screensaver option is currently limited to a simple yes/no
option. While the no option does always disable mpv trying to stop the
screensaver, yes does not mean the screensaver is always stopped. The
screensaver will be enabled again depending on certain conditions (like
if the player is paused). Simply introduce a new value for this option,
always, which does exactly what the name implies: the screensaver will
always be disabled.

Related issue #9872.