### PR TITLE
hwdec: Fix undeclared identifier in mediacodec_embed

### DIFF
--- a/video/out/vo_mediacodec_embed.c
+++ b/video/out/vo_mediacodec_embed.c
@@ -57,7 +57,7 @@ static int preinit(struct vo *vo)
     };
 
     if (!p->hwctx.av_device_ref) {
-        MP_VERBOSE(hw, "Failed to create hwdevice_ctx\n");
+        MP_VERBOSE(vo, "Failed to create hwdevice_ctx\n");
         return -1;
     }
 


### PR DESCRIPTION
mediacodec_embed uses "vo" instead of "hw". Fix the following error:

../video/out/vo_mediacodec_embed.c:60:20: error: use of undeclared identifier 'hw'
        MP_VERBOSE(hw, "Failed to create hwdevice_ctx\n");
