### PR TITLE
console/stats: don't overwrite color and alpha of `osd-back-color`

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -141,9 +141,10 @@ function update()
     local clipping_coordinates = '0,' .. coordinate_top .. ',' ..
                                  screenx .. ',' .. screeny
     local ass = assdraw.ass_new()
+    local has_shadow = mp.get_property('osd-back-color'):sub(2, 3) == '00'
     local style = '{\\r' ..
-                  '\\1a&H00&\\3a&H00&\\4a&H99&' ..
-                  '\\1c&Heeeeee&\\3c&H111111&\\4c&H000000&' ..
+                  '\\1a&H00&\\3a&H00&\\1c&Heeeeee&\\3c&H111111&' ..
+                  (has_shadow and '\\4a&H99&\\4c&H000000&' or '') ..
                   '\\fn' .. opts.font .. '\\fs' .. opts.font_size ..
                   '\\bord' .. opts.border_size .. '\\xshad0\\yshad1\\fsp0\\q1' ..
                   '\\clip(' .. clipping_coordinates .. ')}'

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -173,11 +173,13 @@ local function text_style()
     if o.custom_header and o.custom_header ~= "" then
         return o.custom_header
     else
-        return format("{\\r}{\\an7}{\\fs%d}{\\fn%s}{\\bord%f}{\\3c&H%s&}" ..
-                      "{\\1c&H%s&}{\\alpha&H%s&}{\\xshad%f}{\\yshad%f}{\\4c&H%s&}",
+        local has_shadow = mp.get_property('osd-back-color'):sub(2, 3) == '00'
+        return format("{\\r\\an7\\fs%d\\fn%s\\bord%f\\3c&H%s&" ..
+                      "\\1c&H%s&\\1a&H%s&\\3a&H%s&" ..
+                      (has_shadow and "\\4a&H%s&\\xshad%f\\yshad%f\\4c&H%s&}" or "}"),
                       o.font_size, o.font, o.border_size,
-                      o.border_color, o.font_color, o.alpha, o.shadow_x_offset,
-                      o.shadow_y_offset, o.shadow_color)
+                      o.border_color, o.font_color, o.alpha, o.alpha, o.alpha,
+                      o.shadow_x_offset, o.shadow_y_offset, o.shadow_color)
     end
 end
 


### PR DESCRIPTION
The background from `--osd-back-color` is [mutually exclusive](https://github.com/mpv-player/mpv/blob/2dc8e70093d9f80a01696f059ff02784bcb7b5f0/sub/ass_mp.c#L66-L72) with text shadows and ASS apparently uses the color and alpha set for shadows (`\4c` and `\4a`) for that background.
console and stats were always overwriting those values, effectively ignoring the actual values set in `--osd-back-color`.

Replicate the check done in ass_mp.c and only set shadow color and alpha when there actually are shadows.