### PR TITLE
meson: use require when checking for vdpau

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1494,8 +1494,12 @@ if vaapi_egl['use'] or vaapi_libplacebo['use']
     sources += files('video/out/hwdec/hwdec_vaapi.c')
 endif
 
-vdpau = dependency('vdpau', version: '>= 0.2', required: get_option('vdpau'))
-if vdpau.found() and x11['use']
+vdpau_opt = get_option('vdpau').require(
+    x11['use'],
+    error_message: 'x11 was not found!',
+)
+vdpau = dependency('vdpau', version: '>= 0.2', required: vdpau_opt)
+if vdpau.found()
     dependencies += vdpau
     features += 'vdpau'
     sources += files('video/filter/vf_vdpaupp.c',


### PR DESCRIPTION
Technically this was wrong. If you passed -Dvdpau=enabled but did not
have x11 (a requirement for this), the build would silently just not
build the vdpau VO. The correct behavior is for it to be a hard error.
Accomplish this by using the require function and making sure that x11
is indeed being used before attempting to find the library.

Just making sure this builds correctly first.

Edit: And works as expected.