### PR TITLE
ao_pipewire: allow usage of global volume control

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -161,6 +161,11 @@ Available audio output drivers are:
         sockets.
         An empty <remote> string uses the default remote named ``pipewire-0``.
 
+    ``--pipewire-volume-mode=<channel|global>``
+        Specify if the ``ao-volume`` property should apply to the channel
+        volumes or the global volume.
+        By default the channel volumes are used.
+
 ``sdl``
     SDL 1.2+ audio output driver. Should work on any platform supported by SDL
     1.2, but may require the ``SDL_AUDIODRIVER`` environment variable to be set


### PR DESCRIPTION
PipeWire supports a global volume control for streams that works on top of the per-channel volumes.
As mpv only supports a single volume with ao-volume it can make sense to use the single global volume from PipeWire for it. This allows the user to also specify per-channel volumes and not have mpv trample over them.

This mode is not the default as pulseaudio does not support this global volume control and all tooling controlling PipeWire via pipewire-pulse (like pavucontrol) will not be able to see this channel.