### PR TITLE
player: set playlist title to media title if not set already

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2786,9 +2786,10 @@ Property list
         entry, ``no``/false or unavailable otherwise.
 
     ``playlist/N/title``
-        Name of the Nth entry. Only available if the playlist file contains
-        such fields, and only if mpv's parser supports it for the given
-        playlist format.
+        Name of the Nth entry. Available if the playlist file contains
+        such fields and mpv's parser supports it for the given
+        playlist format, or if the playlist entry has been opened before and a
+        media-title other then then filename has been aquired.
 
     ``playlist/N/id``
         Unique ID for this entry. This is an automatically assigned integer ID

--- a/player/command.c
+++ b/player/command.c
@@ -515,24 +515,27 @@ static int mp_property_media_title(void *ctx, struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    char *name = NULL;
+    const char* name = NULL;
     if (mpctx->opts->media_title)
         name = mpctx->opts->media_title;
+    if ((!name || !name[0]) && mpctx->demuxer) {
+        name = mp_tags_get_str(mpctx->demuxer->metadata, "service_name");
+        if (!name || !name[0]){
+            name = mp_tags_get_str(mpctx->demuxer->metadata, "title");
+            if (!name || !name[0])
+                name = mp_tags_get_str(mpctx->demuxer->metadata, "icy-title");
+        }
+    }
+    struct playlist_entry *const pe = mpctx->playing;
+    if (pe) {
+        if (!name || !name[0]){
+            name = pe->title;
+        } else if (!pe->title) {
+            pe->title = talloc_strdup(pe, name);
+        }
+    }
     if (name && name[0])
         return m_property_strdup_ro(action, arg, name);
-    if (mpctx->demuxer) {
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "service_name");
-        if (name && name[0])
-            return m_property_strdup_ro(action, arg, name);
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "title");
-        if (name && name[0])
-            return m_property_strdup_ro(action, arg, name);
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "icy-title");
-        if (name && name[0])
-            return m_property_strdup_ro(action, arg, name);
-    }
-    if (mpctx->playing && mpctx->playing->title)
-        return m_property_strdup_ro(action, arg, mpctx->playing->title);
     return mp_property_filename(ctx, prop, action, arg);
 }
 


### PR DESCRIPTION
The title in the playlist should get set when we get a title and the playlist title isn't set already.

#8548 has essentially the same goal, but this has the advantage that
1. It actually works (maybe the handling of media-title has changed since that was implemented)
2. The title gets stored in the playlist item instead of only showing the media-title as the playlist-item title when the playlist property gets accessed, so printing the playlist will show the title too.
3. The media-title does not shadow the playlist-item title if it actually has one set.
4. Any playlist item that has been opened will have a title if it didn't already have one from the playlist file, not only the current one

Somewhat closes #4780, but still only shows titles for files/urls that have been opened before. I don't think we should make a bunch of requests just to get the titles.