### PR TITLE
player/command: add udata property

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -33,6 +33,7 @@ API changes
 ::
 
  --- mpv 0.35.0 ---
+ 2.1    - add mpv_del_property()
  2.0    - remove headers/functions of the obsolete opengl_cb API
         - remove mpv_opengl_init_params.extra_exts field
         - remove deprecated mpv_detach_destroy. Use mpv_destroy instead.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -334,6 +334,9 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 ``set <name> <value>``
     Set the given property or option to the given value.
 
+``del <name>``
+    Delete the given property. Most properties cannot be deleted.
+
 ``add <name> [<value>]``
     Add the given value to the property or option. On overflow or underflow,
     clamp the property to the maximum. If ``<value>`` is omitted, assume ``1``.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3256,6 +3256,26 @@ Property list
     (There is no way to ensure synchronization if two scripts try to update the
     same key at the same time.)
 
+``user-data`` (RW)
+    This is a recursive key/value map of arbitrary nodes shared between clients for
+    general use (i.e. scripts, IPC clients, host applications, etc).
+    The player itself does not use any data in it (although some builtin scripts may).
+    The property is not preserved across player restarts.
+
+    This is a more powerful replacement for ``shared-script-properties``.
+
+    Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
+    read, written, or observed.
+
+    The top-level object itself cannot be written directly; write to sub-paths instead.
+
+    Lua scripting has helpers starting with ``utils.user_data_``.
+
+    Converting this property or its sub-properties to strings will give a JSON
+    representation. If converting a leaf-level object (i.e. not a map or array)
+    and not using raw mode, the underlying content will be given (e.g. strings will be
+    printed directly, rather than quoted and JSON-escaped).
+
 ``working-directory``
     The working directory of the mpv process. Can be useful for JSON IPC users,
     because the command line player usually works with relative paths.

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -95,6 +95,8 @@ success, ``error`` is empty string on success.
 
 ``mp.abort_async_command(id)``
 
+``mp.del_property(name)`` (LE)
+
 ``mp.get_property(name [,def])`` (LE)
 
 ``mp.get_property_osd(name [,def])`` (LE)

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -186,6 +186,14 @@ meta-paths like ``~~/foo`` (other JS file functions do expand meta paths).
 
 ``mp.utils.subprocess_detached(t)``
 
+``mp.utils.udata_set(path, val)``
+
+``mp.utils.udata_get(path)``
+
+``mp.utils.udata_del(path)``
+
+``mp.utils.udata_observe(path, type, fn)``
+
 ``mp.utils.get_env_list()``
 
 ``mp.utils.getpid()`` (LE)

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -824,6 +824,34 @@ strictly part of the guaranteed API.
     This is a legacy wrapper around calling the ``run`` command with
     ``mp.commandv`` and other functions.
 
+``utils.udata_set(path, val)``
+    Sets a udata value.
+
+    ``path`` is a path within the ``udata`` property.
+
+    This is a convenience wrapper around ``mp.set_property_native``.
+
+``utils.udata_get(path)``
+    Gets a udata value.
+
+    ``path`` is a path within the ``udata`` property.
+
+    This is a convenience wrapper around ``mp.get_property_native``.
+
+``utils.udata_del(path)``
+    Deletes a udata value.
+
+    ``path`` is a path within the ``udata`` property.
+
+    This is a convenience wrapper around ``mp.del_property_native``.
+
+``utils.udata_observe(path, type, fn)``
+    Observes a udata value.
+
+    ``path`` is a path within the ``udata`` property.
+
+    See ``mp.observe_property`` for further details.
+
 ``utils.getpid()``
     Returns the process ID of the running mpv process. This can be used to identify
     the calling mpv when launching (detached) subprocesses.

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -199,6 +199,12 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     Whether this works and how long it takes depends on the command and the
     situation. The abort call itself is asynchronous. Does not return anything.
 
