### PR TITLE
osc.lua: use minus character with time remaining

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -400,6 +400,12 @@ Configurable Options
     Use ``no`` to disable chapter display on hover. Otherwise it's a lua
     ``string.format`` template and ``%s`` is replaced with the actual name.
 
+``unicodeminus``
+    Default: no
+
+    Use a Unicode minus sign instead of an ASCII hyphen when displaying
+    the remaining playback time.
+
 
 Script Commands
 ~~~~~~~~~~~~~~~

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -315,6 +315,14 @@ Configurable Options
 
     Display timecodes with milliseconds
 
+``tcspace``
+    Default: 100 (allowed: 50-200)
+
+    Adjust space reserved for timecodes (current time and time remaining) in
+    the ``bottombar`` and ``topbar`` layouts. The timecode width depends on the
+    font, and with some fonts the spacing near the timecodes becomes too small.
+    Use values above 100 to increase that spacing, or below 100 to decrease it.
+
 ``visibility``
     Default: auto (auto hide/show on mouse move)
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -53,6 +53,7 @@ local user_opts = {
     chapters_osd = true,        -- whether to show chapters OSD on next/prev
     playlist_osd = true,        -- whether to show playlist OSD on next/prev
     chapter_fmt = "Chapter: %s", -- chapter print format for seekbar-hover. "no" to disable
+    unicodeminus = false,       -- whether to use the Unicode minus sign character
 }
 
 -- read options from config and command-line
@@ -1731,6 +1732,8 @@ function update_options(list)
     request_init()
 end
 
+local UNICODE_MINUS = string.char(0xe2, 0x88, 0x92)  -- UTF-8 for U+2212 MINUS SIGN
+
 -- OSC INIT
 function osc_init()
     msg.debug("osc_init")
@@ -2060,10 +2063,11 @@ function osc_init()
     ne.visible = (mp.get_property_number("duration", 0) > 0)
     ne.content = function ()
         if (state.rightTC_trem) then
+            local minus = user_opts.unicodeminus and UNICODE_MINUS or "-"
             if state.tc_ms then
-                return ("-"..mp.get_property_osd("playtime-remaining/full"))
+                return (minus..mp.get_property_osd("playtime-remaining/full"))
             else
-                return ("-"..mp.get_property_osd("playtime-remaining"))
+                return (minus..mp.get_property_osd("playtime-remaining"))
             end
         else
             if state.tc_ms then

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -43,6 +43,7 @@ local user_opts = {
     tooltipborder = 1,          -- border of tooltip in bottom/topbar
     timetotal = false,          -- display total time instead of remaining time?
     timems = false,             -- display timecodes with milliseconds?
+    tcspace = 100,              -- timecode spacing (compensate font size estimation)
     visibility = "auto",        -- only used at init to set visibility_mode(...)
     boxmaxchars = 80,           -- title crop threshold for box layout
     boxvideo = false,           -- apply osc_param.video_margins to video
@@ -1480,6 +1481,11 @@ function bar_layout(direction)
     local padY = 3
     local buttonW = 27
     local tcW = (state.tc_ms) and 170 or 110
+    if user_opts.tcspace >= 50 and user_opts.tcspace <= 200 then
+        -- adjust our hardcoded font size estimation
+        tcW = tcW * user_opts.tcspace / 100
+    end
+
     local tsW = 90
     local minW = (buttonW + padX)*5 + (tcW + padX)*4 + (tsW + padX)*2
 


### PR DESCRIPTION
This PR replaces the hyphen used to indicate time remaining in the on-screen controls with a U+2212 Minus Sign. The width of the time remaining/media duration region is also increased to accommodate the additional width of the minus sign relative to the hyphen.

Tested and screenshotted on Linux.

Before (hyphen):
![before](https://user-images.githubusercontent.com/1570964/177263622-a22e37b1-12f1-4696-b6c1-d18b59b8cb77.jpg)

After (minus sign):
![after](https://user-images.githubusercontent.com/1570964/177263640-aec44648-b4f0-4693-a468-cc1d3050b794.jpg)