### PR TITLE
github/workflows: workaround git permissions error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,8 @@ jobs:
         run: |
           ./bootstrap.py
           zypper -n install meson
+          # workaround to avoid "fatal: unsafe repository" error
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build with meson
         run: |


### PR DESCRIPTION
Recently, git patched a CVE which makes it much more strict about
different users operating on directories they don't own. For us, this
causes breakage with version.sh and version.py since they both run a git
describe command to fetch the commit hash. Currently, this only affects
the tumbleweed container (likely because it was recently changed) and
thus the git describe command always errors out. Workaround this by just
explictly adding the mpv directory as a safe directory for git.