### PR TITLE
filter_kernels: fix kaiser

### DIFF
--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -240,7 +240,7 @@ static double kaiser(params *p, double x)
 {
     if (x > 1)
         return 0;
-    double i0a = 1.0 / bessel_i0(p->params[1]);
+    double i0a = 1.0 / bessel_i0(p->params[0]);
     return bessel_i0(p->params[0] * sqrt(1.0 - x * x)) * i0a;
 }
 


### PR DESCRIPTION
Seems to me that `params[1]` is set to `NAN` and here should be the same value as in `params[0]`. Also small suggestion, I think that an entire function could be simplified to `return bessel_i0(p->params[0] * sqrt(1.0 - x * x)) / bessel_i0(p->params[0]);` or ` return bessel_i0(p->params[0] * sqrt(1.0 - x * x));`. Because `if (x > 1)` seems to be unnecessary here since we do similar thing elsewhere for all windows and normalization here is also probably unnecessary because we normalize kernel with weight sum.