### PR TITLE
ci: bump macos runner version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,11 +149,11 @@ jobs:
           cat ./build/config.log
 
   freebsd:
-    runs-on: macos-10.15 # until https://github.com/actions/runner/issues/385
+    runs-on: macos-12 # until https://github.com/actions/runner/issues/385
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.1.7 # aka FreeBSD 13.1
+      uses: vmactions/freebsd-vm@v0.2.0 # aka FreeBSD 13.1
       with:
         usesh: true
         prepare: |


### PR DESCRIPTION
Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.

----

GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

I have checked [`vmactions/freebsd-vm`](https://github.com/vmactions/freebsd-vm) does support `macos-12` (which requires `vmactions/freebsd-vm@0.2.0`). The default FreeBSD version of `vmactions/freebsd-vm@0.2.0` is still 13.1.

I have updated the `runs-on` to `macos-12` and bumped `vmactions/freebsd-vm` to `0.2.0` in the PR.