### PR TITLE
sub: fix subs being invisible after track reinits during pause

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2701,6 +2701,8 @@ static int dequeue_packet(struct demux_stream *ds, double min_pts,
             // if read-ahead went above min_pts.
             if (!lazy_stream_needs_wait(ds))
                 ds->eof = eof = true;
+            else
+                eof = false;
         }
         return eof ? -1 : 0;
     }

--- a/player/core.h
+++ b/player/core.h
@@ -634,7 +634,7 @@ void reinit_sub_all(struct MPContext *mpctx);
 void uninit_sub(struct MPContext *mpctx, struct track *track);
 void uninit_sub_all(struct MPContext *mpctx);
 void update_osd_msg(struct MPContext *mpctx);
-bool update_subtitles(struct MPContext *mpctx, double video_pts);
+bool update_subtitles(struct MPContext *mpctx, double video_pts, bool force_read_ahead);
 
 // video.c
 int video_get_colors(struct vo_chain *vo_c, const char *item, int *value);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1217,7 +1217,7 @@ void run_playloop(struct MPContext *mpctx)
 
     update_osd_msg(mpctx);
     if (mpctx->video_status == STATUS_EOF)
-        update_subtitles(mpctx, mpctx->playback_pts);
+        update_subtitles(mpctx, mpctx->playback_pts, false);
 
     handle_each_frame_screenshot(mpctx);
 

--- a/player/video.c
+++ b/player/video.c
@@ -214,7 +214,7 @@ static void filter_update_subtitles(void *ctx, double pts)
     struct MPContext *mpctx = ctx;
 
     if (osd_get_render_subs_in_filter(mpctx->osd))
-        update_subtitles(mpctx, pts);
+        update_subtitles(mpctx, pts, false);
 }
 
 // (track=NULL creates a blank chain, used for lavfi-complex)
@@ -1141,7 +1141,7 @@ void write_video(struct MPContext *mpctx)
     // Enforce timing subtitles to video frames.
     osd_set_force_video_pts(mpctx->osd, MP_NOPTS_VALUE);
 
-    if (!update_subtitles(mpctx, mpctx->next_frames[0]->pts)) {
+    if (!update_subtitles(mpctx, mpctx->next_frames[0]->pts, false)) {
         MP_VERBOSE(mpctx, "Video frame delayed due to waiting on subtitles.\n");
         return;
     }

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -270,7 +270,7 @@ static bool is_new_segment(struct dec_sub *sub, struct demux_packet *p)
 // Read packets from the demuxer stream passed to sub_create(). Return true if
 // enough packets were read, false if the player should wait until the demuxer
 // signals new packets available (and then should retry).
-bool sub_read_packets(struct dec_sub *sub, double video_pts)
+bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force_read_ahead)
 {
     bool r = true;
     pthread_mutex_lock(&sub->lock);
@@ -292,7 +292,7 @@ bool sub_read_packets(struct dec_sub *sub, double video_pts)
             break;
 
         // (Use this mechanism only if sub_delay matters to avoid corner cases.)
-        double min_pts = sub->opts->sub_delay < 0 ? video_pts : MP_NOPTS_VALUE;
+        double min_pts = sub->opts->sub_delay < 0 || force_read_ahead ? video_pts : MP_NOPTS_VALUE;
 
         struct demux_packet *pkt;
         int st = demux_read_packet_async_until(sub->sh, min_pts, &pkt);

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -42,7 +42,7 @@ void sub_destroy(struct dec_sub *sub);
 
 bool sub_can_preload(struct dec_sub *sub);
 void sub_preload(struct dec_sub *sub);
-bool sub_read_packets(struct dec_sub *sub, double video_pts);
+bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force_read_ahead);
 struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
                                     int format, double pts);
 char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type);


### PR DESCRIPTION
This fixes the issue where switching subtitles or dis- and reenabling subs during pause causes the subs to disapper until the next frame is rendered (i.e. until playback is resumed or a seek/frame step is issued). I am not confident my solution is ideal (for example I am not sure if there isn’t a place where you could just call update_subtitles at a later point in time when the demuxer is guaranteed to be caught up), but it works and has negligible performance impact.
