### PR TITLE
various: drop unused #include "config.h"

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -34,7 +34,6 @@
 #include <math.h>
 #include <string.h>
 
-#include "config.h"
 #include "options/options.h"
 #include "options/m_config.h"
 #include "options/m_option.h"

--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "ao.h"
 #include "internal.h"
 #include "audio/format.h"

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -17,7 +17,6 @@
 
 #include <CoreAudio/HostTime.h>
 
-#include "config.h"
 #include "ao.h"
 #include "internal.h"
 #include "audio/format.h"

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -39,7 +39,6 @@
 #include <libavutil/intreadwrite.h>
 #include <libavutil/intfloat.h>
 
-#include "config.h"
 #include "ao.h"
 #include "internal.h"
 #include "audio/format.h"

--- a/audio/out/ao_null.c
+++ b/audio/out/ao_null.c
@@ -28,7 +28,6 @@
 
 #include "mpv_talloc.h"
 
-#include "config.h"
 #include "osdep/timer.h"
 #include "options/m_option.h"
 #include "common/common.h"

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -19,8 +19,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>

--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -35,7 +35,6 @@
 #endif
 #include <sys/types.h>
 
-#include "config.h"
 #include "audio/format.h"
 #include "common/msg.h"
 #include "options/options.h"

--- a/audio/out/ao_pcm.c
+++ b/audio/out/ao_pcm.c
@@ -19,8 +19,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -33,7 +33,6 @@
 #include "ao.h"
 #include "audio/format.h"
 #include "config.h"
-#include "generated/version.h"
 #include "internal.h"
 #include "osdep/timer.h"
 

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -32,7 +32,6 @@
 #include "options/m_option.h"
 #include "ao.h"
 #include "audio/format.h"
-#include "config.h"
 #include "internal.h"
 #include "osdep/timer.h"
 

--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -28,7 +28,6 @@
 
 #include <pulse/pulseaudio.h>
 
-#include "config.h"
 #include "audio/format.h"
 #include "common/msg.h"
 #include "options/m_option.h"

--- a/audio/out/ao_sdl.c
+++ b/audio/out/ao_sdl.c
@@ -18,7 +18,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "audio/format.h"
 #include "mpv_talloc.h"
 #include "ao.h"

--- a/audio/out/ao_sndio.c
+++ b/audio/out/ao_sndio.c
@@ -17,8 +17,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "config.h"
-
 #include <sys/types.h>
 #include <poll.h>
 #include <errno.h>

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -23,7 +23,6 @@
 #include <libavutil/avutil.h>
 #include <libavutil/timestamp.h>
 
-#include "config.h"
 #include "encode_lavc.h"
 #include "common/av_common.h"
 #include "common/global.h"

--- a/common/playlist.c
+++ b/common/playlist.c
@@ -16,7 +16,6 @@
  */
 
 #include <assert.h>
-#include "config.h"
 #include "playlist.h"
 #include "common/common.h"
 #include "common/global.h"

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -22,7 +22,6 @@
 
 #include <libavutil/common.h>
 
-#include "config.h"
 #include "common/common.h"
 #include "options/options.h"
 #include "common/msg.h"

--- a/demux/demux_raw.c
+++ b/demux/demux_raw.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -20,8 +20,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <inttypes.h>

--- a/demux/packet.c
+++ b/demux/packet.c
@@ -23,8 +23,6 @@
 #include <libavcodec/avcodec.h>
 #include <libavutil/intreadwrite.h>
 
-#include "config.h"
-
 #include "common/av_common.h"
 #include "common/common.h"
 #include "demux.h"

--- a/filters/f_autoconvert.c
+++ b/filters/f_autoconvert.c
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include "audio/aframe.h"
 #include "audio/chmap_sel.h"
 #include "audio/format.h"

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -27,7 +27,6 @@
 #include <libavutil/common.h>
 #include <libavutil/rational.h>
 
-#include "config.h"
 #include "options/options.h"
 #include "common/msg.h"
 #include "options/m_config.h"

--- a/filters/f_swresample.c
+++ b/filters/f_swresample.c
@@ -22,8 +22,6 @@
 #include <libavutil/mathematics.h>
 #include <libswresample/swresample.h>
 
-#include "config.h"
-
 #include "audio/aframe.h"
 #include "audio/fmt-conversion.h"
 #include "audio/format.h"

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -26,8 +26,6 @@
 #include <sys/stat.h>
 #include <sys/un.h>
 
