### PR TITLE
clean up driver lists for AOs/VOs

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -102,12 +102,11 @@ static const struct ao_driver * const audio_out_drivers[] = {
 #endif
     &audio_out_pcm,
     &audio_out_lavc,
-    NULL
 };
 
 static bool get_desc(struct m_obj_desc *dst, int index)
 {
-    if (index >= MP_ARRAY_SIZE(audio_out_drivers) - 1)
+    if (index >= MP_ARRAY_SIZE(audio_out_drivers))
         return false;
     const struct ao_driver *ao = audio_out_drivers[index];
     *dst = (struct m_obj_desc) {
@@ -313,7 +312,7 @@ struct ao *ao_init_best(struct mpv_global *global,
     }
 
     if (autoprobe) {
-        for (int n = 0; audio_out_drivers[n]; n++) {
+        for (int n = 0; n < MP_ARRAY_SIZE(audio_out_drivers); n++) {
             const struct ao_driver *driver = audio_out_drivers[n];
             if (driver == &audio_out_null)
                 break;
@@ -521,7 +520,7 @@ struct ao_device_list *ao_hotplug_get_device_list(struct ao_hotplug *hp,
         }
     }
 
-    for (int n = 0; audio_out_drivers[n]; n++) {
+    for (int n = 0; n < MP_ARRAY_SIZE(audio_out_drivers); n++) {
         const struct ao_driver *d = audio_out_drivers[n];
         if (d == &audio_out_null)
             break; // don't add unsafe/special entries

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -69,7 +69,7 @@ extern const struct vo_driver video_out_tct;
 extern const struct vo_driver video_out_sixel;
 extern const struct vo_driver video_out_kitty;
 
-const struct vo_driver *const video_out_drivers[] =
+static const struct vo_driver *const video_out_drivers[] =
 {
     &video_out_libmpv,
 #if HAVE_ANDROID

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -121,7 +121,6 @@ const struct vo_driver *const video_out_drivers[] =
 #endif
     &video_out_kitty,
     &video_out_lavc,
-    NULL
 };
 
 struct vo_internal {
@@ -189,7 +188,7 @@ static void *vo_thread(void *ptr);
 
 static bool get_desc(struct m_obj_desc *dst, int index)
 {
-    if (index >= MP_ARRAY_SIZE(video_out_drivers) - 1)
+    if (index >= MP_ARRAY_SIZE(video_out_drivers))
         return false;
     const struct vo_driver *vo = video_out_drivers[index];
     *dst = (struct m_obj_desc) {
@@ -371,7 +370,7 @@ struct vo *init_best_video_out(struct mpv_global *global, struct vo_extra *ex)
     }
 autoprobe:
     // now try the rest...
-    for (int i = 0; video_out_drivers[i]; i++) {
+    for (int i = 0; i < MP_ARRAY_SIZE(video_out_drivers); i++) {
         const struct vo_driver *driver = video_out_drivers[i];
         if (driver == &video_out_null)
             break;


### PR DESCRIPTION
As discussed in #11145 instead of relying on the last element to be NULL we can use the known length of the list.

Also the VO driver list can be static.