### PR TITLE
swresample: don't forcibly clip on every conversion

### DIFF
--- a/filters/f_swresample.c
+++ b/filters/f_swresample.c
@@ -327,26 +327,6 @@ static void reset(struct mp_filter *f)
         close_lavrr(p);
 }
 
-static void extra_output_conversion(struct mp_aframe *mpa)
-{
-    int format = af_fmt_from_planar(mp_aframe_get_format(mpa));
-    int num_planes = mp_aframe_get_planes(mpa);
-    uint8_t **planes = mp_aframe_get_data_rw(mpa);
-    if (!planes)
-        return;
-    for (int p = 0; p < num_planes; p++) {
-        void *ptr = planes[p];
-        int total = mp_aframe_get_total_plane_samples(mpa);
-        if (format == AF_FORMAT_FLOAT) {
-            for (int s = 0; s < total; s++)
-                ((float *)ptr)[s] = av_clipf(((float *)ptr)[s], -1.0f, 1.0f);
-        } else if (format == AF_FORMAT_DOUBLE) {
-            for (int s = 0; s < total; s++)
-                ((double *)ptr)[s] = MPCLAMP(((double *)ptr)[s], -1.0, 1.0);
-        }
-    }
-}
-
 // This relies on the tricky way mpa was allocated.
 static bool reorder_planes(struct mp_aframe *mpa, int *reorder,
                            struct mp_chmap *newmap)
@@ -450,8 +430,6 @@ static struct mp_frame filter_resample_output(struct priv *p,
         if (got != out_samples)
             goto error;
     }
-
-    extra_output_conversion(out);
 
     if (in) {
         mp_aframe_copy_attributes(out, in);


### PR DESCRIPTION
This was introduced in 04257417 without a clear explanation of the bug
it was solving, so I have no idea if it's still needed (or why it ever
was). And it definitely creates unexpected behavior, e.g. forced
clipping when converting between float and floatp.

I therefore think we should simply remove this logic and see if it
regresses anything else, then fix those other bugs *properly* (if
they're still around).

Fixes #9979