### PR TITLE
wayland: enable screensaver inhibition in GNOME

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1347,35 +1347,10 @@ Disabling Screensaver
 By default, mpv tries to disable the OS screensaver during playback (only if
 a VO using the OS GUI API is active). ``--stop-screensaver=no`` disables this.
 
-A common problem is that Linux desktop environments ignore the standard
-screensaver APIs on which mpv relies. In particular, mpv uses the Screen Saver
-extension (XSS) on X11, and the idle-inhibit on Wayland.
-
-GNOME is one of the worst offenders, and ignores even the now widely supported
-idle-inhibit protocol. (This is either due to a combination of malice and
-incompetence, but since implementing this protocol would only take a few lines
-of code, it is most likely the former. You will also notice how GNOME advocates
-react offended whenever their sabotage is pointed out, which indicates either
-hypocrisy, or even worse ignorance.)
-
-Such incompatible desktop environments (i.e. which ignore standards) typically
-require using a DBus API. This is ridiculous in several ways. The immediate
-practical problem is that it would require adding a quite unwieldy dependency
-for a DBus library, somehow integrating its mainloop into mpv, and other
-generally unacceptable things.
-
-However, since mpv does not officially support GNOME, this is not much of a
-problem. If you are one of those miserable users who want to use mpv on GNOME,
-report a bug on the GNOME issue tracker:
-https://gitlab.gnome.org/groups/GNOME/-/issues
-
-Alternatively, you may be able to write a Lua script that calls the
-``xdg-screensaver`` command line program. (By the way, this a command line
-program is an utterly horrible kludge that tries to identify your DE, and then
-tries to send the correct DBus command via a DBus CLI tool.) If you find the
-idea of having to write a script just so your screensaver doesn't kick in
-ridiculous, do not use GNOME, or use GNOME video software instead of mpv (good
-luck).
+To inhibit the screensaver, mpv uses the Screen Saver extension (XSS) on X11,
+and the idle-inhibit protocol on Wayland. If idle-inhibit is not found on
+Wayland, the org.freedesktop.ScreenSaver or org.freedesktop.portal.Inhibit
+D-Bus interfaces will be used to inhibit the screensaver.
 
 Before mpv 0.33.0, the X11 backend ran ``xdg-screensaver reset`` in 10 second
 intervals when not paused. This hack was removed in 0.33.0.

--- a/meson.build
+++ b/meson.build
@@ -1056,6 +1056,16 @@ if wayland['use'] and memfd_create
     sources += files('video/out/vo_wlshm.c')
 endif
 
+gio = {
+    'name': 'gio',
+    'deps': dependency('gio-2.0', version: '>= 2.26', required: get_option('gio')),
+}
+gio += {'use': gio['deps'].found() and wayland['use']}
+if gio['use']
+    dependencies += gio['deps']
+    features += gio['name']
+endif
+
 x11_opt = get_option('x11').require(
     get_option('gpl'),
     error_message: 'the build is not GPL!',
@@ -1733,6 +1743,7 @@ conf_data.set10('HAVE_EGL_ANGLE_WIN32', egl_angle_win32.allowed())
 conf_data.set10('HAVE_EGL_DRM', egl_drm.allowed())
 conf_data.set10('HAVE_EGL_HELPERS', egl_helpers)
 conf_data.set10('HAVE_EGL_X11', egl_x11.allowed())
+conf_data.set10('HAVE_GIO', gio['use'])
 conf_data.set10('HAVE_GLIBC_THREAD_NAME', glibc_thread_name and posix)
 conf_data.set10('HAVE_GL', gl['use'])
 conf_data.set10('HAVE_GL_COCOA', gl_cocoa.allowed())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,6 +68,7 @@ option('egl-drm', type: 'feature', value: 'auto', description: 'OpenGL DRM EGL B
 option('egl-wayland', type: 'feature', value: 'auto', description: 'OpenGL Wayland Backend')
 option('egl-x11', type: 'feature', value: 'auto', description: 'OpenGL X11 EGL Backend')
 option('gbm', type: 'feature', value: 'auto', description: 'GBM')
+option('gio', type: 'feature', value: 'auto', description: 'GNOME inhibit support')
 option('gl', type: 'feature', value: 'enabled', description: 'OpenGL context support')
 option('gl-cocoa', type: 'feature', value: 'auto', description: 'gl-cocoa')
 option('gl-dxinterop', type: 'feature', value: 'auto', description: 'OpenGL/DirectX Interop Backend')

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -19,6 +19,7 @@
 #define MPLAYER_WAYLAND_COMMON_H
 
 #include <wayland-client.h>
+#include "config.h"
 #include "input/event.h"
 #include "vo.h"
 
@@ -131,6 +132,11 @@ struct vo_wayland_state {
     bool                    cursor_visible;
     int                     allocated_cursor_scale;
     uint32_t                pointer_id;
+
+#if HAVE_GIO
+    /* Screen Saver */
+    struct vo_wayland_screensaver *screensaver;
+#endif
 };
 
 bool vo_wayland_check_visible(struct vo *vo);

--- a/wscript
+++ b/wscript
@@ -778,6 +778,11 @@ video_output_features = [
         'name': '--sixel',
         'desc': 'Sixel',
         'func': check_pkg_config('libsixel', '>= 1.5'),
+    }, {
+        'name': '--gio',
+        'desc': 'GNOME inhibit support',
+        'deps': 'wayland',
+        'func': check_pkg_config('gio-2.0', '>= 2.26'),
     }
 ]
 


### PR DESCRIPTION
Eventually it would be good if GNOME Shell was updated to use the idle-inhibit protocol. But currently, support for it is still unfinished, and there are distros like Ubuntu Jammy LTS that ship with GNOME 42 and will keep that for the next 5 years. Thus those LTS distros will likely never get support for the protocol if it even lands in GNOME 43 or later. In order to get support for screensaver inhibition on those distros, this patch is able to inhibit the screensaver from within a Snap or Flatpak using the [Portal API](https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-method-org-freedesktop-portal-Inhibit.Inhibit). See some similar code in WebKit as a point of comparison: [SleepDisablerGLib.cpp](https://github.com/WebKit/WebKit/blob/83a6feae0199a933bd8f8c144ecbea1e2472e2d7/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.cpp)

My use case is for Flatpak and I have tested it works there, but it should also work with the mpv Snap. It will also work outside a sandbox as well, by falling back to `org.freedesktop.ScreenSaver`. 