### PR TITLE
build: fix vulkan-wayland linker failure with nvidia drivers on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -411,7 +411,7 @@ endif
 if darwin
     path_source = files('osdep/path-darwin.c')
     sources += path_source + files('osdep/timer-darwin.c')
-                     
+
 endif
 
 if posix and not darwin
@@ -1251,7 +1251,10 @@ if features['vulkan'] and features['android']
     sources += files('video/out/vulkan/context_android.c')
 endif
 
-if features['vulkan'] and features['wayland']
+features += {'vk_khr_wayland': cc.has_function('vkCreateWaylandSurfaceKHR', prefix: '#include <vulkan/vulkan_wayland.h>',
+                                               dependencies: [vulkan, wayland['deps']])}
+
+if features['vk_khr_wayland']
     sources += files('video/out/vulkan/context_wayland.c')
 endif
 

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -104,7 +104,7 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_WIN32_DESKTOP
     &ra_ctx_vulkan_win,
 #endif
-#if HAVE_WAYLAND
+#if HAVE_WAYLAND && HAVE_VK_KHR_WAYLAND
     &ra_ctx_vulkan_wayland,
 #endif
 #if HAVE_X11

--- a/wscript
+++ b/wscript
@@ -809,6 +809,12 @@ video_output_features = [
         'func': check_statement('vulkan/vulkan_core.h', 'vkCreateDisplayPlaneSurfaceKHR(0, 0, 0, 0)',
                                 use='vulkan')
     }, {
+        'name': 'vk-khr-wayland',
+        'desc': "VK_KHR_wayland extension",
+        'deps': 'vulkan && wayland',
+        'func': check_statement('vulkan/vulkan_wayland.h', 'vkCreateWaylandSurfaceKHR(0, 0, 0, 0)',
+                                use='vulkan')
+    }, {
         'name': 'vaapi-libplacebo',
         'desc': 'VAAPI libplacebo',
         'deps': 'vaapi && libplacebo',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -546,7 +546,7 @@ def build(ctx):
         ( "video/out/vulkan/context.c",          "vulkan" ),
         ( "video/out/vulkan/context_display.c",  "vulkan && vk-khr-display" ),
         ( "video/out/vulkan/context_android.c",  "vulkan && android" ),
-        ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland" ),
+        ( "video/out/vulkan/context_wayland.c",  "vulkan && wayland && vk-khr-wayland" ),
         ( "video/out/vulkan/context_win.c",      "vulkan && win32-desktop" ),
         ( "video/out/vulkan/context_xlib.c",     "vulkan && x11" ),
         ( "video/out/vulkan/utils.c",            "vulkan" ),


### PR DESCRIPTION
When building mpv on a Linux system with Wayland and proprietary Nvidia drivers, auto configuration sets options that cause the build to fail with a linker error regarding the vkCreateWaylandSurfaceKHR function. This fixes the issue by adding checks in meson.build, wscript, and wscript_build.py for vkCreateWaylandSurfaceKHR before pulling in context_wayland.c.