### PR TITLE
audio: drain ao on EOF

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -945,6 +945,7 @@ void fill_audio_out_buffers(struct MPContext *mpctx)
                           (opts->gapless_audio && !ao_untimed(ao_c->ao))))
         {
             MP_VERBOSE(mpctx, "audio EOF reached\n");
+            ao_drain(mpctx->ao);
             mpctx->audio_status = STATUS_EOF;
             mp_wakeup_core(mpctx);
         }


### PR DESCRIPTION
This gives pull-based AOs the chance to play all queued audio.
Also it will make sure that the audio has finished playing so we can
reinitialize the AO if format changes are necessary.

Fixes #10018
Fixes #9835
Fixes #8904

@Hello71 @gbpi @kookiesgh Can you validate that this fixes your issues?