### PR TITLE
vo_gpu_next: use pl_dispatch_info_move to avoid useless data copy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -930,8 +930,8 @@ if features['libplacebo']
 endif
 
 libplacebo_next = get_option('libplacebo-next').require(
-    features['libplacebo'] and libplacebo.version().version_compare('>=5.264.0'),
-    error_message: 'libplacebo v5.264.0+ was not found!',
+    features['libplacebo'] and libplacebo.version().version_compare('>=5.266.0'),
+    error_message: 'libplacebo v5.266.0+ was not found!',
 )
 features += {'libplacebo-next': libplacebo_next.allowed()}
 if features['libplacebo-next']


### PR DESCRIPTION
Instead copy the data on-demand when VOCTRL_PERFORMANCE_DATA is requested.

This require minimal libplacebo API version bump. Since new libplacebo release is close and the requirement in mpv is planned to be bumped too let's wait for it instead ifdefing everything. In the meantime we can review, so it is ready when it gets unblocked.