### PR TITLE
meson: fix libplacebo check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1227,7 +1227,7 @@ endif
 
 # vulkan
 vulkan_opt = get_option('vulkan').require(
-    libplacebo.found(),
+    libplacebo.get_variable('pl_has_vulkan', default_value: '0') == '1',
     error_message: 'libplacebo could not be found!',
 )
 vulkan = dependency('vulkan', required: vulkan_opt)


### PR DESCRIPTION
Missing waf quivalent, and doesn't necessarily output a good error
message. But I might as well set this rather than sitting on it
unnecessarily.