### PR TITLE
ao_wasapi: only report actually read data to wasapi

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -129,14 +129,13 @@ static bool thread_feed(struct ao *ao)
 
     BYTE *data[1] = {pData};
 
-    ao_read_data_converted(ao, &state->convert_format,
-                           (void **)data, frame_count,
-                           mp_time_us() + (int64_t)llrint(delay_us));
+    int read_data = ao_read_data_converted(ao, &state->convert_format,
+                                           (void **)data, frame_count,
+                                           mp_time_us() +
+                                           (int64_t)llrint(delay_us));
 
-    // note, we can't use ao_read_data return value here since we already
-    // committed to frame_count above in the GetBuffer call
     hr = IAudioRenderClient_ReleaseBuffer(state->pRenderClient,
-                                          frame_count, 0);
+                                          read_data, 0);
     EXIT_ON_ERROR(hr);
 
     atomic_fetch_add(&state->sample_count, frame_count);


### PR DESCRIPTION
We can signal the exact number of frames to wasapi. The comment about having committed to a certain number in GetBuffer() contradicts the documentation of ReleaseBuffer().

The number of audio frames written by the client to the data packet. The value of this parameter must be less than or equal to the size of the data packet, as specified in the NumFramesRequested parameter passed to the IAudioRenderClient::GetBuffer method.

*Note: This is completely untested, not even compiled.*