### PR TITLE
drm_prime: fix issue detected by valgrind

### DIFF
--- a/video/out/drm_prime.c
+++ b/video/out/drm_prime.c
@@ -129,9 +129,12 @@ void drm_prime_add_handle_ref(struct drm_prime_handle_refs *handle_refs,
 {
     if (handle) {
         if (handle > handle_refs->size) {
-            handle_refs->size = handle;
             MP_TARRAY_GROW(handle_refs->ctx, handle_refs->handle_ref_count,
-                           handle_refs->size);
+                           handle);
+            memset(&handle_refs->handle_ref_count[handle_refs->size + 1], 0,
+                           (handle - handle_refs->size)
+                           * sizeof(handle_refs->handle_ref_count[0]));
+            handle_refs->size = handle;
         }
         handle_refs->handle_ref_count[handle - 1]++;
     }


### PR DESCRIPTION
Conditional jump or move depends on uninitialised value(s)
   at 0x10FE22: drm_prime_remove_handle_ref (drm_prime.c:144)
   by 0x10FCCD: drm_prime_destroy_framebuffer (drm_prime.c:107)
   by 0x10FEB1: set_current_frame (hwdec_drmprime_drm.c:73)
   by 0x11054F: overlay_frame (hwdec_drmprime_drm.c:223)
   by 0xF1311: gl_video_render_frame (video.c:3315)
   by 0xFA015: draw_frame (vo_gpu.c:85)
   by 0xF8FDB: render_frame (vo.c:961)
   by 0xF943F: vo_thread (vo.c:1099)
   by 0x5EBE89B: start_thread (in /lib/libpthread-2.31.so)
 Uninitialised value was created by a heap allocation
   at 0x484713C: realloc (vg_replace_malloc.c:1437)
   by 0x10258B: ta_realloc_size (ta.c:195)
   by 0x10325D: ta_xrealloc_size (ta_utils.c:298)
   by 0x10FDBF: drm_prime_add_handle_ref (drm_prime.c:133)
   by 0x10FC57: drm_prime_create_framebuffer (drm_prime.c:87)
   by 0x1102FF: overlay_frame (hwdec_drmprime_drm.c:188)
   by 0xF1311: gl_video_render_frame (video.c:3315)
   by 0xFA015: draw_frame (vo_gpu.c:85)
   by 0xF8FDB: render_frame (vo.c:961)
   by 0xF943F: vo_thread (vo.c:1099)
   by 0x5EBE89B: start_thread (in /lib/libpthread-2.31.so)

Conditional jump or move depends on uninitialised value(s)
   at 0x10FCE4: drm_prime_destroy_framebuffer (drm_prime.c:109)
   by 0x10FEB1: set_current_frame (hwdec_drmprime_drm.c:73)
   by 0x11054F: overlay_frame (hwdec_drmprime_drm.c:223)
   by 0xF1311: gl_video_render_frame (video.c:3315)
   by 0xFA015: draw_frame (vo_gpu.c:85)
   by 0xF8FDB: render_frame (vo.c:961)
   by 0xF943F: vo_thread (vo.c:1099)
   by 0x5EBE89B: start_thread (in /lib/libpthread-2.31.so)
 Uninitialised value was created by a heap allocation
   at 0x484713C: realloc (vg_replace_malloc.c:1437)
   by 0x10258B: ta_realloc_size (ta.c:195)
   by 0x10325D: ta_xrealloc_size (ta_utils.c:298)
   by 0x10FDBF: drm_prime_add_handle_ref (drm_prime.c:133)
   by 0x10FC57: drm_prime_create_framebuffer (drm_prime.c:87)
   by 0x1102FF: overlay_frame (hwdec_drmprime_drm.c:188)
   by 0xF1311: gl_video_render_frame (video.c:3315)
   by 0xFA015: draw_frame (vo_gpu.c:85)
   by 0xF8FDB: render_frame (vo.c:961)
   by 0xF943F: vo_thread (vo.c:1099)
   by 0x5EBE89B: start_thread (in /lib/libpthread-2.31.so)

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.