### PR TITLE
video/image_writer: use effort=4 default for JXL screenshots

### DIFF
--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -52,7 +52,7 @@ const struct image_writer_opts image_writer_opts_defaults = {
     .webp_quality = 75,
     .webp_compression = 4,
     .jxl_distance = 1.0,
-    .jxl_effort = 3,
+    .jxl_effort = 4,
     .tag_csp = 1,
 };
 


### PR DESCRIPTION
effort=4 has a significant increase in quality/bpp compared to effort=3 with a very minor increase in encoding time. It's worth the trade-off as a default setting for lossy encoding.