### PR TITLE
{common,player}: version logging changes

### DIFF
--- a/common/av_log.c
+++ b/common/av_log.c
@@ -193,6 +193,7 @@ void check_library_versions(struct mp_log *log, int v)
         {"libswresample", LIBSWRESAMPLE_VERSION_INT, swresample_version()},
     };
 
+    mp_msg(log, v, "FFmpeg version: %s\n", av_version_info());
     mp_msg(log, v, "FFmpeg library versions:\n");
 
     for (int n = 0; n < MP_ARRAY_SIZE(libs); n++) {
@@ -209,8 +210,6 @@ void check_library_versions(struct mp_log *log, int v)
             abort();
         }
     }
-
-    mp_msg(log, v, "FFmpeg version: %s\n", av_version_info());
 }
 
 #undef V

--- a/player/main.c
+++ b/player/main.c
@@ -25,6 +25,11 @@
 #include <locale.h>
 
 #include "config.h"
+
+#if HAVE_LIBPLACEBO
+#include <libplacebo/config.h>
+#endif
+
 #include "mpv_talloc.h"
 
 #include "misc/dispatch.h"
@@ -144,6 +149,9 @@ void mp_print_version(struct mp_log *log, int always)
     int v = always ? MSGL_INFO : MSGL_V;
     mp_msg(log, v, "%s %s\n built on %s\n",
            mpv_version, mpv_copyright, mpv_builddate);
+#if HAVE_LIBPLACEBO
+    mp_msg(log, v, "libplacebo version: %s\n", PL_VERSION);
+#endif
     check_library_versions(log, v);
     mp_msg(log, v, "\n");
     // Only in verbose mode.


### PR DESCRIPTION
1. Adjust the location of the overall FFmpeg version logging.
2. Add libplacebo version as part of `--version`.