### PR TITLE
sd_lavc: support rendering bitmap subtitles with libaribcaption

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2913,6 +2913,13 @@ Subtitles
 
     If this option is not specified, ``~~/fonts`` will be used by default.
 
+``--sd-lavc-o=<key>=<value>[,<key>=<value>[,...]]``
+    Pass AVOptions to libavcodec decoder. Note, a patch to make the o=
+    unneeded and pass all unknown options through the AVOption system is
+    welcome. A full list of AVOptions can be found in the FFmpeg manual.
+
+    This is a key/value list option. See `List Options`_ for details.
+
 Window
 ------
 

--- a/common/av_common.c
+++ b/common/av_common.c
@@ -385,6 +385,19 @@ int mp_set_avopts_pos(struct mp_log *log, void *avobj, void *posargs, char **kv)
     return success;
 }
 
+// kv is in the format as by OPT_KEYVALUELIST(): kv[0]=key0, kv[1]=val0, ...
+// Find a value by key
+char *mp_get_avopts(char **kv, char *key)
+{
+    for (int n = 0; kv && kv[n * 2]; n++) {
+        char *k = kv[n * 2 + 0];
+        char *v = kv[n * 2 + 1];
+        if (strcmp(k, key) == 0)
+            return v;
+    }
+    return NULL;
+}
+
 /**
  * Must be used to free an AVPacket that was used with mp_set_av_packet().
  *

--- a/common/av_common.h
+++ b/common/av_common.h
@@ -49,6 +49,7 @@ void mp_set_avdict(struct AVDictionary **dict, char **kv);
 void mp_avdict_print_unset(struct mp_log *log, int msgl, struct AVDictionary *d);
 int mp_set_avopts(struct mp_log *log, void *avobj, char **kv);
 int mp_set_avopts_pos(struct mp_log *log, void *avobj, void *posargs, char **kv);
+char *mp_get_avopts(char **kv, char *key);
 void mp_free_av_packet(AVPacket **pkt);
 
 #endif

--- a/options/options.c
+++ b/options/options.c
@@ -293,6 +293,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-clear-on-seek", OPT_BOOL(sub_clear_on_seek)},
         {"teletext-page", OPT_INT(teletext_page), M_RANGE(1, 999)},
         {"sub-past-video-end", OPT_BOOL(sub_past_video_end)},
+        {"sd-lavc-o", OPT_KEYVALUELIST(sdopts)},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),

--- a/options/options.h
+++ b/options/options.h
@@ -110,6 +110,7 @@ struct mp_subtitle_opts {
     bool sub_clear_on_seek;
     int teletext_page;
     bool sub_past_video_end;
+    char **sdopts;
 };
 
 struct mp_sub_filter_opts {

--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -67,7 +67,8 @@ static void disable_styles(bstr header)
 }
 
 struct lavc_conv *lavc_conv_create(struct mp_log *log,
-                                   const struct mp_codec_params *mp_codec)
+                                   const struct mp_codec_params *mp_codec,
+                                   char **sdopts)
 {
     struct lavc_conv *priv = talloc_zero(NULL, struct lavc_conv);
     priv->log = log;
@@ -96,6 +97,9 @@ struct lavc_conv *lavc_conv_create(struct mp_log *log,
     av_dict_set(&opts, "flags2", "+ass_ro_flush_noop", 0);
     if (strcmp(priv->codec, "eia_608") == 0)
         av_dict_set(&opts, "real_time", "1", 0);
+
+    mp_set_avopts(log, avctx, sdopts);
+
     if (avcodec_open2(avctx, codec, &opts) < 0)
         goto error;
     av_dict_free(&opts);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -47,7 +47,8 @@ struct sd_functions {
 // lavc_conv.c
 struct lavc_conv;
 struct lavc_conv *lavc_conv_create(struct mp_log *log,
-                                   const struct mp_codec_params *mp_codec);
+                                   const struct mp_codec_params *mp_codec,
+                                   char **sdopts);
 char *lavc_conv_get_extradata(struct lavc_conv *priv);
 char **lavc_conv_decode(struct lavc_conv *priv, struct demux_packet *packet,
                         double *sub_pts, double *sub_duration);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -261,7 +261,7 @@ static int init(struct sd *sd)
         strcmp(sd->codec->codec, "null") != 0)
     {
         ctx->is_converted = true;
-        ctx->converter = lavc_conv_create(sd->log, sd->codec);
+        ctx->converter = lavc_conv_create(sd->log, sd->codec, sd->opts->sdopts);
         if (!ctx->converter)
             return -1;
 

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -103,7 +103,10 @@ static int init(struct sd *sd)
         goto error;
     priv->pkt_timebase = mp_get_codec_timebase(sd->codec);
     ctx->pkt_timebase = priv->pkt_timebase;
-    if (avcodec_open2(ctx, sub_codec, NULL) < 0)
+
+    mp_set_avopts(sd->log, ctx, sd->opts->sdopts);
+
+    if (avcodec_open2(ctx, sub_codec, &opts) < 0)
         goto error;
     priv->avctx = ctx;
     sd->priv = priv;


### PR DESCRIPTION
[libaribcaption](https://github.com/xqq/libaribcaption) is a library for decoding / rendering ARIB STD-B24 based TV broadcast captions (subtitles). The library supports ouputting decoded subtitles in two ways: ASS subtitles or bitmap subtitles. Building recent version of ffmpeg with libaribcaption also enables ARIB subtitles rendering on mpv.

Currently mpv only supports rendering ARIB subtitles with ASS subtitles driver when libaribcaption codec is in use, which renders poorly compared to bitmap subtitles driver. ASS subtitles lack black transparent background that makes subtitles more readable. Subtitles decoded with libaribcaption render best when rendered with bitmap subtitles driver. 

**New mpv commandline option: sd-lavc-o**

On ffplay you can use `-sub_type=bitmap` option to render ARIB subtitles as bitmap.
There is currenly no way to set the same option to subtitle decoders on mpv unfortunately, so I added one. This would also allow configuring other libaribcaption options like font from mpv.

**libaribcaption support**

mpv only uses bitmap subtitles driver only for codecs listed here: https://github.com/mpv-player/mpv/blob/6234a709202282d8a8bfffd0ee4f9d80561dd4b9/sub/sd_lavc.c#L79-L89

To render subtitles correctly when `sub_type` is set to `bitmap`, I added some code that choose subtitles driver based on the value of this option.
Since ffmpeg's libaribcaption codec defaults to ASS subtitles, just adding `AV_CODEC_ID_ARIB_CAPTION` to the list breaks rendering, because mpv expects bitmap subtitles, and the codec still outputs ASS subtitles.

**Building**
* ffmpeg must be built with `--enable-libaribcaption`. I used this revision: https://github.com/FFmpeg/FFmpeg/tree/2f8690c5d450b984640bd27dd7fd3a96d77ecc6b
* mpv must be built with `-Ddvbin=enabled` if you want to test ASS subtitles support too.
* I built ffmpeg with [forked libaribcaption](https://github.com/vroad/libaribcaption/tree/fix-pkgconfig) becuase it does not install correctly on NixOS

**Running**

Tested on NixOS 22.11. Without `--cache=no`, subtitles does not show up until I seek (Probably because of this issue): https://github.com/mpv-player/mpv/issues/9646

libaribb24 probably has the same problem as libaribcaption and this PR may fix it, I just haven't tested with libaribb24 yet.

Do I need to send m2ts files to mpv developers for testing?

Rendering subtitles with bitmap subtitles driver:

```
mpv --deinterlace \
--sd-lavc-o-add=sub_type=bitmap \
--sd-lavc-o-add=font='Rounded M+ 1m for ARIB' \
--cache=no \
--sid=1 \
/path/to/video.m2ts
```

Rendering subtitles with ASS subtitles driver (Requires mpv to be built with `-Ddvbin=enabled`):

```
mpv --deinterlace \
--sd-lavc-o=sub_type=ass \
--cache=no \
--sid=1 \
/path/to/video.m2ts
```

mpv defaults to ASS subtitles if sub_type is not set:

```
mpv --deinterlace \
--cache=no \
--sid=1 \
/path/to/video.m2ts
```