### PR TITLE
filters: Re-add vavpp deinterlacing auto-filter

### DIFF
--- a/filters/f_auto_filters.c
+++ b/filters/f_auto_filters.c
@@ -82,6 +82,11 @@ static void deint_process(struct mp_filter *f)
         char *args[] = {"mode", "send_field", NULL};
         p->sub.filter =
             mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "yadif_cuda", args);
+    } else if (img->imgfmt == IMGFMT_VAAPI) {
+        char *args[] = {"deint", "motion-adaptive",
+                        "interlaced-only", "yes", NULL};
+        p->sub.filter =
+            mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "vavpp", args);
     } else {
         has_filter = false;
     }


### PR DESCRIPTION
A few years ago, in 25e70f4743c44db59fe8fc902c93a966d95ba8c3, we
disabled the vavpp deinterlacing auto-filter on the basis that it
caused crashes on _some_ hardware with _some_ driver version(s). But
since then, the situation has improved. There is still a limitation
where you can't turn deinterlacing on on the fly with AMD, but it
doesn't crash anymore (That is #7388).
    
So, given that AMD users have to set up the deinterlacing filter
manually either way, let's re-add the auto-filter for Intel users.
