### PR TITLE
vo_gpu_next: avoid 0x0 resizes

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1021,8 +1021,10 @@ static void resize(struct vo *vo)
     struct mp_rect src, dst;
     struct mp_osd_res osd;
     vo_get_src_dst_rects(vo, &src, &dst, &osd);
-    gpu_ctx_resize(p->context, vo->dwidth, vo->dheight);
-    vo->want_redraw = true;
+    if (vo->dwidth && vo->dheight) {
+        gpu_ctx_resize(p->context, vo->dwidth, vo->dheight);
+        vo->want_redraw = true;
+    }
 
     if (mp_rect_equals(&p->src, &src) &&
         mp_rect_equals(&p->dst, &dst) &&


### PR DESCRIPTION
It is possible for vo_gpu_next to attempt a resize before the windowing
backend is fully initialized. In practice, this can happen on wayland
which means libplacebo attempts a 0x0 resize. Depending on the API, a
0x0 resize may be allowed (vulkan or d3d11), but libplacebo just returns
a 0 in this case which mpv doesn't do anything with anyway. In the case
of opengl, this usage is explictly forbidden and will result in a
warning which may confuse users. Solve this by just not trying a resize
if dwidth and dheight in the vo are not available. Fixes https://github.com/mpv-player/mpv/issues/10083.