### PR TITLE
DOCS: stop using git.io

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -30,7 +30,8 @@ Available audio output drivers are:
         explicitly reject multichannel output, as there is no way to detect
         whether a certain channel layout is actually supported.
 
-        You can also try `using the upmix plugin <http://git.io/vfuAy>`_.
+        You can also try `using the upmix plugin
+        <https://github.com/mpv-player/mpv/wiki/ALSA-Surround-Sound-and-Upmixing>`_.
         This setup enables multichannel audio on the ``default`` device
         with automatic upmixing with shared access, so playing stereo
         and multichannel audio at the same time will work as expected.


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/

> *Effective Friday, April 29, 2022 all links on git.io will stop redirecting.*