### PR TITLE
video/out/wayland_common: adjust decoration disagreement log to once

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -967,18 +967,15 @@ static void configure_decorations(void *data,
     struct vo_wayland_state *wl = data;
     struct mp_vo_opts *opts = wl->vo_opts;
 
-    if (wl->requested_decoration) {
-        if (mode != wl->requested_decoration) {
-            MP_MSG(wl, wl->warned_of_mismatch ? MSGL_DEBUG : MSGL_WARN,
-                   "Requested %s decorations but compositor responded with %s\n",
-                   zxdg_decoration_mode_to_str(wl->requested_decoration),
-                   zxdg_decoration_mode_to_str(mode));
-
-            wl->warned_of_mismatch = true;
-        }
-
-        wl->requested_decoration = 0;
+    if (wl->requested_decoration && mode != wl->requested_decoration) {
+        MP_DBG(wl,
+               "Requested %s decorations but compositor responded with %s. "
+               "It is likely that compositor wants us to stay in a given mode.\n",
+               zxdg_decoration_mode_to_str(wl->requested_decoration),
+               zxdg_decoration_mode_to_str(mode));
     }
+
+    wl->requested_decoration = 0;
 
     if (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE) {
         MP_VERBOSE(wl, "Enabling server decorations\n");

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -102,7 +102,6 @@ struct vo_wayland_state {
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;
     struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration;
     int requested_decoration;
-    bool warned_of_mismatch;
 
     /* xdg-shell */
     struct xdg_wm_base      *wm_base;


### PR DESCRIPTION
Originally, I considered warning once to be useful for figuring out whether the change in logic regarding resetting requested mode actually fixed the reported issue or not, but alas not everyone was happy with that decision. Thus the log level will always be debug, and the message will only be logged once. This enables us to lose one level of indent as well, which is always positive.

Additionally, make the message more explicit regarding what could possibly be implied by the mismatch, as it seems like this was not always clear.