### PR TITLE
sd_ass: improve handling of subtitles with unknown duration

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -359,10 +359,14 @@ static void decode(struct sd *sd, struct demux_packet *packet)
             filter_and_add(sd, &pkt2);
         }
         if (ctx->duration_unknown) {
-            for (int n = 0; n < track->n_events - 1; n++) {
+            for (int n = track->n_events - 2; n >= 0; n--) {
                 if (track->events[n].Duration == UNKNOWN_DURATION * 1000) {
-                    track->events[n].Duration = track->events[n + 1].Start -
-                                                track->events[n].Start;
+                    if (track->events[n].Start != track->events[n + 1].Start) {
+                        track->events[n].Duration = track->events[n + 1].Start -
+                                                    track->events[n].Start;
+                    } else {
+                        track->events[n].Duration = track->events[n + 1].Duration;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Existing unknown duration handling can be problematic when a chain of track events (ASS dialogues) shares the same start time.

For reference,
| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 2147483000 |
| 3 | 7869 | 2147483000 |
| 4 | 7869 | 2147483000 |
| 5 | 11707 | 2147483000 |

Becomes,
| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 0 |
| 1 | 5400 | 2469 |
| 2 | 7869 | 0 |
| 3 | 7869 | 0 |
| 4 | 7869 | 3838 |
| 5 | 11707 | 2147483000 |

Instead of,
| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2469 |
| 1 | 5400 | 2469 |
| 2 | 7869 | 3838 |
| 3 | 7869 | 3838 |
| 4 | 7869 | 3838 |
| 5 | 11707 | 2147483000 |