### PR TITLE
x11: fix display-{width,height} calculation

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2078,10 +2078,16 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
         return VO_TRUE;
     }
     case VOCTRL_GET_DISPLAY_RES: {
-        if (!x11->window || x11->parent)
+        struct xrandr_display *selected_disp = NULL;
+        for (int n = 0; n < x11->num_displays; n++) {
+            struct xrandr_display *disp = &x11->displays[n];
+            if (disp->overlaps)
+                selected_disp = disp;
+        }
+        if (!x11->window || x11->parent || !selected_disp)
             return VO_NOTAVAIL;
-        ((int *)arg)[0] = x11->screenrc.x1;
-        ((int *)arg)[1] = x11->screenrc.y1;
+        ((int *)arg)[0] = selected_disp->rc.x1 - selected_disp->rc.x0;
+        ((int *)arg)[1] = selected_disp->rc.y1 - selected_disp->rc.y0;
         return VO_TRUE;
     }
     case VOCTRL_GET_HIDPI_SCALE:


### PR DESCRIPTION
Unexpectedly, x11->screenrc actually doesn't update with randr events.
In a multimonitor configuration it could easily be wrong depending on
the user's layout. While it's tempting to modify the logic so screenrc
changes with randr events, this rectangle is currently used everywhere
and as far as we know, this pretty much works fine. Instead, just loop
over the randr displays that we have and select it if it overlaps with
the winrc. This follows the same logic as the fps selection in the case
of the mpv window overlapping multiple monitors (the last one is
selected).