### PR TITLE
ffmpeg: increase minimum required version to 4.4

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -36,9 +36,7 @@
 #include <libavutil/display.h>
 #include <libavutil/opt.h>
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 43, 100)
 #include <libavutil/dovi_meta.h>
-#endif
 
 #include "audio/chmap_avchannel.h"
 
@@ -745,14 +743,12 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
                 sh->codec->rotate = (((int)(-r) % 360) + 360) % 360;
         }
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 43, 100)
         if ((sd = av_stream_get_side_data(st, AV_PKT_DATA_DOVI_CONF, NULL))) {
             const AVDOVIDecoderConfigurationRecord *cfg = (void *) sd;
             MP_VERBOSE(demuxer, "Found Dolby Vision config record: profile "
                        "%d level %d\n", cfg->dv_profile, cfg->dv_level);
             av_format_inject_global_side_data(avfc);
         }
-#endif
 
         // This also applies to vfw-muxed mkv, but we can't detect these easily.
         sh->codec->avi_dts = matches_avinputformat_name(priv, "avi");

--- a/meson.build
+++ b/meson.build
@@ -16,12 +16,12 @@ source_root = meson.project_source_root()
 python = find_program('python3')
 
 # ffmpeg
-libavcodec = dependency('libavcodec', version: '>= 58.12.100')
-libavfilter = dependency('libavfilter', version: '>= 7.14.100')
-libavformat = dependency('libavformat', version: '>= 58.9.100')
-libavutil = dependency('libavutil', version: '>= 56.12.100')
-libswresample = dependency('libswresample', version: '>= 3.0.100')
-libswscale = dependency('libswscale', version: '>= 5.0.101')
+libavcodec = dependency('libavcodec', version: '>= 58.134.100')
+libavfilter = dependency('libavfilter', version: '>= 7.110.100')
+libavformat = dependency('libavformat', version: '>= 58.76.100')
+libavutil = dependency('libavutil', version: '>= 56.70.100')
+libswresample = dependency('libswresample', version: '>= 3.9.100')
+libswscale = dependency('libswscale', version: '>= 5.9.100')
 
 libass = dependency('libass', version: '>= 0.12.2')
 pthreads = dependency('threads')
@@ -631,7 +631,7 @@ if features['libarchive']
                      'stream/stream_libarchive.c')
 endif
 
-libavdevice = dependency('libavdevice', version: '>= 57.0.0', required: get_option('libavdevice'))
+libavdevice = dependency('libavdevice', version: '>= 58.13.100', required: get_option('libavdevice'))
 features += {'libavdevice': libavdevice.found()}
 if features['libavdevice']
     dependencies += libavdevice

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 
 #include <libavcodec/avcodec.h>
+#include <libavformat/version.h>
 #include <libavutil/common.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/opt.h>
@@ -1153,7 +1154,11 @@ static int decode_frame(struct mp_filter *vd)
     mpi->dts = mp_pts_from_av(ctx->pic->pkt_dts, &ctx->codec_timebase);
 
     mpi->pkt_duration =
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 30, 100)
+        mp_pts_from_av(ctx->pic->duration, &ctx->codec_timebase);
+#else
         mp_pts_from_av(ctx->pic->pkt_duration, &ctx->codec_timebase);
+#endif
 
     av_frame_unref(ctx->pic);
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1026,11 +1026,9 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
     }
 #endif
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 61, 100)
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_FILM_GRAIN_PARAMS);
     if (sd)
         dst->film_grain = sd->buf;
-#endif
 
     for (int n = 0; n < src->nb_side_data; n++) {
         sd = src->side_data[n];

--- a/video/sws_utils.c
+++ b/video/sws_utils.c
@@ -21,6 +21,9 @@
 #include <libavcodec/avcodec.h>
 #include <libavutil/bswap.h>
 #include <libavutil/opt.h>
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 37, 100)
+#include <libavutil/pixdesc.h>
+#endif
 
 #include "config.h"
 
@@ -303,6 +306,16 @@ int mp_sws_reinit(struct mp_sws_context *ctx)
     int cr_src = mp_chroma_location_to_av(src.chroma_location);
     int cr_dst = mp_chroma_location_to_av(dst.chroma_location);
     int cr_xpos, cr_ypos;
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 37, 100)
+    if (av_chroma_location_enum_to_pos(&cr_xpos, &cr_ypos, cr_src) >= 0) {
+        av_opt_set_int(ctx->sws, "src_h_chr_pos", cr_xpos, 0);
+        av_opt_set_int(ctx->sws, "src_v_chr_pos", cr_ypos, 0);
+    }
+    if (av_chroma_location_enum_to_pos(&cr_xpos, &cr_ypos, cr_dst) >= 0) {
+        av_opt_set_int(ctx->sws, "dst_h_chr_pos", cr_xpos, 0);
+        av_opt_set_int(ctx->sws, "dst_v_chr_pos", cr_ypos, 0);
+    }
+#else
     if (avcodec_enum_to_chroma_pos(&cr_xpos, &cr_ypos, cr_src) >= 0) {
         av_opt_set_int(ctx->sws, "src_h_chr_pos", cr_xpos, 0);
         av_opt_set_int(ctx->sws, "src_v_chr_pos", cr_ypos, 0);
@@ -311,6 +324,7 @@ int mp_sws_reinit(struct mp_sws_context *ctx)
         av_opt_set_int(ctx->sws, "dst_h_chr_pos", cr_xpos, 0);
         av_opt_set_int(ctx->sws, "dst_v_chr_pos", cr_ypos, 0);
     }
+#endif
 
     // This can fail even with normal operation, e.g. if a conversion path
     // simply does not support these settings.

--- a/wscript
+++ b/wscript
@@ -412,12 +412,12 @@ libav_dependencies = [
     {
         'name': 'ffmpeg',
         'desc': 'FFmpeg library',
-        'func': check_pkg_config('libavutil',     '>= 56.12.100',
-                                 'libavcodec',    '>= 58.16.100',
-                                 'libavformat',   '>= 58.9.100',
-                                 'libswscale',    '>= 5.0.101',
-                                 'libavfilter',   '>= 7.14.100',
-                                 'libswresample', '>= 3.0.100'),
+        'func': check_pkg_config('libavutil',     '>= 56.70.100',
+                                 'libavcodec',    '>= 58.134.100',
+                                 'libavformat',   '>= 58.76.100',
+                                 'libswscale',    '>= 5.9.100',
+                                 'libavfilter',   '>= 7.110.100',
+                                 'libswresample', '>= 3.9.100'),
         'req': True,
         'fmsg': "Unable to find development files for some of the required \
 FFmpeg libraries. Git master is recommended."
@@ -428,7 +428,7 @@ FFmpeg libraries. Git master is recommended."
     }, {
         'name': '--libavdevice',
         'desc': 'libavdevice',
-        'func': check_pkg_config('libavdevice', '>= 57.0.0'),
+        'func': check_pkg_config('libavdevice', '>= 58.13.100'),
     }
 ]
 


### PR DESCRIPTION
Now that 0.35 has been released, we can consider increasing our minimum
required ffmpeg version. Currently, we think 4.4 is the most recent
version we can move to (from the current requirement of 4.0).

This allows us to remove a few conditionals and I also took the
opportunity to add proper handling for a couple of new deprecations.

I have not handled av_init_packet in this change as it's more
involved and I want us to decide we want to do the version bump before
putting in that work.