### PR TITLE
ci: freebsd improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,3 +196,13 @@ jobs:
                 #
         run: |
           ./ci/build-freebsd.sh
+
+    - name: Print meson log
+      if: ${{ failure() }}
+      run: |
+        cat ./build/meson-logs/meson-log.txt
+
+    - name: Print waf log
+      if: ${{ failure() }}
+      run: |
+        cat ./build/config.log

--- a/ci/build-freebsd.sh
+++ b/ci/build-freebsd.sh
@@ -12,7 +12,6 @@ meson build \
     -Dopenal=enabled \
     -Dsdl2=enabled \
     -Dsndio=enabled \
-    -Ddmabuf-wayland=enabled \
     -Dvdpau=enabled \
     -Dvulkan=enabled \
     -Doss-audio=enabled \
@@ -36,7 +35,6 @@ python3 ./waf configure \
     --enable-openal \
     --enable-sdl2 \
     --enable-sndio \
-    --enable-dmabuf-wayland \
     --enable-vdpau \
     --enable-vulkan \
     --enable-oss-audio \


### PR DESCRIPTION
It turns out that the build files are copied back to the host so for the freebsd vm, we can explicitly try to print out any build logs on failure. This should make it a little clearer when the freebsd build actually fails vs just a random ssh failure.