### PR TITLE
vo: vulkan: allow picking devices by UUID

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5586,11 +5586,11 @@ them.
     results, as can missing or incorrect display FPS information (see
     ``--override-display-fps``).
 
-``--vulkan-device=<device name>``
-    The name of the Vulkan device to use for rendering and presentation. Use
+``--vulkan-device=<device name|UUID>``
+    The name or UUID of the Vulkan device to use for rendering and presentation. Use
     ``--vulkan-device=help`` to see the list of available devices and their
-    names. If left unspecified, the first enumerated hardware Vulkan device will
-    be used.
+    names and UUIDs. If left unspecified, the first enumerated hardware Vulkan
+    device will be used.
 
 ``--vulkan-swap-mode=<mode>``
     Controls the presentation mode of the vulkan swapchain. This is similar

--- a/meson.build
+++ b/meson.build
@@ -747,6 +747,11 @@ if features['uchardet']
     dependencies += uchardet
 endif
 
+features += {'lavu-uuid': libavutil.version().version_compare('>= 57.27.100')}
+if not features['lavu-uuid']
+    sources += files('misc/uuid.c')
+endif
+
 vapoursynth = dependency('vapoursynth', version: '>= 26', required: get_option('vapoursynth'))
 vapoursynth_script = dependency('vapoursynth-script', version: '>= 26',
                                 required: get_option('vapoursynth'))

--- a/misc/uuid.c
+++ b/misc/uuid.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 Pierre-Anthony Lemieux <pal@palemieux.com>
+ *                    Zane van Iperen <zane@zanevaniperen.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * Copyright (C) 1996, 1997 Theodore Ts'o.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, and the entire permission notice in its entirety,
+ *    including the disclaimer of warranties.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+ * WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/**
+ * @file
+ * UUID parsing and serialization utilities.
+ * The library treat the UUID as an opaque sequence of 16 unsigned bytes,
+ * i.e. ignoring the internal layout of the UUID, which depends on the type
+ * of the UUID.
+ *
+ * @author Pierre-Anthony Lemieux <pal@palemieux.com>
+ * @author Zane van Iperen <zane@zanevaniperen.com>
+ */
+
+#include "uuid.h"
+#include "error.h"
+#include "avstring.h"
+
+int av_uuid_parse(const char *in, AVUUID uu)
+{
+    if (strlen(in) != 36)
+        return AVERROR(EINVAL);
+
+    return av_uuid_parse_range(in, in + 36, uu);
+}
+
+static int xdigit_to_int(char c)
+{
+    c = av_tolower(c);
+
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+
+    if (c >= '0' && c <= '9')
+        return c - '0';
+
+    return -1;
+}
+
+int av_uuid_parse_range(const char *in_start, const char *in_end, AVUUID uu)
+{
+    int i;
+    const char *cp;
+
+    if ((in_end - in_start) != 36)
+        return AVERROR(EINVAL);
+
+    for (i = 0, cp = in_start; i < 16; i++) {
+        int hi;
+        int lo;
+
+        if (i == 4 || i == 6 || i == 8 || i == 10)
+            cp++;
+
+        hi = xdigit_to_int(*cp++);
+        lo = xdigit_to_int(*cp++);
+
+        if (hi == -1 || lo == -1)
+            return AVERROR(EINVAL);
+
+        uu[i] = (hi << 4) + lo;
+    }
+
+    return 0;
+}
+
+static const char hexdigits_lower[16] = "0123456789abcdef";
+
+void av_uuid_unparse(const AVUUID uuid, char *out)
+{
+    char *p = out;
+
+    for (int i = 0; i < 16; i++) {
+        uint8_t tmp;
+
+        if (i == 4 || i == 6 || i == 8 || i == 10)
+            *p++ = '-';
+
+        tmp = uuid[i];
+        *p++ = hexdigits_lower[tmp >> 4];
+        *p++ = hexdigits_lower[tmp & 15];
+    }
+
+    *p = '\0';
+}
+
+int av_uuid_urn_parse(const char *in, AVUUID uu)
+{
+    if (av_stristr(in, "urn:uuid:") != in)
+        return AVERROR(EINVAL);
+
+    return av_uuid_parse(in + 9, uu);
+}

--- a/misc/uuid.c
+++ b/misc/uuid.c
@@ -61,8 +61,8 @@
  */
 
 #include "uuid.h"
