### PR TITLE
vo_gpu_next: parse Dolby Vision metadata for dynamic scene brightness

### DIFF
--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -154,8 +154,10 @@ static void vf_format_process(struct mp_filter *f)
             mp_image_params_guess_csp(&img->params);
         }
 
-        if (!priv->opts->dovi)
+        if (!priv->opts->dovi) {
             av_buffer_unref(&img->dovi);
+            av_buffer_unref(&img->dovi_buf);
+        }
 
         if (!priv->opts->film_grain)
             av_buffer_unref(&img->film_grain);

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -112,6 +112,8 @@ typedef struct mp_image {
     struct AVBufferRef *dovi;
     // Film grain data, if any
     struct AVBufferRef *film_grain;
+    // Dolby Vision RPU buffer, if any
+    struct AVBufferRef *dovi_buf;
     // Other side data we don't care about.
     struct mp_ff_side_data *ff_side_data;
     int num_ff_side_data;

--- a/video/out/placebo/utils.h
+++ b/video/out/placebo/utils.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include "config.h"
 #include "common/common.h"
 #include "common/msg.h"
 #include "video/csputils.h"
+#include "video/mp_image.h"
+
+#include <libavutil/buffer.h>
 
 #include <libplacebo/common.h>
 #include <libplacebo/log.h>
 #include <libplacebo/colorspace.h>
+#include <libplacebo/renderer.h>
+#include <libplacebo/utils/libav.h>
 
 pl_log mppl_log_create(void *tactx, struct mp_log *log);
 void mppl_log_set_probing(pl_log log, bool probing);
@@ -27,3 +33,6 @@ enum pl_color_system mp_csp_to_pl(enum mp_csp csp);
 enum pl_color_levels mp_levels_to_pl(enum mp_csp_levels levels);
 enum pl_alpha_mode mp_alpha_to_pl(enum mp_alpha_type alpha);
 enum pl_chroma_location mp_chroma_to_pl(enum mp_chroma_location chroma);
+
+void mp_map_dovi_metadata_to_pl(struct mp_image *mpi,
+                                struct pl_frame *frame);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -699,22 +699,8 @@ static bool map_frame(pl_gpu gpu, pl_tex *tex, const struct pl_source_frame *src
     // Update chroma location, must be done after initializing planes
     pl_frame_set_chroma_location(frame, mp_chroma_to_pl(par->chroma_location));
 
-#ifdef PL_HAVE_LAV_DOLBY_VISION
-    if (mpi->dovi) {
-        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) mpi->dovi->data;
-        struct pl_dovi_metadata *dovi = talloc_ptrtype(mpi, dovi);
-        const AVDOVIColorMetadata *color = av_dovi_get_color(metadata);
-        pl_map_dovi_metadata(dovi, metadata);
-        frame->repr.dovi = dovi;
-        frame->repr.sys = PL_COLOR_SYSTEM_DOLBYVISION;
-        frame->color.primaries = PL_COLOR_PRIM_BT_2020;
-        frame->color.transfer = PL_COLOR_TRC_PQ;
-        frame->color.hdr.min_luma =
-            pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, color->source_min_pq / 4095.0f);
-        frame->color.hdr.max_luma =
-            pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, color->source_max_pq / 4095.0f);
-    }
-#endif
+    // Set the frame DOVI metadata
+    mp_map_dovi_metadata_to_pl(mpi, frame);
 
 #ifdef PL_HAVE_LAV_FILM_GRAIN
     if (mpi->film_grain)


### PR DESCRIPTION
The changes would allow `vo=gpu-next` to have per-frame/scene dynamic brightness metadata coming from the Dolby Vision RPU.

I've changed the implementation to have the dependency in `libplacebo` instead.
Blocked by https://code.videolan.org/videolan/libplacebo/-/merge_requests/371 for now