### PR TITLE
pipewire: add full hotplug support

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -532,10 +532,13 @@ struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp,
             continue;
 
         if (ao->driver->hotplug_init) {
-            if (!hp->ao && ao->driver->hotplug_init(ao) >= 0)
-                hp->ao = ao; // keep this one
-            if (hp->ao && hp->ao->driver == d)
-                get_devices(hp->ao, list);
+            if (ao->driver->hotplug_init(ao) >= 0) {
+                get_devices(ao, list);
+                if (hp->ao)
+                    ao->driver->hotplug_uninit(ao);
+                else
+                    hp->ao = ao; // keep this one
+            }
         } else {
             get_devices(ao, list);
         }

--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -453,8 +453,9 @@ struct ao_hotplug {
     void *wakeup_ctx;
     // A single AO instance is used to listen to hotplug events. It wouldn't
     // make much sense to allow multiple AO drivers; all sane platforms have
-    // a single such audio API.
-    // This is _not_ the same AO instance as used for playing audio.
+    // a single audio API providing all events.
+    // This is _not_ necessarily the same AO instance as used for playing
+    // audio.
     struct ao *ao;
     // cached
     struct ao_device_list *list;
@@ -494,7 +495,8 @@ bool ao_hotplug_check_update(struct ao_hotplug *hp)
 }
 
 // The return value is valid until the next call to this API.
-struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp)
+struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp,
+                                                  struct ao *playback_ao)
 {
     if (hp->list && !hp->needs_update)
         return hp->list;
@@ -505,6 +507,19 @@ struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp)
 
     MP_TARRAY_APPEND(list, list->devices, list->num_devices,
         (struct ao_device_desc){"auto", "Autoselect device"});
