### PR TITLE
various: remove trailing whitespace

### DIFF
--- a/DOCS/man/af.rst
+++ b/DOCS/man/af.rst
@@ -161,14 +161,14 @@ Available filters are:
             Would play media at 1.2x normal speed, with audio at normal pitch.
             Changing playback speed would change pitch, leaving audio tempo at
             1.2x.
-    
+
 ``scaletempo2[=option1:option2:...]``
     Scales audio tempo without altering pitch.
-    The algorithm is ported from chromium and uses the 
+    The algorithm is ported from chromium and uses the
     Waveform Similarity Overlap-and-add (WSOLA) method.
     It seems to achieve a higher audio quality than scaletempo and rubberband.
 
-    By default, the ``search-interval`` and ``window-size`` parameters 
+    By default, the ``search-interval`` and ``window-size`` parameters
     have the same values as in chromium.
 
     ``min-speed=<speed>``
@@ -180,7 +180,7 @@ Available filters are:
 
     ``search-interval=<amount>``
         Length in milliseconds to search for best overlap position. (default: 30)
-    
+
     ``window-size=<amount>``
         Length in milliseconds of the overlap-and-add window. (default: 20)
 

--- a/TOOLS/dylib-unhell.py
+++ b/TOOLS/dylib-unhell.py
@@ -69,7 +69,7 @@ def lib_name(lib):
 
 def process_libraries(libs_dict, binary):
     libs_set = set(libs_dict)
-    # Remove binary from libs_set to prevent a duplicate of the binary being 
+    # Remove binary from libs_set to prevent a duplicate of the binary being
     # added to the libs directory.
     libs_set.remove(binary)
 

--- a/TOOLS/macos-sdk-version.py
+++ b/TOOLS/macos-sdk-version.py
@@ -23,7 +23,7 @@ def find_macos_sdk():
     if not sdk:
         sdk = check_output([xcrun, '--sdk', 'macosx', '--show-sdk-path'],
                             encoding="UTF-8")
-    
+
     # find macOS SDK paths and version
     if sdk_version == '0.0':
         # show-sdk-build-version: is not available on older command line tools, but returns a build version (eg 17A360)

--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -230,7 +230,7 @@ const struct mp_user_filter_entry af_scaletempo2 = {
             .wsola_search_interval_ms = 30,
         },
         .options = (const struct m_option[]) {
-            {"search-interval", 
+            {"search-interval",
                 OPT_FLOAT(wsola_search_interval_ms), M_RANGE(1, 1000)},
             {"window-size",
                 OPT_FLOAT(ola_window_size_ms), M_RANGE(1, 1000)},

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -743,9 +743,9 @@ void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate)
     p->channels = channels;
 
     p->samples_per_second = rate;
-    p->num_candidate_blocks = (int)(p->opts->wsola_search_interval_ms 
+    p->num_candidate_blocks = (int)(p->opts->wsola_search_interval_ms
         * p->samples_per_second / 1000);
-    p->ola_window_size = (int)(p->opts->ola_window_size_ms 
+    p->ola_window_size = (int)(p->opts->ola_window_size_ms
         * p->samples_per_second / 1000);
     // Make sure window size in an even number.
     p->ola_window_size += p->ola_window_size & 1;

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -1,4 +1,4 @@
-// This filter was ported from Chromium 
+// This filter was ported from Chromium
 // (https://chromium.googlesource.com/chromium/chromium/+/51ed77e3f37a9a9b80d6d0a8259e84a8ca635259/media/filters/audio_renderer_algorithm.cc)
 //
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/audio/out/ao_sndio.c
+++ b/audio/out/ao_sndio.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2013 Christian Neukirchen <chneukirchen@gmail.com>
  * Copyright (c) 2020 Rozhuk Ivan <rozhuk.im@gmail.com>
  * Copyright (c) 2021 Andrew Krasavin <noiseless-ak@yandex.ru>
- * 
+ *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.

--- a/meson.build
+++ b/meson.build
@@ -812,7 +812,7 @@ if audiounit['deps'].found() and audiounit['symbol']
     audiounit += {'use': true}
 endif
 
-coreaudio = dependency('appleframeworks', modules: ['CoreFoundation', 'CoreAudio', 
+coreaudio = dependency('appleframeworks', modules: ['CoreFoundation', 'CoreAudio',
                        'AudioUnit', 'AudioToolbox'], required: get_option('coreaudio'))
 if coreaudio.found()
     dependencies += coreaudio

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -485,7 +485,7 @@ local function get_kbinfo_lines(width)
     -- key/subject pre/post formatting for terminal/ass.
     -- key/subject alignment uses spaces (with mono font if ass)
     -- word-wrapping is disabled for ass, or cut at 79 for the terminal
-    local LTR = string.char(0xE2, 0x80, 0x8E)  -- U+200E Left To Right mark 
+    local LTR = string.char(0xE2, 0x80, 0x8E)  -- U+200E Left To Right mark
     local term = not o.use_ass
     local kpre = term and "" or format("{\\q2\\fn%s}%s", o.font_mono, LTR)
     local kpost = term and " " or format(" {\\fn%s}", o.font)

--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -297,7 +297,7 @@ static void remove_leading_hyphen_space(struct sd_filter *sd, int start_pos,
 {
     int old_pos = buf->pos;
     if (start_pos < 0 || start_pos >= old_pos)
-        return; 
+        return;
     append(sd, buf, '\0');  // \0 terminate for reading
 
     // move past leading ass tags

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -786,7 +786,7 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
         ADD(header, "#else\n");
         ADD(header, "precision mediump float;\n");
         ADD(header, "#endif\n");
-        
+
         ADD(header, "precision mediump sampler2D;\n");
         if (sc->ra->caps & RA_CAP_TEX_3D)
             ADD(header, "precision mediump sampler3D;\n");

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -549,7 +549,7 @@ static void update_dpi(struct vo_w32_state *w32)
         ReleaseDC(NULL, hdc);
         MP_VERBOSE(w32, "DPI detected from the old API: %d\n", dpi);
     }
- 
+
     if (dpi <= 0) {
         dpi = 96;
         MP_VERBOSE(w32, "Couldn't determine DPI, falling back to %d\n", dpi);


### PR DESCRIPTION
The modified paragraphs in af.rst could also just be reformatted instead of removing trailing spaces.