### PR TITLE
options: minor style fixes

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -1033,9 +1033,7 @@ static const struct MPOpts mp_default_opts = {
                      [STREAM_VIDEO] = -2,
                      [STREAM_SUB] = -2, }, },
     .stream_lang = {
-        NULL, // video
-        NULL, // audio
-        (char**)(const char*[]) {"auto", NULL} // subtitles
+        [STREAM_SUB] = (char**)(const char*[]) {"auto", NULL},
     },
     .stream_auto_sel = true,
     .subs_with_matching_audio = false,

--- a/options/options.c
+++ b/options/options.c
@@ -1033,7 +1033,7 @@ static const struct MPOpts mp_default_opts = {
                      [STREAM_VIDEO] = -2,
                      [STREAM_SUB] = -2, }, },
     .stream_lang = {
-        [STREAM_SUB] = (char**)(const char*[]) {"auto", NULL},
+        [STREAM_SUB] = (char *[]){ "auto", NULL },
     },
     .stream_auto_sel = true,
     .subs_with_matching_audio = false,
@@ -1057,7 +1057,7 @@ static const struct MPOpts mp_default_opts = {
 
     .mf_fps = 1.0,
 
-    .display_tags = (char **)(const char*[]){
+    .display_tags = (char *[]){
         "Artist", "Album", "Album_Artist", "Comment", "Composer",
         "Date", "Description", "Genre", "Performer", "Rating",
         "Series", "Title", "Track", "icy-title", "service_name",
@@ -1067,7 +1067,7 @@ static const struct MPOpts mp_default_opts = {
 
     .cuda_device = -1,
 
-    .watch_later_options = (char **)(const char*[]){
+    .watch_later_options = (char *[]){
         "start",
         "osd-level",
         "speed",


### PR DESCRIPTION
### options: use designated initializer

shorter and more robust this way instead of inserting at an index by
manually counting.

the surrounding code also uses `[STREAM_*] = ..` so it's more consistent
as well.

### options: drop unnecessary casts

the reason for these casts are unknown but they were presumably to
silence warnings 9 years ago. but it doesn't seem to be necessary
nowadays, so just drop the casts and also drop the `const` from the
compound literal type.

some small technical notes:

1. while string literals aren't `const` in C, writing to them is
undefined (do not ask me why). and so compilers will typically put
string literals into read only section anyways, regardless of
weather `const` was used in the source or not. so this shouldn't make
any difference codegen wise.
2. making the array of pointers `const` on the other hand might affect
codegen, eg: `(char *const []){...}`. however, that'd trigger a lot
of discarded qualifier warnings.
