### PR TITLE
TOOLS/lua/autoload: support directories

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -21,6 +21,7 @@ additional_video_exts=list,of,ext
 additional_audio_exts=list,of,ext
 ignore_hidden=yes
 same_type=yes
+directory_mode=recursive
 
 --]]
 
@@ -40,7 +41,8 @@ o = {
     additional_video_exts = "",
     additional_audio_exts = "",
     ignore_hidden = true,
-    same_type = false
+    same_type = false,
+    directory_mode = "auto"
 }
 options.read_options(o, nil, function(list)
     split_option_exts(list.additional_video_exts, list.additional_audio_exts, list.additional_image_exts)
@@ -48,6 +50,9 @@ options.read_options(o, nil, function(list)
         list.audio or list.additional_audio_exts or
         list.images or list.additional_image_exts then
         create_extensions()
+    end
+    if list.directory_mode then
+        validate_directory_mode()
     end
 end)
 
@@ -97,6 +102,13 @@ function create_extensions()
     if o.images then SetUnion(SetUnion(EXTENSIONS, EXTENSIONS_IMAGES), o.additional_image_exts) end
 end
 create_extensions()
+
+function validate_directory_mode()
+    if o.directory_mode ~= "recursive" and o.directory_mode ~= "lazy" and o.directory_mode ~= "ignore" then
+        o.directory_mode = nil
+    end
+end
+validate_directory_mode()
 
 function add_files(files)
     local oldcount = mp.get_property_number("playlist-count", 1)
@@ -244,7 +256,7 @@ function find_and_add_entries()
 
     local files = {}
     do
-        local dir_mode = mp.get_property("directory-mode")
+        local dir_mode = o.directory_mode or mp.get_property("directory-mode", "lazy")
         local separator = mp.get_property_native("platform") == "windows" and "\\" or "/"
         scan_dir(autoloaded_dir, path, dir_mode, separator, 0, files)
     end

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -122,6 +122,13 @@ table.filter = function(t, iter)
     end
 end
 
+table.append = function(t1, t2)
+    local t1_size = #t1
+    for i = 1, #t2 do
+        t1[t1_size + i] = t2[i]
+    end
+end
+
 -- alphanum sorting for humans in Lua
 -- http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua
 
@@ -147,8 +154,7 @@ local autoloaded = nil
 function get_playlist_filenames(playlist)
     local filenames = {}
     for i = 1, #playlist do
-        local _, file = utils.split_path(playlist[i].filename)
-        filenames[file] = true
+        filenames[playlist[i].filename] = true
     end
     return filenames
 end
@@ -194,10 +200,13 @@ function find_and_add_entries()
         utils.to_string(pl)))
 
     local files = utils.readdir(dir, "files")
-    if files == nil then
-        msg.verbose("no other files in directory")
+    local load_dirs = mp.get_property("directory-mode") ~= "ignore"
+    local dirs = load_dirs and utils.readdir(dir, "dirs") or nil
+    if files == nil and dirs == nil then
+        msg.verbose("no other files or directories in directory")
         return
     end
+    files, dirs = files or {}, dirs or {}
     table.filter(files, function (v, k)
         -- The current file could be a hidden file, ignoring it doesn't load other
         -- files from the current directory.
@@ -210,7 +219,12 @@ function find_and_add_entries()
         end
         return EXTENSIONS_TARGET[string.lower(ext)]
     end)
+    table.filter(dirs, function(d)
+        return not ((o.ignore_hidden and string.match(d, "^%.")))
+    end)
     alphanumsort(files)
+    alphanumsort(dirs)
+    table.append(files, dirs)
 
     if dir == "." then
         dir = ""
@@ -243,12 +257,12 @@ function find_and_add_entries()
             -- skip files already in playlist
             if not filenames[file] then
                 if direction == -1 then
-                    msg.info("Prepending " .. file)
-                    table.insert(append[-1], 1, {filepath, pos - 1})
+                    msg.info("Prepending " .. filepath)
+                    table.insert(append[-1], 1, {filepath, pl_current + i * direction + 1})
                 else
-                    msg.info("Adding " .. file)
+                    msg.info("Adding " .. filepath)
                     if pl_count > 1 then
-                        table.insert(append[1], {filepath, pos - 1})
+                        table.insert(append[1], {filepath, pl_current + i * direction - 1})
                     else
                         mp.commandv("loadfile", filepath, "append")
                     end


### PR DESCRIPTION
Adds support for adding directories to the playlist in addition to files.
The new option `directories` controls if directories get added.
Directories get sorted together with files to behave the same way mpv behaves when it loads directories directly.