### PR TITLE
stream: accept dav:// and davs:// urls

### DIFF
--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -285,16 +285,16 @@ static int open_f(stream_t *stream)
     }
 
     // Replace "mms://" with "mmsh://", so that most mms:// URLs just work.
-    // Replace "webdav://" with "http://" and "webdavs://" with "https://"
+    // Replace "dav://" or "webdav://" with "http://" and "davs://" or "webdavs://" with "https://"
     bstr b_filename = bstr0(filename);
     if (bstr_eatstart0(&b_filename, "mms://") ||
         bstr_eatstart0(&b_filename, "mmshttp://"))
     {
         filename = talloc_asprintf(temp, "mmsh://%.*s", BSTR_P(b_filename));
-    } else if (bstr_eatstart0(&b_filename, "webdav://"))
+    } else if (bstr_eatstart0(&b_filename, "dav://") || bstr_eatstart0(&b_filename, "webdav://"))
     {
         filename = talloc_asprintf(temp, "http://%.*s", BSTR_P(b_filename));
-    } else if (bstr_eatstart0(&b_filename, "webdavs://"))
+    } else if (bstr_eatstart0(&b_filename, "davs://") || bstr_eatstart0(&b_filename, "webdavs://"))
     {
         filename = talloc_asprintf(temp, "https://%.*s", BSTR_P(b_filename));
     }
@@ -418,8 +418,8 @@ const stream_info_t stream_info_ffmpeg = {
   .protocols = (const char *const[]){
      "rtmp", "rtsp", "rtsps", "http", "https", "mms", "mmst", "mmsh", "mmshttp",
      "rtp", "httpproxy", "rtmpe", "rtmps", "rtmpt", "rtmpte", "rtmpts", "srt",
-     "rist", "srtp", "gopher", "gophers", "data", "ipfs", "ipns", "webdav",
-     "webdavs",
+     "rist", "srtp", "gopher", "gophers", "data", "ipfs", "ipns", "dav",
+     "davs", "webdav", "webdavs",
      NULL },
   .can_write = true,
   .stream_origin = STREAM_ORIGIN_NET,


### PR DESCRIPTION
Re-submit the pull request based on https://github.com/mpv-player/mpv/pull/11703.

https://github.com/mpv-player/mpv/issues/11080 has been submitted to mpv for handling webdav:// and webdavs:// links. However, the GNOME Nautilus file manager that I'm using does not support browsing of webdav:// and webdavs:// links.

The GNOME Nautilus file manager supports browsing of dav:// and davs:// links only. Additionally, dav:// and davs:// are also types of webdav links. Therefore, adding an "or" operation to include support for dav:// and davs:// links.