### PR TITLE
sub: use Unicode linebreaking for non-ASS subs and OSD

### DIFF
--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -133,7 +133,9 @@ static void create_ass_track(struct osd_state *osd, struct osd_object *obj,
     track->WrapStyle = 1; // end-of-line wrapping instead of smart wrapping
     track->Kerning = true;
     track->ScaledBorderAndShadow = true;
-
+#if LIBASS_VERSION >= 0x01600010
+    ass_track_set_feature(track, ASS_FEATURE_WRAP_UNICODE, 1);
+#endif
     update_playres(ass, &obj->vo_res);
 }
 

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -442,6 +442,10 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     ass_set_font_scale(priv, set_font_scale);
     ass_set_hinting(priv, set_hinting);
     ass_set_line_spacing(priv, set_line_spacing);
+#if LIBASS_VERSION >= 0x01600010
+    if (converted)
+        ass_track_set_feature(track, ASS_FEATURE_WRAP_UNICODE, 1);
+#endif
 }
 
 static bool has_overrides(char *s)


### PR DESCRIPTION
ASS must only automatically break at ASCII spaces (\x20), but other subtitle formats might expect more breaking oppurtinities. Especially non-ASS subs in scripts, which typically do not use (ASCII) spaces to seperate words, like e.g. CJK, might overflow the screen if the conversion didn't insert additional linebreaks (ffmpeg does not).

Thus try to enable Unicode linebreaking for converted subs and the OSD if libass is new enough. The feature may still be unavailable at runtime if libass wasn't build with Unicode linebreaking support.

---

As an example here's an excerpt of the subs from https://github.com/mpv-player/mpv/issues/7158:
```
WEBVTT

1
00:00:00.000 --> 00:43:06.160
任何一个有远大抱负的男人都不会因为区区一个女人
```

When rendering with `--sub-font-size=84` and without Unicode linebreaking:
![without-unibreak](https://user-images.githubusercontent.com/1668471/187981664-a52e8793-0a96-43a5-9ca1-4c3a0dc88af2.png)

and here with Unicode linebreaking enabled:
![with-unibreak](https://user-images.githubusercontent.com/1668471/187981683-7d66aeee-0d8c-415d-871c-a50a414959a0.png)