### PR TITLE
audio: don't try to drain non-existent AO

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -945,7 +945,8 @@ void fill_audio_out_buffers(struct MPContext *mpctx)
                           (opts->gapless_audio && !ao_untimed(ao_c->ao))))
         {
             MP_VERBOSE(mpctx, "audio EOF reached\n");
-            ao_drain(mpctx->ao);
+            if (mpctx->ao)
+                ao_drain(mpctx->ao);
             mpctx->audio_status = STATUS_EOF;
             mp_wakeup_core(mpctx);
         }


### PR DESCRIPTION
52aed495cb ("audio: drain ao on EOF") introduced logic to drain an AO
when EOF of the input has been reached.
When no AO however is present this leads to a NULL-dereference.

Fixes #10556
