### PR TITLE
player: delete watch_later file after successful load

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -396,17 +396,18 @@ void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file)
     talloc_free(fname);
 }
 
-void mp_load_playback_resume(struct MPContext *mpctx, const char *file)
+bool mp_load_playback_resume(struct MPContext *mpctx, const char *file)
 {
+    bool resume = false;
     if (!mpctx->opts->position_resume)
-        return;
+        return resume;
     char *fname = mp_get_playback_resume_config_filename(mpctx, file);
     if (fname && mp_path_exists(fname)) {
         if (mpctx->opts->position_check_mtime &&
             !mp_is_url(bstr0(file)) && !check_mtime(file, fname))
         {
             talloc_free(fname);
-            return;
+            return resume;
         }
 
         // Never apply the saved start position to following files
@@ -414,9 +415,10 @@ void mp_load_playback_resume(struct MPContext *mpctx, const char *file)
         MP_INFO(mpctx, "Resuming playback. This behavior can "
                "be disabled with --no-resume-playback.\n");
         try_load_config(mpctx, fname, M_SETOPT_PRESERVE_CMDLINE, MSGL_V);
-        unlink(fname);
+        resume = true;
     }
     talloc_free(fname);
+    return resume;
 }
 
 // Returns the first file that has a resume config.

--- a/player/core.h
+++ b/player/core.h
@@ -495,7 +495,7 @@ void audio_start_ao(struct MPContext *mpctx);
 // configfiles.c
 void mp_parse_cfgfiles(struct MPContext *mpctx);
 void mp_load_auto_profiles(struct MPContext *mpctx);
-void mp_load_playback_resume(struct MPContext *mpctx, const char *file);
+bool mp_load_playback_resume(struct MPContext *mpctx, const char *file);
 void mp_write_watch_later_conf(struct MPContext *mpctx);
 void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file);
 struct playlist_entry *mp_check_playlist_resume(struct MPContext *mpctx,

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1590,7 +1590,7 @@ static void play_current_file(struct MPContext *mpctx)
 
     mp_load_auto_profiles(mpctx);
 
-    mp_load_playback_resume(mpctx, mpctx->filename);
+    bool watch_later = mp_load_playback_resume(mpctx, mpctx->filename);
 
     load_per_file_options(mpctx->mconfig, mpctx->playing->params,
                           mpctx->playing->num_params);
@@ -1736,6 +1736,9 @@ static void play_current_file(struct MPContext *mpctx)
     mpctx->playback_initialized = true;
     mp_notify(mpctx, MPV_EVENT_FILE_LOADED, NULL);
     update_screensaver_state(mpctx);
+
+    if (watch_later)
+        mp_delete_watch_later_conf(mpctx, mpctx->filename);
 
     if (mpctx->max_frames == 0) {
         if (!mpctx->stop_play)


### PR DESCRIPTION
Currently, mpv immediately deletes the watch_later file after an attempt at playing the file is made. This is not really ideal because the file may fail to load for a variety of reasons (including not even existing), but the state is cleared anyway unconditionally. Instead, just wait until after playback is successfully initialized before deleting it. This way silly mistakes like forgetting to mount the drive doesn't result in deleting your watch_later data. Fixes #3427.