### PR TITLE
Small fixes for gpu-next and wayland

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1238,7 +1238,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
     case VOCTRL_PAUSE:
         if (p->is_interpolated)
             vo->want_redraw = true;
-        return VO_TRUE;
+        break;
 
     case VOCTRL_OSD_CHANGED:
         pl_renderer_flush_cache(p->rr);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1016,8 +1016,10 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
 {
     struct vo_wayland_state *wl = data;
 
-    if (fback)
+    if (fback) {
         wp_presentation_feedback_destroy(fback);
+        wl->feedback = NULL;
+    }
 
     if (!wl->use_present)
         return;


### PR DESCRIPTION
Something that doesn't really matter outside of my own experiment for gpu-next.

And a small fix for Wayland. It shouldn't be possible to have 2 presentation feedback events in-fly, so it should be safe to always zero it out.