### PR TITLE
WIP: single-pixel-buffer-v1

### DIFF
--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -2,6 +2,7 @@ wl_protocol_dir = wayland['deps'][2].get_variable(pkgconfig: 'pkgdatadir', inter
 protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml'],
              [wl_protocol_dir, 'stable/viewporter/viewporter.xml'],
              [wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+             [wl_protocol_dir, 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml'],
              [wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
              [wl_protocol_dir, 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml'],
              [wl_protocol_dir, 'unstable/xdg-decoration/xdg-decoration-unstable-v1.xml']]

--- a/meson.build
+++ b/meson.build
@@ -1445,7 +1445,7 @@ if vaapi_wayland['use']
     features += vaapi_wayland['name']
 endif
 
-if vaapi_wayland['use'] and memfd_create
+if vaapi_wayland['use'] and memfd_create and wayland['deps'][2].version().version_compare('>= 1.26')
     features += 'vaapi-wayland-memfd'
     sources += files('video/out/vo_vaapi_wayland.c')
 endif

--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -27,6 +27,7 @@
 #include "wayland_common.h"
 
 #include "generated/wayland/linux-dmabuf-unstable-v1.h"
+#include "generated/wayland/single-pixel-buffer-v1.h"
 #include "generated/wayland/viewporter.h"
 
 #define VA_POOL_NUM_ALLOCATED_INIT 30
@@ -269,23 +270,31 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     struct priv *p = vo->priv;
     struct vo_wayland_state *wl = vo->wl;
 
-    if (!p->solid_buffer_pool) {
-        int width = 1;
-        int height = 1;
-        int stride = MP_ALIGN_UP(width * 4, 16);
-        int fd = vo_wayland_allocate_memfd(vo, stride);
-        if (fd < 0)
-            return VO_ERROR;
-        p->solid_buffer_pool = wl_shm_create_pool(wl->shm, fd, height * stride);
-        if (!p->solid_buffer_pool)
-            return VO_ERROR;
-        p->solid_buffer = wl_shm_pool_create_buffer(p->solid_buffer_pool, 0,
-                                                    width, height, stride,
-                                                    WL_SHM_FORMAT_XRGB8888);
-        if (!p->solid_buffer)
-            return VO_ERROR;
-        wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
+    if (!p->solid_buffer) {
+        /* Use single-pixel if it exists, falling back to wl_shm */
+        if (wl->single_pixel_manager) {
+            p->solid_buffer = wp_single_pixel_buffer_manager_v1_create_u32_rgba_buffer(
+                wl->single_pixel_manager, 0, 0, 0, UINT32_MAX); /* R, G, B, A */
+            wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
+        } else {
+            int width = 1;
+            int height = 1;
+            int stride = MP_ALIGN_UP(width * 4, 16);
+            int fd = vo_wayland_allocate_memfd(vo, stride);
+            if (fd < 0)
+                return VO_ERROR;
+            p->solid_buffer_pool = wl_shm_create_pool(wl->shm, fd, height * stride);
+            if (!p->solid_buffer_pool)
+                return VO_ERROR;
+            p->solid_buffer = wl_shm_pool_create_buffer(p->solid_buffer_pool, 0,
+                                                        width, height, stride,
+                                                        WL_SHM_FORMAT_XRGB8888);
+            wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
+        }
     }
+
+    if (!p->solid_buffer)
+        return VO_ERROR;
 
     if (!vo_wayland_reconfig(vo))
         return VO_ERROR;

--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -58,7 +58,6 @@ struct priv {
 
     VADisplay display;
     struct mp_vaapi_ctx *mpvaapi;
-    struct wl_shm_pool *solid_buffer_pool;
     struct wl_buffer *solid_buffer;
     struct va_pool *va_pool;
 };
@@ -211,8 +210,6 @@ static void uninit(struct vo *vo)
 
     va_pool_free(p->va_pool);
 
-    if (p->solid_buffer_pool)
-        wl_shm_pool_destroy(p->solid_buffer_pool);
     if (p->solid_buffer)
         wl_buffer_destroy(p->solid_buffer);
 
@@ -271,30 +268,20 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     struct vo_wayland_state *wl = vo->wl;
 
     if (!p->solid_buffer) {
-        /* Use single-pixel if it exists, falling back to wl_shm */
-        if (wl->single_pixel_manager) {
-            p->solid_buffer = wp_single_pixel_buffer_manager_v1_create_u32_rgba_buffer(
-                wl->single_pixel_manager, 0, 0, 0, UINT32_MAX); /* R, G, B, A */
-            wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
-        } else {
-            int width = 1;
-            int height = 1;
-            int stride = MP_ALIGN_UP(width * 4, 16);
-            int fd = vo_wayland_allocate_memfd(vo, stride);
-            if (fd < 0)
-                return VO_ERROR;
-            p->solid_buffer_pool = wl_shm_create_pool(wl->shm, fd, height * stride);
-            if (!p->solid_buffer_pool)
-                return VO_ERROR;
-            p->solid_buffer = wl_shm_pool_create_buffer(p->solid_buffer_pool, 0,
-                                                        width, height, stride,
-                                                        WL_SHM_FORMAT_XRGB8888);
-            wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
+        if (!wl->single_pixel_manager) {
+            MP_ERR(vo,
+                  "Compositor does not support single-pixel-buffer-v1!"
+                  " --vo=vaapi-wayland is unavailable\n");
+            return VO_ERROR;
         }
-    }
 
-    if (!p->solid_buffer)
-        return VO_ERROR;
+        p->solid_buffer = wp_single_pixel_buffer_manager_v1_create_u32_rgba_buffer(
+            wl->single_pixel_manager, 0, 0, 0, UINT32_MAX); /* R, G, B, A */
+        wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
+
+        if (!p->solid_buffer)
+            return VO_ERROR;
+    }
 
     if (!vo_wayland_reconfig(vo))
         return VO_ERROR;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -38,6 +38,7 @@
 #include "generated/wayland/idle-inhibit-unstable-v1.h"
 #include "generated/wayland/linux-dmabuf-unstable-v1.h"
 #include "generated/wayland/presentation-time.h"
+#include "generated/wayland/single-pixel-buffer-v1.h"
 #include "generated/wayland/xdg-decoration-unstable-v1.h"
 #include "generated/wayland/xdg-shell.h"
 #include "generated/wayland/viewporter.h"
@@ -1130,6 +1131,10 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         wl->idle_inhibit_manager = wl_registry_bind(reg, id, &zwp_idle_inhibit_manager_v1_interface, 1);
     }
 
+    if (!strcmp(interface, wp_single_pixel_buffer_manager_v1_interface.name) && found++) {
+        wl->single_pixel_manager = wl_registry_bind(reg, id, &wp_single_pixel_buffer_manager_v1_interface, 1);
+    }
+
     if (found > 1)
         MP_VERBOSE(wl, "Registered for protocol %s\n", interface);
 }
@@ -2031,6 +2036,9 @@ void vo_wayland_uninit(struct vo *vo)
 
     if (wl->xdg_surface)
         xdg_surface_destroy(wl->xdg_surface);
+
+    if (wl->single_pixel_manager)
+        wp_single_pixel_buffer_manager_v1_destroy(wl->single_pixel_manager);
 
     if (wl->xkb_context)
         xkb_context_unref(wl->xkb_context);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -90,6 +90,9 @@ struct vo_wayland_state {
     struct mp_present *present;
     int64_t refresh_interval;
 
+    /* single-pixel-buffer */
+    struct wp_single_pixel_buffer_manager_v1 *single_pixel_manager;
+
     /* xdg-decoration */
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;
     struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration;

--- a/wscript
+++ b/wscript
@@ -662,7 +662,7 @@ video_output_features = [
         'name': 'vaapi-wayland-memfd',
         'desc': 'VAAPI (Wayland dmabuf support)',
         'deps': 'vaapi-wayland && memfd_create',
-        'func': check_true,
+        'func': check_pkg_config_datadir('wayland-protocols', '>=1.26'),
     }, {
         'name': '--vaapi-drm',
         'desc': 'VAAPI (DRM/EGL support)',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -133,6 +133,9 @@ def build(ctx):
         ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
             protocol  = "unstable/linux-dmabuf/linux-dmabuf-unstable-v1",
             target    = "generated/wayland/linux-dmabuf-unstable-v1.h")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/single-pixel-buffer/single-pixel-buffer-v1.h",
+            target    = "generated/wayland/single-pixel-buffer-v1.h")
         ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
             protocol  = "stable/viewporter/viewporter",
             target    = "generated/wayland/viewporter.c")


### PR DESCRIPTION
This commit implements `single-pixel-buffer-v1` for optimizing the use of the wl_shm 1x1 pixel case.

WIP because:
1. ~~I did not test this (waiting for some compositors to update their patches to implement this protocol)~~ This is tested and it works as expected
2. ~The [protocol itself ](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/104 ) is WIP~
3. ~I probably messed something up~