### PR TITLE
external_files: set log level for potential files to trace

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -254,7 +254,7 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
         if (!limit_fuzziness && fuzz >= 2)
             prio |= 1;
 
-        mp_dbg(log, "Potential external file: \"%s\"  Priority: %d\n",
+        mp_trace(log, "Potential external file: \"%s\"  Priority: %d\n",
                de->d_name, prio);
 
         if (prio) {


### PR DESCRIPTION
We ask users to freely share log files with us, which is usually okay, unless a user has some unrelated and potentially embarrassing files in their working directory. These would show up in the debug level message output that `--log-file` enables.

Change the listing of potential external files to trace log level, to save the users and the developers the embarrassment.