### PR TITLE
console.lua: don't render a 2nd cursor on the OSC

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -188,7 +188,7 @@ function update()
     -- cursor appear in front of the text.
     ass:new_event()
     ass:an(1)
-    ass:pos(2, screeny - 2)
+    ass:pos(2, screeny - 2 - global_margin_y * screeny)
     ass:append(style .. '{\\alpha&HFF&}> ' .. before_cur)
     ass:append(cglyph)
     ass:append(style .. '{\\alpha&HFF&}' .. after_cur)


### PR DESCRIPTION
09ea3a424fe moved the console above the OSC when it is visible so they
don't overlap, but only changed the first ass:pos() call and forgot to
update the second one, which redraws the cursor on top of the text, so
when both the OSC and the console are visible, a second cursor is drawn
on the OSC. You have to type past where the buttons are to notice it.

This commit synchronizes the position of the 2 ASS events.