### PR TITLE
options: show profile name when no restore data

### DIFF
--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -1041,7 +1041,7 @@ int m_config_restore_profile(struct m_config *config, char *name)
         return M_OPT_INVALID;
 
     if (!p->backups)
-        MP_WARN(config, "Profile contains no restore data.\n");
+        MP_WARN(config, "Profile '%s' contains no restore data.\n", name);
 
     restore_backups(&p->backups, config);
 


### PR DESCRIPTION
Add the profile name to the warning message to clarify the target. Helpful when there are many unhit restores.

close https://github.com/mpv-player/mpv/issues/10785https://github.com/mpv-player/mpv/issues/10785