### PR TITLE
ao: promote ao_pipewire

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -65,6 +65,9 @@ static const struct ao_driver * const audio_out_drivers[] = {
 #if HAVE_COREAUDIO
     &audio_out_coreaudio,
 #endif
+#if HAVE_PIPEWIRE
+    &audio_out_pipewire,
+#endif
 #if HAVE_PULSE
     &audio_out_pulse,
 #endif
@@ -89,9 +92,6 @@ static const struct ao_driver * const audio_out_drivers[] = {
 #endif
 #if HAVE_SDL2_AUDIO
     &audio_out_sdl,
-#endif
-#if HAVE_PIPEWIRE
-    &audio_out_pipewire,
 #endif
 #if HAVE_SNDIO
     &audio_out_sndio,

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -388,7 +388,6 @@ static int pipewire_init_boilerplate(struct ao *ao)
 {
     struct priv *p = ao->priv;
     struct pw_context *context;
-    int ret;
 
     pw_init(NULL, NULL);
 
@@ -416,15 +415,12 @@ static int pipewire_init_boilerplate(struct ao *ao)
         goto error;
     }
 
-    ret = 0;
-
-out:
     pw_thread_loop_unlock(p->loop);
-    return ret;
+    return 0;
 
 error:
-    ret = -1;
-    goto out;
+    pw_thread_loop_unlock(p->loop);
+    return -1;
 }
 
 


### PR DESCRIPTION
The AO is feature-complete now.
As PipeWire also provides compatibility with PulseAudio, ALSA and Jack we should put it before those for the autodetection to work.

It may make sense to delay merging this after 0.35 is release to get some more opt-in testing.