### PR TITLE
DOCS: document E to cycle through Editions

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -128,6 +128,9 @@ m
 \#
     Cycle through the available audio tracks.
 
+E
+    Cycle through the available Editions.
+
 f
     Toggle fullscreen (see also ``--fs``).
 


### PR DESCRIPTION
Pushing E (aka Shift+e) cycles through Editions for containers that support editions, such as Matroska, although this feature was not documented before this commit.
