### PR TITLE
common/playlist.c: seed playlist_shuffle rand with microsecond timer

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -23,6 +23,7 @@
 #include "common/msg.h"
 #include "mpv_talloc.h"
 #include "options/path.h"
+#include "osdep/timer.h"
 
 #include "demux/demux.h"
 #include "stream/stream.h"
@@ -144,6 +145,7 @@ void playlist_add_file(struct playlist *pl, const char *filename)
 
 void playlist_shuffle(struct playlist *pl)
 {
+    srand(mp_time_us());
     for (int n = 0; n < pl->num_entries; n++)
         pl->entries[n]->original_index = n;
     for (int n = 0; n < pl->num_entries - 1; n++) {


### PR DESCRIPTION
This commit calls srand() using mp_time_us() before shuffling the
playlist with playlist_shuffle in order to prevent getting the same
results every time you shuffle the playlist, i.e. the playlist should
actually shuffle, rather than reorder itself in a predictable way.

Fixes #10389. 