### PR TITLE
player: always try to detect subtitle language from file name

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -248,10 +248,9 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
             prio |= 32; // exact movie name match
 
         bstr lang = {0};
+        int start = 0;
+        lang = guess_lang_from_filename(tmp_fname_trim, &start);
         if (bstr_startswith(tmp_fname_trim, f_fname_trim)) {
-            int start = 0;
-            lang = guess_lang_from_filename(tmp_fname_trim, &start);
-
             if (lang.len && start == f_fname_trim.len)
                 prio |= 16; // exact movie name + followed by lang
         }


### PR DESCRIPTION
Previously, we'd only attempt to call guess_lang_from_filename if the external file name matched the video name ignoring the extensions. So if they didn't match, we'd just report the language as "unknown". And since the name will never match for urls, the language would always be treated as unknown.

Now we'll always try to guess the language from the filename regardless of its similarity to the video file name.

Closes #10348

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.