### PR TITLE
player/screenshot: add filename return field

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -386,6 +386,9 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     ``async`` flag to make encoding/writing the image file asynchronous. For
     normal standalone commands, this is always asynchronous, and the flag has
     no effect. (This behavior changed with mpv 0.29.0.)
+    
+    On success, returns a ``mpv_node`` with a ``filename`` field set to the
+    saved screenshot location.
 
 ``screenshot-to-file <filename> <flags>``
     Take a screenshot and save it to a given file. The format of the file will

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -460,6 +460,7 @@ void cmd_screenshot(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
+    struct mpv_node *res = &cmd->result;
     int mode = cmd->args[0].v.i & 3;
     bool each_frame_toggle = (cmd->args[0].v.i | cmd->args[1].v.i) & 8;
     bool each_frame_mode = cmd->args[0].v.i & 16;
@@ -491,8 +492,13 @@ void cmd_screenshot(void *p)
 
     if (image) {
         char *filename = gen_fname(cmd, image_writer_file_ext(opts));
-        if (filename)
+        if (filename) {
             cmd->success = write_screenshot(cmd, image, filename, NULL);
+            if (cmd->success) {
+                node_init(res, MPV_FORMAT_NODE_MAP, NULL);
+                node_map_add_string(res, "filename", filename);
+            }
+        }
         talloc_free(filename);
     } else {
         mp_cmd_msg(cmd, MSGL_ERR, "Taking screenshot failed.");


### PR DESCRIPTION
This feels like the most sane way to resolve the copying to clipboard issues that I've had with other scripts, where you had to take 2 screenshots if you wanted to keep a copy on disk.

Now all it takes is this:
```lua
res, err = mp.command_native({"screenshot"})
if err == nil or res == nil then
    mp.command_native_async({'run', 'xclip', '-sel', 'c', '-t', 'image/png', '-i', res.filename}, function(suc, _, err)
        mp.osd_message(suc and 'Copied screenshot to clipboard' or err)
    end)
end
```