### PR TITLE
hwdec_cuda: drop support for PL_HANDLE_WIN32_KMT

### DIFF
--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -29,9 +29,6 @@ struct cuda_hw_priv {
     CUcontext display_ctx;
     CUcontext decode_ctx;
 
-    // Stored as int to avoid depending on libplacebo enum
-    int handle_type;
-
     // Do we need to do a full CPU sync after copying
     bool do_full_sync;
 


### PR DESCRIPTION
This handle type was only needed for backwards compatibility with windows 7. Dropping it allows us to simplify the code: there is no longer a need for runtime checks, as the handle type can now be statically assigned based on the platform.

The motivating usecase here, apart from code simplification, is a desired switch to timeline semaphores, which (in the CUDA API) only supports the non-KMT win32 handles.

It's worth pointing out that we need no runtime check for IsWindows8OrGreater(), because the `export_caps.sync` check will already fail on versions of windows not supporting PL_HANDLE_WIN32.