### PR TITLE
ytdl_hook: broadcast ytdl_path and json

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1679,6 +1679,19 @@ The following hooks are currently defined:
     Run after an ``end-file`` event. Useful to drain property changes after a
     file has finished.
 
+List of script messages
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following script messages are currently sent out,
+with the list of arguments supplied to the handler function in braces:
+
+``ytdl_path`` (``path``)
+    Sent after successfully finding the path to ytdl.
+
+``ytdl_json`` (``url, json``)
+    Sent after the JSON has been returned from ytdl for that URL.
+
+
 Input Command Prefixes
 ----------------------
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -873,6 +873,38 @@ Example:
 
 For the existing event types, see `List of events`_.
 
+Script Messages
+---------------
+
+Script messages are notifications to scripts. A script message can be sent with
+the commands ``script-message`` and ``script-message-to``. You can register a
+script message handler with ``mp.register_script_message``.
+
+Note that all scripts receive events equally,
+and there's no such thing as blocking other scripts from receiving
+script messages.
+
+Example:
+
+::
+
+    function my_message_handler(url, json)
+        print("got json from ytdl for url!")
+    end
+    mp.register_script_message("ytdl_json", my_message_handler)
+
+This will print the message ``got json from ytdl for url!`` when ``ytdl_json``
+was received.
+
+::
+
+    mp.commandv('script-message', 'ytdl_path', 'path to ytdl')
+
+This sends the ``ytdl_path`` message to all scripts that have registered a
+message handler for it with ``'path to ytdl'`` as the argument.
+
+For script messages that are sent out by mpv, see `List of script messages`_.
+
 Extras
 ------
 

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -817,6 +817,7 @@ function run_ytdl_hook(url)
         end
 
         ytdl.searched = true
+        mp.commandv('script-message', 'ytdl_path', ytdl.path)
     end
 
     if aborted then
@@ -824,6 +825,7 @@ function run_ytdl_hook(url)
     end
 
     local parse_err = nil
+    local json_string = json
 
     if (es ~= 0) or (json == "") then
         json = nil
@@ -936,6 +938,8 @@ function run_ytdl_hook(url)
         elseif self_redirecting_url and #json.entries == 1 then
             msg.verbose("Playlist with single entry detected.")
             add_single_video(json.entries[1])
+            local json_string = utils.format_json(json.entries[1])
+            mp.commandv('script-message', 'ytdl_json', url, json_string)
         else
             local playlist_index = parse_yt_playlist(url, json)
             local playlist = {"#EXTM3U"}
@@ -982,6 +986,7 @@ function run_ytdl_hook(url)
 
     else -- probably a video
         add_single_video(json)
+        mp.commandv('script-message', 'ytdl_json', url, json_string)
     end
     msg.debug('script running time: '..os.clock()-start_time..' seconds')
 end


### PR DESCRIPTION
Share the found path to yt-dlp/youtube-dl and the acquired json for videos with other scripts.

I've been using this together with a modified [quality-menu](https://github.com/christoph-heinrich/mpv-quality-menu/blob/get_json_from_ytdl_hook/quality-menu.lua) for about a week now without any problems and was curious what you think about this.

There are currently no script messages being sent out to user scripts (afaik), but this seems like the easiest way of sharing that information with others.

The documentation is based on the one for events.