### PR TITLE
stream_file: Get optional path field from fd protocol url.

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -272,9 +272,13 @@ static int open_f(stream_t *stream, const struct stream_open_args *args)
     if (strncmp(url, "fd://", 5) == 0 || is_fdclose) {
         char *begin = strstr(stream->url, "://") + 3, *end = NULL;
         p->fd = strtol(begin, &end, 0);
-        if (!end || end == begin || end[0]) {
+        if (!end || end == begin) {
             MP_ERR(stream, "Invalid FD: %s\n", stream->url);
             return STREAM_ERROR;
+        }
+        if (strncmp(end, "/p/", 3) == 0) {
+            begin = strstr(end, "/p/") + 3, end = NULL;
+            filename = stream->path = begin;
         }
         if (is_fdclose)
             p->close = true;


### PR DESCRIPTION
The current version of the fd and fdclose protocols can only get the file descriptor from the url, which causes path-based features like remembering the playback position and getting the title from the filename to be abnormal.

This change helps address this issue.