### PR TITLE
TOOLS/umpv: prefer $XDG_RUNTIME_DIR

### DIFF
--- a/TOOLS/umpv
+++ b/TOOLS/umpv
@@ -52,7 +52,7 @@ def make_abs(filename):
     return filename
 files = (make_abs(f) for f in files)
 
-SOCK = os.path.join(os.getenv("HOME"), ".umpv_socket")
+SOCK = os.path.join(os.getenv("XDG_RUNTIME_DIR", os.getenv("HOME")), ".umpv_socket")
 
 sock = None
 try:


### PR DESCRIPTION
Conform more to the [XDG standards](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

> There is a single base directory relative to which user-specific runtime files and other file objects should be placed. This directory is defined by the environment variable $XDG_RUNTIME_DIR. 

Didn't test.