### PR TITLE
x11: correct provider detection logic

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -422,8 +422,8 @@ static void xrandr_read(struct vo_x11_state *x11)
             int intel = bstr_find0(provider_name, "intel");
             int nvidia = bstr_find0(provider_name, "nvidia");
             int radeon = bstr_find0(provider_name, "radeon");
-            x11->has_mesa = amd >= 0 || intel >= 0 || radeon >= 0;
-            x11->has_nvidia = nvidia >= 0;
+            x11->has_mesa = x11->has_mesa || amd >= 0 || intel >= 0 || radeon >= 0;
+            x11->has_nvidia = x11->has_nvidia || nvidia >= 0;
         }
         XRRFreeProviderResources(pr);
     }


### PR DESCRIPTION
The old logic always reset the x11->has_mesa/has_nvidia values on every
loop through the provider. This meant that it would always just match
whatever the last provider happened to be. So in the case of a dual GPU
system, if nvidia was the very first provider and the integrated
intel/amd card was the second (in practice, this is probably mostly the
other way around), then mpv would set has_mesa to true and has_nvidia to
false and thus try to use presentation. This is not the intended
behavior. Just rework this by also checking x11->has_mesa/has_nvidia in
the loop so a true value from the previous iteration is preserved.