### PR TITLE
options: read config file as stream

### DIFF
--- a/options/parse_configfile.c
+++ b/options/parse_configfile.c
@@ -29,6 +29,7 @@
 #include "misc/ctype.h"
 #include "m_option.h"
 #include "m_config.h"
+#include "stream/stream.h"
 
 // Skip whitespace and comments (assuming there are no line breaks)
 static bool skip_ws(bstr *s)
@@ -149,51 +150,29 @@ int m_config_parse(m_config_t *config, const char *location, bstr data,
     return 1;
 }
 
-static bstr read_file(struct mp_log *log, const char *filename)
-{
-    FILE *f = fopen(filename, "rb");
-    if (!f) {
-        mp_verbose(log, "Can't open config file: %s\n", mp_strerror(errno));
-        return (bstr){0};
-    }
-    char *data = talloc_array(NULL, char, 0);
-    size_t size = 0;
-    while (1) {
-        size_t left = talloc_get_size(data) - size;
-        if (!left) {
-            MP_TARRAY_GROW(NULL, data, size + 1);
-            continue;
-        }
-        size_t s = fread(data + size, 1, left, f);
-        if (!s) {
-            if (ferror(f))
-                mp_err(log, "Error reading config file.\n");
-            fclose(f);
-            MP_TARRAY_APPEND(NULL, data, size, 0);
-            return (bstr){data, size - 1};
-        }
-        size += s;
-    }
-    MP_ASSERT_UNREACHABLE();
-}
-
 // Load options and profiles from a config file.
 //  conffile: path to the config file
 //  initial_section: default section where to add normal options
 //  flags: M_SETOPT_* bits
 //  returns: 1 on success, -1 on error, 0 if file not accessible.
-int m_config_parse_config_file(m_config_t *config, const char *conffile,
-                               char *initial_section, int flags)
+int m_config_parse_config_file(m_config_t *config, struct mpv_global *global,
+                               const char *conffile, char *initial_section,
+                               int flags)
 {
     flags = flags | M_SETOPT_FROM_CONFIG_FILE;
 
     MP_VERBOSE(config, "Reading config file %s\n", conffile);
 
-    bstr data = read_file(config->log, conffile);
+    struct stream *s = stream_create(conffile, STREAM_READ | STREAM_ORIGIN_DIRECT,
+                                     NULL, global);
+    if (!s)
+        return 0;
+    bstr data = stream_read_complete(s, s, 1000000000);
     if (!data.start)
         return 0;
 
     int r = m_config_parse(config, conffile, data, initial_section, flags);
     talloc_free(data.start);
+    free_stream(s);
     return r;
 }

--- a/options/parse_configfile.h
+++ b/options/parse_configfile.h
@@ -20,8 +20,9 @@
 
 #include "m_config_frontend.h"
 
-int m_config_parse_config_file(m_config_t* config, const char *conffile,
-                               char *initial_section, int flags);
+int m_config_parse_config_file(m_config_t* config, struct mpv_global *global,
+                               const char *conffile, char *initial_section,
+                               int flags);
 
 int m_config_parse(m_config_t *config, const char *location, bstr data,
                    char *initial_section, int flags);

--- a/player/client.c
+++ b/player/client.c
@@ -1848,7 +1848,7 @@ int mpv_hook_continue(mpv_handle *ctx, uint64_t id)
 int mpv_load_config_file(mpv_handle *ctx, const char *filename)
 {
     lock_core(ctx);
-    int r = m_config_parse_config_file(ctx->mpctx->mconfig, filename, NULL, 0);
+    int r = m_config_parse_config_file(ctx->mpctx->mconfig, ctx->mpctx->global, filename, NULL, 0);
     unlock_core(ctx);
     if (r == 0)
         return MPV_ERROR_INVALID_PARAMETER;

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -52,7 +52,7 @@ static void load_all_cfgfiles(struct MPContext *mpctx, char *section,
 {
     char **cf = mp_find_all_config_files(NULL, mpctx->global, filename);
     for (int i = 0; cf && cf[i]; i++)
-        m_config_parse_config_file(mpctx->mconfig, cf[i], section, 0);
+        m_config_parse_config_file(mpctx->mconfig, mpctx->global, cf[i], section, 0);
     talloc_free(cf);
 }
 
@@ -99,7 +99,7 @@ static int try_load_config(struct MPContext *mpctx, const char *file, int flags,
     if (!mp_path_exists(file))
         return 0;
     MP_MSG(mpctx, msgl, "Loading config '%s'\n", file);
-    m_config_parse_config_file(mpctx->mconfig, file, NULL, flags);
+    m_config_parse_config_file(mpctx->mconfig, mpctx->global, file, NULL, flags);
     return 1;
 }
 

--- a/player/main.c
+++ b/player/main.c
@@ -232,7 +232,7 @@ static int cfg_include(void *ctx, char *filename, int flags)
 {
     struct MPContext *mpctx = ctx;
     char *fname = mp_get_user_path(NULL, mpctx->global, filename);
-    int r = m_config_parse_config_file(mpctx->mconfig, fname, NULL, flags);
+    int r = m_config_parse_config_file(mpctx->mconfig, mpctx->global, fname, NULL, flags);
     talloc_free(fname);
     return r;
 }


### PR DESCRIPTION
This aligns the possible sources of config files other loaded data. For example `--input-conf`.