### PR TITLE
wayland: add cursor-shape-v1 support

### DIFF
--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -19,6 +19,12 @@ if features['wayland_protocols_1_31']
     protocols += [[wl_protocol_dir, 'staging/fractional-scale/fractional-scale-v1.xml']]
 endif
 
+features += {'wayland_protocols_1_32': wayland['deps'][2].version().version_compare('>=1.32')}
+if features['wayland_protocols_1_32']
+    protocols += [[wl_protocol_dir, 'staging/cursor-shape/cursor-shape-v1.xml'],
+                  [wl_protocol_dir, 'unstable/tablet/tablet-unstable-v2.xml']] # required by cursor-shape
+endif
+
 foreach p: protocols
     xml = join_paths(p)
     wl_protocols_source += custom_target(xml.underscorify() + '_c',

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -88,6 +88,11 @@ struct vo_wayland_state {
     void *content_type;
     int current_content_type;
 
+    /* cursor-shape */
+    /* TODO: unvoid these if required wayland protocols is bumped to 1.32+ */
+    void *cursor_shape_manager;
+    void *cursor_shape_device;
+
     /* fractional-scale */
     /* TODO: unvoid these if required wayland protocols is bumped to 1.31+ */
     void *fractional_scale_manager;

--- a/wscript
+++ b/wscript
@@ -559,6 +559,11 @@ video_output_features = [
         'deps': 'wayland',
         'func': check_pkg_config('wayland-protocols >= 1.31'),
     } , {
+        'name': 'wayland-protocols-1-32',
+        'desc': 'wayland-protocols version 1.32+',
+        'deps': 'wayland',
+        'func': check_pkg_config('wayland-protocols >= 1.32'),
+    } , {
         'name': 'memfd_create',
         'desc': "Linux's memfd_create()",
         'deps': 'wayland',

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -163,6 +163,20 @@ def build(ctx):
             protocol  = "staging/fractional-scale/fractional-scale-v1",
             target    = "generated/wayland/fractional-scale-v1.h")
 
+    if ctx.dependency_satisfied('wayland-protocols-1-32'):
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/cursor-shape/cursor-shape-v1",
+            target    = "generated/wayland/cursor-shape-v1.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "staging/cursor-shape/cursor-shape-v1",
+            target    = "generated/wayland/cursor-shape-v1.h")
+        ctx.wayland_protocol_code(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "unstable/tablet/tablet-unstable-v2",
+            target    = "generated/wayland/tablet-unstable-v2.c")
+        ctx.wayland_protocol_header(proto_dir = ctx.env.WL_PROTO_DIR,
+            protocol  = "unstable/tablet/tablet-unstable-v2",
+            target    = "generated/wayland/tablet-unstable-v2.h")
+
     ctx(features = "ebml_header", target = "generated/ebml_types.h")
     ctx(features = "ebml_definitions", target = "generated/ebml_defs.inc")
 


### PR DESCRIPTION
This protocol no longer requires us to draw a separate cursor surface and all of that horrible stuff. We can just ask the compositor for the default cursor instead since that's literally all mpv cares about.

Should theoretically fix #11671.

Tested with https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4106 + https://github.com/swaywm/sway/pull/7571. Also requires wayland-protocols from master right now hence draft.