### PR TITLE
cocoa-cb: fix hang when flush() isn't on main queue

### DIFF
--- a/video/out/mac/gl_layer.swift
+++ b/video/out/mac/gl_layer.swift
@@ -82,8 +82,6 @@ class GLLayer: CAOpenGLLayer {
     enum Draw: Int { case normal = 1, atomic, atomicEnd }
     var draw: Draw = .normal
 
-    let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue.draw")
-
     var needsICCUpdate: Bool = false {
         didSet {
             if needsICCUpdate == true {
@@ -229,7 +227,7 @@ class GLLayer: CAOpenGLLayer {
 
     func update(force: Bool = false) {
         if force { forceDraw = true }
-        queue.async {
+        DispatchQueue.main.async {
             if self.forceDraw || !self.inLiveResize {
                 self.needsFlip = true
                 self.display()


### PR DESCRIPTION
Fix #10276.
Fix #10579.