### PR TITLE
Revert property transition

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -224,7 +224,70 @@ const m_option_type_t m_option_type_bool = {
 
 #undef VAL
 
+// Flag
+
+#define VAL(x) (*(int *)(x))
+
+static int parse_flag(struct mp_log *log, const m_option_t *opt,
+                      struct bstr name, struct bstr param, void *dst)
+{
+    bool bdst = false;
+    int r = parse_bool(log, opt, name, param, &bdst);
+    if (dst)
+        VAL(dst) = bdst;
+    return r;
+}
+
+static char *print_flag(const m_option_t *opt, const void *val)
+{
+    return print_bool(opt, &(bool){VAL(val)});
+}
+
+static void add_flag(const m_option_t *opt, void *val, double add, bool wrap)
+{
+    bool bval = VAL(val);
+    add_bool(opt, &bval, add, wrap);
+    VAL(val) = bval;
+}
+
+static int flag_set(const m_option_t *opt, void *dst, struct mpv_node *src)
+{
+    bool bdst = false;
+    int r = bool_set(opt, &bdst, src);
+    if (r >= 0)
+        VAL(dst) = bdst;
+    return r;
+}
+
+static int flag_get(const m_option_t *opt, void *ta_parent,
+                    struct mpv_node *dst, void *src)
+{
+    return bool_get(opt, ta_parent, dst, &(bool){VAL(src)});
+}
+
+static bool flag_equal(const m_option_t *opt, void *a, void *b)
+{
+    return VAL(a) == VAL(b);
+}
+
+// Only exists for libmpv interopability and should not be used anywhere.
+const m_option_type_t m_option_type_flag = {
+    // need yes or no in config files
+    .name  = "Flag",
+    .size  = sizeof(int),
+    .flags = M_OPT_TYPE_OPTIONAL_PARAM | M_OPT_TYPE_CHOICE,
+    .parse = parse_flag,
+    .print = print_flag,
+    .copy  = copy_opt,
+    .add   = add_flag,
+    .set   = flag_set,
+    .get   = flag_get,
+    .equal = flag_equal,
+};
+
 // Integer
+
+#undef VAL
 
 static int clamp_longlong(const m_option_t *opt, long long i_min, long long i_max,
                           void *val)

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -213,6 +213,7 @@ struct m_sub_options {
 };
 
 #define CONF_TYPE_BOOL          (&m_option_type_bool)
+#define CONF_TYPE_FLAG          (&m_option_type_flag)
 #define CONF_TYPE_INT           (&m_option_type_int)
 #define CONF_TYPE_INT64         (&m_option_type_int64)
 #define CONF_TYPE_FLOAT         (&m_option_type_float)
@@ -232,6 +233,7 @@ struct m_sub_options {
 // size/alignment requirements for option values in general.
 union m_option_value {
     bool bool_;
+    int flag; // not the C type "bool"!
     int int_;
     int64_t int64;
     float float_;

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -352,11 +352,11 @@ void m_properties_print_help_list(struct mp_log *log,
     mp_info(log, "\nTotal: %d properties\n", count);
 }
 
-int m_property_bool_ro(int action, void* arg, int var)
+int m_property_bool_ro(int action, void* arg, bool var)
 {
     switch (action) {
     case M_PROPERTY_GET:
-        *(int *)arg = !!var;
+        *(bool *)arg = !!var;
         return M_PROPERTY_OK;
     case M_PROPERTY_GET_TYPE:
         *(struct m_option *)arg = (struct m_option){.type = CONF_TYPE_BOOL};

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -176,7 +176,7 @@ char* m_properties_expand_string(const struct m_property *prop_list,
                                  const char *str, void *ctx);
 
 // Trivial helpers for implementing properties.
-int m_property_bool_ro(int action, void* arg, int var);
+int m_property_bool_ro(int action, void* arg, bool var);
 int m_property_int_ro(int action, void* arg, int var);
 int m_property_int64_ro(int action, void* arg, int64_t var);
 int m_property_float_ro(int action, void* arg, float var);

--- a/player/client.c
+++ b/player/client.c
@@ -970,7 +970,7 @@ void mpv_wakeup(mpv_handle *ctx)
 // map client API types to internal types
 static const struct m_option type_conv[] = {
     [MPV_FORMAT_STRING]     = { .type = CONF_TYPE_STRING },
-    [MPV_FORMAT_FLAG]       = { .type = CONF_TYPE_BOOL },
+    [MPV_FORMAT_FLAG]       = { .type = CONF_TYPE_FLAG },
     [MPV_FORMAT_INT64]      = { .type = CONF_TYPE_INT64 },
     [MPV_FORMAT_DOUBLE]     = { .type = CONF_TYPE_DOUBLE },
     [MPV_FORMAT_NODE]       = { .type = CONF_TYPE_NODE },


### PR DESCRIPTION
Changing the CONF_TYPE_FLAG was a bad idea because mpv_node.u.flag
continues to be an int, leading to a mismatch in type sizes which can
lead to problems with memcpy().

Closes #11373