### PR TITLE
wl_buffer_pool : refactor and fix memory leak

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -186,7 +186,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     // to avoid stutter artifact
     p->reset_count++;
     if (p->want_reset &&  p->reset_count <= 2){
-        wlbuf_pool_clean(p->wlbuf_pool);
+        wlbuf_pool_clean(p->wlbuf_pool,false);
         if (p->reset_count == 2)
             p->want_reset = false;
     }

--- a/video/out/wlbuf_pool.c
+++ b/video/out/wlbuf_pool.c
@@ -41,43 +41,53 @@ struct wlbuf_pool *wlbuf_pool_alloc(struct vo *vo, struct vo_wayland_state *wl, 
     pool->vo = vo;
     pool->key_provider = key_provider;
     pool->dmabuf_importer = dmabuf_importer;
-    pthread_mutex_init(&pool->lock, NULL);
     pool->wl = wl;
+    for (int i = 0; i < WLBUF_NUM_PURG_ENTRIES; ++i)
+        pool->purg.entries[i] = NULL;
 
     return pool;
 }
 
-void wlbuf_pool_clean(struct wlbuf_pool *pool)
+void wlbuf_pool_clean(struct wlbuf_pool *pool, bool final_clean)
 {
     int i;
     if (!pool)
         return;
-    pthread_mutex_lock(&pool->lock);
-    MP_VERBOSE(pool->vo, "Begin clean pool\n");
+    MP_TRACE(pool->vo, "Begin clean pool\n");
+    if (final_clean) {
+        // free all purgatory entries
+        for (i = 0; i < WLBUF_NUM_PURG_ENTRIES; ++i){
+            struct wlbuf_pool_entry *entry = pool->purg.entries[i];
+            if (entry){
+                if (entry->image)
+                    mp_image_unrefp(&entry->image);
+                entry->image = NULL;
+                wlbuf_pool_entry_free(entry);
+            }
+        }
+    }
     for (i = 0; i < pool->num_allocated; ++i) {
         struct wlbuf_pool_entry *entry = pool->entries[i];
         if (!entry)
             continue;
-        // force frame unref
-        if (pool->final_clean && entry->frame){
-            mp_image_unrefp(&entry->frame);
-            entry->frame = NULL;
+        // force image unref
+        if (final_clean && entry->image){
+            mp_image_unrefp(&entry->image);
+            entry->image = NULL;
         }
         wlbuf_pool_entry_free(entry);
         pool->entries[i] = NULL;
     }
     pool->num_entries = 0;
-    MP_VERBOSE(pool->vo, "End clean pool\n");
-    pthread_mutex_unlock(&pool->lock);
+    MP_TRACE(pool->vo, "End clean pool\n");
 }
 
 void wlbuf_pool_free(struct wlbuf_pool *pool)
 {
     if (!pool)
         return;
-    pool->final_clean = true;
-    wlbuf_pool_clean(pool);
-    pthread_mutex_destroy(&pool->lock);
+
+    wlbuf_pool_clean(pool,true);
     talloc_free(pool);
 }
 
@@ -85,34 +95,53 @@ static void wlbuf_pool_entry_free(struct wlbuf_pool_entry *entry)
 {
     if (!entry)
         return;
-    if (entry->frame) {
-        MP_VERBOSE(entry->vo, "Pending free buffer pool entry : %lu\n",entry->key );
-        entry->pending_delete = true;
+    if (entry->image) {
+        MP_TRACE(entry->vo, "Pending free for buffer pool entry : %lu\n",entry->key );
+        entry->pending_free = true;
+        // add to purgatory
+        struct wlbuf_pool *pool = entry->pool;
+        for (int i = 0; i < WLBUF_NUM_PURG_ENTRIES; ++i){
+            if (pool->purg.entries[i] == NULL) {
+                pool->purg.entries[i] = entry;
+                break;
+            }
+        }
     }
     else {
-        MP_VERBOSE(entry->vo, "Free buffer pool entry : %lu\n",entry->key );
+        MP_TRACE(entry->vo, "Free buffer pool entry : %lu\n",entry->key );
         if (entry->buffer)
             wl_buffer_destroy(entry->buffer);
-        entry->buffer = NULL;
         talloc_free(entry);
     }
 }
 
+/**
+ * Unref pool entry's image, and also free entry itself if it's set to pending_free
+ */
 static void wlbuf_pool_entry_release(void *data, struct wl_buffer *wl_buffer)
 {
     struct wlbuf_pool_entry *entry = (struct wlbuf_pool_entry*)data;
-    struct mp_image *frame;
-    pthread_mutex_t *lock = entry->pool_lock;
 
-    MP_VERBOSE(entry->vo, "Release buffer pool entry : %lu\n",entry->key );
-    pthread_mutex_lock(lock);
-    frame = entry->frame;
-    entry->frame = NULL;
-    if (entry->pending_delete)
+    MP_TRACE(entry->vo, "Release buffer pool entry : %lu\n",entry->key );
+
+    // 1. unref image
+    if (entry->image)
+        mp_image_unrefp(&entry->image);
+    entry->image = NULL;
+
+    // 2. complete pending free
+    if (entry->pending_free) {
+        // remove from purgatory
+        struct wlbuf_pool *pool = entry->pool;
+        for (int i = 0; i < WLBUF_NUM_PURG_ENTRIES; ++i){
+            if (pool->purg.entries[i] == entry){
+                pool->purg.entries[i] = NULL;
+                break;
+            }
+        }
+        // destroy entry
         wlbuf_pool_entry_free(entry);
-    if (frame)
-        mp_image_unrefp(&frame);
-    pthread_mutex_unlock(lock);
+    }
 }
 
 static const struct wl_buffer_listener wlbuf_pool_listener = {
@@ -133,32 +162,32 @@ struct wlbuf_pool_entry *wlbuf_pool_get_entry(struct wlbuf_pool *pool, struct mp
     /* 1. try to find existing entry in pool */
     src = mp_image_new_ref(src);
     key = pool->key_provider(src);
-    pthread_mutex_lock(&pool->lock);
     for (int i = 0; i < pool->num_entries; ++i) {
         struct wlbuf_pool_entry *item = pool->entries[i];
+        if (!item)
+            continue;
         if (item->key == key) {
-            pthread_mutex_unlock(&pool->lock);
-            if (item->frame){
+            if (item->image){
                 mp_image_unrefp(&src);
+                MP_DBG(item->vo, "Buffer already scheduled - returning NULL.\n");
                 return NULL;
             } else {
-                item->frame = src;
+                item->image = src;
                 return item;
             }
         }
     }
-    pthread_mutex_unlock(&pool->lock);
     /* 2. otherwise allocate new entry and buffer */
     entry = talloc(pool, struct wlbuf_pool_entry);
     memset(entry, 0, sizeof(struct wlbuf_pool_entry));
     entry->vo = pool->vo;
     entry->key = pool->key_provider(src);
-    entry->pool_lock = &pool->lock;
-    MP_VERBOSE(entry->vo, "Allocate buffer pool entry : %lu\n",entry->key );
+    entry->pool = pool;
+    MP_TRACE(entry->vo, "Allocate buffer pool entry : %lu\n",entry->key );
     params = zwp_linux_dmabuf_v1_create_params(wl->dmabuf);
     import_successful = pool->dmabuf_importer(src,entry,params);
     if (!import_successful) {
-        MP_VERBOSE(entry->vo, "Failed to import\n");
+        MP_DBG(entry->vo, "Failed to import\n");
         wlbuf_pool_entry_free(entry);
     } else {
         entry->buffer = zwp_linux_buffer_params_v1_create_immed(params, src->params.w, src->params.h,
@@ -169,22 +198,17 @@ struct wlbuf_pool_entry *wlbuf_pool_get_entry(struct wlbuf_pool *pool, struct mp
          mp_image_unrefp(&src);
          return NULL;
     }
-
     /* 3. add new entry to pool */
     if (pool->num_entries == pool->num_allocated) {
         int current_num_allocated = pool->num_allocated;
         pool->num_allocated *= 2;
-        pthread_mutex_lock(&pool->lock);
         pool->entries = talloc_realloc(pool, pool->entries, struct wlbuf_pool_entry *, pool->num_allocated);
         for (int i = current_num_allocated; i < pool->num_allocated; ++i)
             pool->entries[i] = NULL;
-        pthread_mutex_unlock(&pool->lock);
     }
     wl_buffer_add_listener(entry->buffer, &wlbuf_pool_listener, entry);
-    entry->frame = src;
-    pthread_mutex_lock(&pool->lock);
+    entry->image = src;
     pool->entries[pool->num_entries++] = entry;
-    pthread_mutex_unlock(&pool->lock);
 
     return entry;
 }


### PR DESCRIPTION
1. remove mutex, since only render thread will access pool
2. add "purgatory" to hold buffers that have been removed from the pool but are still being processed by Wayland. These buffers will be freed and removed from "purgatory" when either of two conditions occurr:
1. Wayland finishes processing the buffer and calls frame listener
2. pool is freed before Wayland finshes processing the buffers

Without purgatory, these buffers will leak when pool is cleared and program then exits before frame listener gets called

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.