### PR TITLE
player: set EOF when seeking to end with keep-open

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -947,8 +947,11 @@ static void handle_keep_open(struct MPContext *mpctx)
     {
         mpctx->stop_play = KEEP_PLAYING;
         if (mpctx->vo_chain) {
-            if (!vo_has_frame(mpctx->video_out)) // EOF not reached normally
+            if (!vo_has_frame(mpctx->video_out)) { // EOF not reached normally
                 seek_to_last_frame(mpctx);
+                mpctx->audio_status = STATUS_EOF;
+                mpctx->video_status = STATUS_EOF;
+            }
         }
         if (opts->keep_open_pause) {
             if (mpctx->ao && ao_is_playing(mpctx->ao))


### PR DESCRIPTION
Normally with the keep-open option, mpv is supposed to set the
eof-reached property to true so clients can possibly do interesting
things at this step. However, there was actually an edge case where this
property notification did not occur. If you use keep-open and then seek
in the file past the end (so mpv stops), property notification is not
actually sent in this case. Internally, mpv does a very exact seek at
this step which also ends playback, but it does not set STATUS_EOF to
the ao and vo before the core idle state is updated. To fix this edge
case, it's simply just a matter of explictly setting STATUS_EOF after
seek_to_last_frame in handle_keep_open. This logic will only ever
trigger if keep-open is being used and the seek goes past the end of the
file, so we know that there will always be an EOF here.

Some related discussion at the very end of #2045 where this bug was discovered.