### PR TITLE
hwdec_drmprime: support yuv420p format

### DIFF
--- a/video/out/hwdec/dmabuf_interop_gl.c
+++ b/video/out/hwdec/dmabuf_interop_gl.c
@@ -180,6 +180,11 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper,
                 format[0] = DRM_FORMAT_R8;
                 format[1] = DRM_FORMAT_GR88;
                 break;
+            case DRM_FORMAT_YUV420:
+                format[0] = DRM_FORMAT_R8;
+                format[1] = DRM_FORMAT_R8;
+                format[2] = DRM_FORMAT_R8;
+                break;
             case DRM_FORMAT_P010:
                 format[0] = DRM_FORMAT_R16;
                 format[1] = DRM_FORMAT_GR1616;

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -115,6 +115,7 @@ static int init(struct ra_hwdec *hw)
      */
     int num_formats = 0;
     MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_NV12);
+    MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_420P);
     MP_TARRAY_APPEND(p, p->formats, num_formats, 0); // terminate it
 
     p->hwctx.hw_imgfmt = IMGFMT_DRMPRIME;


### PR DESCRIPTION
H264 hardware decode with v4l2m2m wasn't working on the RPi 4. Mpv would report the image format (yuv420p) wasn't supported. The change to hwdec_drmprime.c is to explicitly say that the format now is supported. The change to dmabuf_interop_gl.c is to specify the colour format of the planes before generating egl images. These changes were tested on a Pi 4 with this fork of ffmpeg: https://github.com/jc-kynesim/rpi-ffmpeg.

Should fix #10956 