### PR TITLE
TOOLS/umpv: add desktop notifications and a umpv.desktop file

### DIFF
--- a/TOOLS/umpv
+++ b/TOOLS/umpv
@@ -19,6 +19,9 @@ will typically just fill ~/.xsession-errors with garbage.
 mpv will terminate if there are no more files to play, and running the umpv
 script after that will start a new mpv instance.
 
+If "notify-send" (provided by libnotify) is installed, a temporary notification
+will be shown as feedback for every file appended to the playlist.
+
 Note: you can supply custom mpv path and options with the MPV environment
       variable. The environment variable will be split on whitespace, and the
       first item is used as path to mpv binary and the rest is passed as options
@@ -64,7 +67,7 @@ except socket.error as e:
         pass  # abandoned socket
     elif e.errno == errno.ENOENT:
         sock = None
-        pass # doesn't exist
+        pass  # doesn't exist
     else:
         raise e
 
@@ -75,6 +78,20 @@ if sock:
         f = f.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
         f = "\"" + f + "\""
         sock.send(("raw loadfile " + f + " append\n").encode("utf-8"))
+
+    try:
+        # Try to show a notification
+        subprocess.call([
+            "notify-send",  # A binary, provided by libnotify 
+            "--hint=int:transient:1",  # Don't keep the notification in a history
+            "--urgency=low",
+            "--icon=multimedia-player",  # Alt. icons: video-x-generic, list-add
+            "File appended to playlist",  # Title
+            f  # Body
+        ])
+    except FileNotFoundError:
+        # notify-send not installed; ignore
+        pass
 else:
     # Let mpv recreate socket if it doesn't already exist.
 

--- a/TOOLS/umpv.desktop
+++ b/TOOLS/umpv.desktop
@@ -1,0 +1,41 @@
+# Desktop entry for the umpv script
+# Place in /usr/share/applications/ or /usr/local/share/applications/ or ~/.local/share/applications/
+# Make sure umpv is installed and in your path: https://github.com/mpv-player/mpv/blob/master/TOOLS/umpv
+# Based on https://github.com/mpv-player/mpv/blob/master/etc/mpv.desktop
+[Desktop Entry]
+Type=Application
+Name=mpv Media Player (unique)
+Name[ca]=Reproductor multimèdia mpv (unique)
+Name[cs]=mpv přehrávač (unique)
+Name[da]=mpv-medieafspiller (unique)
+Name[fr]=Lecteur multimédia mpv (unique)
+Name[pl]=Odtwarzacz mpv (unique)
+Name[ru]=Проигрыватель mpv (unique)
+Name[zh_CN]=mpv 媒体播放器 (unique)
+Name[zh_TW]=mpv 媒體播放器 (unique)
+GenericName=Multimedia player
+GenericName[cs]=Multimediální přehrávač
+GenericName[da]=Multimedieafspiller
+GenericName[fr]=Lecteur multimédia
+GenericName[zh_CN]=多媒体播放器
+GenericName[zh_TW]=多媒體播放器
+Comment=Play movies and songs
+Comment[ca]=Reproduïu vídeos i cançons
+Comment[cs]=Přehrává filmy a hudbu
+Comment[da]=Afspil film og sange
+Comment[de]=Filme und Musik abspielen
+Comment[es]=Reproduzca vídeos y canciones
+Comment[fr]=Lire des vidéos et des musiques
+Comment[it]=Lettore multimediale
+Comment[pl]=Odtwarzaj filmy i muzykę
+Comment[ru]=Воспроизвести фильмы и музыку
+Comment[zh_CN]=播放电影和歌曲
+Comment[zh_TW]=播放電影和歌曲
+Icon=mpv
+TryExec=umpv
+Exec=umpv %U
+Terminal=false
+Categories=AudioVideo;Audio;Video;Player;TV;
+MimeType=application/ogg;application/x-ogg;application/mxf;application/sdp;application/smil;application/x-smil;application/streamingmedia;application/x-streamingmedia;application/vnd.rn-realmedia;application/vnd.rn-realmedia-vbr;audio/aac;audio/x-aac;audio/vnd.dolby.heaac.1;audio/vnd.dolby.heaac.2;audio/aiff;audio/x-aiff;audio/m4a;audio/x-m4a;application/x-extension-m4a;audio/mp1;audio/x-mp1;audio/mp2;audio/x-mp2;audio/mp3;audio/x-mp3;audio/mpeg;audio/mpeg2;audio/mpeg3;audio/mpegurl;audio/x-mpegurl;audio/mpg;audio/x-mpg;audio/rn-mpeg;audio/musepack;audio/x-musepack;audio/ogg;audio/scpls;audio/x-scpls;audio/vnd.rn-realaudio;audio/wav;audio/x-pn-wav;audio/x-pn-windows-pcm;audio/x-realaudio;audio/x-pn-realaudio;audio/x-ms-wma;audio/x-pls;audio/x-wav;video/mpeg;video/x-mpeg2;video/x-mpeg3;video/mp4v-es;video/x-m4v;video/mp4;application/x-extension-mp4;video/divx;video/vnd.divx;video/msvideo;video/x-msvideo;video/ogg;video/quicktime;video/vnd.rn-realvideo;video/x-ms-afs;video/x-ms-asf;audio/x-ms-asf;application/vnd.ms-asf;video/x-ms-wmv;video/x-ms-wmx;video/x-ms-wvxvideo;video/x-avi;video/avi;video/x-flic;video/fli;video/x-flc;video/flv;video/x-flv;video/x-theora;video/x-theora+ogg;video/x-matroska;video/mkv;audio/x-matroska;application/x-matroska;video/webm;audio/webm;audio/vorbis;audio/x-vorbis;audio/x-vorbis+ogg;video/x-ogm;video/x-ogm+ogg;application/x-ogm;application/x-ogm-audio;application/x-ogm-video;application/x-shorten;audio/x-shorten;audio/x-ape;audio/x-wavpack;audio/x-tta;audio/AMR;audio/ac3;audio/eac3;audio/amr-wb;video/mp2t;audio/flac;audio/mp4;application/x-mpegurl;video/vnd.mpegurl;application/vnd.apple.mpegurl;audio/x-pn-au;video/3gp;video/3gpp;video/3gpp2;audio/3gpp;audio/3gpp2;video/dv;audio/dv;audio/opus;audio/vnd.dts;audio/vnd.dts.hd;audio/x-adpcm;application/x-cue;audio/m3u;
+X-KDE-Protocols=ftp,http,https,mms,rtmp,rtsp,sftp,smb,srt
+StartupWMClass=mpv


