### PR TITLE
meson: use the new build_options method

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3329,8 +3329,9 @@ Property list
     might contain either a release version, or just a git hash.
 
 ``mpv-configuration``
-    The configuration arguments which were passed to the build system
-    (typically the way ``./waf configure ...`` was invoked).
+    The configuration arguments that were passed to the build system. If the
+    meson version used to compile mpv is older than 1.1.0, then a hardcoded
+    string of a few, arbitrary options is displayed instead.
 
 ``ffmpeg-version``
     The contents of the ``av_version_info()`` API call. This is a string which

--- a/meson.build
+++ b/meson.build
@@ -1613,12 +1613,15 @@ if features['pdf-build']
 endif
 
 
-# Currently, we can't easily get every single thing a user might have passed
-# on the cli, but we might as well just hardcode a few options (even if they are
-# not specifically set) for verbosity's sake.
-configuration = 'meson configure build ' + '-Dprefix=' + get_option('prefix') + \
-                ' -Dbuildtype=' + get_option('buildtype') + \
-                ' -Doptimization=' + get_option('optimization')
+if meson.version().version_compare('>= 1.1.0')
+    configuration = meson.build_options()
+else
+    # Arbitrary hardcoded things to pass if the meson version is too
+    # old to have the build_options method.
+    configuration = 'meson configure build ' + '-Dprefix=' + get_option('prefix') + \
+                    ' -Dbuildtype=' + get_option('buildtype') + \
+                    ' -Doptimization=' + get_option('optimization')
+endif
 
 
 # Set config.h


### PR DESCRIPTION
This finally allows us to put any user defined options into the CONFIGURATION variable like what waf does. The arbitrary hardcoded fallback is left in place for old meson versions. Also update the documentation in regards to the mpv-configuration variable to be relevant to meson.

I opted to just pass the string from `meson.build_options()` directly into the define instead of trying to prefix it with `meson setup build` or something since there's a lot of different ways you can change the build options.