### PR TITLE
ci/msys2: double down on running meson through python3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,6 @@ jobs:
             libjpeg-turbo:p
             libplacebo:p
             lua51:p
-            meson:p
             ninja:p
             pkgconf:p
             python3.11:p
@@ -280,6 +279,7 @@ jobs:
       - name: Run meson tests
         id: tests
         run: |
+          source ./venv/bin/activate
           meson test -C build
 
       - name: Print meson test log

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -1,8 +1,10 @@
 #!/bin/sh -e
 
 if [ "$1" = "meson" ]; then
+    python3.11 -m venv venv
+    source ./venv/bin/activate
+    python -m pip install meson
     meson setup build            \
-      --native-file=ci/msys2-meson.txt \
       -D cdda=enabled            \
       -D d3d-hwaccel=enabled     \
       -D d3d11=enabled           \

--- a/ci/msys2-meson.txt
+++ b/ci/msys2-meson.txt
@@ -1,2 +1,0 @@
-[binaries]
-python3 = 'python3.11'


### PR DESCRIPTION
Fixes: eb4da3400a1c37eea7b258b00297e8b8fcdd8db4