### PR TITLE
add support for AVChannelLayout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: mingw_prefix/
-          key: "${{ matrix.target }}-2"
+          key: "${{ matrix.target }}-3"
 
       - name: Install dependencies
         run: |

--- a/audio/aframe.c
+++ b/audio/aframe.c
@@ -18,9 +18,12 @@
 #include <libavutil/frame.h>
 #include <libavutil/mem.h>
 
+#include "config.h"
+
 #include "common/common.h"
 
 #include "chmap.h"
+#include "chmap_avchannel.h"
 #include "fmt-conversion.h"
 #include "format.h"
 #include "aframe.h"
@@ -121,6 +124,16 @@ struct mp_aframe *mp_aframe_from_avframe(struct AVFrame *av_frame)
     if (!av_frame || av_frame->width > 0 || av_frame->height > 0)
         return NULL;
 
+#if HAVE_AV_CHANNEL_LAYOUT
+    if (!av_channel_layout_check(&av_frame->ch_layout))
+        return NULL;
+
+    struct mp_chmap converted_map = { 0 };
+    if (!mp_chmap_from_av_layout(&converted_map, &av_frame->ch_layout)) {
+        return NULL;
+    }
+#endif
+
     int format = af_from_avformat(av_frame->format);
     if (!format && av_frame->format != AV_SAMPLE_FMT_NONE)
         return NULL;
@@ -132,11 +145,15 @@ struct mp_aframe *mp_aframe_from_avframe(struct AVFrame *av_frame)
         abort();
 
     frame->format = format;
+#if !HAVE_AV_CHANNEL_LAYOUT
     mp_chmap_from_lavc(&frame->chmap, frame->av_frame->channel_layout);
 
     // FFmpeg being a stupid POS again
     if (frame->chmap.num != frame->av_frame->channels)
         mp_chmap_from_channels(&frame->chmap, av_frame->channels);
+#else
+    frame->chmap = converted_map;
+#endif
 
     if (av_frame->opaque_ref) {
         struct avframe_opaque *op = (void *)av_frame->opaque_ref->data;
@@ -204,9 +221,16 @@ void mp_aframe_config_copy(struct mp_aframe *dst, struct mp_aframe *src)
 
     dst->av_frame->sample_rate = src->av_frame->sample_rate;
     dst->av_frame->format = src->av_frame->format;
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     dst->av_frame->channel_layout = src->av_frame->channel_layout;
     // FFmpeg being a stupid POS again
     dst->av_frame->channels = src->av_frame->channels;
+#else
+    if (av_channel_layout_copy(&dst->av_frame->ch_layout,
+                               &src->av_frame->ch_layout) < 0)
+        abort();
+#endif
 }
 
 // Copy "soft" attributes from src to dst, excluding things which affect
@@ -315,13 +339,21 @@ bool mp_aframe_set_chmap(struct mp_aframe *frame, struct mp_chmap *in)
         return false;
     if (mp_aframe_is_allocated(frame) && in->num != frame->chmap.num)
         return false;
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     uint64_t lavc_layout = mp_chmap_to_lavc_unchecked(in);
     if (!lavc_layout && in->num)
         return false;
+#endif
     frame->chmap = *in;
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     frame->av_frame->channel_layout = lavc_layout;
     // FFmpeg being a stupid POS again
     frame->av_frame->channels = frame->chmap.num;
+#else
+    mp_chmap_to_av_layout(&frame->av_frame->ch_layout, in);
+#endif
     return true;
 }
 

--- a/audio/chmap.c
+++ b/audio/chmap.c
@@ -470,6 +470,23 @@ char *mp_chmap_to_str_hr_buf(char *buf, size_t buf_size, const struct mp_chmap *
     return mp_chmap_to_str_buf(buf, buf_size, &map);
 }
 
