### PR TITLE
demux_mf: add support for QOI, PHM and HDR images

### DIFF
--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -291,6 +291,8 @@ static const struct {
     { "db",             "mjpeg" },
     { "pcd",            "photocd" },
     { "pfm",            "pfm" },
+    { "phm",            "phm" },
+    { "hdr",            "hdr" },
     { "pcx",            "pcx" },
     { "png",            "png" },
     { "pns",            "png" },
@@ -319,6 +321,7 @@ static const struct {
     { "pix",            "brender_pix" },
     { "exr",            "exr" },
     { "pic",            "pictor" },
+    { "qoi",            "qoi" },
     { "xface",          "xface" },
     { "xwd",            "xwd" },
     {0}


### PR DESCRIPTION
Adds support for some float formats: PHM and HDR and new very simple image codec QOI.