-#include "config.h"
-
 #include "osdep/io.h"
 #include "osdep/threads.h"
 

--- a/input/ipc-win.c
+++ b/input/ipc-win.c
@@ -18,8 +18,6 @@
 #include <windows.h>
 #include <sddl.h>
 
-#include "config.h"
-
 #include "osdep/io.h"
 #include "osdep/threads.h"
 #include "osdep/windows_utils.h"

--- a/input/ipc.c
+++ b/input/ipc.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include "common/msg.h"
 #include "input/input.h"
 #include "misc/json.h"

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -18,8 +18,6 @@
 /// \file
 /// \ingroup Properties
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/options/parse_commandline.c
+++ b/options/parse_commandline.c
@@ -22,8 +22,6 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#include "config.h"
-
 #include "osdep/io.h"
 #include "common/global.h"
 #include "common/msg.h"

--- a/options/parse_configfile.c
+++ b/options/parse_configfile.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/osdep/main-fn-win.c
+++ b/osdep/main-fn-win.c
@@ -4,8 +4,6 @@
 #define BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE (0x0001)
 #endif
 
-#include "config.h"
-
 #include "common/common.h"
 #include "osdep/io.h"
 #include "osdep/terminal.h"

--- a/osdep/subprocess.c
+++ b/osdep/subprocess.c
@@ -17,8 +17,6 @@
 
 #include <pthread.h>
 
-#include "config.h"
-
 #include "common/common.h"
 #include "common/msg.h"
 #include "common/msg_control.h"

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -17,8 +17,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -18,7 +18,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/osdep/timer-darwin.c
+++ b/osdep/timer-darwin.c
@@ -23,7 +23,6 @@
 #include <sys/time.h>
 #include <mach/mach_time.h>
 
-#include "config.h"
 #include "common/msg.h"
 #include "timer.h"
 

--- a/osdep/timer-linux.c
+++ b/osdep/timer-linux.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <time.h>
 #include <sys/time.h>
-#include "config.h"
 #include "timer.h"
 
 void mp_sleep_us(int64_t us)

--- a/player/audio.c
+++ b/player/audio.c
@@ -22,7 +22,6 @@
 #include <math.h>
 #include <assert.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "common/msg.h"

--- a/player/command.c
+++ b/player/command.c
@@ -31,7 +31,6 @@
 #include <libavutil/avstring.h>
 #include <libavutil/common.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 #include "client.h"
 #include "common/av_common.h"

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -26,7 +26,6 @@
 
 #include <libavutil/md5.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "osdep/io.h"

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -23,7 +23,6 @@
 
 #include <libavutil/avutil.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "misc/thread_pool.h"

--- a/player/misc.c
+++ b/player/misc.c
@@ -20,7 +20,6 @@
 #include <errno.h>
 #include <assert.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "osdep/io.h"

--- a/player/osd.c
+++ b/player/osd.c
@@ -22,7 +22,6 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "common/msg.h"

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -23,7 +23,6 @@
 
 #include "client.h"
 #include "command.h"
-#include "config.h"
 #include "core.h"
 #include "mpv_talloc.h"
 #include "screenshot.h"

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -21,8 +21,6 @@
 
 #include <libavcodec/avcodec.h>
 
-#include "config.h"
-
 #include "osdep/io.h"
 
 #include "mpv_talloc.h"

--- a/player/sub.c
+++ b/player/sub.c
@@ -21,7 +21,6 @@
 #include <math.h>
 #include <assert.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "common/msg.h"

--- a/player/video.c
+++ b/player/video.c
@@ -21,7 +21,6 @@
 #include <math.h>
 #include <assert.h>
 
-#include "config.h"
 #include "mpv_talloc.h"
 
 #include "common/msg.h"

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -35,7 +35,6 @@
 #include <linux/dvb/dmx.h>
 #include <linux/dvb/frontend.h>
 
-#include "config.h"
 #include "osdep/io.h"
 #include "dvbin.h"
 #include "dvb_tune.h"

--- a/stream/stream_avdevice.c
+++ b/stream/stream_avdevice.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include "stream.h"
 
 static int open_f(stream_t *stream)

--- a/stream/stream_cb.c
+++ b/stream/stream_cb.c
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/stream/stream_mf.c
+++ b/stream/stream_mf.c
@@ -20,8 +20,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/stream/stream_null.c
+++ b/stream/stream_null.c
@@ -17,8 +17,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -22,7 +22,6 @@
 #include <assert.h>
 #include <pthread.h>
 
