### PR TITLE
wayland: use wl_surface_damage_buffer

### DIFF
--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -269,8 +269,8 @@ static void flip_page(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wl;
 
-    wl_surface_damage(wl->surface, 0, 0, mp_rect_w(wl->geometry),
-                      mp_rect_h(wl->geometry));
+    wl_surface_damage_buffer(wl->surface, 0, 0, vo->dwidth,
+                             vo->dheight);
     wl_surface_commit(wl->surface);
 
     if (!wl->opts->disable_vsync)

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1045,8 +1045,8 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
     int found = 1;
     struct vo_wayland_state *wl = data;
 
-    if (!strcmp(interface, wl_compositor_interface.name) && (ver >= 3) && found++) {
-        wl->compositor = wl_registry_bind(reg, id, &wl_compositor_interface, 3);
+    if (!strcmp(interface, wl_compositor_interface.name) && (ver >= 4) && found++) {
+        wl->compositor = wl_registry_bind(reg, id, &wl_compositor_interface, 4);
         wl->surface = wl_compositor_create_surface(wl->compositor);
         wl->cursor_surface = wl_compositor_create_surface(wl->compositor);
         wl_surface_add_listener(wl->surface, &surface_listener, wl);
@@ -1395,7 +1395,7 @@ static int set_cursor_visibility(struct vo_wayland_state *wl, bool on)
                               img->hotspot_x/wl->scaling, img->hotspot_y/wl->scaling);
         wl_surface_set_buffer_scale(wl->cursor_surface, wl->scaling);
         wl_surface_attach(wl->cursor_surface, buffer, 0, 0);
-        wl_surface_damage(wl->cursor_surface, 0, 0, img->width, img->height);
+        wl_surface_damage_buffer(wl->cursor_surface, 0, 0, img->width, img->height);
         wl_surface_commit(wl->cursor_surface);
     } else {
         wl_pointer_set_cursor(wl->pointer, wl->pointer_id, NULL, 0, 0);


### PR DESCRIPTION
Since 2018, wl_surface_damage_buffer has been explicitly preferred and
recommended over wl_surface_damage*. mpv was still using the old
function in a couple of spots. The only difference is that we need to
pass buffer coordinates instead of surface coordinates. In vo_wlshm,
this is done by using vo->dwidth/vo->dheight since that is always used
whenever wl_buffers are created. In the case of the cursor surfaace, we
actually already passed buffer coordinates to it (img->width/height)
which was probablly technically wrong with wl_surface_damage, but it
doesn't really matter in practice. This requires bumping wl_compositor
to version 4 which is no problem since this dates back to 2015*.

https://gitlab.freedesktop.org/wayland/wayland/-/commit/921d0548035673a1bf6aeb9396b9bc728133411e
https://gitlab.freedesktop.org/wayland/wayland/-/commit/3384f69ecf043d62a4e036c0353c2daa01d7c4d0