### PR TITLE
vulkan: fix build error for 32bit builds with clang

### DIFF
--- a/video/out/vulkan/utils.c
+++ b/video/out/vulkan/utils.c
@@ -34,7 +34,7 @@ void mpvk_uninit(struct mpvk_ctx *vk)
     if (vk->surface) {
         assert(vk->vkinst);
         vkDestroySurfaceKHR(vk->vkinst->instance, vk->surface, NULL);
-        vk->surface = NULL;
+        vk->surface = VK_NULL_HANDLE;
     }
 
     pl_vk_inst_destroy(&vk->vkinst);


### PR DESCRIPTION
vk->surface is a handle and not a pointer, so assign VK_NULL_HANDLE. This fixes the following build error on 32bit Windows when using clang for example, which errors out when assigning a 32bit pointer to a 64bit integer:

```
  ../mpv-0.35.0/video/out/vulkan/utils.c:37:21:
    error: incompatible pointer to integer conversion assigning to 'VkSurfaceKHR' (aka 'unsigned long long') from 'void *' [-Wint-conversion]
          vk->surface = NULL;
                      ^ ~~~~
```

