### PR TITLE
add --no-drag-and-drop and a windows implementation

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3078,13 +3078,14 @@ Window
 ``--snap-window``
     (Windows only) Snap the player window to screen edges.
 
-``--drag-and-drop=<auto|replace|append>``
+``--drag-and-drop=<no|auto|replace|append>``
     (X11 and Wayland only)
     Controls the default behavior of drag and drop on platforms that support this.
     ``auto`` will obey what the underlying os/platform gives mpv. Typically, holding
     shift during the drag and drop will append the item to the playlist. Otherwise,
     it will completely replace it. ``replace`` and ``append`` always force replacing
-    and appending to the playlist respectively.
+    and appending to the playlist respectively. ``no`` disables all drag and drop
+    behavior.
 
 ``--ontop``
     Makes the player window stay on top of other windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3079,7 +3079,7 @@ Window
     (Windows only) Snap the player window to screen edges.
 
 ``--drag-and-drop=<no|auto|replace|append>``
-    (X11 and Wayland only)
+    (X11, Wayland and Windows only)
     Controls the default behavior of drag and drop on platforms that support this.
     ``auto`` will obey what the underlying os/platform gives mpv. Typically, holding
     shift during the drag and drop will append the item to the playlist. Otherwise,

--- a/options/options.c
+++ b/options/options.c
@@ -38,6 +38,7 @@
 #include "m_config.h"
 #include "m_option.h"
 #include "common/common.h"
+#include "input/event.h"
 #include "stream/stream.h"
 #include "video/csputils.h"
 #include "video/hwdec.h"
@@ -106,8 +107,8 @@ static const struct m_sub_options screenshot_conf = {
 static const m_option_t mp_vo_opt_list[] = {
     {"vo", OPT_SETTINGSLIST(video_driver_list, &vo_obj_list)},
     {"taskbar-progress", OPT_BOOL(taskbar_progress)},
-    {"drag-and-drop", OPT_CHOICE(drag_and_drop, {"auto", -1}, {"replace", 0},
-        {"append", 1})},
+    {"drag-and-drop", OPT_CHOICE(drag_and_drop, {"no", -2}, {"auto", -1},
+        {"replace", DND_REPLACE}, {"append", DND_APPEND})},
     {"snap-window", OPT_BOOL(snap_window)},
     {"ontop", OPT_BOOL(ontop)},
     {"ontop-level", OPT_CHOICE(ontop_level, {"window", -1}, {"system", -2},

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1594,7 +1594,7 @@ static void *gui_thread(void *ptr)
     if (SUCCEEDED(OleInitialize(NULL))) {
         ole_ok = true;
 
-        IDropTarget *dt = mp_w32_droptarget_create(w32->log, w32->input_ctx);
+        IDropTarget *dt = mp_w32_droptarget_create(w32->log, w32->opts, w32->input_ctx);
         RegisterDragDrop(w32->window, dt);
 
         // ITaskbarList2 has the MarkFullscreenWindow method, which is used to

--- a/video/out/win32/droptarget.h
+++ b/video/out/win32/droptarget.h
@@ -25,9 +25,11 @@
 #include "input/input.h"
 #include "common/msg.h"
 #include "common/common.h"
+#include "options/options.h"
 
 // Create a IDropTarget implementation that sends dropped files to input_ctx
 IDropTarget *mp_w32_droptarget_create(struct mp_log *log,
+                                      struct mp_vo_opts *opts,
                                       struct input_ctx *input_ctx);
 
 #endif

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -982,7 +982,8 @@ static void vo_x11_dnd_handle_selection(struct vo *vo, XSelectionEvent *se)
 
     if (se->selection == XA(x11, XdndSelection) &&
         se->property == XAs(x11, DND_PROPERTY) &&
-        se->target == x11->dnd_requested_format)
+        se->target == x11->dnd_requested_format &&
+        x11->opts->drag_and_drop != -2)
     {
         int nitems;
         void *prop = x11_get_property(x11, x11->window, XAs(x11, DND_PROPERTY),


### PR DESCRIPTION
First commit implements the `no` option for `drag-and-drop`. The second commit attempts to implement the option in windows (didn't seem too bad looking at again). Of course, that is completely untested so if someone (ping @kasper93) could test to make sure it actually works, that would be appreciated.