### PR TITLE
Revert "vo_dmabuf_wayland: drop support for linux-dmabuf-v2"

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -368,8 +368,8 @@ static int preinit(struct vo *vo)
        goto err;
     assert(p->ctx->ra);
 
-    if (!vo->wl->dmabuf || !vo->wl->dmabuf_feedback) {
-        MP_FATAL(vo->wl, "Compositor doesn't support the %s (ver. 4) protocol!\n",
+    if (!vo->wl->dmabuf) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
                  zwp_linux_dmabuf_v1_interface.name);
         goto err;
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1124,6 +1124,24 @@ static const struct wl_callback_listener frame_listener = {
     frame_callback,
 };
 
+static void dmabuf_format(void *data, struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf,
+                          uint32_t format)
+{
+    struct vo_wayland_state *wl = data;
+
+    if (wl->drm_format_ct == wl->drm_format_ct_max) {
+        wl->drm_format_ct_max *= 2;
+        wl->drm_formats = talloc_realloc(wl, wl->drm_formats, int, wl->drm_format_ct_max);
+    }
+
+    wl->drm_formats[wl->drm_format_ct++] = format;
+    MP_VERBOSE(wl, "%s is supported by the compositor.\n", mp_tag_str(format));
+}
+
+static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
+    dmabuf_format
+};
+
 #if HAVE_WAYLAND_PROTOCOLS_1_24
 static void done(void *data,
                  struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
@@ -1214,6 +1232,11 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         wl->dmabuf_feedback = zwp_linux_dmabuf_v1_get_default_feedback(wl->dmabuf);
         zwp_linux_dmabuf_feedback_v1_add_listener(wl->dmabuf_feedback, &dmabuf_feedback_listener, wl);
 #endif
+    } else if (!strcmp (interface, zwp_linux_dmabuf_v1_interface.name) && (ver >= 2) && found++) {
+        wl->dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, 2);
+        zwp_linux_dmabuf_v1_add_listener(wl->dmabuf, &dmabuf_listener, wl);
+        wl->drm_format_ct_max = 64;
+        wl->drm_formats = talloc_array(wl, int, wl->drm_format_ct_max);
     }
 
     if (!strcmp (interface, wp_viewporter_interface.name) && (ver >= 1) && found++) {

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -104,6 +104,10 @@ struct vo_wayland_state {
     void *dmabuf_feedback;
     wayland_format *format_map;
     uint32_t format_size;
+    /* TODO: remove these once zwp_linux_dmabuf_v1 version 2 support is removed. */
+    int *drm_formats;
+    int drm_format_ct;
+    int drm_format_ct_max;
 
     /* presentation-time */
     struct wp_presentation  *presentation;
@@ -162,7 +166,6 @@ struct vo_wayland_state {
 bool vo_wayland_check_visible(struct vo *vo);
 bool vo_wayland_init(struct vo *vo);
 bool vo_wayland_reconfig(struct vo *vo);
-bool vo_wayland_supported_format(struct vo *vo, uint32_t format, uint64_t modifier);
 
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);

--- a/video/out/wldmabuf/ra_wldmabuf.c
+++ b/video/out/wldmabuf/ra_wldmabuf.c
@@ -34,9 +34,13 @@ bool ra_compatible_format(struct ra* ra, uint32_t drm_format, uint64_t modifier)
     struct vo_wayland_state *wl = p->vo->wl;
     const wayland_format *formats = wl->format_map;
 
-    for (int i = 0; i < wl->format_size / sizeof(wayland_format); i++)
-    {
+    for (int i = 0; i < wl->format_size / sizeof(wayland_format); i++) {
         if (drm_format == formats[i].format && modifier == formats[i].modifier)
+            return true;
+    }
+
+    for (int i = 0; i < wl->drm_format_ct; i++) {
+        if (drm_format == wl->drm_formats[i])
             return true;
     }
 


### PR DESCRIPTION
This was originally dropped because it was thought to be unneeded at the time, but at least some devices (rockchip) apparently are still on old compositors that use linux-dmabuf v2. It's not much code, and for testing purposes it's good to have around since it's hard to test drmprime otherwise. Some minor additions are here to support the newly added vaapi-format mapping in v2 of the protocol.

This reverts commit a5b9d529eec8d4bb6fc858143337c3573ec8afd0.