-#include "config.h"
 #include "demux/demux.h"
 #include "sd.h"
 #include "dec_sub.h"

--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -23,8 +23,6 @@
 #include <libavutil/common.h>
 #include <libavutil/opt.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "common/msg.h"
 #include "common/av_common.h"

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -21,8 +21,6 @@
 #include <string.h>
 #include <assert.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "misc/bstr.h"
 #include "common/common.h"

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -24,8 +24,6 @@
 #include <libavutil/intreadwrite.h>
 #include <libavutil/opt.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "common/msg.h"
 #include "common/av_common.h"

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -21,8 +21,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stdint.h>
 #include <math.h>
 #include <assert.h>

--- a/video/cuda.c
+++ b/video/cuda.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include "hwdec.h"
 #include "options/m_config.h"
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -30,8 +30,6 @@
 #include <libavutil/intreadwrite.h>
 #include <libavutil/pixdesc.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "common/global.h"
 #include "common/msg.h"

--- a/video/drmprime.c
+++ b/video/drmprime.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <libavutil/hwcontext.h>
 
 #include "hwdec.h"

--- a/video/filter/vf_sub.c
+++ b/video/filter/vf_sub.c
@@ -18,8 +18,6 @@
  */
 
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,7 +25,6 @@
 #include <assert.h>
 #include <libavutil/common.h>
 
-#include "config.h"
 #include "common/msg.h"
 #include "filters/filter.h"
 #include "filters/filter_internal.h"

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -29,8 +29,6 @@
 #include <libavutil/rational.h>
 #include <libavutil/cpu.h>
 
-#include "config.h"
-
 #include "common/msg.h"
 #include "options/m_option.h"
 #include "options/path.h"

--- a/video/filter/vf_vavpp.c
+++ b/video/filter/vf_vavpp.c
@@ -23,7 +23,6 @@
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vaapi.h>
 
-#include "config.h"
 #include "options/options.h"
 #include "filters/filter.h"
 #include "filters/filter_internal.h"

--- a/video/fmt-conversion.c
+++ b/video/fmt-conversion.c
@@ -20,7 +20,6 @@
 
 #include "video/img_format.h"
 #include "fmt-conversion.h"
