### PR TITLE
BUG: mouse scroll wheel sensitivity is too low/slow/laggy: WHEEL_DOWN WHEEL_UP WHEEL_LEFT WHEEL_RIGHT are ignored for 200ms #11851

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -651,7 +651,7 @@ static bool process_wheel(struct input_ctx *ictx, int code, double *scale,
     static const double DEADZONE_DIST = 0.125;
     // The deadzone accumulator is reset if no scrolls happened in this many
     // seconds, eg. the user is assumed to have finished scrolling.
-    static const double DEADZONE_SCROLL_TIME = 0.2;
+    static const double DEADZONE_SCROLL_TIME = 0;
     // The scale_units accumulator is reset if no scrolls happened in this many
     // seconds. This value should be fairly large, so commands will still be
     // sent when the user scrolls slowly.

--- a/input/input.c
+++ b/input/input.c
@@ -648,7 +648,7 @@ static bool process_wheel(struct input_ctx *ictx, int code, double *scale,
 {
     // Size of the deadzone in scroll units. The user must scroll at least this
     // much in any direction before their scroll is registered.
-    static const double DEADZONE_DIST = 0.125;
+    static const double DEADZONE_DIST = 0;
     // The deadzone accumulator is reset if no scrolls happened in this many
     // seconds, eg. the user is assumed to have finished scrolling.
     static const double DEADZONE_SCROLL_TIME = 0;


### PR DESCRIPTION
fixes #11851
reverting back to old behaviour (and thus unfixing #4613 ), which = very fast mouse scroll responses

no knowledge how to make deadzone mpv config options now, but we can reopen that 6 year old issue when touchpad users begin having issues again

compiled and tested. fixed issue