### PR TITLE
bump minimum required wayland versions

### DIFF
--- a/generated/wayland/meson.build
+++ b/generated/wayland/meson.build
@@ -8,8 +8,6 @@ protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml']
 wl_protocols_source = []
 wl_protocols_headers = []
 
-features += {'wayland_protocols_1_24': wayland['deps'][2].version().version_compare('>=1.24')}
-
 features += {'wayland_protocols_1_27': wayland['deps'][2].version().version_compare('>=1.27')}
 if features['wayland_protocols_1_27']
     protocols += [[wl_protocol_dir, 'staging/content-type/content-type-v1.xml'],

--- a/meson.build
+++ b/meson.build
@@ -978,8 +978,8 @@ if features['d3d11']
 endif
 
 wayland = {
-    'deps': [dependency('wayland-client', version: '>= 1.15.0', required: get_option('wayland')),
-             dependency('wayland-cursor', version: '>= 1.15.0', required: get_option('wayland')),
+    'deps': [dependency('wayland-client', version: '>= 1.20.0', required: get_option('wayland')),
+             dependency('wayland-cursor', version: '>= 1.20.0', required: get_option('wayland')),
              dependency('wayland-protocols', version: '>= 1.15', required: get_option('wayland')),
              dependency('xkbcommon', version: '>= 0.3.0', required: get_option('wayland'))],
     'header': cc.has_header('linux/input-event-codes.h', required: get_option('wayland')),

--- a/meson.build
+++ b/meson.build
@@ -980,7 +980,7 @@ endif
 wayland = {
     'deps': [dependency('wayland-client', version: '>= 1.20.0', required: get_option('wayland')),
              dependency('wayland-cursor', version: '>= 1.20.0', required: get_option('wayland')),
-             dependency('wayland-protocols', version: '>= 1.15', required: get_option('wayland')),
+             dependency('wayland-protocols', version: '>= 1.25', required: get_option('wayland')),
              dependency('xkbcommon', version: '>= 0.3.0', required: get_option('wayland'))],
     'header': cc.has_header('linux/input-event-codes.h', required: get_option('wayland')),
     'scanner': find_program('wayland-scanner', required: get_option('wayland')),

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -475,8 +475,8 @@ static int preinit(struct vo *vo)
 
     wl_list_init(&p->buffer_list);
 
-    if (!vo->wl->dmabuf) {
-        MP_FATAL(vo->wl, "Compositor doesn't support the %s protocol!\n",
+    if (!vo->wl->dmabuf || !vo->wl->dmabuf_feedback) {
+        MP_FATAL(vo->wl, "Compositor doesn't support the %s (ver. 4) protocol!\n",
                  zwp_linux_dmabuf_v1_interface.name);
         goto err;
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1152,24 +1152,6 @@ static const struct wl_callback_listener frame_listener = {
     frame_callback,
 };
 
-static void dmabuf_format(void *data, struct zwp_linux_dmabuf_v1 *zwp_linux_dmabuf,
-                          uint32_t format)
-{
-    struct vo_wayland_state *wl = data;
-
-    if (wl->drm_format_ct == wl->drm_format_ct_max) {
-        wl->drm_format_ct_max *= 2;
-        wl->drm_formats = talloc_realloc(wl, wl->drm_formats, int, wl->drm_format_ct_max);
-    }
-
-    wl->drm_formats[wl->drm_format_ct++] = format;
-    MP_VERBOSE(wl, "%s is supported by the compositor.\n", mp_tag_str(format));
-}
-
-static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
-    dmabuf_format
-};
-
 static void done(void *data,
                  struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
 {
@@ -1261,11 +1243,6 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         wl->dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, 4);
         wl->dmabuf_feedback = zwp_linux_dmabuf_v1_get_default_feedback(wl->dmabuf);
         zwp_linux_dmabuf_feedback_v1_add_listener(wl->dmabuf_feedback, &dmabuf_feedback_listener, wl);
-    } else if (!strcmp (interface, zwp_linux_dmabuf_v1_interface.name) && (ver >= 2) && found++) {
-        wl->dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, 2);
-        zwp_linux_dmabuf_v1_add_listener(wl->dmabuf, &dmabuf_listener, wl);
-        wl->drm_format_ct_max = 64;
-        wl->drm_formats = talloc_array(wl, int, wl->drm_format_ct_max);
     }
 
     if (!strcmp (interface, wp_viewporter_interface.name) && (ver >= 1) && found++) {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -51,10 +51,6 @@
 #include "generated/wayland/fractional-scale-v1.h"
 #endif
 
-#if WAYLAND_VERSION_MAJOR > 1 || WAYLAND_VERSION_MINOR >= 20
-#define HAVE_WAYLAND_1_20
-#endif
-
 #if WAYLAND_VERSION_MAJOR > 1 || WAYLAND_VERSION_MINOR >= 22
 #define HAVE_WAYLAND_1_22
 #endif
@@ -722,7 +718,6 @@ static void output_handle_scale(void *data, struct wl_output *wl_output,
     output->scale = factor;
 }
 
-#ifdef HAVE_WAYLAND_1_20
 static void output_handle_name(void *data, struct wl_output *wl_output,
                                const char *name)
 {
@@ -734,17 +729,14 @@ static void output_handle_description(void *data, struct wl_output *wl_output,
                                       const char *description)
 {
 }
-#endif
 
 static const struct wl_output_listener output_listener = {
     output_handle_geometry,
     output_handle_mode,
     output_handle_done,
     output_handle_scale,
-#ifdef HAVE_WAYLAND_1_20
     output_handle_name,
     output_handle_description,
-#endif
 };
 
 static void surface_handle_enter(void *data, struct wl_surface *wl_surface,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -800,7 +800,6 @@ static void surface_handle_leave(void *data, struct wl_surface *wl_surface,
 }
 
 #ifdef HAVE_WAYLAND_1_22
-
 static void surface_handle_preferred_buffer_scale(void *data,
                                                   struct wl_surface *wl_surface,
                                                   int32_t scale)
@@ -828,7 +827,6 @@ static void surface_handle_preferred_buffer_transform(void *data,
                                                       uint32_t transform)
 {
 }
-
 #endif
 
 static const struct wl_surface_listener surface_listener = {
@@ -987,7 +985,6 @@ static void handle_toplevel_close(void *data, struct xdg_toplevel *xdg_toplevel)
     mp_input_put_key(wl->vo->input_ctx, MP_KEY_CLOSE_WIN);
 }
 
-#ifdef XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION
 static void handle_configure_bounds(void *data, struct xdg_toplevel *xdg_toplevel,
                                     int32_t width, int32_t height)
 {
@@ -995,14 +992,11 @@ static void handle_configure_bounds(void *data, struct xdg_toplevel *xdg_topleve
     wl->bounded_width = width * wl->scaling;
     wl->bounded_height = height * wl->scaling;
 }
-#endif
 
 static const struct xdg_toplevel_listener xdg_toplevel_listener = {
     handle_toplevel_config,
     handle_toplevel_close,
-#ifdef XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION
     handle_configure_bounds,
-#endif
 };
 
 #if HAVE_WAYLAND_PROTOCOLS_1_31
@@ -1176,7 +1170,6 @@ static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
     dmabuf_format
 };
 
-#if HAVE_WAYLAND_PROTOCOLS_1_24
 static void done(void *data,
                  struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
 {
@@ -1236,7 +1229,6 @@ static const struct zwp_linux_dmabuf_feedback_v1_listener dmabuf_feedback_listen
     tranche_formats,
     tranche_flags,
 };
-#endif
 
 static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id,
                                 const char *interface, uint32_t ver)
@@ -1267,10 +1259,8 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
 
     if (!strcmp (interface, zwp_linux_dmabuf_v1_interface.name) && (ver >= 4) && found++) {
         wl->dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, 4);
-#if HAVE_WAYLAND_PROTOCOLS_1_24
         wl->dmabuf_feedback = zwp_linux_dmabuf_v1_get_default_feedback(wl->dmabuf);
         zwp_linux_dmabuf_feedback_v1_add_listener(wl->dmabuf_feedback, &dmabuf_feedback_listener, wl);
-#endif
     } else if (!strcmp (interface, zwp_linux_dmabuf_v1_interface.name) && (ver >= 2) && found++) {
         wl->dmabuf = wl_registry_bind(reg, id, &zwp_linux_dmabuf_v1_interface, 2);
         zwp_linux_dmabuf_v1_add_listener(wl->dmabuf, &dmabuf_listener, wl);
@@ -2397,10 +2387,8 @@ void vo_wayland_uninit(struct vo *vo)
     if (wl->dmabuf)
         zwp_linux_dmabuf_v1_destroy(wl->dmabuf);
 
-#if HAVE_WAYLAND_PROTOCOLS_1_24
     if (wl->dmabuf_feedback)
         zwp_linux_dmabuf_feedback_v1_destroy(wl->dmabuf_feedback);
-#endif
 
     if (wl->seat)
         wl_seat_destroy(wl->seat);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -99,8 +99,7 @@ struct vo_wayland_state {
 
     /* linux-dmabuf */
     struct zwp_linux_dmabuf_v1 *dmabuf;
-    /* TODO: unvoid this if required wayland protocols is bumped to 1.24+ */
-    void *dmabuf_feedback;
+    struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
     wayland_format *format_map;
     uint32_t format_size;
     bool using_dmabuf_wayland;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -103,10 +103,6 @@ struct vo_wayland_state {
     wayland_format *format_map;
     uint32_t format_size;
     bool using_dmabuf_wayland;
-    /* TODO: remove these once zwp_linux_dmabuf_v1 version 2 support is removed. */
-    int *drm_formats;
-    int drm_format_ct;
-    int drm_format_ct_max;
 
     /* presentation-time */
     struct wp_presentation  *presentation;

--- a/video/out/wldmabuf/ra_wldmabuf.c
+++ b/video/out/wldmabuf/ra_wldmabuf.c
@@ -39,11 +39,6 @@ bool ra_compatible_format(struct ra* ra, uint32_t drm_format, uint64_t modifier)
             return true;
     }
 
-    for (int i = 0; i < wl->drm_format_ct; i++) {
-        if (drm_format == wl->drm_formats[i])
-            return true;
-    }
-
     return false;
 }
 

--- a/waftools/checks/custom.py
+++ b/waftools/checks/custom.py
@@ -102,7 +102,7 @@ def check_lua(ctx, dependency_identifier):
 
 def check_wl_protocols(ctx, dependency_identifier):
     def fn(ctx, dependency_identifier):
-        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.15")
+        ret = check_pkg_config_datadir("wayland-protocols", ">= 1.25")
         ret = ret(ctx, dependency_identifier)
         if ret != None:
             ctx.env.WL_PROTO_DIR = ret.split()[0]

--- a/wscript
+++ b/wscript
@@ -541,8 +541,8 @@ video_output_features = [
         'name': '--wayland',
         'desc': 'Wayland',
         'deps': 'wayland-protocols && wayland-scanner && linux-input-event-codes',
-        'func': check_pkg_config('wayland-client', '>= 1.15.0',
-                                 'wayland-cursor', '>= 1.15.0',
+        'func': check_pkg_config('wayland-client', '>= 1.20.0',
+                                 'wayland-cursor', '>= 1.20.0',
                                  'xkbcommon',      '>= 0.3.0'),
     } , {
         'name': 'wayland-protocols-1-24',

--- a/wscript
+++ b/wscript
@@ -545,11 +545,6 @@ video_output_features = [
                                  'wayland-cursor', '>= 1.20.0',
                                  'xkbcommon',      '>= 0.3.0'),
     } , {
-        'name': 'wayland-protocols-1-24',
-        'desc': 'wayland-protocols version 1.24+',
-        'deps': 'wayland',
-        'func': check_pkg_config('wayland-protocols >= 1.24'),
-    } , {
         'name': 'wayland-protocols-1-27',
         'desc': 'wayland-protocols version 1.27+',
         'deps': 'wayland',


### PR DESCRIPTION
Since debian 12 is out, we can bump quite a few wayland-related things without feeling too bad. This lets us drop a lot of annoying guards and stuff.