### PR TITLE
configfiles: don't save position if EOF has been reached

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -286,6 +286,11 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     if (!cur)
         goto exit;
 
+    if (mpctx->video_status == STATUS_EOF &&
+        mpctx->audio_status == STATUS_EOF &&
+        mpctx->opts->keep_open_pause)
+        goto exit;
+
     struct demuxer *demux = mpctx->demuxer;
 
     conffile = mp_get_playback_resume_config_filename(mpctx, cur->filename);


### PR DESCRIPTION
If the options `--keep-open` and `--save-position-on-quit` are both enabled, it creates a unique issue.

When playback finishes, the file still needs to be manually closed. Doing so triggers the `cmd_quit` function, which then triggers the `mp_write_watch_later_conf` function. If the same file is re-opened, the saved position from the previous playthrough will cause it to seek to the end, which means we then have to manually seek it back to the beginning and unpause it on every close and re-open.

If this is the desired behavior, it can still be achieved by disabling `--keep-open-pause`. My reasoning for this was that it's the more active version of `keep_open`, where any seek input will cause the file to start playing again. If it's still considered too niche of a scenario, the condition can be removed.