### PR TITLE
dmabuf-wayland fixes

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6150,8 +6150,6 @@ them.
         X11/EGL
     android
         Android/EGL. Requires ``--wid`` be set to an ``android.view.Surface``.
-    wldmabuf
-        dmabuf buffers are rendered directly by Wayland compositor
 
 ``--gpu-api=<type>``
     Controls which type of graphics APIs will be accepted:
@@ -6164,9 +6162,6 @@ them.
         Allow only Vulkan (requires a valid/working ``--spirv-compiler``)
     d3d11
         Allow only ``--gpu-context=d3d11``
-    none
-        No graphics API is used - Wayland alone is used for rendering
-        (requires Wayland compositor)
 
 ``--opengl-es=<mode>``
     Controls which type of OpenGL context will be accepted:

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -124,8 +124,10 @@ static int ra_ctx_api_help(struct mp_log *log, const struct m_option *opt,
 {
     mp_info(log, "GPU APIs (contexts):\n");
     mp_info(log, "    auto (autodetect)\n");
-    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
-        mp_info(log, "    %s (%s)\n", contexts[n]->type, contexts[n]->name);
+    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++) {
+        if (!contexts[n]->hidden)
+            mp_info(log, "    %s (%s)\n", contexts[n]->type, contexts[n]->name);
+    }
     return M_OPT_EXIT;
 }
 
@@ -136,7 +138,7 @@ static int ra_ctx_validate_api(struct mp_log *log, const struct m_option *opt,
     if (bstr_equals0(param, "auto"))
         return 1;
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
-        if (bstr_equals0(param, contexts[i]->type))
+        if (bstr_equals0(param, contexts[i]->type) && !contexts[i]->hidden)
             return 1;
     }
     return M_OPT_INVALID;
@@ -147,8 +149,10 @@ static int ra_ctx_context_help(struct mp_log *log, const struct m_option *opt,
 {
     mp_info(log, "GPU contexts (APIs):\n");
     mp_info(log, "    auto (autodetect)\n");
-    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++)
-        mp_info(log, "    %s (%s)\n", contexts[n]->name, contexts[n]->type);
+    for (int n = 0; n < MP_ARRAY_SIZE(contexts); n++) {
+        if (!contexts[n]->hidden)
+            mp_info(log, "    %s (%s)\n", contexts[n]->name, contexts[n]->type);
+    }
     return M_OPT_EXIT;
 }
 
@@ -159,7 +163,7 @@ static int ra_ctx_validate_context(struct mp_log *log, const struct m_option *op
     if (bstr_equals0(param, "auto"))
         return 1;
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
-        if (bstr_equals0(param, contexts[i]->name))
+        if (bstr_equals0(param, contexts[i]->name) && !contexts[i]->hidden)
             return 1;
     }
     return M_OPT_INVALID;
@@ -183,6 +187,8 @@ struct ra_ctx *ra_ctx_create(struct vo *vo, struct ra_ctx_opts opts)
     vo->probing = opts.probing;
 
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
+        if (contexts[i]->hidden)
+            continue;
         if (!opts.probing && strcmp(contexts[i]->name, opts.context_name) != 0)
             continue;
         if (!api_auto && strcmp(contexts[i]->type, opts.context_type) != 0)
@@ -212,6 +218,28 @@ struct ra_ctx *ra_ctx_create(struct vo *vo, struct ra_ctx_opts opts)
     // requested, or the backend creation failed for all of them.
     if (!vo->probing)
         MP_ERR(vo, "Failed initializing any suitable GPU context!\n");
+    return NULL;
+}
+
+struct ra_ctx *ra_ctx_create_by_name(struct vo *vo, const char *name)
+{
+    for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
+        if (strcmp(name, contexts[i]->name) != 0)
+            continue;
+
+        struct ra_ctx *ctx = talloc_ptrtype(NULL, ctx);
+        *ctx = (struct ra_ctx) {
+            .vo = vo,
+            .global = vo->global,
+            .log = mp_log_new(ctx, vo->log, contexts[i]->type),
+            .fns = contexts[i],
+        };
+
+        MP_VERBOSE(ctx, "Initializing GPU context '%s'\n", ctx->fns->name);
+        if (contexts[i]->init(ctx))
+            return ctx;
+        talloc_free(ctx);
+    }
     return NULL;
 }
 

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -36,6 +36,8 @@ struct ra_ctx_fns {
     const char *type; // API type (for --gpu-api)
     const char *name; // name (for --gpu-context)
 
+    bool hidden; // hide the ra_ctx from users
+
     // Resize the window, or create a new window if there isn't one yet.
     // Currently, there is an unfortunate interaction with ctx->vo, and
     // display size etc. are determined by it.
@@ -101,3 +103,6 @@ struct ra_swapchain_fns {
 // the underlying `struct ra`, and perhaps the underlying VO backend.
 struct ra_ctx *ra_ctx_create(struct vo *vo, struct ra_ctx_opts opts);
 void ra_ctx_destroy(struct ra_ctx **ctx);
+
+// Special case of creating a ra_ctx while specifiying a specific context by name.
+struct ra_ctx *ra_ctx_create_by_name(struct vo *vo, const char *name);

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -316,14 +316,10 @@ static void uninit(struct vo *vo)
 static int preinit(struct vo *vo)
 {
     struct priv *p = vo->priv;
-    struct ra_ctx_opts ctx_opts;
 
     p->log = vo->log;
     p->global = vo->global;
-    ctx_opts.context_name = "wldmabuf";
-    ctx_opts.context_type = "none";
-    ctx_opts.probing = false;
-    p->ctx = ra_ctx_create(vo, ctx_opts);
+    p->ctx = ra_ctx_create_by_name(vo, "wldmabuf");
     if (!p->ctx)
        goto err_out;
     assert(p->ctx->ra);

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -335,7 +335,7 @@ static int preinit(struct vo *vo)
         .global = p->global,
         .ra = p->ctx->ra,
     };
-    ra_hwdec_ctx_init(&p->hwdec_ctx, vo->hwdec_devs, NULL, false);
+    ra_hwdec_ctx_init(&p->hwdec_ctx, vo->hwdec_devs, NULL, true);
 
     return 0;
 err_out:

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1995,6 +1995,10 @@ int vo_wayland_init(struct vo *vo)
     wl_callback_add_listener(wl->frame_callback, &frame_listener, wl);
     wl_surface_commit(wl->surface);
 
+    /* Do another roundtrip to ensure all of the above is initialized
+     * before mpv does anything else. */
+    wl_display_roundtrip(wl->display);
+
     return true;
 }
 

--- a/video/out/wldmabuf/context_wldmabuf.c
+++ b/video/out/wldmabuf/context_wldmabuf.c
@@ -39,6 +39,7 @@ static bool init(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_wldmabuf = {
     .type               = "none",
     .name               = "wldmabuf",
+    .hidden             = true,
     .init               = init,
     .uninit             = uninit,
 };


### PR DESCRIPTION
The first two commits fix the potential crash. Should be pretty straight forward. 

The last commit introduces a new `ra_ctx_create_hidden` function that is used specifically for `vo_dmabuf_wayland`. It internally uses `hidden_type` and `hidden_name` so these options are not exposed to users. Overall, it is much more simple than the other counterpart since we don't care about probing, opts, etc. We just want the ra_ctx for hwdec.