### PR TITLE
ao_pipewire: only try to read requested data

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -136,11 +136,8 @@ static void on_process(void *userdata)
         nframes = b->requested;
 #endif
 
-    for (int i = 0; i < buf->n_datas; i++) {
+    for (int i = 0; i < buf->n_datas; i++)
         data[i] = buf->datas[i].data;
-        buf->datas[i].chunk->offset = 0;
-        buf->datas[i].chunk->stride = ao->sstride;
-    }
 
     pw_stream_get_time_n(p->stream, &time, sizeof(time));
     if (time.rate.denom == 0)
@@ -158,6 +155,8 @@ static void on_process(void *userdata)
 
     for (int i = 0; i < buf->n_datas; i++) {
         buf->datas[i].chunk->size = samples * ao->sstride;
+        buf->datas[i].chunk->offset = 0;
+        buf->datas[i].chunk->stride = ao->sstride;
     }
 
     pw_stream_queue_buffer(p->stream, b);

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -131,6 +131,10 @@ static void on_process(void *userdata)
 
     int bytes_per_channel = buf->datas[0].maxsize / ao->channels.num;
     int nframes = bytes_per_channel / ao->sstride;
+#if PW_CHECK_VERSION(0, 3, 49)
+    if (b->requested != 0)
+        nframes = b->requested;
+#endif
 
     for (int i = 0; i < buf->n_datas; i++) {
         data[i] = buf->datas[i].data;

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -134,8 +134,8 @@ static void on_process(void *userdata)
 
     for (int i = 0; i < buf->n_datas; i++) {
         data[i] = buf->datas[i].data;
-        buf->datas[i].chunk->size = bytes_per_channel;
         buf->datas[i].chunk->offset = 0;
+        buf->datas[i].chunk->stride = ao->sstride;
     }
 
     pw_stream_get_time_n(p->stream, &time, sizeof(time));
@@ -151,6 +151,10 @@ static void on_process(void *userdata)
 
     int samples = ao_read_data(ao, data, nframes, end_time);
     b->size = samples;
+
+    for (int i = 0; i < buf->n_datas; i++) {
+        buf->datas[i].chunk->size = samples * ao->sstride;
+    }
 
     pw_stream_queue_buffer(p->stream, b);
 }


### PR DESCRIPTION
Newer versions of Pipewire request a specific amount of data, try to honor it.
Also add some more information about the buffers sent to Pipewire.