### PR TITLE
ao_oss: add "spdif" passthrough support for high bitrate codecs (e.g Dolby Atmos, DTS-HD, etc.) over HDMI

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -188,11 +188,11 @@ static int init(struct ao *ao)
 
     /* Channels count. */
     if (af_fmt_is_spdif(format)) {
-        /* Probably could be fixed by setting number of channels;
-         * needs testing. */
-        if (channels.num != 2) {
-            MP_ERR(ao, "Format %s not implemented.\n", af_fmt_to_str(format));
-            goto err_out;
+        nchannels = reqchannels = channels.num;
+        if (ioctl(p->dsp_fd, SNDCTL_DSP_CHANNELS, &nchannels) == -1) {
+            MP_ERR(ao, "Failed to set audio device to %d channels.\n",
+                reqchannels);
+            goto err_out_ioctl;
         }
     } else {
         struct mp_chmap_sel sel = {0};


### PR DESCRIPTION
   In addition to the patch, appropriate additions to the mpv.conf file
will of course be needed for this to work. For example on my system:

audio-device=oss//dev/dsp4
audio-spdif=ac3,dts,dts-hd,eac3,truehd

   This has been tested using recent FreeBSD-13.1-stable, using external
surround processors (both a Trinnov Altitude 16 and an LG OLED that supports Dolby Atmos, and connected with HDMI to an NVidia RTX 2070).

Author and tester: David G Lawrence <dg1007@dglawrence.com>