### PR TITLE
ytdl_hook: always set HTTP headers

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -525,6 +525,10 @@ local function add_single_video(json)
     local max_bitrate = 0
     local requested_formats = json["requested_formats"]
     local all_formats = json["formats"]
+    local has_requested_formats = requested_formats and #requested_formats > 0
+    local http_headers = has_requested_formats
+                         and requested_formats[1].http_headers
+                         or json.http_headers
 
     if o.use_manifests and valid_manifest(json) then
         -- prefer manifest_url if present
@@ -554,7 +558,6 @@ local function add_single_video(json)
     if streamurl == ""  then
         -- possibly DASH/split tracks
         local res = nil
-        local has_requested_formats = requested_formats and #requested_formats > 0
 
         -- Not having requested_formats usually hints to HLS master playlist
         -- usage, which we don't want to split off, at least not yet.
@@ -591,13 +594,14 @@ local function add_single_video(json)
         end
         -- normal video or single track
         streamurl = edl_track or json.url
-        set_http_headers(json.http_headers)
     end
 
     if streamurl == "" then
         msg.error("No URL found in JSON data.")
         return
     end
+
+    set_http_headers(http_headers)
 
     msg.verbose("format selection: " .. format_info)
     msg.debug("streamurl: " .. streamurl)


### PR DESCRIPTION
Closes #8786 and #9978.
Also closes #10225, except not really because as it turns out bilibili now works even without setting HTTP headers (the JSON doesn't even contain them anymore).
Regardless they should always be set, just in case they are needed.