### PR TITLE
player: don't force saving start in watch-later-options

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -41,6 +41,10 @@ Interface changes
     - deprecate `--drm-atomic`
     - add `--demuxer-hysteresis-secs`
     - add `--video-sync=display-tempo`
+    - the `start` option is no longer unconditionally written by
+      watch-later. It is still written by default but you may
+      need to explictly add `start` depending on how you have
+      `--watch-later-options` configured.
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1032,8 +1032,8 @@ Watch Later
 ``--watch-later-options=option1,option2,...``
     The options that are saved in "watch later" files if they have been changed
     since when mpv started. These values will be restored the next time the
-    files are played. The playback position is always saved as ``start``, so
-    adding ``start`` to this list has no effect.
+    files are played. Note that the playback position is saved via the ``start``
+    option.
 
     When removing options, existing watch later data won't be modified and will
     still be applied fully, but new watch later data won't contain these
@@ -1049,8 +1049,7 @@ Watch Later
           ``--watch-later-options-remove=mute``
           The volume and mute state won't be saved to watch later files.
         - ``--watch-later-options-clr``
-          No option will be saved to watch later files except the starting
-          position.
+          No option will be saved to watch later files.
 
 ``--write-filename-in-watch-later-config``
     Prepend the watch later config files with the name of the file they refer

--- a/options/options.c
+++ b/options/options.c
@@ -1069,6 +1069,7 @@ static const struct MPOpts mp_default_opts = {
     .cuda_device = -1,
 
     .watch_later_options = (char **)(const char*[]){
+        "start",
         "osd-level",
         "speed",
         "edition",

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -303,18 +303,23 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
 
     write_filename(mpctx, file, cur->filename);
 
+    bool write_start = true;
     double pos = get_current_time(mpctx);
 
     if ((demux && (!demux->seekable || demux->partially_seekable)) ||
         pos == MP_NOPTS_VALUE)
     {
+        write_start = false;
         MP_INFO(mpctx, "Not seekable, or time unknown - not saving position.\n");
-    } else {
-        fprintf(file, "start=%f\n", pos);
     }
     char **watch_later_options = mpctx->opts->watch_later_options;
     for (int i = 0; watch_later_options && watch_later_options[i]; i++) {
         char *pname = watch_later_options[i];
+        // Always save start if we have it in the array.
+        if (write_start && strcmp(pname, "start") == 0) {
+            fprintf(file, "%s=%f\n", pname, pos);
+            continue;
+        }
         // Only store it if it's different from the initial value.
         if (m_config_watch_later_backup_opt_changed(mpctx->mconfig, pname)) {
             char *val = NULL;


### PR DESCRIPTION
The watch-later mechanism has always unconditionally wrote start to files to save the playback position. When this was later expanded to watch-later-options, this logic was kept in place. But we don't actually have to unconditionally write this and can allow users to remove the option from the list if they want to. The start value still requires some special handling; it should always be written if possible regardless of the value changing. However, we can just place it within the default set of options for watch-later-options so it can be removed like any other.

This should fix #10776 since the auto profile condition in there would work with this PR.