### PR TITLE
context_x11egl: remove supposed transparency fix

### DIFF
--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -121,9 +121,6 @@ static bool mpegl_init(struct ra_ctx *ctx)
         .refine_config = ctx->opts.want_alpha ? pick_xrgba_config : NULL,
     };
 
-    if (!strcmp(eglQueryString(p->egl_display, EGL_VENDOR), "Mesa Project"))
-        ctx->opts.want_alpha = 0;
-
     EGLConfig config;
     if (!mpegl_create_context_cb(ctx, p->egl_display, cb, &p->egl_context, &config))
         goto uninit;


### PR DESCRIPTION
This was introduced in 7fb972fd3997bfa389caa7c1eb899ea4b8444083 and
later revised in f5a094db047ee0162774301a2ce4ed685ca9d539. Transparency
in EGL/X11 has been broken upstream for years in Mesa unfortunately.
However, the first commit claimed to have found a way to preserve
transparency by doing a trick with picking EGLConfigs (the second commit
revises this but keeps the logic in place). However, it doesn't appear
that the first commit actually fixes anything (transparency doesn't work
on my machine) and no one else seems to have reported it working. On the
other hand, if Mesa does ever actually fix this, transparency would
immediately be broken since mpv would always set the EGL_ALPHA_SIZE to
0. Go ahead and remove this since it doesn't seem to have any actual
utility and is technically a bit of a timebomb (not that deleting two
lines is a lot of work but still) if upstream ever does fix this.