### PR TITLE
wayland_common: fix typo in zxdg_toplevel_decoration_v1.configure

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -955,7 +955,8 @@ static void configure_decorations(void *data,
     struct vo_wayland_state *wl = data;
     struct mp_vo_opts *opts = wl->vo_opts;
 
-    if (wl->requested_decoration == mode)
+    /* If we got what we requested, do not re-request the mode */
+    if (wl->requested_decoration == (mode - 1))
         wl->requested_decoration = 0;
 
     if (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE) {


### PR DESCRIPTION
mode == 1 -> client-side decorations
mode == 2 -> server-side decorations

requested_mode == 0 -> client-side decorations (none) requested_mode == 1 -> server-side decorations

This resulted in mpv DDOSing the compositor as it was never happy with the mode configured, causing the compositor to keep sending new xdg_configure events which in turn caused mpv to keep asking.

During playback, the compositor waits for a frame before sending any new xdg_configure events, but when it's paused, there's no rate control, so both the compositor and mpv end up maxing a core.

Broken by 2d348980cbbb8a1d4f547c0cf5b09bd8d9208a0f.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.