### PR TITLE
context_angle: include eglext_angle.h explicitly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1104,9 +1104,14 @@ if features['gl-dxinterop']
 endif
 
 egl_angle = get_option('egl-angle').require(
-    features['gl-win32'] and cc.has_header_symbol('EGL/eglext.h',
-                                                  'EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE',
-                                                  prefix: '#include <EGL/egl.h>'),
+    features['gl-win32'] and
+        cc.has_header_symbol('EGL/eglext.h',
+                             'EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE',
+                             prefix: '#include <EGL/egl.h>') and
+        cc.has_header_symbol('EGL/eglext_angle.h',
+                             'PFNEGLCREATEDEVICEANGLEPROC',
+                             # TODO: change to list when meson 1.0.0 is required
+                             prefix: '#include <EGL/egl.h>\n#include <EGL/eglext.h>'),
     error_message: 'egl-angle could not be found!',
 )
 features += {'egl-angle': egl_angle.allowed()}

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -18,6 +18,7 @@
 #include <windows.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <EGL/eglext_angle.h>
 #include <d3d11.h>
 #include <dxgi1_2.h>
 #include <dwmapi.h>

--- a/wscript
+++ b/wscript
@@ -637,8 +637,9 @@ video_output_features = [
         'desc': 'OpenGL ANGLE headers',
         'deps': 'os-win32 || os-cygwin',
         'groups': [ 'gl' ],
-        'func': check_statement(['EGL/egl.h', 'EGL/eglext.h'],
-                                'int x = EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE')
+        'func': check_statement(['EGL/egl.h', 'EGL/eglext.h', 'EGL/eglext_angle.h'],
+                                'int x = EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE; '
+                                'PFNEGLCREATEDEVICEANGLEPROC y = NULL')
     } , {
         'name': '--egl-angle-lib',
         'desc': 'OpenGL Win32 ANGLE Library',


### PR DESCRIPTION
Recent MSYS update switched to using vanilla EGL headers, which doesn't include eglext_angle.h implicitly.