### PR TITLE
hwdec_vulkan: account for vulkan frames now using presentation size

### DIFF
--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -235,16 +235,6 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     const AVVulkanFramesContext *vkfc = hwfc->hwctx;
     AVVkFrame *vkf = (AVVkFrame *) mapper->src->planes[0];
 
-    /*
-     * We need to use the dimensions from the HW Frames Context for the
-     * textures, as the underlying images may be larger than the logical frame
-     * size. This most often happens with 1080p content where the actual frame
-     * height is 1088.
-     */
-    struct mp_image raw_layout;
-    mp_image_setfmt(&raw_layout, p->layout.params.imgfmt);
-    mp_image_set_size(&raw_layout, hwfc->width, hwfc->height);
-
     int num_images;
     for (num_images = 0; (vkf->img[num_images] != NULL); num_images++);
     const VkFormat *vk_fmt = av_vkfmt_from_pixfmt(hwfc->sw_format);
@@ -278,8 +268,8 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
 
         *tex = pl_vulkan_wrap(p_owner->gpu, pl_vulkan_wrap_params(
             .image = vkf->img[index],
-            .width = mp_image_plane_w(&raw_layout, i),
-            .height = mp_image_plane_h(&raw_layout, i),
+            .width = mp_image_plane_w(&p->layout, i),
+            .height = mp_image_plane_h(&p->layout, i),
             .format = vk_fmt[i],
             .usage = vkfc->usage,
             .aspect = aspect,


### PR DESCRIPTION
ffmpeg was previously allocating images for frames as the code size,
rather than the presentation one (1088 vs 1080 in the most common
example). Using the coded size when wrapping images for libplacebo
resulted in incorrect scaling from 1088 -> 1080, but even using the
presentation size wasn't perfect, as discussed in the original
commit.

However, ffmpeg has now been updated to use the presentation size for
the frame images, after discussions that concluded this must be done
because there is no way for a frame consumer to fix the dimensions
without copying the frame.

With that ffmpeg change, we can just use the normal layout information
like all the other hwdecs.
