### PR TITLE
wayland: add support for content-type protocol

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,7 @@ Interface changes
 
  --- mpv 0.36.0 ---
     - add `--force-render`
+    - add `--wayland-content-type`
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5587,6 +5587,12 @@ them.
     it first renders. This option will take precedence over any ``autofit`` or
     ``geometry`` type settings if the configure bounds are used.
 
+``--wayland-content-type=<auto|none|photo|video|game>``
+    If supported by the compositor, mpv will send a hint using the content-type
+    protocol telling the compositor what type of content is being displayed. ``auto``
+    (default) will automatically switch between telling the compositor the content
+    is a photo, video or possibly none depending on internal heuristics.
+
 ``--wayland-disable-vsync=<yes|no>``
     Disable mpv's internal vsync for Wayland-based video output (default: no).
     This is mainly useful for benchmarking wayland VOs when combined with

--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -10,6 +10,11 @@ wl_protocols_headers = []
 
 features += {'wayland_protocols_1_24': wayland['deps'][2].version().version_compare('>=1.24')}
 
+features += {'wayland_protocols_1_27': wayland['deps'][2].version().version_compare('>=1.27')}
+if features['wayland_protocols_1_27']
+    protocols += [[wl_protocol_dir, 'staging/content-type/content-type-v1.xml']]
+endif
+
 foreach p: protocols
     xml = join_paths(p)
     wl_protocols_source += custom_target(xml.underscorify() + '_c',

--- a/options/options.c
+++ b/options/options.c
@@ -179,6 +179,10 @@ static const m_option_t mp_vo_opt_list[] = {
     {"x11-present", OPT_CHOICE(x11_present,
         {"no", 0}, {"auto", 1}, {"yes", 2})},
 #endif
+#if HAVE_WAYLAND
+    {"wayland-content-type", OPT_CHOICE(content_type, {"auto", -1}, {"none", 0},
+        {"photo", 1}, {"video", 2}, {"game", 3})},
+#endif
 #if HAVE_WIN32_DESKTOP
     {"vo-mmcss-profile", OPT_STRING(mmcss_profile)},
 #endif
@@ -212,6 +216,7 @@ const struct m_sub_options vo_sub_opts = {
         .border = 1,
         .fit_border = 1,
         .appid = "mpv",
+        .content_type = -1,
         .WinID = -1,
         .window_scale = 1.0,
         .x11_bypass_compositor = 2,

--- a/options/options.h
+++ b/options/options.h
@@ -27,6 +27,7 @@ typedef struct mp_vo_opts {
     char *fsscreen_name;
     char *winname;
     char *appid;
+    int content_type;
     int x11_netwm;
     int x11_bypass_compositor;
     int x11_present;

--- a/player/core.h
+++ b/player/core.h
@@ -556,6 +556,7 @@ double get_play_end_pts(struct MPContext *mpctx);
 double get_play_start_pts(struct MPContext *mpctx);
 bool get_ab_loop_times(struct MPContext *mpctx, double t[2]);
 void merge_playlist_files(struct playlist *pl);
+void update_content_type(struct MPContext *mpctx, struct track *track);
 void update_vo_playback_state(struct MPContext *mpctx);
 void update_window_title(struct MPContext *mpctx, bool force);
 void error_on_track(struct MPContext *mpctx, struct track *track);

--- a/player/misc.c
+++ b/player/misc.c
@@ -169,6 +169,20 @@ void issue_refresh_seek(struct MPContext *mpctx, enum seek_precision min_prec)
     queue_seek(mpctx, MPSEEK_ABSOLUTE, get_current_time(mpctx), min_prec, 0);
 }
 
+void update_content_type(struct MPContext *mpctx, struct track *track)
+{
+    enum mp_content_type content_type;
+    if (!track || !track->vo_c) {
+        content_type = MP_CONTENT_NONE;
+    } else if (track->image) {
+        content_type = MP_CONTENT_IMAGE;
+    } else {
+        content_type = MP_CONTENT_VIDEO;
+    }
+    if (mpctx->video_out)
+        vo_control(mpctx->video_out, VOCTRL_CONTENT_TYPE, (void *)content_type);
+}
+
 void update_vo_playback_state(struct MPContext *mpctx)
 {
     if (mpctx->video_out && mpctx->video_out->config_ok) {

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1036,6 +1036,8 @@ int handle_force_window(struct MPContext *mpctx, bool force)
         };
         if (vo_reconfig(vo, &p) < 0)
             goto err;
+        struct track *track = mpctx->current_track[0][STREAM_VIDEO];
+        update_content_type(mpctx, track);
         update_screensaver_state(mpctx);
         vo_set_paused(vo, true);
         vo_redraw(vo);

--- a/player/video.c
+++ b/player/video.c
@@ -276,6 +276,7 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
     if (!recreate_video_filters(mpctx))
         goto err_out;
 
+    update_content_type(mpctx, track);
     update_screensaver_state(mpctx);
 
     vo_set_paused(vo_c->vo, get_internal_paused(mpctx));

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -95,6 +95,8 @@ enum mp_voctrl {
 
     VOCTRL_SET_CURSOR_VISIBILITY,       // bool*
 
+    VOCTRL_CONTENT_TYPE,                // enum mp_content_type*
+
     VOCTRL_KILL_SCREENSAVER,
     VOCTRL_RESTORE_SCREENSAVER,
 
@@ -127,6 +129,13 @@ enum mp_voctrl {
 
     /* private to vo_gpu and vo_gpu_next */
     VOCTRL_EXTERNAL_RESIZE,
+};
+
+// Helper to expose what kind of content is curently playing to the VO.
+enum mp_content_type {
+    MP_CONTENT_NONE, // used for force-window
+    MP_CONTENT_IMAGE,
+    MP_CONTENT_VIDEO,
 };
 
 #define VO_TRUE         true

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -24,6 +24,7 @@
 
 struct wayland_opts {
     int configure_bounds;
+    int content_type;
     int disable_vsync;
     int edge_pixels_pointer;
     int edge_pixels_touch;
@@ -76,6 +77,12 @@ struct vo_wayland_state {
     int scaling;
     int timeout_count;
     int wakeup_pipe[2];
+
+    /* content-type */
+    /* TODO: unvoid these if required wayland protocols is bumped to 1.27+ */
+    void *content_type_manager;
+    void *content_type;
+    int current_content_type;
 
     /* idle-inhibit */
     struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager;

--- a/wscript
+++ b/wscript
@@ -536,6 +536,11 @@ video_output_features = [
         'deps': 'wayland',
         'func': check_pkg_config('wayland-protocols >= 1.24'),
     } , {
+        'name': 'wayland-protocols-1-27',
+        'desc': 'wayland-protocols version 1.27+',
+        'deps': 'wayland',
+        'func': check_pkg_config('wayland-protocols >= 1.27'),
+    } , {
         'name': 'memfd_create',
         'desc': "Linux's memfd_create()",
         'deps': 'wayland',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -140,6 +140,14 @@ def build(ctx):
             protocol  = "stable/viewporter/viewporter",
             target    = "generated/wayland/viewporter.h")
 
+    if ctx.dependency_satisfied('wayland-protocols-1-27'):
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/content-type/content-type-v1",
+            target    = "generated/wayland/content-type-v1.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/content-type/content-type-v1",
+            target    = "generated/wayland/content-type-v1.h")
+
     ctx(features = "ebml_header", target = "generated/ebml_types.h")
     ctx(features = "ebml_definitions", target = "generated/ebml_defs.inc")
 
@@ -540,6 +548,7 @@ def build(ctx):
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),
         ( "video/out/vulkan/utils.c",            "vulkan" ),
         ( "video/out/w32_common.c",              "win32-desktop" ),
+        ( "generated/wayland/content-type-v1.c", "wayland-protocols-1-27" ),
         ( "generated/wayland/idle-inhibit-unstable-v1.c", "wayland" ),
         ( "generated/wayland/presentation-time.c", "wayland" ),
         ( "generated/wayland/xdg-decoration-unstable-v1.c", "wayland" ),


### PR DESCRIPTION
The content-type protocol allows mpv to send compositor a hint about the type of content being displayed on its surface so it could potentially make some sort of optimization. Fundamentally, this is pretty simple but since this requires a very new wayland-protocols version (1.27), we have to mess with the build to add a new define and add a bunch of if's in here. The protocol itself exposes 4 different types of content: none, photo, video, and game. For mpv, we of course send video by default but it is certainly common to view images/photos as well. Additionally, maybe the compositor is bugged in some way and one would like to turn this off. In light of that, a new option has also been added (wayland-content-type) that lets users control what content hint to send to the compositor. For completion's sake, game is also allowed here, but in practice there shouldn't ever be a reason to use that.

Supercedes: https://github.com/mpv-player/mpv/pull/10262