### PR TITLE
Bump libx11 required version to 1.4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1021,7 +1021,7 @@ x11_opt = get_option('x11').require(
     error_message: 'the build is not GPL!',
 )
 x11 = {
-    'deps': [dependency('x11', version: '>= 1.0.0', required: x11_opt),
+    'deps': [dependency('x11', version: '>= 1.4.0', required: x11_opt),
              dependency('xscrnsaver', version: '>= 1.0.0', required: x11_opt),
              dependency('xext', version: '>= 1.0.0', required: x11_opt),
              dependency('xinerama', version: '>= 1.0.0', required: x11_opt),


### PR DESCRIPTION
According to [repology](https://repology.org/projects/?search=libx11), everyone should have at least libx11 1.4.0.
And since that's the required version to ease the [transition from xlib to xcb](https://xcb.freedesktop.org/MixingCalls/), it only makes sense to set that as the dependency version.