### PR TITLE
context_drm_egl: skip page flip wait on error

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -545,7 +545,7 @@ static void queue_flip(struct ra_ctx *ctx, struct gbm_frame *frame)
             talloc_free(data);
         }
     }
-    p->waiting_for_flip = true;
+    p->waiting_for_flip = !ret;
 
     if (atomic_ctx) {
         drmModeAtomicFree(atomic_ctx->request);


### PR DESCRIPTION
Any error in page flipping caused mpv to wait indefinitely for a page
flip callback.