### PR TITLE
x11: add modesetting to the xpresent whitelist

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -436,11 +436,12 @@ static void xrandr_read(struct vo_x11_state *x11)
             bstr_lower(provider_name);
             int amd = bstr_find0(provider_name, "amd");
             int intel = bstr_find0(provider_name, "intel");
+            int modesetting = bstr_find0(provider_name, "modesetting");
             int nouveau = bstr_find0(provider_name, "nouveau");
             int nvidia = bstr_find0(provider_name, "nvidia");
             int radeon = bstr_find0(provider_name, "radeon");
             x11->has_mesa = x11->has_mesa || amd >= 0 || intel >= 0 ||
-                            nouveau >= 0 || radeon >= 0;
+                            modesetting >= 0 || nouveau >= 0 || radeon >= 0;
             x11->has_nvidia = x11->has_nvidia || nvidia >= 0;
             XRRFreeProviderInfo(info);
         }


### PR DESCRIPTION
Since the modesetting driver now has TearFree support with integration into xpresent, it's important that xpresent is used with the modesetting driver to get the correct vsync timing when a frame is delayed by one vblank interval due to a pending page-flip enqueued by a different entity. The modesetting driver ensures that the xpresent extension reports the correct presentation timing when TearFree is used; mpv just needs to listen to it.

Add the modesetting driver to the xpresent whitelist so mpv can get the correct presentation completion timing when modesetting TearFree is used.

This is also helpful for when xpresent performs page flips directly in the modesetting driver and a natural delay in the display pipeline causes a page flip to be delayed by one vblank interval or more.