### PR TITLE
common/av_log.c: add version.h includes

### DIFF
--- a/common/av_log.c
+++ b/common/av_log.c
@@ -32,12 +32,18 @@
 
 #include <libavutil/avutil.h>
 #include <libavutil/log.h>
+#include <libavutil/version.h>
 
 #include <libavcodec/avcodec.h>
+#include <libavcodec/version.h>
 #include <libavformat/avformat.h>
+#include <libavformat/version.h>
 #include <libswresample/swresample.h>
+#include <libswresample/version.h>
 #include <libswscale/swscale.h>
+#include <libswscale/version.h>
 #include <libavfilter/avfilter.h>
+#include <libavfilter/version.h>
 
 #if HAVE_LIBAVDEVICE
 #include <libavdevice/avdevice.h>


### PR DESCRIPTION
FFmpeg recently split version.h into version.h and
version_major.h, and no longer automatically includes
version.h in avcodec.h (and the other libraries). This
should allow mpv to build against ffmpeg git master. See
FFmpeg/ffmpeg@f2da2e1458b76a1d6c068673430b46cf2850bc51