### PR TITLE
options.lua: remove unused function

### DIFF
--- a/player/lua/options.lua
+++ b/player/lua/options.lua
@@ -1,12 +1,5 @@
 local msg = require 'mp.msg'
 
-local function val2str(val)
-    if type(val) == "boolean" then
-        if val then val = "yes" else val = "no" end
-    end
-    return val
-end
-
 -- converts val to type of desttypeval
 local function typeconv(desttypeval, val)
     if type(desttypeval) == "boolean" then


### PR DESCRIPTION
val2str isn't used anywhere. Its only use was removed in dd3e52fe68,
when it was still part of osc.lua.