### PR TITLE
vobsub: fix loading with url and non-ascii path

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -565,7 +565,9 @@ static void guess_and_set_vobsub_name(struct demuxer *demuxer, AVDictionary **d)
             subname = replace_idx_ext(tmp, start);
             if (subname)
                 subname = talloc_asprintf(tmp, "%s?%.*s", subname, BSTR_P(end));
-        }
+        } else {
+	    bfilename = bstr0(mp_file_get_path(tmp, bfilename));
+	}
     }
     if (!subname)
         subname = replace_idx_ext(tmp, bfilename);


### PR DESCRIPTION
When dragging a vobsub idx file onto the mpv window, the file will be a URL, such as file:///path/to/subs.idx

mpv then tries to guess the corressponding vobsub sub file for that idx file, and then passes that guess to ffmpeg.

ffmpeg then internally removes the file:// prefix and does a open() call.

The problem occurs if the URL contains non-ASCII characters where we see percent encoding. The URL is not decoded and passed to ffmpeg directly, so ffmpeg tries to open /path/to/%E5%A4%A9/subs.sub which obviously doesn't exist.

The idx file works because we decode that somewhere else before passing to ffmpeg.

If we know the vobsub idx file path is a URL, update the filename we use for the vobsub sub file guess to use the decoded path to the vobsub idx file

Fixes https://github.com/mpv-player/mpv/issues/10860

Signed-off-by: Nick Sarnie <sarnex@gentoo.org>

