### PR TITLE
DOCS: added display-p3 to --target-prim options

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6275,6 +6275,8 @@ them.
         CIE 1931 RGB (not to be confused with CIE XYZ)
     dci-p3
         DCI-P3 (Digital Cinema Colorspace), SMPTE RP431-2
+    display-p3
+        Display-P3 (like DCI-P3 with D65 whitepoint), SMPTE RP431-1
     v-gamut
         Panasonic V-Gamut (VARICAM) primaries
     s-gamut


### PR DESCRIPTION
Mpv already have support for display-p3 primaries from commit d7d670fcbf3974894429e5693e76536f0d2fe847, but this not described in manual.