### PR TITLE
screenshot: notify via MPV_EVENT_SCREENSHOT

### DIFF
--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -1347,6 +1347,10 @@ typedef enum mpv_event_id {
      * See also mpv_event and mpv_event_hook.
      */
     MPV_EVENT_HOOK              = 25,
+    /**
+     * Happens when a screenshot is saved.
+     */
+    MPV_EVENT_SCREENSHOT        = 26,
     // Internal note: adjust INTERNAL_EVENT_BASE when adding new events.
 } mpv_event_id;
 

--- a/player/client.c
+++ b/player/client.c
@@ -692,6 +692,9 @@ static void dup_event_data(struct mpv_event *ev)
     case MPV_EVENT_END_FILE:
         ev->data = talloc_memdup(NULL, ev->data, sizeof(mpv_event_end_file));
         break;
+    case MPV_EVENT_SCREENSHOT:
+        ev->data = talloc_strdup(NULL, (const char *) ev->data);
+        break;
     default:
         // Doesn't use events with memory allocation.
         if (ev->data)
@@ -2025,6 +2028,13 @@ int mpv_event_to_node(mpv_node *dst, mpv_event *event)
         break;
     }
 
+    case MPV_EVENT_SCREENSHOT: {
+        const char *filename = event->data;
+
+        node_map_add_string(dst, "filename", filename);
+        break;
+    }
+
     }
     return 0;
 }
@@ -2084,6 +2094,7 @@ static const char *const event_table[] = {
     [MPV_EVENT_PROPERTY_CHANGE] = "property-change",
     [MPV_EVENT_QUEUE_OVERFLOW] = "event-queue-overflow",
     [MPV_EVENT_HOOK] = "hook",
+    [MPV_EVENT_SCREENSHOT] = "screenshot",
 };
 
 const char *mpv_event_name(mpv_event_id event)

--- a/player/command.h
+++ b/player/command.h
@@ -92,7 +92,7 @@ uint64_t mp_get_property_event_mask(const char *name);
 enum {
     // Must start with the first unused positive value in enum mpv_event_id
     // MPV_EVENT_* and MP_EVENT_* must not overlap.
-    INTERNAL_EVENT_BASE = 26,
+    INTERNAL_EVENT_BASE = 27,
     MP_EVENT_CHANGE_ALL,
     MP_EVENT_CACHE_UPDATE,
     MP_EVENT_WIN_RESIZE,

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -91,6 +91,7 @@ static bool write_screenshot(struct mp_cmd_ctx *cmd, struct mp_image *img,
 
     if (ok) {
         mp_cmd_msg(cmd, MSGL_INFO, "Screenshot: '%s'", filename);
+        mp_notify(mpctx, MPV_EVENT_SCREENSHOT, (void *) filename);
     } else {
         mp_cmd_msg(cmd, MSGL_ERR, "Error writing screenshot!");
     }


### PR DESCRIPTION
I am using mpv to make many screenshots which are then automatically post processed.

Until now it is not possible to get notified by mpv about new screenshots.

This pull requests adds an MPV_EVENT_SCREENSHOT which gets triggered everytime a screenshot is created.