### PR TITLE
w32_common: fix --geometry parameter being constrainted to the incorrect monitor

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1450,7 +1450,7 @@ static void gui_thread_reconfig(void *ptr)
                 geo.win.x0 + vo->dwidth, geo.win.y0 + vo->dheight);
         w32->prev_windowrc = w32->windowrc;
         w32->window_bounds_initialized = true;
-        w32->fit_on_screen = true;
+        w32->fit_on_screen = !(geo.flags & VO_WIN_FORCE_POS);
         goto finish;
     }
 

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -674,8 +674,12 @@ static MONITORINFO get_monitor_info(struct vo_w32_state *w32)
     HMONITOR mon;
     if (IsWindowVisible(w32->window) && !w32->current_fs) {
         mon = MonitorFromWindow(w32->window, MONITOR_DEFAULTTOPRIMARY);
-    } else {
+	} else if (w32->window_bounds_initialized && !w32->current_fs) {
         // The window is not visible during initialization, so get the
+        // monitor by the cached window rect, or fallback to primary.
+        mon = MonitorFromRect(&w32->windowrc, MONITOR_DEFAULTTOPRIMARY);
+    } else {
+        // The window bounds have not been initialized, so get the
         // monitor by --screen or --fs-screen id, or fallback to primary.
         mon = get_default_monitor(w32);
     }


### PR DESCRIPTION
Currently the `--geometry` parameter is constrained by the size of the primary monitor even if the position of the window is located on another monitor. This PR attempts to fix this in two ways:

1. Don't constrain the window size if `VO_WIN_FORCE_POS` is set, this is set when either `--geometry` or `--force-window-pos` is used.
2. Fix the root cause issue by fetching the monitor based on the cached window bounds when the window is not yet visible.