### PR TITLE
vo_gpu[_next]: hwdec: fix logging regression when probing

### DIFF
--- a/filters/filter.c
+++ b/filters/filter.c
@@ -704,7 +704,11 @@ struct AVBufferRef *mp_filter_load_hwdec_device(struct mp_filter *f, int avtype)
                "Unrecognised HW Device type requested. Loading all devices\n");
     }
 
-    hwdec_devices_request_for_img_fmt(info->hwdec_devs, imgfmt);
+    struct hwdec_imgfmt_request params = {
+        .imgfmt = imgfmt,
+        .probing = false,
+    };
+    hwdec_devices_request_for_img_fmt(info->hwdec_devs, &params);
 
     return hwdec_devices_get_lavc(info->hwdec_devs, avtype);
 }

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -431,8 +431,11 @@ static AVBufferRef *hwdec_create_dev(struct mp_filter *vd,
             return ref;
         }
     } else if (ctx->hwdec_devs) {
-        hwdec_devices_request_for_img_fmt(ctx->hwdec_devs,
-                                          pixfmt2imgfmt(hwdec->pix_fmt));
+        struct hwdec_imgfmt_request params = {
+            .imgfmt = pixfmt2imgfmt(hwdec->pix_fmt),
+            .probing = autoprobe,
+        };
+        hwdec_devices_request_for_img_fmt(ctx->hwdec_devs, &params);
         return hwdec_devices_get_lavc(ctx->hwdec_devs, hwdec->lavc_device);
     }
 
@@ -512,9 +515,14 @@ static void select_and_set_hwdec(struct mp_filter *vd)
             } else if (!hwdec->copying) {
                 // Most likely METHOD_INTERNAL, which often use delay-loaded
                 // VO support as well.
-                if (ctx->hwdec_devs)
+                if (ctx->hwdec_devs) {
+                    struct hwdec_imgfmt_request params = {
+                        .imgfmt = pixfmt2imgfmt(hwdec->pix_fmt),
+                        .probing = hwdec_auto,
+                    };
                     hwdec_devices_request_for_img_fmt(
-                        ctx->hwdec_devs, pixfmt2imgfmt(hwdec->pix_fmt));
+                        ctx->hwdec_devs, &params);
+                }
             }
 
             ctx->use_hwdec = true;

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -428,7 +428,11 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
     if (!info || !info->hwdec_devs)
         goto fail;
 
-    hwdec_devices_request_for_img_fmt(info->hwdec_devs, IMGFMT_D3D11);
+    struct hwdec_imgfmt_request params = {
+        .imgfmt = IMGFMT_D3D11,
+        .probing = false,
+    };
+    hwdec_devices_request_for_img_fmt(info->hwdec_devs, &params);
 
     struct mp_hwdec_ctx *hwctx =
         hwdec_devices_get_by_lavc(info->hwdec_devs, AV_HWDEVICE_TYPE_D3D11VA);

--- a/video/hwdec.c
+++ b/video/hwdec.c
@@ -13,7 +13,8 @@ struct mp_hwdec_devices {
     struct mp_hwdec_ctx **hwctxs;
     int num_hwctxs;
 
-    void (*load_api)(void *ctx, int imgfmt);
+    void (*load_api)(void *ctx,
+                     struct hwdec_imgfmt_request *params);
     void *load_api_ctx;
 };
 
@@ -95,16 +96,18 @@ void hwdec_devices_remove(struct mp_hwdec_devices *devs, struct mp_hwdec_ctx *ct
 }
 
 void hwdec_devices_set_loader(struct mp_hwdec_devices *devs,
-    void (*load_api)(void *ctx, int imgfmt), void *load_api_ctx)
+    void (*load_api)(void *ctx, struct hwdec_imgfmt_request *params),
+    void *load_api_ctx)
 {
     devs->load_api = load_api;
     devs->load_api_ctx = load_api_ctx;
 }
 
