### PR TITLE
drm: avoid drmModeAtomicCommit races by blocking

### DIFF
--- a/video/out/opengl/hwdec_drmprime_drm.c
+++ b/video/out/opengl/hwdec_drmprime_drm.c
@@ -131,7 +131,7 @@ static void disable_video_plane(struct ra_hwdec *hw)
         drm_object_set_property(request, p->ctx->drmprime_video_plane, "CRTC_ID", 0);
 
         int ret = drmModeAtomicCommit(p->ctx->fd, request,
-                                  DRM_MODE_ATOMIC_NONBLOCK, NULL);
+                                  0, NULL);
 
         if (ret)
             MP_ERR(hw, "Failed to commit disable plane request (code %d)", ret);


### PR DESCRIPTION
On S905X (meson) boards drmModeAtomicCommit called from
disable_video_plane in hwdec_drmprime_drm.c might still be running when
another call is made from queue_flip in context_drm_egl.c.

This causes EBUSY error in queue_flip, and causes mpv to hang.