### PR TITLE
Fix various typos in the code base

### DIFF
--- a/DOCS/build-system-differences.md
+++ b/DOCS/build-system-differences.md
@@ -27,7 +27,7 @@ that you get for free. In some cases, these overlapped with custom waf options.
   supported in the meson build. Instead, pass the generic pkg-config values
   such as ``lua52``, ``lua5.2``, etc.
 * ``--lgpl`` was changed to ``gpl``. If ``gpl`` is false, the build is LGPL2.1+.
-* ``--tests`` was removed since unit tests now explictly require meson to run
+* ``--tests`` was removed since unit tests now explicitly require meson to run
 
 ### Boolean Options
 

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -45,7 +45,7 @@ Interface changes
     - add `--video-sync=display-tempo`
     - the `start` option is no longer unconditionally written by
       watch-later. It is still written by default but you may
-      need to explictly add `start` depending on how you have
+      need to explicitly add `start` depending on how you have
       `--watch-later-options` configured.
     - add `--vd-lavc-dr=auto` and make it the default
     - add support for the fractional scale protocol in wayland

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -186,7 +186,7 @@ character at the value.
 
 Custom quotes also take the content literally, but are more flexible than single
 quotes. They start with ````` (back-quote) followed by any ASCII character,
-and end at the first occurance of the same pair in reverse order, e.g.
+and end at the first occurrence of the same pair in reverse order, e.g.
 ```-foo-``` or ````bar````. The final pair sequence is not allowed at the
 value - in these examples ``-``` and `````` respectively. In the second
 example the last character of the value also can't be a back-quote.
@@ -2565,7 +2565,7 @@ Property list
     is unavailable if no video is active.
 
     When setting this property in the fullscreen or maximized state, the behavior
-    is the same as window-scale. In all ther cases, setting the value of this
+    is the same as window-scale. In all other cases, setting the value of this
     property will always resize the window. This does not affect the value of
     ``window-scale``.
 
@@ -2795,7 +2795,7 @@ Property list
         Name of the Nth entry. Available if the playlist file contains
         such fields and mpv's parser supports it for the given
         playlist format, or if the playlist entry has been opened before and a
-        media-title other then then filename has been aquired.
+        media-title other then then filename has been acquired.
 
     ``playlist/N/id``
         Unique ID for this entry. This is an automatically assigned integer ID

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -260,7 +260,7 @@ Playback Control
 
         The way older versions of mpv played playlist files via ``--playlist``
         was not safe against maliciously constructed files. Such files may
-        trigger harmful actions. This has been the case for all verions of
+        trigger harmful actions. This has been the case for all versions of
         mpv prior to 0.31.0, and all MPlayer versions, but unfortunately this
         fact was not well documented earlier, and some people have even
         misguidedly recommended the use of ``--playlist`` with untrusted
@@ -1253,7 +1253,7 @@ Video
     :nvdec:     requires ``--vo=gpu`` (Any platform CUDA is available)
     :nvdec-copy: copies video back to system RAM (Any platform CUDA is available)
     :drm:       requires ``--vo=gpu`` (Linux only)
-    :drm-copy:   copies video back to system RAM (Linux ony)
+    :drm-copy:   copies video back to system RAM (Linux only)
 
     Other hwdecs (only use if you know you have to):
 
@@ -3076,7 +3076,7 @@ Window
 
     :window:  On top of all other windows.
     :system:  On top of system elements like Taskbar, Menubar and Dock.
-    :desktop: On top of the Dekstop behind windows and Desktop icons.
+    :desktop: On top of the Desktop behind windows and Desktop icons.
     :level:   A level as integer.
 
 ``--focus-on-open``, ``--no-focus-on-open``
@@ -6103,7 +6103,7 @@ them.
 
     ``<material>`` can be one of the following:
 
-    :titlebar:              The standard macOS titel bar material.
+    :titlebar:              The standard macOS title bar material.
     :selection:             The standard macOS selection material.
     :menu:                  The standard macOS menu material. (macOS 10.11+)
     :popover:               The standard macOS popover material. (macOS 10.11+)

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -174,7 +174,7 @@ Configurable Options
 ``seekbarhandlesize``
     Default: 0.6
 
