### PR TITLE
player: always write redirect entries for resuming playback

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -228,19 +228,6 @@ void playlist_add_base_path(struct playlist *pl, bstr base_path)
     }
 }
 
-// Add redirected_from as new redirect entry to each item in pl.
-void playlist_add_redirect(struct playlist *pl, const char *redirected_from)
-{
-    for (int n = 0; n < pl->num_entries; n++) {
-        struct playlist_entry *e = pl->entries[n];
-        if (e->num_redirects >= 10) // arbitrary limit for sanity
-            continue;
-        char *s = talloc_strdup(e, redirected_from);
-        if (s)
-            MP_TARRAY_APPEND(e, e->redirects, e->num_redirects, s);
-    }
-}
-
 void playlist_set_stream_flags(struct playlist *pl, int flags)
 {
     for (int n = 0; n < pl->num_entries; n++)

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -40,11 +40,6 @@ struct playlist_entry {
 
     char *title;
 
-    // If the user plays a playlist, then the playlist's URL will be appended
-    // as redirect to each entry. (Same for directories etc.)
-    char **redirects;
-    int num_redirects;
-
     // Used for unshuffling: the pl_index before it was shuffled. -1 => unknown.
     int original_index;
 
@@ -103,7 +98,6 @@ struct playlist_entry *playlist_get_next(struct playlist *pl, int direction);
 struct playlist_entry *playlist_entry_get_rel(struct playlist_entry *e,
                                               int direction);
 void playlist_add_base_path(struct playlist *pl, bstr base_path);
-void playlist_add_redirect(struct playlist *pl, const char *redirected_from);
 void playlist_set_stream_flags(struct playlist *pl, int flags);
 int64_t playlist_transfer_entries(struct playlist *pl, struct playlist *source_pl);
 int64_t playlist_append_entries(struct playlist *pl, struct playlist *source_pl);

--- a/options/path.c
+++ b/options/path.c
@@ -341,6 +341,14 @@ char *mp_getcwd(void *talloc_ctx)
     return wd;
 }
 
+char *mp_normalize_path(void *talloc_ctx, const char *path)
+{
+    if (mp_is_url(bstr0(path)))
+        return talloc_strdup(talloc_ctx, path);
+
+    return mp_path_join(talloc_ctx, mp_getcwd(talloc_ctx), path);
+}
+
 bool mp_path_exists(const char *path)
 {
     struct stat st;

--- a/options/path.h
+++ b/options/path.h
@@ -83,6 +83,8 @@ bool mp_path_is_absolute(struct bstr path);
 
 char *mp_getcwd(void *talloc_ctx);
 
+char *mp_normalize_path(void *talloc_ctx, const char *path);
+
 bool mp_path_exists(const char *path);
 bool mp_path_isdir(const char *path);
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1086,8 +1086,6 @@ static void transfer_playlist(struct MPContext *mpctx, struct playlist *pl,
     if (pl->num_entries) {
         prepare_playlist(mpctx, pl);
         struct playlist_entry *new = pl->current;
-        if (mpctx->playlist->current)
-            playlist_add_redirect(pl, mpctx->playlist->current->filename);
         *num_new_entries = pl->num_entries;
         *start_id = playlist_transfer_entries(mpctx->playlist, pl);
         // current entry is replaced
@@ -1649,7 +1647,7 @@ static void play_current_file(struct MPContext *mpctx)
     handle_force_window(mpctx, false);
 
     if (mpctx->playlist->num_entries > 1 ||
-        mpctx->playing->num_redirects)
+        mpctx->playing->playlist_path)
         MP_INFO(mpctx, "Playing: %s\n", mpctx->filename);
 
     assert(mpctx->demuxer == NULL);


### PR DESCRIPTION
35f43dfacbe added a system to write resume files for redirects, i.e. directories and playlists that mpv expands.

It creates a resume file for each redirect, and for the first redirect only, it writes a resume file for each segment of its path, without even converting it to an absolute path if it's relative. This is incomplete and overcomplicated and it's strange that wm4 went for it:

`mpv 'Iron Maiden/1982 The Number of the Beast/8 Hallowed Be Thy Name.mp3'`
This doesn't save any redirect entry.

`mpv --directory-mode=recursive 'Iron Maiden'`, then quit-watch-later on Hallowed Be Thy Name
This saves a redirect entry for "Iron Maiden", but not for "1982 The Number of the Beast". It doesn't save redirect entries for the directories above "Iron Maiden" either because "Iron Maiden" isn't converted to an absolute path.

In both of these cases `mpv --directory-mode=lazy 'Iron Maiden'` won't resume from "Hallowed Be Thy Name" because "1982 The Number of the Beast" isn't the first subdirectory and there is no redirect entry for it.

503dada42f made mpv recursively expand subdirectories precisely to fix this, and f266eadf1e added back an option not to expand them. But if we fix how redirect entries are stored, we can make the superior `--directory-mode=lazy` (because it's faster and doesn't result in massive playlists) the default, and also ensure that mpv will resume playback even when you quit-watch-later a file without redirects and then play the directories above it.

To fix this just ignore redirects and always create redirect entries for all segments of the absolute path of the file, so that both

`mpv 'Iron Maiden/1982 The Number of the Beast/8 Hallowed Be Thy Name.mp3'`
`mpv --directory-mode=lazy 'Iron Maiden'`

will create redirect entries for

/$USER
/$USER/music
/$USER/music/Iron Maiden
/$USER/music/Iron Maiden/1982 The Number of the Beast

making `mpv --directory-mode=lazy "Iron Maiden"` resume from "Hallowed Be Thy Name".

The only case where creating resume files specifically for redirected playlists is useful is when you have a playlist pointing to files in different parent directories, e.g. /foo/bar.m3u => /baz/qux.mkv, and then do `mpv quux.mkv /foo/bar.m3u`. This should be very uncommon and therefore not worth adding code for. It doesn't look like wm4 was thinking of this use case either from 35f43dfacbe's git message and code comments.

The code to track redirects could now be removed altogether if it wasn't for `player/loadfile.c` checking `mpctx->playing->num_redirects` to determine whether to log the filename when playing a file in a directory with a single file.