### PR TITLE
audio: simplify implementation of property ao-volume

### DIFF
--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -26,8 +26,7 @@
 #include "audio/chmap_sel.h"
 
 enum aocontrol {
-    // _VOLUME commands take struct ao_control_vol pointer for input/output.
-    // If there's only one volume, SET should use average of left/right.
+    // _VOLUME commands take a pointer to float for input/output.
     AOCONTROL_GET_VOLUME,
     AOCONTROL_SET_VOLUME,
     // _MUTE commands take a pointer to bool
@@ -60,11 +59,6 @@ enum {
     // Force exclusive mode, i.e. lock out the system mixer.
     AO_INIT_EXCLUSIVE = 1 << 3,
 };
-
-typedef struct ao_control_vol {
-    float left;
-    float right;
-} ao_control_vol_t;
 
 enum aocontrol_media_role {
     AOCONTROL_MEDIA_ROLE_MUSIC,

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -168,14 +168,12 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 
         switch (cmd) {
         case AOCONTROL_SET_VOLUME: {
-            ao_control_vol_t *vol = arg;
-            set_vol = vol->left / f_multi + pmin + 0.5;
+            float *vol = arg;
+            set_vol = *vol / f_multi + pmin + 0.5;
 
             err = snd_mixer_selem_set_playback_volume(elem, 0, set_vol);
             CHECK_ALSA_ERROR("Error setting left channel");
             MP_DBG(ao, "left=%li, ", set_vol);
-
-            set_vol = vol->right / f_multi + pmin + 0.5;
 
             err = snd_mixer_selem_set_playback_volume(elem, 1, set_vol);
             CHECK_ALSA_ERROR("Error setting right channel");
@@ -184,12 +182,14 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
             break;
         }
         case AOCONTROL_GET_VOLUME: {
-            ao_control_vol_t *vol = arg;
+            float *vol = arg;
+            float left, right;
             snd_mixer_selem_get_playback_volume(elem, 0, &get_vol);
-            vol->left = (get_vol - pmin) * f_multi;
+            left = (get_vol - pmin) * f_multi;
             snd_mixer_selem_get_playback_volume(elem, 1, &get_vol);
-            vol->right = (get_vol - pmin) * f_multi;
-            MP_DBG(ao, "left=%f, right=%f\n", vol->left, vol->right);
+            right = (get_vol - pmin) * f_multi;
+            *vol = (left + right) / 2.0;
+            MP_DBG(ao, "vol=%f\n", *vol);
             break;
         }
         case AOCONTROL_SET_MUTE: {

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -83,7 +83,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
     return noErr;
 }
 
-static int get_volume(struct ao *ao, struct ao_control_vol *vol) {
+static int get_volume(struct ao *ao, float *vol) {
     struct priv *p = ao->priv;
     float auvol;
     OSStatus err =
@@ -91,15 +91,15 @@ static int get_volume(struct ao *ao, struct ao_control_vol *vol) {
                               kAudioUnitScope_Global, 0, &auvol);
 
     CHECK_CA_ERROR("could not get HAL output volume");
-    vol->left = vol->right = auvol * 100.0;
+    *vol = auvol * 100.0;
     return CONTROL_TRUE;
 coreaudio_error:
     return CONTROL_ERROR;
 }
 
-static int set_volume(struct ao *ao, struct ao_control_vol *vol) {
+static int set_volume(struct ao *ao, float *vol) {
     struct priv *p = ao->priv;
-    float auvol = (vol->left + vol->right) / 200.0;
+    float auvol = *vol / 100.0;
     OSStatus err =
         AudioUnitSetParameter(p->audio_unit, kHALOutputParam_Volume,
                               kAudioUnitScope_Global, 0, auvol, 0);

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -67,13 +67,13 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
     case AOCONTROL_GET_VOLUME:
     case AOCONTROL_SET_VOLUME: {
         ALfloat volume;
-        ao_control_vol_t *vol = (ao_control_vol_t *)arg;
+        float *vol = arg;
         if (cmd == AOCONTROL_SET_VOLUME) {
-            volume = (vol->left + vol->right) / 200.0;
+            volume = *vol / 100.0;
             alListenerf(AL_GAIN, volume);
         }
         alGetListenerf(AL_GAIN, &volume);
-        vol->left = vol->right = volume * 100;
+        *vol = volume * 100;
         return CONTROL_TRUE;
     }
     case AOCONTROL_GET_MUTE:

--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -267,7 +267,7 @@ static void uninit(struct ao *ao)
 static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 {
     struct priv *p = ao->priv;
-    ao_control_vol_t *vol = (ao_control_vol_t *)arg;
+    float *vol = arg;
     int v;
 
     if (p->dsp_fd < 0)
@@ -279,11 +279,10 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
             MP_WARN_IOCTL_ERR(ao);
             return CONTROL_ERROR;
         }
-        vol->right = ((v & 0xff00) >> 8);
-        vol->left = (v & 0x00ff);
+        *vol = ((v & 0x00ff) + ((v & 0xff00) >> 8)) / 2.0;
         return CONTROL_OK;
     case AOCONTROL_SET_VOLUME:
-        v = ((int)vol->right << 8) | (int)vol->left;
+        v = ((int)*vol << 8) | (int)*vol;
         if (ioctl(p->dsp_fd, SNDCTL_DSP_SETPLAYVOL, &v) == -1) {
             MP_WARN_IOCTL_ERR(ao);
             return CONTROL_ERROR;

--- a/audio/out/ao_sndio.c
+++ b/audio/out/ao_sndio.c
@@ -211,18 +211,18 @@ static void uninit(struct ao *ao)
 static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 {
     struct priv *p = ao->priv;
-    ao_control_vol_t *vol = arg;
+    float *vol = arg;
 
     switch (cmd) {
     case AOCONTROL_GET_VOLUME:
         if (!p->havevol)
             return CONTROL_FALSE;
-        vol->left = vol->right = p->vol * 100 / SIO_MAXVOL;
+        *vol = p->vol * 100 / SIO_MAXVOL;
         break;
     case AOCONTROL_SET_VOLUME:
         if (!p->havevol)
             return CONTROL_FALSE;
-        sio_setvol(p->hdl, vol->left * SIO_MAXVOL / 100);
+        sio_setvol(p->hdl, *vol * SIO_MAXVOL / 100);
         break;
     default:
         return CONTROL_UNKNOWN;

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -348,13 +348,10 @@ static int thread_control_exclusive(struct ao *ao, enum aocontrol cmd, void *arg
     case AOCONTROL_GET_VOLUME:
         IAudioEndpointVolume_GetMasterVolumeLevelScalar(
             state->pEndpointVolume, &volume);
-        *(ao_control_vol_t *)arg = (ao_control_vol_t){
-            .left  = 100.0f * volume,
-            .right = 100.0f * volume,
-        };
+        *(float *)arg = volume;
         return CONTROL_OK;
     case AOCONTROL_SET_VOLUME:
-        volume = ((ao_control_vol_t *)arg)->left / 100.f;
+        volume = (*(float *)arg) / 100.f;
         IAudioEndpointVolume_SetMasterVolumeLevelScalar(
             state->pEndpointVolume, volume, NULL);
         return CONTROL_OK;
@@ -381,13 +378,10 @@ static int thread_control_shared(struct ao *ao, enum aocontrol cmd, void *arg)
     switch(cmd) {
     case AOCONTROL_GET_VOLUME:
         ISimpleAudioVolume_GetMasterVolume(state->pAudioVolume, &volume);
-        *(ao_control_vol_t *)arg = (ao_control_vol_t){
-            .left  = 100.0f * volume,
-            .right = 100.0f * volume,
-        };
+        *(float *)arg = volume;
         return CONTROL_OK;
     case AOCONTROL_SET_VOLUME:
-        volume = ((ao_control_vol_t *)arg)->left / 100.f;
+        volume = (*(float *)arg) / 100.f;
         ISimpleAudioVolume_SetMasterVolume(state->pAudioVolume, volume, NULL);
         return CONTROL_OK;
     case AOCONTROL_GET_MUTE:

--- a/player/command.c
+++ b/player/command.c
@@ -1616,17 +1616,14 @@ static int mp_property_ao_volume(void *ctx, struct m_property *prop,
 
     switch (action) {
     case M_PROPERTY_SET: {
-        float value = *(float *)arg;
-        ao_control_vol_t vol = {value, value};
+        float vol = *(float *)arg;
         if (ao_control(ao, AOCONTROL_SET_VOLUME, &vol) != CONTROL_OK)
             return M_PROPERTY_UNAVAILABLE;
         return M_PROPERTY_OK;
     }
     case M_PROPERTY_GET: {
-        ao_control_vol_t vol = {0};
-        if (ao_control(ao, AOCONTROL_GET_VOLUME, &vol) != CONTROL_OK)
+        if (ao_control(ao, AOCONTROL_GET_VOLUME, arg) != CONTROL_OK)
             return M_PROPERTY_UNAVAILABLE;
-        *(float *)arg = (vol.left + vol.right) / 2.0f;
         return M_PROPERTY_OK;
     }
     case M_PROPERTY_GET_TYPE:
@@ -1637,10 +1634,10 @@ static int mp_property_ao_volume(void *ctx, struct m_property *prop,
         };
         return M_PROPERTY_OK;
     case M_PROPERTY_PRINT: {
-        ao_control_vol_t vol = {0};
+        float vol = 0;
         if (ao_control(ao, AOCONTROL_GET_VOLUME, &vol) != CONTROL_OK)
             return M_PROPERTY_UNAVAILABLE;
-        *(char **)arg = talloc_asprintf(NULL, "%.f", (vol.left + vol.right) / 2.0f);
+        *(char **)arg = talloc_asprintf(NULL, "%.f", vol);
         return M_PROPERTY_OK;
     }
     }


### PR DESCRIPTION
ao-volume is represented in the code with a `struct ao_control_vol_t` which contains volumes for two channels, left and right.

However the code implementing this property in command.c never treats these values individually. They are always averaged together. On the other hand the code in the AOs handling these values also has to handle the case where *not* exactly two channels are handled.

So let's remove the `struct ao_control_vol_t` and replace it with a simple float.
This makes the semantics clear to AO authors and allows us to drop some code from the AOs and command.c.

Tested with:

- [x] ao_pipewire (@t-8ch)
- [x] ao_pulse (@t-8ch)
- [ ] ao_alsa (Seems to be fairly broken for me when modifying `ao-volume`, even before this patch)
- [ ] ao_openal
- [ ] ao_oss
- [ ] ao_sndio
- [ ] ao_wasapi
- [ ] ao_coreaudio