### PR TITLE
charset_conv: fix memory corruption in mp_iconv_to_utf8

### DIFF
--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -161,6 +161,9 @@ const char *mp_charset_guess(void *talloc_ctx, struct mp_log *log,  bstr buf,
 bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
 {
 #if HAVE_ICONV
+    if (!buf.len)
+        return buf;
+
     if (!cp || !cp[0] || mp_charset_is_utf8(cp))
         return buf;
 


### PR DESCRIPTION
If mp_iconv_to_utf8 was given an empty string to convert in the buf parameter it would corrupt memory when writing a null into outbuf before returning it to the caller. This happened when streaming from a URL that ends in a slash. For such a URL the method mp_basename returns an empty string. The method append_dir_subtitles passes the result returned from mp_basename to mp_iconv_to_utf8 which then corrupts memory. This was detected using Guard Malloc. The fix changes mp_iconv_to_utf8 check up front if buf is empty and if it is return buf as the result in compliance with the documented behavior of the method when no conversion is needed.

Fixes #11626