### PR TITLE
DOCS: Mention "mono" audio channels option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2022,9 +2022,9 @@ Audio
 
         Using this mode is recommended for direct hardware output, especially
         over HDMI (see HDMI warning below).
-    - ``--audio-channels=stereo``
-        Force  a plain stereo downmix. This is a special-case of the previous
-        item. (See paragraphs below for implications.)
+    - ``--audio-channels=<stereo|mono>``
+        Force a downmix to stereo or mono. These are special-cases of the
+        previous item. (See paragraphs below for implications.)
 
     If a list of layouts is given, each item can be either an explicit channel
     layout name (like ``5.1``), or a channel number. Channel numbers refer to


### PR DESCRIPTION
Several times in the past, I've searched the man page for the word "mono" to remind myself how to do this. This is an incredibly minor change, but I think it's worth explicitly mentioning this special case of `--audio-channels`. Hope it helps at least one other person like me.