### PR TITLE
player: add jxl and tiff/tif to list of image extensions

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -43,7 +43,7 @@ static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",
                                          NULL};
 
 static const char *const image_exts[] = {"jpg", "jpeg", "png", "gif", "bmp",
-                                         "webp", "jxl",
+                                         "webp", "jxl", "tiff", "tif",
                                          NULL};
 
 // Stolen from: vlc/-/blob/master/modules/meta_engine/folder.c#L40

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -43,7 +43,7 @@ static const char *const audio_exts[] = {"mp3", "aac", "mka", "dts", "flac",
                                          NULL};
 
 static const char *const image_exts[] = {"jpg", "jpeg", "png", "gif", "bmp",
-                                         "webp",
+                                         "webp", "jxl",
                                          NULL};
 
 // Stolen from: vlc/-/blob/master/modules/meta_engine/folder.c#L40


### PR DESCRIPTION
Maybe useful to others.
Does anyone else want them in cover_files[]?