### PR TITLE
vo_gpu_next: fix crash on uninit after startup failure

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1352,7 +1352,7 @@ static void uninit(struct vo *vo)
     pthread_mutex_destroy(&p->dr_lock);
 
     char *cache_file = get_cache_file(p);
-    if (cache_file) {
+    if (cache_file && p->rr) {
         FILE *cache = fopen(cache_file, "wb");
         if (cache) {
             size_t size = pl_renderer_save(p->rr, NULL);


### PR DESCRIPTION
`pl_renderer_save` will crash if passed NULL in the first arg (reasonably enough).