### PR TITLE
egl_helpers: request at least 8 alpha bits if necessary

### DIFF
--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -132,7 +132,7 @@ static bool create_context(struct ra_ctx *ctx, EGLDisplay display,
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
         EGL_BLUE_SIZE, 8,
-        EGL_ALPHA_SIZE, ctx->opts.want_alpha ? 1 : 0,
+        EGL_ALPHA_SIZE, ctx->opts.want_alpha ? 8 : 0,
         EGL_RENDERABLE_TYPE, rend,
         EGL_NONE
     };


### PR DESCRIPTION
Previously on wayland, it would result in an egl config with only 2 alpha
bits, which technically matches what was requested, but is not very useful.
Fixes #9862

I've been using this patch for a while and have not observed any adverse effects.