### PR TITLE
ao_pipewire: set media role during init()

### DIFF
--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -56,6 +56,8 @@ enum {
     AO_INIT_STREAM_SILENCE = 1 << 2,
     // Force exclusive mode, i.e. lock out the system mixer.
     AO_INIT_EXCLUSIVE = 1 << 3,
+    // Initialize with music role.
+    AO_INIT_MEDIA_ROLE_MUSIC = 1 << 4,
 };
 
 struct ao_device_desc {

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -553,7 +553,7 @@ static int init(struct ao *ao)
     struct pw_properties *props = pw_properties_new(
         PW_KEY_MEDIA_TYPE, "Audio",
         PW_KEY_MEDIA_CATEGORY, "Playback",
-        PW_KEY_MEDIA_ROLE, "Movie",
+        PW_KEY_MEDIA_ROLE, ao->init_flags & AO_INIT_MEDIA_ROLE_MUSIC ?  "Music" : "Movie",
         PW_KEY_NODE_NAME, ao->client_name,
         PW_KEY_NODE_DESCRIPTION, ao->client_name,
         PW_KEY_APP_NAME, ao->client_name,

--- a/player/audio.c
+++ b/player/audio.c
@@ -190,6 +190,20 @@ void update_playback_speed(struct MPContext *mpctx)
     update_speed_filters(mpctx);
 }
 
+static bool has_video_track(struct MPContext *mpctx)
+{
+    if (mpctx->vo_chain && mpctx->vo_chain->is_coverart)
+        return false;
+
+    for (int n = 0; n < mpctx->num_tracks; n++) {
+        struct track *track = mpctx->tracks[n];
+        if (track->type == STREAM_VIDEO && !track->attached_picture && !track->image)
+            return true;
+    }
+
+    return false;
+}
+
 static void ao_chain_reset_state(struct ao_chain *ao_c)
 {
     ao_c->last_out_pts = MP_NOPTS_VALUE;
@@ -415,6 +429,9 @@ static int reinit_audio_filters_and_output(struct MPContext *mpctx)
                           opts->audio_output_channels.chmaps,
                           opts->audio_output_channels.num_chmaps);
     }
+
+    if (!has_video_track(mpctx))
+        ao_flags |= AO_INIT_MEDIA_ROLE_MUSIC;
 
     mpctx->ao_filter_fmt = out_fmt;
 


### PR DESCRIPTION
wireplumber uses the media role when the node is first created.
To have the property available at this point reliably we need to set it
directly when creating the stream/node.

Cc @philipl 