### PR TITLE
meson: fix macos-touchbar check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1530,17 +1530,13 @@ if swift.allowed()
     subdir(join_paths('generated', 'osdep'))
 endif
 
-macos_touchbar = {
-    'name': 'macos-touchbar',
-    'deps': dependency('appleframeworks', modules: 'AppKit',
-                       required: get_option('macos-touchbar')),
-    'fragment': files(join_paths(fragments, 'touchbar.m')),
-}
-features += {'macos-touchbar': cc.compiles(macos_touchbar['fragment'], name: 'macos-touchbar check')}
+macos_touchbar = get_option('macos-touchbar').require(
+    cc.compiles(files(join_paths(fragments, 'touchbar.m')), name: 'macos-touchbar check') and features['cocoa'],
+    error_message: 'Either cocoa could not be found or the macos-touchbar check failed!',
+)
+features += {'macos-touchbar': macos_touchbar.allowed()}
 if features['macos-touchbar']
     sources += files('osdep/macosx_touchbar.m')
-elif get_option('macos-touchbar').enabled()
-    error('macos-touchbar enabled but it could not be found!')
 endif
 
 


### PR DESCRIPTION
Apparently, it is possible for touchbar.m to compile on non-macos machines. Also, the disable switch didn't actually work either. Fix this by using the require() function and making sure that Cocoa (should be apple-only) is found in addition to the compile check passing which is what waf does. Fixes #10847.