### PR TITLE
add an input command prefix for displaying volume in decibels

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1725,6 +1725,9 @@ prefixes can be specified. They are separated by whitespace.
     Allow synchronous execution (if possible). Normally, all commands are
     synchronous by default, but some are asynchronous by default for
     compatibility with older behavior.
+``dB``
+    If a request is made to print the volume or ao-volume property, it will be
+    shown in decibels.
 
 All of the osd prefixes are still overridden by the global ``--osd-level``
 settings.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2285,6 +2285,12 @@ Property list
     Similar to ``ao-volume``, but controls the mute state. May be unimplemented
     even if ``ao-volume`` works.
 
+``volume-db``
+    Read-only - mpv's internal volume in decibel format.
+
+``ao-volume-db``
+    Read-only - mpv's system volume in decibel format.
+
 ``audio-codec``
     Audio codec selected for decoding.
 

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -54,6 +54,7 @@ static const struct flag cmd_flags[] = {
     {"repeatable",          0,               MP_ALLOW_REPEAT},
     {"async",               MP_SYNC_CMD,     MP_ASYNC_CMD},
     {"sync",                MP_ASYNC_CMD,     MP_SYNC_CMD},
+    {"dB",                  0,               MP_ON_VOL_DB},
     {0}
 };
 

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -74,6 +74,7 @@ enum mp_cmd_flags {
     // the command parser (prefixes and mp_cmd_def.default_async).
     MP_ASYNC_CMD = 32,          // do not wait for command to complete
     MP_SYNC_CMD = 64,           // block on command completion
+    MP_ON_VOL_DB = 128,         // display volume as decibels, if applicable
 
     MP_ON_OSD_FLAGS = MP_ON_OSD_NO | MP_ON_OSD_AUTO |
                       MP_ON_OSD_BAR | MP_ON_OSD_MSG,

--- a/player/core.h
+++ b/player/core.h
@@ -267,6 +267,7 @@ typedef struct MPContext {
     bool osd_force_update, osd_idle_update;
     char *osd_msg_text;
     bool osd_show_pos;
+    bool osd_decibels;
     struct osd_progbar_state osd_progbar;
 
     struct playlist *playlist;


### PR DESCRIPTION
Use the input prefix `dB` before a volume change.
Aims to address feature request #3545.

You'll notice that the display method for `volume` is slightly different from the method for `ao-volume`. This is because soft volume gets cubed, so we need to account for that when translating it over to decibels.

To change volume in whole decibel increments, you can add something like this to your `input.conf` file:
```ini
# Soft Volume
9 dB multiply    volume 0.9261187281287935 # -2 dB  10^(-2/60)
0 dB multiply    volume 1.0797751623277097 # +2 dB  10^(+2/60)

# AO Volume
/ dB multiply ao-volume 0.7943282347242815 # -2 dB  10^(-2/20)
* dB multiply ao-volume 1.2589254117941672 # +2 dB  10^(+2/20)
```
Also, to make the max volume more compatible with decibels, something like this can be added to `mpv.conf`:

```ini
volume-max=125.892541179416721 # 10^(126/60) or 100% + 6 dB
```

Read-only input properties `volume-db` and `ao-volume-db` have been added so that volume percentage and decibels can be printed in the same message, like so:
```ini
a show-text "Volume: ${volume} (${volume-db})"
```