### PR TITLE
cocoa-cb: fix NSEnableScreenUpdates deprecation

### DIFF
--- a/video/out/mac/gl_layer.swift
+++ b/video/out/mac/gl_layer.swift
@@ -156,12 +156,14 @@ class GLLayer: CAOpenGLLayer {
         needsFlip = false
         forceDraw = false
 
-        if draw.rawValue >= Draw.atomic.rawValue {
-             if draw == .atomic {
-                draw = .atomicEnd
-             } else {
-                atomicDrawingEnd()
-             }
+        if #available(macOS 10.11, *) {} else {
+            if draw.rawValue >= Draw.atomic.rawValue {
+                if draw == .atomic {
+                    draw = .atomicEnd
+                } else {
+                    atomicDrawingEnd()
+                }
+            }
         }
 
         updateSurfaceSize()
@@ -186,16 +188,20 @@ class GLLayer: CAOpenGLLayer {
     }
 
     func atomicDrawingStart() {
-        if draw == .normal {
-            NSDisableScreenUpdates()
-            draw = .atomic
+        if #available(macOS 10.11, *) {} else {
+            if draw == .normal {
+                NSDisableScreenUpdates()
+                draw = .atomic
+            }
         }
     }
 
     func atomicDrawingEnd() {
-        if draw.rawValue >= Draw.atomic.rawValue {
-            NSEnableScreenUpdates()
-            draw = .normal
+        if #available(macOS 10.11, *) {} else {
+            if draw.rawValue >= Draw.atomic.rawValue {
+                NSEnableScreenUpdates()
+                draw = .normal
+            }
         }
     }
 


### PR DESCRIPTION
As of 10.11 it is not generally necessary to take explicit action to achieve visual atomicity.

Review note 1: with Xcode 13.3 or newer (Swift 5.6 and newer), we could use `#unavailable` instead. I kept `#available` for compatibility with older tools.

Review note 2: this change is entirely independent from #10585: it has no impact on it and can be reviewed and merged independently.