### PR TITLE
player/command: Added ability to scale overlay.

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1033,7 +1033,7 @@ Input Commands that are Possibly Subject to Change
     information about the key state. The special key name ``unmapped`` can be
     used to match any unmapped key.
 
-``overlay-add <id> <x> <y> <file> <offset> <fmt> <w> <h> <stride>``
+``overlay-add <id> <x> <y> <file> <offset> <fmt> <w> <h> <stride> <dw> <dh>``
     Add an OSD overlay sourced from raw data. This might be useful for scripts
     and applications controlling mpv, and which want to display things on top
     of the video window.
@@ -1090,6 +1090,11 @@ Input Commands that are Possibly Subject to Change
     In general, the total amount of memory accessed is ``stride * h``.
     (Technically, the minimum size would be ``stride * (h - 1) + w * 4``, but
     for simplicity, the player will access all ``stride * h`` bytes.)
+
+    ``dw`` and ``dh`` specify the (optional) display size of the overlay.
+    The overlay visible portion of the overlay (``w`` and ``h``) is scaled to
+    in display to ``dw`` and ``dh``.  If parameters are not present, the
+    values for ``w`` and ``h`` are used.
 
     .. note::
 

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -23,7 +23,7 @@
 #include "misc/bstr.h"
 #include "options/m_option.h"
 
-#define MP_CMD_DEF_MAX_ARGS 9
+#define MP_CMD_DEF_MAX_ARGS 11
 #define MP_CMD_OPT_ARG M_OPT_OPTIONAL_PARAM
 
 struct mp_log;

--- a/player/command.c
+++ b/player/command.c
@@ -124,6 +124,7 @@ static const struct m_option udata_type = {
 struct overlay {
     struct mp_image *source;
     int x, y;
+    int dw, dh;
 };
 
 struct hook_handler {
@@ -4450,8 +4451,8 @@ static void recreate_overlays(struct MPContext *mpctx)
             struct sub_bitmap b = {
                 .bitmap = s->planes[0],
                 .stride = s->stride[0],
-                .w = s->w, .dw = s->w,
-                .h = s->h, .dh = s->h,
+                .w = s->w, .dw = o->dw,
+                .h = s->h, .dh = o->dh,
                 .x = o->x,
                 .y = o->y,
             };
@@ -4548,7 +4549,12 @@ static void cmd_overlay_add(void *pcmd)
     int offset = cmd->args[4].v.i;
     char *fmt = cmd->args[5].v.s;
     int w = cmd->args[6].v.i, h = cmd->args[7].v.i, stride = cmd->args[8].v.i;
+    int dw = cmd->args[9].v.i, dh = cmd->args[10].v.i;
 
+    if (dw <= 0)
+      dw = w;
+    if (dh <= 0)
+      dh = h;
     if (strcmp(fmt, "bgra") != 0) {
         MP_ERR(mpctx, "overlay-add: unsupported OSD format '%s'\n", fmt);
         goto error;
@@ -4565,6 +4571,8 @@ static void cmd_overlay_add(void *pcmd)
         .source = mp_image_alloc(IMGFMT_BGRA, w, h),
         .x = x,
         .y = y,
+        .dw = dw,
+        .dh = dh,
     };
     if (!overlay.source)
         goto error;
@@ -6719,7 +6727,9 @@ const struct mp_cmd_def mp_cmds[] = {
                                         {"fmt", OPT_STRING(v.s)},
                                         {"w", OPT_INT(v.i)},
                                         {"h", OPT_INT(v.i)},
-                                        {"stride", OPT_INT(v.i)}, }},
+                                        {"stride", OPT_INT(v.i)},
+                                        {"dw", OPT_INT(v.i)},
+                                        {"dh", OPT_INT(v.i)}, }},
     { "overlay-remove", cmd_overlay_remove, { {"id", OPT_INT(v.i)} } },
 
     { "osd-overlay", cmd_osd_overlay,


### PR DESCRIPTION
Added display width/height to `overlay-add` command to allow overlay to be scaled on display.  Useful when a fullscreen overlay is rendered at a lower resolution than the `osd-width`/`height` for performance reasons.