### PR TITLE
lcms: always parse lcms2-related options

### DIFF
--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -486,11 +486,8 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
 static int validate_3dlut_size_opt(struct mp_log *log, const m_option_t *opt,
                                    struct bstr name, const char **value)
 {
-    struct bstr param = bstr0(*value);
     int p1, p2, p3;
-    char s[20];
-    snprintf(s, sizeof(s), "%.*s", BSTR_P(param));
-    return gl_parse_3dlut_size(s, &p1, &p2, &p3);
+    return gl_parse_3dlut_size(*value, &p1, &p2, &p3) ? 0 : M_OPT_INVALID;
 }
 
 #define OPT_BASE_STRUCT struct mp_icc_opts

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -54,40 +54,6 @@ struct gl_lcms {
     struct mp_icc_opts *opts;
 };
 
-static int validate_3dlut_size_opt(struct mp_log *log, const m_option_t *opt,
-                                   struct bstr name, const char **value)
-{
-    struct bstr param = bstr0(*value);
-    int p1, p2, p3;
-    char s[20];
-    snprintf(s, sizeof(s), "%.*s", BSTR_P(param));
-    return gl_parse_3dlut_size(s, &p1, &p2, &p3);
-}
-
-#define OPT_BASE_STRUCT struct mp_icc_opts
-const struct m_sub_options mp_icc_conf = {
-    .opts = (const m_option_t[]) {
-        {"use-embedded-icc-profile", OPT_FLAG(use_embedded)},
-        {"icc-profile", OPT_STRING(profile), .flags = M_OPT_FILE},
-        {"icc-profile-auto", OPT_FLAG(profile_auto)},
-        {"icc-cache-dir", OPT_STRING(cache_dir), .flags = M_OPT_FILE},
-        {"icc-intent", OPT_INT(intent)},
-        {"icc-force-contrast", OPT_CHOICE(contrast, {"no", 0}, {"inf", -1}),
-            M_RANGE(0, 1000000)},
-        {"icc-3dlut-size", OPT_STRING_VALIDATE(size_str, validate_3dlut_size_opt)},
-        {"3dlut-size", OPT_REPLACED("icc-3dlut-size")},
-        {"icc-cache", OPT_REMOVED("see icc-cache-dir")},
-        {"icc-contrast", OPT_REMOVED("see icc-force-contrast")},
-        {0}
-    },
-    .size = sizeof(struct mp_icc_opts),
-    .defaults = &(const struct mp_icc_opts) {
-        .size_str = "64x64x64",
-        .intent = INTENT_RELATIVE_COLORIMETRIC,
-        .use_embedded = true,
-    },
-};
-
 static void lcms2_error_handler(cmsContext ctx, cmsUInt32Number code,
                                 const char *msg)
 {
@@ -487,12 +453,6 @@ error_exit:
 
 #else /* HAVE_LCMS2 */
 
-const struct m_sub_options mp_icc_conf = {
-    .opts = (const m_option_t[]) { {0} },
-    .size = sizeof(struct mp_icc_opts),
-    .defaults = &(const struct mp_icc_opts) {0},
-};
-
 struct gl_lcms *gl_lcms_init(void *talloc_ctx, struct mp_log *log,
                              struct mpv_global *global,
                              struct mp_icc_opts *opts)
@@ -522,3 +482,37 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
 }
 
 #endif
+
+static int validate_3dlut_size_opt(struct mp_log *log, const m_option_t *opt,
+                                   struct bstr name, const char **value)
+{
+    struct bstr param = bstr0(*value);
+    int p1, p2, p3;
+    char s[20];
+    snprintf(s, sizeof(s), "%.*s", BSTR_P(param));
+    return gl_parse_3dlut_size(s, &p1, &p2, &p3);
+}
+
+#define OPT_BASE_STRUCT struct mp_icc_opts
+const struct m_sub_options mp_icc_conf = {
+    .opts = (const m_option_t[]) {
+        {"use-embedded-icc-profile", OPT_FLAG(use_embedded)},
+        {"icc-profile", OPT_STRING(profile), .flags = M_OPT_FILE},
+        {"icc-profile-auto", OPT_FLAG(profile_auto)},
+        {"icc-cache-dir", OPT_STRING(cache_dir), .flags = M_OPT_FILE},
+        {"icc-intent", OPT_INT(intent)},
+        {"icc-force-contrast", OPT_CHOICE(contrast, {"no", 0}, {"inf", -1}),
+            M_RANGE(0, 1000000)},
+        {"icc-3dlut-size", OPT_STRING_VALIDATE(size_str, validate_3dlut_size_opt)},
+        {"3dlut-size", OPT_REPLACED("icc-3dlut-size")},
+        {"icc-cache", OPT_REMOVED("see icc-cache-dir")},
+        {"icc-contrast", OPT_REMOVED("see icc-force-contrast")},
+        {0}
+    },
+    .size = sizeof(struct mp_icc_opts),
+    .defaults = &(const struct mp_icc_opts) {
+        .size_str = "64x64x64",
+        .intent = MP_INTENT_RELATIVE_COLORIMETRIC,
+        .use_embedded = true,
+    },
+};


### PR DESCRIPTION
Currently, the lcms-related options are only defined when lcms2 is enabled at build time. However, this causes issues (e.g. segfault) for vo_gpu_next, which relies on the presence of these options (to forward them to libplacebo).

(That libplacebo internally depends on lcms2 as well is an implementation detail - compiling mpv *without* lcms against libplacebo *with* lcms should be possible in principle)

Fixes: #10891
Closes: #10856