### PR TITLE
build: bump pipewire dependency to 0.3.44

### DIFF
--- a/ci/build-tumbleweed.sh
+++ b/ci/build-tumbleweed.sh
@@ -9,6 +9,7 @@ if [ "$1" = "meson" ]; then
       -Dlibarchive=enabled    \
       -Dlibmpv=true           \
       -Dmanpage-build=enabled \
+      -Dpipewire=enabled      \
       -Dshaderc=enabled       \
       -Dtests=true            \
       -Dvulkan=enabled
@@ -24,6 +25,7 @@ if [ "$1" = "waf" ]; then
       --enable-libarchive    \
       --enable-libmpv-shared \
       --enable-manpage-build \
+      --enable-pipewire      \
       --enable-shaderc       \
       --enable-tests         \
       --enable-vulkan

--- a/meson.build
+++ b/meson.build
@@ -831,7 +831,7 @@ if features['oss-audio']
     sources += files('audio/out/ao_oss.c')
 endif
 
-pipewire = dependency('libpipewire-0.3', version: '>= 0.3', required: get_option('pipewire'))
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.44', required: get_option('pipewire'))
 features += {'pipewire': pipewire.found()}
 if features['pipewire']
     dependencies += pipewire

--- a/wscript
+++ b/wscript
@@ -446,7 +446,7 @@ audio_output_features = [
     }, {
         'name': '--pipewire',
         'desc': 'PipeWire audio output',
-        'func': check_pkg_config('libpipewire-0.3', '>= 0.3.0')
+        'func': check_pkg_config('libpipewire-0.3', '>= 0.3.44')
     }, {
         'name': '--sndio',
         'desc': 'sndio audio input/output',


### PR DESCRIPTION
This version is required since 5e49c09f2ea2bcf6d993abf0fe839d5d7e0cad15 where usage of PW_KEY_TARGET_OBJECT was added into the AO.

Fixes #10786