### PR TITLE
disable fork usage when building for tvOS

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -221,7 +221,7 @@ def build(ctx):
     ])
 
     subprocess_c = ctx.pick_first_matching_dep([
-        ( "osdep/subprocess-posix.c",            "posix" ),
+        ( "osdep/subprocess-posix.c",            "posix && !tvos" ),
         ( "osdep/subprocess-win.c",              "win32-desktop" ),
         ( "osdep/subprocess-dummy.c" ),
     ])


### PR DESCRIPTION
This fixes builds for tvOS which are currently broken because `fork` is unavailable. 
See https://github.com/mpv-player/mpv/issues/5331