### PR TITLE
terminal-unix: better error detection logic

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -420,7 +420,7 @@ static void *terminal_thread(void *ptr)
             break;
         if (fds[1].revents) {
             int retval = read(tty_in, &buf.b[buf.len], BUF_LEN - buf.len);
-            if (!retval || (retval == -1 && (errno == EBADF || errno == EINVAL)))
+            if (!retval || (retval == -1 && errno != EINTR && errno != EAGAIN))
                 break; // EOF/closed
             if (retval > 0) {
                 buf.len += retval;


### PR DESCRIPTION
the reason for checking `EBADF|EINVAL` specifically is unknown. but it's clearly not working as intended since it can cause issues like #11795.

instead of checking for "bad errors" check for known "good errors" where we might not want to break out. this includes:

* EINTR: which can happen if read() is interrupted by some signal.
* EAGAIN: which happens if a non-blocking fd would block. `tty_in` is _not_ non-blocking, so EAGAIN should never occur here. but it's added just in case that changes in the future.

Fixes: https://github.com/mpv-player/mpv/issues/11795

- - -

Supersedes https://github.com/mpv-player/mpv/pull/11805, since that PR seems to be abandoned by the author. There was some discussion about the issue in that PR.