### PR TITLE
player: add drag-and-drop option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3064,6 +3064,14 @@ Window
 ``--snap-window``
     (Windows only) Snap the player window to screen edges.
 
+``--drag-and-drop=<auto|replace|append>``
+    (X11 and Wayland only)
+    Controls the default behavior of drag and drop on platforms that support this.
+    ``auto`` will obey what the underlying os/platform gives mpv. Typically, holding
+    shift during the drag and drop will append the item to the playlist. Otherwise,
+    it will completely replace it. ``replace`` and ``append`` always force replacing
+    and appending to the playlist respectively.
+
 ``--ontop``
     Makes the player window stay on top of other windows.
 

--- a/options/options.c
+++ b/options/options.c
@@ -106,6 +106,8 @@ static const struct m_sub_options screenshot_conf = {
 static const m_option_t mp_vo_opt_list[] = {
     {"vo", OPT_SETTINGSLIST(video_driver_list, &vo_obj_list)},
     {"taskbar-progress", OPT_BOOL(taskbar_progress)},
+    {"drag-and-drop", OPT_CHOICE(drag_and_drop, {"auto", -1}, {"replace", 0},
+        {"append", 1})},
     {"snap-window", OPT_BOOL(snap_window)},
     {"ontop", OPT_BOOL(ontop)},
     {"ontop-level", OPT_CHOICE(ontop_level, {"window", -1}, {"system", -2},
@@ -196,6 +198,7 @@ const struct m_sub_options vo_sub_opts = {
     .size = sizeof(struct mp_vo_opts),
     .defaults = &(const struct mp_vo_opts){
         .video_driver_list = NULL,
+        .drag_and_drop = -1,
         .monitor_pixel_aspect = 1.0,
         .screen_id = -1,
         .fsscreen_id = -1,

--- a/options/options.h
+++ b/options/options.h
@@ -11,6 +11,7 @@ typedef struct mp_vo_opts {
 
     bool taskbar_progress;
     bool snap_window;
+    int drag_and_drop;
     bool ontop;
     int ontop_level;
     bool fullscreen;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -535,8 +535,12 @@ static void data_offer_action(void *data, struct wl_data_offer *wl_data_offer, u
 {
     struct vo_wayland_state *wl = data;
     if (dnd_action) {
-        wl->dnd_action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
-                         DND_REPLACE : DND_APPEND;
+        if (wl->vo_opts->drag_and_drop >= 0) {
+            wl->dnd_action = wl->vo_opts->drag_and_drop;
+        } else {
+            wl->dnd_action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
+                             DND_REPLACE : DND_APPEND;
+        }
         MP_VERBOSE(wl, "DND action is %s\n",
                    wl->dnd_action == DND_REPLACE ? "DND_REPLACE" : "DND_APPEND");
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -534,10 +534,12 @@ static void data_offer_source_actions(void *data, struct wl_data_offer *offer, u
 static void data_offer_action(void *data, struct wl_data_offer *wl_data_offer, uint32_t dnd_action)
 {
     struct vo_wayland_state *wl = data;
-    wl->dnd_action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
-                     DND_REPLACE : DND_APPEND;
-    MP_VERBOSE(wl, "DND action is %s\n",
-               wl->dnd_action == DND_REPLACE ? "DND_REPLACE" : "DND_APPEND");
+    if (dnd_action) {
+        wl->dnd_action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
+                         DND_REPLACE : DND_APPEND;
+        MP_VERBOSE(wl, "DND action is %s\n",
+                   wl->dnd_action == DND_REPLACE ? "DND_REPLACE" : "DND_APPEND");
+    }
 }
 
 static const struct wl_data_offer_listener data_offer_listener = {

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -988,9 +988,13 @@ static void vo_x11_dnd_handle_selection(struct vo *vo, XSelectionEvent *se)
         void *prop = x11_get_property(x11, x11->window, XAs(x11, DND_PROPERTY),
                                       x11->dnd_requested_format, 8, &nitems);
         if (prop) {
-            enum mp_dnd_action action =
-                x11->dnd_requested_action == XA(x11, XdndActionCopy) ?
-                DND_REPLACE : DND_APPEND;
+            enum mp_dnd_action action;
+            if (x11->opts->drag_and_drop >= 0) {
+                action = x11->opts->drag_and_drop;
+            } else {
+                action = x11->dnd_requested_action == XA(x11, XdndActionCopy) ?
+                         DND_REPLACE : DND_APPEND;
+            }
 
             char *mime_type = x11_dnd_mime_type(x11, x11->dnd_requested_format);
             MP_VERBOSE(x11, "Dropping type: %s (%s)\n",


### PR DESCRIPTION
See #9201 for some related discussion. tl;dr: wayland sucks but this isn't a bad option to have regardless to allow more precise control over the exact drag-and-drop behavior.

Windows and macOS were omitted because both are surprisingly complicated here. Windows requires using `m_config_cache_get_next_changed` to truly have runtime support option changes which isn't too bad but I have no way of testing it anyway so I didn't bother. No idea what's going on in macOS.