### PR TITLE
TOOLS/lua/autoload.lua: load current file extension into playlist if it's unknown

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -16,6 +16,7 @@ disabled=no
 images=no
 videos=yes
 audio=yes
+ownfiletype=yes
 ignore_hidden=yes
 
 --]]
@@ -31,6 +32,7 @@ o = {
     images = true,
     videos = true,
     audio = true,
+    ownfiletype = true,
     ignore_hidden = true
 }
 options.read_options(o)
@@ -136,6 +138,10 @@ function find_and_add_entries()
     elseif #dir == 0 then
         msg.verbose("stopping: not a local path")
         return
+    end
+
+    if o.ownfiletype then
+        EXTENSIONS = SetUnion(EXTENSIONS, Set{string.lower(get_extension(filename))})
     end
 
     pl_count = mp.get_property_number("playlist-count", 1)


### PR DESCRIPTION
Added an option to load other files that are the same as the file extension of the currently playing file, even if they are unknown file type to the script, extending the functionality of the script.

If the newly created option - `ownfiletype` - is enabled, the filetype of the currently playing file will be added to `EXTENSIONS`. This is done even if the filetype is already contained in the default table sets.

### Example
Playing an obscure filetype like `.bfstm` will now result in the script being able to add other `.bfstm` files into the playlist.

![image](https://github.com/mpv-player/mpv/assets/50119098/1b4c3cf4-34f4-4000-9f74-1439853ba235)
![image](https://github.com/mpv-player/mpv/assets/50119098/c5b16aa8-18f5-4fd3-8384-e8513f67ebac)