### PR TITLE
ao_pipewire: make sure not to exceed the available buffer

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -133,7 +133,7 @@ static void on_process(void *userdata)
     int nframes = bytes_per_channel / ao->sstride;
 #if PW_CHECK_VERSION(0, 3, 49)
     if (b->requested != 0)
-        nframes = b->requested;
+        nframes = MPMIN(b->requested, nframes);
 #endif
 
     for (int i = 0; i < buf->n_datas; i++)


### PR DESCRIPTION
The error description in #10545 could indicate that we are overflowing
we are corrupting the buffer metadata ourselves through out-of-bound
writes.
This check is also present in pw-cat so it seems to be expected for
b->requested to exceed the actual available buffer space.

Potential fix for #10545

Cc @sfan5 @philipl @thebombzen 