### PR TITLE
mp_image: always add AV_FRAME_DATA_DOVI_METADATA when present

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1019,14 +1019,8 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
 
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 16, 100)
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_DOVI_METADATA);
-    if (sd) {
-        // Strip DoVi metadata that requires an EL, since it's near-impossible
-        // for us to support easily or sanely
-        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) sd->buf->data;
-        const AVDOVIRpuDataHeader *rpu = av_dovi_get_header(metadata);
-        if (rpu->disable_residual_flag)
-            dst->dovi = sd->buf;
-    }
+    if (sd)
+        dst->dovi = sd->buf;
 
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_DOVI_RPU_BUFFER);
     if (sd)


### PR DESCRIPTION
As the Dolby Vision metadata is only supported for vo_gpu_next, the check whether to use the metadata is now handled by `mp_map_dovi_metadata_to_pl` in `placebo/utils.c`.

It doesn't hurt to keep the metadata in `mp_image`, and might be useful to library users.

I'm just not sure how it affects encoding?