### PR TITLE
DOCS/mpv: add an example for applying profiles to certain paths

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -844,6 +844,14 @@ and unintuitive behavior.
         profile-cond=width >= 1280
         hue=-50
 
+    Make only videos containing "youtube" or "youtu.be" in their path brighter:
+
+    ::
+
+        [youtube]
+        profile-cond=path:find('youtu%.?be')
+        gamma=20
+
     If you want the profile to be reverted if the condition goes to false again,
     you can set ``profile-restore``:
 


### PR DESCRIPTION
It is worth adding this example because it has been asked multiple times in the issue tracker and the IRC channel.

string.find() is used because it's 20 times faster than string.match().