### PR TITLE
Use atomic for osd_state.force_video_pts to reduce contention with vo thread

### DIFF
--- a/osdep/atomic.h
+++ b/osdep/atomic.h
@@ -25,6 +25,7 @@
 #if HAVE_STDATOMIC
 #include <stdatomic.h>
 typedef _Atomic float mp_atomic_float;
+typedef _Atomic double mp_atomic_double;
 typedef _Atomic int64_t mp_atomic_int64;
 typedef _Atomic uint64_t mp_atomic_uint64;
 #else
@@ -40,6 +41,7 @@ typedef struct { uint_least32_t v;     } atomic_uint_least32_t;
 typedef struct { unsigned long long v; } atomic_ullong;
 
 typedef struct { float v;              } mp_atomic_float;
+typedef struct { double v;             } mp_atomic_double;
 typedef struct { int64_t v;            } mp_atomic_int64;
 typedef struct { uint64_t v;           } mp_atomic_uint64;
 

--- a/sub/osd_state.h
+++ b/sub/osd_state.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 
+#include "osdep/atomic.h"
 #include "osd.h"
 
 enum mp_osdtype {
@@ -70,7 +71,7 @@ struct osd_state {
     struct osd_object *objs[MAX_OSD_PARTS];
 
     bool render_subs_in_filter;
-    double force_video_pts;
+    mp_atomic_double force_video_pts;
 
     bool want_redraw;
     bool want_redraw_notification;


### PR DESCRIPTION
mpv/core's `write_video` calls `osd_set_force_video_pts`, thus interacting with `osd->lock`:

https://github.com/mpv-player/mpv/blob/1c2dde91d369987199782f4914f56019e5a2272c/player/video.c#L1141-L1144

typically this is not a problem, but in the case of `vo_rpi` the vo thread also interacts with `osd->lock` via `update_osd` which ends up calling into `mpgl_osd_generate` > `osd_draw` > `osd_render`

i observed cases where mpv/core was stalling due to slow osd rendering on the VO thread, causing issues with sync calculations

with this PR, mpv/core no longer touches `osd->lock` decoupling the video thread from the core.