### PR TITLE
vo: hwdec: remove legacy_names

### DIFF
--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -189,8 +189,6 @@ static int ra_hwdec_validate_opt_full(struct mp_log *log, bool include_modes,
             mp_info(log, "    %s\n", drv->name);
         } else if (bstr_equals0(param, drv->name)) {
             return 1;
-        } else if (bstr_equals0(param, drv->legacy_name)) {
-            return 1;
         }
     }
     if (help) {
@@ -279,12 +277,6 @@ void ra_hwdec_ctx_init(struct ra_hwdec_ctx *ctx, struct mp_hwdec_devices *devs,
         for (int n = 0; ra_hwdec_drivers[n]; n++) {
             const struct ra_hwdec_driver *drv = ra_hwdec_drivers[n];
             if (strcmp(type, drv->name) == 0) {
-                load_add_hwdec(ctx, devs, drv, false);
-                break;
-            } else if (drv->legacy_name && strcmp(type, drv->legacy_name) == 0) {
-                MP_WARN(ctx, "gpu-hwdec-interop was selected with the legacy name '%s'. "
-                             "Please change it to '%s' in your config file or command line.\n",
-                             drv->legacy_name, drv->name);
                 load_add_hwdec(ctx, devs, drv, false);
                 break;
             }

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -127,11 +127,6 @@ struct ra_hwdec_driver {
     // hw_image==src==dst==NULL is passed to clear the overlay.
     int (*overlay_frame)(struct ra_hwdec *hw, struct mp_image *hw_image,
                          struct mp_rect *src, struct mp_rect *dst, bool newframe);
-
-    // Some interop backends have changed name over time. We record the old name
-    // so that config files and command lines continue to work when they
-    // reference the old name.
-    const char *legacy_name;
 };
 
 extern const struct ra_hwdec_driver *const ra_hwdec_drivers[];

--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -283,5 +283,4 @@ const struct ra_hwdec_driver ra_hwdec_cuda = {
         .map = mapper_map,
         .unmap = mapper_unmap,
     },
-    .legacy_name = "cuda-nvdec",
 };

--- a/video/out/hwdec/hwdec_drmprime_overlay.c
+++ b/video/out/hwdec/hwdec_drmprime_overlay.c
@@ -318,5 +318,4 @@ const struct ra_hwdec_driver ra_hwdec_drmprime_overlay = {
     .init = init,
     .overlay_frame = overlay_frame,
     .uninit = uninit,
-    .legacy_name = "drmprime-drm",
 };

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -529,5 +529,4 @@ const struct ra_hwdec_driver ra_hwdec_vaapi = {
         .map = mapper_map,
         .unmap = mapper_unmap,
     },
-    .legacy_name = "vaapi-egl"
 };


### PR DESCRIPTION
These were introduced for configuration compatibility in 0.35 but we don't want to retain them past that point.