### PR TITLE
various: correctly ignore cache files with --no-config

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -719,9 +719,9 @@ Program Behavior
     Print version string and exit.
 
 ``--no-config``
-    Do not load default configuration files. This prevents loading of both the
-    user-level and system-wide ``mpv.conf`` and ``input.conf`` files. Other
-    configuration files are blocked as well, such as resume playback files.
+    Do not load default configuration or any user files. This prevents loading of
+    both the user-level and system-wide ``mpv.conf`` and ``input.conf`` files. Other
+    user files are blocked as well, such as resume playback files and cache files.
 
     .. note::
 

--- a/demux/cache.c
+++ b/demux/cache.c
@@ -105,8 +105,11 @@ struct demux_cache *demux_cache_create(struct mpv_global *global,
     } else {
         cache_dir = mp_find_user_file(NULL, global, "cache", "");
     }
-    mp_mkdirp(cache_dir);
 
+    if (!cache_dir || !cache_dir[0])
+        goto fail;
+
+    mp_mkdirp(cache_dir);
     cache->filename = mp_path_join(cache, cache_dir, "mpv-cache-XXXXXX.dat");
     cache->fd = mp_mkostemps(cache->filename, 4, O_CLOEXEC);
     if (cache->fd < 0) {

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -359,12 +359,13 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
             cache_dir = mp_find_user_file(tmp, p->global, "cache", "");
         }
 
-        cache_file = talloc_strdup(tmp, "");
-        for (int i = 0; i < sizeof(hash); i++)
-            cache_file = talloc_asprintf_append(cache_file, "%02X", hash[i]);
-        cache_file = mp_path_join(tmp, cache_dir, cache_file);
-
-        mp_mkdirp(cache_dir);
+        if (cache_dir && cache_dir[0]) {
+            cache_file = talloc_strdup(tmp, "");
+            for (int i = 0; i < sizeof(hash); i++)
+                cache_file = talloc_asprintf_append(cache_file, "%02X", hash[i]);
+            cache_file = mp_path_join(tmp, cache_dir, cache_file);
+            mp_mkdirp(cache_dir);
+        }
     }
 
     // check cache

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1381,9 +1381,10 @@ static void wait_events(struct vo *vo, int64_t until_time_us)
 
 static char *get_cache_file(struct priv *p)
 {
+    char *file = NULL;
     struct gl_video_opts *opts = p->opts_cache->opts;
     if (!opts->shader_cache)
-        return NULL;
+        goto done;
 
     char *dir = opts->shader_cache_dir;
     if (dir && dir[0]) {
@@ -1391,9 +1392,12 @@ static char *get_cache_file(struct priv *p)
     } else {
         dir = mp_find_user_file(NULL, p->global, "cache", "");
     }
-    char *file = mp_path_join(NULL, dir, "libplacebo.cache");
-    mp_mkdirp(dir);
+    if (dir && dir[0]) {
+        file = mp_path_join(NULL, dir, "libplacebo.cache");
+        mp_mkdirp(dir);
+    }
     talloc_free(dir);
+done:
     return file;
 }
 
@@ -1635,8 +1639,11 @@ static stream_t *icc_open_cache(struct priv *p, uint64_t sig, int flags)
     } else {
         cache_dir = mp_find_user_file(NULL, p->global, "cache", "");
     }
-    char *path = mp_path_join(NULL, cache_dir, cache_name);
 
+    if (!cache_dir || !cache_dir[0])
+        return NULL;
+
+    char *path = mp_path_join(NULL, cache_dir, cache_name);
     stream_t *stream = NULL;
     if (flags & STREAM_WRITE) {
         mp_mkdirp(cache_dir);


### PR DESCRIPTION
mp_get_platform_path has a trick where it will return null if
--no-config is used in order to avoid loading config files. When trying
to get a cache or state path, this logic was copied, but it doesn't
really make any sense. We should always try to get some path when
calling either one of those types and avoid returning NULL. It fixes a
segfault that occurs if you do --no-config --vo=gpu-next because cache
is on by default and the aforementioned behavior of
mp_get_platform_path.

@sfan5: I don't think this should regress anything for android but could you double check?