### PR TITLE
player: set default cache dir on macOS

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1678,3 +1678,11 @@ future.
 
 Note that mpv likes to mix ``/`` and ``\`` path separators for simplicity.
 kernel32.dll accepts this, but cmd.exe does not.
+
+FILES ON MACOS
+==============
+
+On macOS the watch later directory is located at ``~/.config/mpv/watch_later/``
+and the cache directory is set to ``~/Library/Caches/io.mpv/``. These directories
+can't be overwritten by enviroment variables.
+Everything else is the same as `FILES`_.

--- a/osdep/path-darwin.c
+++ b/osdep/path-darwin.c
@@ -27,14 +27,15 @@ static pthread_once_t path_init_once = PTHREAD_ONCE_INIT;
 
 static char mpv_home[512];
 static char old_home[512];
+static char mpv_cache[512];
 
 static void path_init(void)
 {
     char *home = getenv("HOME");
-    char *xdg_dir = getenv("XDG_CONFIG_HOME");
+    char *xdg_config = getenv("XDG_CONFIG_HOME");
 
-    if (xdg_dir && xdg_dir[0]) {
-        snprintf(mpv_home, sizeof(mpv_home), "%s/mpv", xdg_dir);
+    if (xdg_config && xdg_config[0]) {
+        snprintf(mpv_home, sizeof(mpv_home), "%s/mpv", xdg_config);
     } else if (home && home[0]) {
         snprintf(mpv_home, sizeof(mpv_home), "%s/.config/mpv", home);
     }
@@ -43,10 +44,14 @@ static void path_init(void)
     if (home && home[0])
         snprintf(old_home, sizeof(old_home), "%s/.mpv", home);
 
+    if (home && home[0])
+        snprintf(mpv_cache, sizeof(mpv_cache), "%s/Library/Caches/io.mpv", home);
+
     // If the old ~/.mpv exists, and the XDG config dir doesn't, use the old
     // config dir only.
     if (mp_path_exists(old_home) && !mp_path_exists(mpv_home)) {
         snprintf(mpv_home, sizeof(mpv_home), "%s", old_home);
+        snprintf(mpv_cache, sizeof(mpv_cache), "%s", old_home);
         old_home[0] = '\0';
     }
 }
@@ -58,6 +63,8 @@ const char *mp_get_platform_path_darwin(void *talloc_ctx, const char *type)
         return mpv_home;
     if (strcmp(type, "old_home") == 0)
         return old_home;
+    if (strcmp(type, "cache") == 0)
+        return mpv_cache;
     if (strcmp(type, "global") == 0)
         return MPV_CONFDIR;
     if (strcmp(type, "desktop") == 0)


### PR DESCRIPTION
Since shader/icc caches are enabled by default now `~/.config/mpv` may contain a lot of cache files on macOS. Most likely, users want to have only configuration files here so change default cache path to macOS specific directory.