### PR TITLE
wayland geometry/scaling fixes and improvements

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5610,13 +5610,13 @@ them.
 ``--wayland-app-id=<string>``
     Set the client app id for Wayland-based video output methods (default: ``mpv``).
 
-``--wayland-configure-bounds=<yes|no>``
+``--wayland-configure-bounds=<auto|yes|no>``
     Controls whether or not mpv opts into the configure bounds event if sent by the
-    compositor (default: yes). This restricts the initial size of the mpv window to
+    compositor (default: auto). This restricts the initial size of the mpv window to
     a certain maximum size intended by the compositor. In most cases, this simply
     just prevents the mpv window from being larger than the size of the monitor when
-    it first renders. This option will take precedence over any ``autofit`` or
-    ``geometry`` type settings if the configure bounds are used.
+    it first renders. With the default value of ``auto``, configure-bounds will
+    silently be ignored if any ``autofit`` or ``geometry`` type option is also set.
 
 ``--wayland-content-type=<auto|none|photo|video|game>``
     If supported by the compositor, mpv will send a hint using the content-type

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1698,11 +1698,7 @@ static void set_surface_scaling(struct vo_wayland_state *wl)
     // dmabuf_wayland is always wl->scaling = 1
     bool dmabuf_wayland = !strcmp(wl->vo->driver->name, "dmabuf-wayland");
     double old_scale = wl->scaling;
-    if (wl->vo_opts->hidpi_window_scale && !dmabuf_wayland) {
-        wl->scaling = wl->current_output->scale;
-    } else {
-        wl->scaling = 1;
-    }
+    wl->scaling = !dmabuf_wayland ? wl->current_output->scale : 1;
 
     rescale_geometry(wl, old_scale);
     wl_surface_set_buffer_scale(wl->surface, wl->scaling);
@@ -1921,7 +1917,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
             if (opt == &opts->fullscreen)
                 toggle_fullscreen(wl);
             if (opt == &opts->hidpi_window_scale)
-                set_surface_scaling(wl);
+                set_geometry(wl, true);
             if (opt == &opts->window_maximized)
                 toggle_maximized(wl);
             if (opt == &opts->window_minimized)


### PR DESCRIPTION
The first two commits are fixes. The last one adds a new choice to `wayland-configure-bounds` so it behaves in a more user-friendly manner.