### PR TITLE
ao_pipewire: compatibility for libpipewire 0.3.19

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -42,6 +42,12 @@
 #define PW_KEY_NODE_RATE "node.rate"
 #endif
 
+// Added in Pipewire 0.3.44
+// remove the fallback when we require a newer version
+#ifndef PW_KEY_TARGET_OBJECT
+#define PW_KEY_TARGET_OBJECT "target.object"
+#endif
+
 #if !PW_CHECK_VERSION(0, 3, 50)
 static inline int pw_stream_get_time_n(struct pw_stream *stream, struct pw_time *time, size_t size) {
 	return pw_stream_get_time(stream, time);

--- a/ci/build-tumbleweed.sh
+++ b/ci/build-tumbleweed.sh
@@ -9,6 +9,7 @@ if [ "$1" = "meson" ]; then
       -Dlibarchive=enabled    \
       -Dlibmpv=true           \
       -Dmanpage-build=enabled \
+      -Dpipewire=enabled      \
       -Dshaderc=enabled       \
       -Dtests=true            \
       -Dvulkan=enabled
@@ -24,6 +25,7 @@ if [ "$1" = "waf" ]; then
       --enable-libarchive    \
       --enable-libmpv-shared \
       --enable-manpage-build \
+      --enable-pipewire      \
       --enable-shaderc       \
       --enable-tests         \
       --enable-vulkan

--- a/meson.build
+++ b/meson.build
@@ -831,7 +831,7 @@ if features['oss-audio']
     sources += files('audio/out/ao_oss.c')
 endif
 
-pipewire = dependency('libpipewire-0.3', version: '>= 0.3', required: get_option('pipewire'))
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.19', required: get_option('pipewire'))
 features += {'pipewire': pipewire.found()}
 if features['pipewire']
     dependencies += pipewire

--- a/wscript
+++ b/wscript
@@ -446,7 +446,7 @@ audio_output_features = [
     }, {
         'name': '--pipewire',
         'desc': 'PipeWire audio output',
-        'func': check_pkg_config('libpipewire-0.3', '>= 0.3.0')
+        'func': check_pkg_config('libpipewire-0.3', '>= 0.3.19')
     }, {
         'name': '--sndio',
         'desc': 'sndio audio input/output',


### PR DESCRIPTION
This patch provides compatibility with the version of libpipewire as shipped in Debian stable.

Supersedes #10787 
Fixes #10786

Cc @philipl @jeeb 