### PR TITLE
WIP: DRM HDR support

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,6 +27,7 @@ Interface changes
 ::
 
  --- mpv 0.36.0 ---
+    - add `--drm-hdr-metadata`
     - `playlist/N/title` gets set upon opening the file if it wasn't already set
       and a title is available.
     - add the `--vo=kitty` video output driver, as well as the options

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -713,6 +713,12 @@ Available video output drivers are:
         :yes:   Attempt to enable VRR, whether the capability is reported or not.
         :auto:  Attempt to enable VRR if support is reported.
 
+    ``--drm-hdr-metadata=<no|auto>``
+        Signal to the display that HDR metadata, if present, should be sent over
+        the connector.
+
+        (default: auto)
+
 ``mediacodec_embed`` (Android)
     Renders ``IMGFMT_MEDIACODEC`` frames directly to an ``android.view.Surface``.
     Requires ``--hwdec=mediacodec`` for hardware decoding, along with

--- a/meson.build
+++ b/meson.build
@@ -895,6 +895,8 @@ if features['drm']
                      'video/out/vo_drm.c')
 endif
 
+features += {'drm-hdr': features['drm'] and drm.version().version_compare('>= 2.4.104')}
+
 # This can be removed roughly when Debian 12 is released.
 features += {'drm-is-kms': features['drm'] and drm.version().version_compare('>= 2.4.105')}
 

--- a/video/out/drm_atomic.h
+++ b/video/out/drm_atomic.h
@@ -23,11 +23,14 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
+#include "config.h"
+
 #include "common/msg.h"
 #include "drm_common.h"
 
 #define DRM_OPTS_PRIMARY_PLANE -1
 #define DRM_OPTS_OVERLAY_PLANE -2
