### PR TITLE
Use user-data for builtin scripts

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2195,11 +2195,13 @@ function update_margins()
 
     utils.shared_script_property_set("osc-margins",
         string.format("%f,%f,%f,%f", margins.l, margins.r, margins.t, margins.b))
+    mp.set_property_native("user-data/osc/margins", margins)
 end
 
 function shutdown()
     reset_margins()
     utils.shared_script_property_set("osc-margins", nil)
+    mp.del_property("user-data/osc")
 end
 
 --
@@ -2853,6 +2855,7 @@ function visibility_mode(mode, no_osd)
 
     user_opts.visibility = mode
     utils.shared_script_property_set("osc-visibility", mode)
+    mp.set_property_native("user-data/osc/visibility", mode)
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC visibility: " .. mode)
@@ -2885,6 +2888,7 @@ function idlescreen_visibility(mode, no_osd)
     end
 
     utils.shared_script_property_set("osc-idlescreen", mode)
+    mp.set_property_native("user-data/osc/idlescreen", user_opts.idlescreen)
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC logo visibility: " .. tostring(mode))


### PR DESCRIPTION
This is pretty self-explanatory. The improvement to `console` is pretty clear.

In theory, `osc` could also use property observation to allow other clients to set `osc/visibility` and `osc/idlescreen`, though it'd need to make sure to avoid infinite recursion with itself.