### PR TITLE
hwdec_vulkan: simplify requirement checks for Vulkan interop

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -933,8 +933,6 @@ if features['libplacebo-next']
                      'video/out/gpu_next/context.c')
 endif
 
-features += {'libplacebo-decode': features['libplacebo'] and libplacebo.version().version_compare('>=5.275.0')}
-
 sdl2_video = get_option('sdl2-video').require(
     features['sdl2'],
     error_message: 'sdl2 was not found!',
@@ -1312,9 +1310,10 @@ if features['cuda-interop'] and features['vulkan']
 endif
 
 vulkan_interop = get_option('vulkan-interop').require(
-    vulkan.found() and features['libplacebo-decode'] and
+    features['vulkan'] and vulkan.version().version_compare('>=1.3.238') and
+    features['libplacebo'] and libplacebo.version().version_compare('>=5.278.0') and
     libavutil.version().version_compare('>=58.11.100'),
-    error_message: 'Vulkan Interop requires vulkan, libplacebo >= 5.275.0, and libavutil >= 58.11.100',
+    error_message: 'Vulkan Interop requires vulkan headers >= 1.3.238, libplacebo >= 5.278.0, and libavutil >= 58.11.100',
 )
 features += {'vulkan-interop': vulkan_interop.allowed()}
 if vulkan_interop.allowed()

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -161,7 +161,11 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
     p->params = params;
     p->opts = mp_get_config_group(p, ctx->global, &vulkan_conf);
 
-#if HAVE_VULKAN_INTEROP && defined(VK_EXT_descriptor_buffer)
+    VkPhysicalDeviceFeatures2 features = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+    };
+
+#if HAVE_VULKAN_INTEROP
     /*
      * Request the additional extensions and features required to make full use
      * of the ffmpeg Vulkan hwcontext and video decoding capability.
@@ -189,16 +193,8 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .shaderBufferFloat32AtomicAdd = true,
     };
 
-    VkPhysicalDeviceFeatures2 features = {
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
-        .pNext = &atomic_float_feature,
-    };
-
-#else
-    VkPhysicalDeviceFeatures2 features = {
-        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
-    };
-#endif // HAVE_VULKAN_INTEROP && defined(VK_EXT_descriptor_buffer)
+    features.pNext = &atomic_float_feature;
+#endif
 
     assert(vk->pllog);
     assert(vk->vkinst);
@@ -210,7 +206,7 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .async_compute = p->opts->async_compute,
         .queue_count = p->opts->queue_count,
         .device_name = p->opts->device,
-#if HAVE_VULKAN_INTEROP && defined(VK_EXT_descriptor_buffer)
+#if HAVE_VULKAN_INTEROP
         .extra_queues = VK_QUEUE_VIDEO_DECODE_BIT_KHR,
         .opt_extensions = opt_extensions,
         .num_opt_extensions = MP_ARRAY_SIZE(opt_extensions),

--- a/wscript
+++ b/wscript
@@ -815,9 +815,14 @@ video_output_features = [
         'func': check_statement('vulkan/vulkan_core.h', 'vkCreateDisplayPlaneSurfaceKHR(0, 0, 0, 0)',
                                 use='vulkan')
     }, {
+        'name': 'vulkan-decode-headers',
+        'desc': 'Vulkan headers with decode support',
+        'deps': 'vulkan',
+        'func': check_pkg_config('vulkan', '>= 1.3.238'),
+    }, {
         'name': '--vulkan-interop',
         'desc': 'Vulkan graphics interop',
-        'deps': 'vulkan && libplacebo-next',
+        'deps': 'vulkan-decode-headers && libplacebo-decode',
         'func': check_pkg_config('libavutil', '>= 58.11.100'),
     }, {
         'name': 'vaapi-libplacebo',


### PR DESCRIPTION
I originally wrote this trying to avoid doing an explicit version check on the headers, but it just makes things more confusing, and the requirements harder to understand.

So, Vulkan interop now takes a dependency on the header release where they finalised the video decode headers. VK_EXT_descriptor_buffer was added in 1.3.235, so that's covered as well.

Along the way I fixed a bug in the waf build where it was depending on libplacebo-next instead of libplacebo-decode.
