### PR TITLE
wscript: remove some bogus configure options

### DIFF
--- a/wscript
+++ b/wscript
@@ -516,11 +516,11 @@ video_output_features = [
         'deps': 'gbm.h',
         'func': check_pkg_config('gbm', '>= 17.1.0'),
     } , {
-        'name': '--wayland-scanner',
+        'name': 'wayland-scanner',
         'desc': 'wayland-scanner',
         'func': check_program('wayland-scanner', 'WAYSCAN')
     } , {
-        'name': '--wayland-protocols',
+        'name': 'wayland-protocols',
         'desc': 'wayland-protocols',
         'func': check_wl_protocols
     } , {


### PR DESCRIPTION
It turns out that wayland-scanner and wayland-protocols are both exposed as configure options in waf meaning you can --enable/--disable them at configure time. This is pretty nonsensical. If you want to control wayland in the build, you should just use --enable-/--disable-wayland. wayland-scanner and wayland-protocols should just be typical checks like in the meson build.