### PR TITLE
mp_image: use the ffmpeg interlaced frame flags where available

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -973,10 +973,17 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
     dst->pict_type = src->pict_type;
 
     dst->fields = 0;
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 7, 100)
+    if (src->flags & AV_FRAME_FLAG_INTERLACED)
+        dst->fields |= MP_IMGFIELD_INTERLACED;
+    if (src->flags & AV_FRAME_FLAG_TOP_FIELD_FIRST)
+        dst->fields |= MP_IMGFIELD_TOP_FIRST;
+#else
     if (src->interlaced_frame)
         dst->fields |= MP_IMGFIELD_INTERLACED;
     if (src->top_field_first)
         dst->fields |= MP_IMGFIELD_TOP_FIRST;
+#endif
     if (src->repeat_pict == 1)
         dst->fields |= MP_IMGFIELD_REPEAT_FIRST;
 
@@ -1098,10 +1105,17 @@ struct AVFrame *mp_image_to_av_frame(struct mp_image *src)
     dst->extended_data = dst->data;
 
     dst->pict_type = src->pict_type;
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 7, 100)
+    if (src->fields & MP_IMGFIELD_INTERLACED)
+        dst->flags |= AV_FRAME_FLAG_INTERLACED;
+    if (src->fields & MP_IMGFIELD_TOP_FIRST)
+        dst->flags |= AV_FRAME_FLAG_TOP_FIELD_FIRST;
+#else
     if (src->fields & MP_IMGFIELD_INTERLACED)
         dst->interlaced_frame = 1;
     if (src->fields & MP_IMGFIELD_TOP_FIRST)
         dst->top_field_first = 1;
+#endif
     if (src->fields & MP_IMGFIELD_REPEAT_FIRST)
         dst->repeat_pict = 1;
 


### PR DESCRIPTION
The old frame properties are deprecated and have been replaced by frame flags.