### PR TITLE
demux_lavf: fix double-free of pb

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1342,6 +1342,8 @@ static void demux_close_lavf(demuxer_t *demuxer)
         // This will be a dangling pointer; but see below.
         AVIOContext *leaking = priv->avfc ? priv->avfc->pb : NULL;
         avformat_close_input(&priv->avfc);
+        if (leaking == priv->pb)
+            priv->pb = NULL; // already freed above
         // The ffmpeg garbage breaks its own API yet again: hls.c will call
         // io_open on the main playlist, but never calls io_close. This happens
         // to work out for us (since we don't really use custom I/O), but it's


### PR DESCRIPTION
when `priv->avfc` is used, `priv->avfc->pb==priv->pb`

this can cause both copies of `pb` to be freed. the initial free occurs
inside `avformat_close_input` > `avio_close` > `avio_context_free` > `av_freep`

    malloc: *** error for object 0x1151fb5a0: pointer being freed was not allocated
    Thread 14 Crashed:
    0   libsystem_kernel.dylib          0x31973a240         __pthread_kill
    1   libsystem_pthread.dylib         0x31988a408         pthread_kill
    2   libsystem_c.dylib               0x3195b8474         abort
    3   libsystem_malloc.dylib          0x319806a5c         <redacted>
    4   libsystem_malloc.dylib          0x319806c34         <redacted>
    5   libsystem_malloc.dylib          0x3197fe6a8         free
    6   libmpv                          0x10454ddc4         [inlined] av_free (mem.c:223)
    7   libmpv                          0x10454ddc4         av_freep (mem.c:233)
    8   libmpv                          0x104488330         demux_shutdown (demux.c:1100)
    9   libmpv                          0x104488214         demux_free (demux.c:1135)
    10  libmpv                          0x1044e59e0         [inlined] kill_demuxers_reentrant (loadfile.c:155)
    11  libmpv                          0x1044e59e0         [inlined] uninit_demuxer (loadfile.c:237)

Signed-off-by: Aman Karmani <aman@tmm1.net>