### PR TITLE
vo_gpu_next: fix null pointer dereference

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1615,14 +1615,18 @@ static void update_icc_opts(struct priv *p, const struct mp_icc_opts *opts)
         p->icc_profile = (struct pl_icc_profile) {0};
     }
 
-    int s_r = 0, s_g = 0, s_b = 0;
-    gl_parse_3dlut_size(opts->size_str, &s_r, &s_g, &s_b);
     p->params.icc_params = &p->icc;
     p->icc = pl_icc_default_params;
     p->icc.intent = opts->intent;
-    p->icc.size_r = s_r;
-    p->icc.size_g = s_g;
-    p->icc.size_b = s_b;
+    if (opts->size_str) {
+        int s_r = 0, s_g = 0, s_b = 0;
+        gl_parse_3dlut_size(opts->size_str, &s_r, &s_g, &s_b);
+        p->icc.size_r = s_r;
+        p->icc.size_g = s_g;
+        p->icc.size_b = s_b;
+    } else {
+        MP_VERBOSE(p, "Using default ICC size.\n");
+    }
 #if PL_API_VER >= 222
     p->icc.cache_priv = p;
     p->icc.cache_save = icc_save;


### PR DESCRIPTION
During the call to `update_icc_opts` by `update_render_options`, sometimes `opts->size_str` is not set, so the call to gl_parse_3dlut_size (https://github.com/mpv-player/mpv/blob/2f747341f99d9f8697303be01c67ae3b3437cd18/video/out/vo_gpu_next.c#L1619) causes a null pointer dereference.
Only parse 3dlut size if `opts->size_str` is set.