### PR TITLE
github/workflows: force meson install on tumbleweed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./bootstrap.py
-          zypper -n install meson
+          zypper -n install --force-resolution --replacefiles meson
           # workaround to avoid "fatal: unsafe repository" error
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 


### PR DESCRIPTION
No clue how tumbleweed works, but apparently this now pulls
python310-base from upstream now but python38-base is installed on the
system already. This requires us to force the installation of the new
python310-base by passing two extra flags to zypper: one that makes it
resolve and the other that replaces conflicting files. Otherwise, the
build errors out at this step since the dependencies aren't properly
installed.