### PR TITLE
x11: fix --on-all-workspaces option (using _NET_WM_STATE_STICKY)

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -67,6 +67,7 @@
 #define vo_wm_STAYS_ON_TOP 4
 #define vo_wm_ABOVE 8
 #define vo_wm_BELOW 16
+#define vo_wm_STICKY 9
 
 /* EWMH state actions, see
          http://freedesktop.org/Standards/wm-spec/index.html#id2768769 */
@@ -149,6 +150,7 @@ static void vo_x11_move_resize(struct vo *vo, bool move, bool resize,
                                struct mp_rect rc);
 static void vo_x11_maximize(struct vo *vo);
 static void vo_x11_minimize(struct vo *vo);
+static void vo_x11_sticky(struct vo *vo, bool sticky);
 
 #define XA(x11, s) (XInternAtom((x11)->display, # s, False))
 #define XAs(x11, s) XInternAtom((x11)->display, s, False)
@@ -1604,10 +1606,16 @@ static void vo_x11_map_window(struct vo *vo, struct mp_rect rc)
     }
 
     if (x11->opts->all_workspaces || x11->opts->geometry.ws > 0) {
-        long v = x11->opts->all_workspaces
-                ? 0xFFFFFFFF : x11->opts->geometry.ws - 1;
-        XChangeProperty(x11->display, x11->window, XA(x11, _NET_WM_DESKTOP),
-                        XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&v, 1);
+        if (x11->wm_type & vo_wm_STICKY) {
+            Atom state = XA(x11, _NET_WM_STATE_STICKY);
+            XChangeProperty(x11->display, x11->window, XA(x11, _NET_WM_STATE), XA_ATOM,
+                            32, PropModeAppend, (unsigned char *)&state, 1);
+        } else {
+            long v = x11->opts->all_workspaces
+                    ? 0xFFFFFFFF : x11->opts->geometry.ws - 1;
+            XChangeProperty(x11->display, x11->window, XA(x11, _NET_WM_DESKTOP),
+                            XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&v, 1);
+        }
     }
 
     vo_x11_update_composition_hint(vo);
@@ -1741,6 +1749,23 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_x11_update_geometry(vo);
     update_vo_size(vo);
     x11->pending_vo_events &= ~VO_EVENT_RESIZE; // implicitly done by the VO
+}
+
+static void vo_x11_sticky(struct vo *vo, bool sticky)
+{
+    struct vo_x11_state *x11 = vo->x11;
+    if (x11->wm_type & vo_wm_STICKY) {
+        x11_set_ewmh_state(x11, "_NET_WM_STATE_STICKY", sticky);
+    } else {
+        long params[5] = {0xFFFFFFFF, 1};
+        if (!sticky) {
+            x11_get_property_copy(x11, x11->rootwin,
+                XA(x11, _NET_CURRENT_DESKTOP),
+                XA_CARDINAL, 32, &params[0],
+                sizeof(params[0]));
+        }
+        x11_send_ewmh_msg(x11, "_NET_WM_DESKTOP", params);
+    }
 }
 
 static void vo_x11_setlayer(struct vo *vo, bool ontop)
@@ -1964,16 +1989,8 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
                 vo_x11_setlayer(vo, opts->ontop);
             if (opt == &opts->border)
                 vo_x11_decoration(vo, opts->border);
-            if (opt == &opts->all_workspaces) {
-                long params[5] = {0xFFFFFFFF, 1};
-                if (!opts->all_workspaces) {
-                    x11_get_property_copy(x11, x11->rootwin,
-                                          XA(x11, _NET_CURRENT_DESKTOP),
-                                          XA_CARDINAL, 32, &params[0],
-                                          sizeof(params[0]));
-                }
-                x11_send_ewmh_msg(x11, "_NET_WM_DESKTOP", params);
-            }
+            if (opt == &opts->all_workspaces)
+                vo_x11_sticky(vo, opts->all_workspaces);
             if (opt == &opts->window_minimized)
                 vo_x11_minimize(vo);
             if (opt == &opts->window_maximized)


### PR DESCRIPTION
tested on `archlinux` with `xfce 4.16` and `bspwm 0.9.10`

### Related
#10635
#4373