### PR TITLE
ao_pipewire: option "remote" and small cleanups

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -156,6 +156,11 @@ Available audio output drivers are:
         value makes the audio stream react faster, e.g. to playback speed
         changes.
 
+    ``--pipewire-remote=<remote>``
+        Specify the PipeWire remote daemon name to connect to via local UNIX
+        sockets.
+        An empty <remote> string uses the default remote named ``pipewire-0``.
+
 ``sdl``
     SDL 1.2+ audio output driver. Should work on any platform supported by SDL
     1.2, but may require the ``SDL_AUDIODRIVER`` environment variable to be set

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -59,6 +59,7 @@ struct priv {
 
     struct {
         int buffer_msec;
+        char *remote;
     } options;
 
     struct {
@@ -405,9 +406,15 @@ static int pipewire_init_boilerplate(struct ao *ao)
     if (!context)
         goto error;
 
-    p->core = pw_context_connect(context, NULL, 0);
-    if (!p->core)
+    p->core = pw_context_connect(
+            context,
+            pw_properties_new(PW_KEY_REMOTE_NAME, p->options.remote, NULL),
+            0);
+    if (!p->core) {
+        MP_WARN(ao, "Could not connect to context '%s': %s\n",
+                p->options.remote, strerror(errno));
         goto error;
+    }
 
     ret = 0;
 
@@ -756,6 +763,7 @@ const struct ao_driver audio_out_pipewire = {
     .options_prefix = "pipewire",
     .options = (const struct m_option[]) {
         {"buffer", OPT_INT(options.buffer_msec), M_RANGE(1, 2000)},
+        {"remote", OPT_STRING(options.remote) },
         {0}
     },
 };


### PR DESCRIPTION
This PR introduce a new option `--pipewire-remote` to specify the PipeWire remote to connect to.
It also removes some unneeded braces and structures the AO-private data a bit.

Cc @philipl 