+mp_ch_layout_tuple *mp_iterate_builtin_layouts(void **opaque)
+{
+    uintptr_t i = (uintptr_t)*opaque;
+
+    if (i >= MP_ARRAY_SIZE(std_layout_names) ||
+        !std_layout_names[i][0])
+        return NULL;
+
+    *opaque = (void *)(i + 1);
+
+    if (std_layout_names[i][1][0] == '\0') {
+        return mp_iterate_builtin_layouts(opaque);
+    }
+
+    return &std_layout_names[i];
+}
+
 void mp_chmap_print_help(struct mp_log *log)
 {
     mp_info(log, "Speakers:\n");

--- a/audio/chmap.h
+++ b/audio/chmap.h
@@ -75,6 +75,8 @@ struct mp_chmap {
     uint8_t speaker[MP_NUM_CHANNELS];
 };
 
+typedef const char * const (mp_ch_layout_tuple)[2];
+
 #define MP_SP(speaker) MP_SPEAKER_ID_ ## speaker
 
 #define MP_CHMAP2(a, b) \
@@ -128,6 +130,19 @@ char *mp_chmap_to_str_hr_buf(char *buf, size_t buf_size, const struct mp_chmap *
 #define mp_chmap_to_str_hr(m) mp_chmap_to_str_hr_buf((char[128]){0}, 128, (m))
 
 bool mp_chmap_from_str(struct mp_chmap *dst, bstr src);
+
+/**
+ * Iterate over all built-in channel layouts which have mapped channels.
+ *
+ * @param opaque a pointer where the iteration state is stored. Must point
+ *               to nullptr to start the iteration.
+ *
+ * @return nullptr when the iteration is finished.
+ *         Otherwise a pointer to an array of two char pointers.
+ *         - [0] being the human-readable layout name.
+ *         - [1] being the string representation of the layout.
+ */
+mp_ch_layout_tuple *mp_iterate_builtin_layouts(void **opaque);
 
 struct mp_log;
 void mp_chmap_print_help(struct mp_log *log);

--- a/audio/chmap_avchannel.c
+++ b/audio/chmap_avchannel.c
@@ -1,0 +1,51 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libavutil/channel_layout.h>
+
+#include "chmap.h"
+#include "chmap_avchannel.h"
+
+bool mp_chmap_from_av_layout(struct mp_chmap *dst, const AVChannelLayout *src)
+{
+    *dst = (struct mp_chmap) {0};
+
+    switch (src->order) {
+    case AV_CHANNEL_ORDER_UNSPEC:
+        mp_chmap_from_channels(dst, src->nb_channels);
+        return dst->num == src->nb_channels;
+    case AV_CHANNEL_ORDER_NATIVE:
+        mp_chmap_from_lavc(dst, src->u.mask);
+        return dst->num == src->nb_channels;
+    default:
+        // TODO: handle custom layouts
+        return false;
+    }
+}
+
+void mp_chmap_to_av_layout(AVChannelLayout *dst, const struct mp_chmap *src)
+{
+    *dst = (AVChannelLayout){
+        .order = AV_CHANNEL_ORDER_UNSPEC,
+        .nb_channels = src->num,
+    };
+
+    // TODO: handle custom layouts
+    if (!mp_chmap_is_unknown(src)) {
+        av_channel_layout_from_mask(dst, mp_chmap_to_lavc(src));
+    }
+}

--- a/audio/chmap_avchannel.h
+++ b/audio/chmap_avchannel.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <libavutil/channel_layout.h>
+
+#include "config.h"
+
+#include "chmap.h"
+
+#if HAVE_AV_CHANNEL_LAYOUT
+
+bool mp_chmap_from_av_layout(struct mp_chmap *dst, const AVChannelLayout *src);
+
+void mp_chmap_to_av_layout(AVChannelLayout *dst, const struct mp_chmap *src);
+
+#endif

--- a/audio/filter/af_lavcac3enc.c
+++ b/audio/filter/af_lavcac3enc.c
@@ -31,7 +31,10 @@
 #include <libavutil/bswap.h>
 #include <libavutil/mem.h>
 
+#include "config.h"
+
 #include "audio/aframe.h"
+#include "audio/chmap_avchannel.h"
 #include "audio/chmap_sel.h"
 #include "audio/fmt-conversion.h"
 #include "audio/format.h"
@@ -104,8 +107,13 @@ static bool reinit(struct mp_filter *f)
 
     // Put sample parameters
     s->lavc_actx->sample_fmt = af_to_avformat(format);
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     s->lavc_actx->channels = chmap.num;
     s->lavc_actx->channel_layout = mp_chmap_to_lavc(&chmap);
+#else
+    mp_chmap_to_av_layout(&s->lavc_actx->ch_layout, &chmap);
+#endif
     s->lavc_actx->sample_rate = rate;
     s->lavc_actx->bit_rate = bit_rate;
 
@@ -270,9 +278,11 @@ static const struct mp_filter_info af_lavcac3enc_filter = {
     .destroy = destroy,
 };
 
-static void add_chmaps_to_autoconv(struct mp_autoconvert *conv,
+static void add_chmaps_to_autoconv(struct mp_filter *f,
+                                   struct mp_autoconvert *conv,
                                    const struct AVCodec *codec)
 {
+#if !HAVE_AV_CHANNEL_LAYOUT
     const uint64_t *lch = codec->channel_layouts;
     for (int n = 0; lch && lch[n]; n++) {
         struct mp_chmap chmap = {0};
@@ -280,6 +290,24 @@ static void add_chmaps_to_autoconv(struct mp_autoconvert *conv,
         if (mp_chmap_is_valid(&chmap))
             mp_autoconvert_add_chmap(conv, &chmap);
     }
+#else
+    const AVChannelLayout *lch = codec->ch_layouts;
+    for (int n = 0; lch && lch[n].nb_channels; n++) {
+        struct mp_chmap chmap = {0};
+
+        if (!mp_chmap_from_av_layout(&chmap, &lch[n])) {
+            char layout[128] = {0};
+            MP_VERBOSE(f, "Skipping unsupported channel layout: %s\n",
+                       av_channel_layout_describe(&lch[n],
+                                                  layout, 128) < 0 ?
+                       "undefined" : layout);
+            continue;
+        }
+
+        if (mp_chmap_is_valid(&chmap))
+            mp_autoconvert_add_chmap(conv, &chmap);
+    }
+#endif
 }
 
 static struct mp_filter *af_lavcac3enc_create(struct mp_filter *parent,
@@ -322,7 +350,12 @@ static struct mp_filter *af_lavcac3enc_create(struct mp_filter *parent,
     // parameters. (Not all decoders do that, but the ones we're interested
     // in do.)
     if (!s->lavc_acodec->sample_fmts ||
-        !s->lavc_acodec->channel_layouts)
+#if !HAVE_AV_CHANNEL_LAYOUT
+        !s->lavc_acodec->channel_layouts
+#else
+        !s->lavc_acodec->ch_layouts
+#endif
+        )
     {
         MP_ERR(f, "Audio encoder doesn't list supported parameters.\n");
         goto error;
@@ -354,7 +387,7 @@ static struct mp_filter *af_lavcac3enc_create(struct mp_filter *parent,
             mp_autoconvert_add_afmt(conv, mpfmt);
     }
 
-    add_chmaps_to_autoconv(conv, s->lavc_acodec);
+    add_chmaps_to_autoconv(f, conv, s->lavc_acodec);
 
     // At least currently, the AC3 encoder doesn't export sample rates.
     mp_autoconvert_add_srate(conv, 48000);

--- a/audio/out/ao_lavc.c
+++ b/audio/out/ao_lavc.c
@@ -31,6 +31,7 @@
 #include "options/options.h"
 #include "common/common.h"
 #include "audio/aframe.h"
+#include "audio/chmap_avchannel.h"
 #include "audio/format.h"
 #include "audio/fmt-conversion.h"
 #include "filters/filter_internal.h"
@@ -124,8 +125,13 @@ static int init(struct ao *ao)
     if (!ao_chmap_sel_adjust2(ao, &sel, &ao->channels, false))
         goto fail;
     mp_chmap_reorder_to_lavc(&ao->channels);
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     encoder->channels = ao->channels.num;
     encoder->channel_layout = mp_chmap_to_lavc(&ao->channels);
+#else
+    mp_chmap_to_av_layout(&encoder->ch_layout, &ao->channels);
+#endif
 
     encoder->sample_fmt = AV_SAMPLE_FMT_NONE;
 

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -69,7 +69,7 @@ fi
 ## zlib
 if [ ! -e "$prefix_dir/lib/libz.dll.a" ]; then
     ver=1.2.11
-    gettar "https://zlib.net/zlib-${ver}.tar.gz"
+    gettar "https://zlib.net/fossils/zlib-${ver}.tar.gz"
     pushd zlib-${ver}
     make -fwin32/Makefile.gcc PREFIX=$TARGET- SHARED_MODE=1 \
         DESTDIR="$prefix_dir" install \

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -188,7 +188,8 @@ if [ $1 = "meson" ]; then
 
     CFLAGS="-I'$prefix_dir/include'" LDFLAGS="-L'$prefix_dir/lib'" \
     meson .. --cross-file "${prefix_dir}/crossfile" --libdir lib \
-        -Dlibmpv=true -Dlua=luajit -D{shaderc,spirv-cross,d3d11,libplacebo}=enabled
+        -D{libmpv,tests}=true -Dlua=luajit \
+        -D{shaderc,spirv-cross,d3d11,libplacebo}=enabled
 
     meson compile
 fi
@@ -197,7 +198,7 @@ if [ $1 = "waf" ]; then
     PKG_CONFIG=pkg-config CFLAGS="-I'$prefix_dir/include'" LDFLAGS="-L'$prefix_dir/lib'" \
     python3 ./waf configure \
         --enable-libmpv-shared --lua=luajit \
-        --enable-{shaderc,spirv-cross,d3d11,libplacebo}
+        --enable-{shaderc,spirv-cross,d3d11,libplacebo,tests}
 
     python3 ./waf build --verbose
 fi

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -58,7 +58,7 @@ function gettar () {
 
 ## iconv
 if [ ! -e "$prefix_dir/lib/libiconv.dll.a" ]; then
-    ver=1.16
+    ver=1.17
     gettar "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ver}.tar.gz"
     builddir libiconv-${ver}
     ../configure --host=$TARGET $commonflags
@@ -68,7 +68,7 @@ fi
 
 ## zlib
 if [ ! -e "$prefix_dir/lib/libz.dll.a" ]; then
-    ver=1.2.11
+    ver=1.2.12
     gettar "https://zlib.net/fossils/zlib-${ver}.tar.gz"
     pushd zlib-${ver}
     make -fwin32/Makefile.gcc PREFIX=$TARGET- SHARED_MODE=1 \
@@ -126,8 +126,8 @@ fi
 
 ## freetype2
 if [ ! -e "$prefix_dir/lib/libfreetype.dll.a" ]; then
-    ver=2.11.0
-    gettar "https://download.savannah.gnu.org/releases/freetype/freetype-${ver}.tar.gz"
+    ver=2.12.1
+    gettar "https://download.savannah.gnu.org/releases/freetype/freetype-${ver}.tar.xz"
     builddir freetype-${ver}
     ZLIB_LIBS="-L'$prefix_dir/lib' -lz" \
     ../configure --host=$TARGET $commonflags --with-png=no
@@ -138,7 +138,7 @@ fi
 
 ## fribidi
 if [ ! -e "$prefix_dir/lib/libfribidi.dll.a" ]; then
-    ver=1.0.11
+    ver=1.0.12
     gettar "https://github.com/fribidi/fribidi/releases/download/v${ver}/fribidi-${ver}.tar.xz"
     builddir fribidi-${ver}
     ../configure --host=$TARGET $commonflags
@@ -148,7 +148,7 @@ fi
 
 ## harfbuzz
 if [ ! -e "$prefix_dir/lib/libharfbuzz.dll.a" ]; then
-    ver=3.0.0
+    ver=4.3.0
     gettar "https://github.com/harfbuzz/harfbuzz/releases/download/${ver}/harfbuzz-${ver}.tar.xz"
     builddir harfbuzz-${ver}
     ../configure --host=$TARGET $commonflags --with-icu=no

--- a/ci/build-tumbleweed.sh
+++ b/ci/build-tumbleweed.sh
@@ -10,9 +10,10 @@ if [ "$1" = "meson" ]; then
       -Dlibmpv=true           \
       -Dmanpage-build=enabled \
       -Dshaderc=enabled       \
+      -Dtests=true            \
       -Dvulkan=enabled
     meson compile -C build --verbose
-    ./build/mpv
+    ./build/mpv --no-config -v --unittest=all-simple
 fi
 
 if [ "$1" = "waf" ]; then
@@ -24,7 +25,8 @@ if [ "$1" = "waf" ]; then
       --enable-libmpv-shared \
       --enable-manpage-build \
       --enable-shaderc       \
+      --enable-tests         \
       --enable-vulkan
     python3 ./waf build --verbose
-    ./build/mpv
+    ./build/mpv -v --no-config -v --unittest=all-simple
 fi

--- a/common/av_common.c
+++ b/common/av_common.c
@@ -30,6 +30,7 @@
 
 #include "config.h"
 
+#include "audio/chmap_avchannel.h"
 #include "common/common.h"
 #include "common/msg.h"
 #include "demux/packet.h"
@@ -108,9 +109,14 @@ AVCodecParameters *mp_codec_params_to_av(struct mp_codec_params *c)
     avp->sample_rate = c->samplerate;
     avp->bit_rate = c->bitrate;
     avp->block_align = c->block_align;
+
+#if !HAVE_AV_CHANNEL_LAYOUT
     avp->channels = c->channels.num;
     if (!mp_chmap_is_unknown(&c->channels))
         avp->channel_layout = mp_chmap_to_lavc(&c->channels);
+#else
+    mp_chmap_to_av_layout(&avp->ch_layout, &c->channels);
+#endif
 
     return avp;
 error:

--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -33,6 +33,8 @@
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 
+#include "config.h"
+
 #include "common/common.h"
 #include "common/av_common.h"
 #include "common/tags.h"
@@ -40,6 +42,7 @@
 
 #include "audio/format.h"
 #include "audio/aframe.h"
+#include "audio/chmap_avchannel.h"
 #include "video/mp_image.h"
 #include "audio/fmt-conversion.h"
 #include "video/fmt-conversion.h"
@@ -470,7 +473,11 @@ static bool init_pads(struct lavfi *c)
             params->sample_rate = mp_aframe_get_rate(fmt);
             struct mp_chmap chmap = {0};
             mp_aframe_get_chmap(fmt, &chmap);
+#if !HAVE_AV_CHANNEL_LAYOUT
             params->channel_layout = mp_chmap_to_lavc(&chmap);
+#else
+            mp_chmap_to_av_layout(&params->ch_layout, &chmap);
+#endif
             pad->timebase = (AVRational){1, mp_aframe_get_rate(fmt)};
             filter_name = "abuffer";
         } else if (pad->type == MP_FRAME_VIDEO) {

--- a/meson.build
+++ b/meson.build
@@ -15,9 +15,11 @@ build_root = meson.project_build_root()
 source_root = meson.project_source_root()
 python = find_program('python3')
 
+avutil = dependency('libavutil', version: '>= 56.12.100')
+
 ffmpeg = {
     'name': 'ffmpeg',
-    'deps': [dependency('libavutil', version: '>= 56.12.100'),
+    'deps': [avutil,
              dependency('libavcodec', version: '>= 58.12.100'),
              dependency('libavformat', version: '>= 58.9.100'),
              dependency('libswscale', version: '>= 5.0.101'),
@@ -595,6 +597,12 @@ endif
 
 
 # misc dependencies
+av_ch_layout_available = avutil.version().version_compare('>= 57.24.100')
+if av_ch_layout_available
+    features += 'av-channel-layout'
+    sources += files('audio/chmap_avchannel.c')
+endif
+
 cdda_opt = get_option('cdda').require(
     get_option('gpl'),
     error_message: 'the build is not GPL!',
@@ -1696,6 +1704,7 @@ conf_data.set_quoted('FULLCONFIG', feature_str)
 conf_data.set10('HAVE_ALSA', alsa.found())
 conf_data.set10('HAVE_ANDROID', android)
 conf_data.set10('HAVE_AUDIOUNIT', audiounit['use'])
+conf_data.set10('HAVE_AV_CHANNEL_LAYOUT', av_ch_layout_available)
 conf_data.set10('HAVE_BSD_FSTATFS', bsd_fstatfs)
 conf_data.set10('HAVE_BSD_THREAD_NAME', bsd_thread_name)
 conf_data.set10('HAVE_CACA', caca.found())

--- a/test/chmap.c
+++ b/test/chmap.c
@@ -1,5 +1,7 @@
 #include "audio/chmap.h"
+#include "audio/chmap_avchannel.h"
 #include "audio/chmap_sel.h"
+#include "common/msg.h"
 #include "tests.h"
 
 #define LAYOUTS(...) (char*[]){__VA_ARGS__, NULL}
@@ -28,6 +30,129 @@ static void test_sel(const char *input, const char *expected_selection,
     assert_string_equal(mp_chmap_to_str(&input_map),
                         mp_chmap_to_str(&expected_map));
 }
+
+#if HAVE_AV_CHANNEL_LAYOUT
+static bool layout_matches(const AVChannelLayout *av_layout,
+                           const struct mp_chmap *mp_layout,
+                           bool require_default_unspec)
+{
+    if (!mp_chmap_is_valid(mp_layout) ||
+        !av_channel_layout_check(av_layout) ||
+        av_layout->nb_channels != mp_layout->num ||
+        mp_layout->num > MP_NUM_CHANNELS)
+        return false;
+
+    switch (av_layout->order) {
+    case AV_CHANNEL_ORDER_UNSPEC:
+    {
+        if (!require_default_unspec)
+            return true;
+
+        // mp_chmap essentially does not have a concept of "unspecified"
+        // so we check if the mp layout matches the default layout for such
+        // channel count.
+        struct mp_chmap default_layout = { 0 };
+        mp_chmap_from_channels(&default_layout, mp_layout->num);
+        return mp_chmap_equals(mp_layout, &default_layout);
+    }
+    case AV_CHANNEL_ORDER_NATIVE:
+        return av_layout->u.mask == mp_chmap_to_lavc(mp_layout);
+    default:
+        // TODO: handle custom layouts
+        return false;
+    }
+
+    return true;
+}
+
+static void test_mp_chmap_to_av_channel_layout(const struct test_ctx *ctx)
+{
+    mp_ch_layout_tuple *mapping_array = NULL;
+    void *iter = NULL;
+    bool anything_failed = false;
+
+    MP_VERBOSE(ctx, "Testing mp_chmap -> AVChannelLayout conversions\n");
+
+    while ((mapping_array = mp_iterate_builtin_layouts(&iter))) {
+        const char *mapping_name = (*mapping_array)[0];
+        const char *mapping_str  = (*mapping_array)[1];
+        struct mp_chmap mp_layout = { 0 };
+        AVChannelLayout av_layout = { 0 };
+        char layout_desc[128] = {0};
+
+        assert_true(mp_chmap_from_str(&mp_layout, bstr0(mapping_str)));
+
+        mp_chmap_to_av_layout(&av_layout, &mp_layout);
+
+        assert_false(av_channel_layout_describe(&av_layout,
+                                                layout_desc, 128) < 0);
+
+        bool success =
+            (strcmp(layout_desc, mp_chmap_to_str(&mp_layout)) == 0 ||
+             layout_matches(&av_layout, &mp_layout, false));
+        if (!success)
+            anything_failed = true;
+
+        MP_MSG(ctx, success ? MSGL_V : MSGL_FATAL,
+               "%s: %s (%s) -> %s\n",
+               success ? "Success" : "Failure",
+               mapping_str, mapping_name, layout_desc);
+
+        av_channel_layout_uninit(&av_layout);
+    }
+
+    assert_false(anything_failed);
+}
+
+static void test_av_channel_layout_to_mp_chmap(const struct test_ctx *ctx)
+{
+    const AVChannelLayout *av_layout = NULL;
+    void *iter = NULL;
+    bool anything_failed = false;
+
+    MP_VERBOSE(ctx, "Testing AVChannelLayout -> mp_chmap conversions\n");
+
+    while ((av_layout = av_channel_layout_standard(&iter))) {
+        struct mp_chmap mp_layout = { 0 };
+        char layout_desc[128] = {0};
+
+        assert_false(av_channel_layout_describe(av_layout,
+                                                layout_desc, 128) < 0);
+
+        bool ret = mp_chmap_from_av_layout(&mp_layout, av_layout);
+        if (!ret) {
+            bool too_many_channels =
+                av_layout->nb_channels > MP_NUM_CHANNELS;
+            MP_MSG(ctx, too_many_channels ? MSGL_V : MSGL_FATAL,
+                    "Conversion from '%s' to mp_chmap failed (%s)!\n",
+                    layout_desc,
+                    too_many_channels ?
+                    "channel count was over max, ignoring" :
+                    "unexpected, failing");
+
+            // we should for now only fail with things such as 22.2
+            // due to mp_chmap being currently limited to 16 channels
+            assert_true(too_many_channels);
+
+            continue;
+        }
+
+        bool success =
+            (strcmp(layout_desc, mp_chmap_to_str(&mp_layout)) == 0 ||
+             layout_matches(av_layout, &mp_layout, true));
+        if (!success)
+            anything_failed = true;
+
+        MP_MSG(ctx, success ? MSGL_V : MSGL_FATAL,
+               "%s: %s -> %s\n",
+               success ? "Success" : "Failure",
+               layout_desc, mp_chmap_to_str(&mp_layout));
+    }
+
+    assert_false(anything_failed);
+}
+#endif
+
 
 static void run(struct test_ctx *ctx)
 {
@@ -84,6 +209,11 @@ static void run(struct test_ctx *ctx)
     mp_chmap_from_str(&b, bstr0("6.1(back)"));
     assert_int_equal(mp_chmap_diffn(&a, &b), 0);
     assert_int_equal(mp_chmap_diffn(&b, &a), 3);
+
+#if HAVE_AV_CHANNEL_LAYOUT
+    test_av_channel_layout_to_mp_chmap(ctx);
+    test_mp_chmap_to_av_channel_layout(ctx);
+#endif
 }
 
 const struct unittest test_chmap = {

--- a/wscript
+++ b/wscript
@@ -412,6 +412,10 @@ libav_dependencies = [
         'fmsg': "Unable to find development files for some of the required \
 FFmpeg libraries. Git master is recommended."
     }, {
+        'name': 'av-channel-layout',
+        'desc': 'FFmpeg AVChannelLayout API',
+        'func': check_pkg_config('libavutil', '>= 57.24.100'),
+    }, {
         'name': '--libavdevice',
         'desc': 'libavdevice',
         'func': check_pkg_config('libavdevice', '>= 57.0.0'),

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -230,6 +230,7 @@ def build(ctx):
         ## Audio
         ( "audio/aframe.c" ),
         ( "audio/chmap.c" ),
+        ( "audio/chmap_avchannel.c", "av-channel-layout" ),
         ( "audio/chmap_sel.c" ),
         ( "audio/decode/ad_lavc.c" ),
         ( "audio/decode/ad_spdif.c" ),


### PR DESCRIPTION
This is the new FFmpeg channel layout API utilized in both AVFrames
and AVCodecContexts. The previous one has been deprecated.

Thus while we cannot yet require this new API, we can attempt to
support it if available (with the convenient effect of not having
unnecessary deprecation warnings).