### PR TITLE
vo_vaapi_wayland: make option name dmabuf-wayland

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -41,7 +41,7 @@ Interface changes
     - add `dolbyvision` sub-parameter to `format` video filter
     - `--sub-visibility` no longer has any effect on secondary subtitles
     - add `film-grain` sub-parameter to `format` video filter
-    - add experimental `--vo=vaapi-wayland` video output driver
+    - add experimental `--vo=dmabuf-wayland` video output driver
     - add `--x11-present` for controlling whether to use xorg's present extension
     - add `engine` option to the `rubberband` audio filter to support the new
       engine introduced in rubberband 3.0.0. Defaults to `finer` (new engine).

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1249,7 +1249,7 @@ Video
     :videotoolbox: requires ``--vo=gpu`` (macOS 10.8 and up),
                    or ``--vo=libmpv`` (iOS 9.0 and up)
     :videotoolbox-copy: copies video back into system RAM (macOS 10.8 or iOS 9.0 and up)
-    :vaapi:     requires ``--vo=gpu``, ``--vo=vaapi`` or ``--vo=vaapi-wayland`` (Linux only)
+    :vaapi:     requires ``--vo=gpu``, ``--vo=vaapi`` or ``--vo=dmabuf-wayland`` (Linux only)
     :vaapi-copy: copies video back into system RAM (Linux with some GPUs only)
     :nvdec:     requires ``--vo=gpu`` (Any platform CUDA is available)
     :nvdec-copy: copies video back to system RAM (Any platform CUDA is available)

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -286,7 +286,7 @@ Available video output drivers are:
     ``--sdl-switch-mode``
         Instruct SDL to switch the monitor video mode when going fullscreen.
 
-``vaapi-wayland``
+``dmabuf-wayland``
     Experimental Wayland output driver designed for use with VA API hardware decoding.
     The driver is designed to avoid any GPU to CPU copies, and to perform scaling and
     color space conversion using fixed-function hardware, if available,

--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -378,7 +378,7 @@ static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 
 const struct vo_driver video_out_vaapi_wayland = {
     .description = "VA API with Wayland video output",
-    .name = "vaapi-wayland",
+    .name = "dmabuf-wayland",
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1482,9 +1482,9 @@ static int set_screensaver_inhibitor(struct vo_wayland_state *wl, int state)
 
 static void set_surface_scaling(struct vo_wayland_state *wl)
 {
-    bool vaapi_wayland = !strcmp(wl->vo->driver->name, "vaapi-wayland");
+    bool dmabuf_wayland = !strcmp(wl->vo->driver->name, "dmabuf-wayland");
     int old_scale = wl->scaling;
-    if (wl->vo_opts->hidpi_window_scale && !vaapi_wayland) {
+    if (wl->vo_opts->hidpi_window_scale && !dmabuf_wayland) {
         wl->scaling = wl->current_output->scale;
     } else {
         wl->scaling = 1;


### PR DESCRIPTION
The work in #10533 will eventually replace vaapi-wayland, but with a different name for the VO (dmabuf-wayland). This is just a temporary stopgap so the upcoming new release won't have a VO that immediately gets renamed to something else.

An alias for the old name could be added if someone wants it I suppose, but I don't think its necessary.