### PR TITLE
console.lua: add script-opt --max-msg-level

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -153,3 +153,15 @@ Configurable Options
     Default: true
 
     Remove duplicate entries in history as to only keep the latest one.
+
+``max_msg_level``
+    Default: v
+
+    Set the maximum message level for the console. Use the levels from
+    ``--msg-level``, excluding ``status``. ``--max_msg_level`` only affects the
+    console, not the outputs of the terminal or log file.
+
+    .. note::
+
+        ``status`` is not a standard verbosity level. It controls the
+        `TERMINAL STATUS LINE`_.


### PR DESCRIPTION
I have been writing scripts to extend mpv for a few months and eventually grew annoyed that the console did not allow trace messages, so I made an option to control this (mentioned in #11761).

If you aren't interested in using the console for trace messages (which is probably more sane), the option can still be useful for nearly the opposite reason. The console can be restricted to only important messages, while the terminal shows more granularity.

These commits are functional & already implement what's mentioned above, but I have a couple related ideas and questions:

**debug and trace message styles/colors**
I think they're identical, at least in the terminal on Windows (and trace wasn't relevant to the console before this). Looking at the theme that the console pulls from [(here)](https://github.com/chriskempson/base16-vim/blob/3be3cd82cd31acfcab9a41bad853d9c68d30478d/colors/base16-eighties.vim#L26), would gui05 (#747369) be a good color for trace to differentiate it from debug messages?

**a non-static default for `--max-msg-level`**
Rather than `info`, when `--max-msg-level` is not explicitly set, maybe determine the most noisy level set in `--msg-level` and use that? I actually wrote this already, but I wasn't sure if it was desirable to anyone other than myself.

I've tried to be thorough, but please let me know if there's anything I should correct! Thanks!