### PR TITLE
win32: add an option to change window affinity

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6074,6 +6074,7 @@ them.
     X11/GLX only.
 
 ``--opengl-dwmflush=<no|windowed|yes|auto>``
+	(Windows only)
     Calls ``DwmFlush`` after swapping buffers on Windows (default: auto). It
     also sets ``SwapInterval(0)`` to ignore the OpenGL timing. Values are: no
     (disabled), windowed (only in windowed mode), yes (also in full screen).
@@ -6084,8 +6085,6 @@ them.
     This may help to get more consistent frame intervals, especially with
     high-fps clips - which might also reduce dropped frames. Typically, a value
     of ``windowed`` should be enough, since full screen may bypass the DWM.
-
-    Windows only.
 
 ``--angle-d3d11-feature-level=<11_0|10_1|10_0|9_3>``
     Selects a specific feature level when using the ANGLE backend with D3D11.
@@ -7112,12 +7111,20 @@ Miscellaneous
 
     This is a key/value list option. See `List Options`_ for details.
 
+``--window-affinity=<default|excludefromcmcapture|monitor>``
+    (Windows only)
+	Controls the window affinity behavior of mpv.
+
+    :default: Default Windows behavior
+    :excludefromcapture: mpv's window will be completely excluded from capture by external applications or screen recording software. 
+    :monitor: Blacks out the mpv window
+
 ``--vo-mmcss-profile=<name>``
-    (Windows only.)
+    (Windows only)
     Set the MMCSS profile for the video renderer thread (default: ``Playback``).
 
 ``--priority=<prio>``
-    (Windows only.)
+    (Windows only)
     Set process priority for mpv according to the predefined priorities
     available under Windows.
 

--- a/options/options.c
+++ b/options/options.c
@@ -186,6 +186,8 @@ static const m_option_t mp_vo_opt_list[] = {
         {"photo", 1}, {"video", 2}, {"game", 3})},
 #endif
 #if HAVE_WIN32_DESKTOP
+    {"window-affinity", OPT_CHOICE(window_affinity, {"default", WDA_NONE},
+        {"excludefromcapture", WDA_EXCLUDEFROMCAPTURE}, {"monitor", WDA_MONITOR})},
     {"vo-mmcss-profile", OPT_STRING(mmcss_profile)},
 #endif
 #if HAVE_EGL_ANDROID

--- a/options/options.h
+++ b/options/options.h
@@ -63,6 +63,7 @@ typedef struct mp_vo_opts {
     bool force_render;
     bool force_window_position;
 
+    int window_affinity;
     char *mmcss_profile;
 
     double override_display_fps;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -963,6 +963,16 @@ static bool is_visible(HWND window)
     return GetWindowLongPtrW(window, GWL_STYLE) & WS_VISIBLE;
 }
 
+//Set the mpv window's affinity.
+//This will affect how it's displayed on the desktop and in system-level operations like taking screenshots.
+static void update_affinity(struct vo_w32_state *w32)
+{
+    if (!w32 || w32->parent) {
+        return;
+    }
+    SetWindowDisplayAffinity(w32->window, w32->opts->window_affinity);
+}
+
 static void update_window_state(struct vo_w32_state *w32)
 {
     if (w32->parent)
@@ -1612,6 +1622,8 @@ static void *gui_thread(void *ptr)
     }
 
     update_dark_mode(w32);
+    if (w32->opts->window_affinity)
+        update_affinity(w32);
 
     if (SUCCEEDED(OleInitialize(NULL))) {
         ole_ok = true;
@@ -1786,6 +1798,8 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 
             if (changed_option == &vo_opts->fullscreen) {
                 reinit_window_state(w32);
+            } else if (changed_option == &vo_opts->window_affinity) {
+                update_affinity(w32);
             } else if (changed_option == &vo_opts->ontop) {
                 update_window_state(w32);
             } else if (changed_option == &vo_opts->border) {


### PR DESCRIPTION
Add an option to control the mpv window's affinity. This will affect how it's displayed on the desktop and in system-level operations like taking screenshots.