### PR TITLE
lua: script_parse_json increase max_depth to 50

### DIFF
--- a/input/ipc.c
+++ b/input/ipc.c
@@ -126,7 +126,7 @@ static char *json_execute_command(struct mpv_handle *client, void *ta_parent,
     bool async = false;
     bool send_reply = true;
 
-    rc = json_parse(ta_parent, &msg_node, &src, 50);
+    rc = json_parse(ta_parent, &msg_node, &src, MAX_JSON_DEPTH);
     if (rc < 0) {
         mp_err(log, "malformed JSON received: '%s'\n", src);
         rc = MPV_ERROR_INVALID_PARAMETER;

--- a/misc/json.h
+++ b/misc/json.h
@@ -21,6 +21,8 @@
 // We reuse mpv_node.
 #include "libmpv/client.h"
 
+#define MAX_JSON_DEPTH 50
+
 int json_parse(void *ta_parent, struct mpv_node *dst, char **src, int max_depth);
 void json_skip_whitespace(char **src);
 int json_write(char **s, struct mpv_node *src);

--- a/player/lua.c
+++ b/player/lua.c
@@ -1163,7 +1163,7 @@ static int script_parse_json(lua_State *L, void *tmp)
     bool trail = lua_toboolean(L, 2);
     bool ok = false;
     struct mpv_node node;
-    if (json_parse(tmp, &node, &text, 32) >= 0) {
+    if (json_parse(tmp, &node, &text, MAX_JSON_DEPTH) >= 0) {
         json_skip_whitespace(&text);
         ok = !text[0] || trail;
     }

--- a/test/json.c
+++ b/test/json.c
@@ -63,8 +63,6 @@ static const struct entry entries[] = {
         NODE_MAP(L("_a12"), L(NODE_STR("b")))},
 };
 
-#define MAX_DEPTH 10
-
 int main(void)
 {
     for (int n = 0; n < MP_ARRAY_SIZE(entries); n++) {
@@ -73,7 +71,7 @@ int main(void)
         char *s = talloc_strdup(tmp, e->src);
         json_skip_whitespace(&s);
         struct mpv_node res;
-        bool ok = json_parse(tmp, &res, &s, MAX_DEPTH) >= 0;
+        bool ok = json_parse(tmp, &res, &s, MAX_JSON_DEPTH) >= 0;
         assert_true(ok != e->expect_fail);
         if (!ok) {
             talloc_free(tmp);


### PR DESCRIPTION
This change allows decoding deeper nested JSON with `utils.parse_json()` from Lua scripts.

I have no clue if 50 is a good or bad value. There seems to be no information why it was set to 32. I set the value to 50 because that value is used here as well:
https://github.com/mpv-player/mpv/blob/6ed521fd14a4cb3ac5bcf69610a8b30fc44facb0/input/ipc.c#L129

**I did not compile nor test this change.**

---
My use-case:
I want to decode the JSON data that is embedded in the Youtube website. This worked until a few days ago. But now the JSON data got bigger (deeper nested/JSON tree has more levels) and the current value 32 is not enough. I tested it with a few Youtube videos and it seems 36 would be enough for my use-case as well. [Related issue in my lua script](https://github.com/cvzi/mpv-youtube-upnext/issues/31).
