### PR TITLE
displayvk: load various vulkan functions at runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1248,6 +1248,7 @@ features += {'vulkan': vulkan.found()}
 if features['vulkan']
     dependencies += vulkan
     sources += files('video/out/vulkan/context.c',
+                     'video/out/vulkan/context_display.c',
                      'video/out/vulkan/utils.c')
 endif
 
@@ -1265,13 +1266,6 @@ endif
 
 if features['vulkan'] and features['x11']
      sources += files('video/out/vulkan/context_xlib.c')
-endif
-
-features += {'vk_khr_display': cc.has_function('vkCreateDisplayPlaneSurfaceKHR', prefix: '#include <vulkan/vulkan_core.h>',
-                                               dependencies: [vulkan])}
-
-if features['vk_khr_display']
-    sources += files('video/out/vulkan/context_display.c')
 endif
 
 

--- a/options/options.c
+++ b/options/options.c
@@ -797,9 +797,7 @@ static const m_option_t mp_opts[] = {
 
 #if HAVE_VULKAN
     {"", OPT_SUBSTRUCT(vulkan_opts, vulkan_conf)},
-#if HAVE_VK_KHR_DISPLAY
     {"", OPT_SUBSTRUCT(vulkan_display_opts, vulkan_display_conf)},
-#endif
 #endif
 
 #if HAVE_D3D11

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -110,9 +110,7 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_X11
     &ra_ctx_vulkan_xlib,
 #endif
-#if HAVE_VK_KHR_DISPLAY
     &ra_ctx_vulkan_display,
-#endif
 #endif
 
 /* No API contexts: */

--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -11,6 +11,13 @@
 #include "common/common.h"
 #include "common/msg.h"
 
+// Helpers for loading functions at runtime. Omit the "vk" prefix.
+// VK_LOAD_FUN_PL is preferred if possible.
+#define VK_LOAD_FUN_PL(vkinst, name) \
+    PFN_vk##name name = (PFN_vk##name) vkinst->get_proc_addr(vkinst->instance, "vk" #name);
+#define VK_LOAD_FUN(inst, name) \
+    PFN_vk##name name = (PFN_vk##name) vkGetInstanceProcAddr(inst, "vk" #name);
+
 // We need to define all platforms we want to support. Since we have
 // our own mechanism for checking this, we re-define the right symbols
 #if HAVE_WAYLAND

--- a/wscript
+++ b/wscript
@@ -791,12 +791,6 @@ video_output_features = [
         'deps': 'libplacebo',
         'func': check_pkg_config('vulkan'),
     }, {
-        'name': 'vk-khr-display',
-        'desc': "VK_KHR_display extension",
-        'deps': 'vulkan',
-        'func': check_statement('vulkan/vulkan_core.h', 'vkCreateDisplayPlaneSurfaceKHR(0, 0, 0, 0)',
-                                use='vulkan')
-    }, {
         'name': 'vaapi-libplacebo',
         'desc': 'VAAPI libplacebo',
         'deps': 'vaapi && libplacebo',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -557,7 +557,7 @@ def build(ctx):
         ( "video/out/vo_x11.c" ,                 "x11" ),
         ( "video/out/vo_xv.c",                   "xv" ),
         ( "video/out/vulkan/context.c",          "vulkan" ),
-        ( "video/out/vulkan/context_display.c",  "vulkan && vk-khr-display" ),
+        ( "video/out/vulkan/context_display.c",  "vulkan" ),
         ( "video/out/vulkan/context_android.c",  "vulkan && android" ),
         ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
         ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),


### PR DESCRIPTION
Instead of checking for this function in the build system, we can load it at runtime from the vulkan instance and error out if the extension isn't supported.

Based on a suggestion by @haasn. Should work I think. cc @rcombs.