### PR TITLE
player: add mpv-semantic-version property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3303,6 +3303,10 @@ Property list
     The mpv version/copyright string. Depending on how the binary was built, it
     might contain either a release version, or just a git hash.
 
+``mpv-semantic-version``
+    The mpv version in the strict, semantic release format. When built from an
+    arbitrary git hash, the point release will always be 99 (i.e. 0.34.99).
+
 ``mpv-configuration``
     The configuration arguments which were passed to the build system
     (typically the way ``./waf configure ...`` was invoked).

--- a/common/common.h
+++ b/common/common.h
@@ -87,6 +87,7 @@ enum video_sync {
                        (x) == VS_DISP_NONE)
 
 extern const char mpv_version[];
+extern const char mpv_semantic_version[];
 extern const char mpv_builddate[];
 extern const char mpv_copyright[];
 

--- a/common/version.c
+++ b/common/version.c
@@ -23,5 +23,6 @@
 #endif
 
 const char mpv_version[]  = "mpv " VERSION;
+const char mpv_semantic_version[] = SEMANTIC_VERSION;
 const char mpv_builddate[] = BUILDDATE;
 const char mpv_copyright[] = MPVCOPYRIGHT;

--- a/player/command.c
+++ b/player/command.c
@@ -3260,6 +3260,12 @@ static int mp_property_version(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, mpv_version);
 }
 
+static int mp_property_semantic_version(void *ctx, struct m_property *prop,
+                                        int action, void *arg)
+{
+    return m_property_strdup_ro(action, arg, mpv_semantic_version);
+}
+
 static int mp_property_configuration(void *ctx, struct m_property *prop,
                                      int action, void *arg)
 {
@@ -3735,6 +3741,7 @@ static const struct m_property mp_properties_base[] = {
     {"input-key-list", mp_property_keylist},
 
     {"mpv-version", mp_property_version},
+    {"mpv-semantic-version", mp_property_semantic_version},
     {"mpv-configuration", mp_property_configuration},
     {"ffmpeg-version", mp_property_ffmpeg},
     {"libass-version", mp_property_libass_version},

--- a/version.py
+++ b/version.py
@@ -15,11 +15,19 @@ git = which('git')
 if git and os.path.exists(git_dir):
     version = check_output([git, "-C", srcdir, "describe", "--always", "--tags",
                             "--dirty"], encoding="UTF-8")
+    semantic_version = check_output([git, "-C", srcdir, "describe", "--always",
+                                     "--tags", "--abbrev=0"], encoding="UTF-8")
     version = version[1:].strip()
+    semantic_version = semantic_version[1:].strip()
+
+    if version != semantic_version:
+        # arbitrary git hash; change the point release to 99
+        semantic_version = semantic_version.rsplit(".", 1)[0] + ".99"
 else:
     version_path = os.path.join(srcdir, "VERSION")
     with open(version_path, "r") as f:
         version = f.readline().strip()
+    semantic_version = version
 
 if len(sys.argv) < 2:
     print(version)
@@ -32,6 +40,7 @@ date_str = date.strftime("%a %b %d %I:%M:%S %Y")
 
 NEW_REVISION = "#define VERSION \"" + version + "\"\n"
 OLD_REVISION = ""
+SEMANTIC_VER = "#define SEMANTIC_VERSION \"" + semantic_version + "\"\n"
 BUILDDATE = "#define BUILDDATE \"" + date_str + "\"\n"
 MPVCOPYRIGHT = "#define MPVCOPYRIGHT \"Copyright \u00A9 2000-2022 mpv/MPlayer/mplayer2 projects\"" + "\n"
 
@@ -41,5 +50,5 @@ if os.path.isfile(sys.argv[1]):
 
 if NEW_REVISION != OLD_REVISION:
     with open(sys.argv[1], "w", encoding="utf-8") as f:
-        f.writelines([NEW_REVISION, BUILDDATE, MPVCOPYRIGHT])
+        f.writelines([NEW_REVISION, SEMANTIC_VER, BUILDDATE, MPVCOPYRIGHT])
 


### PR DESCRIPTION
Not sure if we wanted this, but someone asked for it a long time ago (#7785) and it's not too bad to implement. One thing to note that is the current implementation will always change the point release version to 99 (i.e. you get 0.34.99; not my original idea) if building from an arbitrary git hash.