### PR TITLE
ytdl_hook: fix default track for single format

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -388,7 +388,7 @@ local function formats_to_edl(json, formats, use_all_formats)
     }
 
     local default_formats = {}
-    local requested_formats = json["requested_formats"]
+    local requested_formats = json["requested_formats"] or json["requested_downloads"]
     if use_all_formats and requested_formats then
         for _, track in ipairs(requested_formats) do
             local id = track["format_id"]
@@ -523,7 +523,7 @@ local function add_single_video(json)
     local streamurl = ""
     local format_info = ""
     local max_bitrate = 0
-    local requested_formats = json["requested_formats"]
+    local requested_formats = json["requested_formats"] or json["requested_downloads"]
     local all_formats = json["formats"]
 
     if o.use_manifests and valid_manifest(json) then


### PR DESCRIPTION
Only matters when configuring ytdl_hook with all_formats=yes.

Tracks are marked as default tracks based on what yt-dlp/youtube-dl returns in the field `requested_formats`.
The problem is that this field only exists when there is more then one requested format.
So `ytdl-format=bestvideo+bestaudio` would have that field, but `ytdl-format=bestaudio` would not, leading to no tracks being marked as default tracks.

The requested formats can also be found under `requested_downloads`, which exists regardless of the number of requested formats. However when there is more then one requested format, `requested_downloads` doesn't contain those formats directly and instead has a field `requested_formats` that is identical to the other `requested_formats`.
Therefore use `requested_downloads` as a fallback for when `requested_formats` doesn't exist.