### PR TITLE
d3d11: use IDXGIInfoQueue instead ID3D11InfoQueue

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -994,6 +994,7 @@ features += {'d3d11': d3d11.allowed()}
 if features['d3d11']
     sources += files('video/out/d3d11/context.c',
                      'video/out/d3d11/ra_d3d11.c')
+    features += {'dxgi-debug-d3d11': cc.has_header_symbol('d3d11sdklayers.h', 'DXGI_DEBUG_D3D11')}
 endif
 
 wayland = {

--- a/meson.build
+++ b/meson.build
@@ -995,6 +995,7 @@ if features['d3d11']
     sources += files('video/out/d3d11/context.c',
                      'video/out/d3d11/ra_d3d11.c')
     features += {'dxgi-debug-d3d11': cc.has_header_symbol('d3d11sdklayers.h', 'DXGI_DEBUG_D3D11')}
+    features += {'dxgi-debug': cc.has_header_symbol('dxgidebug.h', 'IID_IDXGIInfoQueue')}
 endif
 
 wayland = {

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -44,9 +44,11 @@ struct ra_d3d11 {
 
     struct dll_version d3d_compiler_ver;
 
+#if HAVE_DXGI_DEBUG
     // Debug interfaces (--gpu-debug)
     IDXGIDebug *debug;
     IDXGIInfoQueue *iqueue;
+#endif
 
     // Device capabilities
     D3D_FEATURE_LEVEL fl;
@@ -2095,6 +2097,7 @@ static uint64_t timer_stop(struct ra *ra, ra_timer *ratimer)
     return timer->result;
 }
 
+#if HAVE_DXGI_DEBUG
 static int map_msg_severity(DXGI_INFO_QUEUE_MESSAGE_SEVERITY sev)
 {
     switch (sev) {
@@ -2169,9 +2172,11 @@ static int map_msg_severity_by_id(D3D11_MESSAGE_ID id,
         return map_msg_severity(sev);
     }
 }
+#endif
 
 static void debug_marker(struct ra *ra, const char *msg)
 {
+#if HAVE_DXGI_DEBUG
     struct ra_d3d11 *p = ra->priv;
     void *talloc_ctx = talloc_new(NULL);
     HRESULT hr;
@@ -2212,6 +2217,7 @@ static void debug_marker(struct ra *ra, const char *msg)
     IDXGIInfoQueue_ClearStoredMessages(p->iqueue, DXGI_DEBUG_ALL);
 done:
     talloc_free(talloc_ctx);
+#endif
 }
 
 static void destroy(struct ra *ra)
@@ -2242,6 +2248,7 @@ static void destroy(struct ra *ra)
     }
     SAFE_RELEASE(p->ctx);
 
+#if HAVE_DXGI_DEBUG
     if (p->debug) {
         // Report any leaked objects
         debug_marker(ra, "after destroy");
@@ -2252,6 +2259,7 @@ static void destroy(struct ra *ra)
     }
     SAFE_RELEASE(p->debug);
     SAFE_RELEASE(p->iqueue);
+#endif
 
     talloc_free(ra);
 }
@@ -2443,8 +2451,10 @@ struct ra *ra_d3d11_create(ID3D11Device *dev, struct mp_log *log,
         p->max_uavs = D3D11_PS_CS_UAV_REGISTER_COUNT;
     }
 
+#if HAVE_DXGI_DEBUG
     if (ID3D11Device_GetCreationFlags(p->dev) & D3D11_CREATE_DEVICE_DEBUG)
         mp_d3d11_get_debug_interfaces(ra->log, &p->debug, &p->iqueue);
+#endif
 
     // Some level 9_x devices don't have timestamp queries
     hr = ID3D11Device_CreateQuery(p->dev,
@@ -2458,9 +2468,11 @@ struct ra *ra_d3d11_create(ID3D11Device *dev, struct mp_log *log,
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ff476874.aspx
     find_max_texture_dimension(ra);
 
+#if HAVE_DXGI_DEBUG
     // Ignore any messages during find_max_texture_dimension
     if (p->iqueue)
         IDXGIInfoQueue_ClearStoredMessages(p->iqueue, DXGI_DEBUG_ALL);
+#endif
 
     MP_VERBOSE(ra, "Maximum Texture2D size: %dx%d\n", ra->max_texture_wh,
                ra->max_texture_wh);

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -13,6 +13,7 @@
 #include "osdep/windows_utils.h"
 #include "video/out/gpu/spirv.h"
 #include "video/out/gpu/utils.h"
+#include "video/out/gpu/d3d11_helpers.h"
 
 #include "ra_d3d11.h"
 
@@ -44,8 +45,8 @@ struct ra_d3d11 {
     struct dll_version d3d_compiler_ver;
 
     // Debug interfaces (--gpu-debug)
-    ID3D11Debug *debug;
-    ID3D11InfoQueue *iqueue;
+    IDXGIDebug *debug;
+    IDXGIInfoQueue *iqueue;
 
     // Device capabilities
     D3D_FEATURE_LEVEL fl;
@@ -2094,24 +2095,24 @@ static uint64_t timer_stop(struct ra *ra, ra_timer *ratimer)
     return timer->result;
 }
 
-static int map_msg_severity(D3D11_MESSAGE_SEVERITY sev)
+static int map_msg_severity(DXGI_INFO_QUEUE_MESSAGE_SEVERITY sev)
 {
     switch (sev) {
-    case D3D11_MESSAGE_SEVERITY_CORRUPTION:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION:
         return MSGL_FATAL;
-    case D3D11_MESSAGE_SEVERITY_ERROR:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR:
         return MSGL_ERR;
-    case D3D11_MESSAGE_SEVERITY_WARNING:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_WARNING:
         return MSGL_WARN;
     default:
-    case D3D11_MESSAGE_SEVERITY_INFO:
-    case D3D11_MESSAGE_SEVERITY_MESSAGE:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_INFO:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_MESSAGE:
         return MSGL_DEBUG;
     }
 }
 
 static int map_msg_severity_by_id(D3D11_MESSAGE_ID id,
-                                  D3D11_MESSAGE_SEVERITY sev)
+                                  DXGI_INFO_QUEUE_MESSAGE_SEVERITY sev)
 {
     switch (id) {
     // These are normal. The RA timer queue habitually reuses timer objects
@@ -2180,31 +2181,35 @@ static void debug_marker(struct ra *ra, const char *msg)
 
     // Copy debug-layer messages to mpv's log output
     bool printed_header = false;
-    uint64_t messages = ID3D11InfoQueue_GetNumStoredMessages(p->iqueue);
+    uint64_t messages = IDXGIInfoQueue_GetNumStoredMessages(p->iqueue,
+                                                            DXGI_DEBUG_ALL);
     for (uint64_t i = 0; i < messages; i++) {
         SIZE_T len;
-        hr = ID3D11InfoQueue_GetMessage(p->iqueue, i, NULL, &len);
+        hr = IDXGIInfoQueue_GetMessage(p->iqueue, DXGI_DEBUG_ALL, i, NULL, &len);
         if (FAILED(hr) || !len)
             goto done;
 
-        D3D11_MESSAGE *d3dmsg = talloc_size(talloc_ctx, len);
-        hr = ID3D11InfoQueue_GetMessage(p->iqueue, i, d3dmsg, &len);
+        DXGI_INFO_QUEUE_MESSAGE *dxgimsg = talloc_size(talloc_ctx, len);
+        hr = IDXGIInfoQueue_GetMessage(p->iqueue, DXGI_DEBUG_ALL, i, dxgimsg, &len);
         if (FAILED(hr))
             goto done;
 
-        int msgl = map_msg_severity_by_id(d3dmsg->ID, d3dmsg->Severity);
+        int msgl = IsEqualGUID(&dxgimsg->Producer, &DXGI_DEBUG_D3D11)
+                        ? map_msg_severity_by_id(dxgimsg->ID, dxgimsg->Severity)
+                        : map_msg_severity(dxgimsg->Severity);
+
         if (mp_msg_test(ra->log, msgl)) {
             if (!printed_header)
                 MP_INFO(ra, "%s:\n", msg);
             printed_header = true;
 
-            MP_MSG(ra, msgl, "%d: %.*s\n", (int)d3dmsg->ID,
-                (int)d3dmsg->DescriptionByteLength, d3dmsg->pDescription);
-            talloc_free(d3dmsg);
+            MP_MSG(ra, msgl, "%d: %.*s\n", (int)dxgimsg->ID,
+                (int)dxgimsg->DescriptionByteLength, dxgimsg->pDescription);
+            talloc_free(dxgimsg);
         }
     }
 
-    ID3D11InfoQueue_ClearStoredMessages(p->iqueue);
+    IDXGIInfoQueue_ClearStoredMessages(p->iqueue, DXGI_DEBUG_ALL);
 done:
     talloc_free(talloc_ctx);
 }
@@ -2240,9 +2245,9 @@ static void destroy(struct ra *ra)
     if (p->debug) {
         // Report any leaked objects
         debug_marker(ra, "after destroy");
-        ID3D11Debug_ReportLiveDeviceObjects(p->debug, D3D11_RLDO_DETAIL);
+        IDXGIDebug_ReportLiveObjects(p->debug, DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_DETAIL);
         debug_marker(ra, "after leak check");
-        ID3D11Debug_ReportLiveDeviceObjects(p->debug, D3D11_RLDO_SUMMARY);
+        IDXGIDebug_ReportLiveObjects(p->debug, DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_SUMMARY);
         debug_marker(ra, "after leak summary");
     }
     SAFE_RELEASE(p->debug);
@@ -2278,34 +2283,6 @@ void ra_d3d11_flush(struct ra *ra)
 {
     struct ra_d3d11 *p = ra->priv;
     ID3D11DeviceContext_Flush(p->ctx);
-}
-
-static void init_debug_layer(struct ra *ra)
-{
-    struct ra_d3d11 *p = ra->priv;
-    HRESULT hr;
-
-    hr = ID3D11Device_QueryInterface(p->dev, &IID_ID3D11Debug,
-                                     (void**)&p->debug);
-    if (FAILED(hr)) {
-        MP_ERR(ra, "Failed to get debug device: %s\n", mp_HRESULT_to_str(hr));
-        return;
-    }
-
-    hr = ID3D11Device_QueryInterface(p->dev, &IID_ID3D11InfoQueue,
-                                     (void**)&p->iqueue);
-    if (FAILED(hr)) {
-        MP_ERR(ra, "Failed to get info queue: %s\n", mp_HRESULT_to_str(hr));
-        return;
-    }
-
-    // Store an unlimited amount of messages in the buffer. This is fine
-    // because we flush stored messages regularly (in debug_marker.)
-    ID3D11InfoQueue_SetMessageCountLimit(p->iqueue, -1);
-
-    // Push empty filter to get everything
-    D3D11_INFO_QUEUE_FILTER filter = {0};
-    ID3D11InfoQueue_PushStorageFilter(p->iqueue, &filter);
 }
 
 static struct dll_version get_dll_version(HMODULE dll)
@@ -2467,7 +2444,7 @@ struct ra *ra_d3d11_create(ID3D11Device *dev, struct mp_log *log,
     }
 
     if (ID3D11Device_GetCreationFlags(p->dev) & D3D11_CREATE_DEVICE_DEBUG)
-        init_debug_layer(ra);
+        mp_d3d11_get_debug_interfaces(ra->log, &p->debug, &p->iqueue);
 
     // Some level 9_x devices don't have timestamp queries
     hr = ID3D11Device_CreateQuery(p->dev,
@@ -2483,7 +2460,7 @@ struct ra *ra_d3d11_create(ID3D11Device *dev, struct mp_log *log,
 
     // Ignore any messages during find_max_texture_dimension
     if (p->iqueue)
-        ID3D11InfoQueue_ClearStoredMessages(p->iqueue);
+        IDXGIInfoQueue_ClearStoredMessages(p->iqueue, DXGI_DEBUG_ALL);
 
     MP_VERBOSE(ra, "Maximum Texture2D size: %dx%d\n", ra->max_texture_wh,
                ra->max_texture_wh);

--- a/video/out/gpu/d3d11_helpers.c
+++ b/video/out/gpu/d3d11_helpers.c
@@ -1003,6 +1003,7 @@ done:
     return ret;
 }
 
+#if HAVE_DXGI_DEBUG
 void mp_d3d11_get_debug_interfaces(struct mp_log *log, IDXGIDebug **debug,
                                    IDXGIInfoQueue **iqueue)
 {
@@ -1037,3 +1038,4 @@ void mp_d3d11_get_debug_interfaces(struct mp_log *log, IDXGIDebug **debug,
         return;
     }
 }
+#endif

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -23,6 +23,7 @@
 #include <d3d11.h>
 #include <dxgi1_2.h>
 #include <dxgi1_6.h>
+#include <dxgidebug.h>
 
 #include "video/mp_image.h"
 
@@ -34,6 +35,10 @@
 #define DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P709     ((DXGI_COLOR_SPACE_TYPE)22)
 #define DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_LEFT_P2020    ((DXGI_COLOR_SPACE_TYPE)23)
 #define DXGI_COLOR_SPACE_YCBCR_STUDIO_G24_TOPLEFT_P2020 ((DXGI_COLOR_SPACE_TYPE)24)
+
+#if !HAVE_DXGI_DEBUG_D3D11
+DEFINE_GUID(DXGI_DEBUG_D3D11, 0x4b99317b, 0xac39, 0x4aa6, 0xbb, 0xb, 0xba, 0xa0, 0x47, 0x84, 0x79, 0x8f);
+#endif
 
 struct d3d11_device_opts {
     // Enable the debug layer (D3D11_CREATE_DEVICE_DEBUG)
@@ -108,5 +113,8 @@ struct d3d11_swapchain_opts {
 bool mp_d3d11_create_swapchain(ID3D11Device *dev, struct mp_log *log,
                                struct d3d11_swapchain_opts *opts,
                                IDXGISwapChain **swapchain_out);
+
+void mp_d3d11_get_debug_interfaces(struct mp_log *log, IDXGIDebug **debug,
+                                   IDXGIInfoQueue **iqueue);
 
 #endif

--- a/video/out/gpu/d3d11_helpers.h
+++ b/video/out/gpu/d3d11_helpers.h
@@ -23,7 +23,10 @@
 #include <d3d11.h>
 #include <dxgi1_2.h>
 #include <dxgi1_6.h>
+
+#if HAVE_DXGI_DEBUG
 #include <dxgidebug.h>
+#endif
 
 #include "video/mp_image.h"
 
@@ -114,7 +117,9 @@ bool mp_d3d11_create_swapchain(ID3D11Device *dev, struct mp_log *log,
                                struct d3d11_swapchain_opts *opts,
                                IDXGISwapChain **swapchain_out);
 
+#if HAVE_DXGI_DEBUG
 void mp_d3d11_get_debug_interfaces(struct mp_log *log, IDXGIDebug **debug,
                                    IDXGIInfoQueue **iqueue);
+#endif
 
 #endif


### PR DESCRIPTION
DXGI debug interface encapsulate multiple message queues, which allows
to get validation not only for D3D11 calls, but also DXGI ones.

Also this makes leak detector not report self debug interface as alive
like it was before. And same as with validation, it has ability to
detect more alive objects, not being limited to D3D11.

It works with latest version of mingw-w64. I tested in MSYS env, only DXGI_DEBUG_D3D11 is missing, but it was easy to define ourselves. Needs this commit for the rest https://github.com/mingw-w64/mingw-w64/commit/7b860f89460c0984f46812ec4475eb58b647595b

As probably we want to keep compatibility with older version I sent this patch only for reference and maybe for the future.

We could disable debug interface, if they are not supported, though, not sure who is using `--gpu-debug` primarily, because at lest for d3d11 you need the sdk installed anyway to make it work.