### PR TITLE
msg: print MSGL_WARN and higher error messages to stderr

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -306,7 +306,8 @@ static void print_terminal_line(struct mp_log *log, int lev,
         return;
 
     struct mp_log_root *root = log->root;
-    FILE *stream = (root->force_stderr || lev == MSGL_STATUS) ? stderr : stdout;
+    FILE *stream = (root->force_stderr || lev == MSGL_STATUS || lev == MSGL_FATAL ||
+                    lev == MSGL_ERR || lev == MSGL_WARN) ? stderr : stdout;
 
     if (lev != MSGL_STATUS)
         flush_status_line(root);


### PR DESCRIPTION
mpv has a historical convention where it actually always prints stuff to stdout. When doing encoding mode and outputing it to stdout, there's logic during startup force all the output to stderr instead so it doesn't mess up the encode. This is well and good, but mpv can put messages into stdout before mp_msg_force_stderr is run (like parsing a config file and finding errors). That puts junk data in the encode and screws up the output. Fix it by simply running an fseek in mp_msg_force_stderr to mark that as the start of the stream. That function is only ever called by encode mode anyways.

Supersedes #9302 (see some discussion there).