### PR TITLE
ao_sndio: fix parentheses warning

### DIFF
--- a/audio/out/ao_sndio.c
+++ b/audio/out/ao_sndio.c
@@ -289,9 +289,9 @@ static void get_state(struct ao *ao, struct mp_pcm_state *state)
     state->delay = p->delay / (double)p->par.rate;
 
     /* report unexpected EOF / underrun */
-    if (state->queued_samples && state->queued_samples &&
-        state->queued_samples < state->free_samples &&
-        p->playing || sio_eof(p->hdl))
+    if ((state->queued_samples && state->queued_samples &&
+        (state->queued_samples < state->free_samples) &&
+        p->playing) || sio_eof(p->hdl))
     {
         MP_VERBOSE(ao, "get_state: EOF/underrun detected.\n");
         MP_VERBOSE(ao, "get_state: free: %d, queued: %d, delay: %lf\n", \


### PR DESCRIPTION
```
../audio/out/ao_sndio.c: In function ‘get_state’:
../audio/out/ao_sndio.c:293:53: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  292 |     if (state->queued_samples && state->queued_samples &&
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  293 |         state->queued_samples < state->free_samples &&
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  294 |         p->playing || sio_eof(p->hdl))
      |         ~~~~~~~~~~        
```
cc @noiseless, just to make sure this logic is intended