### PR TITLE
ao_pipewire: use realtime scheduling for data thread

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -489,7 +489,10 @@ static int pipewire_init_boilerplate(struct ao *ao)
     if (pw_thread_loop_start(p->loop) < 0)
         goto error;
 
-    context = pw_context_new(pw_thread_loop_get_loop(p->loop), NULL, 0);
+    context = pw_context_new(
+            pw_thread_loop_get_loop(p->loop),
+            pw_properties_new(PW_KEY_CONFIG_NAME, "client-rt.conf", NULL),
+            0);
     if (!context)
         goto error;
 


### PR DESCRIPTION
By making the data thread realtime it is able to serve requests faster and more reliable reducing crackling in certain situations.

As the mpv callbacks that are running on the data thread are all non-blocking and very short this should be safe.

The same mechanism is also used by pw-cat and the alsa plugin shipped by pipewire.

Also see the analysis at https://github.com/mpv-player/mpv/issues/9992#issuecomment-1435785244
Cc @MacGyverNL