### PR TITLE
vo_gpu_next: add tunable shader parameters

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -49,6 +49,7 @@ Interface changes
     - deprecate `--gamma-factor`
     - deprecate `--gamma-auto`
     - remove `--vulkan-disable-events`
+    - add `--glsl-shader-opts`
  --- mpv 0.34.0 ---
     - deprecate selecting by card number with `--drm-connector`, add
       `--drm-device` which can be used instead

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5857,6 +5857,13 @@ them.
 ``--glsl-shader=<file>``
     CLI/config file only alias for ``--glsl-shaders-append``.
 
+``--glsl-shader-opts=param1=value1,param2=value2,...``
+    Specifies the options to use for tunable shader parameters. You can target
+    specific named shaders by prefixing the shader name with a ``/``, e.g.
+    ``shader/param=value``. Without a prefix, parameters affect all shaders.
+    The shader name is the base part of the shader filename, without the
+    extension. (``--vo=gpu-next`` only)
+
 ``--deband``
     Enable the debanding algorithm. This greatly reduces the amount of visible
     banding, blocking and other quantization artifacts, at the expense of

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -455,6 +455,7 @@ const struct m_sub_options gl_video_conf = {
             {"video", BLEND_SUBS_VIDEO})},
         {"glsl-shaders", OPT_PATHLIST(user_shaders), .flags = M_OPT_FILE},
         {"glsl-shader", OPT_CLI_ALIAS("glsl-shaders-append")},
+        {"glsl-shader-opts", OPT_KEYVALUELIST(user_shader_opts)},
         {"deband", OPT_FLAG(deband)},
         {"deband", OPT_SUBSTRUCT(deband_opts, deband_conf)},
         {"sharpen", OPT_FLOAT(unsharp)},

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -162,6 +162,7 @@ struct gl_video_opts {
     float interpolation_threshold;
     int blend_subs;
     char **user_shaders;
+    char **user_shader_opts;
     int deband;
     struct deband_opts *deband_opts;
     float unsharp;


### PR DESCRIPTION
This is a very simple but easy way of doing it. Ideally, it would be nice if we could also add some sort of introspection about shader parameters at runtime, ideally exposing the entire list of parameters as a custom property dict. But that is a lot of effort for dubious gain.

It's worth noting that, as currently implemented, re-setting `glsl-shader-opts` to a new value doesn't reset back previously mutated values to their defaults.

TODO:
- [x] depends on https://code.videolan.org/videolan/libplacebo/-/merge_requests/318 to be merged first
- [x] I think the way we parse `uint` params is a bit dubious
- [ ] it would make me happy if we could make the API be something better than a key/value string list, so I can just have a keybinding like `add glsl-shader-opts/intensity 0.1`