### PR TITLE
wayland: hack around erronous playback speed on overlapping monitors

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -69,6 +69,7 @@ struct vo_wayland_state {
     int mouse_unscaled_y;
     int mouse_x;
     int mouse_y;
+    int output_overlaps;
     int pending_vo_events;
     int scaling;
     int timeout_count;


### PR DESCRIPTION
I haven't tested this yet, but this should fix #10489 assuming I did the math right.

