### PR TITLE
ytdl_hook: fix url_is_safe to match URL protocols properly

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -153,7 +153,7 @@ local function edl_escape(url)
 end
 
 local function url_is_safe(url)
-    local proto = type(url) == "string" and url:match("^(.+)://") or nil
+    local proto = type(url) == "string" and url:match("^(%a[%w+.-]*):") or nil
     local safe = proto and safe_protos[proto]
     if not safe then
         msg.error(("Ignoring potentially unsafe url: '%s'"):format(url))


### PR DESCRIPTION
Some youtube_dl extractors retrieve URLs which contain other URLs
inside of them, for example Funimation, like this:
`https://example.com/video?parameter=https://example.net/something`

The url_is_safe function uses a pattern to match the protocol at the
start of the URL. Before this commit, this pattern was not compliant
with the URL spec (see the definition of "A URL-scheme string"):
https://url.spec.whatwg.org/#url-writing
Therefore it would match any characters, including "://", until the
last occurence of "://" in the string. Thus the above URL would match
`https://example.com/video?parameter=https`
which is not in safe_protos so the video will not play.

Now the protocol can only start with a letter and only contain
alphanumerics, "." "+" or "-" as the spec says, so it will only match
the first protocol in the URL (`https` in the above example.)
Previously the URL also had to contain "//" after the ":". Data URLs
do not contain "//": https://datatracker.ietf.org/doc/html/rfc2397
so now the pattern does not look for "//", only ":".

---

Here's the file on which I found this in the wild (requires a free account and is probably region locked (I'm in the UK))
```
$ mpv --no-config "ytdl://https://www.funimation.com/shows/mushoku-tensei-jobless-reincarnation-p2/what-lies-beyond-effort" --ytdl-raw-options=no-check-certificate=,username="USERNAME",password='PASSWORD',cookies=cookies.txt --ytdl-format="[language=japanese]" 
...
[ytdl_hook] Ignoring potentially unsafe url: 'https://video.prd.funimation.com/FunimationStoreFront/V2140267/f937b23a-0f4a-44bb-887c-23127274a0e7_index.mp4?t=exp=1646246493~acl=https://video.prd.funimation.com/FunimationStoreFront/V2140267/*~hmac=redacted'
```
Before there was the above error, now it plays.
For some reason this only happens on some episodes and some languages - don't know why, but a bug is a bug.

The purpose of `url_is_safe` was to fix [a security issue](https://nvd.nist.gov/vuln/detail/CVE-2018-6360) so please do check I'm not going on the wrong path here, but I think this is sensible.