### PR TITLE
meson: add a summary at the end of configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1880,3 +1880,14 @@ if get_option('cplayer')
     executable('mpv', sources, dependencies: dependencies, win_subsystem: 'windows,6.0',
                include_directories: includedir, install: true)
 endif
+
+summary({'d3d11': d3d11.allowed(),
+         'gpu-next': libplacebo_next,
+         'javascript': javascript.found(),
+         'libmpv': get_option('libmpv'),
+         'lua': lua['use'],
+         'opengl': GL.found() or egl['use'],
+         'vulkan': vulkan.found(),
+         'wayland': wayland['use'],
+         'x11': x11['use']},
+         bool_yn: true)


### PR DESCRIPTION
The idea is shamelessly stolen from gnome-remote-desktop. The meson
build does a lot of checks and if you aren't familiar with the internals
of the meson.build, it may not be clear what is actually enabled and
what isn't. Add a little pretty message at the bottom that quickly shows
what the current build has and does not. It's not meant to be
comprehensive. Rather, it's just a short list of the notable features.