### PR TITLE
player/screenshot: avoid non-sRGB spaces with --screenshot-tag-csp=no

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -347,7 +347,7 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
         .subs = mode != 0,
         .osd = mode == MODE_FULL_WINDOW,
         .high_bit_depth = high_depth && imgopts->high_bit_depth,
-        .native_csp = image_writer_flexible_csp(imgopts),
+        .native_csp = imgopts->tag_csp && image_writer_flexible_csp(imgopts),
     };
     if (!mpctx->opts->screenshot_sw)
         vo_control(mpctx->video_out, VOCTRL_SCREENSHOT, &ctrl);


### PR DESCRIPTION
If --screenshot-tag-colorspace=no, then there won't be any color tags in the output space, so PNG and JXL screenshots should be written as sRGB rather than the native space of the input video.