### PR TITLE
vo_gpu_next: switch to unpooled hwdec mapping

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -965,14 +965,14 @@ if libplacebo.found()
     sources += files('video/out/placebo/ra_pl.c',
                      'video/out/placebo/utils.c')
     pl_api_ver = libplacebo.version().split('.')[1]
-    if pl_api_ver.version_compare('>=199')
+    if pl_api_ver.version_compare('>=202')
         features += 'libplacebo-next'
         libplacebo_next = true
-        message('libplacebo v4.199+ found! Enabling vo_gpu_next.')
+        message('libplacebo v4.202+ found! Enabling vo_gpu_next.')
         sources += files('video/out/vo_gpu_next.c',
                          'video/out/gpu_next/context.c')
     else
-        message('libplacebo v4.199+ not found! Disabling vo_gpu_next.')
+        message('libplacebo v4.202+ not found! Disabling vo_gpu_next.')
     endif
 endif
 

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -122,7 +122,7 @@ bool ra_hwdec_test_format(struct ra_hwdec *hwdec, int imgfmt)
 }
 
 struct ra_hwdec_mapper *ra_hwdec_mapper_create(struct ra_hwdec *hwdec,
-                                               struct mp_image_params *params)
+                                               const struct mp_image_params *params)
 {
     assert(ra_hwdec_test_format(hwdec, params->imgfmt));
 

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -138,7 +138,7 @@ void ra_hwdec_uninit(struct ra_hwdec *hwdec);
 bool ra_hwdec_test_format(struct ra_hwdec *hwdec, int imgfmt);
 
 struct ra_hwdec_mapper *ra_hwdec_mapper_create(struct ra_hwdec *hwdec,
-                                               struct mp_image_params *params);
+                                               const struct mp_image_params *params);
 void ra_hwdec_mapper_free(struct ra_hwdec_mapper **mapper);
 void ra_hwdec_mapper_unmap(struct ra_hwdec_mapper *mapper);
 int ra_hwdec_mapper_map(struct ra_hwdec_mapper *mapper, struct mp_image *img);

--- a/wscript
+++ b/wscript
@@ -741,9 +741,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 4.157.0'),
     }, {
         'name': 'libplacebo-next',
-        'desc': 'libplacebo v4.199+, needed for vo_gpu_next',
+        'desc': 'libplacebo v4.202+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 199',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 202',
                                    use='libplacebo'),
     }, {
         'name': '--vulkan',


### PR DESCRIPTION
This makes use of the new frame acquire/release callbacks to hold on to
hwdec images only as long as necessary. This should greatly improve the
smoothness/efficiency of hwdec interop, by not holding on to them for
longer than needed.

This also avoids the need to pool hwdec mappers altogether.

Should fix #10067 as well, since frames are now only mapped when we
actually use them.