### PR TITLE
vd_lavc: hide a deprecation warning in already handled compatible code

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -675,7 +675,9 @@ static void init_avctx(struct mp_filter *vd)
         avctx->opaque = vd;
         avctx->get_buffer2 = get_buffer2_direct;
 #if LIBAVCODEC_VERSION_MAJOR < 60
-        avctx->thread_safe_callbacks = 1;
+        AV_NOWARN_DEPRECATED({
+            avctx->thread_safe_callbacks = 1;
+        });
 #endif
     }
 


### PR DESCRIPTION
The field has been deprecated, yet the upcoming new default is not yet
the default. Thus, until lavc major hits 60 and the default behavior
finally gets changed, we have to explicitly set the field's value.

The deprecation had already been handled by adding the required
version limitation for this code in bbbf3571edfbb0e849d3ef60148743352b84fe84 ,
this change merely just removes the warning which would otherwise
appear until lavc major version gets bumped to 60.