### PR TITLE
Add "auto" option to vd-lavc-dr and make it the default

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -45,6 +45,7 @@ Interface changes
       watch-later. It is still written by default but you may
       need to explictly add `start` depending on how you have
       `--watch-later-options` configured.
+    - add `--vd-lavc-dr=auto` and make it the default
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1700,14 +1700,18 @@ Video
     support this, then it will be treated as ``cpu``, regardless of the setting.
     Currently, only ``gpu-next`` supports film grain application.
 
-``--vd-lavc-dr=<yes|no>``
-    Enable direct rendering (default: yes). If this is set to ``yes``, the
+``--vd-lavc-dr=<auto|yes|no>``
+    Enable direct rendering (default: auto). If this is set to ``yes``, the
     video will be decoded directly to GPU video memory (or staging buffers).
     This can speed up video upload, and may help with large resolutions or
     slow hardware. This works only with the following VOs:
 
         - ``gpu``: requires at least OpenGL 4.4 or Vulkan.
         - ``libmpv``: The libmpv render API has optional support.
+
+    The ``auto`` option will try to guess whether DR can improve performance
+    on your particular hardware. Currently this enables it on AMD or NVIDIA
+    if using OpenGL or unconditionally if using Vulkan.
 
     Using video filters of any kind that write to the image data (or output
     newly allocated frames) will silently disable the DR code path.

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -985,7 +985,7 @@ static int get_buffer2_direct(AVCodecContext *avctx, AVFrame *pic, int flags)
     struct mp_image *img = mp_image_pool_get_no_alloc(p->dr_pool, imgfmt, w, h);
     if (!img) {
         MP_DBG(p, "Allocating new DR image...\n");
-        img = vo_get_image(p->vo, imgfmt, w, h, stride_align);
+        img = vo_get_image(p->vo, imgfmt, w, h, stride_align, 0);
         if (!img) {
             MP_DBG(p, "...failed..\n");
             goto fallback;

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -120,7 +120,8 @@ const struct m_sub_options vd_lavc_conf = {
         {"vd-lavc-software-fallback", OPT_CHOICE(software_fallback,
             {"no", INT_MAX}, {"yes", 1}), M_RANGE(1, INT_MAX)},
         {"vd-lavc-o", OPT_KEYVALUELIST(avopts)},
-        {"vd-lavc-dr", OPT_FLAG(dr)},
+        {"vd-lavc-dr", OPT_CHOICE(dr,
+            {"auto", -1}, {"no", 0}, {"yes", 1})},
         {"hwdec", OPT_STRING(hwdec_api),
             .help = hwdec_opt_help,
             .flags = M_OPT_OPTIONAL_PARAM | UPDATE_HWDEC},
@@ -139,7 +140,7 @@ const struct m_sub_options vd_lavc_conf = {
         .skip_idct = AVDISCARD_DEFAULT,
         .skip_frame = AVDISCARD_DEFAULT,
         .framedrop = AVDISCARD_NONREF,
-        .dr = 1,
+        .dr = -1,
         .hwdec_api = "no",
         .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores",
         // Maximum number of surfaces the player wants to buffer. This number
@@ -984,8 +985,10 @@ static int get_buffer2_direct(AVCodecContext *avctx, AVFrame *pic, int flags)
 
     struct mp_image *img = mp_image_pool_get_no_alloc(p->dr_pool, imgfmt, w, h);
     if (!img) {
-        MP_DBG(p, "Allocating new DR image...\n");
-        img = vo_get_image(p->vo, imgfmt, w, h, stride_align, 0);
+        bool host_cached = p->opts->dr == -1; // auto
+        int dr_flags = host_cached ? VO_DR_FLAG_HOST_CACHED : 0;
+        MP_DBG(p, "Allocating new%s DR image...\n", host_cached ? " (host-cached)" : "");
+        img = vo_get_image(p->vo, imgfmt, w, h, stride_align, dr_flags);
         if (!img) {
             MP_DBG(p, "...failed..\n");
             goto fallback;

--- a/video/out/dr_helper.h
+++ b/video/out/dr_helper.h
@@ -15,7 +15,7 @@ struct mp_dispatch_queue;
 //       dr_helper instance can be destroyed.
 struct dr_helper *dr_helper_create(struct mp_dispatch_queue *dispatch,
             struct mp_image *(*get_image)(void *ctx, int imgfmt, int w, int h,
-                                          int stride_align),
+                                          int stride_align, int flags),
             void *get_image_ctx);
 
 // Make DR release calls (freeing images) reentrant if they are called on this
@@ -34,4 +34,4 @@ void dr_helper_release_thread(struct dr_helper *dr);
 // allocate a DR'ed image on the render thread (at least not in a way which
 // actually works if you want foreign threads to be able to free them).
 struct mp_image *dr_helper_get_image(struct dr_helper *dr, int imgfmt,
-                                     int w, int h, int stride_align);
+                                     int w, int h, int stride_align, int flags);

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -192,11 +192,11 @@ static int render(struct render_backend *ctx, mpv_render_param *params,
 }
 
 static struct mp_image *get_image(struct render_backend *ctx, int imgfmt,
-                                  int w, int h, int stride_align)
+                                  int w, int h, int stride_align, int flags)
 {
     struct priv *p = ctx->priv;
 
-    return gl_video_get_image(p->renderer, imgfmt, w, h, stride_align);
+    return gl_video_get_image(p->renderer, imgfmt, w, h, stride_align, flags);
 }
 
 static void screenshot(struct render_backend *ctx, struct vo_frame *frame,

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -80,6 +80,7 @@ enum {
     RA_CAP_FRAGCOORD      = 1 << 10, // supports reading from gl_FragCoord
     RA_CAP_PARALLEL_COMPUTE  = 1 << 11, // supports parallel compute shaders
     RA_CAP_NUM_GROUPS     = 1 << 12, // supports gl_NumWorkGroups
+    RA_CAP_SLOW_DR        = 1 << 13, // direct rendering is assumed to be slow
 };
 
 enum ra_ctype {

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -4290,6 +4290,13 @@ static void gl_video_dr_free_buffer(void *opaque, uint8_t *data)
 struct mp_image *gl_video_get_image(struct gl_video *p, int imgfmt, int w, int h,
                                     int stride_align, int flags)
 {
+    if (flags & VO_DR_FLAG_HOST_CACHED) {
+        if (p->ra->caps & RA_CAP_SLOW_DR) {
+            MP_VERBOSE(p, "DR path suspected slow/uncached, disabling..");
+            return NULL;
+        }
+    }
+
     if (!gl_video_check_format(p, imgfmt))
         return NULL;
 

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -4288,7 +4288,7 @@ static void gl_video_dr_free_buffer(void *opaque, uint8_t *data)
 }
 
 struct mp_image *gl_video_get_image(struct gl_video *p, int imgfmt, int w, int h,
-                                    int stride_align)
+                                    int stride_align, int flags)
 {
     if (!gl_video_check_format(p, imgfmt))
         return NULL;

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -229,7 +229,7 @@ struct vo;
 void gl_video_configure_queue(struct gl_video *p, struct vo *vo);
 
 struct mp_image *gl_video_get_image(struct gl_video *p, int imgfmt, int w, int h,
-                                    int stride_align);
+                                    int stride_align, int flags);
 
 
 #endif

--- a/video/out/libmpv.h
+++ b/video/out/libmpv.h
@@ -58,7 +58,7 @@ struct render_backend_fns {
                      struct voctrl_performance_data *out);
     // Like vo_driver.get_image().
     struct mp_image *(*get_image)(struct render_backend *ctx, int imgfmt,
-                                  int w, int h, int stride_align);
+                                  int w, int h, int stride_align, int flags);
     // This has two purposes: 1. set queue attributes on VO, 2. update the
     // renderer's OSD pointer. Keep in mind that as soon as the caller releases
     // the renderer lock, the VO pointer can become invalid. The OSD pointer

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdbool.h>
 #include <math.h>
 #include <assert.h>
@@ -45,6 +46,18 @@ static bool is_software_gl(GL *gl)
            strstr(renderer, "softpipe") ||
            strcmp(renderer, "Mesa X11") == 0 ||
            strcmp(renderer, "Apple Software Renderer") == 0;
+}
+
+// This guesses whether our DR path is fast or slow
+static bool is_fast_dr(GL *gl)
+{
+    const char *vendor = gl->GetString(GL_VENDOR);
+    if (!vendor)
+        return false;
+
+    return strcasecmp(vendor, "AMD") == 0 ||
+           strcasecmp(vendor, "NVIDIA Corporation") == 0 ||
+           strcasecmp(vendor, "ATI Technologies Inc.") == 0;    // AMD on Windows
 }
 
 static void GLAPIENTRY dummy_glBindFramebuffer(GLenum target, GLuint framebuffer)
@@ -649,6 +662,9 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
         gl->mpgl_caps |= MPGL_CAP_SW;
         mp_verbose(log, "Detected suspected software renderer.\n");
     }
+
+    if (!is_fast_dr(gl))
+        gl->mpgl_caps |= MPGL_CAP_SLOW_DR;
 
     // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
     if (gl->DispatchCompute && gl->BindImageTexture)

--- a/video/out/opengl/common.h
+++ b/video/out/opengl/common.h
@@ -59,6 +59,7 @@ enum {
     MPGL_CAP_COMPUTE_SHADER     = (1 << 23),    // GL_ARB_compute_shader & GL_ARB_shader_image_load_store
     MPGL_CAP_NESTED_ARRAY       = (1 << 24),    // GL_ARB_arrays_of_arrays
 
+    MPGL_CAP_SLOW_DR            = (1 << 29),    // direct rendering is assumed to be slow
     MPGL_CAP_SW                 = (1 << 30),    // indirect or sw renderer
 };
 

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -103,6 +103,7 @@ static int ra_init_gl(struct ra *ra, GL *gl)
         {RA_CAP_COMPUTE,            MPGL_CAP_COMPUTE_SHADER},
         {RA_CAP_NUM_GROUPS,         MPGL_CAP_COMPUTE_SHADER},
         {RA_CAP_NESTED_ARRAY,       MPGL_CAP_NESTED_ARRAY},
+        {RA_CAP_SLOW_DR,            MPGL_CAP_SLOW_DR},
     };
 
     for (int i = 0; i < MP_ARRAY_SIZE(caps_map); i++) {

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -52,6 +52,10 @@ struct ra *ra_create_pl(pl_gpu gpu, struct mp_log *log)
     if (gpu->limits.max_variables)
         ra->caps |= RA_CAP_GLOBAL_UNIFORM;
 #endif
+#if PL_API_VER >= 234
+    if (!gpu->limits.host_cached)
+        ra->caps |= RA_CAP_SLOW_DR;
+#endif
 
     if (gpu->limits.max_tex_1d_dim)
         ra->caps |= RA_CAP_TEX_1D;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1067,10 +1067,10 @@ static void do_redraw(struct vo *vo)
 }
 
 static struct mp_image *get_image_vo(void *ctx, int imgfmt, int w, int h,
-                                     int stride_align)
+                                     int stride_align, int flags)
 {
     struct vo *vo = ctx;
-    return vo->driver->get_image(vo, imgfmt, w, h, stride_align);
+    return vo->driver->get_image(vo, imgfmt, w, h, stride_align, flags);
 }
 
 static void *vo_thread(void *ptr)
