### PR TITLE
wayland: add wp-fractional-scale-v1 support

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -46,6 +46,10 @@ Interface changes
       need to explictly add `start` depending on how you have
       `--watch-later-options` configured.
     - add `--vd-lavc-dr=auto` and make it the default
+    - add support for the fractional scale protocol in wayland
+    - in wayland, hidpi window scaling now scales the window by the compositor's
+      dpi scale factor by default (can be disabled with --no-hidpi-window-scale
+      if fractional scaling support exists).
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -16,6 +16,11 @@ if features['wayland_protocols_1_27']
                   [wl_protocol_dir, 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml']]
 endif
 
+features += {'wayland_protocols_1_31': wayland['deps'][2].version().version_compare('>=1.31')}
+if features['wayland_protocols_1_31']
+    protocols += [[wl_protocol_dir, 'staging/fractional-scale/fractional-scale-v1.xml']]
+endif
+
 foreach p: protocols
     xml = join_paths(p)
     wl_protocols_source += custom_target(xml.underscorify() + '_c',

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -84,6 +84,8 @@ static void resize(struct ra_ctx *ctx)
 
     wl->vo->dwidth  = width;
     wl->vo->dheight = height;
+
+    vo_wayland_handle_fractional_scale(wl);
 }
 
 static bool wayland_egl_check_visible(struct ra_ctx *ctx)

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -43,8 +43,8 @@ static void egl_create_window(struct ra_ctx *ctx)
     struct vo_wayland_state *wl = ctx->vo->wl;
 
     p->egl_window = wl_egl_window_create(wl->surface,
-                                         mp_rect_w(wl->geometry) * wl->scaling,
-                                         mp_rect_h(wl->geometry) * wl->scaling);
+                                         mp_rect_w(wl->geometry),
+                                         mp_rect_h(wl->geometry));
 
     p->egl_surface = mpegl_create_window_surface(
         p->egl_display, p->egl_config, p->egl_window);
@@ -75,8 +75,8 @@ static void resize(struct ra_ctx *ctx)
     if (!p->egl_window)
         egl_create_window(ctx);
 
-    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
-    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
+    const int32_t width = mp_rect_w(wl->geometry);
+    const int32_t height = mp_rect_h(wl->geometry);
 
     vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
     if (p->egl_window)

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -1,6 +1,4 @@
 /*
- * Based on vo_gl.c by Reimar Doeffinger.
- *
  * This file is part of mpv.
  *
  * mpv is free software; you can redistribute it and/or
@@ -178,8 +176,8 @@ static void resize(struct vo *vo)
     struct mp_rect dst;
     struct mp_osd_res osd;
     struct mp_vo_opts *vo_opts = wl->vo_opts;
-    const int width = wl->scaling * mp_rect_w(wl->geometry);
-    const int height = wl->scaling * mp_rect_h(wl->geometry);
+    const int width = mp_rect_w(wl->geometry);
+    const int height = mp_rect_h(wl->geometry);
     
     vo_wayland_set_opaque_region(wl, 0);
     vo->dwidth = width;
@@ -377,7 +375,6 @@ static int preinit(struct vo *vo)
                  wp_viewporter_interface.name);
         goto err;
     }
-
 
     if (vo->wl->single_pixel_manager) {
 #if HAVE_WAYLAND_PROTOCOLS_1_27

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -182,8 +182,8 @@ static int resize(struct vo *vo)
 {
     struct priv *p = vo->priv;
     struct vo_wayland_state *wl = vo->wl;
-    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
-    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
+    const int32_t width = mp_rect_w(wl->geometry);
+    const int32_t height = mp_rect_h(wl->geometry);
     struct buffer *buf;
 
     vo_wayland_set_opaque_region(wl, 0);

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -204,6 +204,9 @@ static int resize(struct vo *vo)
         p->free_buffers = buf->next;
         talloc_free(buf);
     }
+
+    vo_wayland_handle_fractional_scale(wl);
+
     return mp_sws_reinit(p->sws);
 }
 

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -114,8 +114,8 @@ static bool resize(struct ra_ctx *ctx)
 
     MP_VERBOSE(wl, "Handling resize on the vk side\n");
 
-    const int32_t width = wl->scaling * mp_rect_w(wl->geometry);
-    const int32_t height = wl->scaling * mp_rect_h(wl->geometry);
+    const int32_t width = mp_rect_w(wl->geometry);
+    const int32_t height = mp_rect_h(wl->geometry);
 
     vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
     return ra_vk_ctx_resize(ctx, width, height);

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -118,6 +118,7 @@ static bool resize(struct ra_ctx *ctx)
     const int32_t height = mp_rect_h(wl->geometry);
 
     vo_wayland_set_opaque_region(wl, ctx->opts.want_alpha);
+    vo_wayland_handle_fractional_scale(wl);
     return ra_vk_ctx_resize(ctx, width, height);
 }
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -48,7 +48,6 @@ struct vo_wayland_state {
 
     /* Geometry */
     struct mp_rect geometry;
