### PR TITLE
wayland: add support for content-type-v1

### DIFF
--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -1,4 +1,4 @@
-wl_protocol_dir = wayland['deps'][2].get_variable(pkgconfig: 'pkgdatadir')
+wl_protocol_dir = wayland['deps'][2].get_variable(pkgconfig: 'pkgdatadir', internal: 'pkgdatadir')
 protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml'],
              [wl_protocol_dir, 'stable/viewporter/viewporter.xml'],
              [wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],

--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -2,6 +2,7 @@ wl_protocol_dir = wayland['deps'][2].get_variable(pkgconfig: 'pkgdatadir')
 protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml'],
              [wl_protocol_dir, 'stable/viewporter/viewporter.xml'],
              [wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+             [wl_protocol_dir, 'staging/content-type/content-type-v1.xml'],
              [wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
              [wl_protocol_dir, 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml'],
              [wl_protocol_dir, 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml']]

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -111,6 +111,10 @@ struct vo_wayland_state {
     struct wp_viewport   *viewport;
     struct wp_viewport   *video_viewport;
 
+    /* content-type */
+    struct wp_content_type_manager_v1 *content_type_manager;
+    struct wp_content_type_v1         *content_type;
+
     /* Input */
     struct wl_keyboard *keyboard;
     struct wl_pointer  *pointer;


### PR DESCRIPTION
Allows the compositor to forward the correct information to the
output device (e.g. via HDMI infoframes), and to implement rules
based on the content type hint.

See:
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/150
