### PR TITLE
Plug a few file descriptor leaks

### DIFF
--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -245,6 +245,12 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
     return 0;
 }
 
+static void close_file_descriptors(VADRMPRIMESurfaceDescriptor desc)
+{
+    for (int i = 0; i < desc.num_objects; i++)
+        close(desc.objects[i].fd);
+}
+
 static int mapper_map(struct ra_hwdec_mapper *mapper)
 {
     struct priv_owner *p_owner = mapper->owner->priv;
@@ -261,6 +267,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     if (!CHECK_VA_STATUS_LEVEL(mapper, "vaExportSurfaceHandle()",
                                p_owner->probing_formats ? MSGL_DEBUG : MSGL_ERR))
     {
+        close_file_descriptors(desc);
         goto err;
     }
     vaSyncSurface(display, va_surface_id(mapper->src));

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -389,6 +389,7 @@ static int preinit(struct vo *vo)
         if (fd < 0)
             goto err;
         p->solid_buffer_pool = wl_shm_create_pool(vo->wl->shm, fd, height * stride);
+        close(fd);
         if (!p->solid_buffer_pool)
             goto err;
         p->solid_buffer = wl_shm_pool_create_buffer(


### PR DESCRIPTION
It turns out the vaExportSurfaceHandle() may open file descriptors even if the export fails !