-    struct mp_rect vdparams;
     struct mp_rect window_size;
     struct wl_list output_list;
     struct vo_wayland_output *current_output;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -73,7 +73,7 @@ struct vo_wayland_state {
     int mouse_x;
     int mouse_y;
     int pending_vo_events;
-    int scaling;
+    double scaling;
     int timeout_count;
     int wakeup_pipe[2];
 
@@ -82,6 +82,11 @@ struct vo_wayland_state {
     void *content_type_manager;
     void *content_type;
     int current_content_type;
+
+    /* fractional-scale */
+    /* TODO: unvoid these if required wayland protocols is bumped to 1.31+ */
+    void *fractional_scale_manager;
+    void *fractional_scale;
 
     /* idle-inhibit */
     struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager;
@@ -156,6 +161,7 @@ bool vo_wayland_supported_format(struct vo *vo, uint32_t format, uint64_t modifi
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
 
+void vo_wayland_handle_fractional_scale(struct vo_wayland_state *wl);
 void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);
 void vo_wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_uninit(struct vo *vo);

--- a/wscript
+++ b/wscript
@@ -541,6 +541,11 @@ video_output_features = [
         'deps': 'wayland',
         'func': check_pkg_config('wayland-protocols >= 1.27'),
     } , {
+        'name': 'wayland-protocols-1-31',
+        'desc': 'wayland-protocols version 1.31+',
+        'deps': 'wayland',
+        'func': check_pkg_config('wayland-protocols >= 1.31'),
+    } , {
         'name': 'memfd_create',
         'desc': "Linux's memfd_create()",
         'deps': 'wayland',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -154,6 +154,15 @@ def build(ctx):
             protocol  = "staging/single-pixel-buffer/single-pixel-buffer-v1",
             target    = "generated/wayland/single-pixel-buffer-v1.h")
 
+
+    if ctx.dependency_satisfied('wayland-protocols-1-31'):
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/fractional-scale/fractional-scale-v1",
+            target    = "generated/wayland/fractional-scale-v1.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/fractional-scale/fractional-scale-v1",
+            target    = "generated/wayland/fractional-scale-v1.h")
+
     ctx(features = "ebml_header", target = "generated/ebml_types.h")
     ctx(features = "ebml_definitions", target = "generated/ebml_defs.inc")
 
@@ -557,6 +566,7 @@ def build(ctx):
         ( "video/out/w32_common.c",              "win32-desktop" ),
         ( "generated/wayland/single-pixel-buffer-v1.c", "wayland-protocols-1-27" ),
         ( "generated/wayland/content-type-v1.c", "wayland-protocols-1-27" ),
+        ( "generated/wayland/fractional-scale-v1.c", "wayland-protocols-1-31"),
         ( "generated/wayland/idle-inhibit-unstable-v1.c", "wayland" ),
         ( "generated/wayland/presentation-time.c", "wayland" ),
         ( "generated/wayland/xdg-decoration-unstable-v1.c", "wayland" ),


### PR DESCRIPTION
~Currently depends on wayland-protocols from master. Presumably they'll cut a new release soon though since this is a pretty major feature.~ Now depends on wayland-protocols 1.31.

Tested this on sway/wlroots with https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3511 and https://github.com/swaywm/sway/pull/6929 (with the later rebased/cherry-picked locally). Seems to work as desired and fortunately it's not nearly as invasive into mpv's geometry handling as I initially feared.

This does sort of change the semantics of how mpv on wayland handles HiDPI but it's actually more inline with other platforms now. Basically, the window is always scaled by the extra scale factor. Previously, it was always shown as the exact pixel size with no extra scaling.

Eventually, I'd like to eliminate the old `buffer_scale` codepath and logic completely because the fractional scale protocol is simply better in every way, but that will have to wait for the future so for now we have to juggle these three different cases (fractional scale, regular wayland integer scaling, and no scaling at all).

TODO:
- [x] Fix autofit/geometry options
- [x] Actually tie this to a wayland-protocols release
- [x] waf support
- [x] Document the change in scaling behavior
- [x] Support the `--no-hidpi-window-scale` option with the fractional scale method
- [x] More testing in general

Fixes #9443.