### PR TITLE
options: add secondary-sub-delay

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,8 @@ Interface changes
 
  --- mpv 0.38.0 ---
     - remove shared-script-properties (user-data is a replacement)
+    - add `--secondary-sub-delay`, decouple secondary subtitles from
+      `--sub-delay`
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2312,7 +2312,10 @@ Subtitles
     printed by ``--sub-demuxer=help``.
 
 ``--sub-delay=<sec>``
-    Delays subtitles by ``<sec>`` seconds. Can be negative.
+    Delays primary subtitles by ``<sec>`` seconds. Can be negative.
+
+``--secondary-sub-delay=<sec>``
+    Delays secondary subtitles by ``<sec>`` seconds. Can be negative.
 
 ``--sub-files=<file-list>``, ``--sub-file=<filename>``
     Add a subtitle file to the list of external subtitles.

--- a/options/options.c
+++ b/options/options.c
@@ -281,7 +281,8 @@ const struct m_sub_options mp_sub_filter_opts = {
 
 const struct m_sub_options mp_subtitle_sub_opts = {
     .opts = (const struct m_option[]){
-        {"sub-delay", OPT_FLOAT(sub_delay)},
+        {"sub-delay", OPT_FLOAT(sub_delay[0])},
+        {"secondary-sub-delay", OPT_FLOAT(sub_delay[1])},
         {"sub-fps", OPT_FLOAT(sub_fps)},
         {"sub-speed", OPT_FLOAT(sub_speed)},
         {"sub-visibility", OPT_BOOL(sub_visibility)},

--- a/options/options.h
+++ b/options/options.h
@@ -85,7 +85,7 @@ struct mp_subtitle_opts {
     bool sub_visibility;
     bool sec_sub_visibility;
     float sub_pos;
-    float sub_delay;
+    float sub_delay[2];
     float sub_fps;
     float sub_speed;
     bool sub_forced_events_only;

--- a/player/misc.c
+++ b/player/misc.c
@@ -147,7 +147,12 @@ double get_track_seek_offset(struct MPContext *mpctx, struct track *track)
         if (track->type == STREAM_AUDIO)
             return -opts->audio_delay;
         if (track->type == STREAM_SUB)
-            return -opts->subs_rend->sub_delay;
+        {
+            for (int n = 0; n < num_ptracks[STREAM_SUB]; n++) {
+                if (mpctx->current_track[n][STREAM_SUB] == track)
+                    return -opts->subs_rend->sub_delay[n];
+            }
+        }
     }
     return 0;
 }

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -92,9 +92,10 @@ static void update_subtitle_speed(struct dec_sub *sub)
 static double pts_to_subtitle(struct dec_sub *sub, double pts)
 {
     struct mp_subtitle_opts *opts = sub->opts;
+    float delay = sub->order < 0 ? 0.0f : opts->sub_delay[sub->order];
 
     if (pts != MP_NOPTS_VALUE)
-        pts = (pts * sub->play_dir - opts->sub_delay) / sub->sub_speed;
+        pts = (pts * sub->play_dir - delay) / sub->sub_speed;
 
     return pts;
 }
@@ -102,9 +103,10 @@ static double pts_to_subtitle(struct dec_sub *sub, double pts)
 static double pts_from_subtitle(struct dec_sub *sub, double pts)
 {
     struct mp_subtitle_opts *opts = sub->opts;
+    float delay = sub->order < 0 ? 0.0f : opts->sub_delay[sub->order];
 
     if (pts != MP_NOPTS_VALUE)
-        pts = (pts * sub->sub_speed + opts->sub_delay) * sub->play_dir;
+        pts = (pts * sub->sub_speed + delay) * sub->play_dir;
 
     return pts;
 }
@@ -291,7 +293,8 @@ bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force)
             break;
 
         // (Use this mechanism only if sub_delay matters to avoid corner cases.)
-        double min_pts = sub->opts->sub_delay < 0 || force ? video_pts : MP_NOPTS_VALUE;
+        float delay = sub->order < 0 ? 0.0f : sub->opts->sub_delay[sub->order];
+        double min_pts = delay < 0 || force ? video_pts : MP_NOPTS_VALUE;
 
         struct demux_packet *pkt;
         int st = demux_read_packet_async_until(sub->sh, min_pts, &pkt);


### PR DESCRIPTION
Add --secondary-sub-delay option and decouple --sub-delay from secondary subtitles. This produces desirable behavior in most cases as secondary and primary subtitles tracks tend to be timed independently of one another.

This feature is implemented by turning the sub_delay field in mp_subtitle_opts into an array of 2 floats. From here the track index is either passed around or derived when sub_delay is needed. There are some cases in dec_sub.c where it is possible for dec_sub.order (equivalent to track index) to be -1. In these cases, sub_delay is inferred as 0.

Closes #2629

---

The pull request contains code for the "ideal" solution as far as I'm concerned, but based on the discussion that happened last time in #8954 I doubt it will be merged as is. This time around I'm interested in finding an amicable solution to the problem.

If breaking backwards compatibility is a concern, implementing a boolean option like `--sync-sub-delays` that guarantees `secondary-sub-delay` is the the same value as `sub-delay` if set to `yes` would allow the existing behavior to exist alongside the new behavior.