### PR TITLE
vd_lavc: respect vd-lavc-software-fallback opt

### DIFF
--- a/filters/f_decoder_wrapper.h
+++ b/filters/f_decoder_wrapper.h
@@ -77,6 +77,7 @@ enum dec_ctrl {
     VDCTRL_GET_BFRAMES,
     // framedrop mode: 0=none, 1=standard, 2=hrseek
     VDCTRL_SET_FRAMEDROP,
+    VDCTRL_CHECK_FORCED_EOF,
 };
 
 int mp_decoder_wrapper_control(struct mp_decoder_wrapper *d,

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -1325,6 +1325,10 @@ static int control(struct mp_filter *vd, enum dec_ctrl cmd, void *arg)
     case VDCTRL_SET_FRAMEDROP:
         ctx->framedrop_flags = *(int *)arg;
         return CONTROL_TRUE;
+    case VDCTRL_CHECK_FORCED_EOF: {
+        *(bool *)arg = ctx->force_eof;
+        return CONTROL_TRUE;
+    }
     case VDCTRL_GET_BFRAMES: {
         AVCodecContext *avctx = ctx->avctx;
         if (!avctx)


### PR DESCRIPTION
The first commit actually fixes `--vd-lavc-software-fallback=no` which amusingly will fallback to software decoding anyways on you. The second commit implements a mechanism in vo->driver to specify that no software decoding is allowed (i.e. for dmabuf-wayland).