### PR TITLE
ytdl_hook: improve track detection

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -418,28 +418,25 @@ local function formats_to_edl(json, formats, use_all_formats)
         end
 
         local tracks = {}
-        if track.vcodec and track.vcodec ~= "none" then
+        -- "none" means it is not a video
+        -- nil means it is unknown
+        if (o.force_all_formats or track.vcodec) and track.vcodec ~= "none" then
             tracks[#tracks + 1] = {
                 media_type = "video",
                 codec = map_codec_to_mpv(track.vcodec),
             }
         end
-        -- Tries to follow the strange logic that vcodec unset means it's
-        -- an audio stream, even if acodec is sometimes unset.
-        if (#tracks == 0) or (track.acodec and track.acodec ~= "none") then
+        if (o.force_all_formats or track.acodec) and track.acodec ~= "none" then
             tracks[#tracks + 1] = {
                 media_type = "audio",
                 codec = map_codec_to_mpv(track.acodec) or
                         ext_map[track.ext],
             }
         end
-        if #tracks == 0 then
-            return nil
-        end
 
         local url = edl_track or track.url
         local hdr = {"!new_stream", "!no_clip", "!no_chapters"}
-        local skip = false
+        local skip = #tracks == 0
         local params = ""
 
         if use_all_formats then
@@ -493,12 +490,14 @@ local function formats_to_edl(json, formats, use_all_formats)
             end
         end
 
-        hdr[#hdr + 1] = edl_escape(url) .. params
+        if not skip then
+            hdr[#hdr + 1] = edl_escape(url) .. params
 
-        streams[#streams + 1] = table.concat(hdr, ";")
-        -- In case there is only 1 of these streams.
-        -- Note: assumes it has no important EDL headers
-        single_url = url
+            streams[#streams + 1] = table.concat(hdr, ";")
+            -- In case there is only 1 of these streams.
+            -- Note: assumes it has no important EDL headers
+            single_url = url
+        end
     end
 
     -- Merge all tracks into a single virtual file, but avoid EDL if it's


### PR DESCRIPTION
Every format that was not detected as a video format was added to the
audio tracks. This resulted in e.g. YouTube storyboards from ending up
in the list of audio tracks.

Now formats that are already known to be neither video formats nor audio
formats, will also not end up in any track list.

Formats where it is unknown if they are video or audio formats get
added to tracks if `force_all_formats` is used, otherwise only
formats that are known to contain video or audio become video or audio
tracks respectively.

https://github.com/yt-dlp/yt-dlp/issues/4373#issuecomment-1186637357

Currently it uses `force_all_formats` to decide if questionable formats get added or not. Should we introduce  a new option for that or is this fine?