### PR TITLE
 audio: fix crash during uninit on ao_lavc

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -459,7 +459,7 @@ void ao_uninit(struct ao *ao)
 {
     struct buffer_state *p = ao->buffer_state;
 
-    if (p->thread_valid) {
+    if (p && p->thread_valid) {
         pthread_mutex_lock(&p->pt_lock);
         p->terminate = true;
         pthread_cond_broadcast(&p->pt_wakeup);
@@ -472,17 +472,19 @@ void ao_uninit(struct ao *ao)
     if (ao->driver_initialized)
         ao->driver->uninit(ao);
 
-    talloc_free(p->filter_root);
-    talloc_free(p->queue);
-    talloc_free(p->pending);
-    talloc_free(p->convert_buffer);
-    talloc_free(p->temp_buf);
+    if (p) {
+        talloc_free(p->filter_root);
+        talloc_free(p->queue);
+        talloc_free(p->pending);
+        talloc_free(p->convert_buffer);
+        talloc_free(p->temp_buf);
 
-    pthread_cond_destroy(&p->wakeup);
-    pthread_mutex_destroy(&p->lock);
+        pthread_cond_destroy(&p->wakeup);
+        pthread_mutex_destroy(&p->lock);
 
-    pthread_cond_destroy(&p->pt_wakeup);
-    pthread_mutex_destroy(&p->pt_lock);
+        pthread_cond_destroy(&p->pt_wakeup);
+        pthread_mutex_destroy(&p->pt_lock);
+    }
 
     talloc_free(ao);
 }


### PR DESCRIPTION
~mpv internally has ao_lavc and vo_lavc that are used strictly for encoding mode. Because of the way option selection works, you can actually select these (--vo=lavc and/or --ao=lavc) on the commandline. Of course, these will fail (ao=lavc actually segfaults), but there's no business in allowing this anyway. Rework the ao/vo selection a bit and explictly fail if a user happens to select either one of these without also specifying encoding mode. Fixes #10175.~

Now just a null check basically.