### PR TITLE
meson: unbreak linux/input-event-codes.h detection in some cases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -976,7 +976,10 @@ wayland = {
              dependency('wayland-cursor', version: '>= 1.15.0', required: get_option('wayland')),
              dependency('wayland-protocols', version: '>= 1.15', required: get_option('wayland')),
              dependency('xkbcommon', version: '>= 0.3.0', required: get_option('wayland'))],
-    'header': cc.has_header('linux/input-event-codes.h', required: get_option('wayland')),
+    'header': cc.has_header('linux/input-event-codes.h', required: get_option('wayland'),
+                            # Pass CFLAGS from a related package as a hint for non-Linux
+                            dependencies: dependency('wayland-client', required: get_option('wayland'))),
+
     'scanner': find_program('wayland-scanner', required: get_option('wayland')),
 }
 wayland_deps = true


### PR DESCRIPTION
[Found downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=267765). When disabling some Meson options `-I/usr/local/include` maybe disappear, breaking configure check. `evdev-proto` (a subset of linux-headers) which provides the header on some BSDs doesn't support pkg-config (lacks *.pc file), so use one of wayland libraries as approximate location for now.

Note, using `dependencies` as `include_directories` looks even more hacky:
- `include_directories: include_directories(dependency('wayland-client').get_variable(pkgconfig: 'includedir')))`
- `include_directories: include_directories(get_option('prefix') / 'include')`

https://mesonbuild.com/Reference-manual_returned_compiler.html#compilercheck_header
