### PR TITLE
hwdec autoprobing improvements

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -243,6 +243,8 @@ const struct autoprobe_info hwdec_autoprobe_info[] = {
     {"vdpau-copy",      HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"mmal",            HWDEC_FLAG_AUTO},
     {"mmal-copy",       HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
+    {"mediacodec",      HWDEC_FLAG_AUTO},
+    {"mediacodec-copy", HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"videotoolbox",    HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"videotoolbox-copy", HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {0}

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -267,6 +267,9 @@ static int hwdec_compare(const void *p1, const void *p2)
     // Order by autoprobe preference order.
     if (h1->auto_pos != h2->auto_pos)
         return h1->auto_pos > h2->auto_pos ? 1 : -1;
+    // Put hwdecs without hw_device_ctx last
+    if ((!!h1->lavc_device) != (!!h2->lavc_device))
+        return h1->lavc_device ? -1 : 1;
     // Fallback sort order to make sorting stable.
     return h1->rank > h2->rank ? 1 :-1;
 }


### PR DESCRIPTION
on android the autoprobe order looks as follows:
<pre>
[vd:info]   mediacodec (h264_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (mpeg2_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (av1_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (hevc_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (mpeg4_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (vp8_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (vp9_mediacodec-mediacodec) device=10 copying=0
[vd:info]   v4l2m2m-copy (h263_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (h264_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   mediacodec-copy (h264_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   v4l2m2m-copy (hevc_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg4_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg1_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg2_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   mediacodec-copy (mpeg2_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   v4l2m2m-copy (vc1_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (vp8_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (vp9_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   mediacodec-copy (av1_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (hevc_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (mpeg4_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (vp8_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (vp9_mediacodec-mediacodec-copy) device=10 copying=1
</pre>

when `mediacodec` fails for some reason (e.g. android too old) mpv tries `v4l2m2m-copy` next which always passes the check only to fail during decoding, `mediacodec-copy` is never tried.

after these commits the order is as follows:
<pre>
[vd:info]   mediacodec (h264_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (mpeg2_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (av1_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (hevc_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (mpeg4_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (vp8_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec (vp9_mediacodec-mediacodec) device=10 copying=0
[vd:info]   mediacodec-copy (h264_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (mpeg2_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (av1_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (hevc_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (mpeg4_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (vp8_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   mediacodec-copy (vp9_mediacodec-mediacodec-copy) device=10 copying=1
[vd:info]   v4l2m2m-copy (h263_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (h264_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (hevc_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg4_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg1_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (mpeg2_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (vc1_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (vp8_v4l2m2m-v4l2m2m-copy) device=0 copying=1
[vd:info]   v4l2m2m-copy (vp9_v4l2m2m-v4l2m2m-copy) device=0 copying=1
</pre>