-    Size ratio of the seek handle if ``seekbarstyle`` is set to ``dimaond``
+    Size ratio of the seek handle if ``seekbarstyle`` is set to ``diamond``
     or ``knob``. This is relative to the full height of the seekbar.
 
 ``seekbarkeyframes``

--- a/filters/f_hwtransfer.c
+++ b/filters/f_hwtransfer.c
@@ -124,7 +124,7 @@ int mp_hwupload_find_upload_format(struct mp_hwupload *u, int imgfmt)
     select_format(p, imgfmt, &sw, &up);
     // In th case where the imgfmt is not natively supported, it must be
     // converted, either before or during upload. If the imgfmt is supported as
-    // an hw input format, then prefer that, and if the upload has to do implict
+    // an hw input format, then prefer that, and if the upload has to do implicit
     // conversion, that's fine. On the other hand, if the imgfmt is not a
     // supported input format, then pick the output format as the conversion
     // target to avoid doing two conversions (one before upload, and one during

--- a/libmpv/stream_cb.h
+++ b/libmpv/stream_cb.h
@@ -119,7 +119,7 @@ typedef int64_t (*mpv_stream_cb_read_fn)(void *cookie, char *buf, uint64_t nbyte
  *
  * @param cookie opaque cookie identifying the stream,
  *               returned from mpv_stream_cb_open_fn
- * @param offset target absolut stream position
+ * @param offset target absolute stream position
  * @return the resulting offset of the stream
  *         MPV_ERROR_UNSUPPORTED or MPV_ERROR_GENERIC if the seek failed
  */

--- a/misc/random.h
+++ b/misc/random.h
@@ -29,7 +29,7 @@
 void mp_rand_seed(uint64_t seed);
 
 /*
- * Return the next 64-bit psuedo-random integer, and update the state
+ * Return the next 64-bit pseudo-random integer, and update the state
  * accordingly.
  */
 uint64_t mp_rand_next(void);

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1756,7 +1756,7 @@ static int parse_keyvalue_list(struct mp_log *log, const m_option_t *opt,
     }
 
     if (param.len) {
-        mp_err(log, "Unparseable garbage at end of option value: '%.*s'\n",
+        mp_err(log, "Unparsable garbage at end of option value: '%.*s'\n",
                BSTR_P(param));
         r = M_OPT_INVALID;
     }
@@ -1948,7 +1948,7 @@ const m_option_type_t m_option_type_dummy_flag = {
 
 // Read s sub-option name, or a positional sub-opt value.
 // termset is a string containing the set of chars that terminate an option.
-// Return 0 on succes, M_OPT_ error code otherwise.
+// Return 0 on success, M_OPT_ error code otherwise.
 // optname is for error reporting.
 static int read_subparam(struct mp_log *log, bstr optname, char *termset,
                          bstr *str, bstr *out_subparam)
@@ -2274,7 +2274,7 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
             *widw = *widh * asp;
         }
         // Center window after resize. If valid x:y values are passed to
-        // geometry, then those values will be overriden.
+        // geometry, then those values will be overridden.
         *xpos += prew / 2 - *widw / 2;
         *ypos += preh / 2 - *widh / 2;
     }

--- a/options/parse_configfile.c
+++ b/options/parse_configfile.c
@@ -69,7 +69,7 @@ int m_config_parse(m_config_t *config, const char *location, bstr data,
                 goto error;
             }
             if (skip_ws(&line)) {
-                MP_ERR(config, "%s unparseable extra characters: '%.*s'\n",
+                MP_ERR(config, "%s unparsable extra characters: '%.*s'\n",
                        loc, BSTR_P(line));
                 goto error;
             }
@@ -120,7 +120,7 @@ int m_config_parse(m_config_t *config, const char *location, bstr data,
             }
         }
         if (skip_ws(&line)) {
-            MP_ERR(config, "%s unparseable extra characters: '%.*s'\n",
+            MP_ERR(config, "%s unparsable extra characters: '%.*s'\n",
                    loc, BSTR_P(line));
             goto error;
         }

--- a/player/lua.c
+++ b/player/lua.c
@@ -123,7 +123,7 @@ static void mp_lua_optarg(lua_State *L, int arg)
 
 // autofree: avoid leaks if a lua-error occurs between talloc new/free.
 // If a lua c-function does a new allocation (not tied to an existing context),
-// and an uncaught lua-error occures before "free" - the allocation is leaked.
+// and an uncaught lua-error occurs before "free" - the allocation is leaked.
 
 // autofree lua C function: same as lua_CFunction but with these differences:
 // - It accepts an additional void* argument - a pre-initialized talloc context
@@ -174,7 +174,7 @@ static void add_af_mpv_alloc(void *parent, char *ma)
 
 
 // Perform the equivalent of mpv_free_node_contents(node) when tmp is freed.
-static void steal_node_alloctions(void *tmp, mpv_node *node)
+static void steal_node_allocations(void *tmp, mpv_node *node)
 {
     talloc_steal(tmp, node_get_alloc(node));
 }
@@ -552,7 +552,7 @@ static int script_raw_wait_event(lua_State *L, void *tmp)
 
     struct mpv_node rn;
     mpv_event_to_node(&rn, event);
-    steal_node_alloctions(tmp, &rn);
+    steal_node_allocations(tmp, &rn);
 
     pushnode(L, &rn); // event
 
@@ -924,7 +924,7 @@ static int script_get_property_native(lua_State *L, void *tmp)
     mpv_node node;
     int err = mpv_get_property(ctx->client, name, MPV_FORMAT_NODE, &node);
     if (err >= 0) {
-        steal_node_alloctions(tmp, &node);
+        steal_node_allocations(tmp, &node);
         pushnode(L, &node);
         return 1;
     }
@@ -975,7 +975,7 @@ static int script_command_native(lua_State *L, void *tmp)
     makenode(tmp, &node, L, 1);
     int err = mpv_command_node(ctx->client, &node, &result);
     if (err >= 0) {
-        steal_node_alloctions(tmp, &result);
+        steal_node_allocations(tmp, &result);
         pushnode(L, &result);
         return 1;
     }

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -452,7 +452,7 @@ local elements = {}
 
 function prepare_elements()
 
-    -- remove elements without layout or invisble
+    -- remove elements without layout or invisible
     local elements2 = {}
     for n, element in pairs(elements) do
         if not (element.layout == nil) and (element.visible) then
@@ -2325,7 +2325,7 @@ function render()
 
     -- init management
     if state.active_element then
-        -- mouse is held down on some element - keep ticking and igore initReq
+        -- mouse is held down on some element - keep ticking and ignore initReq
         -- till it's released, or else the mouse-up (click) will misbehave or
         -- get ignored. that's because osc_init() recreates the osc elements,
         -- but mouse handling depends on the elements staying unmodified

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -431,7 +431,7 @@ local function keyname_cells(k)
 end
 
 local function get_kbinfo_lines(width)
-    -- active keys: only highest priotity of each key, and not our (stats) keys
+    -- active keys: only highest priority of each key, and not our (stats) keys
     local bindings = mp.get_property_native("input-bindings", {})
     local active = {}  -- map: key-name -> bind-info
     for _, bind in pairs(bindings) do

--- a/player/video.c
+++ b/player/video.c
@@ -598,7 +598,7 @@ static void update_avsync_before_frame(struct MPContext *mpctx)
 
         if (opts->autosync) {
             /* Smooth reported playback position from AO by averaging
-             * it with the value expected based on previus value and
+             * it with the value expected based on previous value and
              * time elapsed since then. May help smooth video timing
              * with audio output that have inaccurate position reporting.
              * This is badly implemented; the behavior of the smoothing

--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -238,7 +238,7 @@ static bool skip_bracketed(struct sd_filter *sd, char **rpp, struct buffer *buf)
 // return true if parenthesized text was removed.
 // if not valid SDH read pointer and write buffer position will be unchanged
 // otherwise they point to next position after text and next write position
-static bool skip_parenthesed(struct sd_filter *sd, char **rpp, struct buffer *buf)
+static bool skip_parenthesized(struct sd_filter *sd, char **rpp, struct buffer *buf)
 {
     int filter_harder = sd->opts->sub_filter_SDH_harder;
     char *rp = *rpp;
@@ -378,7 +378,7 @@ static char *filter_SDH(struct sd_filter *sd, char *data, int length, ptrdiff_t 
                     line_with_text =  true;
                 }
             } else if (rp[0] == '(') {
-                if (!skip_parenthesed(sd, &rp, buf)) {
+                if (!skip_parenthesized(sd, &rp, buf)) {
                     append(sd, buf, rp[0]);
                     rp++;
                     line_with_text =  true;

--- a/test/meson.build
+++ b/test/meson.build
@@ -107,7 +107,7 @@ endif
 # Will need to be manually updated when ffmpeg adds/removes more formats in the future.
 if libavutil.version().version_compare('>= 57.39.101')
 
-# The CI can randomly fail if libavutil isn't explictly linked again here.
+# The CI can randomly fail if libavutil isn't explicitly linked again here.
     img_format = executable('img-format', 'img_format.c', include_directories: incdir,
                             dependencies: libavutil, link_with: [img_utils, test_utils])
     test('img-format', img_format, args: [refdir, outdir], suite: 'ffmpeg')

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -180,7 +180,7 @@ static int recreate_video_proc(struct mp_filter *vf)
         rindex = 0;
     }
 
-    // TOOD: so, how do we select which rate conversion mode the processor uses?
+    // TODO: so, how do we select which rate conversion mode the processor uses?
 
     hr = ID3D11VideoDevice_CreateVideoProcessor(p->video_dev, p->vp_enum, rindex,
                                                 &p->video_proc);

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -136,7 +136,7 @@ static bool mp_image_fill_alloc(struct mp_image *mpi, int stride_align,
 // The allocated size of buffer must be given by buffer_size. buffer_size should
 // be at least the value returned by mp_image_get_alloc_size(). If buffer is not
 // already aligned to stride_align, the function will attempt to align the
-// pointer itself by incrementing the buffer pointer until ther alignment is
+// pointer itself by incrementing the buffer pointer until their alignment is
 // achieved (if buffer_size is not large enough to allow aligning the buffer
 // safely, the function fails). To be safe, you may want to overallocate the
 // buffer by stride_align bytes, and include the overallocation in buffer_size.
@@ -939,7 +939,7 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
 
     if (params->color.light == MP_CSP_LIGHT_AUTO) {
         // HLG is always scene-referred (using its own OOTF), everything else
-        // we assume is display-refered by default.
+        // we assume is display-referred by default.
         if (params->color.gamma == MP_CSP_TRC_HLG) {
             params->color.light = MP_CSP_LIGHT_SCENE_HLG;
         } else {

--- a/video/mp_image_pool.c
+++ b/video/mp_image_pool.c
@@ -274,7 +274,7 @@ int mp_image_hw_download_get_sw_format(struct mp_image *src)
     return imgfmt;
 }
 
-// Copies the contents of the HW surface src to system memory and retuns it.
+// Copies the contents of the HW surface src to system memory and returns it.
 // If swpool is not NULL, it's used to allocate the target image.
 // src must be a hw surface with a AVHWFramesContext attached.
 // The returned image is cropped as needed.

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -2021,7 +2021,7 @@ static ra_timer *timer_create(struct ra *ra)
 
     // Measuring duration in D3D11 requires three queries: start and end
     // timestamps, and a disjoint query containing a flag which says whether
-    // the timestamps are usable or if a discontinuity occured between them,
+    // the timestamps are usable or if a discontinuity occurred between them,
     // like a change in power state or clock speed. The disjoint query also
     // contains the timer frequency, so the timestamps are useless without it.
     hr = ID3D11Device_CreateQuery(p->dev,

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -103,5 +103,5 @@ struct ra_swapchain_fns {
 struct ra_ctx *ra_ctx_create(struct vo *vo, struct ra_ctx_opts opts);
 void ra_ctx_destroy(struct ra_ctx **ctx);
 
-// Special case of creating a ra_ctx while specifiying a specific context by name.
+// Special case of creating a ra_ctx while specifying a specific context by name.
 struct ra_ctx *ra_ctx_create_by_name(struct vo *vo, const char *name);

--- a/video/out/gpu/ra.h
+++ b/video/out/gpu/ra.h
@@ -408,7 +408,7 @@ struct ra_fns {
     void (*tex_destroy)(struct ra *ra, struct ra_tex *tex);
 
     // Upload data to a texture. This is an extremely common operation. When
-    // using a buffer, the contants of the buffer must exactly match the image
+    // using a buffer, the contents of the buffer must exactly match the image
     // - conversions between bit depth etc. are not supported. The buffer *may*
     // be marked as "in use" while this operation is going on, and the contents
     // must not be touched again by the API user until buf_poll returns true.
@@ -461,7 +461,7 @@ struct ra_fns {
 
     // Copy a sub-rectangle from one texture to another. The source/dest region
     // is always within the texture bounds. Areas outside the dest region are
-    // preserved. The formats of the textures must be losely compatible. The
+    // preserved. The formats of the textures must be loosely compatible. The
     // dst texture can be a swapchain framebuffer, but src can not. Only 2D
     // textures are supported.
     // The textures must have blit_src and blit_dst set, respectively.

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -236,7 +236,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     }
 
     // We can handle composed formats if the total number of planes is still
-    // equal the number of planes we expect. Complex formats with auxilliary
+    // equal the number of planes we expect. Complex formats with auxiliary
     // planes cannot be supported.
 
     int num_returned_planes = 0;

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -301,7 +301,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     }
 
     // We can handle composed formats if the total number of planes is still
-    // equal the number of planes we expect. Complex formats with auxilliary
+    // equal the number of planes we expect. Complex formats with auxiliary
     // planes cannot be supported.
     if (p->num_planes != 0 && p->num_planes != num_returned_planes) {
         mp_msg(mapper->log, p_owner->probing_formats ? MSGL_DEBUG : MSGL_ERR,

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -132,7 +132,7 @@ enum mp_voctrl {
     VOCTRL_EXTERNAL_RESIZE,
 };
 
-// Helper to expose what kind of content is curently playing to the VO.
+// Helper to expose what kind of content is currently playing to the VO.
 enum mp_content_type {
     MP_CONTENT_NONE, // used for force-window
     MP_CONTENT_IMAGE,

--- a/video/out/vo_direct3d.c
+++ b/video/out/vo_direct3d.c
@@ -570,7 +570,7 @@ static bool change_d3d_backbuffer(d3d_priv *priv)
         }
     } else {
         if (FAILED(IDirect3DDevice9_Reset(priv->d3d_device, &present_params))) {
-            MP_ERR(priv, "Reseting Direct3D device failed.\n");
+            MP_ERR(priv, "Resetting Direct3D device failed.\n");
             return 0;
         }
     }

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -200,7 +200,7 @@ static void resize(struct vo *vo)
     if (wl->viewport)
         wp_viewport_set_destination(wl->viewport, 2 * dst.x0 + mp_rect_w(dst), 2 * dst.y0 + mp_rect_h(dst));
 
-    //now we restore pan for video viewport caculation
+    //now we restore pan for video viewport calculation
     vo->opts->pan_x = vo_opts->pan_x;
     vo->opts->pan_y = vo_opts->pan_y;
     vo_get_src_dst_rects(vo, &src, &dst, &osd);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1141,7 +1141,7 @@ static void video_screenshot(struct vo *vo, struct voctrl_screenshot *args)
     status = pl_queue_update(p->queue, &mix, pl_queue_params(.pts = p->last_pts));
     assert(status != PL_QUEUE_EOF);
     if (status == PL_QUEUE_ERR) {
-        MP_ERR(vo, "Unknown error occured while trying to take screenshot!\n");
+        MP_ERR(vo, "Unknown error occurred while trying to take screenshot!\n");
         return;
     }
     if (!mix.num_frames) {

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -77,7 +77,7 @@ struct priv {
     int num_cols, num_rows;  // terminal size in cells
     int canvas_ok;  // whether canvas vo->dwidth and vo->dheight are positive
 
-    int previous_histgram_colors;
+    int previous_histogram_colors;
 
     struct mp_rect src_rect;
     struct mp_rect dst_rect;
@@ -91,23 +91,23 @@ static const unsigned int depth = 3;
 static int detect_scene_change(struct vo* vo)
 {
     struct priv* priv = vo->priv;
-    int previous_histgram_colors = priv->previous_histgram_colors;
-    int histgram_colors = 0;
+    int previous_histogram_colors = priv->previous_histogram_colors;
+    int histogram_colors = 0;
 
     // If threshold is set negative, then every frame must be a scene change
     if (priv->dither == NULL || priv->opts.threshold < 0)
         return 1;
 
-    histgram_colors = sixel_dither_get_num_of_histogram_colors(priv->testdither);
+    histogram_colors = sixel_dither_get_num_of_histogram_colors(priv->testdither);
 
-    int color_difference_count = previous_histgram_colors - histgram_colors;
+    int color_difference_count = previous_histogram_colors - histogram_colors;
     color_difference_count = (color_difference_count > 0) ?  // abs value
                               color_difference_count : -color_difference_count;
 
     if (100 * color_difference_count >
-        priv->opts.threshold * previous_histgram_colors)
+        priv->opts.threshold * previous_histogram_colors)
     {
-        priv->previous_histgram_colors = histgram_colors; // update history
+        priv->previous_histogram_colors = histogram_colors; // update history
         return 1;
     } else {
         return 0;
@@ -161,7 +161,7 @@ static SIXELSTATUS prepare_dynamic_palette(struct vo *vo)
     SIXELSTATUS status = SIXEL_FALSE;
     struct priv *priv = vo->priv;
 
-    /* create histgram and construct color palette
+    /* create histogram and construct color palette
      * with median cut algorithm. */
     status = sixel_dither_initialize(priv->testdither, priv->buffer,
                                      priv->width, priv->height,
@@ -536,7 +536,7 @@ static int preinit(struct vo *vo)
         }
     }
 
-    priv->previous_histgram_colors = 0;
+    priv->previous_histogram_colors = 0;
 
     return 0;
 }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -276,7 +276,7 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
         } else {
             window_move(wl, serial);
         }
