### PR TITLE
player: don't load unwanted files after 519e56f

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -253,18 +253,18 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
         if (bstr_startswith(tmp_fname_trim, f_fname_trim)) {
             if (lang.len && start == f_fname_trim.len)
                 prio |= 16; // exact movie name + followed by lang
-        }
 
-        for (int n = 0; langs && langs[n]; n++) {
-            if (lang.len && bstr_case_startswith(lang, bstr0(langs[n]))) {
-                if (fuzz >= 1)
-                    prio |= 8; // known language -> boost priority
-                break;
+            if (lang.len && fuzz >= 1)
+                prio |= 4; // matches the movie name + a language was matched
+
+            for (int n = 0; langs && langs[n]; n++) {
+                if (lang.len && bstr_case_startswith(lang, bstr0(langs[n]))) {
+                    if (fuzz >= 1)
+                        prio |= 8; // known language -> boost priority
+                    break;
+                }
             }
         }
-
-        if (lang.len && fuzz >= 1)
-            prio |= 4; // matches the movie name + a language was matched
 
         if (bstr_find(tmp_fname_trim, f_fname_trim) >= 0 && fuzz >= 1)
             prio |= 2; // contains the movie name


### PR DESCRIPTION
519e56f caused an attempt to get the language even if the file name didn't start with the movie title. However, detecting a language when fuzz >= 1 or the language is known, caused prio to be non-zero which caused the file to be included regardless of its name. This shouldn't be the behavior when sub-auto != all.

Now all the prio updates that depend on lang will only happen if the file in question starts with the movie name. Since language was never detected before if this wasn't true, the behavior should be the same as before 519e56f when sub-auto != all.

Closes: #11749

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.