### PR TITLE
meson: fix rst2html command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1650,7 +1650,7 @@ if rst2html.found()
     custom_target('html-manpages',
         input: manpage,
         output: 'mpv.html',
-        command: [rst2html, manpage, '@INPUT@', '@OUTPUT@'],
+        command: [rst2html, '@INPUT@', '@OUTPUT@'],
         install: true,
         install_dir: join_paths(datadir, 'doc', 'mpv')
     )


### PR DESCRIPTION
Fixes:
```
[20/228] Generating html-manpages with a custom command
FAILED: mpv.html
rst2html DOCS/man/mpv.rst ../DOCS/man/mpv.rst mpv.html
Usage
=====
  rst2html [options] [<source> [<destination>]]

rst2html: error: Maximum 2 arguments allowed.
```
cc: @Dudemanguy