### PR TITLE
hwdec_drmprime: fix memory leak

### DIFF
--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -47,6 +47,7 @@ static void uninit(struct ra_hwdec *hw)
     struct priv_owner *p = hw->priv;
     if (p->hwctx.driver_name)
         hwdec_devices_remove(hw->devs, &p->hwctx);
+    av_buffer_unref(&p->hwctx.av_device_ref);
 }
 
 const static dmabuf_interop_init interop_inits[] = {


### PR DESCRIPTION
This commit fixes an issue happening in "hwdec_drmprime.c". This issue generates a cascade of small memory leaks. The logs were reported by the gcc sanitizer (-fsanitize=leak).

```
==4914==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f974f4c80 in __interceptor_posix_memalign (/usr/lib64/libasan.so.6+0xa4c80)
    #1 0x7f95aa1638 in av_malloc (/usr/local/lib64/libavutil.so.56+0x31638)
    #2 0x7f95aa185c in av_mallocz (/usr/local/lib64/libavutil.so.56+0x3185c)
    #3 0x7f95a8bc30 in av_buffer_create (/usr/local/lib64/libavutil.so.56+0x1bc30)
    #4 0x7f95a975e4 in av_hwdevice_ctx_alloc (/usr/local/lib64/libavutil.so.56+0x275e4)
    #5 0x7f95a97b74 in av_hwdevice_ctx_create (/usr/local/lib64/libavutil.so.56+0x27b74)
    #6 0x969e5c in init ../video/out/hwdec/hwdec_drmprime.c:102
    #7 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #8 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #9 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #10 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #11 0x8e0dec in control ../video/out/vo_gpu.c:202
    #12 0x8ccc9c in run_control ../video/out/vo.c:661
    #13 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #14 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #15 0x7f944f89cc  (/lib64/libc.so.6+0x789cc)
    #16 0x7f9455c498  (/lib64/libc.so.6+0xdc498)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f974f4c80 in __interceptor_posix_memalign (/usr/lib64/libasan.so.6+0xa4c80)
    #1 0x7f95aa1638 in av_malloc (/usr/local/lib64/libavutil.so.56+0x31638)
    #2 0x7f95aa185c in av_mallocz (/usr/local/lib64/libavutil.so.56+0x3185c)
    #3 0x7f95a97594 in av_hwdevice_ctx_alloc (/usr/local/lib64/libavutil.so.56+0x27594)
    #4 0x7f95a97b74 in av_hwdevice_ctx_create (/usr/local/lib64/libavutil.so.56+0x27b74)
    #5 0x969e5c in init ../video/out/hwdec/hwdec_drmprime.c:102
    #6 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #7 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #8 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #9 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #10 0x8e0dec in control ../video/out/vo_gpu.c:202
    #11 0x8ccc9c in run_control ../video/out/vo.c:661
    #12 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #13 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #14 0x7f944f89cc  (/lib64/libc.so.6+0x789cc)
    #15 0x7f9455c498  (/lib64/libc.so.6+0xdc498)

Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7f974f4c80 in __interceptor_posix_memalign (/usr/lib64/libasan.so.6+0xa4c80)
    #1 0x7f95aa1638 in av_malloc (/usr/local/lib64/libavutil.so.56+0x31638)
    #2 0x7f95aa185c in av_mallocz (/usr/local/lib64/libavutil.so.56+0x3185c)
    #3 0x7f95a8bbec in av_buffer_create (/usr/local/lib64/libavutil.so.56+0x1bbec)
    #4 0x7f95a975e4 in av_hwdevice_ctx_alloc (/usr/local/lib64/libavutil.so.56+0x275e4)
    #5 0x7f95a97b74 in av_hwdevice_ctx_create (/usr/local/lib64/libavutil.so.56+0x27b74)
    #6 0x969e5c in init ../video/out/hwdec/hwdec_drmprime.c:102
    #7 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #8 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #9 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #10 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #11 0x8e0dec in control ../video/out/vo_gpu.c:202
    #12 0x8ccc9c in run_control ../video/out/vo.c:661
    #13 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #14 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #15 0x7f944f89cc  (/lib64/libc.so.6+0x789cc)
    #16 0x7f9455c498  (/lib64/libc.so.6+0xdc498)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f974f4c80 in __interceptor_posix_memalign (/usr/lib64/libasan.so.6+0xa4c80)
    #1 0x7f95aa1638 in av_malloc (/usr/local/lib64/libavutil.so.56+0x31638)
    #2 0x7f95aa185c in av_mallocz (/usr/local/lib64/libavutil.so.56+0x3185c)
    #3 0x7f95a975a8 in av_hwdevice_ctx_alloc (/usr/local/lib64/libavutil.so.56+0x275a8)
    #4 0x7f95a97b74 in av_hwdevice_ctx_create (/usr/local/lib64/libavutil.so.56+0x27b74)
    #5 0x969e5c in init ../video/out/hwdec/hwdec_drmprime.c:102
    #6 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #7 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #8 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #9 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #10 0x8e0dec in control ../video/out/vo_gpu.c:202
    #11 0x8ccc9c in run_control ../video/out/vo.c:661
    #12 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #13 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #14 0x7f944f89cc  (/lib64/libc.so.6+0x789cc)
    #15 0x7f9455c498  (/lib64/libc.so.6+0xdc498)

Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f974f4c80 in __interceptor_posix_memalign (/usr/lib64/libasan.so.6+0xa4c80)
    #1 0x7f95aa1638 in av_malloc (/usr/local/lib64/libavutil.so.56+0x31638)
    #2 0x7f95aa185c in av_mallocz (/usr/local/lib64/libavutil.so.56+0x3185c)
    #3 0x7f95a9761c in av_hwdevice_ctx_alloc (/usr/local/lib64/libavutil.so.56+0x2761c)
    #4 0x7f95a97b74 in av_hwdevice_ctx_create (/usr/local/lib64/libavutil.so.56+0x27b74)
    #5 0x969e5c in init ../video/out/hwdec/hwdec_drmprime.c:102
    #6 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #7 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #8 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #9 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #10 0x8e0dec in control ../video/out/vo_gpu.c:202
    #11 0x8ccc9c in run_control ../video/out/vo.c:661
    #12 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #13 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #14 0x7f944f89cc  (/lib64/libc.so.6+0x789cc)
    #15 0x7f9455c498  (/lib64/libc.so.6+0xdc498)

```