### PR TITLE
vo_gpu_next: vulkan: libplacebo: unify log prefix

### DIFF
--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -127,7 +127,7 @@ struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct gl_video_opts *gl_opts)
     }
 #endif
 
-    ctx->pllog = mppl_log_create(ctx->log);
+    ctx->pllog = mppl_log_create(ctx, ctx->log);
     if (!ctx->pllog)
         goto err_out;
 

--- a/video/out/placebo/utils.c
+++ b/video/out/placebo/utils.c
@@ -48,12 +48,12 @@ static void log_cb_probing(void *priv, enum pl_log_level level, const char *msg)
     mp_msg(log, pl_log_to_msg_lev[probing_map(level)], "%s\n", msg);
 }
 
-pl_log mppl_log_create(struct mp_log *log)
+pl_log mppl_log_create(void *tactx, struct mp_log *log)
 {
     return pl_log_create(PL_API_VER, &(struct pl_log_params) {
         .log_cb     = log_cb,
         .log_level  = msg_lev_to_pl_log[mp_msg_level(log)],
-        .log_priv   = log,
+        .log_priv   = mp_log_new(tactx, log, "libplacebo"),
     });
 }
 

--- a/video/out/placebo/utils.h
+++ b/video/out/placebo/utils.h
@@ -8,7 +8,7 @@
 #include <libplacebo/log.h>
 #include <libplacebo/colorspace.h>
 
-pl_log mppl_log_create(struct mp_log *log);
+pl_log mppl_log_create(void *tactx, struct mp_log *log);
 void mppl_log_set_probing(pl_log log, bool probing);
 
 static inline struct pl_rect2d mp_rect2d_to_pl(struct mp_rect rc)

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -27,7 +27,6 @@
 
 // Shared struct used to hold vulkan context information
 struct mpvk_ctx {
-    struct mp_log *log;
     pl_log pllog;
     pl_vk_inst vkinst;
     pl_vulkan vulkan;

--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -3,8 +3,7 @@
 
 bool mpvk_init(struct mpvk_ctx *vk, struct ra_ctx *ctx, const char *surface_ext)
 {
-    vk->log = mp_log_new(ctx, ctx->log, "libplacebo");
-    vk->pllog = mppl_log_create(vk->log);
+    vk->pllog = mppl_log_create(ctx, ctx->vo->log);
     if (!vk->pllog)
         goto error;
 
@@ -40,5 +39,4 @@ void mpvk_uninit(struct mpvk_ctx *vk)
 
     pl_vk_inst_destroy(&vk->vkinst);
     pl_log_destroy(&vk->pllog);
-    TA_FREEP(&vk->log);
 }


### PR DESCRIPTION
The new status quo is simple: all messages coming from libplacebo are marked "vo/gpu{-next}/libplacebo", regardless of the backend API (vulkan vs opengl/d3d11).

Messages coming from mpv's internal vulkan code will continue to come from "vo/gpu{-next}/vulkan", and messages coming from the vo module itself will be marked "vo/gpu{-next}".

This is significantly better than the old status quo of vulkan messages coming from "vo/gpu{-next}/vulkan/libplacebo" whereas opengl/d3d11 messages simply came from "vo/gpu{-next}", even when those messages originated from libplacebo.

(It's worth noting that the the destructor for the log is redundant because it's attached to the ctx which is freed on uninit anyway)