### PR TITLE
demux: use consistent volume for Opus files with replaygain (EBU R128)

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2963,6 +2963,10 @@ static struct replaygain_data *decode_rgain(struct mp_log *log,
         }
         rg.track_gain /= 256.;
         rg.album_gain /= 256.;
+        // Add 5dB to compensate for the different reference levels between
+        // ReplayGain (89dB) and EBU R128 (-23 LUFS)
+        rg.track_gain += 5.;
+        rg.album_gain += 5.;
         return talloc_dup(NULL, &rg);
     }
 


### PR DESCRIPTION
I noticed that my Vorbis and Opus files have a different volume when played with mpv using replaygain. The same files have the same volume with [mpd](https://www.musicpd.org/) and replaygain.

To reproduce (I used [loudgain](https://github.com/Moonbase59/loudgain) to add R128/replaygain tags):
<pre>
$ oggenc x.wav
$ opusenc x.wav x.opus
$ loudgain -a -k -s e x.ogg
$ loudgain -a -k -s e x.opus
$ mpv --replaygain=track x.ogg x.opus
</pre>

The Opus file is quieter than the Vorbis file.

The solution is taken from mpd which increases the replaygain for R128 by 5dB.

This change increases the volume of all Opus files but makes the volume consistent with other file formats supporting Replaygain.