### PR TITLE
vo_wlshm: use draw_frame instead of draw_image

### DIFF
--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -213,10 +213,11 @@ static int control(struct vo *vo, uint32_t request, void *data)
     return ret;
 }
 
-static void draw_image(struct vo *vo, struct mp_image *src)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *p = vo->priv;
     struct vo_wayland_state *wl = vo->wl;
+    struct mp_image *src = frame->current;
     struct buffer *buf;
 
     bool render = vo_wayland_check_visible(vo);
@@ -261,7 +262,6 @@ static void draw_image(struct vo *vo, struct mp_image *src)
         mp_image_clear(&buf->mpi, 0, 0, buf->mpi.w, buf->mpi.h);
         osd_draw_on_image(vo->osd, p->osd, 0, 0, &buf->mpi);
     }
-    talloc_free(src);
     wl_surface_attach(wl->surface, buf->buffer, 0, 0);
 }
 
@@ -310,7 +310,7 @@ const struct vo_driver video_out_wlshm = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .get_vsync = get_vsync,
     .wakeup = vo_wayland_wakeup,


### PR DESCRIPTION
draw_image is an old API that was deprecated long ago. However when
wlshm was originally added, it used draw_image. There's no particular
reason for this and it can trivially be switched to draw_frame instead.
This has some real advantages (notably --vo=wlshm --idle --force-window
actually works).