### PR TITLE
wayland: refactor presentation feedback to a linked list

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -101,7 +101,8 @@ struct vo_wayland_state {
 
     /* presentation-time */
     struct wp_presentation  *presentation;
-    struct wp_presentation_feedback *feedback;
+    struct wl_list feedback_list;
+    struct vo_wayland_feedback *feedback;
     struct mp_present *present;
     int64_t refresh_interval;
     bool use_present;


### PR DESCRIPTION
mpv is a bit unusual in that it uses a combination of both frame callbacks and presentation events (this was designed so you would use one or the other). The reason is that we want the maximum amount of time for rendering while also having ideal frame presentation. We set the presentation feedback listener in the frame callback so that way the next presentation event corresponds immediately to the next frame. This used to work out nicely so that the presentation feedback associated with a frame would be immediately destroyed after it is presented.

Well at some point, something somewhere changed and the presentation event that mpv receives now corresponds to 2 frame callbacks ago instead of 1. This results in a leak whenever the VO is destroyed while visible and it happens in every compositor. Since we now seem to have multiple presentation feedbacks "in-flight" and there seems to be no way to avoid this (at least as far as I can tell), just give in and keep track of them all. Wayland has its own linked list utility that is convenient so employ it here. Fixes #11022.