### PR TITLE
hwdec_drmprime: support rpi4_8 and rpi4_10 formats

### DIFF
--- a/video/out/hwdec/dmabuf_interop_gl.c
+++ b/video/out/hwdec/dmabuf_interop_gl.c
@@ -186,6 +186,9 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper,
                 format[2] = DRM_FORMAT_R8;
                 break;
             case DRM_FORMAT_P010:
+#ifdef DRM_FORMAT_P030 /* Format added in a newer libdrm version than minimum */
+            case DRM_FORMAT_P030:
+#endif
                 format[0] = DRM_FORMAT_R16;
                 format[1] = DRM_FORMAT_GR1616;
                 break;

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -167,7 +167,17 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
     struct dmabuf_interop_priv *p = mapper->priv;
 
     mapper->dst_params = mapper->src_params;
-    mapper->dst_params.imgfmt = mapper->src_params.hw_subfmt;
+
+    /*
+     * rpi4_8 and rpi4_10 function identically to NV12. These two pixel
+     * formats however are not defined in upstream ffmpeg so a string
+     * comparison is used to identify them instead of a mpv IMGFMT.
+     */
+    const char* fmt_name = mp_imgfmt_to_name(mapper->src_params.hw_subfmt);
+    if (strcmp(fmt_name, "rpi4_8") == 0 || strcmp(fmt_name, "rpi4_10") == 0)
+        mapper->dst_params.imgfmt = IMGFMT_NV12;
+    else
+        mapper->dst_params.imgfmt = mapper->src_params.hw_subfmt;
     mapper->dst_params.hw_subfmt = 0;
 
     struct ra_imgfmt_desc desc = {0};


### PR DESCRIPTION
With these changes mpv is now aware of the "rpi4_8" and "rpi4_10" formats that are used for HEVC hardware decode on the Raspberry Pi 4. To make this work with the existing mpv structure I had to do a couple things. The first was manually defining the IMGFMTs because ffmpeg doesn't. Usually for special HW accel formats ffmpeg handles it, but not in this case, so it is just made to act like NV12. The second was to use a #define for the AV_PIX_FMTs because otherwise mpv wouldn't compile with normal ffmpeg. This is admittedly a little hacky but it shouldn't interfere with anything and can be removed once the changes from https://github.com/jc-kynesim/rpi-ffmpeg are upstreamed. These formats also won't work without some changes I did in mesa which the status of can be found here https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/20510. These changes are similar to the yuv420p one I created to get H264 hardware decode working. I have tested these changes on a Pi 4 with a H264 file, HEVC 8-bit file and HEVC 10-bit file.

Resolves #10773 