### PR TITLE
osc.lua: add idlescreen and osc-idlescreen

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -236,6 +236,11 @@ Configurable Options
 
     Enable the OSC when fullscreen
 
+``showidlescreen``
+    Default: yes
+
+    Show the mpv logo and message when idle
+
 ``scalewindowed``
     Default: 1.0
 
@@ -417,6 +422,10 @@ to set auto mode (the default) with ``b``::
 
     a script-message osc-visibility never
     b script-message osc-visibility auto
+
+``osc-idlescreen``
+    Controls the visibility of the mpv logo on idle. Valid arguments are ``yes``,
+    ``no``, and ``cycle`` to toggle between yes and no.
 
 ``osc-playlist``, ``osc-chapterlist``, ``osc-tracklist``
     Shows a limited view of the respective type of list using the OSC. First


### PR DESCRIPTION
This is mainly for other user scripts that may conflict with the osc
logo in some way. While you can use script-message and
shared-script-properties (highly discouraged in the documentation for
some reason) to work around this, there's still some brittle edge cases
and complicated logic that can pop up. Adding an option for these two
things (the logo and the "drop files..." text) is really trivial and
would make things easier for scripts. Discussed in a couple of issues
below:
https://github.com/mpv-player/mpv/issues/10201
https://github.com/CogentRedTester/mpv-file-browser/issues/55