+
+    // Try to use the same AO for hotplug handling as for playback.
+    // Different AOs may not agree and the playback one is the only one the
+    // user knows about and may even have configured explicitly.
+    if (!hp->ao && playback_ao && playback_ao->driver->hotplug_init) {
+        struct ao *ao = ao_alloc(true, hp->global, hp->wakeup_cb, hp->wakeup_ctx,
+                                 (char *)playback_ao->driver->name);
+        if (playback_ao->driver->hotplug_init(ao) >= 0) {
+            hp->ao = ao;
+        } else {
+            talloc_free(ao);
+        }
+    }
 
     for (int n = 0; audio_out_drivers[n]; n++) {
         const struct ao_driver *d = audio_out_drivers[n];
@@ -569,10 +584,11 @@ static void dummy_wakeup(void *ctx)
 {
 }
 
-void ao_print_devices(struct mpv_global *global, struct mp_log *log)
+void ao_print_devices(struct mpv_global *global, struct mp_log *log,
+                      struct ao *playback_ao)
 {
     struct ao_hotplug *hp = ao_hotplug_create(global, dummy_wakeup, NULL);
-    struct ao_device_list *list = ao_hotplug_get_device_list(hp);
+    struct ao_device_list *list = ao_hotplug_get_device_list(hp, playback_ao);
     mp_info(log, "List of detected audio devices:\n");
     for (int n = 0; n < list->num_devices; n++) {
         struct ao_device_desc *desc = &list->devices[n];

--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -119,8 +119,8 @@ struct ao_hotplug *ao_hotplug_create(struct mpv_global *global,
                                      void *wakeup_ctx);
 void ao_hotplug_destroy(struct ao_hotplug *hp);
 bool ao_hotplug_check_update(struct ao_hotplug *hp);
-struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp);
+struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp, struct ao *playback_ao);
 
-void ao_print_devices(struct mpv_global *global, struct mp_log *log);
+void ao_print_devices(struct mpv_global *global, struct mp_log *log, struct ao *playback_ao);
 
 #endif /* MPLAYER_AUDIO_OUT_H */

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -626,19 +626,22 @@ static void add_device_to_list(struct ao *ao, uint32_t id, const struct spa_dict
     ao_device_list_add(list, ao, &(struct ao_device_desc){name, description});
 }
 
+static int hotplug_init(struct ao *ao)
+{
+    return pipewire_init_boilerplate(ao);
+}
+
+static void hotplug_uninit(struct ao *ao)
+{
+    uninit(ao);
+}
+
 static void list_devs(struct ao *ao, struct ao_device_list *list)
 {
-    // we are not using hotplug_{,un}init() because the AO core will only call
-    // the hotplug functions of a single AO. That will probably be ao_pulse.
-    if (pipewire_init_boilerplate(ao) < 0)
-        return;
-
     ao_device_list_add(list, ao, &(struct ao_device_desc){});
 
     if (for_each_sink(ao, add_device_to_list, list) < 0)
         MP_WARN(ao, "Could not list devices, list may be incomplete\n");
-
-    uninit(ao);
 }
 
 #define OPT_BASE_STRUCT struct priv
@@ -654,7 +657,9 @@ const struct ao_driver audio_out_pipewire = {
 
     .control     = control,
 
-    .list_devs = list_devs,
+    .hotplug_init   = hotplug_init,
+    .hotplug_uninit = hotplug_uninit,
+    .list_devs      = list_devs,
 
     .priv_size = sizeof(struct priv),
     .priv_defaults = &(const struct priv)

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -276,6 +276,21 @@ struct registry_event_global_ctx {
     void *sink_cb_ctx;
 };
 
+static bool is_sink_node(const char *type, const struct spa_dict *props)
+{
+    if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
+        return false;
+
+    if (!props)
+        return false;
+
+    const char *class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+    if (!class || strcmp(class, "Audio/Sink") != 0)
+        return false;
+
+    return true;
+}
+
 static void for_each_sink_registry_event_global(void *data, uint32_t id,
                                                 uint32_t permissions, const
                                                 char *type, uint32_t version,
@@ -283,14 +298,7 @@ static void for_each_sink_registry_event_global(void *data, uint32_t id,
 {
     struct registry_event_global_ctx *ctx = data;
 
-    if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
-        return;
-
-    if (!props)
-        return;
-
-    const char *class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
-    if (!class || strcmp(class, "Audio/Sink") != 0)
+    if (!is_sink_node(type, props))
         return;
 
     ctx->sink_cb(ctx->ao, id, props, ctx->sink_cb_ctx);

--- a/player/command.c
+++ b/player/command.c
@@ -1702,7 +1702,7 @@ static int mp_property_audio_device(void *ctx, struct m_property *prop,
         if (mp_property_generic_option(mpctx, prop, M_PROPERTY_GET, &name) < 1)
             name = NULL;
 
-        struct ao_device_list *list = ao_hotplug_get_device_list(cmd->hotplug);
+        struct ao_device_list *list = ao_hotplug_get_device_list(cmd->hotplug, mpctx->ao);
         for (int n = 0; n < list->num_devices; n++) {
             struct ao_device_desc *dev = &list->devices[n];
             if (dev->name && name && strcmp(dev->name, name) == 0) {
@@ -1724,7 +1724,7 @@ static int mp_property_audio_devices(void *ctx, struct m_property *prop,
     struct command_ctx *cmd = mpctx->command_ctx;
     create_hotplug(mpctx);
 
-    struct ao_device_list *list = ao_hotplug_get_device_list(cmd->hotplug);
+    struct ao_device_list *list = ao_hotplug_get_device_list(cmd->hotplug, mpctx->ao);
     return m_property_read_list(action, arg, list->num_devices,
                                 get_device_entry, list);
 }

--- a/player/main.c
+++ b/player/main.c
@@ -204,7 +204,7 @@ static bool handle_help_options(struct MPContext *mpctx)
     if (opts->ao_opts->audio_device &&
         strcmp(opts->ao_opts->audio_device, "help") == 0)
     {
-        ao_print_devices(mpctx->global, log);
+        ao_print_devices(mpctx->global, log, mpctx->ao);
         return true;
     }
     if (opts->property_print_help) {

--- a/ta/ta.c
+++ b/ta/ta.c
@@ -333,7 +333,7 @@ static void print_leak_report(void)
             // Don't list those with parent; logically, only parents are listed
             if (!cur->next) {
                 size_t c_size = get_children_size(cur);
-                char name[30] = {0};
+                char name[50] = {0};
                 if (cur->name)
                     snprintf(name, sizeof(name), "%s", cur->name);
                 if (cur->name == &allocation_is_string) {


### PR DESCRIPTION
This adds full hotplug support to the Pipewire AO.
Effectively this means proper use of the initialization APIs `hotplug_init()` and `hotplug_uninit()` and sending of hotplug events.

Unfortunately same changes to core code are necessary. This is because currently mpv expects each system/platform to have only a single AO driver that implements hotplug events and all others only implement device listing.

For pulse and pipewire this is not really applicable. It is possible to have systems where mpv is built with only one of ao_pulse or ao_pipewire, or where ao_pulse and ao_pipewire disagree on the audio devices they see (the audio servers may be running on different machines).

For this to work properly the following changes to the audio core are made:
* Try to use the same AO driver for hotplug events as for playback.
* List devices for `hotplug_init()`-capable AO-drivers.

Each commit contains more explanations in the commit message.

Finally there is a small fix for `ta/ta.c` to print more parts of the allocation name because in my case the linenumber was truncated.

Cc @philipl 