### PR TITLE
wayland presentation fixes (again)

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1030,9 +1030,6 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
         wl->feedback = NULL;
     }
 
-    if (!wl->use_present)
-        return;
-
     wl->refresh_interval = (int64_t)refresh_nsec / 1000;
 
     // Very similar to oml_sync_control, in this case we assume that every
@@ -1079,7 +1076,7 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
     wl->frame_callback = wl_surface_frame(wl->surface);
     wl_callback_add_listener(wl->frame_callback, &frame_listener, wl);
 
-    if (wl->presentation) {
+    if (wl->use_present) {
         wl->feedback = wp_presentation_feedback(wl->presentation, wl->surface);
         wp_presentation_feedback_add_listener(wl->feedback, &feedback_listener, wl);
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1724,6 +1724,9 @@ static void window_move(struct vo_wayland_state *wl, uint32_t serial)
 
 static void vo_wayland_dispatch_events(struct vo_wayland_state *wl, int nfds, int timeout)
 {
+    if (wl->display_fd == -1)
+        return;
+
     struct pollfd fds[2] = {
         {.fd = wl->display_fd,     .events = POLLIN },
         {.fd = wl->wakeup_pipe[0], .events = POLLIN },
@@ -1947,6 +1950,7 @@ int vo_wayland_init(struct vo *vo)
         .refresh_interval = 0,
         .scaling = 1,
         .wakeup_pipe = {-1, -1},
+        .display_fd = -1,
         .dnd_fd = -1,
         .cursor_visible = true,
         .vo_opts_cache = m_config_cache_alloc(wl, vo->global, &vo_sub_opts),
@@ -2345,9 +2349,6 @@ void vo_wayland_wait_frame(struct vo_wayland_state *wl)
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us)
 {
     struct vo_wayland_state *wl = vo->wl;
-
-    if (wl->display_fd == -1)
-        return;
 
     int64_t wait_us = until_time_us - mp_time_us();
     int timeout_ms = MPCLAMP((wait_us + 999) / 1000, 0, 10000);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -101,7 +101,6 @@ struct vo_wayland_state {
 
     /* presentation-time */
     struct wp_presentation  *presentation;
-    struct wp_presentation_feedback *feedback;
     struct mp_present *present;
     int64_t refresh_interval;
     bool use_present;


### PR DESCRIPTION
Fixes #11022 but it's better this time.

First commit is just extra. The actual fix is the second one which basically just dispatches wayland events and then does another roundtrip before doing uninit. A `wl->feedback == fback` check is added now since these two are not necessarily the same pointer.