### PR TITLE
versions: adding /env to the shebang line

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 export LC_ALL=C
 


### PR DESCRIPTION
Previously the first line/shebang was #!/bin/sh 
I am proposing to change the first line to #!/usr/bin/env sh for portability.
In Summary: Changing #!/bin/sh to  #!/usr/bin/env sh
