### PR TITLE
lua/js: remove user-data helpers

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3269,8 +3269,6 @@ Property list
 
     The top-level object itself cannot be written directly; write to sub-paths instead.
 
-    Lua scripting has helpers starting with ``utils.user_data_``.
-
     Converting this property or its sub-properties to strings will give a JSON
     representation. If converting a leaf-level object (i.e. not a map or array)
     and not using raw mode, the underlying content will be given (e.g. strings will be

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -186,14 +186,6 @@ meta-paths like ``~~/foo`` (other JS file functions do expand meta paths).
 
 ``mp.utils.subprocess_detached(t)``
 
-``mp.utils.user_data_set(path, val)``
-
-``mp.utils.user_data_get(path)``
-
-``mp.utils.user_data_del(path)``
-
-``mp.utils.user_data_observe(path, type, fn)``
-
 ``mp.utils.get_env_list()``
 
 ``mp.utils.getpid()`` (LE)

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -824,34 +824,6 @@ strictly part of the guaranteed API.
     This is a legacy wrapper around calling the ``run`` command with
     ``mp.commandv`` and other functions.
 
-``utils.user_data_set(path, val)``
-    Sets a user-data value.
-
-    ``path`` is a path within the ``user-data`` property.
-
-    This is a convenience wrapper around ``mp.set_property_native``.
-
-``utils.user_data_get(path)``
-    Gets a user-data value.
-
-    ``path`` is a path within the ``user-data`` property.
-
-    This is a convenience wrapper around ``mp.get_property_native``.
-
-``utils.user_data_del(path)``
-    Deletes a user-data value.
-
-    ``path`` is a path within the ``user-data`` property.
-
-    This is a convenience wrapper around ``mp.del_property_native``.
-
-``utils.user_data_observe(path, type, fn)``
-    Observes a user-data value.
-
-    ``path`` is a path within the ``user-data`` property.
-
-    See ``mp.observe_property`` for further details.
-
 ``utils.getpid()``
     Returns the process ID of the running mpv process. This can be used to identify
     the calling mpv when launching (detached) subprocesses.

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -199,30 +199,6 @@ mp.utils.shared_script_property_set = shared_script_property_set;
 mp.utils.shared_script_property_get = shared_script_property_get;
 mp.utils.shared_script_property_observe = shared_script_property_observe;
 
-// user_data - always an object, even if empty
-function user_data_set(path, val) {
-    return mp.set_proprty_native("user-data/" + path, val);
-}
-
-function user_data_del(path) {
-    return mp.del_property("user-data/" + path);
-}
-
-function user_data_get(path) {
-    return mp.get_property_native("user-data/" + path);
-}
-
-function user_data_observe(path, t, cb) {
-    return mp.observe_property("user-data/" + path, t,
-        function user_data_cb(_name, val) { cb(path, val) }
-    );
-}
-
-mp.utils.user_data_set = user_data_set;
-mp.utils.user_data_del = user_data_del;
-mp.utils.user_data_get = user_data_get;
-mp.utils.user_data_observe = user_data_observe;
-
 // osd-ass
 var next_assid = 1;
 mp.create_osd_overlay = function create_osd_overlay(format) {

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -831,23 +831,4 @@ function mp_utils.shared_script_property_observe(name, cb)
     end)
 end
 
-function mp_utils.user_data_set(path, value)
-    return mp.set_property_native("user-data/" .. path, value)
-end
-
-function mp_utils.user_data_get(path)
-    return mp.get_property_native("user-data/" .. path)
-end
-
-function mp_utils.user_data_del(path)
-    return mp.del_property("user-data/" .. path)
-end
-
--- cb(name, value) on change and on init
-function mp_utils.user_data_observe(path, t, cb)
-    return mp.observe_property("user-data/" .. path, t, function(_, val)
-        cb(path, val)
-    end)
-end
-
 return {}


### PR DESCRIPTION
This reverts:
  3fb4140c lua/defaults: add user_data helpers
  68a20e7a javascript/defaults: add user_data helpers
  00510379 lua/js: fix user_data_del util function

As well as the lua/js parts of:
  3ec2a098 docs: document new user-data property

user-data and its sub-properties can be set/get/observed/deleted via the standard properties interface, so there's no need for additional helpers specific to user-data, which only added maintenance burden.
