### PR TITLE
audio: reset pull AO at end of file

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -357,7 +357,7 @@ void ao_set_paused(struct ao *ao, bool paused)
 
     pthread_mutex_lock(&p->lock);
 
-    if (p->playing && !p->paused && paused) {
+    if ((p->playing || !ao->driver->write) && !p->paused && paused) {
         if (p->streaming && !ao->stream_silence) {
             if (ao->driver->write) {
                 if (!p->recover_pause)


### PR DESCRIPTION
When a pull AO reaches reaches EOF then ao_read_data() will set p->playing = false.
Because the ao is marked as not playing ao_set_pause(true) will not reset the AO.
This keeps the output stream unintentionally open.

Another conditional is added that makes sure the necessary reset is performed.

Fixes #9835 

This is a revised version of the change presented in #9835 before.
I am not entirely sure this is the correct place to fix this.

Test protocol:

* `pw-top`
* `mpv --no-config --ao=pipewire --keep-open $FILE`
* Validate that the `S`(tate) column in `pw-top` for the mpv node shows `I`

Cc @philipl @sfan5 , if maybe uau could take a look that would be great, too.