### PR TITLE
wayland: add 1.32 protocols to sources

### DIFF
--- a/wscript_build.py
+++ b/wscript_build.py
@@ -575,6 +575,8 @@ def build(ctx):
         ( "generated/wayland/single-pixel-buffer-v1.c", "wayland-protocols-1-27" ),
         ( "generated/wayland/content-type-v1.c", "wayland-protocols-1-27" ),
         ( "generated/wayland/fractional-scale-v1.c", "wayland-protocols-1-31"),
+        ( "generated/wayland/cursor-shape-v1.c", "wayland-protocols-1-32"),
+        ( "generated/wayland/tablet-unstable-v2.c", "wayland-protocols-1-32"),
         ( "generated/wayland/idle-inhibit-unstable-v1.c", "wayland" ),
         ( "generated/wayland/presentation-time.c", "wayland" ),
         ( "generated/wayland/xdg-decoration-unstable-v1.c", "wayland" ),


### PR DESCRIPTION
The patch that added these protocols (#11701) didn't include them in the list of sources, which caused build failure with wayland-protocols 1.32.