### PR TITLE
hwdec_vaapi_pl: support simple multi-plane image formats

### DIFF
--- a/video/out/hwdec/hwdec_vaapi_gl.c
+++ b/video/out/hwdec/hwdec_vaapi_gl.c
@@ -166,6 +166,12 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper, bool probing)
     GL *gl = ra_gl_get(mapper->ra);
 
     for (int n = 0; n < p_mapper->num_planes; n++) {
+        if (p_mapper->desc.layers[n].num_planes > 1) {
+            // Should never happen because we request separate layers
+            MP_ERR(mapper, "Multi-plane VA surfaces are not supported\n");
+            return false;
+        }
+
         int attribs[48] = {EGL_NONE};
         int num_attribs = 0;
 


### PR DESCRIPTION
This is somewhat academic for now, as we explicitly ask for separate
layers and the scenarios where multi-plane images are required also use
complex formats that cannot be decomposed after the fact, but
nevertheless it is possible for us to consume simple multi-plane
images where there is one layer with n planes instead of n layers with
one plane each.

In these cases, we just treat the planes the same as we would if they
were each in a separate layer and everything works out.

It ought to be possible to make this work for OpenGL but I couldn't
wrap my head around how to provide the right DRM fourcc when
pretending a plane is a layer by itself. So I've left that
unimplemented.