-        // Explictly send an UP event after the client finishes a move/resize
+        // Explicitly send an UP event after the client finishes a move/resize
         mp_input_put_key(wl->vo->input_ctx, button | MP_KEY_STATE_UP);
     }
 }
@@ -1443,7 +1443,7 @@ static int create_xdg_surface(struct vo_wayland_state *wl)
     xdg_toplevel_add_listener(wl->xdg_toplevel, &xdg_toplevel_listener, wl);
 
     if (!wl->xdg_surface || !wl->xdg_toplevel) {
-        MP_ERR(wl, "failled to create xdg_surface and xdg_toplevel!\n");
+        MP_ERR(wl, "failed to create xdg_surface and xdg_toplevel!\n");
         return 1;
     }
     return 0;
@@ -2414,7 +2414,7 @@ void vo_wayland_wait_frame(struct vo_wayland_state *wl)
     /* We need some vblank interval to use for the timeout in
      * this function. The order of preference of values to use is:
      * 1. vsync duration from presentation time
-     * 2. refresh inteval reported by presentation time
+     * 2. refresh interval reported by presentation time
      * 3. refresh rate of the output reported by the compositor
      * 4. make up crap if vblank_time is still <= 0 (better than nothing) */
 

--- a/wscript
+++ b/wscript
@@ -405,7 +405,7 @@ iconv support use --disable-iconv.",
         'func': check_pkg_config('rubberband >= 3.0.0'),
     }, {
         'name': 'zimg-st428',
-        'desc': 'ZIMG suport for ZIMG_TRANSFER_ST428',
+        'desc': 'ZIMG support for ZIMG_TRANSFER_ST428',
         'func': check_pkg_config('zimg', '>= 3.0.5'),
     }
 ]


### PR DESCRIPTION
Corrects various typos that I've found in the repository.