### PR TITLE
wayland: error out if essential protocol support is missing

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -329,6 +329,31 @@ static int preinit(struct vo *vo)
     if (!p->ctx)
        goto err_out;
     assert(p->ctx->ra);
+
+    if (!vo->wl->dmabuf) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+                 zwp_linux_dmabuf_v1_interface.name);
+        return VO_ERROR;
+    }
+
+    if (!vo->wl->shm) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+                 wl_shm_interface.name);
+        return VO_ERROR;
+    }
+
+    if (!vo->wl->video_subsurface) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+                 wl_subcompositor_interface.name);
+        return VO_ERROR;
+    }
+
+    if (!vo->wl->viewport) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+                 wp_viewporter_interface.name);
+        return VO_ERROR;
+    }
+
     vo->hwdec_devs = hwdec_devices_create();
     hwdec_devices_set_loader(vo->hwdec_devs, call_request_hwdec_api, vo);
     assert(!p->hwdec_ctx.ra);

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -134,6 +134,11 @@ static int preinit(struct vo *vo)
 
     if (!vo_wayland_init(vo))
         return -1;
+    if (!vo->wl->shm) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+                 wl_shm_interface.name);
+        return -1;
+    }
     p->sws = mp_sws_alloc(vo);
     p->sws->log = vo->log;
     mp_sws_enable_cmdline_opts(p->sws, vo->global);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1931,6 +1931,12 @@ int vo_wayland_init(struct vo *vo)
     /* Do a roundtrip to run the registry */
     wl_display_roundtrip(wl->display);
 
+    if (!wl->surface) {
+        MP_FATAL(wl, "Compositor doesn't support %s (ver. 4)\n",
+                 wl_compositor_interface.name);
+        return false;
+    }
+
     if (!wl->wm_base) {
         MP_FATAL(wl, "Compositor doesn't support the required %s protocol!\n",
                  xdg_wm_base_interface.name);


### PR DESCRIPTION
Related issue: #10868. While most protocols are in theory optional, a small amount of them are absolutely essential and nothing will work without them. We should make sure to error out in those cases and not try to actually do anything. For wayland support in general, wl_compositor support is obviously required. If there is no wl_surface, you can't do anything. Additionally, vo_wlshm quite obviously requires wl_shm so mark that one as well. vo_dmabuf_wayland needs linux_dmabuf, viewporter, wl_shm, and wl_subcompositor. In practice, these are all very standard protocols and shouldn't be missing but the linked issue above is at least one example where a compositor was stuck on an ancient version of a wayland interface.