### PR TITLE
mp_image: fix mp_image_plane_w/h

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -218,15 +218,13 @@ int mp_chroma_div_up(int size, int shift)
 // Return the storage width in pixels of the given plane.
 int mp_image_plane_w(struct mp_image *mpi, int plane)
 {
-    return mp_chroma_div_up(MP_ALIGN_UP(mpi->w, mpi->fmt.align_x),
-                            mpi->fmt.xs[plane]);
+    return mp_chroma_div_up(mpi->w, mpi->fmt.xs[plane]);
 }
 
 // Return the storage height in pixels of the given plane.
 int mp_image_plane_h(struct mp_image *mpi, int plane)
 {
-    return mp_chroma_div_up(MP_ALIGN_UP(mpi->h, mpi->fmt.align_y),
-                            mpi->fmt.ys[plane]);
+    return mp_chroma_div_up(mpi->h, mpi->fmt.ys[plane]);
 }
 
 // Caller has to make sure this doesn't exceed the allocated plane data/strides.


### PR DESCRIPTION
These helpers, for some reason, decided to round the returned values up
to multiples of the nearest plane alignment. This logic makes no sense
to me, and completely breaks any sort of oddly-sized mp_image.

This logic was introduced, presumably in error and without real
justification, as part of a major refactor commit (caee8748), As far as
I can tell, removing it again doesn't regress anything.

Fixes several serious bugs including buffer underflows and GPU crashes
in vo_gpu and vo_gpu_next.