### PR TITLE
ra_d3d11: corrected VRAM leak.

### DIFF
--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -2229,7 +2229,7 @@ static void destroy(struct ra *ra)
     SAFE_RELEASE(p->dev1);
     SAFE_RELEASE(p->dev);
 
-    if (p->debug && p->ctx) {
+    if (p->ctx) {
         // Destroy the device context synchronously so referenced objects don't
         // show up in the leak check
         ID3D11DeviceContext_ClearState(p->ctx);


### PR DESCRIPTION
A VRAM memory leak was present in d3d11 when `idle=yes` and playback stops for an item. This patch re-enables some of the code which is only used during diagnostic which fixes the issue.

I had previously mentioned this and the fix in the #mpv IRC channel.  This resolves the leak in our testing so we are upstreaming it.