### PR TITLE
vo_gpu_next: drop various PL_API_VER checks

### DIFF
--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -148,10 +148,8 @@ struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct gl_video_opts *gl_opts)
             pl_opengl_params(
                 .debug = ctx_opts->debug,
                 .allow_software = ctx_opts->allow_sw,
-# if PL_API_VER >= 215
                 .get_proc_addr_ex = (void *) ra_gl_get(ctx->ra_ctx->ra)->get_fn,
                 .proc_ctx = ra_gl_get(ctx->ra_ctx->ra)->fn_ctx,
-# endif
 # if HAVE_EGL
                 .egl_display = eglGetCurrentDisplay(),
                 .egl_context = eglGetCurrentContext(),

--- a/wscript
+++ b/wscript
@@ -780,9 +780,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 4.157.0'),
     }, {
         'name': 'libplacebo-next',
-        'desc': 'libplacebo v4.202+, needed for vo_gpu_next',
+        'desc': 'libplacebo v5.264.0+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 202',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 264',
                                    use='libplacebo'),
     }, {
         'name': '--vulkan',


### PR DESCRIPTION
We don't need these anymore now that we require PL_API_VER>=264 for building libplacebo-next. Also bump PL_API_VER for waf