### PR TITLE
vo_opengl: do not blindly reject all Microsoft's OpenGL implementations

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -37,12 +37,12 @@
 static bool is_software_gl(GL *gl)
 {
     const char *renderer = gl->GetString(GL_RENDERER);
-    const char *vendor = gl->GetString(GL_VENDOR);
-    return !(renderer && vendor) ||
+    // Note we don't attempt to blacklist Microsoft's fallback implementation.
+    // It only provides OpenGL 1.1 and will be skipped anyway.
+    return !renderer ||
            strcmp(renderer, "Software Rasterizer") == 0 ||
            strstr(renderer, "llvmpipe") ||
            strstr(renderer, "softpipe") ||
-           strcmp(vendor, "Microsoft Corporation") == 0 ||
            strcmp(renderer, "Mesa X11") == 0 ||
            strcmp(renderer, "Apple Software Renderer") == 0;
 }


### PR DESCRIPTION
This change enables mpv to work in the WSL2 (WSLg) environment where OpenGL is implemented on top of D3D12.

This reverts commit 149d98d244.

Mentioned OpenGL implementation (GDI Generic) in the original change will be rejected by version check, so there is no need to handle it manually.

Signed-off-by: Kacper Michajłow <kasper93@gmail.com>