### PR TITLE
wscript: bump required libplacebo-next version to 5.266

### DIFF
--- a/wscript
+++ b/wscript
@@ -792,9 +792,9 @@ video_output_features = [
         'func': check_pkg_config('libplacebo >= 4.157.0'),
     }, {
         'name': '--libplacebo-next',
-        'desc': 'libplacebo v5.264.0+, needed for vo_gpu_next',
+        'desc': 'libplacebo v5.266.0+, needed for vo_gpu_next',
         'deps': 'libplacebo',
-        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 264',
+        'func': check_preprocessor('libplacebo/config.h', 'PL_API_VER >= 266',
                                    use='libplacebo'),
     }, {
         'name': 'libplacebo-decode',


### PR DESCRIPTION
Was forgotten in b73d96776cfee61f88bf60b27315baab32a2115d. Can't wait until we finally remove the waf build.