### PR TITLE
vo_gpu/d3d11: mimic libplacebo backbuffer usage

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -189,11 +189,21 @@ static bool d3d11_reconfig(struct ra_ctx *ctx)
 static int d3d11_color_depth(struct ra_swapchain *sw)
 {
     struct priv *p = sw->priv;
+    DXGI_SWAP_CHAIN_DESC desc;
 
-    if (!p->backbuffer)
+    HRESULT hr = IDXGISwapChain_GetDesc(p->swapchain, &desc);
+    if (FAILED(hr)) {
+        MP_ERR(sw->ctx, "Failed to query swap chain description: %s!\n",
+               mp_HRESULT_to_str(hr));
+        return 0;
+    }
+
+    const struct ra_format *ra_fmt =
+        ra_d3d11_get_ra_format(sw->ctx->ra, desc.BufferDesc.Format);
+    if (!ra_fmt)
         return 0;
 
-    return p->backbuffer->params.format->component_depth[0];
+    return ra_fmt->component_depth[0];
 }
 
 static bool d3d11_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -202,6 +202,18 @@ DXGI_FORMAT ra_d3d11_get_format(const struct ra_format *fmt)
     return d3d->fmt;
 }
 
+const struct ra_format *ra_d3d11_get_ra_format(struct ra *ra, DXGI_FORMAT fmt)
+{
+    for (int i = 0; i < ra->num_formats; i++) {
+        struct ra_format *ra_fmt = ra->formats[i];
+
+        if (ra_d3d11_get_format(ra_fmt) == fmt)
+            return ra_fmt;
+    }
+
+    return NULL;
+}
+
 static void setup_formats(struct ra *ra)
 {
     // All formats must be usable as a 2D texture

--- a/video/out/d3d11/ra_d3d11.h
+++ b/video/out/d3d11/ra_d3d11.h
@@ -11,6 +11,10 @@
 // Get the underlying DXGI format from an RA format
 DXGI_FORMAT ra_d3d11_get_format(const struct ra_format *fmt);
 
+// Gets the matching ra_format for a given DXGI format.
+// Returns a nullptr in case of no known match.
+const struct ra_format *ra_d3d11_get_ra_format(struct ra *ra, DXGI_FORMAT fmt);
+
 // Create an RA instance from a D3D11 device. This takes a reference to the
 // device, which is released when the RA instance is destroyed.
 struct ra *ra_d3d11_create(ID3D11Device *device, struct mp_log *log,


### PR DESCRIPTION
Instead of always having the reference outside of calling resize,
request a backbuffer at start and relieve the backbuffer at
submission for presentation.