### PR TITLE
ao_pipewire: adjust message level based on probing

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -461,8 +461,9 @@ static int pipewire_init_boilerplate(struct ao *ao)
             pw_properties_new(PW_KEY_REMOTE_NAME, p->options.remote, NULL),
             0);
     if (!p->core) {
-        MP_VERBOSE(ao, "Could not connect to context '%s': %s\n",
-                   p->options.remote, strerror(errno));
+        MP_MSG(ao, ao->probing ? MSGL_V : MSGL_ERR,
+               "Could not connect to context '%s': %s\n",
+               p->options.remote, strerror(errno));
         pw_context_destroy(context);
         goto error;
     }


### PR DESCRIPTION
Use the ao->probing property to upgrade the status message when the AO is explicitly selected.

Suggested-by: uau on #mpv-devel

Cc @philipl 