### PR TITLE
vo_vaapi_wayland: Bump zwp_linux_dmabuf_v1 to version 4

### DIFF
--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -104,9 +104,9 @@ static struct va_pool_entry *va_alloc_entry(struct vo *vo, struct mp_image *src)
         MP_VERBOSE(vo, "VA export to composed layers not supported.\n");
         va_free_entry(entry);
         return NULL;
-    } else if (!vo_wayland_supported_format(vo, entry->desc.layers[0].drm_format)) {
-        MP_VERBOSE(vo, "%s is not supported.\n",
-                   mp_tag_str(entry->desc.layers[0].drm_format));
+    } else if (!vo_wayland_supported_format(vo, entry->desc.layers[0].drm_format, entry->desc.objects[0].drm_format_modifier)) {
+        MP_VERBOSE(vo, "%s(%016lx) is not supported.\n",
+                   mp_tag_str(entry->desc.layers[0].drm_format), entry->desc.objects[0].drm_format_modifier);
         va_free_entry(entry);
         return NULL;
     } else if (!CHECK_VA_STATUS(vo, "vaExportSurfaceHandle()")) {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1041,14 +1041,8 @@ static void dmabuf_format(void *data, struct zwp_linux_dmabuf_v1 *zwp_linux_dmab
     MP_VERBOSE(wl, "%s is supported by the compositor.\n", mp_tag_str(format));
 }
 
-static void dmabuf_modifier(void *data, struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf,
-                            uint32_t format, uint32_t modifier_hi, uint32_t modifier_lo)
-{
-}
-
 static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
     dmabuf_format,
-    dmabuf_modifier
 };
 
 static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id,

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -80,6 +80,10 @@ struct vo_wayland_state {
 
     /* linux-dmabuf */
     struct zwp_linux_dmabuf_v1 *dmabuf;
+    struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
+    void *format_map;
+    uint32_t format_size;
+    /* TODO: remove these once zwp_linux_dmabuf_v1 version 2 support is removed. */
     int *drm_formats;
     int drm_format_ct;
     int drm_format_ct_max;
@@ -134,7 +138,7 @@ struct vo_wayland_state {
 };
 
 bool vo_wayland_check_visible(struct vo *vo);
-bool vo_wayland_supported_format(struct vo *vo, uint32_t format);
+bool vo_wayland_supported_format(struct vo *vo, uint32_t format, uint64_t modifier);
 
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);


### PR DESCRIPTION
This allows compositors to import the dmabuf using explicit modifiers, which makes it possible for the buffer to end up on a hardware plane instead of being composited with GL.

This PR is draft because, at least on Weston when using said hardware planes, there is a synchronisation issue which makes the whole thing unusable.  The last commit is an attempt at fixing said issue, but I couldn’t finish it before falling ill, hence the draft PR. I expect the issue to be that vaapi reuses buffers before the compositor gives them back, so I added a callback on wl_buffer release which marks it not busy any longer, but that’s not enough, good luck to whoever finishes that code. :)

Fixes #10357.