### PR TITLE
github/workflows: explicitly install Xinerama on FreeBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,7 @@ jobs:
                 ffmpeg \
                 libplacebo \
                 libxkbcommon \
+                libXinerama \
                 libxpresent \
                 luajit \
                 meson \


### PR DESCRIPTION
Apparently an implicit dependency on it through one of the otherwise installed packages is no longer there.