### PR TITLE
renamed 'PGDN' to 'PGDWN' in the docs for consistency

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -73,7 +73,7 @@ DOWN and Ctrl+N
 PGUP
     Go to the first command in the history.
 
-PGDN
+PGDWN
     Stop navigating the command history.
 
 INSERT


### PR DESCRIPTION
the code results for `PGDWN`: https://github.com/mpv-player/mpv/search?q=pgdwn
the code results for `PGDN`: https://github.com/mpv-player/mpv/search?q=pgdn

https://mpv.io/manual/stable/#keyboard-control

> PGDN  
>    Stop navigating the command history.

In `input.conf`, mpv doesn't detect the key `PGDN`.