### PR TITLE
waf, meson: bump wayland-protocols requirement to >= 1.24

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -980,7 +980,7 @@ endif
 wayland = {
     'deps': [dependency('wayland-client', version: '>= 1.15.0', required: get_option('wayland')),
              dependency('wayland-cursor', version: '>= 1.15.0', required: get_option('wayland')),
-             dependency('wayland-protocols', version: '>= 1.15', required: get_option('wayland')),
+             dependency('wayland-protocols', version: '>= 1.24', required: get_option('wayland')),
              dependency('xkbcommon', version: '>= 0.3.0', required: get_option('wayland'))],
     'header': cc.check_header('linux/input-event-codes.h', required: get_option('wayland')),
     'scanner': find_program('wayland-scanner', required: get_option('wayland')),

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -102,7 +102,7 @@ def check_lua(ctx, dependency_identifier):
 
 def check_wl_protocols(ctx, dependency_identifier):
     def fn(ctx, dependency_identifier):
-        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.15")
+        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.24")
         ret = ret(ctx, dependency_identifier)
         if ret != None:
             ctx.env.WL_PROTO_DIR = ret.split()[0]


### PR DESCRIPTION
When dmabuf went to version 4 in 666cb91cf12a4f8b the wayland-protocols version requirement should have been bumped as 1.24 is required for this change.

Fixes #10807.
