### PR TITLE
meson: rearrange library dependency order to avoid crash with fontconfig

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,8 +30,10 @@ ffmpeg = {
 libass = dependency('libass', version: '>= 0.12.2')
 pthreads = dependency('threads')
 
-dependencies = [ffmpeg['deps'],
-                libass,
+# the dependency order of libass -> ffmpeg is necessary due to
+# static linking symbol resolution between fontconfig and MinGW
+dependencies = [libass,
+                ffmpeg['deps'],
                 pthreads]
 
 features = [ffmpeg['name'], libass.name(), pthreads.name()]


### PR DESCRIPTION
In win32 build, if libass and libfontconfig appear after libmingwex
during linking, crash happens whenever fontconfig calls to opendir().

Moving them before ffmpeg (which pulls in libmingwex) makes sure they always appear first.

More info on https://github.com/shinchiro/mpv-winbuild-cmake/issues/217.

CI build passes: https://github.com/CrendKing/mpv/runs/6909174698.