-#include "config.h"
 
 static const struct {
     int fmt;

--- a/video/img_format.c
+++ b/video/img_format.c
@@ -23,8 +23,6 @@
 #include <libavutil/pixfmt.h>
 #include <libavutil/pixdesc.h>
 
-#include "config.h"
-
 #include "video/img_format.h"
 #include "video/mp_image.h"
 #include "video/fmt-conversion.h"

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -35,7 +35,6 @@
 
 #include "mpv_talloc.h"
 
-#include "config.h"
 #include "common/av_common.h"
 #include "common/common.h"
 #include "hwdec.h"

--- a/video/mp_image_pool.c
+++ b/video/mp_image_pool.c
@@ -15,8 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
-
 #include <stddef.h>
 #include <stdbool.h>
 #include <pthread.h>

--- a/video/out/cocoa_common.m
+++ b/video/out/cocoa_common.m
@@ -34,8 +34,6 @@
 #include "osdep/macosx_compat.h"
 #include "osdep/macosx_events_objc.h"
 
-#include "config.h"
-
 #include "osdep/timer.h"
 #include "osdep/macosx_application.h"
 #include "osdep/macosx_application_objc.h"

--- a/video/out/d3d11/hwdec_d3d11va.c
+++ b/video/out/d3d11/hwdec_d3d11va.c
@@ -19,8 +19,6 @@
 #include <d3d11.h>
 #include <d3d11_1.h>
 
-#include "config.h"
-
 #include "common/common.h"
 #include "options/m_config.h"
 #include "osdep/windows_utils.h"

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -3,7 +3,6 @@
 #include "video/out/vo.h"
 #include "video/csputils.h"
 
-#include "config.h"
 #include "ra.h"
 
 struct ra_ctx_opts {

--- a/video/out/hwdec/dmabuf_interop.h
+++ b/video/out/hwdec/dmabuf_interop.h
@@ -19,7 +19,6 @@
 
 #include <libavutil/hwcontext_drm.h>
 
-#include "config.h"
 #include "video/out/gpu/hwdec.h"
 
 struct dmabuf_interop {

--- a/video/out/hwdec/dmabuf_interop_gl.c
+++ b/video/out/hwdec/dmabuf_interop_gl.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "dmabuf_interop.h"
 
 #include <drm_fourcc.h>

--- a/video/out/hwdec/dmabuf_interop_pl.c
+++ b/video/out/hwdec/dmabuf_interop_pl.c
@@ -18,7 +18,6 @@
 #include <errno.h>
 #include <unistd.h>
 
-#include "config.h"
 #include "dmabuf_interop.h"
 #include "video/out/placebo/ra_pl.h"
 #include "video/out/placebo/utils.h"

--- a/video/out/hwdec/dmabuf_interop_wl.c
+++ b/video/out/hwdec/dmabuf_interop_wl.c
@@ -15,7 +15,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "video/out/wldmabuf/ra_wldmabuf.h"
-#include "config.h"
 #include "dmabuf_interop.h"
 
 static bool mapper_init(struct ra_hwdec_mapper *mapper,

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -17,7 +17,6 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "hwdec_cuda.h"
 #include "options/m_config.h"
 #include "video/out/opengl/formats.h"

--- a/video/out/libmpv_sw.c
+++ b/video/out/libmpv_sw.c
@@ -1,4 +1,3 @@
-#include "config.h"
 #include "libmpv/render_gl.h"
 #include "libmpv.h"
 #include "sub/osd.h"

--- a/video/out/opengl/hwdec_ios.m
+++ b/video/out/opengl/hwdec_ios.m
@@ -25,8 +25,6 @@
 
 #include <libavutil/hwcontext.h>
 
-#include "config.h"
-
 #include "video/out/gpu/hwdec.h"
 #include "video/mp_image_pool.h"
 #include "ra_gl.h"

--- a/video/out/opengl/hwdec_osx.c
+++ b/video/out/opengl/hwdec_osx.c
@@ -26,8 +26,6 @@
 
 #include <libavutil/hwcontext.h>
 
-#include "config.h"
-
 #include "video/mp_image_pool.h"
 #include "video/out/gpu/hwdec.h"
 #include "ra_gl.h"

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -26,8 +26,6 @@
 
 #include <libavutil/common.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "common/common.h"
 #include "misc/bstr.h"

--- a/video/out/vo_image.c
+++ b/video/out/vo_image.c
@@ -24,7 +24,6 @@
 
 #include <libswscale/swscale.h>
 
-#include "config.h"
 #include "misc/bstr.h"
 #include "osdep/io.h"
 #include "options/m_config.h"

--- a/video/out/vo_lavc.c
+++ b/video/out/vo_lavc.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "config.h"
 #include "common/common.h"
 #include "options/options.h"
 #include "video/fmt-conversion.h"

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -7,8 +7,6 @@
 #include <pthread.h>
 #include <assert.h>
 
-#include "config.h"
-
 #include "mpv_talloc.h"
 #include "common/common.h"
 #include "misc/bstr.h"

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -44,7 +44,6 @@
 #include "video/mp_image.h"
 
 #include "win_state.h"
-#include "config.h"
 #include "vo.h"
 
 struct formatmap_entry {

--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -28,7 +28,6 @@
 #include <X11/Xutil.h>
 #include <va/va_x11.h>
 
-#include "config.h"
 #include "common/msg.h"
 #include "video/out/vo.h"
 #include "video/mp_image_pool.h"

--- a/video/out/vo_vdpau.c
+++ b/video/out/vo_vdpau.c
@@ -31,7 +31,6 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "config.h"
 #include "video/vdpau.h"
 #include "video/vdpau_mixer.h"
 #include "video/hwdec.h"

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -24,7 +24,6 @@
 
 #include <libswscale/swscale.h>
 
-#include "config.h"
 #include "vo.h"
 #include "video/csputils.h"
 #include "video/mp_image.h"

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -29,8 +29,6 @@
 
 #include <libavutil/common.h>
 
-#include "config.h"
-
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -39,7 +39,6 @@
 #include <X11/extensions/Xpresent.h>
 #include <X11/extensions/Xrandr.h>
 
-#include "config.h"
 #include "misc/bstr.h"
 #include "options/options.h"
 #include "options/m_config.h"


### PR DESCRIPTION
Most sources don't need config.h.
The inclusion only leads to lots of unneeded recompilation if the
configuration is changed.

Also drop an unused include of version.h from ao_pipewire.