### PR TITLE
ao_coreaudio: specify UTF-8 as text encoding for CFString conversions

### DIFF
--- a/audio/out/ao_coreaudio_utils.h
+++ b/audio/out/ao_coreaudio_utils.h
@@ -26,7 +26,7 @@
 #include "audio/out/ao.h"
 #include "internal.h"
 
-#define CA_CFSTR_ENCODING kCFStringEncodingASCII
+#define CA_CFSTR_ENCODING kCFStringEncodingUTF8
 
 CFStringRef cfstr_from_cstr(char *str);
 char *cfstr_get_cstr(CFStringRef cfstr);


### PR DESCRIPTION
This matches our internal expectations, as well as fixes handling of non-ASCII device descriptions.
