### PR TITLE
vo_gpu_next: allow to use ICC profile luminance value

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,6 +27,10 @@ Interface changes
 ::
 
  --- mpv 0.36.0 ---
+    - Target luminance value is now also applied when ICC profile is used.
+      `--icc-use-luma` has been added to use ICC profile luminance value.
+      If target luminance and ICC luminance is not used, old behavior apply,
+      defaulting to 203 nits. (Only applies for `--vo=gpu-next`)
     - `playlist/N/title` gets set upon opening the file if it wasn't already set
       and a title is available.
     - add the `--vo=kitty` video output driver, as well as the options

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6669,6 +6669,9 @@ them.
     value ``inf`` causes the BT.1886 curve to be treated as a pure power gamma
     2.4 function.
 
+``--icc-use-luma``
+    Use ICC profile luminance value. (Only for ``--vo=gpu-next``)
+
 ``--lut=<file>``
     Specifies a custom LUT (in Adobe .cube format) to apply to the colors
     as part of color conversion. The exact interpretation depends on the value

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -499,6 +499,7 @@ const struct m_sub_options mp_icc_conf = {
         {"icc-force-contrast", OPT_CHOICE(contrast, {"no", 0}, {"inf", -1}),
             M_RANGE(0, 1000000)},
         {"icc-3dlut-size", OPT_STRING_VALIDATE(size_str, validate_3dlut_size_opt)},
+        {"icc-use-luma", OPT_BOOL(icc_use_luma)},
         {"3dlut-size", OPT_REPLACED("icc-3dlut-size")},
         {"icc-cache", OPT_REMOVED("see icc-cache-dir")},
         {"icc-contrast", OPT_REMOVED("see icc-force-contrast")},

--- a/video/out/gpu/lcms.h
+++ b/video/out/gpu/lcms.h
@@ -17,6 +17,7 @@ struct mp_icc_opts {
     char *size_str;
     int intent;
     int contrast;
+    bool icc_use_luma;
 };
 
 struct lut3d {


### PR DESCRIPTION
Also while at it respect target-peak option when ICC profile is used.

Fixes #11449