### PR TITLE
DOCS/mpv: added COMMAND INTERFACE refs to INTERACTIVE CONTROL

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -39,9 +39,11 @@ LIRC support - configure remotes as input devices instead).
 
 See the ``--input-`` options for ways to customize it.
 
-The following listings are not necessarily complete. See ``etc/input.conf`` for
-a list of default bindings. User ``input.conf`` files and Lua scripts can
-define additional key bindings.
+The following listings are not necessarily complete. See ``etc/input.conf`` 
+in the mpv source files for a list of default bindings. User ``input.conf`` files 
+and Lua scripts can define additional key bindings.
+
+See `COMMAND INTERFACE`_ and `Key names`_ sections for more details on configuring keybindings.
 
 See also ``--input-test`` for interactive binding details by key, and the
 `stats`_ built-in script for key bindings list (including print to terminal).


### PR DESCRIPTION
Additional guidance added to the main INTERACTIVE CONTROLS section to
point the user at the COMMAND INTERFACE section and clarify the location
of default key bindings referenced in the existing wording.