### PR TITLE
auto_profiles: check for non-existent properties

### DIFF
--- a/player/lua/auto_profiles.lua
+++ b/player/lua/auto_profiles.lua
@@ -87,8 +87,13 @@ function get(name, default)
     -- Normally, we use the cached value only
     if not watched_properties[name] then
         watched_properties[name] = true
+        local res, err = mp.get_property_native(name)
+        if err == "property not found" then
+            msg.error("Property '" .. name .. "' was not found.")
+            return default
+        end
+        cached_properties[name] = res
         mp.observe_property(name, "native", on_property_change)
-        cached_properties[name] = mp.get_property_native(name)
     end
     -- The first time the property is read we need add it to the
     -- properties_to_profiles table, which will be used to mark the profile


### PR DESCRIPTION
Previously, it just silently didn't do anything which is not very intuitive. Since the lua api returns an error string, check to see if it matches the "property not found" case and print an error message. Additionally, don't add the fake property to the internal cached_properties list or try to observe it. This avoids redundant evaluate calls which will never actually succeed. We do still mark it under watched_properties however. This avoids having to call mp.get_property_native multiple times.
