### PR TITLE
wayland: Use bool type for vo_wayland_set_opaque_region

### DIFF
--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -7,7 +7,7 @@
 
 struct ra_ctx_opts {
     bool allow_sw;        // allow software renderers
-    int want_alpha;      // create an alpha framebuffer if possible
+    bool want_alpha;      // create an alpha framebuffer if possible
     bool debug;           // enable debugging layers/callbacks etc.
     bool probing;        // the backend was auto-probed
     char *context_name;  // filter by `ra_ctx_fns.name`

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -189,7 +189,7 @@ static void resize(struct vo *vo)
     const int width = mp_rect_w(wl->geometry);
     const int height = mp_rect_h(wl->geometry);
     
-    vo_wayland_set_opaque_region(wl, 0);
+    vo_wayland_set_opaque_region(wl, false);
     vo->dwidth = width;
     vo->dheight = height;
 

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -186,7 +186,7 @@ static int resize(struct vo *vo)
     const int32_t height = mp_rect_h(wl->geometry);
     struct buffer *buf;
 
-    vo_wayland_set_opaque_region(wl, 0);
+    vo_wayland_set_opaque_region(wl, false);
     vo->want_redraw = true;
     vo->dwidth = width;
     vo->dheight = height;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2242,7 +2242,7 @@ bool vo_wayland_reconfig(struct vo *vo)
     return true;
 }
 
-void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha)
+void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, bool alpha)
 {
     const int32_t width = mp_rect_w(wl->geometry);
     const int32_t height = mp_rect_h(wl->geometry);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -171,7 +171,7 @@ int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
 
 void vo_wayland_handle_fractional_scale(struct vo_wayland_state *wl);
-void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, int alpha);
+void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, bool alpha);
 void vo_wayland_sync_swap(struct vo_wayland_state *wl);
 void vo_wayland_uninit(struct vo *vo);
 void vo_wayland_wait_events(struct vo *vo, int64_t until_time_us);


### PR DESCRIPTION
The alpha argument is only used as a bool but is an int. Passing a 0 or 1 to an argument called alpha is confusing - at first glance it looks like you're specifying an alpha value of 0 or 1. Since it's only used as a bool, make it a bool.