### PR TITLE
DOCS/options: document required parameter for --x11-name

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3353,7 +3353,7 @@ Window
 ``--no-window-dragging``
     Don't move the window when clicking on it and moving the mouse pointer.
 
-``--x11-name``
+``--x11-name=<string>``
     Set the window class name for X11-based video output methods.
 
 ``--x11-netwm=<yes|no|auto>``


### PR DESCRIPTION
The `--x11-name` option takes a string for the window class name, but this isn't reflected in the man page.