### PR TITLE
Vulkan: add configure check for VK_KHR_display extension

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1248,7 +1248,6 @@ features += {'vulkan': vulkan.found()}
 if features['vulkan']
     dependencies += vulkan
     sources += files('video/out/vulkan/context.c',
-                     'video/out/vulkan/context_display.c',
                      'video/out/vulkan/utils.c')
 endif
 
@@ -1266,6 +1265,13 @@ endif
 
 if features['vulkan'] and features['x11']
      sources += files('video/out/vulkan/context_xlib.c')
+endif
+
+features += {'vk_khr_display': cc.has_function('vkCreateDisplayPlaneSurfaceKHR', prefix: '#include <vulkan/vulkan_core.h>',
+                                               dependencies: [vulkan])}
+
+if features['vk_khr_display']
+    sources += files('video/out/vulkan/context_display.c')
 endif
 
 

--- a/options/options.c
+++ b/options/options.c
@@ -800,7 +800,9 @@ static const m_option_t mp_opts[] = {
 
 #if HAVE_VULKAN
     {"", OPT_SUBSTRUCT(vulkan_opts, vulkan_conf)},
+#if HAVE_VK_KHR_DISPLAY
     {"", OPT_SUBSTRUCT(vulkan_display_opts, vulkan_display_conf)},
+#endif
 #endif
 
 #if HAVE_D3D11

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -110,7 +110,9 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_X11
     &ra_ctx_vulkan_xlib,
 #endif
+#if HAVE_VK_KHR_DISPLAY
     &ra_ctx_vulkan_display,
+#endif
 #endif
 
 /* No API contexts: */

--- a/wscript
+++ b/wscript
@@ -791,6 +791,12 @@ video_output_features = [
         'deps': 'libplacebo',
         'func': check_pkg_config('vulkan'),
     }, {
+        'name': 'vk-khr-display',
+        'desc': "VK_KHR_display extension",
+        'deps': 'vulkan',
+        'func': check_statement('vulkan/vulkan_core.h', 'vkCreateDisplayPlaneSurfaceKHR(0, 0, 0, 0)',
+                                use='vulkan')
+    }, {
         'name': 'vaapi-libplacebo',
         'desc': 'VAAPI libplacebo',
         'deps': 'vaapi && libplacebo',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -557,7 +557,7 @@ def build(ctx):
         ( "video/out/vo_x11.c" ,                 "x11" ),
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),
-        ( "video/out/vulkan/context_display.c",  "vulkan" ),
+        ( "video/out/vulkan/context_display.c",  "vulkan && vk-khr-display" ),
         ( "video/out/vulkan/context_android.c",  "vulkan && android" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
         ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),


### PR DESCRIPTION
This allows building directly against ICDs that don't implement this extension.