-void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs, int imgfmt)
+void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs,
+                                       struct hwdec_imgfmt_request *params)
 {
     if (devs->load_api && !hwdec_devices_get_first(devs))
-        devs->load_api(devs->load_api_ctx, imgfmt);
+        devs->load_api(devs->load_api_ctx, params);
 }
 
 char *hwdec_devices_get_names(struct mp_hwdec_devices *devs)

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -51,16 +51,23 @@ void hwdec_devices_add(struct mp_hwdec_devices *devs, struct mp_hwdec_ctx *ctx);
 // not added yet. This is not thread-safe.
 void hwdec_devices_remove(struct mp_hwdec_devices *devs, struct mp_hwdec_ctx *ctx);
 
+struct hwdec_imgfmt_request {
+    int imgfmt;
+    bool probing;
+};
+
 // Can be used to enable lazy loading of an API with hwdec_devices_request().
 // If used at all, this must be set/unset during initialization/uninitialization,
 // as concurrent use with hwdec_devices_request() is a race condition.
 void hwdec_devices_set_loader(struct mp_hwdec_devices *devs,
-    void (*load_api)(void *ctx, int imgfmt), void *load_api_ctx);
+    void (*load_api)(void *ctx, struct hwdec_imgfmt_request *params),
+    void *load_api_ctx);
 
 // Cause VO to lazily load all devices for a specified img format, and will
 // block until this is done (even if not available). Pass IMGFMT_NONE to load
 // all available devices.
