### PR TITLE
various function return consistency fixes

### DIFF
--- a/video/out/android_common.c
+++ b/video/out/android_common.c
@@ -29,7 +29,7 @@ struct vo_android_state {
     ANativeWindow *native_window;
 };
 
-int vo_android_init(struct vo *vo)
+bool vo_android_init(struct vo *vo)
 {
     vo->android = talloc_zero(vo, struct vo_android_state);
     struct vo_android_state *ctx = vo->android;
@@ -51,11 +51,11 @@ int vo_android_init(struct vo *vo)
         goto fail;
     }
 
-    return 1;
+    return true;
 fail:
     talloc_free(ctx);
     vo->android = NULL;
-    return 0;
+    return false;
 }
 
 void vo_android_uninit(struct vo *vo)

--- a/video/out/android_common.h
+++ b/video/out/android_common.h
@@ -23,7 +23,7 @@
 
 struct vo;
 
-int vo_android_init(struct vo *vo);
+bool vo_android_init(struct vo *vo);
 void vo_android_uninit(struct vo *vo);
 ANativeWindow *vo_android_native_window(struct vo *vo);
 bool vo_android_surface_size(struct vo *vo, int *w, int *h);

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -149,10 +149,7 @@ static bool egl_create_context(struct ra_ctx *ctx)
 
 static bool wayland_egl_reconfig(struct ra_ctx *ctx)
 {
-    if (!vo_wayland_reconfig(ctx->vo))
-        return false;
-
-    return true;
+    return vo_wayland_reconfig(ctx->vo);
 }
 
 static void wayland_egl_uninit(struct ra_ctx *ctx)

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -208,11 +208,8 @@ static void wayland_egl_update_render_opts(struct ra_ctx *ctx)
 
 static bool wayland_egl_init(struct ra_ctx *ctx)
 {
-    if (!vo_wayland_init(ctx->vo)) {
-        vo_wayland_uninit(ctx->vo);
+    if (!vo_wayland_init(ctx->vo))
         return false;
-    }
-
     return egl_create_context(ctx);
 }
 

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -123,10 +123,7 @@ static bool resize(struct ra_ctx *ctx)
 
 static bool wayland_vk_reconfig(struct ra_ctx *ctx)
 {
-    if (!vo_wayland_reconfig(ctx->vo))
-        return false;
-
-    return true;
+    return vo_wayland_reconfig(ctx->vo);
 }
 
 static int wayland_vk_control(struct ra_ctx *ctx, int *events, int request, void *arg)

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1618,8 +1618,7 @@ done:
     return NULL;
 }
 
-// Returns: 1 = Success, 0 = Failure
-int vo_w32_init(struct vo *vo)
+bool vo_w32_init(struct vo *vo)
 {
     assert(!vo->w32);
 
@@ -1651,11 +1650,11 @@ int vo_w32_init(struct vo *vo)
         talloc_free(profile);
     }
 
-    return 1;
+    return true;
 fail:
     talloc_free(w32);
     vo->w32 = NULL;
-    return 0;
+    return false;
 }
 
 struct disp_names_data {

--- a/video/out/w32_common.h
+++ b/video/out/w32_common.h
@@ -26,7 +26,7 @@
 
 struct vo;
 
-int vo_w32_init(struct vo *vo);
+bool vo_w32_init(struct vo *vo);
 void vo_w32_uninit(struct vo *vo);
 int vo_w32_control(struct vo *vo, int *events, int request, void *arg);
 void vo_w32_config(struct vo *vo);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1953,10 +1953,10 @@ bool vo_wayland_init(struct vo *vo)
     wl_list_init(&wl->output_list);
 
     if (!wl->display)
-        return false;
+        goto err;
 
     if (create_input(wl))
-        return false;
+        goto err;
 
     wl->registry = wl_display_get_registry(wl->display);
     wl_registry_add_listener(wl->registry, &registry_listener, wl);
@@ -1967,24 +1967,24 @@ bool vo_wayland_init(struct vo *vo)
     if (!wl->surface) {
         MP_FATAL(wl, "Compositor doesn't support %s (ver. 4)\n",
                  wl_compositor_interface.name);
-        return false;
+        goto err;
     }
 
     if (!wl->wm_base) {
         MP_FATAL(wl, "Compositor doesn't support the required %s protocol!\n",
                  xdg_wm_base_interface.name);
-        return false;
+        goto err;
     }
 
     if (!wl_list_length(&wl->output_list)) {
         MP_FATAL(wl, "No outputs found or compositor doesn't support %s (ver. 2)\n",
                  wl_output_interface.name);
-        return false;
+        goto err;
     }
 
     /* Can't be initialized during registry due to multi-protocol dependence */
     if (create_xdg_surface(wl))
-        return false;
+        goto err;
 
     if (wl->subcompositor) {
         wl->video_subsurface = wl_subcompositor_get_subsurface(wl->subcompositor, wl->video_surface, wl->surface);
@@ -2063,6 +2063,10 @@ bool vo_wayland_init(struct vo *vo)
     wl_display_roundtrip(wl->display);
 
     return true;
+
+err:
+    vo_wayland_uninit(vo);
+    return false;
 }
 
 int vo_wayland_reconfig(struct vo *vo)

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2069,7 +2069,7 @@ err:
     return false;
 }
 
