### PR TITLE
ci/msys2: switch to Python 3.11 to fix crashes during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
             meson:p
             ninja:p
             pkgconf:p
-            python:p
+            python3.11:p
             rst2pdf:p
             rubberband:p
             shaderc:p

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -2,6 +2,7 @@
 
 if [ "$1" = "meson" ]; then
     meson setup build            \
+      --native-file=ci/msys2-meson.txt \
       -D cdda=enabled            \
       -D d3d-hwaccel=enabled     \
       -D d3d11=enabled           \

--- a/ci/msys2-meson.txt
+++ b/ci/msys2-meson.txt
@@ -1,0 +1,2 @@
+[binaries]
+python3 = 'python3.11'


### PR DESCRIPTION
There is a long-standing bug with random crashes of Python 3.10 on CI.

See:
https://github.com/python/cpython/issues/105400
https://github.com/msys2/MINGW-packages/issues/11864
https://github.com/msys2/MINGW-packages/issues/17415