### PR TITLE
Revert "ao/audiounit: include AVAudioSession buffer in latency calc"

### DIFF
--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -218,7 +218,7 @@ static void start(struct ao *ao)
     struct priv *p = ao->priv;
     AVAudioSession *instance = AVAudioSession.sharedInstance;
 
-    p->device_latency = [instance outputLatency] + [instance IOBufferDuration];
+    p->device_latency = [instance outputLatency];
 
     OSStatus err = AudioOutputUnitStart(p->audio_unit);
     CHECK_CA_WARN("can't start audio unit");


### PR DESCRIPTION
This reverts commit 8b114e574abd08892612e21e784ea1872e1adf8c from https://github.com/mpv-player/mpv/pull/6485

My understanding of IOBufferDuration is still unclear, because the docs don't really say much: https://developer.apple.com/documentation/avfaudio/avaudiosession/1616498-iobufferduration

But since AVAudioSession explicitly exposes `outputLatency`, it should be safe to assume it has already included its own I/O buffers in that latency calculation.