### PR TITLE
github/workflows: remove pip usage in mingw CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf automake pkg-config g++-mingw-w64 gcc-multilib nasm ninja-build
-          pip3 install --no-input meson
+          sudo apt-get install -y autoconf automake pkg-config g++-mingw-w64 gcc-multilib meson nasm
           ./bootstrap.py
 
       - name: Build libraries


### PR DESCRIPTION
This was only needed because the mingw CI used to run on Ubuntu 20.04 which had a version of meson too old for mpv. This hasn't been the case since we switched to 22.04 in f7164fcfaca1b1d8f0ceb9cb58e532c172cf83fa and can now just use the package manager version.