### PR TITLE
demux_mkv: add AVS2 and AVS3 to tag list

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1362,6 +1362,8 @@ static const char *const mkv_video_tags[][2] = {
     {"V_SNOW",              "snow"},
     {"V_AV1",               "av1"},
     {"V_PNG",               "png"},
+    {"V_AVS2",              "avs2"},
+    {"V_AVS3",              "avs3"},
     {0}
 };
 


### PR DESCRIPTION
Add support for playing back AVS2 and AVS3 video streams inside mkv containers if ffmpeg was compiled with avs2/avs3 support.

Fixes: #10695