### PR TITLE
stats.lua: set sans-serif as default font

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -35,13 +35,6 @@ UP      Scroll one line up
 DOWN    Scroll one line down
 ====   ==================
 
-Font
-~~~~
-
-For optimal visual experience, a font with support for many font weights and
-monospaced digits is recommended. By default, the open source font
-`Source Sans Pro <https://github.com/adobe-fonts/source-sans-pro>`_ is used.
-
 Configuration
 -------------
 
@@ -110,13 +103,13 @@ Configurable Options
     Clear data buffers used for drawing graphs when toggling.
 
 ``font``
-    Default: Source Sans Pro
+    Default: sans-serif
 
     Font name. Should support as many font weights as possible for optimal
     visual experience.
 
 ``font_mono``
-    Default: Source Sans Pro
+    Default: monospace
 
     Font name for parts where monospaced characters are necessary to align
     text. Currently, monospaced digits are sufficient.

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -43,7 +43,7 @@ local o = {
     plot_color = "FFFFFF",
 
     -- Text style
-    font = "sans",
+    font = "sans-serif",
     font_mono = "monospace",   -- monospaced digits are sufficient
     font_size = 8,
     font_color = "FFFFFF",


### PR DESCRIPTION
This replaces deprecated `sans` with `sans-serif` in the `stats.lua`.
Also updates documentation with correct default values.

Fixes such warnings on platforms without `sans` aliases (e.g. macOS and probably Windows):
```
[osd/libass] fontselect: Using default font family: (sans, 400, 0) -> /System/Library/Fonts/Helvetica.ttc, -1, Helvetica
[osd/libass] fontselect: Using default font family: (sans, 700, 0) -> /System/Library/Fonts/Helvetica.ttc, -1, Helvetica-Bold
```

`fontconfig` maps `sans` to `sans-serif`:
https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/fonts.conf.in#L57-67