### PR TITLE
sd_ass: never mangle colours on RGB video

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -904,7 +904,8 @@ static void mangle_colors(struct sd *sd, struct sub_bitmaps *parts)
         };
     }
 
-    if (csp == params.color.space && levels == params.color.levels)
+    if ((csp == params.color.space && levels == params.color.levels) ||
+            params.color.space == MP_CSP_RGB) // Even VSFilter doesn't mangle on RGB video
         return;
 
     bool basic_conv = params.color.space == MP_CSP_BT_709 &&


### PR DESCRIPTION
It turns out, even xy-VSFilter and XySubFilter do not mangle colours if the video is native RGB regardless of the sub's YCbCr header. libass' docs were also [updated](https://github.com/libass/libass/commit/52783a46c0f56ccfb66795667f069a1d2993cfcf) to reflect this.

To see the difference use `mpv --no-config --sub-ass-vsfilter-color-compat=full -sub-file vid_gbr.ass vid_gbr.mkv` with the provided sample files: [mpv-10826_colourmangling-rgbvid.tar.gz](https://github.com/mpv-player/mpv/files/9922816/mpv-10826_colourmangling-rgbvid.tar.gz).
The values used in the ASS sub are `&HFFFFFF` for text colour and `&HHA184F4` for the rectangle.

On current master (6acb7db9facd41f67aebb54a0daeddaaa30d54b3) there's obviously some severe colour mangling occuring *(which would be good if xy\* did the same, but they don't)*:
![mpv_master-6acb7db9fa](https://user-images.githubusercontent.com/1668471/199560014-3b9f55ef-085c-475a-a6e5-16d40b554d0f.png)

With this patch:
![mpv_withPatch](https://user-images.githubusercontent.com/1668471/199560074-7d7559a9-156e-433d-904b-e3adc330a285.png)
