### PR TITLE
TOOLS/lua/autoload: add `m2ts` extension

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -49,7 +49,7 @@ function SetUnion (a,b)
 end
 
 EXTENSIONS_VIDEO = Set {
-    'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp'
+    'mkv', 'avi', 'mp4', 'ogv', 'webm', 'rmvb', 'flv', 'wmv', 'mpeg', 'mpg', 'm4v', '3gp', 'm2ts'
 }
 
 EXTENSIONS_AUDIO = Set {


### PR DESCRIPTION
- [.m2ts](https://en.wikipedia.org/wiki/.m2ts) used for the Blu-ray disc container file format.

ref: https://github.com/mpv-player/mpv/pull/9772, https://github.com/mpv-player/mpv/pull/9404