### PR TITLE
clean up drm verison checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -928,6 +928,7 @@ drm = {
     'name': 'drm',
     'deps': dependency('libdrm', version: '>= 2.4.75', required: get_option('drm')),
     'header': vt_h or consio_h,
+    '64_bpp_rgb': false,
 }
 drm += {'use': drm['deps'].found() and drm['header']}
 if drm['use']
@@ -938,6 +939,7 @@ if drm['use']
                      'video/out/drm_prime.c',
                      'video/out/opengl/hwdec_drmprime_drm.c',
                      'video/out/vo_drm.c')
+    drm += {'64_bpp_rgb': drm['deps'].version().version_compare('>=2.4.108')}
 endif
 
 gbm = dependency('gbm', version: '>=17.1.0', required: get_option('gbm'))
@@ -1712,6 +1714,7 @@ conf_data.set10('HAVE_D3D11', d3d11.allowed())
 conf_data.set10('HAVE_DIRECT3D', direct3d)
 conf_data.set10('HAVE_DOS_PATHS', win32)
 conf_data.set10('HAVE_DRM', drm['use'])
+conf_data.set10('HAVE_DRM_64_BPP_RGB', drm['64_bpp_rgb'])
 conf_data.set10('HAVE_DVBIN', dvbin.allowed())
 conf_data.set10('HAVE_DVDNAV', dvdnav.found() and dvdread.found())
 conf_data.set10('HAVE_EGL', egl['use'])

--- a/meson.build
+++ b/meson.build
@@ -926,7 +926,7 @@ endif
 
 drm = {
     'name': 'drm',
-    'deps': dependency('libdrm', version: '>= 2.4.75', required: get_option('drm')),
+    'deps': dependency('libdrm', version: '>= 2.4.96', required: get_option('drm')),
     'header': vt_h or consio_h,
     '64_bpp_rgb': false,
 }

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -1263,6 +1263,7 @@ const char* drm_format_string(uint drm_format) {
     case DRM_FORMAT_BGRA1010102:
         return "DRM_FORMAT_BGRA1010102";
         break;
+#if HAVE_DRM_64_BPP_RGB
         /* 64 bpp RGB */
     case DRM_FORMAT_XRGB16161616:
         return "DRM_FORMAT_XRGB16161616";
@@ -1276,6 +1277,7 @@ const char* drm_format_string(uint drm_format) {
     case DRM_FORMAT_ABGR16161616:
         return "DRM_FORMAT_ABGR16161616";
         break;
+#endif
         /*
          * Floating point 64bpp RGB
          * IEEE 754-2008 binary16 half-precision float

--- a/wscript
+++ b/wscript
@@ -495,7 +495,7 @@ video_output_features = [
         'name': '--drm',
         'desc': 'DRM',
         'deps': 'vt.h || consio.h',
-        'func': check_pkg_config('libdrm', '>= 2.4.75'),
+        'func': check_pkg_config('libdrm', '>= 2.4.96'),
     }, {
         'name': 'drm_64_bpp_rgb',
         'desc': 'DRM 64 BPP RBG format support',

--- a/wscript
+++ b/wscript
@@ -497,6 +497,10 @@ video_output_features = [
         'deps': 'vt.h || consio.h',
         'func': check_pkg_config('libdrm', '>= 2.4.75'),
     }, {
+        'name': 'drm_64_bpp_rgb',
+        'desc': 'DRM 64 BPP RBG format support',
+        'func': check_pkg_config('libdrm', '>= 2.4.108'),
+    }, {
         'name': '--gbm',
         'desc': 'GBM',
         'deps': 'gbm.h',


### PR DESCRIPTION
Two commits. The first one fixes https://github.com/mpv-player/mpv-build/issues/184. The libdrm version of note here is 2.4.108 which exposed these newer formats that may not be available on an older distro. The second one is just a simple bump of the libdrm version check in general. We're now assuming some new formats that didn't become available until 2.4.96. Fortunately, that version is 3 years old and even debian oldstable has it, so there should be no issue just doing a simple bump. Pretty much everyone is already running this, we're just being more correct now.