### PR TITLE
ci/msys2: enable egl-angle-lib

### DIFF
--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -6,6 +6,7 @@ if [ "$1" = "meson" ]; then
       -D d3d-hwaccel=enabled     \
       -D d3d11=enabled           \
       -D dvdnav=enabled          \
+      -D egl-angle-lib=enabled   \
       -D egl-angle-win32=enabled \
       -D jpeg=enabled            \
       -D lcms2=enabled           \
@@ -35,6 +36,7 @@ if [ "$1" = "waf" ]; then
       --enable-d3d-hwaccel     \
       --enable-d3d11           \
       --enable-dvdnav          \
+      --enable-egl-angle-lib   \
       --enable-egl-angle-win32 \
       --enable-jpeg            \
       --enable-lcms2           \


### PR DESCRIPTION
Now that it has been fixed upstream we can enable and test if it links correctly.