### PR TITLE
loop-file: add seamless-looping option to ensure that there are no delayed frames at beginning of each loop

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -84,7 +84,10 @@ struct demux_lavf_opts {
     int rtsp_transport;
     int linearize_ts;
     bool propagate_opts;
+    bool seamless_looping;
 };
+
+static void demux_seek_lavf(demuxer_t *demuxer, double seek_pts, int flags);
 
 const struct m_sub_options demux_lavf_conf = {
     .opts = (const m_option_t[]) {
@@ -111,6 +114,7 @@ const struct m_sub_options demux_lavf_conf = {
         {"demuxer-lavf-linearize-timestamps", OPT_CHOICE(linearize_ts,
             {"no", 0}, {"auto", -1}, {"yes", 1})},
         {"demuxer-lavf-propagate-opts", OPT_BOOL(propagate_opts)},
+        {"seamless-looping", OPT_BOOL(seamless_looping)},
         {0}
     },
     .size = sizeof(struct demux_lavf_opts),
@@ -267,6 +271,9 @@ typedef struct lavf_priv {
 #else
     void (*default_io_close)(struct AVFormatContext *s, AVIOContext *pb);
 #endif
+    double highest_pts,pts_off;
+    double highest_dts,dts_off;
+    double duration;
 } lavf_priv_t;
 
 static void update_read_stats(struct demuxer *demuxer)
@@ -1197,14 +1204,22 @@ static bool demux_lavf_read_packet(struct demuxer *demux,
                                    struct demux_packet **mp_pkt)
 {
     lavf_priv_t *priv = demux->priv;
+    struct demux_lavf_opts *lavfdopts = priv->opts;
 
     AVPacket *pkt = &(AVPacket){0};
     int r = av_read_frame(priv->avfc, pkt);
     update_read_stats(demux);
     if (r < 0) {
         av_packet_unref(pkt);
-        if (r == AVERROR_EOF)
+        if (r == AVERROR_EOF) {
+            if (lavfdopts->seamless_looping) {
+                demux_seek_lavf(demux,0,0);
+                priv->pts_off = priv->highest_pts + priv->duration;
+                priv->dts_off = priv->highest_dts + priv->duration;
+                return demux_lavf_read_packet(demux, mp_pkt);
+            }
             return false;
+        }
         MP_WARN(demux, "error reading packet: %s.\n", av_err2str(r));
         if (priv->retry_counter >= 10) {
             MP_ERR(demux, "...treating it as fatal error.\n");
@@ -1237,9 +1252,16 @@ static bool demux_lavf_read_packet(struct demuxer *demux,
     if (priv->pcm_seek_hack == st && !priv->pcm_seek_hack_packet_size)
         priv->pcm_seek_hack_packet_size = pkt->size;
 
-    dp->pts = mp_pts_from_av(pkt->pts, &st->time_base);
-    dp->dts = mp_pts_from_av(pkt->dts, &st->time_base);
+    dp->pts = mp_pts_from_av(pkt->pts, &st->time_base) + priv->pts_off;
+    dp->dts = mp_pts_from_av(pkt->dts, &st->time_base) + priv->dts_off;
     dp->duration = pkt->duration * av_q2d(st->time_base);
+    if (lavfdopts->seamless_looping) {
+        if (priv->highest_pts < dp->pts)
+            priv->highest_pts = dp->pts;
+        if (priv->highest_dts < dp->dts)
+            priv->highest_dts = dp->dts;
+        priv->duration = dp->duration;
+    }
     dp->pos = pkt->pos;
     dp->keyframe = pkt->flags & AV_PKT_FLAG_KEY;
     if (pkt->flags & AV_PKT_FLAG_DISCARD)


### PR DESCRIPTION
With these changes :

1. lavf demuxer performs seek to 0 when encountering EOF and does not signal EOF to rest of library, but
dts and pts time stamps are not reset, so that the video appears infinite to the rest of mpv
1. tested with 30fps and 60 fps content - no delays detected at beginning of each loop

It can be difficult to detect the artifact this PR is designed to fix. The attached file, an MOV of moving text at 30fps,
should reveal the problem.

To enable seamless looping, use `--loop` **and** `--seamless-looping` command line args.


https://user-images.githubusercontent.com/95393/195938081-e76a6126-be6a-454e-9e4a-c25e9f9dfedf.mov


