### PR TITLE
player: choose speed of smallest acceptable factor for display sync

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -665,20 +665,16 @@ double calc_average_frame_duration(struct MPContext *mpctx)
 // effective video FPS. If this is not possible, try to do it for multiples,
 // which still leads to an improved end result.
 // Both parameters are durations in seconds.
-static double calc_best_speed(double vsync, double frame, int max_factor)
+static double calc_best_speed(double vsync, double frame,
+                              double max_change, int max_factor)
 {
     double ratio = frame / vsync;
-    double best_scale = -1;
-    double best_dev = INFINITY;
     for (int factor = 1; factor <= max_factor; factor++) {
         double scale = ratio * factor / rint(ratio * factor);
-        double dev = fabs(scale - 1);
-        if (dev < best_dev) {
-            best_scale = scale;
-            best_dev = dev;
-        }
+        if (fabs(scale - 1) <= max_change)
+            return scale;
     }
-    return best_scale;
+    return -1;
 }
 
 static double find_best_speed(struct MPContext *mpctx, double vsync)
@@ -689,10 +685,15 @@ static double find_best_speed(struct MPContext *mpctx, double vsync)
         double dur = mpctx->past_frames[n].approx_duration;
         if (dur <= 0)
             continue;
-        total += calc_best_speed(vsync, dur / mpctx->opts->playback_speed,
+        double best = calc_best_speed(vsync, dur / mpctx->opts->playback_speed,
+                                 mpctx->opts->sync_max_video_change / 100,
                                  mpctx->opts->sync_max_factor);
+        if (best <= 0)
+            continue;
+        total += best;
         num++;
     }
+    // If it doesn't work, play at normal speed.
     return num > 0 ? total / num : 1;
 }
 
@@ -827,12 +828,8 @@ static void handle_display_sync_frame(struct MPContext *mpctx,
         return;
 
     mpctx->speed_factor_v = 1.0;
-    if (mode != VS_DISP_VDROP) {
-        double best = find_best_speed(mpctx, vsync);
-        // If it doesn't work, play at normal speed.
-        if (fabs(best - 1.0) <= opts->sync_max_video_change / 100)
-            mpctx->speed_factor_v = best;
-    }
+    if (mode != VS_DISP_VDROP)
+        mpctx->speed_factor_v = find_best_speed(mpctx, vsync);
 
     // Determine for how many vsyncs a frame should be displayed. This can be
     // e.g. 2 for 30hz on a 60hz display. It can also be 0 if the video


### PR DESCRIPTION
Instead of choosing based on smallest deviation from set speed,
use the speed change from the smallest factor that does not
exceed `video-sync-max-video-change`.

Example where this makes a difference:
`mpv --no-config --speed=1.21 --video-sync=display-resample --video-sync-max-video-change=5 --video-sync-max-factor=10 https://github.com/haasn/interpolation-samples/raw/master/24fps/native.mkv`
(the same speed as pressing `]` twice)
Playback with these changes is noticeably smoother then without.

Explanation:
Without this it calculates
```
factor  1 scale 1.032727
factor  2 scale 1.032727
factor  3 scale 1.032727
factor  4 scale 1.032727
factor  5 scale 1.032727
factor  6 scale 1.032727
factor  7 scale 1.032727
factor  8 scale 0.971979
factor  9 scale 0.978373
factor 10 scale 0.983550
```
and ends up choosing the last one because it is the closest to 1, which means the frames only line up with the display refresh rate at a multiple of 10.
With this change it calculates the first one and stops there, because any higher factors would only lead to less smooth playback.

Interestingly this actually used to work this way, but was changed in 62b386c2fdb6d113c2c1042f0b3a973f3fb11828 without an explanation.
The comment above the function still describes the old behavior.