### PR TITLE
ao_coreaudio: use device's nominal sample rate for latency properties

### DIFF
--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -456,7 +456,14 @@ int64_t ca_get_device_latency_us(struct ao *ao, AudioDeviceID device)
         }
     }
 
-    return ca_frames_to_us(ao, latency_frames);
+    double sample_rate = ao->samplerate;
+    OSStatus err = CA_GET_O(device, kAudioDevicePropertyNominalSampleRate, &sample_rate);
+    CHECK_CA_WARN("cannot get device sample rate, falling back to AO sample rate!");
+    if (err == noErr) {
+        MP_VERBOSE(ao, "Device sample rate: %f\n", sample_rate);
+    }
+
+    return latency_frames / sample_rate * 1e6;
 }
 
 static OSStatus ca_change_format_listener(


### PR DESCRIPTION
Fixes sync issues when using high-latency devices at non-native sample rates. Closes #10984.