### PR TITLE
ra: assert when using params with dimensions

### DIFF
--- a/video/out/gpu/ra.c
+++ b/video/out/gpu/ra.c
@@ -26,6 +26,16 @@ void *ra_get_native_resource(struct ra *ra, const char *name)
 
 struct ra_tex *ra_tex_create(struct ra *ra, const struct ra_tex_params *params)
 {
+    switch (params->dimensions) {
+    case 1:
+        assert(params->h == 1 && params->d == 1);
+        break;
+    case 2:
+        assert(params->d == 1);
+        break;
+    default:
+        assert(params->dimensions >= 1 && params->dimensions <= 3);
+    }
     return ra->fns->tex_create(ra, params);
 }
 


### PR DESCRIPTION
This came up in #9828. According to the header comments, creating a 1D ra_tex requires height and depth to be set to 1. For a 2D texture, it requires depth be set to 1. There were a couple of spots in mpv's code where this wasn't be followed. Although there was no known bug from this, the rest of the code works like this so it was a good idea to go ahead and sync it up. As a followup, let's just add a couple of simple asserts to ra.c to enforce this so it doesn't go unnoticed in the future.

Inspired by @sfan5's comment: https://github.com/mpv-player/mpv/pull/9828#issuecomment-1448491152