-#include "error.h"
-#include "avstring.h"
+#include "libavutil/error.h"
+#include "libavutil/avstring.h"
 
 int av_uuid_parse(const char *in, AVUUID uu)
 {

--- a/misc/uuid.h
+++ b/misc/uuid.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022 Pierre-Anthony Lemieux <pal@palemieux.com>
+ *                    Zane van Iperen <zane@zanevaniperen.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * UUID parsing and serialization utilities.
+ * The library treats the UUID as an opaque sequence of 16 unsigned bytes,
+ * i.e. ignoring the internal layout of the UUID, which depends on the type
+ * of the UUID.
+ *
+ * @author Pierre-Anthony Lemieux <pal@palemieux.com>
+ * @author Zane van Iperen <zane@zanevaniperen.com>
+ */
+
+#ifndef AVUTIL_UUID_H
+#define AVUTIL_UUID_H
+
+#include <stdint.h>
+#include <string.h>
+
+#define AV_PRI_UUID                          \
+    "%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-" \
+    "%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx"
+
+#define AV_PRI_URN_UUID                               \
+    "urn:uuid:%02hhx%02hhx%02hhx%02hhx-%02hhx%02hhx-" \
+    "%02hhx%02hhx-%02hhx%02hhx-%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx"
+
+/* AV_UUID_ARG() is used together with AV_PRI_UUID() or AV_PRI_URN_UUID
+ * to print UUIDs, e.g.
+ * av_log(NULL, AV_LOG_DEBUG, "UUID: " AV_PRI_UUID, AV_UUID_ARG(uuid));
+ */
+#define AV_UUID_ARG(x)                  \
+    (x)[ 0], (x)[ 1], (x)[ 2], (x)[ 3], \
+    (x)[ 4], (x)[ 5], (x)[ 6], (x)[ 7], \
+    (x)[ 8], (x)[ 9], (x)[10], (x)[11], \
+    (x)[12], (x)[13], (x)[14], (x)[15]
+
+#define AV_UUID_LEN 16
+
+/* Binary representation of a UUID */
+typedef uint8_t AVUUID[AV_UUID_LEN];
+
+/**
+ * Parses a string representation of a UUID formatted according to IETF RFC 4122
+ * into an AVUUID. The parsing is case-insensitive. The string must be 37
+ * characters long, including the terminating NUL character.
+ *
+ * Example string representation: "2fceebd0-7017-433d-bafb-d073a7116696"
+ *
+ * @param[in]  in  String representation of a UUID,
+ *                 e.g. 2fceebd0-7017-433d-bafb-d073a7116696
+ * @param[out] uu  AVUUID
+ * @return         A non-zero value in case of an error.
+ */
+int av_uuid_parse(const char *in, AVUUID uu);
+
+/**
+ * Parses a URN representation of a UUID, as specified at IETF RFC 4122,
+ * into an AVUUID. The parsing is case-insensitive. The string must be 46
+ * characters long, including the terminating NUL character.
+ *
+ * Example string representation: "urn:uuid:2fceebd0-7017-433d-bafb-d073a7116696"
+ *
+ * @param[in]  in  URN UUID
+ * @param[out] uu  AVUUID
+ * @return         A non-zero value in case of an error.
+ */
+int av_uuid_urn_parse(const char *in, AVUUID uu);
+
+/**
+ * Parses a string representation of a UUID formatted according to IETF RFC 4122
+ * into an AVUUID. The parsing is case-insensitive.
+ *
+ * @param[in]  in_start Pointer to the first character of the string representation
+ * @param[in]  in_end   Pointer to the character after the last character of the
+ *                      string representation. That memory location is never
+ *                      accessed. It is an error if `in_end - in_start != 36`.
+ * @param[out] uu       AVUUID
+ * @return              A non-zero value in case of an error.
+ */
+int av_uuid_parse_range(const char *in_start, const char *in_end, AVUUID uu);
+
+/**
+ * Serializes a AVUUID into a string representation according to IETF RFC 4122.
+ * The string is lowercase and always 37 characters long, including the
+ * terminating NUL character.
+ *
+ * @param[in]  uu  AVUUID
+ * @param[out] out Pointer to an array of no less than 37 characters.
+ */
+void av_uuid_unparse(const AVUUID uu, char *out);
+
+/**
+ * Compares two UUIDs for equality.
+ *
+ * @param[in]  uu1  AVUUID
+ * @param[in]  uu2  AVUUID
+ * @return          Nonzero if uu1 and uu2 are identical, 0 otherwise
+ */
+static inline int av_uuid_equal(const AVUUID uu1, const AVUUID uu2)
+{
+    return memcmp(uu1, uu2, AV_UUID_LEN) == 0;
+}
+
+/**
+ * Copies the bytes of src into dest.
+ *
+ * @param[out]  dest  AVUUID
+ * @param[in]   src   AVUUID
+ */
+static inline void av_uuid_copy(AVUUID dest, const AVUUID src)
+{
+    memcpy(dest, src, AV_UUID_LEN);
+}
+
+/**
+ * Sets a UUID to the nil UUID, i.e. a UUID with have all
+ * its 128 bits set to zero.
+ *
+ * @param[in,out]  uu  UUID to be set to the nil UUID
+ */
+static inline void av_uuid_nil(AVUUID uu)
+{
+    memset(uu, 0, AV_UUID_LEN);
+}
+
+#endif /* AVUTIL_UUID_H */


### PR DESCRIPTION
We currently only allow specifying the Vulkan device to use by name. We
did this to avoid confusion around devices being enumerated in an
unpredictable order. However, there is a valid edge case where a system
may contain multiple devices of the same type - which means they will
have the same name, and so you can't control which one is used.

This change implements picking devices by UUID so that if names don't
work, you have some option available. As Vulkan 1.1 is a hard
requirement for libplacebo, we can just use UUIDs without conditional
checks.

Fixes #10898