### PR TITLE
mp_image: copy side data in mp_image_copy_attributes

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -516,6 +516,8 @@ static void assign_bufref(AVBufferRef **dst, AVBufferRef *new)
 
 void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
 {
+    assert(dst != src);
+
     dst->pict_type = src->pict_type;
     dst->fields = src->fields;
     dst->pts = src->pts;

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -549,6 +549,18 @@ void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
     assign_bufref(&dst->dovi_buf, src->dovi_buf);
     assign_bufref(&dst->film_grain, src->film_grain);
     assign_bufref(&dst->a53_cc, src->a53_cc);
+
+    for (int n = 0; n < dst->num_ff_side_data; n++)
+        av_buffer_unref(&dst->ff_side_data[n].buf);
+
+    MP_RESIZE_ARRAY(NULL, dst->ff_side_data, src->num_ff_side_data);
+    dst->num_ff_side_data = src->num_ff_side_data;
+
+    for (int n = 0; n < dst->num_ff_side_data; n++) {
+        dst->ff_side_data[n].type = src->ff_side_data[n].type;
+        dst->ff_side_data[n].buf = av_buffer_ref(src->ff_side_data[n].buf);
+        MP_HANDLE_OOM(dst->ff_side_data[n].buf);
+    }
 }
 
 // Crop the given image to (x0, y0)-(x1, y1) (bottom/right border exclusive)


### PR DESCRIPTION
This fixes HDR10 and HDR10+ metadata usage in vo_gpu_next when hwdec copy variant is used.