### PR TITLE
options: Add watch-later-key

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1018,9 +1018,9 @@ Watch Later
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
-``--watch-later-use-title``
-    Use the video title instead of the current file name for saving
-    and resuming.
+``--watch-later-key=<key>``
+    Use the specified key instead of the current file name to determine the file
+    name to save/resume from.
 
 ``--no-resume-playback``
     Do not restore playback position from the ``watch_later`` configuration

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1018,6 +1018,10 @@ Watch Later
     The default is a subdirectory named "watch_later" underneath the
     config directory (usually ``~/.config/mpv/``).
 
+``--watch-later-use-title``
+    Use the video title instead of the current file name for saving
+    and resuming.
+
 ``--no-resume-playback``
     Do not restore playback position from the ``watch_later`` configuration
     subdirectory (usually ``~/.config/mpv/watch_later/``).

--- a/options/options.c
+++ b/options/options.c
@@ -722,7 +722,7 @@ static const m_option_t mp_opts[] = {
         OPT_FLAG(ignore_path_in_watch_later_config)},
     {"watch-later-directory", OPT_STRING(watch_later_directory),
         .flags = M_OPT_FILE},
-    {"watch-later-use-title", OPT_BOOL(watch_later_use_title)},
+    {"watch-later-key", OPT_STRING(watch_later_key)},
     {"watch-later-options", OPT_STRINGLIST(watch_later_options)},
 
     {"ordered-chapters", OPT_FLAG(ordered_chapters)},

--- a/options/options.c
+++ b/options/options.c
@@ -722,6 +722,7 @@ static const m_option_t mp_opts[] = {
         OPT_FLAG(ignore_path_in_watch_later_config)},
     {"watch-later-directory", OPT_STRING(watch_later_directory),
         .flags = M_OPT_FILE},
+    {"watch-later-use-title", OPT_BOOL(watch_later_use_title)},
     {"watch-later-options", OPT_STRINGLIST(watch_later_options)},
 
     {"ordered-chapters", OPT_FLAG(ordered_chapters)},

--- a/options/options.h
+++ b/options/options.h
@@ -258,7 +258,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
-    bool watch_later_use_title;
+    char *watch_later_key;
     char **watch_later_options;
     int pause;
     int keep_open;

--- a/options/options.h
+++ b/options/options.h
@@ -258,6 +258,7 @@ typedef struct MPOpts {
     int write_filename_in_watch_later_config;
     int ignore_path_in_watch_later_config;
     char *watch_later_directory;
+    bool watch_later_use_title;
     char **watch_later_options;
     int pause;
     int keep_open;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -201,8 +201,8 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     void *tmp = talloc_new(NULL);
     const char *realpath = fname;
     bstr bfname = bstr0(fname);
-    if (mpctx->opts->watch_later_use_title) {
-        realpath = mp_property_expand_string(mpctx, mpctx->opts->wintitle);
+    if (mpctx->opts->watch_later_key) {
+        realpath = mpctx->opts->watch_later_key;
     } else if (!mp_is_url(bfname)) {
         if (opts->ignore_path_in_watch_later_config) {
             realpath = mp_basename(fname);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -201,7 +201,9 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     void *tmp = talloc_new(NULL);
     const char *realpath = fname;
     bstr bfname = bstr0(fname);
-    if (!mp_is_url(bfname)) {
+    if (mpctx->opts->watch_later_use_title) {
+        realpath = mp_property_expand_string(mpctx, mpctx->opts->wintitle);
+    } else if (!mp_is_url(bfname)) {
         if (opts->ignore_path_in_watch_later_config) {
             realpath = mp_basename(fname);
         } else {


### PR DESCRIPTION
A new option has been added to override the filename in mp_get_playback_resume_config_filename.

This option was made for the case where the video path or url changes or just isn't unique but the user still wants progress to be saved.

Examples include
- Streaming a url where the upstream path contains transient information like a session id
- Streaming a url where irrelevant query parameters are added/removed.
- Playing from stdin since the "file name" is always "-"
- Playing a local file from a link vs the real file


Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.