### PR DESCRIPTION
TOOLS/umpv.desktop is similar to etc/mpv.desktop, but starts the umpv script instead of mpv directly.

The umpv script will show a notification every time a file is appended to the playlist, but not the first time umpv is started. It will only work with libnotify installed (a very common package) and otherwise be ignored.

Also a non-functional space in line 70 is added for code consistency.

`diff mpv.desktop umpv.desktop`:

```diff
0a1,4
> # Desktop entry for the umpv script
> # Place in /usr/share/applications/ or /usr/local/share/applications/ or ~/.local/share/applications/
> # Make sure umpv is installed and in your path: https://github.com/mpv-player/mpv/blob/master/TOOLS/umpv
> # Based on https://github.com/mpv-player/mpv/blob/master/etc/mpv.desktop
3,11c7,15
< Name=mpv Media Player
< Name[ca]=Reproductor multimèdia mpv
< Name[cs]=mpv přehrávač
< Name[da]=mpv-medieafspiller
< Name[fr]=Lecteur multimédia mpv
< Name[pl]=Odtwarzacz mpv
< Name[ru]=Проигрыватель mpv
< Name[zh_CN]=mpv 媒体播放器
< Name[zh_TW]=mpv 媒體播放器
---
> Name=mpv Media Player (unique)
> Name[ca]=Reproductor multimèdia mpv (unique)
> Name[cs]=mpv přehrávač (unique)
> Name[da]=mpv-medieafspiller (unique)
> Name[fr]=Lecteur multimédia mpv (unique)
> Name[pl]=Odtwarzacz mpv (unique)
> Name[ru]=Проигрыватель mpv (unique)
> Name[zh_CN]=mpv 媒体播放器 (unique)
> Name[zh_TW]=mpv 媒體播放器 (unique)
31,32c35,36
< TryExec=mpv
< Exec=mpv --player-operation-mode=pseudo-gui -- %U
---
> TryExec=umpv
> Exec=umpv %U
```