### PR TITLE
vd_lavc: let the user provide a priority list of hwdecs to consider

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1185,7 +1185,7 @@ Video
 ``--display-fps=<fps>``
     Deprecated alias for ``--override-display-fps``.
 
-``--hwdec=<api>``
+``--hwdec=<api1,api2,...|no|auto|auto-safe|auto-copy>``
     Specify the hardware video decoding API that should be used if possible.
     Whether hardware decoding is actually done depends on the video codec. If
     hardware decoding is not possible, mpv will fall back on software decoding.
@@ -1244,13 +1244,20 @@ Video
         - If you're a developer, or want to perform elaborate tests, you may
           need any of the other possible option values.
 
-    ``<api>`` can be one of the following:
+    This option accepts a comma delimited list of ``api`` types, along with certain
+    special values:
 
     :no:        always use software decoding (default)
     :auto:      forcibly enable any hw decoder found (see below)
     :yes:       exactly the same as ``auto``
     :auto-safe: enable any whitelisted hw decoder (see below)
     :auto-copy: enable best hw decoder with copy-back (see below)
+
+    .. note::
+
+        Special values can be mixed with api names. eg: ``vaapi,auto`` will try
+        and use the ``vaapi`` hwdec, and if that fails, will run through the
+        normal ``auto`` logic.
 
     Actively supported hwdecs:
 


### PR DESCRIPTION
Today, the only way to make mpv consider multiple hwdecs and pick the first one that works is to use one of the `auto` modes. But the list that is considered in those cases is hard-coded. If the user wants to provide their own list, they are out of luck.

And I think that there is now a significant reason to support this - the new Vulkan hwdec is definitely not ready to be in the auto list, but if you want to use it by default, it will not work with many codecs that are normally hardware decodable (only h.264, hevc and av1 if you are very lucky). Everything else will fall back to software decoding.

Instead, what you really want to say is: use Vulkan for whatever it supports, and fall back to my old hwdec for everything else.

One side-effect of this implementation is that you can freely mix hwdec names and special values like `auto` and `no`. The behaviour will be correct, so I didn't try and prohibit any combinations. However, some combinations will be silly - eg: sticking any further values after `no` will result in them being ignored. On the other hand, a combination like `vulkan,auto` could be very useful as that will use Vulkan if possible, and if not, run the normal auto routine.

Fixes #11797 
