### PR TITLE
osc: skip rendering when osd_dimensions are 0

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2592,6 +2592,9 @@ function tick()
         -- render idle message
         msg.trace("idle message")
         local _, _, display_aspect = mp.get_osd_size()
+        if display_aspect == 0 then
+            return
+        end
         local display_h = 360
         local display_w = display_h * display_aspect
         -- logo is rendered at 2^(6-1) = 32 times resolution with size 1800x1800


### PR DESCRIPTION
The idle logo could appear on the left side of the window for a split second after starting.
That is because when osd dimensions can be reported as 0 at the very beginning.
Since the width gets calculated based on a fixed height and the aspect ratio, which is 0, that results in a width of 0 until the next update.

ref. https://github.com/mpv-player/mpv/pull/10712#issuecomment-1274398139

@Obegg can you please test if this fixes the problem for you?