### PR TITLE
player: delete watch later redirect entries again

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1629,6 +1629,8 @@ static void play_current_file(struct MPContext *mpctx)
         goto terminate_playback;
 
     if (mpctx->demuxer->playlist) {
+        if (watch_later)
+            mp_delete_watch_later_conf(mpctx, mpctx->filename);
         struct playlist *pl = mpctx->demuxer->playlist;
         transfer_playlist(mpctx, pl, &end_event.playlist_insert_id,
                           &end_event.playlist_insert_num_entries);


### PR DESCRIPTION
6a365b258a broke deleting redirect entries for resuming playback. If you do mpv dir1 dir2, quit-watch-later on a file in dir1, then later quit-watch-later on a file in dir2, mpv dir1 dir2 would not resume from dir2 because the redirect entry for dir1 is never deleted.

Fix this by deleting watch later config files for directory/playlist entries,