### PR TITLE
osdep/macos: update play now menu bar item to show progress

### DIFF
--- a/osdep/macos/libmpv_helper.swift
+++ b/osdep/macos/libmpv_helper.swift
@@ -247,4 +247,9 @@ class LibmpvHelper {
     class func mpvFlagToBool(_ obj: UnsafeMutableRawPointer) -> Bool? {
         return UnsafePointer<Bool>(OpaquePointer(obj))?.pointee
     }
+
+    // MPV_FORMAT_DOUBLE
+    class func mpvDoubleToDouble(_ obj: UnsafeMutableRawPointer) -> Double? {
+        return UnsafePointer<Double>(OpaquePointer(obj))?.pointee
+    }
 }


### PR DESCRIPTION
#11233 
<img width="316" alt="Screenshot 2023-02-03 at 9 26 16 PM" src="https://user-images.githubusercontent.com/58533624/216746890-74a01d5b-1e56-450d-b7bb-bcd811293fd2.png">

Updates the Play Now menu item to correctly show the progress of the media.

This does not fix/add the ability to change the time position of the media through the Play Now menu item slider. With this change anytime the user tries to update through the slider it will just reset to the current time position.

It does not update the title to what is being played.