### PR TITLE
audio/chmap: support up to 64 channels

### DIFF
--- a/audio/chmap.c
+++ b/audio/chmap.c
@@ -52,6 +52,11 @@ static const char *const speaker_names[MP_SPEAKER_ID_COUNT][2] = {
     [MP_SPEAKER_ID_SDL]         = {"sdl",  "surround direct left"},
     [MP_SPEAKER_ID_SDR]         = {"sdr",  "surround direct right"},
     [MP_SPEAKER_ID_LFE2]        = {"lfe2", "low frequency 2"},
+    [MP_SPEAKER_ID_TSL]         = {"tsl",  "top side left"},
+    [MP_SPEAKER_ID_TSR]         = {"tsr",  "top side right"},
+    [MP_SPEAKER_ID_BFC]         = {"bfc",  "bottom front center"},
+    [MP_SPEAKER_ID_BFL]         = {"bfl",  "bottom front left"},
+    [MP_SPEAKER_ID_BFR]         = {"bfr",  "bottom front right"},
     [MP_SPEAKER_ID_NA]          = {"na",   "not available"},
 };
 
@@ -83,7 +88,7 @@ static const char *const std_layout_names[][2] = {
     {"6.0(front)",      "fl-fr-flc-frc-sl-sr"},
     {"hexagonal",       "fl-fr-fc-bl-br-bc"},
     {"6.1",             "fl-fr-fc-lfe-bc-sl-sr"},
-    {"6.1(back)",       "fl-fr-fc-lfe-bl-br-bc"}, // lavc calls this "6.1" too
+    {"6.1(back)",       "fl-fr-fc-lfe-bl-br-bc"},
     {"6.1(top)",        "fl-fr-fc-lfe-bl-br-tc"}, // not in lavc
     {"6.1(front)",      "fl-fr-lfe-flc-frc-sl-sr"},
     {"7.0",             "fl-fr-fc-bl-br-sl-sr"},
@@ -93,8 +98,13 @@ static const char *const std_layout_names[][2] = {
     {"7.1(alsa)",       "fl-fr-bl-br-fc-lfe-sl-sr"}, // not in lavc
     {"7.1(wide)",       "fl-fr-fc-lfe-bl-br-flc-frc"},
     {"7.1(wide-side)",  "fl-fr-fc-lfe-flc-frc-sl-sr"},
+    {"7.1(top)",        "fl-fr-fc-lfe-bl-br-tfl-tfr"},
     {"7.1(rear)",       "fl-fr-fc-lfe-bl-br-sdl-sdr"}, // not in lavc
     {"octagonal",       "fl-fr-fc-bl-br-bc-sl-sr"},
+    {"cube",            "fl-fr-bl-br-tfl-tfr-tbl-tbr"},
+    {"hexadecagonal",   "fl-fr-fc-bl-br-bc-sl-sr-tfc-tfl-tfr-tbl-tbc-tbr-wl-wr"},
+    {"downmix",         "fl-fr"},
+    {"22.2",            "fl-fr-fc-lfe-bl-br-flc-frc-bc-sl-sr-tc-tfl-tfc-tfr-tbl-tbc-tbr-lfe2-tsl-tsr-bfc-bfl-bfr"},
     {"auto",            ""}, // not in lavc
     {0}
 };

--- a/audio/chmap.h
+++ b/audio/chmap.h
@@ -124,10 +124,12 @@ void mp_chmap_get_reorder(int src[MP_NUM_CHANNELS], const struct mp_chmap *from,
 int mp_chmap_diffn(const struct mp_chmap *a, const struct mp_chmap *b);
 
 char *mp_chmap_to_str_buf(char *buf, size_t buf_size, const struct mp_chmap *src);
-#define mp_chmap_to_str(m) mp_chmap_to_str_buf((char[64]){0}, 64, (m))
+#define mp_chmap_to_str_(m, sz) mp_chmap_to_str_buf((char[sz]){0}, sz, (m))
+#define mp_chmap_to_str(m) mp_chmap_to_str_(m, MP_NUM_CHANNELS * 4)
 
 char *mp_chmap_to_str_hr_buf(char *buf, size_t buf_size, const struct mp_chmap *src);
-#define mp_chmap_to_str_hr(m) mp_chmap_to_str_hr_buf((char[128]){0}, 128, (m))
+#define mp_chmap_to_str_hr_(m, sz) mp_chmap_to_str_hr_buf((char[sz]){0}, sz, (m))
+#define mp_chmap_to_str_hr(m) mp_chmap_to_str_hr_(m, MP_NUM_CHANNELS * 4)
 
 bool mp_chmap_from_str(struct mp_chmap *dst, bstr src);
 

--- a/audio/chmap.h
+++ b/audio/chmap.h
@@ -22,7 +22,7 @@
 #include <stdbool.h>
 #include "misc/bstr.h"
 
-#define MP_NUM_CHANNELS 16
+#define MP_NUM_CHANNELS 64
 
 // Speaker a channel can be assigned to.
 // This corresponds to WAVEFORMATEXTENSIBLE channel mask bit indexes.

--- a/audio/chmap.h
+++ b/audio/chmap.h
@@ -55,6 +55,11 @@ enum mp_speaker_id {
     MP_SPEAKER_ID_SDL,          // SURROUND_DIRECT_LEFT
     MP_SPEAKER_ID_SDR,          // SURROUND_DIRECT_RIGHT
     MP_SPEAKER_ID_LFE2,         // LOW_FREQUENCY_2
+    MP_SPEAKER_ID_TSL,          // TOP_SIDE_LEFT
+    MP_SPEAKER_ID_TSR,          // TOP_SIDE_RIGHT,
+    MP_SPEAKER_ID_BFC,          // BOTTOM_FRONT_CENTER
+    MP_SPEAKER_ID_BFL,          // BOTTOM_FRONT_LEFT
+    MP_SPEAKER_ID_BFR,          // BOTTOM_FRONT_RIGHT
 
     // Speaker IDs >= 64 are not representable in WAVEFORMATEXTENSIBLE or libav*.
 

--- a/audio/out/ao_coreaudio_chmap.c
+++ b/audio/out/ao_coreaudio_chmap.c
@@ -15,6 +15,8 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <Availability.h>
+
 #include "common/common.h"
 
 #include "ao_coreaudio_utils.h"
@@ -47,6 +49,13 @@ static const int speaker_map[][2] = {
     { kAudioChannelLabel_LeftWide,             MP_SPEAKER_ID_WL   },
     { kAudioChannelLabel_RightWide,            MP_SPEAKER_ID_WR   },
     { kAudioChannelLabel_LFE2,                 MP_SPEAKER_ID_LFE2 },
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+    { kAudioChannelLabel_LeftTopSurround,      MP_SPEAKER_ID_TSL  },
+    { kAudioChannelLabel_RightTopSurround,     MP_SPEAKER_ID_TSR  },
+    { kAudioChannelLabel_CenterBottom,         MP_SPEAKER_ID_BFC  },
+    { kAudioChannelLabel_LeftBottom,           MP_SPEAKER_ID_BFL  },
+    { kAudioChannelLabel_RightBottom,          MP_SPEAKER_ID_BFR  },
+#endif
 
     { kAudioChannelLabel_HeadphonesLeft,       MP_SPEAKER_ID_DL   },
     { kAudioChannelLabel_HeadphonesRight,      MP_SPEAKER_ID_DR   },

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -133,6 +133,11 @@ static enum spa_audio_channel mp_speaker_id_to_spa(struct ao *ao, enum mp_speake
     case MP_SPEAKER_ID_SDL:  return SPA_AUDIO_CHANNEL_SL;
     case MP_SPEAKER_ID_SDR:  return SPA_AUDIO_CHANNEL_SL;
     case MP_SPEAKER_ID_LFE2: return SPA_AUDIO_CHANNEL_LFE2;
+    case MP_SPEAKER_ID_TSL:  return SPA_AUDIO_CHANNEL_TSL;
+    case MP_SPEAKER_ID_TSR:  return SPA_AUDIO_CHANNEL_TSR;
+    case MP_SPEAKER_ID_BFC:  return SPA_AUDIO_CHANNEL_BC;
+    case MP_SPEAKER_ID_BFL:  return SPA_AUDIO_CHANNEL_BLC;
+    case MP_SPEAKER_ID_BFR:  return SPA_AUDIO_CHANNEL_BRC;
     case MP_SPEAKER_ID_NA:   return SPA_AUDIO_CHANNEL_NA;
     default:
                              MP_WARN(ao, "Unhandled channel %d\n", mp_speaker_id);

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -236,7 +236,8 @@ static char *waveformat_to_str_buf(char *buf, size_t buf_size, WAVEFORMATEX *wf)
              (unsigned) wf->nSamplesPerSec);
     return buf;
 }
-#define waveformat_to_str(wf) waveformat_to_str_buf((char[64]){0}, 64, (wf))
+#define waveformat_to_str_(wf, sz) waveformat_to_str_buf((char[sz]){0}, sz, (wf))
+#define waveformat_to_str(wf) waveformat_to_str_(wf, MP_NUM_CHANNELS * 4 + 42)
 
 static void waveformat_copy(WAVEFORMATEXTENSIBLE* dst, WAVEFORMATEX* src)
 {


### PR DESCRIPTION
This fixes AAC 22.2 playback