### PR TITLE
vo_dmabuf_wayland: add osd support

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -292,8 +292,7 @@ Available video output drivers are:
     and to perform scaling and color space conversion using fixed-function hardware,
     if available, rather than GPU shaders. This frees up GPU resources for other tasks.
     Currently this driver is experimental and only works with the ``--hwdec=vaapi``
-    or ``hwdec=drm`` drivers;
-    OSD is also not supported. Supported compositors : Weston and Sway.
+    or ``hwdec=drm`` drivers. Supported compositors : Weston and Sway.
 
 ``vaapi``
     Intel VA API video output driver with support for hardware decoding. Note

--- a/sub/draw_bmp.c
+++ b/sub/draw_bmp.c
@@ -485,6 +485,10 @@ static void clear_rgba_overlay(struct mp_draw_sub_cache *p)
         for (int sx = 0; sx < p->s_w; sx++) {
             struct slice *s = &line[sx];
 
+            // Ensure this final slice doesn't extend beyond the width of p->s_w
+            if (s->x1 == SLICE_W && sx == p->s_w - 1 && y == p->rgba_overlay->h - 1)
+                s->x1 = MPMIN(p->w - ((p->s_w - 1) * SLICE_W), s->x1);
+
             if (s->x0 <= s->x1) {
                 memset(px + s->x0, 0, (s->x1 - s->x0) * 4);
                 *s = (struct slice){SLICE_W, 0};

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -467,11 +467,11 @@ static int preinit(struct vo *vo)
     p->log = vo->log;
     p->global = vo->global;
     p->ctx = ra_ctx_create_by_name(vo, "wldmabuf");
+    wl_list_init(&p->buffer_list);
     if (!p->ctx)
        goto err;
-    assert(p->ctx->ra);
 
-    wl_list_init(&p->buffer_list);
+    assert(p->ctx->ra);
 
     if (!vo->wl->dmabuf || !vo->wl->dmabuf_feedback) {
         MP_FATAL(vo->wl, "Compositor doesn't support the %s (ver. 4) protocol!\n",

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -328,15 +328,13 @@ static void resize(struct vo *vo)
     vo->opts->pan_x = 0;
     vo->opts->pan_y = 0;
     vo_get_src_dst_rects(vo, &src, &dst, &osd);
-    if (wl->viewport)
-        wp_viewport_set_destination(wl->viewport, 2 * dst.x0 + mp_rect_w(dst), 2 * dst.y0 + mp_rect_h(dst));
+    wp_viewport_set_destination(wl->viewport, 2 * dst.x0 + mp_rect_w(dst), 2 * dst.y0 + mp_rect_h(dst));
 
     //now we restore pan for video viewport calculation
     vo->opts->pan_x = vo_opts->pan_x;
     vo->opts->pan_y = vo_opts->pan_y;
     vo_get_src_dst_rects(vo, &src, &dst, &osd);
-    if (wl->video_viewport)
-        wp_viewport_set_destination(wl->video_viewport, mp_rect_w(dst), mp_rect_h(dst));
+    wp_viewport_set_destination(wl->video_viewport, mp_rect_w(dst), mp_rect_h(dst));
     wl_subsurface_set_position(wl->video_subsurface, dst.x0, dst.y0);
     set_viewport_source(vo, src);
 }

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -49,6 +49,8 @@ struct vo_wayland_state {
     struct wl_registry      *registry;
     struct wl_shm           *shm;
     struct wl_surface       *surface;
+    struct wl_surface       *osd_surface;
+    struct wl_subsurface    *osd_subsurface;
     struct wl_surface       *video_surface;
     struct wl_surface       *callback_surface;
     struct wl_subsurface    *video_subsurface;
@@ -133,6 +135,7 @@ struct vo_wayland_state {
     /* viewporter */
     struct wp_viewporter *viewporter;
     struct wp_viewport   *viewport;
+    struct wp_viewport   *osd_viewport;
     struct wp_viewport   *video_viewport;
 
     /* Input */


### PR DESCRIPTION
Fixes #10342 and supersedes #10322.

Draft right now for two reasons.
- [x] The osd flickers kind of funny (minor and not a blocker imo).
- [x] If you rapidly resize with the mouse and hover over the video to trigger the osd, you can cause a buffer overflow sometimes (ouch).

vo_vaapi, where the drawing osd bits of this code are lifted from, actually crashes right now on master with ASAN as soon as you try to resize it with the mouse. I just think there's something fundamentally wrong with the code in this area (without d1d2370d073e9b70a181696e57075545b4802517 and e97819f88e451623a397b79d101497205fe849f9 it just crashed instantly in mark_rect instead so those didn't cause a regression; they help). I'll try to look into it.