### PR TITLE
github/workflows: add macOS 12 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
         os:
           - "macos-10.15"
           - "macos-11"
+          - "macos-12"
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Apparently it is now in public beta.

ref actions/virtual-environments#5446