### PR TITLE
client API: add client communication functions

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -33,6 +33,11 @@ API changes
 ::
 
  --- mpv 0.35.0 ---
+ 2.1    - add mpv_send_data, mpv_send_data_node, mpv_request_data,
+          and mpv_request_data_node
+        - add mpv_request_flag enum
+        - add MPV_EVENT_CLIENT_DATA_MESSAGE event
+        - add the following fileds to mpv_event_client_message: sender and flag
  2.0    - remove headers/functions of the obsolete opengl_cb API
         - remove mpv_opengl_init_params.extra_exts field
         - remove deprecated mpv_detach_destroy. Use mpv_destroy instead.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1578,6 +1578,29 @@ This list uses the event name field value, and the C API symbol in brackets:
     ``result``
         The result (on success) of any ``mpv_node`` type, if any.
 
+``client-data-message`` (``MPV_EVENT_CLIENT_DATA_MESSAGE``)
+    This happens when one client sends data or requests data from this client.
+
+    This event has the following fields:
+    ``args``
+        Array of strings with the data from the client.
+
+    ``sender``
+        String containing the name of the sender of the event.
+
+    ``flags``
+        Has one of the following values:
+
+        ``none``
+            The flag was not set. This indicates that the other client is
+            sending data.
+
+        ``read``
+            The client that sent this event is asking to read data.
+
+        ``write``
+            The client that sent this event is asking to write data.
+
 ``client-message`` (``MPV_EVENT_CLIENT_MESSAGE``)
     Lua and possibly other backends treat this specially and may not pass the
     actual event to the user.

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -581,6 +581,32 @@ are useful only in special situations.
     Undo a previous registration with ``mp.register_script_message``. Does
     nothing if the ``name`` wasn't registered.
 
+``mp.request_data(name, flag, arg1, arg2, ...)``
+    This is a special way for one script to read or write data to another
+    script. It sends a ``client-data-request`` event with ``arg1``, ``arg2``,
+    etc. stored in ``args``. The ``flag`` argument can be either ``read`` or
+    ``write``. Passing ``read`` indicates that the caller wants to read some
+    arbitrary data (perhaps an option). Passing ``write`` indicates that the
+    caller wants to write data to the receiver of the script. It is up to the
+    receiver of the event to interpret this and act on it. It may choose to
+    ignore it completely. Additionally the name argument can be passed as ``""``
+    to indicate that this event should be broadcasted to all clients insted of
+    specifically one.
+
+``mp.request_data_native(name, flag, table)``
+    The same as ``mp.request_data`` but instead the args are passed as a lua
+    table.
+
+``mp.send_data(name, arg1, arg2, ...)``
+    This is a special way for one script to send data to another script. It
+    sends a ``client-data-sent`` event with ``arg1``, ``arg2``, etc. stored
+    in ``args``. Additionally, the name argument can be passed as ``""`` to
+    indicate that that this event should be broadcasted to all clients instead
+    of specifically one.
+
+``mp.send_data_native(name, table)``
+    The same as ``mp.send_data`` but instead the args are passed as a lua table.
+
 ``mp.create_osd_overlay(format)``
     Create an OSD overlay. This is a very thin wrapper around the ``osd-overlay``
     command. The function returns a table, which mostly contains fields that

--- a/libmpv/mpv.def
+++ b/libmpv/mpv.def
@@ -36,8 +36,12 @@ mpv_render_context_report_swap
 mpv_render_context_set_parameter
 mpv_render_context_set_update_callback
 mpv_render_context_update
+mpv_request_data
+mpv_request_data_node
 mpv_request_event
 mpv_request_log_messages
+mpv_send_data
+mpv_send_data_node
 mpv_set_option
 mpv_set_option_string
 mpv_set_property

--- a/player/command.h
+++ b/player/command.h
@@ -92,7 +92,7 @@ uint64_t mp_get_property_event_mask(const char *name);
 enum {
     // Must start with the first unused positive value in enum mpv_event_id
     // MPV_EVENT_* and MP_EVENT_* must not overlap.
-    INTERNAL_EVENT_BASE = 26,
+    INTERNAL_EVENT_BASE = 27,
     MP_EVENT_CHANGE_ALL,
     MP_EVENT_CACHE_UPDATE,
     MP_EVENT_WIN_RESIZE,


### PR DESCRIPTION
The main motivation for this was to add some way for mpv clients to communicate data to each other. There are some existing things, but they are all limited in certain ways (see the commit message if you want a long explanation).

Basically the gist is that this adds a `send_data` and `request_data` family of functions in the client API. They both send a new `MPV_EVENT_CLIENT_DATA_MESSAGE` event which clients can listen for and respond to appropriately. The event contains fields that indicate the name of the sender, the actual data, as well as a flag that corresponds to the type of data message that is sent.

If you want a quick example, you can try a couple of dummy scripts.

test.lua
```
mp.send_data("", "hello", "there")
```

test1.lua
```
function testing_fn(event)
    print("Sender: "..event.sender)
    print("Flag: "..event.flag)
    print("Arg1: "..event.args[1])
    print("Arg2: "..event.args[2])
end

mp.register_event("client-data-message", testing_fn)
```

The first argument to `send_data` being `""` means that it is broadcast to all clients. To pick just one, you just put in the client name:
```
mp.send_data("test1", "hello", "there")
```

Of course, clients can interpret the data however they like but the most logical thing to do is probably to just pass key-value pairs (that's what I had in mind while writing this). There is also `send_data_native` and `request_data_native` variants that allow sending the data as lua tables (in C, the equivalent is passing them as mpv_nodes).

TODO:

- [ ] JS implementation (left that out for now)

If this is liked enough, we could deprecate `shared-script-properties` in favor of this mechanism.