### PR TITLE
vo_dmabuf_wayland: reset resized state

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -267,6 +267,8 @@ static void flip_page(struct vo *vo)
         wlbuf_pool_clean(p->wlbuf_pool,false);
         p->want_reset = false;
     }
+
+    p->resized = false;
 }
 
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)


### PR DESCRIPTION
Without resetting the resized state the resize is only performed when a new frame is drawn.
For still images or paused videos this never happens, so the output is not resized at all.

Cc: @boxerab 