### PR TITLE
sub/lavc_conv: properly fill avctx with codecpar values at init

### DIFF
--- a/common/av_common.c
+++ b/common/av_common.c
@@ -64,7 +64,7 @@ enum AVMediaType mp_to_av_stream_type(int type)
     }
 }
 
-AVCodecParameters *mp_codec_params_to_av(struct mp_codec_params *c)
+AVCodecParameters *mp_codec_params_to_av(const struct mp_codec_params *c)
 {
     AVCodecParameters *avp = avcodec_parameters_alloc();
     if (!avp)
@@ -125,7 +125,7 @@ error:
 }
 
 // Set avctx codec headers for decoding. Returns <0 on failure.
-int mp_set_avctx_codec_headers(AVCodecContext *avctx, struct mp_codec_params *c)
+int mp_set_avctx_codec_headers(AVCodecContext *avctx, const struct mp_codec_params *c)
 {
     enum AVMediaType codec_type = avctx->codec_type;
     enum AVCodecID codec_id = avctx->codec_id;
@@ -145,7 +145,7 @@ int mp_set_avctx_codec_headers(AVCodecContext *avctx, struct mp_codec_params *c)
 
 // Pick a "good" timebase, which will be used to convert double timestamps
 // back to fractions for passing them through libavcodec.
-AVRational mp_get_codec_timebase(struct mp_codec_params *c)
+AVRational mp_get_codec_timebase(const struct mp_codec_params *c)
 {
     AVRational tb = {c->native_tb_num, c->native_tb_den};
     if (tb.num < 1 || tb.den < 1) {

--- a/common/av_common.c
+++ b/common/av_common.c
@@ -40,20 +40,6 @@
 #include "av_common.h"
 #include "codecs.h"
 
-int mp_lavc_set_extradata(AVCodecContext *avctx, void *ptr, int size)
-{
-    if (size) {
-        av_free(avctx->extradata);
-        avctx->extradata_size = 0;
-        avctx->extradata = av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE);
-        if (!avctx->extradata)
-            return -1;
-        avctx->extradata_size = size;
-        memcpy(avctx->extradata, ptr, size);
-    }
-    return 0;
-}
-
 enum AVMediaType mp_to_av_stream_type(int type)
 {
     switch (type) {

--- a/common/av_common.h
+++ b/common/av_common.h
@@ -31,7 +31,6 @@ struct mp_codec_params;
 struct AVDictionary;
 struct mp_log;
 
-int mp_lavc_set_extradata(AVCodecContext *avctx, void *ptr, int size);
 enum AVMediaType mp_to_av_stream_type(int type);
 AVCodecParameters *mp_codec_params_to_av(const struct mp_codec_params *c);
 int mp_set_avctx_codec_headers(AVCodecContext *avctx, const struct mp_codec_params *c);

--- a/common/av_common.h
+++ b/common/av_common.h
@@ -33,9 +33,9 @@ struct mp_log;
 
 int mp_lavc_set_extradata(AVCodecContext *avctx, void *ptr, int size);
 enum AVMediaType mp_to_av_stream_type(int type);
-AVCodecParameters *mp_codec_params_to_av(struct mp_codec_params *c);
-int mp_set_avctx_codec_headers(AVCodecContext *avctx, struct mp_codec_params *c);
-AVRational mp_get_codec_timebase(struct mp_codec_params *c);
+AVCodecParameters *mp_codec_params_to_av(const struct mp_codec_params *c);
+int mp_set_avctx_codec_headers(AVCodecContext *avctx, const struct mp_codec_params *c);
+AVRational mp_get_codec_timebase(const struct mp_codec_params *c);
 void mp_set_av_packet(AVPacket *dst, struct demux_packet *mpkt, AVRational *tb);
 int64_t mp_pts_to_av(double mp_pts, AVRational *tb);
 double mp_pts_from_av(int64_t av_pts, AVRational *tb);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -46,8 +46,8 @@ struct sd_functions {
 
 // lavc_conv.c
 struct lavc_conv;
-struct lavc_conv *lavc_conv_create(struct mp_log *log, const char *codec_name,
-                                   char *extradata, int extradata_len);
+struct lavc_conv *lavc_conv_create(struct mp_log *log,
+                                   const struct mp_codec_params *mp_codec);
 char *lavc_conv_get_extradata(struct lavc_conv *priv);
 char **lavc_conv_decode(struct lavc_conv *priv, struct demux_packet *packet,
                         double *sub_pts, double *sub_duration);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -261,9 +261,7 @@ static int init(struct sd *sd)
         strcmp(sd->codec->codec, "null") != 0)
     {
         ctx->is_converted = true;
-        ctx->converter = lavc_conv_create(sd->log, sd->codec->codec,
-                                          sd->codec->extradata,
-                                          sd->codec->extradata_size);
+        ctx->converter = lavc_conv_create(sd->log, sd->codec);
         if (!ctx->converter)
             return -1;
 

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -99,7 +99,8 @@ static int init(struct sd *sd)
     priv->avpkt = av_packet_alloc();
     if (!priv->avpkt)
         goto error;
-    mp_lavc_set_extradata(ctx, sd->codec->extradata, sd->codec->extradata_size);
+    if (mp_set_avctx_codec_headers(ctx, sd->codec) < 0)
+        goto error;
     priv->pkt_timebase = mp_get_codec_timebase(sd->codec);
     ctx->pkt_timebase = priv->pkt_timebase;
     if (avcodec_open2(ctx, sub_codec, NULL) < 0)


### PR DESCRIPTION
First const'ifies all getters that take in `mp_codec_params` as an argument, then extends lavc_conv's init to take in the full mp codecpar struct.

This way we receive such minor details as the profile (necessary for ARIB captions, among others) during init. This enables decoders to switch between ARIB caption profile A and profile C streams.

- [x] Test with libaribb24/libaribcaption decoders (it is getting late, now that I figured out that it always re-inits subtitle decoders at track switching there needs to be zero patching on the decoder side lol).
    Verified by @aimoff  .
- [ ] ~Test with zvbi and teletext~
- [x] Test with US closed captions
- [x] Test with mov_text
- [x] SRT?

For image based subs (`sd_lavc`):

- [x] PGS
- [x] DVD
- [x] DVB