### PR TITLE
ao_pipewire: bump dependency to 0.3.48

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -35,18 +35,6 @@
 #include "internal.h"
 #include "osdep/timer.h"
 
-// Added in Pipewire 0.3.33
-// remove the fallback when we require a newer version
-#ifndef PW_KEY_NODE_RATE
-#define PW_KEY_NODE_RATE "node.rate"
-#endif
-
-// Added in Pipewire 0.3.44
-// remove the fallback when we require a newer version
-#ifndef PW_KEY_TARGET_OBJECT
-#define PW_KEY_TARGET_OBJECT "target.object"
-#endif
-
 #if !PW_CHECK_VERSION(0, 3, 50)
 static inline int pw_stream_get_time_n(struct pw_stream *stream, struct pw_time *time, size_t size) {
 	return pw_stream_get_time(stream, time);

--- a/meson.build
+++ b/meson.build
@@ -826,7 +826,7 @@ if features['oss-audio']
     sources += files('audio/out/ao_oss.c')
 endif
 
-pipewire = dependency('libpipewire-0.3', version: '>= 0.3.19', required: get_option('pipewire'))
+pipewire = dependency('libpipewire-0.3', version: '>= 0.3.48', required: get_option('pipewire'))
 features += {'pipewire': pipewire.found()}
 if features['pipewire']
     dependencies += pipewire


### PR DESCRIPTION
Now that Debian 12 is released, bump the minium required version to what is provided in Ubuntu Jammy (22.04).
The same as has been done for the wayland dependencies.