### PR TITLE
console: add history deduplication

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -142,4 +142,9 @@ Configurable Options
     Default: 16
 
     Set the font size used for the REPL and the console. This will be
-    multiplied by "scale."
+    multiplied by "scale".
+
+``history_dedup``
+    Default: true
+
+    Remove duplicate entries in history as to only keep the latest one.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -25,8 +25,10 @@ local opts = {
     -- have to be a monospaced font.
     font = "",
     -- Set the font size used for the REPL and the console. This will be
-    -- multiplied by "scale."
+    -- multiplied by "scale".
     font_size = 16,
+    -- Remove duplicate entries in history as to only keep the latest one.
+    history_dedup = true,
 }
 
 function detect_platform()
@@ -222,7 +224,7 @@ function show_and_type(text, cursor_pos)
 
     -- Save the line currently being edited, just in case
     if line ~= text and line ~= '' and history[#history] ~= line then
-        history[#history + 1] = line
+        history_add(line)
     end
 
     line = text
@@ -364,13 +366,28 @@ function help_command(param)
     log_add('', output)
 end
 
+-- Add a line to the history and deduplicate
+function history_add(text)
+    if opts.history_dedup then
+        -- More recent entries are more likely to be repeated
+        for i = #history, 1, -1 do
+            if history[i] == text then
+                table.remove(history, i)
+                break
+            end
+        end
+    end
+
+    history[#history + 1] = text
+end
+
 -- Run the current command and clear the line (Enter)
 function handle_enter()
     if line == '' then
         return
     end
     if history[#history] ~= line then
-        history[#history + 1] = line
+        history_add(line)
     end
 
     -- match "help [<text>]", return <text> or "", strip all whitespace
@@ -406,7 +423,7 @@ function go_history(new_pos)
     -- entry. This makes it much less frustrating to accidentally hit Up/Down
     -- while editing a line.
     if old_pos == #history + 1 and line ~= '' and history[#history] ~= line then
-        history[#history + 1] = line
+        history_add(line)
     end
 
     -- Now show the history line (or a blank line for #history + 1)


### PR DESCRIPTION
Deduplicate history like the fish shell. So for example
entering "cmd 1" then "cmd 2" then "cmd 3" then "cmd 1"
would result in a history of
[cmd 2][cmd 3][cmd 1]
instead of
[cmd 1][cmd 2][cmd 3][cmd 1]

Adds a function `history_append` to replace directly appending to
history.
Adds an option `history_dedup` to deactivate the deduplication.

(I already opened a [PR](https://github.com/mpv-player/mpv/pull/10300) for this, but when I moved the commit to a separate branch the PR got automatically closed.)