### PR TITLE
meson: compile mpv.exe as a win32 gui application

### DIFF
--- a/generated/meson.build
+++ b/generated/meson.build
@@ -20,8 +20,7 @@ sources += [ebml_defs, ebml_types, version_h]
 # Just generate the com in here for windows builds.
 if win32 and get_option('cplayer')
     features += 'win32-executable'
-    wrapper_flags = ['-municode', '-Wl,--subsystem,console']
     wrapper_sources= '../osdep/win32-console-wrapper.c'
-    executable('mpv', wrapper_sources, c_args: wrapper_flags, link_args: wrapper_flags,
+    executable('mpv', wrapper_sources, c_args: '-municode', link_args: '-municode',
                name_suffix: 'com', install: true)
 endif

--- a/meson.build
+++ b/meson.build
@@ -297,18 +297,13 @@ endif
 mswin_flags = ['-D_WIN32_WINNT=0x0602', '-DUNICODE', '-DCOBJMACROS',
                '-DINITGUID', '-U__STRICT_ANSI__']
 
-mswin_linkflags = ['-Wl,--major-os-version=6,--minor-os-version=0',
-                   '-Wl,--major-subsystem-version=6,--minor-subsystem-version=0']
-
 if host_machine.system() == 'windows'
     flags += [mswin_flags, '-D__USE_MINGW_ANSI_STDIO=1']
-    link_flags += [mswin_linkflags, '-mwindows']
 endif
 
 if host_machine.system() == 'cygwin'
     features += 'cygwin'
     flags += [mswin_flags, '-mwin32']
-    link_flags += mswin_linkflags
 endif
 
 noexecstack = false
@@ -1865,6 +1860,6 @@ if get_option('cplayer')
                  rename: 'mpv.svg')
     install_data('etc/mpv-symbolic.svg', install_dir: join_paths(hicolor_dir, 'symbolic', 'apps'))
 
-    executable('mpv', sources, dependencies: dependencies,
+    executable('mpv', sources, dependencies: dependencies, win_subsystem: 'windows,6.0',
                include_directories: includedir, install: true)
 endif


### PR DESCRIPTION
Some compiler flags were passed to mpv in order to get it to build as a
gui application on windows. However on the meson build, this always
resulted in mpv being built as a console application. This is because
the function for making executables in meson specifically has a kwarg
called win_subsystem* which defaults to 'console'. That always added
link arguments at the end which compiled mpv.exe as a console
application. The correct thing to do is to remove all of the
subsystem-related flags in the meson build and use the win_subsystem
kwarg as intended by setting it to 'windows,6.0'. For mpv.com, we can
remove the -Wl,--subsystem,console flag since meson will set this by
default in that executable. This makes mpv.exe function correctly and
open with the pseudo-gui while mpv.com acts as a console wrapper.

https://github.com/mesonbuild/meson/commit/1a0603835e3c9f1047d9b7694efc996219a422e4