### PR TITLE
video/image_writer: change screenshot-tag-colorspace default to yes

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -50,6 +50,7 @@ Interface changes
     - in wayland, hidpi window scaling now scales the window by the compositor's
       dpi scale factor by default (can be disabled with --no-hidpi-window-scale
       if fractional scaling support exists).
+    - change --screenshot-tag-colorspace default value from `no` to `yes`
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4275,7 +4275,7 @@ Screenshot
 
     Note that not all formats are supported.
 
-    Default: ``no``.
+    Default: ``yes``.
 
 ``--screenshot-high-bit-depth=<yes|no>``
     If possible, write screenshots with a bit depth similar to the source

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -53,7 +53,7 @@ const struct image_writer_opts image_writer_opts_defaults = {
     .webp_compression = 4,
     .jxl_distance = 1.0,
     .jxl_effort = 3,
-    .tag_csp = 0,
+    .tag_csp = 1,
 };
 
 const struct m_opt_choice_alternatives mp_image_writer_formats[] = {


### PR DESCRIPTION
With significant improvements to the color tagging support in various screenshot formats, e.g. cICP in FFmpeg, and JPEG XL's generally robust color support, it's safe to default this to yes.