-int vo_wayland_reconfig(struct vo *vo)
+bool vo_wayland_reconfig(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wl;
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1929,7 +1929,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
     return VO_NOTIMPL;
 }
 
-int vo_wayland_init(struct vo *vo)
+bool vo_wayland_init(struct vo *vo)
 {
     vo->wl = talloc_zero(NULL, struct vo_wayland_state);
     struct vo_wayland_state *wl = vo->wl;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -154,11 +154,11 @@ struct vo_wayland_state {
 
 bool vo_wayland_check_visible(struct vo *vo);
 bool vo_wayland_init(struct vo *vo);
+bool vo_wayland_reconfig(struct vo *vo);
 bool vo_wayland_supported_format(struct vo *vo, uint32_t format, uint64_t modifier);
 
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
-int vo_wayland_reconfig(struct vo *vo);
 
 void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);
 void vo_wayland_sync_swap(struct vo_wayland_state *wl);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -153,11 +153,11 @@ struct vo_wayland_state {
 };
 
 bool vo_wayland_check_visible(struct vo *vo);
+bool vo_wayland_init(struct vo *vo);
 bool vo_wayland_supported_format(struct vo *vo, uint32_t format, uint64_t modifier);
 
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
-int vo_wayland_init(struct vo *vo);
 int vo_wayland_reconfig(struct vo *vo);
 
 void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);

--- a/video/out/wldmabuf/context_wldmabuf.c
+++ b/video/out/wldmabuf/context_wldmabuf.c
@@ -27,10 +27,8 @@ static void uninit(struct ra_ctx *ctx)
 
 static bool init(struct ra_ctx *ctx)
 {
-    if (!vo_wayland_init(ctx->vo)) {
-        vo_wayland_uninit(ctx->vo);
+    if (!vo_wayland_init(ctx->vo))
         return false;
-    }
     ctx->ra = ra_create_wayland(ctx->log, ctx->vo->wl->display);
 
     return true;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -596,7 +596,7 @@ static void vo_x11_get_bounding_monitors(struct vo_x11_state *x11, long b[4])
     XFree(screens);
 }
 
-int vo_x11_init(struct vo *vo)
+bool vo_x11_init(struct vo *vo)
 {
     char *dispName;
 
@@ -685,11 +685,11 @@ int vo_x11_init(struct vo *vo)
 
     vo_x11_update_geometry(vo);
 
-    return 1;
+    return true;
 
 error:
     vo_x11_uninit(vo);
-    return 0;
+    return false;
 }
 
 static const struct mp_keymap keymap[] = {

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -142,7 +142,7 @@ struct vo_x11_state {
     Atom icc_profile_property;
 };
 
-int vo_x11_init(struct vo *vo);
+bool vo_x11_init(struct vo *vo);
 void vo_x11_uninit(struct vo *vo);
 void vo_x11_check_events(struct vo *vo);
 bool vo_x11_screen_is_composited(struct vo *vo);


### PR DESCRIPTION
1. Make anything that's like `vo_platform_init` return a bool.
2. Cleanup vo_wayland_init on error.
3. Make vo_wayland_reconfig a bool.