### PR TITLE
sub: fix UPDATE_SUB_HARD for converted and external subtitles

### DIFF
--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -421,10 +421,18 @@ int sub_control(struct dec_sub *sub, enum sd_ctrl cmd, void *arg)
         if (r == CONTROL_OK)
             a[0] = pts_from_subtitle(sub, arg2[0]);
         break;
-    case SD_CTRL_UPDATE_OPTS:
+    }
+    case SD_CTRL_UPDATE_OPTS: {
+        int flags = (uintptr_t)arg;
         if (m_config_cache_update(sub->opts_cache))
             update_subtitle_speed(sub);
         propagate = true;
+        if (flags & UPDATE_SUB_HARD) {
+            // forget about the previous preload because
+            // UPDATE_SUB_HARD will cause a sub reinit
+            // that clears all preloaded sub packets
+            sub->preload_attempted = false;
+        }
         break;
     }
     default:

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -826,6 +826,10 @@ static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
             ctx->clear_once = true; // allow reloading on seeks
         }
         if (flags & UPDATE_SUB_HARD) {
+            // ass_track will be recreated, so clear duplicate cache
+            ctx->clear_once = true;
+            reset(sd);
+
             assobjects_destroy(sd);
             assobjects_init(sd);
         }


### PR DESCRIPTION
Previously, changing options like sub-ass at runtime only worked for interleaved ASS subs whereas external or converted subs would simply disappear. This PR fixes that issue.