### PR TITLE
terminal-unix: fix infinite loop when read returns EIO

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -418,7 +418,7 @@ static void *terminal_thread(void *ptr)
         int r = polldev(fds, stdin_ok ? 2 : 1, buf.len ? ESC_TIMEOUT : INPUT_TIMEOUT);
         if (fds[0].revents)
             break;
-        if (fds[1].revents) {
+        if (fds[1].revents & POLLIN) {
             int retval = read(tty_in, &buf.b[buf.len], BUF_LEN - buf.len);
             if (!retval || (retval == -1 && (errno == EBADF || errno == EINVAL)))
                 break; // EOF/closed
@@ -426,6 +426,9 @@ static void *terminal_thread(void *ptr)
                 buf.len += retval;
                 process_input(input_ctx, false);
             }
+        }
+        if (fds[1].revents & POLLHUP) {
+            break;
         }
         if (r == 0)
             process_input(input_ctx, true);


### PR DESCRIPTION
This commit fixes #11795.

If parent terminal is closed while mpv is running, read(2) starts returning EIO, resulting in an infinite loop using 100% of the CPU.

This commit makes sure we don't loop needlessly if read(2) returns EIO.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.