### PR TITLE
vo_dmabuf_wayland: honor video src rectangle in viewport configuration

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -160,7 +160,13 @@ static void resize(struct vo *vo)
         wp_viewport_set_destination(wl->viewport, 2 * dst.x0 + mp_rect_w(dst), 2 * dst.y0 + mp_rect_h(dst));
 
     if (wl->video_viewport)
+    {
+        wp_viewport_set_source(wl->video_viewport, wl_fixed_from_int(src.x0),
+                                                   wl_fixed_from_int(src.y0),
+                                                   wl_fixed_from_int(mp_rect_w(src)),
+                                                   wl_fixed_from_int(mp_rect_h(src)));
         wp_viewport_set_destination(wl->video_viewport, mp_rect_w(dst), mp_rect_h(dst));
+    }
     wl_subsurface_set_position(wl->video_subsurface, dst.x0, dst.y0);
     vo->want_redraw = true;
 }


### PR DESCRIPTION
vo_dmabuf_wayland uses the Wayland viewporter API to configure video scaling. Although it was correctly setting up the destination rectangle, the source rectangle was being discarded. The result was that options like --video-pan-x were not having the desired effect. Passing the src rectangle into wp_viewport_set_source means that the Wayland compositor now picks the correct source rectangle of the video.