### PR TITLE
vaapi-wayland: clean up code

### DIFF
--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -318,7 +318,6 @@ static int resize(struct vo *vo)
     struct vo_wayland_state *wl = vo->wl;
     struct priv *p = vo->priv;
 
-    wl_subsurface_set_sync(wl->video_subsurface);
     vo_wayland_set_opaque_region(wl, 0);
     const int width = wl->scaling * mp_rect_w(wl->geometry);
     const int height = wl->scaling * mp_rect_h(wl->geometry);
@@ -334,7 +333,6 @@ static int resize(struct vo *vo)
     wl_subsurface_set_position(wl->video_subsurface, p->dst.x0, p->dst.y0);
 
     vo->want_redraw = true;
-    wl_subsurface_set_desync(wl->video_subsurface);
 
     return VO_TRUE;
 }

--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -305,6 +305,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
                                                     WL_SHM_FORMAT_XRGB8888);
         if (!p->solid_buffer)
             return VO_ERROR;
+        wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
     }
 
     if (!vo_wayland_reconfig(vo))
@@ -374,7 +375,6 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     if (!entry)
         return;
 
-    wl_surface_attach(wl->surface, p->solid_buffer, 0, 0);
     wl_surface_attach(wl->video_surface, entry->buffer, 0, 0);
     wl_surface_damage_buffer(wl->video_surface, 0, 0, INT32_MAX, INT32_MAX);
     wl_surface_commit(wl->video_surface);


### PR DESCRIPTION
1. Remove sync/desync calls in resize.  The resize() method only changes the subsurface's position, which is always synchronized with the parent surface. Reference:
https://wayland-book.com/surfaces-in-depth/subsurfaces.html

2. Only need to attach solid buffer once to main surface, on creation.