### PR TITLE
mp_image: abort on av_buffer_ref() failure

### DIFF
--- a/sub/osd.c
+++ b/sub/osd.c
@@ -548,7 +548,6 @@ struct sub_bitmaps *sub_bitmaps_copy(struct sub_bitmap_copy_cache **p_cache,
     assert(in->packed && in->packed->bufs[0]);
 
     res->packed = mp_image_new_ref(res->packed);
-    MP_HANDLE_OOM(res->packed);
     talloc_steal(res, res->packed);
 
     res->parts = NULL;

--- a/video/filter/refqueue.c
+++ b/video/filter/refqueue.c
@@ -266,7 +266,6 @@ struct mp_image *mp_refqueue_execute_reinit(struct mp_refqueue *q)
     mp_refqueue_flush(q);
 
     q->in_format = mp_image_new_ref(cur);
-    MP_HANDLE_OOM(q->in_format);
     mp_image_unref_data(q->in_format);
 
     mp_refqueue_add_input(q, cur);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1438,10 +1438,8 @@ struct vo_frame *vo_frame_ref(struct vo_frame *frame)
     struct vo_frame *new = talloc_ptrtype(NULL, new);
     talloc_set_destructor(new, destroy_frame);
     *new = *frame;
-    for (int n = 0; n < frame->num_frames; n++) {
+    for (int n = 0; n < frame->num_frames; n++)
         new->frames[n] = mp_image_new_ref(frame->frames[n]);
-        MP_HANDLE_OOM(new->frames[n]);
-    }
     new->current = new->num_frames ? new->frames[0] : NULL;
     return new;
 }


### PR DESCRIPTION
this changes mp_image_new_ref() to handle allocation failure itself instead of doing it at its many call-sites (some of which never checked for failure at all).

also remove MP_HANDLE_OOM() from the call sites since this is not necessary anymore.

not all the call-sites have been touched, since some of the caller might be relying on `mp_image_new_ref(NULL)` returning NULL.

Fixes: https://github.com/mpv-player/mpv/issues/11840