### PR TITLE
vo: hwdec: fix drmGetDeviceNameFromFd2() related memory leak

### DIFF
--- a/video/out/hwdec/hwdec_drmprime_overlay.c
+++ b/video/out/hwdec/hwdec_drmprime_overlay.c
@@ -299,10 +299,14 @@ static int init(struct ra_hwdec *hw)
         .driver_name = hw->driver->name,
         .hw_imgfmt = IMGFMT_DRMPRIME,
     };
+
+    char *device = drmGetDeviceNameFromFd2(p->ctx->fd);
     if (!av_hwdevice_ctx_create(&p->hwctx.av_device_ref, AV_HWDEVICE_TYPE_DRM,
-                                drmGetDeviceNameFromFd2(p->ctx->fd), NULL, 0)) {
+                                device, NULL, 0)) {
         hwdec_devices_add(hw->devs, &p->hwctx);
     }
+    if (device)
+        free(device);
 
     return 0;
 


### PR DESCRIPTION
This commit fixes a minor memory leak related to drmGetDeviceNameFromFd2(). This function returns a string allocated with strdup().

```
Direct leak of 15 byte(s) in 1 object(s) allocated from:
    #0 0x7f95cd9050 in __interceptor_strdup (/usr/lib64/libasan.so.6+0x59050)
    #1 0x7f93dd2520 in drmGetDeviceNameFromFd2 ../xf86drm.c:4787
    #2 0x971494 in init ../video/out/hwdec/hwdec_drmprime_overlay.c:303
    #3 0x842548 in ra_hwdec_load_driver ../video/out/gpu/hwdec.c:103
    #4 0x842a2c in load_add_hwdec ../video/out/gpu/hwdec.c:235
    #5 0x845684 in ra_hwdec_ctx_load_fmt ../video/out/gpu/hwdec.c:331
    #6 0x8e0dec in request_hwdec_api ../video/out/vo_gpu.c:131
    #7 0x8e0dec in control ../video/out/vo_gpu.c:202
    #8 0x8ccc9c in run_control ../video/out/vo.c:661
    #9 0x62c7ac in mp_dispatch_queue_process ../misc/dispatch.c:300
    #10 0x8d5ccc in vo_thread ../video/out/vo.c:1100
    #11 0x7f92d289cc  (/lib64/libc.so.6+0x789cc)
    #12 0x7f92d8c498  (/lib64/libc.so.6+0xdc498)

```