### PR TITLE
WIP: vo_vaapi_wayland: refactor into generic VO for dmabuf buffers

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -41,7 +41,7 @@ Interface changes
     - add `dolbyvision` sub-parameter to `format` video filter
     - `--sub-visibility` no longer has any effect on secondary subtitles
     - add `film-grain` sub-parameter to `format` video filter
-    - add experimental `--vo=vaapi-wayland` video output driver
+    - add experimental `--vo=dmabuf-wayland` video output driver
     - add `--x11-present` for controlling whether to use xorg's present extension
     - add `engine` option to the `rubberband` audio filter to support the new
       engine introduced in rubberband 3.0.0. Defaults to `finer` (new engine).

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1249,7 +1249,7 @@ Video
     :videotoolbox: requires ``--vo=gpu`` (macOS 10.8 and up),
                    or ``--vo=libmpv`` (iOS 9.0 and up)
     :videotoolbox-copy: copies video back into system RAM (macOS 10.8 or iOS 9.0 and up)
-    :vaapi:     requires ``--vo=gpu``, ``--vo=vaapi`` or ``--vo=vaapi-wayland`` (Linux only)
+    :vaapi:     requires ``--vo=gpu``, ``--vo=vaapi`` or ``--vo=dmabuf-wayland`` (Linux only)
     :vaapi-copy: copies video back into system RAM (Linux with some GPUs only)
     :nvdec:     requires ``--vo=gpu`` (Any platform CUDA is available)
     :nvdec-copy: copies video back to system RAM (Any platform CUDA is available)

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -286,7 +286,7 @@ Available video output drivers are:
     ``--sdl-switch-mode``
         Instruct SDL to switch the monitor video mode when going fullscreen.
 
-``vaapi-wayland``
+``dmabuf-wayland``
     Experimental Wayland output driver designed for use with VA API hardware decoding.
     The driver is designed to avoid any GPU to CPU copies, and to perform scaling and
     color space conversion using fixed-function hardware, if available,

--- a/meson.build
+++ b/meson.build
@@ -1444,8 +1444,8 @@ if vaapi_wayland['use']
 endif
 
 if vaapi_wayland['use'] and memfd_create
-    features += 'vaapi-wayland-memfd'
-    sources += files('video/out/vo_vaapi_wayland.c')
+    features += 'dmabuf-wayland-memfd'
+    sources += files('video/out/vo_dmabuf_wayland.c')
 endif
 
 vaapi_x11 = {

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -62,7 +62,7 @@ extern const struct vo_driver video_out_drm;
 extern const struct vo_driver video_out_direct3d;
 extern const struct vo_driver video_out_sdl;
 extern const struct vo_driver video_out_vaapi;
-extern const struct vo_driver video_out_vaapi_wayland;
+extern const struct vo_driver video_out_dmabuf_wayland;
 extern const struct vo_driver video_out_wlshm;
 extern const struct vo_driver video_out_rpi;
 extern const struct vo_driver video_out_tct;
@@ -94,7 +94,7 @@ const struct vo_driver *const video_out_drivers[] =
     &video_out_sdl,
 #endif
 #if HAVE_VAAPI_WAYLAND && HAVE_MEMFD_CREATE
-    &video_out_vaapi_wayland,
+    &video_out_dmabuf_wayland,
 #endif
 #if HAVE_VAAPI_X11 && HAVE_GPL
     &video_out_vaapi,

--- a/wscript
+++ b/wscript
@@ -659,9 +659,9 @@ video_output_features = [
         'deps': 'vaapi && gl-wayland',
         'func': check_pkg_config('libva-wayland', '>= 1.1.0'),
     }, {
-        'name': 'vaapi-wayland-memfd',
-        'desc': 'VAAPI (Wayland dmabuf support)',
         'deps': 'vaapi-wayland && memfd_create',
+        'name': 'dmabuf-wayland-memfd',
+        'desc': 'Wayland dmabuf support',
         'func': check_true,
     }, {
         'name': '--vaapi-drm',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -519,7 +519,7 @@ def build(ctx):
         ( "video/out/vo_sixel.c",                "sixel" ),
         ( "video/out/vo_tct.c" ),
         ( "video/out/vo_vaapi.c",                "vaapi-x11 && gpl" ),
-        ( "video/out/vo_vaapi_wayland.c",        "vaapi-wayland-memfd"  ),
+        ( "video/out/vo_dmabuf_wayland.c",        "dmabuf-wayland-memfd"  ),
         ( "video/out/vo_vdpau.c",                "vdpau" ),
         ( "video/out/vo_wlshm.c",                "wayland && memfd_create" ),
         ( "video/out/vo_x11.c" ,                 "x11" ),


### PR DESCRIPTION
1. Re-design buffer pool so it is generic and does not depend on VAAPI.
This vo design will be re-used for upcoming drmprime decoder, so it will
be easier to re-use if vaapi dependencies are reduced to minimum. With
these changes, all vaapi-specific buffer transformations are grouped
into one single method.

2. rename vo_vaapi_wayland to more generic vo_dmabuf_wayland