### PR TITLE
x11: avoid XPresent API calls when it's not needed

### DIFF
--- a/video/out/opengl/context_glx.c
+++ b/video/out/opengl/context_glx.c
@@ -206,14 +206,17 @@ static bool glx_check_visible(struct ra_ctx *ctx)
 static void glx_swap_buffers(struct ra_ctx *ctx)
 {
     glXSwapBuffers(ctx->vo->x11->display, ctx->vo->x11->window);
-    vo_x11_present(ctx->vo);
-    present_sync_swap(ctx->vo->x11->present);
+    if (ctx->vo->x11->use_present) {
+        vo_x11_present(ctx->vo);
+        present_sync_swap(ctx->vo->x11->present);
+    }
 }
 
 static void glx_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_x11_state *x11 = ctx->vo->x11;
-    present_sync_get_info(x11->present, info);
+    if (ctx->vo->x11->use_present)
+        present_sync_get_info(x11->present, info);
 }
 
 static bool glx_init(struct ra_ctx *ctx)

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -82,14 +82,17 @@ static void mpegl_swap_buffers(struct ra_ctx *ctx)
     struct priv *p = ctx->priv;
 
     eglSwapBuffers(p->egl_display, p->egl_surface);
-    vo_x11_present(ctx->vo);
-    present_sync_swap(ctx->vo->x11->present);
+    if (ctx->vo->x11->use_present) {
+        vo_x11_present(ctx->vo);
+        present_sync_swap(ctx->vo->x11->present);
+    }
 }
 
 static void mpegl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_x11_state *x11 = ctx->vo->x11;
-    present_sync_get_info(x11->present, info);
+    if (ctx->vo->x11->use_present)
+        present_sync_get_info(x11->present, info);
 }
 
 static bool mpegl_init(struct ra_ctx *ctx)

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -308,14 +308,17 @@ static void flip_page(struct vo *vo)
     struct priv *p = vo->priv;
     Display_Image(p, p->myximage[p->current_buf]);
     p->current_buf = (p->current_buf + 1) % 2;
-    vo_x11_present(vo);
-    present_sync_swap(vo->x11->present);
+    if (vo->x11->use_present) {
+        vo_x11_present(vo);
+        present_sync_swap(vo->x11->present);
+    }
 }
 
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 {
     struct vo_x11_state *x11 = vo->x11;
-    present_sync_get_info(x11->present, info);
+    if (x11->use_present)
+        present_sync_get_info(x11->present, info);
 }
 
 // Note: REDRAW_FRAME can call this with NULL.

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -691,14 +691,17 @@ static void flip_page(struct vo *vo)
     if (!ctx->Shmem_Flag)
         XSync(vo->x11->display, False);
 
-    vo_x11_present(vo);
-    present_sync_swap(vo->x11->present);
+    if (vo->x11->use_present) {
+        vo_x11_present(vo);
+        present_sync_swap(vo->x11->present);
+    }
 }
 
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 {
     struct vo_x11_state *x11 = vo->x11;
-    present_sync_get_info(x11->present, info);
+    if (x11->use_present)
+        present_sync_get_info(x11->present, info);
 }
 
 // Note: REDRAW_FRAME can call this with NULL.

--- a/video/out/vulkan/context_xlib.c
+++ b/video/out/vulkan/context_xlib.c
@@ -34,14 +34,17 @@ static bool xlib_check_visible(struct ra_ctx *ctx)
 
 static void xlib_vk_swap_buffers(struct ra_ctx *ctx)
 {
-    vo_x11_present(ctx->vo);
-    present_sync_swap(ctx->vo->x11->present);
+    if (ctx->vo->x11->use_present) {
+        vo_x11_present(ctx->vo);
+        present_sync_swap(ctx->vo->x11->present);
+    }
 }
 
 static void xlib_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_x11_state *x11 = ctx->vo->x11;
-    present_sync_get_info(x11->present, info);
+    if (ctx->vo->x11->use_present)
+        present_sync_get_info(x11->present, info);
 }
 
 static void xlib_uninit(struct ra_ctx *ctx)

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -76,7 +76,7 @@ struct vo_x11_state {
     double screensaver_time_last;
 
     struct mp_present *present;
-    bool have_present;
+    bool use_present;
     int present_code;
 
     XIM xim;


### PR DESCRIPTION
This commit kind of mixes several related things together. The main
thing is to avoid calling any XPresent functions or internal functions
related to presentation when the feature is not auto-whitelisted or
enabled by the user. Internally rework this so it all works off of a
use_present bool (have_present is eliminated because having a non-zero
present_code covers exactly the same thing) and make sure it updates on
runtime. Finally, put some actual logging in here whenever XPresent is
enabled/disabled. Fixes #10326.

Also fixes #10327.