### PR TITLE
console: show suggestions for completion

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -135,8 +135,9 @@ Configurable Options
 ``font``
     Default: unset (picks a hardcoded font depending on detected platform)
 
-    Set the font used for the REPL and the console. This probably doesn't
-    have to be a monospaced font.
+    Set the font used for the REPL and the console.
+    This has to be a monospaced font for the completion suggestions to be
+    aligned correctly.
 
 ``font_size``
     Default: 16
@@ -153,3 +154,10 @@ Configurable Options
     Default: true
 
     Remove duplicate entries in history as to only keep the latest one.
+    multiplied by "scale."
+
+``font_hw_ratio``
+    Default: 2.0
+
+    The ratio of font height to font width.
+    Adjusts table width of completion suggestions.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -55,6 +55,21 @@ end
 -- Apply user-set options
 options.read_options(opts)
 
+local styles = {
+    -- Colors are stolen from base16 Eighties by Chris Kempson
+    -- and converted to BGR as is required by ASS.
+    -- 2d2d2d 393939 515151 697374
+    -- 939fa0 c8d0d3 dfe6e8 ecf0f2
+    -- 7a77f2 5791f9 66ccff 99cc99
+    -- cccc66 cc9966 cc99cc 537bd2
+
+    debug = '{\\1c&Ha09f93&}',
+    verbose = '{\\1c&H99cc99&}',
+    warn = '{\\1c&H66ccff&}',
+    error = '{\\1c&H7a77f2&}',
+    fatal = '{\\1c&H5791f9&\\b1}',
+}
+
 local repl_active = false
 local insert_mode = false
 local pending_update = false
@@ -329,7 +344,6 @@ function help_command(param)
     table.sort(cmdlist, function(c1, c2)
         return c1.name < c2.name
     end)
-    local error_style = '{\\1c&H7a77f2&}'
     local output = ''
     if param == '' then
         output = 'Available commands:\n'
@@ -350,7 +364,7 @@ function help_command(param)
             end
         end
         if not cmd then
-            log_add(error_style, 'No command matches "' .. param .. '"!')
+            log_add(styles.error, 'No command matches "' .. param .. '"!')
             return
         end
         output = output .. 'Command "' .. cmd.name .. '"\n'
@@ -836,19 +850,18 @@ mp.register_event('log-message', function(e)
     -- OSD display itself.
     if e.level == 'trace' then return end
 
-    -- Use color for debug/v/warn/error/fatal messages. Colors are stolen from
-    -- base16 Eighties by Chris Kempson.
+    -- Use color for debug/v/warn/error/fatal messages.
     local style = ''
     if e.level == 'debug' then
-        style = '{\\1c&Ha09f93&}'
+        style = styles.debug
     elseif e.level == 'v' then
-        style = '{\\1c&H99cc99&}'
+        style = styles.verbose
     elseif e.level == 'warn' then
-        style = '{\\1c&H66ccff&}'
+        style = styles.warn
     elseif e.level == 'error' then
-        style = '{\\1c&H7a77f2&}'
+        style = styles.error
     elseif e.level == 'fatal' then
-        style = '{\\1c&H5791f9&\\b1}'
+        style = styles.fatal
     end
 
     log_add(style, '[' .. e.prefix .. '] ' .. e.text)

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -158,6 +158,11 @@ function format_table(list, width_max, rows_max)
     -- total width without spacing
     local width_total = 0
 
+    local list_widths = {}
+    for i, item in ipairs(list) do
+        list_widths[i] = len_utf8(item)
+    end
+
     -- use as many columns as possible
     for rows = 1, list_size do
         local columns = math.ceil(list_size / rows)
@@ -170,9 +175,9 @@ function format_table(list, width_max, rows_max)
             for row = 1, rows do
                 local i = row + (column - 1) * rows
                 if i > #list then break end
-                local len = list[i]:len()
-                if width < len then
-                    width = len
+                local item_width = list_widths[i]
+                if width < item_width then
+                    width = item_width
                 end
             end
             column_widths[column] = width
@@ -358,6 +363,16 @@ function prev_utf8(str, pos)
         pos = pos - 1
     until pos <= 1 or str:byte(pos) < 0x80 or str:byte(pos) > 0xbf
     return pos
+end
+
+function len_utf8(str)
+    local len = 0
+    local pos = 1
+    while pos <= str:len() do
+        pos = next_utf8(str, pos)
+        len = len + 1
+    end
+    return len
 end
 
 -- Insert a character at the current cursor position (any_unicode)


### PR DESCRIPTION
Tab completion now temporarily shows a colored table of all potential completions
between the log messages and prompt.
The table automatically adjusts its column count depending on the space available.

As there is no way of knowing the exact width in characters, this is an estimate
and can be adjusted with the new option `font_hw_ratio`.
I expect the default value to work for everyone who doesn't set their own font.

The spacing between the columns also adjusts automatically, depending on
how much space is left.

![suggestions_screenshot](https://user-images.githubusercontent.com/8932183/184987886-82644646-27db-480f-9f62-c74fae2a4555.png)
