### PR TITLE
meson: also search for rst2html with .py extension

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1568,7 +1568,7 @@ if features['manpage-build']
     )
 endif
 
-rst2html = find_program('rst2html', required: get_option('html-build'))
+rst2html = find_program('rst2html', 'rst2html.py', required: get_option('html-build'))
 features += {'html-build': rst2html.found()}
 if features['html-build']
     datadir = get_option('datadir')


### PR DESCRIPTION
docutils installs these by default with .py, there just happen to be some distros that symlink/rename (Gentoo doesn't and keeps upstream's names).

waf automatically finds it even with .py, so used not to be an issue.

Thanks.