### PR TITLE
af_scaletempo2: fix crash when the number of channels increases

### DIFF
--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -472,10 +472,8 @@ static int frames_needed(struct mp_scaletempo2 *p)
 
 static void resize_input_buffer(struct mp_scaletempo2 *p, int size)
 {
-    if (size > p->input_buffer_size) {
-        p->input_buffer_size = size;
-        p->input_buffer = realloc_2d(p->input_buffer, p->channels, size);
-    }
+    p->input_buffer_size = size;
+    p->input_buffer = realloc_2d(p->input_buffer, p->channels, size);
 }
 
 int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
@@ -487,7 +485,8 @@ int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
     if (total_fill == 0) return 0;
 
     int required_size = total_fill + p->input_buffer_frames;
-    resize_input_buffer(p, required_size);
+    if (required_size > p->input_buffer_size)
+        resize_input_buffer(p, required_size);
 
     for (int i = 0; i < p->channels; ++i) {
         memcpy(p->input_buffer[i] + p->input_buffer_frames,


### PR DESCRIPTION
When `af_scaletempo2.c:process()` detects a format change, it goes back through `mp_scaletempo2_init()` to reinitialize everything.  However, `mp_scaletempo2.input_buffer` is not necessarily reallocated due to a
check in `af_scaletempo2_internals.c:resize_input_buffer()`.  This is a problem if the number of audio channels increases, since without reallocating, the buffer for the new channel(s) will at best point to NULL, and at worst uninitialized memory.

Since `resize_input_buffer()` is only called from two places, pull size check out into `mp_scaletempo2_fill_input_buffer()`.  This allows each caller to decide whether they want to resize or not.  We could be smarter about when to reallocate, but that would add a lot of machinery for a case I don't expect to be hit often in practice.