### PR TITLE
lua: add_timeout: pass additional arguments to the callback

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -432,19 +432,20 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     that are equal to the ``fn`` parameter. This uses normal Lua ``==``
     comparison, so be careful when dealing with closures.
 
-``mp.add_timeout(seconds, fn)``
-    Call the given function fn when the given number of seconds has elapsed.
+``mp.add_timeout(seconds, fn [,arg1 [,arg2...]])``
+    Call the given function ``fn`` when the given number of seconds has elapsed.
     Note that the number of seconds can be fractional. For now, the timer's
     resolution may be as low as 50 ms, although this will be improved in the
-    future.
+    future. Any additional arguments will be passed as arguments to ``fn``.
 
     This is a one-shot timer: it will be removed when it's fired.
 
     Returns a timer object. See ``mp.add_periodic_timer`` for details.
 
-``mp.add_periodic_timer(seconds, fn)``
+``mp.add_periodic_timer(seconds, fn [,arg1 [,arg2...]])``
     Call the given function periodically. This is like ``mp.add_timeout``, but
-    the timer is re-added after the function fn is run.
+    the timer is re-added after the function ``fn`` is run.
+    Any additional arguments will be passed as arguments to ``fn``.
 
     Returns a timer object. The timer object provides the following methods:
         ``stop()``


### PR DESCRIPTION
Previously any additional arguments to `mp.add_timeout` and
`mp.add_periodic_timer` were dropped.
This commit stores the additional arguments and passes them to the
callback function when it is called.

This improves consistency with the Javascript `setTimeout` and
`setInterval` functions, which already support this feature, and allows
for tidier code.

To correctly store the arguments we need to use `table.pack`, otherwise
a nil value argument could cause any proceeding arguments to be dropped
when passed to `unpack`. However this function is only
available from Lua 5.2 onwards. To support Lua 5.1 and LuaJit a custom
`table.pack` function is used if it is not already defined.

I have not actually tested this because I don't have the mpv build process
set up on my PC, but it is a very minor change and I've tested the general
edge cases in the Lua interpreter.
