### PR TITLE
x11: add --x11-present option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -42,6 +42,7 @@ Interface changes
     - `--sub-visibility` no longer has any effect on secondary subtitles
     - add `film-grain` sub-parameter to `format` video filter
     - add experimental `--vo=vaapi-wayland` video output driver
+    - add `--x11-present` for controlling whether to use xorg's present extension
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3354,6 +3354,23 @@ Window
 
     ``never`` asks the window manager to never disable the compositor.
 
+``--x11-present=<no|auto|yes>``
+    Whether or not to use presentation statistics from X11's presentation
+    extension (default: ``auto``).
+
+    mpv asks X11 for present events which it then may use for more accurate
+    frame presentation. This only has an effect if ``--video-sync=display-...``
+    is being used.
+
+    The auto option enumerates XRandr providers for autodetection. If amd, radeon,
+    intel, or nouveau (the standard x86 Mesa drivers) is found and nvidia is NOT
+    found, presentation feedback is enabled. Other drivers are not assumed to
+    work, so they are not enabled automatically.
+
+    ``yes`` or ``no`` can still be passed regardless to enable/disable this
+    mechanism in case there is good/bad behavior with whatever your combination
+    of hardware/drivers/etc. happens to be.
+
 
 Disc Devices
 ------------

--- a/options/options.c
+++ b/options/options.c
@@ -175,6 +175,8 @@ static const m_option_t mp_vo_opt_list[] = {
     {"x11-netwm", OPT_CHOICE(x11_netwm, {"auto", 0}, {"no", -1}, {"yes", 1})},
     {"x11-bypass-compositor", OPT_CHOICE(x11_bypass_compositor,
         {"no", 0}, {"yes", 1}, {"fs-only", 2}, {"never", 3})},
+    {"x11-present", OPT_CHOICE(x11_present,
+        {"no", 0}, {"auto", 1}, {"yes", 2})},
 #endif
 #if HAVE_WIN32_DESKTOP
     {"vo-mmcss-profile", OPT_STRING(mmcss_profile)},
@@ -212,6 +214,7 @@ const struct m_sub_options vo_sub_opts = {
         .WinID = -1,
         .window_scale = 1.0,
         .x11_bypass_compositor = 2,
+        .x11_present = 1,
         .mmcss_profile = "Playback",
         .ontop_level = -1,
         .timing_offset = 0.050,

--- a/options/options.h
+++ b/options/options.h
@@ -29,6 +29,7 @@ typedef struct mp_vo_opts {
     char *appid;
     int x11_netwm;
     int x11_bypass_compositor;
+    int x11_present;
     int native_keyrepeat;
 
     float panscan;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -420,9 +420,11 @@ static void xrandr_read(struct vo_x11_state *x11)
             bstr_lower(provider_name);
             int amd = bstr_find0(provider_name, "amd");
             int intel = bstr_find0(provider_name, "intel");
+            int nouveau = bstr_find0(provider_name, "nouveau");
             int nvidia = bstr_find0(provider_name, "nvidia");
             int radeon = bstr_find0(provider_name, "radeon");
-            x11->has_mesa = x11->has_mesa || amd >= 0 || intel >= 0 || radeon >= 0;
+            x11->has_mesa = x11->has_mesa || amd >= 0 || intel >= 0 ||
+                            nouveau >= 0 || radeon >= 0;
             x11->has_nvidia = x11->has_nvidia || nvidia >= 0;
         }
         XRRFreeProviderResources(pr);

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1286,11 +1286,13 @@ void vo_x11_check_events(struct vo *vo)
             break;
         case GenericEvent: {
             XGenericEventCookie *cookie = (XGenericEventCookie *)&Event.xcookie;
-            if (cookie->extension == x11->present_code && x11->have_present &&
-                x11->has_mesa && !x11->has_nvidia)
+            if (cookie->extension == x11->present_code && x11->have_present)
             {
+                int present = x11->opts->x11_present;
+                bool use_present = (x11->has_mesa && !x11->has_nvidia &&
+                                   present) || present == 2;
                 XGetEventData(x11->display, cookie);
-                if (cookie->evtype == PresentCompleteNotify) {
+                if (cookie->evtype == PresentCompleteNotify && use_present) {
                     XPresentCompleteNotifyEvent *present_event;
                     present_event = (XPresentCompleteNotifyEvent *)cookie->data;
                     present_update_sync_values(x11->present, present_event->ust,


### PR DESCRIPTION
The first commit just adds nouveau to the x11 whitelist (not strictly related but).

~~The second commit is the more interesting one that exposes whether or not to use presentation feedback. In the past, mpv has always just used it, but there's potentially some cases where someone would want to have yes/no control over it (particularly on xorg). Windows was omitted because I have no clue how it works. @rossy: no idea if it makes any sense for Windows to have yes/no type control but feel free to add a commit or something.~~

The second commit is now just a `no/auto/yes` toggle for using present on xorg.