### PR TITLE
video/out/wayland_common: clear decoration request even if compositor disagrees

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -963,7 +963,7 @@ static void configure_decorations(void *data,
     } else {
         MP_VERBOSE(wl, "Disabling server decorations\n");
     }
-    opts->border = mode - 1;
+    opts->border = mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
     m_config_cache_write_opt(wl->vo_opts_cache, &opts->border);
 }
 
@@ -1699,7 +1699,10 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
                     opts->border = !opts->border;
                     m_config_cache_write_opt(wl->vo_opts_cache,
                                              &opts->border);
-                    request_decoration_mode(wl, !opts->border + 1);
+                    request_decoration_mode(
+                        wl, !opts->border ?
+                            ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE :
+                            ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE);
                 } else {
                     opts->border = false;
                     m_config_cache_write_opt(wl->vo_opts_cache,
@@ -1882,7 +1885,10 @@ int vo_wayland_init(struct vo *vo)
     if (wl->xdg_decoration_manager) {
         wl->xdg_toplevel_decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(wl->xdg_decoration_manager, wl->xdg_toplevel);
         zxdg_toplevel_decoration_v1_add_listener(wl->xdg_toplevel_decoration, &decoration_listener, wl);
-        request_decoration_mode(wl, wl->vo_opts->border + 1);
+        request_decoration_mode(
+            wl, wl->vo_opts->border ?
+                ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE :
+                ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE);
     } else {
         wl->vo_opts->border = false;
         m_config_cache_write_opt(wl->vo_opts_cache,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1696,11 +1696,12 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
                 // unless we get a configure event. Change it back to its old
                 // value and let configure_decorations handle it after the request.
                 if (wl->xdg_toplevel_decoration) {
+                    int requested_border_mode = opts->border;
                     opts->border = !opts->border;
                     m_config_cache_write_opt(wl->vo_opts_cache,
                                              &opts->border);
                     request_decoration_mode(
-                        wl, !opts->border ?
+                        wl, requested_border_mode ?
                             ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE :
                             ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE);
                 } else {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -948,6 +948,18 @@ static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 #endif
 };
 
+static const char *zxdg_decoration_mode_to_str(const uint32_t mode)
+{
+    switch (mode) {
+    case ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE:
+        return "server-side";
+    case ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE:
+        return "client-side";
+    default:
+        return "<unknown>";
+    }
+}
+
 static void configure_decorations(void *data,
                                   struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration,
                                   uint32_t mode)
@@ -955,8 +967,18 @@ static void configure_decorations(void *data,
     struct vo_wayland_state *wl = data;
     struct mp_vo_opts *opts = wl->vo_opts;
 
-    if (wl->requested_decoration == mode)
+    if (wl->requested_decoration) {
+        if (mode != wl->requested_decoration) {
+            MP_MSG(wl, wl->warned_of_mismatch ? MSGL_DEBUG : MSGL_WARN,
+                   "Requested %s decorations but compositor responded with %s\n",
+                   zxdg_decoration_mode_to_str(wl->requested_decoration),
+                   zxdg_decoration_mode_to_str(mode));
+
+            wl->warned_of_mismatch = true;
+        }
+
         wl->requested_decoration = 0;
+    }
 
     if (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE) {
         MP_VERBOSE(wl, "Enabling server decorations\n");

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -98,6 +98,7 @@ struct vo_wayland_state {
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;
     struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration;
     int requested_decoration;
+    bool warned_of_mismatch;
 
     /* xdg-shell */
     struct xdg_wm_base      *wm_base;


### PR DESCRIPTION
Otherwise mpv and the compositor can end up in an eternal loop where
mpv requests one mode, and compositor tells that the mode is not
that (and will most likely not change).

Additionally, log these mismatches - first time as a warning, and
later as debug logging.