### PR TITLE
Improving directories in playlists

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -84,6 +84,7 @@ Interface changes
       passthrough the mpv window
     - icc and gpu-shader cache are now saved by default (use --no-icc-shader-cache and
       --no-gpu-shader-cache to disable)
+    - add `--directory-mode=recursive|lazy|ignore`
  --- mpv 0.35.0 ---
     - add the `--vo=gpu-next` video output driver, as well as the options
       `--allow-delayed-peak-detect`, `--builtin-scalers`,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3945,6 +3945,13 @@ Demuxer
     libarchive opens all volumes anyway when playing the main file, even though
     mpv iterated no archive entries yet.
 
+``--directory-mode=<recursive|lazy|ignore>``
+    When opening a directory, open subdirectories recursively, lazily or not at
+    all (default: recursive).
+
+    Values other then ``recursive`` can lead to problems with resuming playlists
+    (`RESUMING PLAYBACK`_) and possibly other things.
+
 Input
 -----
 

--- a/options/options.c
+++ b/options/options.c
@@ -63,6 +63,7 @@ extern const struct m_sub_options zimg_conf;
 extern const struct m_sub_options drm_conf;
 extern const struct m_sub_options demux_rawaudio_conf;
 extern const struct m_sub_options demux_rawvideo_conf;
+extern const struct m_sub_options demux_playlist_conf;
 extern const struct m_sub_options demux_lavf_conf;
 extern const struct m_sub_options demux_mkv_conf;
 extern const struct m_sub_options demux_cue_conf;
@@ -591,6 +592,7 @@ static const m_option_t mp_opts[] = {
     {"", OPT_SUBSTRUCT(demux_lavf, demux_lavf_conf)},
     {"demuxer-rawaudio", OPT_SUBSTRUCT(demux_rawaudio, demux_rawaudio_conf)},
     {"demuxer-rawvideo", OPT_SUBSTRUCT(demux_rawvideo, demux_rawvideo_conf)},
+    {"", OPT_SUBSTRUCT(demux_playlist, demux_playlist_conf)},
     {"demuxer-mkv", OPT_SUBSTRUCT(demux_mkv, demux_mkv_conf)},
     {"demuxer-cue", OPT_SUBSTRUCT(demux_cue, demux_cue_conf)},
 

--- a/options/options.h
+++ b/options/options.h
@@ -326,6 +326,7 @@ typedef struct MPOpts {
 
     struct demux_rawaudio_opts *demux_rawaudio;
     struct demux_rawvideo_opts *demux_rawvideo;
+    struct demux_playlist_opts *demux_playlist;
     struct demux_lavf_opts *demux_lavf;
     struct demux_mkv_opts *demux_mkv;
     struct demux_cue_opts *demux_cue;


### PR DESCRIPTION
Adds a new option `--directory-mode=recursive|lazy|ignore` to control recursive loading of directories, as suggested in https://github.com/mpv-player/mpv/pull/11292#issuecomment-1426792272

Sort files in front of directories, as suggested in https://github.com/mpv-player/mpv/pull/11292#issuecomment-1426701499