### PR TITLE
add a MPV_FORMAT_BOOL for libmpv

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,6 +32,9 @@ API changes
 
 ::
 
+ --- mpv 0.37.0 ---
+ 2.2    - add MPV_FORMAT_BOOL
+        - deprecate MPV_FORMAT_FLAG in favor of MPV_FORMAT_BOOL
  --- mpv 0.36.0 ---
  2.1    - add mpv_del_property()
  --- mpv 0.35.0 ---

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -23,6 +23,7 @@
 #ifndef MPV_CLIENT_API_H_
 #define MPV_CLIENT_API_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -750,6 +751,7 @@ typedef enum mpv_format {
 typedef struct mpv_node {
     union {
         char *string;   /** valid if format==MPV_FORMAT_STRING */
+        bool bool_;     /** strictly for internal use; do not access **/
         int flag;       /** valid if format==MPV_FORMAT_FLAG   */
         int64_t int64;  /** valid if format==MPV_FORMAT_INT64  */
         double double_; /** valid if format==MPV_FORMAT_DOUBLE */
@@ -778,7 +780,8 @@ typedef struct mpv_node {
      *  MPV_FORMAT_NONE         (no member)
      *
      * If you encounter a value you don't know, you must not make any
-     * assumptions about the contents of union u.
+     * assumptions about the contents of union u. The u.bool_ member also
+     * exists, but you should not attempt to access it.
      */
     mpv_format format;
 } mpv_node;

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -240,7 +240,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 1)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 2)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before
@@ -667,6 +667,7 @@ typedef enum mpv_format {
      * Only valid when doing read access. The rest works like MPV_FORMAT_STRING.
      */
     MPV_FORMAT_OSD_STRING       = 2,
+#if MPV_ENABLE_DEPRECATED
     /**
      * The basic type is int. The only allowed values are 0 ("no")
      * and 1 ("yes").
@@ -682,8 +683,14 @@ typedef enum mpv_format {
      *
      *     int flag = 1;
      *     mpv_set_property(ctx, "property", MPV_FORMAT_FLAG, &flag);
+     *
+     * @deprecated Use MPV_FORMAT_BOOL instead as a replacement. When querying
+     *             the format returned by a node, it will still be MPV_FORMAT_FLAG,
+     *             for compatibility reasons, but in the future this will be changed
+     *             to MPV_FORMAT_BOOL.
      */
     MPV_FORMAT_FLAG             = 3,
+#endif
     /**
      * The basic type is int64_t.
      */
@@ -737,7 +744,13 @@ typedef enum mpv_format {
      * A raw, untyped byte array. Only used only with mpv_node, and only in
      * some very specific situations. (Some commands use it.)
      */
-    MPV_FORMAT_BYTE_ARRAY       = 9
+    MPV_FORMAT_BYTE_ARRAY       = 9,
+    /**
+     * The basic type is bool and can be used instead of MPV_FORMAT_FLAG.
+     * In the future this will replace it completely. It is recommended to
+     * use MPV_FORMAT_BOOL when possible.
+     */
+    MPV_FORMAT_BOOL             = 10,
 } mpv_format;
 
 /**
@@ -1383,9 +1396,11 @@ typedef struct mpv_event_property {
     const char *name;
     /**
      * Format of the data field in the same struct. See enum mpv_format.
-     * This is always the same format as the requested format, except when
-     * the property could not be retrieved (unavailable, or an error happened),
-     * in which case the format is MPV_FORMAT_NONE.
+     * This is always the same format as the requested format, except in
+     * two cases. If the property could not be retrieved (unavailable,
+     * or an error happened), the format is MPV_FORMAT_NONE. The other
+     * case is if the requested format is MPV_FORMAT_BOOL. It will return
+     * MPV_FORMAT_FLAG for compatibility reasons.
      */
     mpv_format format;
     /**

--- a/misc/json.c
+++ b/misc/json.c
@@ -201,6 +201,7 @@ int json_parse(void *ta_parent, struct mpv_node *dst, char **src, int max_depth)
         return 0;
     } else if (c == 't' && strncmp(*src, "true", 4) == 0) {
         *src += 4;
+        // Used to push to clients; must remain flag.
         dst->format = MPV_FORMAT_FLAG;
         dst->u.flag = 1;
         return 0;
@@ -292,6 +293,9 @@ static int json_append(bstr *b, const struct mpv_node *src, int indent)
     switch (src->format) {
     case MPV_FORMAT_NONE:
         APPEND(b, "null");
+        return 0;
+    case MPV_FORMAT_BOOL:
+        APPEND(b, src->u.bool_ ? "true" : "false");
         return 0;
     case MPV_FORMAT_FLAG:
         APPEND(b, src->u.flag ? "true" : "false");

--- a/misc/node.c
+++ b/misc/node.c
@@ -10,9 +10,9 @@ void node_init(struct mpv_node *dst, int format, struct mpv_node *parent)
 {
     // Other formats need to be initialized manually.
     assert(format == MPV_FORMAT_NODE_MAP || format == MPV_FORMAT_NODE_ARRAY ||
-           format == MPV_FORMAT_FLAG || format == MPV_FORMAT_INT64 ||
-           format == MPV_FORMAT_DOUBLE || format == MPV_FORMAT_BYTE_ARRAY ||
-           format == MPV_FORMAT_NONE);
+           format == MPV_FORMAT_BOOL || format == MPV_FORMAT_FLAG ||
+           format == MPV_FORMAT_INT64 || format == MPV_FORMAT_DOUBLE ||
+           format == MPV_FORMAT_BYTE_ARRAY || format == MPV_FORMAT_NONE);
 
     void *ta_parent = NULL;
     if (parent) {
@@ -83,6 +83,11 @@ void node_map_add_double(struct mpv_node *dst, const char *key, double v)
     node_map_add(dst, key, MPV_FORMAT_DOUBLE)->u.double_ = v;
 }
 
+void node_map_add_bool(struct mpv_node *dst, const char *key, bool v)
+{
+    node_map_add(dst, key, MPV_FORMAT_BOOL)->u.bool_ = v;
+}
+
 void node_map_add_flag(struct mpv_node *dst, const char *key, bool v)
 {
     node_map_add(dst, key, MPV_FORMAT_FLAG)->u.flag = v;
@@ -116,6 +121,8 @@ bool equal_mpv_value(const void *a, const void *b, mpv_format format)
     case MPV_FORMAT_STRING:
     case MPV_FORMAT_OSD_STRING:
         return strcmp(*(char **)a, *(char **)b) == 0;
+    case MPV_FORMAT_BOOL:
+        return *(bool *)a == *(bool *)b;
     case MPV_FORMAT_FLAG:
         return *(int *)a == *(int *)b;
     case MPV_FORMAT_INT64:

--- a/misc/node.h
+++ b/misc/node.h
@@ -11,6 +11,7 @@ struct mpv_node *node_map_badd(struct mpv_node *dst, struct bstr key, int format
 void node_map_add_string(struct mpv_node *dst, const char *key, const char *val);
 void node_map_add_int64(struct mpv_node *dst, const char *key, int64_t v);
 void node_map_add_double(struct mpv_node *dst, const char *key, double v);
+void node_map_add_bool(struct mpv_node *dst, const char *key, bool v);
 void node_map_add_flag(struct mpv_node *dst, const char *key, bool v);
 mpv_node *node_map_get(mpv_node *src, const char *key);
 mpv_node *node_map_bget(mpv_node *src, struct bstr key);

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -39,7 +39,6 @@ struct mpv_global;
 
 // Simple types
 extern const m_option_type_t m_option_type_bool;
-extern const m_option_type_t m_option_type_flag;
 extern const m_option_type_t m_option_type_dummy_flag;
 extern const m_option_type_t m_option_type_int;
 extern const m_option_type_t m_option_type_int64;
@@ -213,7 +212,6 @@ struct m_sub_options {
 };
 
 #define CONF_TYPE_BOOL          (&m_option_type_bool)
-#define CONF_TYPE_FLAG          (&m_option_type_flag)
 #define CONF_TYPE_INT           (&m_option_type_int)
 #define CONF_TYPE_INT64         (&m_option_type_int64)
 #define CONF_TYPE_FLOAT         (&m_option_type_float)
@@ -233,7 +231,6 @@ struct m_sub_options {
 // size/alignment requirements for option values in general.
 union m_option_value {
     bool bool_;
-    int flag; // not the C type "bool"!
     int int_;
     int64_t int64;
     float float_;

--- a/osdep/macos/libmpv_helper.swift
+++ b/osdep/macos/libmpv_helper.swift
@@ -199,9 +199,9 @@ class LibmpvHelper {
 
     func getBoolProperty(_ name: String) -> Bool {
         if mpvHandle == nil { return false }
-        var value = Int32()
-        mpv_get_property(mpvHandle, name, MPV_FORMAT_FLAG, &value)
-        return value > 0
+        var value = Bool()
+        mpv_get_property(mpvHandle, name, MPV_FORMAT_BOOL, &value)
+        return value
     }
 
     func getIntProperty(_ name: String) -> Int {

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -157,7 +157,7 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
     if ([[EventsResponder sharedInstance] setMpvHandle:ctx]) {
         mpv_observe_property(ctx, 0, "duration", MPV_FORMAT_DOUBLE);
         mpv_observe_property(ctx, 0, "time-pos", MPV_FORMAT_DOUBLE);
-        mpv_observe_property(ctx, 0, "pause", MPV_FORMAT_FLAG);
+        mpv_observe_property(ctx, 0, "pause", MPV_FORMAT_BOOL);
         mpv_set_wakeup_callback(ctx, wakeup, NULL);
     }
 }

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -661,8 +661,8 @@ static void script_set_property(js_State *J)
 // args: name, boolean
 static void script_set_property_bool(js_State *J)
 {
-    int v = js_toboolean(J, 2);
-    int e = mpv_set_property(jclient(J), js_tostring(J, 1), MPV_FORMAT_FLAG, &v);
+    bool v = js_toboolean(J, 2);
+    int e = mpv_set_property(jclient(J), js_tostring(J, 1), MPV_FORMAT_BOOL, &v);
     push_status(J, e);
 }
 
@@ -708,9 +708,9 @@ static void script_del_property(js_State *J)
 // args: name [,def]
 static void script_get_property_bool(js_State *J)
 {
-    int result;
+    bool result;
     mpv_handle *h = jclient(J);
-    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_FLAG, &result);
+    int e = mpv_get_property(h, js_tostring(J, 1), MPV_FORMAT_BOOL, &result);
     if (!pushed_error(J, e, 2))
         js_pushboolean(J, result);
 }
@@ -752,7 +752,7 @@ static void script_get_property_osd(js_State *J, void *af)
 static void script__observe_property(js_State *J)
 {
     const char *fmts[] = {"none", "native", "bool", "string", "number", NULL};
-    const mpv_format mf[] = {MPV_FORMAT_NONE, MPV_FORMAT_NODE, MPV_FORMAT_FLAG,
+    const mpv_format mf[] = {MPV_FORMAT_NONE, MPV_FORMAT_NODE, MPV_FORMAT_BOOL,
                              MPV_FORMAT_STRING, MPV_FORMAT_DOUBLE};
 
     mpv_format f = mf[checkopt(J, 3, "none", fmts, "observe type")];
@@ -1025,6 +1025,8 @@ static void pushnode(js_State *J, mpv_node *node)
     case MPV_FORMAT_STRING: js_pushstring(J, node->u.string); break;
     case MPV_FORMAT_INT64:  js_pushnumber(J, node->u.int64); break;
     case MPV_FORMAT_DOUBLE: js_pushnumber(J, node->u.double_); break;
+    // Must keep FLAG since it pushes to clients.
+    case MPV_FORMAT_BOOL:
     case MPV_FORMAT_FLAG:   js_pushboolean(J, node->u.flag); break;
     case MPV_FORMAT_BYTE_ARRAY:
         js_pushlstring(J, node->u.ba->data, node->u.ba->size);
@@ -1097,7 +1099,7 @@ static void makenode(void *ta_ctx, mpv_node *dst, js_State *J, int idx)
         dst->format = MPV_FORMAT_NONE;
 
     } else if (js_isboolean(J, idx)) {
-        dst->format = MPV_FORMAT_FLAG;
+        dst->format = MPV_FORMAT_BOOL;
         dst->u.bool_ = js_toboolean(J, idx);
 
     } else if (js_isnumber(J, idx)) {

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -1098,7 +1098,7 @@ static void makenode(void *ta_ctx, mpv_node *dst, js_State *J, int idx)
 
     } else if (js_isboolean(J, idx)) {
         dst->format = MPV_FORMAT_FLAG;
-        dst->u.flag = js_toboolean(J, idx);
+        dst->u.bool_ = js_toboolean(J, idx);
 
     } else if (js_isnumber(J, idx)) {
         double val = js_tonumber(J, idx);

--- a/player/lua.c
+++ b/player/lua.c
@@ -634,9 +634,9 @@ static int script_set_property_bool(lua_State *L)
 {
     struct script_ctx *ctx = get_ctx(L);
     const char *p = luaL_checkstring(L, 1);
-    int v = lua_toboolean(L, 2);
+    bool v = lua_toboolean(L, 2);
 
-    return check_error(L, mpv_set_property(ctx->client, p, MPV_FORMAT_FLAG, &v));
+    return check_error(L, mpv_set_property(ctx->client, p, MPV_FORMAT_BOOL, &v));
 }
 
 static bool is_int(double d)
@@ -684,7 +684,7 @@ static void makenode(void *tmp, mpv_node *dst, lua_State *L, int t)
         break;
     }
     case LUA_TBOOLEAN:
-        dst->format = MPV_FORMAT_FLAG;
+        dst->format = MPV_FORMAT_BOOL;
         dst->u.bool_ = lua_toboolean(L, t);
         break;
     case LUA_TSTRING: {
@@ -833,8 +833,8 @@ static int script_get_property_bool(lua_State *L)
     struct script_ctx *ctx = get_ctx(L);
     const char *name = luaL_checkstring(L, 1);
 
-    int result = 0;
-    int err = mpv_get_property(ctx->client, name, MPV_FORMAT_FLAG, &result);
+    bool result = false;
+    int err = mpv_get_property(ctx->client, name, MPV_FORMAT_BOOL, &result);
     if (err >= 0) {
         lua_pushboolean(L, !!result);
         return 1;
@@ -880,6 +880,8 @@ static void pushnode(lua_State *L, mpv_node *node)
     case MPV_FORMAT_NONE:
         lua_pushnil(L);
         break;
+    // Must keep FLAG since it pushes to clients.
+    case MPV_FORMAT_BOOL:
     case MPV_FORMAT_FLAG:
         lua_pushboolean(L, node->u.flag);
         break;
@@ -941,7 +943,7 @@ static mpv_format check_property_format(lua_State *L, int arg)
     switch (luaL_checkoption(L, arg, "none", fmts)) {
     case 0: return MPV_FORMAT_NONE;
     case 1: return MPV_FORMAT_NODE;
-    case 2: return MPV_FORMAT_FLAG;
+    case 2: return MPV_FORMAT_BOOL;
     case 3: return MPV_FORMAT_STRING;
     case 4: return MPV_FORMAT_DOUBLE;
     }

--- a/player/lua.c
+++ b/player/lua.c
@@ -685,7 +685,7 @@ static void makenode(void *tmp, mpv_node *dst, lua_State *L, int t)
     }
     case LUA_TBOOLEAN:
         dst->format = MPV_FORMAT_FLAG;
-        dst->u.flag = !!lua_toboolean(L, t);
+        dst->u.bool_ = lua_toboolean(L, t);
         break;
     case LUA_TSTRING: {
         size_t len = 0;

--- a/test/libmpv_test.c
+++ b/test/libmpv_test.c
@@ -39,6 +39,7 @@
 
 // Dummy values for test_options_and_properties
 static const char *str = "string";
+static bool bool_ = true;
 static int flag = 1;
 static int64_t int_ = 20;
 static double double_ = 1.5;
@@ -64,6 +65,14 @@ static void check_api_error(int status)
 {
     if (status < 0)
         fail("mpv API error: %s\n", mpv_error_string(status));
+}
+
+static void check_bool(const char *property, bool expect)
+{
+    bool result_bool;
+    check_api_error(mpv_get_property(ctx, property, MPV_FORMAT_BOOL, &result_bool));
+    if (expect != result_bool)
+        fail("Bool: expected '%d' but got '%d'!\n", expect, result_bool);
 }
 
 static void check_double(const char *property, double expect)
@@ -106,6 +115,9 @@ static void check_results(const char *properties[], enum mpv_format formats[])
         case MPV_FORMAT_STRING:
             check_string(properties[i], str);
             break;
+        case MPV_FORMAT_BOOL:
+            check_bool(properties[i], bool_);
+            break;
         case MPV_FORMAT_FLAG:
             check_flag(properties[i], flag);
             break;
@@ -127,6 +139,10 @@ static void set_options_and_properties(const char *options[], const char *proper
         case MPV_FORMAT_STRING:
             check_api_error(mpv_set_option(ctx, options[i], formats[i], &str));
             check_api_error(mpv_set_property(ctx, properties[i], formats[i], &str));
+            break;
+        case MPV_FORMAT_BOOL:
+            check_api_error(mpv_set_option(ctx, options[i], formats[i], &bool_));
+            check_api_error(mpv_set_property(ctx, properties[i], formats[i], &bool_));
             break;
         case MPV_FORMAT_FLAG:
             check_api_error(mpv_set_option(ctx, options[i], formats[i], &flag));
@@ -200,10 +216,11 @@ static void test_lavfi_complex(char *file)
 // have the expected values.
 static void test_options_and_properties(void)
 {
-    // Order matters. string -> flag -> int -> double (repeat)
+    // Order matters. string -> bool -> flag -> int -> double (repeat)
     // One for set_option the other for set_property
     const char *options[] = {
         "screen-name",
+        "ontop",
         "save-position-on-quit",
         "cursor-autohide",
         "speed",
@@ -212,6 +229,7 @@ static void test_options_and_properties(void)
 
     const char *properties[] = {
         "fs-screen-name",
+        "window-maximized",
         "shuffle",
         "sub-pos",
         "window-scale",
@@ -221,6 +239,7 @@ static void test_options_and_properties(void)
     // Must match above ordering.
     enum mpv_format formats[] = {
         MPV_FORMAT_STRING,
+        MPV_FORMAT_BOOL,
         MPV_FORMAT_FLAG,
         MPV_FORMAT_INT64,
         MPV_FORMAT_DOUBLE,


### PR DESCRIPTION
We recently axed all internal usage of `OPT_FLAG`, but unfortunately realized that `m_option_type_flag` and its associated things are still need for libmpv. So we still have that extra code around that does this weird mapping. If we ever want to get rid of it for good, we need an mpv format in libmpv that is a true boolean type: hence MPV_FORMAT_BOOL.

Three main parts:
1. Actually implement it and mark MPV_FORMAT_FLAG as deprecated.
2. Move internal stuff to using MPV_FORMAT_BOOL instead of MPV_FORMAT_FLAG when possible.
3. Make libmpv's test more elaborate to make sure I didn't break something.

Ideally this is seamless and you can use `MPV_FORMAT_BOOL` and `MPV_FORMAT_FLAG` interchangeably. When accessing an mpv_node, the flag and bool_ fields will have the same value. The one big legacy thing still in place is when the client receives anything that has a format field, it should still be `MPV_FORMAT_FLAG`.

Needs much more testing of course. Other than the expanded libmpv test, I briefly played around with sending events and property changes and the behavior seemed correct.