### PR TITLE
drm: context_drm_egl: add support for enabling VRR

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -647,6 +647,18 @@ Available video output drivers are:
         Note: this option is only available with DRM atomic support.
         (default: display resolution)
 
+    ``--drm-vrr-enabled=<no|yes|auto>``
+        Toggle use of Variable Refresh Rate (VRR), aka Freesync or Adapative Sync
+        on compatible systems. VRR allows for the display to be refreshed at any
+        rate within a range (usually ~40Hz-60Hz for 60Hz displays). This can help
+        with playback of 24/25/50fps content. Support depends on the use of a
+        compatible monitor, GPU, and a sufficiently new kernel with drivers
+        that support the feature.
+
+        :no:    Do not attempt to enable VRR. (default)
+        :yes:   Attempt to enable VRR, whether the capability is reported or not.
+        :auto:  Attempt to enable VRR if support is reported.
+
 ``mediacodec_embed`` (Android)
     Renders ``IMGFMT_MEDIACODEC`` frames directly to an ``android.view.Surface``.
     Requires ``--hwdec=mediacodec`` for hardware decoding, along with

--- a/video/out/drm_atomic.c
+++ b/video/out/drm_atomic.c
@@ -389,6 +389,9 @@ bool drm_atomic_save_old_state(struct drm_atomic_context *ctx)
     if (0 > drm_object_get_property(ctx->crtc, "ACTIVE", &ctx->old_state.crtc.active))
         ret = false;
 
+    // This property was added in kernel 5.0. We will just ignore any errors.
+    drm_object_get_property(ctx->crtc, "VRR_ENABLED", &ctx->old_state.crtc.vrr_enabled);
+
     if (0 > drm_object_get_property(ctx->connector, "CRTC_ID", &ctx->old_state.connector.crtc_id))
         ret = false;
 
@@ -411,6 +414,9 @@ bool drm_atomic_restore_old_state(drmModeAtomicReqPtr request, struct drm_atomic
 
     if (0 > drm_object_set_property(request, ctx->connector, "CRTC_ID", ctx->old_state.connector.crtc_id))
         ret = false;
+
+    // This property was added in kernel 5.0. We will just ignore any errors.
+    drm_object_set_property(request, ctx->crtc, "VRR_ENABLED", ctx->old_state.crtc.vrr_enabled);
 
     if (!drm_mode_ensure_blob(ctx->fd, &ctx->old_state.crtc.mode))
         ret = false;

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -56,6 +56,7 @@ struct drm_atomic_state {
     struct {
         struct drm_mode mode;
         uint64_t active;
+        uint64_t vrr_enabled;
     } crtc;
     struct drm_atomic_plane_state draw_plane;
     struct drm_atomic_plane_state drmprime_video_plane;

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -98,6 +98,8 @@ const struct m_sub_options drm_conf = {
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},
         {"drm-video-plane-id", OPT_REPLACED("drm-drmprime-video-plane")},
         {"drm-osd-size", OPT_REPLACED("drm-draw-surface-size")},
+        {"drm-vrr-enabled", OPT_CHOICE(drm_vrr_enabled,
+            {"no", 0}, {"yes", 1}, {"auto", -1})},
         {0},
     },
     .defaults = &(const struct drm_opts) {
@@ -105,6 +107,7 @@ const struct m_sub_options drm_conf = {
         .drm_atomic = 1,
         .drm_draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drm_drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
+        .drm_vrr_enabled = 0,
     },
     .size = sizeof(struct drm_opts),
 };

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -57,6 +57,7 @@ struct drm_opts {
     int drm_drmprime_video_plane;
     int drm_format;
     struct m_geometry drm_draw_surface_size;
+    int drm_vrr_enabled;
 };
 
 struct drm_vsync_tuple {


### PR DESCRIPTION
Variable Refresh Rate (VRR), aka Freesync or Adaptive Sync can be used
with DRM by setting the VRR_ENABLED property on a crtc if the
connector reports that it is VRR_CAPABLE. This is a useful feature
for us as it is common to play 24/25/50 fps content on displays that
are nominally locked to 60Hz. VRR can allow this content to play at
native framerates.

This is a simple change as we just need to check the capability
and set the enabled property if requested by the user. I've defaulted
it to disabled for now, but it might make sense to default to auto
in the long term.