### PR TITLE
vo_gpu_next: overhaul screenshot support (HDR/native screenshots, better colorspace defaulting, better triggering of fast path)

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -369,6 +369,7 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
     if (image && need_add_subs)
         add_subs(mpctx, image);
 
+    mp_image_params_guess_csp(&image->params);
     return image;
 }
 

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -19,6 +19,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <libavcodec/avcodec.h>
+
 #include "config.h"
 
 #include "osdep/io.h"
@@ -332,6 +334,7 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
                                        bool high_depth)
 {
     struct mp_image *image = NULL;
+    const struct image_writer_opts *imgopts = mpctx->opts->screenshot_image_opts;
     if (mode == MODE_SUBTITLES && osd_get_render_subs_in_filter(mpctx->osd))
         mode = 0;
     bool need_add_subs = mode == MODE_SUBTITLES;
@@ -343,8 +346,8 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
             .scaled = mode == MODE_FULL_WINDOW,
             .subs = mode != 0,
             .osd = mode == MODE_FULL_WINDOW,
-            .high_bit_depth = high_depth &&
-                              mpctx->opts->screenshot_image_opts->high_bit_depth,
+            .high_bit_depth = high_depth && imgopts->high_bit_depth,
+            .native_csp = image_writer_flexible_csp(imgopts),
         };
         if (!mpctx->opts->screenshot_sw)
             vo_control(mpctx->video_out, VOCTRL_SCREENSHOT, &ctrl);

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -332,6 +332,19 @@ bool image_writer_high_depth(const struct image_writer_opts *opts)
     ;
 }
 
+bool image_writer_flexible_csp(const struct image_writer_opts *opts)
+{
+    return false
+#if HAVE_JPEGXL
+        || opts->format == AV_CODEC_ID_JPEGXL
+#endif
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 58, 100)
+        // This version added support for cICP tag writing
+        || opts->format == AV_CODEC_ID_PNG
+#endif
+    ;
+}
+
 int image_writer_format_from_ext(const char *ext)
 {
     for (int n = 0; mp_image_writer_formats[n].name; n++) {

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -356,6 +356,7 @@ int image_writer_format_from_ext(const char *ext)
 
 static struct mp_image *convert_image(struct mp_image *image, int destfmt,
                                       enum mp_csp_levels yuv_levels,
+                                      const struct image_writer_opts *opts,
                                       struct mpv_global *global,
                                       struct mp_log *log)
 {
@@ -372,13 +373,17 @@ static struct mp_image *convert_image(struct mp_image *image, int destfmt,
     };
     mp_image_params_guess_csp(&p);
 
-    // If RGB, just assume everything is correct.
-    if (p.color.space != MP_CSP_RGB) {
-        // Currently, assume what FFmpeg's jpg encoder or libwebp needs.
-        // Of course this works only for non-HDR (no HDR support in libswscale).
-        p.color.levels = yuv_levels;
-        p.color.space = MP_CSP_BT_601;
-        p.chroma_location = MP_CHROMA_CENTER;
+    if (!image_writer_flexible_csp(opts)) {
+        // Formats that don't support non-sRGB csps should be forced to sRGB
+        p.color.primaries = MP_CSP_PRIM_BT_709;
+        p.color.gamma = MP_CSP_TRC_SRGB;
+        p.color.light = MP_CSP_LIGHT_DISPLAY;
+        p.color.sig_peak = 0;
+        if (p.color.space != MP_CSP_RGB) {
+            p.color.levels = yuv_levels;
+            p.color.space = MP_CSP_BT_601;
+            p.chroma_location = MP_CHROMA_CENTER;
+        }
         mp_image_params_guess_csp(&p);
     }
 
@@ -445,7 +450,7 @@ bool write_image(struct mp_image *image, const struct image_writer_opts *opts,
         levels = MP_CSP_LEVELS_PC;
     }
 
-    struct mp_image *dst = convert_image(image, destfmt, levels, global, log);
+    struct mp_image *dst = convert_image(image, destfmt, levels, opts, global, log);
     if (!dst)
         return false;
 

--- a/video/image_writer.h
+++ b/video/image_writer.h
@@ -50,6 +50,9 @@ const char *image_writer_file_ext(const struct image_writer_opts *opts);
 // Return whether the selected format likely supports >8 bit per component.
 bool image_writer_high_depth(const struct image_writer_opts *opts);
 
+// Return whether the selected format likely supports non-sRGB colorspaces
+bool image_writer_flexible_csp(const struct image_writer_opts *opts);
+
 // Map file extension to format ID - return 0 (which is invalid) if unknown.
 int image_writer_format_from_ext(const char *ext);
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -179,7 +179,7 @@ struct voctrl_performance_data {
 };
 
 struct voctrl_screenshot {
-    bool scaled, subs, osd, high_bit_depth;
+    bool scaled, subs, osd, high_bit_depth, native_csp;
     struct mp_image *res;
 };
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1217,6 +1217,7 @@ static void video_screenshot(struct vo *vo, struct voctrl_screenshot *args)
     }
 
     struct pl_frame target = {
+        .repr = pl_color_repr_rgb,
         .num_planes = 1,
         .planes[0] = {
             .texture = fbo,

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1229,6 +1229,8 @@ static void video_screenshot(struct vo *vo, struct voctrl_screenshot *args)
     if (args->scaled) {
         // Apply target LUT, ICC profile and CSP override only in window mode
         apply_target_options(p, &target);
+    } else if (args->native_csp) {
+        target.color = image.color;
     } else {
         target.color = pl_color_space_srgb;
     }
@@ -1262,6 +1264,9 @@ static void video_screenshot(struct vo *vo, struct voctrl_screenshot *args)
         args->res->params.color.levels = p->output_levels;
         args->res->params.color.sig_peak = opts->target_peak;
         args->res->params.p_w = args->res->params.p_h = 1;
+    } else if (args->native_csp) {
+        args->res->params.color = mpi->params.color;
+        args->res->params.color.space = MP_CSP_RGB;
     } else {
         args->res->params.color.primaries = MP_CSP_PRIM_BT_709;
         args->res->params.color.gamma = MP_CSP_TRC_SRGB;

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1226,7 +1226,11 @@ static void video_screenshot(struct vo *vo, struct voctrl_screenshot *args)
         },
     };
 
-    apply_target_options(p, &target);
+    if (args->scaled) {
+        // Apply target LUT, ICC profile and CSP override only in window mode
+        apply_target_options(p, &target);
+    }
+
     apply_crop(&image, src, mpi->params.w, mpi->params.h);
     apply_crop(&target, dst, fbo->params.w, fbo->params.h);
 


### PR DESCRIPTION
A series of screenshot-related changes aimed at fixing #10988.

Testing very heavily welcome. I'm not entirely happy with this, because I think there are a few corner cases that need to be ironed out. And in particular, it might be worth making sure `screenshot window` still dumps out pixels as-is, since this is actually a useful debugging tool (for myself and others), which I think this series breaks.

RFC, I guess.