### PR TITLE
ao_pipewire: use mpv logging

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -123,7 +123,7 @@ static void on_process(void *userdata)
     void *data[MP_NUM_CHANNELS];
 
     if ((b = pw_stream_dequeue_buffer(p->stream)) == NULL) {
-        pw_log_warn("out of buffers: %m");
+        MP_WARN(ao, "out of buffers: %m\n");
         return;
     }
 


### PR DESCRIPTION
Note:
It would also be possible to redirect the logging of the pipewire library to the mpv logging subsystem. Not sure if it makes sense though.