### PR TITLE
ao_pipewire: Do not hold thread lock during loop stop

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -230,10 +230,8 @@ static const struct pw_stream_events stream_events = {
 static void uninit(struct ao *ao)
 {
     struct priv *p = ao->priv;
-    if (p->loop) {
-        pw_thread_loop_lock(p->loop);
+    if (p->loop)
         pw_thread_loop_stop(p->loop);
-    }
     if (p->stream)
         pw_stream_destroy(p->stream);
     p->stream = NULL;


### PR DESCRIPTION
Stopping the thread is done using pw_thread_loop_stop(),
*which must be called without the lock held.*

Fixes #10033

Cc @philipl 
See #10023