### PR TITLE
DOCS/osc: fix option "showidlescreen" -> "idlescreen"

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -236,7 +236,7 @@ Configurable Options
 
     Enable the OSC when fullscreen
 
-``showidlescreen``
+``idlescreen``
     Default: yes
 
     Show the mpv logo and message when idle


### PR DESCRIPTION
This option was added in mpv-player@ec236f7, but its name in the document description is incorrect.