### PR TITLE
wayland: correctly handle non-CLOCK_MONOTONIC clocks

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -101,14 +101,14 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
 
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_swap(wl->present);
 }
 
 static void wayland_egl_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_get_info(wl->present, info);
 }
 

--- a/video/out/vo_vaapi_wayland.c
+++ b/video/out/vo_vaapi_wayland.c
@@ -361,7 +361,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
 
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_swap(wl->present);
 }
 static void flip_page(struct vo *vo)
@@ -372,7 +372,7 @@ static void flip_page(struct vo *vo)
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = vo->wl;
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_get_info(wl->present, info);
 }
 

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -262,14 +262,14 @@ static void flip_page(struct vo *vo)
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
 
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_swap(wl->present);
 }
 
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = vo->wl;
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_get_info(wl->present, info);
 }
 

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -39,14 +39,14 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
     if (!wl->opts->disable_vsync)
         vo_wayland_wait_frame(wl);
 
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_swap(wl->present);
 }
 
 static void wayland_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
-    if (wl->presentation)
+    if (wl->use_present)
         present_sync_get_info(wl->present, info);
 }
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -92,6 +92,7 @@ struct vo_wayland_state {
     struct wp_presentation_feedback *feedback;
     struct mp_present *present;
     int64_t refresh_interval;
+    bool use_present;
 
     /* xdg-decoration */
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;


### PR DESCRIPTION
The wayland presentation time code currently always assumes that only CLOCK_MONOTONIC can be used. There is a naive attempt to ignore clocks other than CLOCK_MONOTONIC, but the logic is actually totally wrong and the timestamps would be used anyway. Fix this by checking a use_present bool (similar to use_present in xorg) which is set to true if we receive a valid clock in the clockid event. Additionally, allow CLOCK_MONOTONIC_RAW as a valid clockid. In practice, it should be the same as CLOCK_MONOTONIC for us (ntp/adjustime difference wouldn't matter). Since this is a linux-specific clock, add a define for it if it is not found.