### PR TITLE
libplacebo: fix compatibility with libplacebo >= 5

### DIFF
--- a/video/out/placebo/utils.h
+++ b/video/out/placebo/utils.h
@@ -5,7 +5,7 @@
 #include "video/csputils.h"
 
 #include <libplacebo/common.h>
-#include <libplacebo/context.h>
+#include <libplacebo/log.h>
 #include <libplacebo/colorspace.h>
 
 pl_log mppl_log_create(struct mp_log *log);


### PR DESCRIPTION
libplacebo 4.157[^1] rename context.h to log.h, and left a compatibility
header. In 5.x, this header has been removed.

Since we require libplacebo 4.157 to build mpv, we can just use log.h to
fix compatibility with 5.x.

[^1]: https://github.com/haasn/libplacebo/commit/2459200a133d1a0f36f092a32a2d5d443cfbee55
