### PR TITLE
video/image_writer: avoid stripping colorspace info when writing image

### DIFF
--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -355,6 +355,7 @@ static struct mp_image *convert_image(struct mp_image *image, int destfmt,
         .h = d_h,
         .p_w = 1,
         .p_h = 1,
+        .color = image->params.color,
     };
     mp_image_params_guess_csp(&p);
 


### PR DESCRIPTION
Writing an image either with vo_image or with a screenshot will strip the colorspace info because it allocates a new mp_image that contains the same data as the old image after calling mp_image_params_guess_csp. However, mp_image_params_guess_csp cannot always guess the appropriate colorspace, so it picks a "sane default." Since this function also changes parameters so the space always makes sense, this extra info isn't harmful and allows screenshots and vo_image outs to be properly tagged with the correct colorspace.

Fixes #10988.