### PR TITLE
context_drm_egl: support monitor par

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -968,6 +968,15 @@ static bool drm_egl_init(struct ra_ctx *ctx)
     ra_add_native_resource(ctx->ra, "drm_params_v2", &p->drm_params);
     ra_add_native_resource(ctx->ra, "drm_draw_surface_size", &p->draw_surface_size);
 
+    if (ctx->vo->opts->force_monitor_aspect != 0.0) {
+        ctx->vo->monitor_par = p->fb->width / (double) p->fb->height /
+                               ctx->vo->opts->force_monitor_aspect;
+    } else {
+        ctx->vo->monitor_par = 1 / ctx->vo->opts->monitor_pixel_aspect;
+    }
+
+    mp_verbose(ctx->vo->log, "Monitor pixel aspect: %g\n", ctx->vo->monitor_par);
+
     p->vsync_info.vsync_duration = 0;
     p->vsync_info.skipped_vsyncs = -1;
     p->vsync_info.last_queue_display_time = -1;


### PR DESCRIPTION
These values and options were simply never looked at in the drm egl
context. This pretty much is just a copy and paste of what is in vo_drm.
Fixes #10157.

As an aside, if someone is bored, a lot of the drm code could be merged together. It'd be a little involved though.