### PR TITLE
osc: scale rendered aspect ratio with window aspect ratio

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2585,7 +2585,11 @@ function tick()
 
         -- render idle message
         msg.trace("idle message")
-        local icon_x, icon_y = 320 - 26, 140
+        local _, _, display_aspect = mp.get_osd_size()
+        local display_h = 360
+        local display_w = display_h * display_aspect
+        -- logo is rendered at 2^(6-1) = 32 times resolution with size 1800x1800
+        local icon_x, icon_y = (display_w - 1800 / 32) / 2, 140
         local line_prefix = ("{\\rDefault\\an7\\1a&H00&\\bord0\\shad0\\pos(%f,%f)}"):format(icon_x, icon_y)
 
         local ass = assdraw.ass_new()
@@ -2607,11 +2611,11 @@ function tick()
 
         if user_opts.idlescreen then
             ass:new_event()
-            ass:pos(320, icon_y+65)
+            ass:pos(display_w / 2, icon_y + 65)
             ass:an(8)
             ass:append("Drop files or URLs to play here.")
         end
-        set_osd(640, 360, ass.text)
+        set_osd(display_w, display_h, ass.text)
 
         if state.showhide_enabled then
             mp.disable_key_bindings("showhide")


### PR DESCRIPTION
Should behave pretty much the same as it used to, but the logo stays centered better and it doesn't distort anymore, which was caused by a recent change in libass https://github.com/libass/libass/pull/645.

Has been tested with the latest libass release 0.16.0 and with their latest master commit https://github.com/libass/libass/commit/44f6532daf5eb13cb1aa95f5449a77b5df1dd85b

Closes #10710