### PR TITLE
TOOLS/idet.sh: update the msg-level option for modern mpv syntax

### DIFF
--- a/TOOLS/idet.sh
+++ b/TOOLS/idet.sh
@@ -22,7 +22,7 @@
 testfun()
 {
     $ILDETECT_MPV "$@" \
-        --vf-add=lavfi="[idet]" --msg-level ffmpeg=v \
+        --vf-add=lavfi="[idet]" --msg-level=ffmpeg=v \
         --o= --vo=null --no-audio --untimed \
         $ILDETECT_MPVFLAGS \
         | { if [ -n "$ILDETECT_QUIET" ]; then cat; else tee /dev/stderr; fi } \


### PR DESCRIPTION
idet.sh generates an error with recent versions of mpv.  PR corrects the mpv syntax for `--msg-level=<module1=level1>`, allowing idet.sh to execute without `Fatal Error`.

**Before PR**
```
$ ./mpv/TOOLS/idet.sh infile.mp4 

Error parsing commandline option msg-level: option requires parameter
Make sure you're using e.g. '--msg-level=value' instead of '--msg-level value'.
Exiting... (Fatal error)
```

**After PR**

- [x] Script executes successfully.

```
% ./mpv/TOOLS/idet.sh infile.mp4
 (+) Video --vid=1 (*) (h264 1920x1080 30.000fps)
     Audio --aid=1 (*) (mp3 2ch 48000Hz)
     Audio --aid=2 (*) (ac3 6ch 48000Hz)
 (+) Subs  --sid=1 (*) (eia_608)

[ffmpeg] Parsed_idet_0: Repeated Fields: Neither:     0 Top:     0 Bottom:     0
[ffmpeg] Parsed_idet_0: Single frame detection: TFF:     0 BFF:     0 Progressive:     0 Undetermined:     0
[ffmpeg] Parsed_idet_0: Multi frame detection: TFF:     0 BFF:     0 Progressive:     0 Undetermined:     0
VO: [null] 1920x1080 yuv420p
V: 00:04:17 / 00:10:34 (41%)

[ffmpeg] Parsed_idet_0: Repeated Fields: Neither:  1110 Top:     0 Bottom:     0
[ffmpeg] Parsed_idet_0: Single frame detection: TFF:     0 BFF:     0 Progressive:   614 Undetermined:   496
[ffmpeg] Parsed_idet_0: Multi frame detection: TFF:     0 BFF:     0 Progressive:  1101 Undetermined:     9
```


- [x] Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md