-void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs, int imgfmt);
+void hwdec_devices_request_for_img_fmt(struct mp_hwdec_devices *devs,
+                                       struct hwdec_imgfmt_request *params);
 
 // Return "," concatenated list (for introspection/debugging). Use talloc_free().
 char *hwdec_devices_get_names(struct mp_hwdec_devices *devs);

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -275,8 +275,9 @@ void ra_hwdec_ctx_uninit(struct ra_hwdec_ctx *ctx)
 }
 
 void ra_hwdec_ctx_load_fmt(struct ra_hwdec_ctx *ctx, struct mp_hwdec_devices *devs,
-                           int imgfmt)
+                           struct hwdec_imgfmt_request *params)
 {
+    int imgfmt = params->imgfmt;
     if (ctx->loading_done) {
         /*
          * If we previously marked interop loading as done (for reasons
@@ -307,7 +308,7 @@ void ra_hwdec_ctx_load_fmt(struct ra_hwdec_ctx *ctx, struct mp_hwdec_devices *de
             continue;
         }
 
-        load_add_hwdec(ctx, devs, drv, false);
+        load_add_hwdec(ctx, devs, drv, params->probing);
     }
 }
 

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -25,7 +25,7 @@ void ra_hwdec_ctx_init(struct ra_hwdec_ctx *ctx, struct mp_hwdec_devices *devs,
 void ra_hwdec_ctx_uninit(struct ra_hwdec_ctx *ctx);
 
 void ra_hwdec_ctx_load_fmt(struct ra_hwdec_ctx *ctx, struct mp_hwdec_devices *devs,
-                           int imgfmt);
+                           struct hwdec_imgfmt_request *params);
 
 // Gets the right `ra_hwdec` for a format, if any
 struct ra_hwdec *ra_hwdec_get(struct ra_hwdec_ctx *ctx, int imgfmt);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -4323,10 +4323,9 @@ void gl_video_init_hwdecs(struct gl_video *p, struct mp_hwdec_devices *devs,
     ra_hwdec_ctx_init(&p->hwdec_ctx, devs, p->opts.hwdec_interop, load_all_by_default);
 }
 
-void gl_video_load_hwdecs_for_img_fmt(struct gl_video *p,
-                                      struct mp_hwdec_devices *devs,
-                                      int imgfmt)
+void gl_video_load_hwdecs_for_img_fmt(struct gl_video *p, struct mp_hwdec_devices *devs,
+                                      struct hwdec_imgfmt_request *params)
 {
     assert(p->hwdec_ctx.ra);
-    ra_hwdec_ctx_load_fmt(&p->hwdec_ctx, devs, imgfmt);
+    ra_hwdec_ctx_load_fmt(&p->hwdec_ctx, devs, params);
 }

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -220,8 +220,9 @@ bool gl_video_showing_interpolated_frame(struct gl_video *p);
 struct mp_hwdec_devices;
 void gl_video_init_hwdecs(struct gl_video *p, struct mp_hwdec_devices *devs,
                           bool load_all_by_default);
+struct hwdec_imgfmt_request;
 void gl_video_load_hwdecs_for_img_fmt(struct gl_video *p, struct mp_hwdec_devices *devs,
-                                      int imgfmt);
+                                      struct hwdec_imgfmt_request *params);
 
 struct vo;
 void gl_video_configure_queue(struct gl_video *p, struct vo *vo);

--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -74,10 +74,11 @@ static int cuda_init(struct ra_hwdec *hw)
     int ret = 0;
     struct cuda_hw_priv *p = hw->priv;
     CudaFunctions *cu;
+    int level = hw->probing ? MSGL_V : MSGL_ERR;
 
     ret = cuda_load_functions(&p->cu, NULL);
     if (ret != 0) {
-        MP_VERBOSE(hw, "Failed to load CUDA symbols\n");
+        MP_MSG(hw, level, "Failed to load CUDA symbols\n");
         return -1;
     }
     cu = p->cu;
@@ -94,7 +95,8 @@ static int cuda_init(struct ra_hwdec *hw)
     }
 
     if (!p->ext_init || !p->ext_uninit) {
-        MP_VERBOSE(hw, "CUDA hwdec only works with OpenGL or Vulkan backends.\n");
+        MP_MSG(hw, level,
+               "CUDA hwdec only works with OpenGL or Vulkan backends.\n");
         return -1;
     }
 
@@ -109,7 +111,7 @@ static int cuda_init(struct ra_hwdec *hw)
 
     ret = av_hwdevice_ctx_init(hw_device_ctx);
     if (ret < 0) {
-        MP_ERR(hw, "av_hwdevice_ctx_init failed\n");
+        MP_MSG(hw, level, "av_hwdevice_ctx_init failed\n");
         goto error;
     }
 

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -52,7 +52,6 @@ struct gpu_priv {
 
     int events;
 };
-
 static void resize(struct vo *vo)
 {
     struct gpu_priv *p = vo->priv;
@@ -129,16 +128,15 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
 static void request_hwdec_api(struct vo *vo, void *data)
 {
     struct gpu_priv *p = vo->priv;
-    int imgfmt = (intptr_t)data;
-
-    gl_video_load_hwdecs_for_img_fmt(p->renderer, vo->hwdec_devs, imgfmt);
+    gl_video_load_hwdecs_for_img_fmt(p->renderer, vo->hwdec_devs, data);
 }
 
-static void call_request_hwdec_api(void *ctx, int imgfmt)
+static void call_request_hwdec_api(void *ctx,
+                                   struct hwdec_imgfmt_request *params)
 {
     // Roundabout way to run hwdec loading on the VO thread.
     // Redirects to request_hwdec_api().
-    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, (void *)(intptr_t)imgfmt);
+    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, params);
 }
 
 static void get_and_update_icc_profile(struct gpu_priv *p)

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1218,7 +1218,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
         return true;
 
     case VOCTRL_LOAD_HWDEC_API:
-        ra_hwdec_ctx_load_fmt(&p->hwdec_ctx, vo->hwdec_devs, (intptr_t) data);
+        ra_hwdec_ctx_load_fmt(&p->hwdec_ctx, vo->hwdec_devs, data);
         return true;
     }
 
@@ -1312,9 +1312,9 @@ static void uninit(struct vo *vo)
     gpu_ctx_destroy(&p->context);
 }
 
-static void load_hwdec_api(void *ctx, int imgfmt)
+static void load_hwdec_api(void *ctx, struct hwdec_imgfmt_request *params)
 {
-    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, (void *)(intptr_t) imgfmt);
+    vo_control(ctx, VOCTRL_LOAD_HWDEC_API, params);
 }
 
 static int preinit(struct vo *vo)


### PR DESCRIPTION
When I introduced the concept of lazy loading of hwdecs by img format,
I did not propagate the probing flag correctly, leading to the new
normal loading path not runnng with probing set, meaning that any
errors would show up, creating unnecessary noise.

This change fixes this regression.