+
 
 struct drm_atomic_plane_state {
     uint64_t fb_id;
@@ -96,5 +99,9 @@ bool drm_atomic_restore_old_state(drmModeAtomicReq *request, struct drm_atomic_c
 
 bool drm_mode_ensure_blob(int fd, struct drm_mode *mode);
 bool drm_mode_destroy_blob(int fd, struct drm_mode *mode);
+
+// append HDR blob to the connector properties
+int drm_create_hdr_metadata(struct drm_atomic_context *ctx, struct drm_hdr *hdr_data);
+void drm_destroy_hdr_metadata(struct drm_atomic_context *ctx, struct drm_hdr *hdr_data);
 
 #endif // MP_DRMATOMIC_H

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -98,10 +98,10 @@ const struct m_sub_options drm_conf = {
         {"drm-draw-surface-size", OPT_SIZE_BOX(draw_surface_size)},
         {"drm-vrr-enabled", OPT_CHOICE(vrr_enabled,
             {"no", 0}, {"yes", 1}, {"auto", -1})},
-
         {"drm-osd-plane-id", OPT_REPLACED("drm-draw-plane")},
         {"drm-video-plane-id", OPT_REPLACED("drm-drmprime-video-plane")},
         {"drm-osd-size", OPT_REPLACED("drm-draw-surface-size")},
+        {"drm-hdr-metadata", OPT_CHOICE(hdr_metadata, {"no", 0}, {"auto", 1})}, 
         {0},
     },
     .defaults = &(const struct drm_opts) {
@@ -109,6 +109,8 @@ const struct m_sub_options drm_conf = {
         .drm_atomic = 1,
         .draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
+        .vrr_enabled = 0,
+        .hdr_metadata = 1
     },
     .size = sizeof(struct drm_opts),
 };

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -21,6 +21,8 @@
 #include <stdbool.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+
+#include "video/csputils.h"
 #include "vo.h"
 
 #define DRM_OPTS_FORMAT_XRGB8888    0
@@ -50,6 +52,12 @@ struct drm_mode {
     uint32_t blob_id;
 };
 
+struct drm_hdr {
+    struct mp_colorspace new_csp;
+    struct mp_colorspace current_csp;
+    uint32_t blob_id;
+};
+
 struct drm_opts {
     char *device_path;
     char *connector_spec;
@@ -60,6 +68,7 @@ struct drm_opts {
     int drm_format;
     struct m_geometry draw_surface_size;
     int vrr_enabled;
+    int hdr_metadata;
 };
 
 struct vt_switcher {
@@ -69,6 +78,7 @@ struct vt_switcher {
     void *handler_data[2];
 };
 
+
 struct vo_drm_state {
     drmModeConnector *connector;
     drmModeEncoder *encoder;
@@ -77,6 +87,7 @@ struct vo_drm_state {
     struct drm_atomic_context *atomic_context;
     struct drm_mode mode;
     struct drm_opts *opts;
+    struct drm_hdr hdr_metadata;
     struct drm_vsync_tuple vsync;
     struct framebuffer *fb;
     struct mp_log *log;

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -79,6 +79,12 @@ struct ra_swapchain_fns {
     // Gets the current framebuffer depth in bits (0 if unknown). Optional.
     int (*color_depth)(struct ra_swapchain *sw);
 
+    // Called to provide the output context with color space metadata and
+    // CLL and MDCV side data.
+    bool (*colorspace_hint)(struct ra_swapchain *sw,
+                            const struct mp_image *csp_hint_frame,
+                            struct mp_colorspace *configured_csp);
+
     // Called when rendering starts. Returns NULL on failure. This must be
     // followed by submit_frame, to submit the rendered frame. This function
     // can also fail sporadically, and such errors should be ignored unless

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -150,6 +150,8 @@ bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_gl_ctx_params params)
     if (ext) {
         if (ext->color_depth)
             p->fns.color_depth = ext->color_depth;
+        if (ext->colorspace_hint)
+            p->fns.colorspace_hint = ext->colorspace_hint;
         if (ext->start_frame)
             p->fns.start_frame = ext->start_frame;
         if (ext->submit_frame)

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -79,6 +79,8 @@ struct priv {
 
     struct mpv_opengl_drm_params_v2 drm_params;
     struct mpv_opengl_drm_draw_surface_size draw_surface_size;
+
+    struct mp_colorspace out_color;
 };
 
 // Not general. Limited to only the formats being used in this module
@@ -465,10 +467,24 @@ static void drm_egl_swap_buffers(struct ra_swapchain *sw)
     }
 }
 
+static bool drm_egl_colorspace_hint(struct ra_swapchain *sw,
+                                    const struct mp_image *csp_hint_frame,
+                                    struct mp_colorspace *configured_csp)
+{
+    struct priv *p = sw->ctx->priv;
+
+    if (csp_hint_frame) {
+        p->out_color = csp_hint_frame->params.color;
+        return true;
+    }
+    return false;
+}
+
 static const struct ra_swapchain_fns drm_egl_swapchain = {
-    .start_frame   = drm_egl_start_frame,
-    .submit_frame  = drm_egl_submit_frame,
-    .swap_buffers  = drm_egl_swap_buffers,
+    .colorspace_hint = drm_egl_colorspace_hint,
+    .start_frame     = drm_egl_start_frame,
+    .submit_frame    = drm_egl_submit_frame,
+    .swap_buffers    = drm_egl_swap_buffers,
 };
 
 static void drm_egl_uninit(struct ra_ctx *ctx)

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -76,6 +76,19 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     struct gpu_priv *p = vo->priv;
     struct ra_swapchain *sw = p->ctx->swapchain;
 
+    // vo_gpu utilizes the fbo color space to receive the configured result,
+    // so nullptr is passed for the result.
+    if (frame->current && sw->fns->colorspace_hint &&
+        !sw->fns->colorspace_hint(sw, frame->current, NULL)) {
+        MP_WARN(vo, "Passing a color space hint of %s/%s to context failed!\n",
+                m_opt_choice_str(
+                    mp_csp_prim_names,
+                    frame->current->params.color.primaries),
+                m_opt_choice_str(
+                    mp_csp_trc_names,
+                    frame->current->params.color.gamma));
+    }
+
     struct ra_fbo fbo;
     if (!sw->fns->start_frame(sw, &fbo))
         return;

--- a/wscript
+++ b/wscript
@@ -520,6 +520,11 @@ video_output_features = [
         'deps': 'vt.h || consio.h',
         'func': check_pkg_config('libdrm', '>= 2.4.75'),
     }, {
+        'name': 'drm-hdr',
+        'desc': 'DRM HDR metadata support',
+        'deps': 'drm',
+        'func': check_pkg_config('libdrm', '>= 2.4.104'),
+    }, {
         'name': '--gbm',
         'desc': 'GBM',
         'deps': 'gbm.h',


### PR DESCRIPTION
This is a rebase of #8648 and #8456 and supersedes them. It is not finished, so please do not spam this PR with "when will this be merged?", it won't be for a while.

Some TODOS:
- [x] Is the way HDR is deactivated correct? (apparently)
- [x] ~~`--gpu-api=vulkan`?~~
- [ ] `--vo=gpu-next`?
- [ ] Automatically set `--drm-format=` if needed
- [ ] Automatically set `--target-trc`, etc. like is done on windows
- [ ] Get someone to review the drm atomic stuff
- [ ] Make sure the colorspace being passed in is correct

@evelikov @emersion I believe I addressed most (all?) of your comments from the previous PRs, but I am a complete novice at drm so any drive-bys would be appreciated.

For others testing, the following command (in a tty) will work:
```bash
mpv --vo=gpu --gpu-api=opengl --gpu-context=drm $my_hdr_file
```
DRM metadata should be automatically sent.

Closes #8219