@@ -1401,12 +1401,12 @@ struct vo_frame *vo_get_current_vo_frame(struct vo *vo)
 }
 
 struct mp_image *vo_get_image(struct vo *vo, int imgfmt, int w, int h,
-                              int stride_align)
+                              int stride_align, int flags)
 {
     if (vo->driver->get_image_ts)
-        return vo->driver->get_image_ts(vo, imgfmt, w, h, stride_align);
+        return vo->driver->get_image_ts(vo, imgfmt, w, h, stride_align, flags);
     if (vo->in->dr_helper)
-        return dr_helper_get_image(vo->in->dr_helper, imgfmt, w, h, stride_align);
+        return dr_helper_get_image(vo->in->dr_helper, imgfmt, w, h, stride_align, flags);
     return NULL;
 }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -359,6 +359,8 @@ struct vo_driver {
      * stride_align is always a value >=1 that is a power of 2. The stride
      * values of the returned image must be divisible by this value.
      *
+     * flags is a combination of VO_DR_FLAG_* flags.
+     *
      * Currently, the returned image must have exactly 1 AVBufferRef set, for
      * internal implementation simplicity.
      *
@@ -366,7 +368,7 @@ struct vo_driver {
      * will silently fallback to a default allocator
      */
     struct mp_image *(*get_image)(struct vo *vo, int imgfmt, int w, int h,
-                                  int stride_align);
+                                  int stride_align, int flags);
 
     /*
      * Thread-safe variant of get_image. Set at most one of these callbacks.
@@ -374,7 +376,7 @@ struct vo_driver {
      * vo_driver.uninit is not called before this function returns.
      */
     struct mp_image *(*get_image_ts)(struct vo *vo, int imgfmt, int w, int h,
-                                     int stride_align);
+                                     int stride_align, int flags);
 
     /*
      * Render the given frame to the VO's backbuffer. This operation will be
@@ -526,7 +528,7 @@ double vo_get_delay(struct vo *vo);
 void vo_discard_timing_info(struct vo *vo);
 struct vo_frame *vo_get_current_vo_frame(struct vo *vo);
 struct mp_image *vo_get_image(struct vo *vo, int imgfmt, int w, int h,
-                              int stride_align);
+                              int stride_align, int flags);
 
 void vo_wakeup(struct vo *vo);
 void vo_wait_default(struct vo *vo, int64_t until_time);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -194,6 +194,11 @@ enum {
     VO_CAP_FILM_GRAIN   = 1 << 3,
 };
 
+enum {
+    // Require DR buffers to be host-cached (i.e. fast readback)
+    VO_DR_FLAG_HOST_CACHED = 1 << 0,
+};
+
 #define VO_MAX_REQ_FRAMES 10
 
 struct vo;

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -265,11 +265,11 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
 }
 
 static struct mp_image *get_image(struct vo *vo, int imgfmt, int w, int h,
-                                  int stride_align)
+                                  int stride_align, int flags)
 {
     struct gpu_priv *p = vo->priv;
 
-    return gl_video_get_image(p->renderer, imgfmt, w, h, stride_align);
+    return gl_video_get_image(p->renderer, imgfmt, w, h, stride_align, flags);
 }
 
 static void uninit(struct vo *vo)

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -189,7 +189,7 @@ static void free_dr_buf(void *opaque, uint8_t *data)
 }
 
 static struct mp_image *get_image(struct vo *vo, int imgfmt, int w, int h,
-                                  int stride_align)
+                                  int stride_align, int flags)
 {
     struct priv *p = vo->priv;
     pl_gpu gpu = p->gpu;

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -196,6 +196,11 @@ static struct mp_image *get_image(struct vo *vo, int imgfmt, int w, int h,
     if (!gpu->limits.thread_safe || !gpu->limits.max_mapped_size)
         return NULL;
 
+#if PL_API_VER >= 234
+    if ((flags & VO_DR_FLAG_HOST_CACHED) && !gpu->limits.host_cached)
+        return NULL;
+#endif
+
     int size = mp_image_get_alloc_size(imgfmt, w, h, stride_align);
     if (size < 0)
         return NULL;

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -152,11 +152,11 @@ static void dispatch_wakeup(void *ptr)
 }
 
 static struct mp_image *render_get_image(void *ptr, int imgfmt, int w, int h,
-                                         int stride_align)
+                                         int stride_align, int flags)
 {
     struct mpv_render_context *ctx = ptr;
 
-    return ctx->renderer->fns->get_image(ctx->renderer, imgfmt, w, h, stride_align);
+    return ctx->renderer->fns->get_image(ctx->renderer, imgfmt, w, h, stride_align, flags);
 }
 
 int mpv_render_context_create(mpv_render_context **res, mpv_handle *mpv,
@@ -654,13 +654,13 @@ static int control(struct vo *vo, uint32_t request, void *data)
 }
 
 static struct mp_image *get_image(struct vo *vo, int imgfmt, int w, int h,
-                                  int stride_align)
+                                  int stride_align, int flags)
 {
     struct vo_priv *p = vo->priv;
     struct mpv_render_context *ctx = p->ctx;
 
     if (ctx->dr)
-        return dr_helper_get_image(ctx->dr, imgfmt, w, h, stride_align);
+        return dr_helper_get_image(ctx->dr, imgfmt, w, h, stride_align, flags);
 
     return NULL;
 }


### PR DESCRIPTION
This reverts commit d6af6efbf9873906bd21000551fa0f284c441eff.

On platforms where the GPU cannot cache snoop the buffers we're rendering into, DR makes the decoding horrifically slow. Some of the affected platforms are any ARM with either lima, panfrost or vc4, (A64, RK3xxx, RPis, etc.) as well as seemingly low-end Intel SoCs according to user reports.

Defaulting this option to on is therefore a potential show stopper for many people who are unaware of it, as it makes the playback unusable. Meanwhile, on systems where DR works (like mine), the performance benefit appears to be in the realm of 10%, which is fine to miss out on if a user doesn't know about the option.

What seemingly changed to make this problem crop up as of late is that both mpv and drivers have gotten better, and DR is used more often.

Closes #10997
Closes #10972 