### PR TITLE
[RFC] vo_gpu_next: use libplacebo interop for GL hwdec

### DIFF
--- a/video/out/gpu_next/context.h
+++ b/video/out/gpu_next/context.h
@@ -27,6 +27,7 @@ struct gl_video_opts;
 struct gpu_ctx {
     struct mp_log *log;
     struct ra_ctx *ra_ctx;
+    struct ra *ra_hwdec; // `ra` to use for hwdec purposes
 
     pl_log pllog;
     pl_gpu gpu;

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1399,7 +1399,7 @@ static int preinit(struct vo *vo)
     p->hwdec_ctx = (struct ra_hwdec_ctx) {
         .log = p->log,
         .global = p->global,
-        .ra = p->ra_ctx->ra,
+        .ra = p->context->ra_hwdec,
     };
 
     vo->hwdec_devs = hwdec_devices_create();


### PR DESCRIPTION
Pass a `ra_pl` wrapper to the hwdec functions, instead of the original `ra_ctx` the OpenGL context was created from.

I'm well aware that this is all a gigantic mess and we should be making the code *less* reliant on `ra`, not more... but at least this allows us to start using the OpenGL interop inside libplcaebo for --vo=gpu-next, which is a step forwards as it allows for less messy integration and upstream bug fixes (e.g. EGLImageKHR mapping on desktop GL).