### PR TITLE
ao_pipewire: fix removal of zeroed hooks on old pipewire

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -55,6 +55,11 @@ static inline int pw_stream_get_time_n(struct pw_stream *stream, struct pw_time 
 }
 #endif
 
+#if !PW_CHECK_VERSION(0, 3, 57)
+// Earlier versions segfault on zeroed hooks
+#define spa_hook_remove(hook) if ((hook)->link.prev) spa_hook_remove(hook)
+#endif
+
 enum init_state {
     INIT_STATE_NONE,
     INIT_STATE_SUCCESS,


### PR DESCRIPTION
Older versions of pipewire segfault when calling spa_hook_remove() on hooks that are zeroed.
Add a backfill for the logic added by pipewire 0.3.57.

Being able to remove zeroed hooks makes errorhandling much easier.

Fixes #11309

Cc @philipl 
@acedogblast  Could you validate this?