### PR TITLE
ao_pipewire: add support for exclusive mode und report errors from init()

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1846,10 +1846,10 @@ Audio
     Enable exclusive output mode. In this mode, the system is usually locked
     out, and only mpv will be able to output audio.
 
-    This only works for some audio outputs, such as ``wasapi`` and
-    ``coreaudio``. Other audio outputs silently ignore this options. They either
-    have no concept of exclusive mode, or the mpv side of the implementation is
-    missing.
+    This only works for some audio outputs, such as ``wasapi``, ``coreaudio``
+    and ``pipewire``. Other audio outputs silently ignore this option.
+    They either have no concept of exclusive mode, or the mpv side of the
+    implementation is missing.
 
 ``--audio-fallback-to-null=<yes|no>``
     If no audio device can be opened, behave as if ``--ao=null`` was given. This

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -553,6 +553,9 @@ static int init(struct ao *ao)
                                  PW_STREAM_FLAG_MAP_BUFFERS |
                                  PW_STREAM_FLAG_RT_PROCESS;
 
+    if (ao->init_flags & AO_INIT_EXCLUSIVE)
+        flags |= PW_STREAM_FLAG_EXCLUSIVE;
+
     if (pw_stream_connect(p->stream,
                     PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, params, 1) < 0) {
         pw_thread_loop_unlock(p->loop);

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -548,13 +548,13 @@ static int init(struct ao *ao)
 
     pw_stream_add_listener(p->stream, &p->stream_listener, &stream_events, ao);
 
+    enum pw_stream_flags flags = PW_STREAM_FLAG_AUTOCONNECT |
+                                 PW_STREAM_FLAG_INACTIVE |
+                                 PW_STREAM_FLAG_MAP_BUFFERS |
+                                 PW_STREAM_FLAG_RT_PROCESS;
+
     if (pw_stream_connect(p->stream,
-                    PW_DIRECTION_OUTPUT, PW_ID_ANY,
-                    PW_STREAM_FLAG_AUTOCONNECT |
-                    PW_STREAM_FLAG_INACTIVE |
-                    PW_STREAM_FLAG_MAP_BUFFERS |
-                    PW_STREAM_FLAG_RT_PROCESS,
-                    params, 1) < 0) {
+                    PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, params, 1) < 0) {
         pw_thread_loop_unlock(p->loop);
         goto error;
     }

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -55,12 +55,19 @@ static inline int pw_stream_get_time_n(struct pw_stream *stream, struct pw_time 
 }
 #endif
 
+enum init_state {
+    INIT_STATE_NONE,
+    INIT_STATE_SUCCESS,
+    INIT_STATE_ERROR,
+};
+
 struct priv {
     struct pw_thread_loop *loop;
     struct pw_stream *stream;
     struct pw_core *core;
     struct spa_hook stream_listener;
     struct spa_hook core_listener;
+    enum init_state init_state;
 
     bool muted;
     float volume;
@@ -194,6 +201,14 @@ static void on_param_changed(void *userdata, uint32_t id, const struct spa_pod *
     uint8_t buffer[1024];
     struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
 
+    /* We want to know when our node is linked.
+     * As there is no proper callback for this we use the Latency param for this
+     */
+    if (id == SPA_PARAM_Latency) {
+        p->init_state = INIT_STATE_SUCCESS;
+        pw_thread_loop_signal(p->loop, false);
+    }
+
     if (param == NULL || id != SPA_PARAM_Format)
         return;
 
@@ -218,11 +233,14 @@ static void on_param_changed(void *userdata, uint32_t id, const struct spa_pod *
 static void on_state_changed(void *userdata, enum pw_stream_state old, enum pw_stream_state state, const char *error)
 {
     struct ao *ao = userdata;
+    struct priv *p = ao->priv;
     MP_DBG(ao, "Stream state changed: old_state=%s state=%s error=%s\n",
            pw_stream_state_as_string(old), pw_stream_state_as_string(state), error);
 
     if (state == PW_STREAM_STATE_ERROR) {
         MP_WARN(ao, "Stream in error state, trying to reload...\n");
+        p->init_state = INIT_STATE_ERROR;
+        pw_thread_loop_signal(p->loop, false);
         ao_request_reload(ao);
     }
 
@@ -484,6 +502,27 @@ error:
     return -1;
 }
 
+static void wait_for_init_done(struct ao *ao)
+{
+    struct priv *p = ao->priv;
+    struct timespec abstime;
+    int r;
+
+    r = pw_thread_loop_get_time(p->loop, &abstime, 50 * SPA_NSEC_PER_MSEC);
+    if (r < 0) {
+        MP_WARN(ao, "Could not get timeout for initialization: %s\n", spa_strerror(r));
+        return;
+    }
+
+    while (p->init_state == INIT_STATE_NONE) {
+        r = pw_thread_loop_timed_wait_full(p->loop, &abstime);
+        if (r < 0) {
+            MP_WARN(ao, "Could not wait for initialization: %s\n", spa_strerror(r));
+            return;
+        }
+    }
+}
+
 static int init(struct ao *ao)
 {
     struct priv *p = ao->priv;
@@ -562,7 +601,12 @@ static int init(struct ao *ao)
         goto error;
     }
 
+    wait_for_init_done(ao);
+
     pw_thread_loop_unlock(p->loop);
+
+    if (p->init_state == INIT_STATE_ERROR)
+        goto error;
 
     return 0;
 
@@ -807,6 +851,7 @@ const struct ao_driver audio_out_pipewire = {
     {
         .loop = NULL,
         .stream = NULL,
+        .init_state = INIT_STATE_NONE,
         .options.buffer_msec = 20,
     },
     .options_prefix = "pipewire",


### PR DESCRIPTION
Note: If this leads to a conflict and therefore an error then the failure will not be properly returned from `init()` and playback will be stuck. I am working on an independent PR that fixes this.