### PR TITLE
meson: bump libplacebo-next required version to 5.264

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -917,13 +917,13 @@ if features['libplacebo']
     sources += files('video/out/placebo/ra_pl.c',
                      'video/out/placebo/utils.c')
     pl_api_ver = libplacebo.version().split('.')[1]
-    if pl_api_ver.version_compare('>=202')
+    if pl_api_ver.version_compare('>=264.0')
         features += {'libplacebo-next': true}
-        message('libplacebo v4.202+ found! Enabling vo_gpu_next.')
+        message('libplacebo v5.264.0+ found! Enabling vo_gpu_next.')
         sources += files('video/out/vo_gpu_next.c',
                          'video/out/gpu_next/context.c')
     else
-        message('libplacebo v4.202+ not found! Disabling vo_gpu_next.')
+        message('libplacebo v5.264.0+ not found! Disabling vo_gpu_next.')
     endif
 endif
 


### PR DESCRIPTION
This is the latest stable release, and what we should use for libplacebo-next per haasn's recommendation.

The previous 202 version wasn't even a release.