### PR TITLE
drm: remove legacy API

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -29,6 +29,7 @@ Interface changes
  --- mpv 0.36.0 ---
     - add `--force-render`
     - add `--wayland-content-type`
+    - deprecate `--drm-atomic`
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -597,16 +597,6 @@ Available video output drivers are:
         Use ``--drm-mode=help`` to get a list of available modes for all active
         connectors.
 
-    ``--drm-atomic=<no|auto>``
-        Toggle use of atomic modesetting. Mostly useful for debugging.
-
-        :no:    Use legacy modesetting.
-        :auto:  Use atomic modesetting, falling back to legacy modesetting if
-                not available. (default)
-
-        Note: Only affects ``gpu-context=drm``. ``vo=drm`` supports legacy
-        modesetting only.
-
     ``--drm-draw-plane=<primary|overlay|N>``
         Select the DRM plane to which video and OSD is drawn to, under normal
         circumstances. The plane can be specified as ``primary``, which will
@@ -653,7 +643,6 @@ Available video output drivers are:
         just cause the video to get rendered at a different resolution and then
         scaled to screen size.
 
-        Note: this option is only available with DRM atomic support.
         (default: display resolution)
 
     ``--drm-vrr-enabled=<no|yes|auto>``

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -88,8 +88,7 @@ struct kms *kms_create(struct mp_log *log,
                        const char *drm_device_path,
                        const char *connector_spec,
                        const char *mode_spec,
-                       int draw_plane, int drmprime_video_plane,
-                       bool use_atomic);
+                       int draw_plane, int drmprime_video_plane);
 void kms_destroy(struct kms *kms);
 double kms_get_display_fps(const struct kms *kms);
 

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -569,7 +569,7 @@ static int preinit(struct vo *vo)
                         vo->opts->drm_opts->drm_device_path,
                         vo->opts->drm_opts->drm_connector_spec,
                         vo->opts->drm_opts->drm_mode_spec,
-                        0, 0, false);
+                        0, 0);
     if (!p->kms) {
         MP_ERR(vo, "Failed to create KMS.\n");
         goto err;


### PR DESCRIPTION
The legacy DRM API adds some complexity to the DRM code. There are only 4 drivers that do not support the DRM API:

1. radeon (early GCN amd cards)
2. gma500 (ancient intel GPUs)
3. ast (ASPEED SoCs)
4. nouveau

Going forward, new DRM drivers will be guaranteed to support the atomic API so this is a safe removal.

tested on `--vo=drm` and `--vo=gpu{,-next} --gpu-context=drm`