### PR TITLE
demux_playlist: do not trim lines

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -295,7 +295,7 @@ static int parse_txt(struct pl_parser *p)
         return 0;
     MP_WARN(p, "Reading plaintext playlist.\n");
     while (!pl_eof(p)) {
-        bstr line = bstr_strip(pl_get_line(p));
+        bstr line = pl_get_line(p);
         if (line.len == 0)
             continue;
         pl_add(p, line);


### PR DESCRIPTION
If filenames start with whitespaces (as can happen with automatic 'artist - title' naming when there is no title) then mpv --playlist=relative_playlist will fail to find '- title' because it stripped the leading space

That can be worked around by using './ - title' in the playlist file, but that is unintuitive and that stripping seems to be purely historical accoording to the git
history: it shouldn't be needed for anything demux_playlist is parsing. Hopefully.

------

This has bitten me with some stream dumper generating files with leading spaces and me lazily creating a playlist file with just filenames.
Since there's an obvious workaround I guess it might be safer to play safe and keep the trim -- I can bet there are some playlist files out there that rely on this trimming -- but I might as well report this and make sure this is voluntary. Since the fix is obvious I'm opening this as a PR, but think of it as an issue with benefits ;)
