### PR TITLE
vo_dmabuf_wayland: drop support for linux-dmabuf-v2

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -354,8 +354,8 @@ static int preinit(struct vo *vo)
        goto err;
     assert(p->ctx->ra);
 
-    if (!vo->wl->dmabuf) {
-        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+    if (!vo->wl->dmabuf || !vo->wl->dmabuf_feedback) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s (ver. 4) protocol!\n",
                  zwp_linux_dmabuf_v1_interface.name);
         goto err;
     }

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -94,10 +94,6 @@ struct vo_wayland_state {
     void *dmabuf_feedback;
     void *format_map;
     uint32_t format_size;
-    /* TODO: remove these once zwp_linux_dmabuf_v1 version 2 support is removed. */
-    int *drm_formats;
-    int drm_format_ct;
-    int drm_format_ct_max;
 
     /* presentation-time */
     struct wp_presentation  *presentation;


### PR DESCRIPTION
The only real reason this was ever supported is because it was dramatically simpler than v4, so it was put in as an initial implementation. Later, v4 support was added and we left v2 for compatibility, but let's just drop it. Compositors all use v4 nowadays, and v2 is significantly limited (no modifier support for example). It's better to just remove this dead code for simplicity.