+``mp.del_property(name [,def])``
+    Delete the given property. See ``mp.get_property`` and `Properties`_ for more
+    information about properties. Most properties cannot be deleted.
+
+    Returns true on success, or ``nil, error`` on error.
+
 ``mp.get_property(name [,def])``
     Return the value of the given property as string. These are the same
     properties as used in input.conf. See `Properties`_ for a list of

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -240,7 +240,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 0)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 1)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before
@@ -1067,6 +1067,16 @@ MPV_EXPORT int mpv_set_property(mpv_handle *ctx, const char *name, mpv_format fo
  * This is like calling mpv_set_property() with MPV_FORMAT_STRING.
  */
 MPV_EXPORT int mpv_set_property_string(mpv_handle *ctx, const char *name, const char *data);
+
+/**
+ * Convenience function to delete a property.
+ *
+ * This is equivalent to running the command "del [name]".
+ *
+ * @param name The property name. See input.rst for a list of properties.
+ * @return error code
+ */
+MPV_EXPORT int mpv_del_property(mpv_handle *ctx, const char *name);
 
 /**
  * Set a property asynchronously. You will receive the result of the operation

--- a/misc/json.c
+++ b/misc/json.c
@@ -300,12 +300,15 @@ static int json_append(bstr *b, const struct mpv_node *src, int indent)
         bstr_xappend_asprintf(NULL, b, "%"PRId64, src->u.int64);
         return 0;
     case MPV_FORMAT_DOUBLE: {
-        const char *px = isfinite(src->u.double_) ? "" : "\"";
+        const char *px = (isfinite(src->u.double_) || indent == 0) ? "" : "\"";
         bstr_xappend_asprintf(NULL, b, "%s%f%s", px, src->u.double_, px);
         return 0;
     }
     case MPV_FORMAT_STRING:
-        write_json_str(b, src->u.string);
+        if (indent == 0)
+            APPEND(b, src->u.string);
+        else
+            write_json_str(b, src->u.string);
         return 0;
     case MPV_FORMAT_NODE_ARRAY:
     case MPV_FORMAT_NODE_MAP: {

--- a/misc/node.c
+++ b/misc/node.c
@@ -45,12 +45,18 @@ struct mpv_node *node_array_add(struct mpv_node *dst, int format)
 struct mpv_node *node_map_add(struct mpv_node *dst, const char *key, int format)
 {
     assert(key);
+    return node_map_badd(dst, bstr0(key), format);
+}
+
+struct mpv_node *node_map_badd(struct mpv_node *dst, struct bstr key, int format)
+{
+    assert(key.start);
 
     struct mpv_node_list *list = dst->u.list;
     assert(dst->format == MPV_FORMAT_NODE_MAP && dst->u.list);
     MP_TARRAY_GROW(list, list->values, list->num);
     MP_TARRAY_GROW(list, list->keys, list->num);
-    list->keys[list->num] = talloc_strdup(list, key);
+    list->keys[list->num] = bstrdup0(list, key);
     node_init(&list->values[list->num], format, dst);
     return &list->values[list->num++];
 }
@@ -84,11 +90,16 @@ void node_map_add_flag(struct mpv_node *dst, const char *key, bool v)
 
 mpv_node *node_map_get(mpv_node *src, const char *key)
 {
+    return node_map_bget(src, bstr0(key));
+}
+
+mpv_node *node_map_bget(mpv_node *src, struct bstr key)
+{
     if (src->format != MPV_FORMAT_NODE_MAP)
         return NULL;
 
     for (int i = 0; i < src->u.list->num; i++) {
-        if (strcmp(key, src->u.list->keys[i]) == 0)
+        if (bstr_equals0(key, src->u.list->keys[i]))
             return &src->u.list->values[i];
     }
 

--- a/misc/node.h
+++ b/misc/node.h
@@ -2,15 +2,18 @@
 #define MP_MISC_NODE_H_
 
 #include "libmpv/client.h"
+#include "misc/bstr.h"
 
 void node_init(struct mpv_node *dst, int format, struct mpv_node *parent);
 struct mpv_node *node_array_add(struct mpv_node *dst, int format);
 struct mpv_node *node_map_add(struct mpv_node *dst, const char *key, int format);
+struct mpv_node *node_map_badd(struct mpv_node *dst, struct bstr key, int format);
 void node_map_add_string(struct mpv_node *dst, const char *key, const char *val);
 void node_map_add_int64(struct mpv_node *dst, const char *key, int64_t v);
 void node_map_add_double(struct mpv_node *dst, const char *key, double v);
 void node_map_add_flag(struct mpv_node *dst, const char *key, bool v);
 mpv_node *node_map_get(mpv_node *src, const char *key);
+mpv_node *node_map_bget(mpv_node *src, struct bstr key);
 bool equal_mpv_value(const void *a, const void *b, mpv_format format);
 bool equal_mpv_node(const struct mpv_node *a, const struct mpv_node *b);
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -3774,6 +3774,16 @@ static void dup_node(void *ta_parent, struct mpv_node *node)
         }
         break;
     }
+    case MPV_FORMAT_BYTE_ARRAY: {
+        struct mpv_byte_array *old = node->u.ba;
+        struct mpv_byte_array *new = talloc_zero(ta_parent, struct mpv_byte_array);
+        node->u.ba = new;
+        if (old->size > 0) {
+            *new = *old;
+            new->data = talloc_memdup(new, old->data, old->size);
+        }
+        break;
+    }
     case MPV_FORMAT_NONE:
     case MPV_FORMAT_FLAG:
     case MPV_FORMAT_INT64:

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -86,6 +86,11 @@ enum mp_property_action {
     // Pass down an action to a sub-property.
     //  arg: struct m_property_action_arg*
     M_PROPERTY_KEY_ACTION,
+
+    // Delete a value.
+    // Most properties do not implement this.
+    //  arg: (ignored)
+    M_PROPERTY_DELETE,
 };
 
 // Argument for M_PROPERTY_SWITCH

--- a/player/client.c
+++ b/player/client.c
@@ -1337,6 +1337,12 @@ int mpv_set_property(mpv_handle *ctx, const char *name, mpv_format format,
     return req.status;
 }
 
+int mpv_del_property(mpv_handle *ctx, const char *name)
+{
+    const char* args[] = { "del", name, NULL };
+    return mpv_command(ctx, args);
+}
+
 int mpv_set_property_string(mpv_handle *ctx, const char *name, const char *data)
 {
     return mpv_set_property(ctx, name, MPV_FORMAT_STRING, &data);

--- a/player/command.c
+++ b/player/command.c
@@ -107,12 +107,17 @@ struct command_ctx {
     struct mp_cmd_ctx *cache_dump_cmd; // in progress cache dumping
 
     char **script_props;
+    mpv_node udata;
 
     double cached_window_scale;
 };
 
 static const struct m_option script_props_type = {
     .type = &m_option_type_keyvalue_list
+};
+
+static const struct m_option udata_type = {
+    .type = CONF_TYPE_NODE
 };
 
 struct overlay {
@@ -3555,6 +3560,168 @@ static int mp_property_script_props(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
+static int do_list_udata(int item, int action, void *arg, void *ctx);
+
+struct udata_ctx {
+    MPContext *mpctx;
+    const char *path;
+    mpv_node *node;
+};
+
+static int do_op_udata(struct udata_ctx* ctx, int action, void *arg)
+{
+    MPContext *mpctx = ctx->mpctx;
+    mpv_node *node = ctx->node;
+
+    switch (action) {
+    case M_PROPERTY_GET_TYPE:
+        *(struct m_option *)arg = udata_type;
+        return M_PROPERTY_OK;
+    case M_PROPERTY_GET:
+    case M_PROPERTY_GET_NODE: // same as GET, because type==mpv_node
+        assert(node);
+        m_option_copy(&udata_type, arg, node);
+        return M_PROPERTY_OK;
+    case M_PROPERTY_PRINT: {
+        char *str = m_option_pretty_print(&udata_type, node);
+        *(char **)arg = str;
+        return str != NULL;
+    }
+    case M_PROPERTY_SET:
+    case M_PROPERTY_SET_NODE:
+        assert(node);
+        m_option_copy(&udata_type, node, arg);
+        mp_notify_property(mpctx, ctx->path);
+        return M_PROPERTY_OK;
+    case M_PROPERTY_KEY_ACTION: {
+        assert(node);
+
+        // If we're operating on an array, sub-object access is handled by m_property_read_list
+        if (node->format == MPV_FORMAT_NODE_ARRAY)
+            return m_property_read_list(action, arg, node->u.list->num, &do_list_udata, ctx);
+
+        // Sub-objects only make sense for arrays and maps
+        if (node->format != MPV_FORMAT_NODE_MAP)
+            return M_PROPERTY_NOT_IMPLEMENTED;
+
+        struct m_property_action_arg *act = arg;
+
+        // See if the next layer down will also be a sub-object access
+        bstr key;
+        char *rem;
+        bool has_split = m_property_split_path(act->key, &key, &rem);
+
+        if (!has_split && act->action == M_PROPERTY_DELETE) {
+            // Find the object we're looking for
+            int i;
+            for (i = 0; i < node->u.list->num; i++) {
+                if (bstr_equals0(key, node->u.list->keys[i]))
+                    break;
+            }
+
+            // Return if it didn't exist
+            if (i == node->u.list->num)
+                return M_PROPERTY_UNKNOWN;
+
+            // Delete the item
+            m_option_free(&udata_type, &node->u.list->values[i]);
+            talloc_free(node->u.list->keys[i]);
+
+            // Shift the remaining items back
+            for (i++; i < node->u.list->num; i++) {
+                node->u.list->values[i - 1] = node->u.list->values[i];
+                node->u.list->keys[i - 1] = node->u.list->keys[i];
+            }
+
+            // And decrement the count
+            node->u.list->num--;
+
+            return M_PROPERTY_OK;
+        }
+
+        // Look up the next level down
+        mpv_node *cnode = node_map_bget(node, key);
+
+        if (!cnode) {
+            switch (act->action) {
+                case M_PROPERTY_SET:
+                case M_PROPERTY_SET_NODE: {
+                    // If we're doing a set, and the key doesn't exist, create it.
+                    // If we're recursing another layer down, make it an empty map;
+                    // otherwise, make it NONE, since we'll be overwriting it at the next level.
+                    cnode = node_map_badd(node, key, has_split ? MPV_FORMAT_NODE_MAP : MPV_FORMAT_NONE);
+                    if (!cnode)
+                        return M_PROPERTY_ERROR;
+                    break;
+                case M_PROPERTY_GET_TYPE:
+                    // Nonexistent keys have type NODE, so they can be overwritten
+                    *(struct m_option *)act->arg = udata_type;
+                    return M_PROPERTY_OK;
+                default:
+                    // We can't perform any other options on nonexistent keys
+                    return M_PROPERTY_UNKNOWN;
+                }
+            }
+        }
+
+        struct udata_ctx nctx = *ctx;
+        nctx.node = cnode;
+
+        // If we're going down another level, set up a new key-action.
+        if (has_split) {
+            struct m_property_action_arg sub_act = {
+                .key = rem,
+                .action = act->action,
+                .arg = act->arg,
+            };
+
+            return do_op_udata(&nctx, M_PROPERTY_KEY_ACTION, &sub_act);
+        } else {
+            return do_op_udata(&nctx, act->action, act->arg);
+        }
+    }
+    }
+    return M_PROPERTY_NOT_IMPLEMENTED;
+}
+
+static int do_list_udata(int item, int action, void *arg, void *ctx)
+{
+    struct udata_ctx nctx = *(struct udata_ctx*)ctx;
+    nctx.node = &nctx.node->u.list->values[item];
+
+    return do_op_udata(&nctx, action, arg);
+}
+
+static int mp_property_udata(void *ctx, struct m_property *prop,
+                                 int action, void *arg)
+{
+    // The root of udata is a shared map; don't allow overwriting
+    // or deleting the whole thing
+    if (action == M_PROPERTY_SET || action == M_PROPERTY_SET_NODE ||
+        action == M_PROPERTY_DELETE)
+        return M_PROPERTY_NOT_IMPLEMENTED;
+
+    char *path = NULL;
+    if (action == M_PROPERTY_KEY_ACTION) {
+        struct m_property_action_arg *act = arg;
+        if (act->action == M_PROPERTY_SET || act->action == M_PROPERTY_SET_NODE)
+            path = talloc_asprintf(NULL, "%s/%s", prop->name, act->key);
+    }
+
+    struct MPContext *mpctx = ctx;
+    struct udata_ctx nctx = {
+        .mpctx = mpctx,
+        .path = path,
+        .node = &mpctx->command_ctx->udata,
+    };
+
+    int ret = do_op_udata(&nctx, action, arg);
+
+    talloc_free(path);
+
+    return ret;
+}
+
 // Redirect a property name to another
 #define M_PROPERTY_ALIAS(name, real_property) \
     {(name), mp_property_alias, .priv = (real_property)}
@@ -3757,6 +3924,7 @@ static const struct m_property mp_properties_base[] = {
     {"input-bindings", mp_property_bindings},
 
     {"shared-script-properties", mp_property_script_props},
+    {"user-data", mp_property_udata},
 
     M_PROPERTY_ALIAS("video", "vid"),
     M_PROPERTY_ALIAS("audio", "aid"),
@@ -6551,6 +6719,9 @@ void command_init(struct MPContext *mpctx)
 
         ctx->properties[count++] = prop;
     }
+
+    node_init(&ctx->udata, MPV_FORMAT_NODE_MAP, NULL);
+    talloc_steal(ctx, ctx->udata.u.list);
 }
 
 static void command_event(struct MPContext *mpctx, int event, void *arg)

--- a/player/command.c
+++ b/player/command.c
@@ -4882,6 +4882,29 @@ static void cmd_set(void *p)
                         M_PROPERTY_SET_STRING, cmd->args[1].v.s);
 }
 
+static void cmd_del(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+    const char *name = cmd->args[0].v.s;
+    int osdl = cmd->msg_osd ? 1 : OSD_LEVEL_INVISIBLE;
+    int osd_duration = mpctx->opts->osd_duration;
+
+    int r = mp_property_do(name, M_PROPERTY_DELETE, NULL, mpctx);
+
+    if (r == M_PROPERTY_OK) {
+        set_osd_msg(mpctx, osdl, osd_duration, "Deleted property: '%s'", name);
+        cmd->success = true;
+    } else if (r == M_PROPERTY_UNKNOWN) {
+        set_osd_msg(mpctx, osdl, osd_duration, "Unknown property: '%s'", name);
+        cmd->success = false;
+    } else if (r <= 0) {
+        set_osd_msg(mpctx, osdl, osd_duration, "Failed to set property '%s'",
+                    name);
+        cmd->success = false;
+    }
+}
+
 static void cmd_change_list(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6310,6 +6333,7 @@ const struct mp_cmd_def mp_cmds[] = {
     },
 
     { "set", cmd_set, {{"name", OPT_STRING(v.s)}, {"value", OPT_STRING(v.s)}}},
+    { "del", cmd_del, {{"name", OPT_STRING(v.s)}}},
     { "change-list", cmd_change_list, { {"name", OPT_STRING(v.s)},
                                         {"operation", OPT_STRING(v.s)},
                                         {"value", OPT_STRING(v.s)} }},

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -698,6 +698,13 @@ static void script_get_property(js_State *J, void *af)
         js_pushstring(J, res);
 }
 
+// args: name
+static void script_del_property(js_State *J)
+{
+    int e = mpv_del_property(jclient(J), js_tostring(J, 1));
+    push_status(J, e);
+}
+
 // args: name [,def]
 static void script_get_property_bool(js_State *J)
 {
@@ -1171,6 +1178,7 @@ static const struct fn_entry main_fns[] = {
     AF_ENTRY(command_native, 2),
     AF_ENTRY(_command_native_async, 2),
     FN_ENTRY(_abort_async_command, 1),
+    FN_ENTRY(del_property, 1),
     FN_ENTRY(get_property_bool, 2),
     FN_ENTRY(get_property_number, 2),
     AF_ENTRY(get_property_native, 2),

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -199,6 +199,30 @@ mp.utils.shared_script_property_set = shared_script_property_set;
 mp.utils.shared_script_property_get = shared_script_property_get;
 mp.utils.shared_script_property_observe = shared_script_property_observe;
 
+// user_data - always an object, even if empty
+function user_data_set(path, val) {
+    return mp.set_proprty_native("user-data/" + path, val);
+}
+
+function user_data_del(path) {
+    return mp.del_property_native("user-data/" + path);
+}
+
+function user_data_get(path) {
+    return mp.get_property_native("user-data/" + path);
+}
+
+function user_data_observe(path, t, cb) {
+    return mp.observe_property("user-data/" + path, t,
+        function user_data_cb(_name, val) { cb(path, val) }
+    );
+}
+
+mp.utils.user_data_set = user_data_set;
+mp.utils.user_data_del = user_data_del;
+mp.utils.user_data_get = user_data_get;
+mp.utils.user_data_observe = user_data_observe;
+
 // osd-ass
 var next_assid = 1;
 mp.create_osd_overlay = function create_osd_overlay(format) {

--- a/player/lua.c
+++ b/player/lua.c
@@ -613,6 +613,14 @@ static int script_commandv(lua_State *L)
     return check_error(L, mpv_command(ctx->client, args));
 }
 
+static int script_del_property(lua_State *L)
+{
+    struct script_ctx *ctx = get_ctx(L);
+    const char *p = luaL_checkstring(L, 1);
+
+    return check_error(L, mpv_del_property(ctx->client, p));
+}
+
 static int script_set_property(lua_State *L)
 {
     struct script_ctx *ctx = get_ctx(L);
@@ -1219,6 +1227,7 @@ static const struct fn_entry main_fns[] = {
     FN_ENTRY(get_property_bool),
     FN_ENTRY(get_property_number),
     AF_ENTRY(get_property_native),
+    FN_ENTRY(del_property),
     FN_ENTRY(set_property),
     FN_ENTRY(set_property_bool),
     FN_ENTRY(set_property_number),

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -831,4 +831,23 @@ function mp_utils.shared_script_property_observe(name, cb)
     end)
 end
 
+function mp_utils.user_data_set(path, value)
+    return mp.set_property_native("user-data/" .. path, value)
+end
+
+function mp_utils.user_data_get(path)
+    return mp.get_property_native("user-data/" .. path)
+end
+
+function mp_utils.user_data_del(path)
+    return mp.del_property_native("user-data/" .. path)
+end
+
+-- cb(name, value) on change and on init
+function mp_utils.user_data_observe(path, t, cb)
+    return mp.observe_property("user-data/" .. path, t, function(_, val)
+        cb(path, val)
+    end)
+end
+
 return {}


### PR DESCRIPTION
This will replace shared-script-properties in new usage. It can be used for all the same things, but is much more versatile. Clients can create arbitrary sub-objects, and text expansion can access them.

For instance, if a script sets `udata/my-script/property1` to "test", that value will be available by expanding `${udata/my-script/property1}`.