### PR TITLE
client API: always export symbols on windows

### DIFF
--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -27,10 +27,10 @@
 #include <stdint.h>
 
 /* New symbols must still be added to libmpv/mpv.def. */
-#if defined(__GNUC__) || defined(__clang__)
-#define MPV_EXPORT __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
+#ifdef _WIN32
 #define MPV_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define MPV_EXPORT __attribute__((visibility("default")))
 #else
 #define MPV_EXPORT
 #endif


### PR DESCRIPTION
Windows is weird and symbols weren't actually being exported. This is
because \_\_GNUC\_\_ is defined and picked up in the conditional, but
\_\_attribute\_\_((visibility("default"))) doesn't actually export anything
to the dll. Instead, just check if we have win32 defined first and then
always set __declspec(dllexport). Fixes #10171.