### PR TITLE
meson: dynamically compute dependencies for manpage and html build

### DIFF
--- a/TOOLS/docutils-wrapper.py
+++ b/TOOLS/docutils-wrapper.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Wrapper around docutils rst2x commands,
+converting their dependency files to a format understood by meson/ninja.
+"""
+
+#
+# This file is part of mpv.
+#
+# mpv is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# mpv is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+import subprocess
+import sys
+
+
+def convert_depfile(output, depfile):
+    with open(depfile, 'r') as f:
+        deps = f.readlines()
+
+    with open(depfile, 'w') as f:
+        f.write(os.path.abspath(output))
+        f.write(': \\\n')
+        for dep in deps:
+            dep = dep[:-1]
+            f.write('\t')
+            f.write(os.path.abspath(dep))
+            f.write(' \\\n')
+
+argv = sys.argv[1:]
+
+depfile = None
+output = argv[-1]
+
+for opt, optarg in zip(argv, argv[1:]):
+    if opt == '--record-dependencies':
+        depfile = optarg
+
+try:
+    subprocess.run(argv)
+    convert_depfile(output, depfile)
+except:
+    os.remove(output)
+    os.remove(depfile)

--- a/meson.build
+++ b/meson.build
@@ -554,6 +554,7 @@ tools_directory = join_paths(source_root, 'TOOLS')
 file2string = find_program(join_paths(tools_directory, 'file2string.py'))
 matroska = find_program(join_paths(tools_directory, 'matroska.py'))
 version_py = find_program(join_paths(source_root, 'version.py'))
+docutils_wrapper = find_program(join_paths(tools_directory, 'docutils-wrapper.py'))
 
 subdir('generated')
 subdir(join_paths('generated', 'etc'))
@@ -1556,7 +1557,12 @@ if features['manpage-build']
     custom_target('manpages',
         input: manpage,
         output: 'mpv.1',
-        command: [rst2man, '--strip-elements-with-class=contents', '@INPUT@', '@OUTPUT@'],
+        command: [
+          docutils_wrapper, rst2man,
+          '--record-dependencies', '@DEPFILE@',
+          '--strip-elements-with-class=contents',
+          '@INPUT@', '@OUTPUT@'],
+        depfile: 'mpv.1.dep',
         install: true,
         install_dir: join_paths(mandir, 'man1')
     )
@@ -1569,7 +1575,11 @@ if features['html-build']
     custom_target('html-manpages',
         input: manpage,
         output: 'mpv.html',
-        command: [rst2html, '@INPUT@', '@OUTPUT@'],
+        command: [
+          docutils_wrapper, rst2html,
+          '--record-dependencies', '@DEPFILE@',
+          '@INPUT@', '@OUTPUT@'],
+        depfile: 'mpv.html.dep',
         install: true,
         install_dir: join_paths(datadir, 'doc', 'mpv')
     )


### PR DESCRIPTION
This allows us to rebuild the manpages and html documentation only when necessary. It is not necessary to manually keep the list of dependencies up to date.

Unfortunately rst2pdf does not yet support this feature, see https://github.com/rst2pdf/rst2pdf/issues/1108