### PR TITLE
libplacebo v6 updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,11 @@ jobs:
         copyback: false
         usesh: true
         prepare: |
+            # Update to latest release channel
+            mkdir -p /usr/local/etc/pkg/repos
+            echo "FreeBSD: { url: "pkg+http://pkg.freebsd.org/\${ABI}/latest" }" \
+                > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update
             # Requested in ci/build-freebsd.sh
             pkg install -y \
                 cmake \

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -204,7 +204,7 @@ rm -rf build
 meson setup build --cross-file "$prefix_dir/crossfile" \
     --buildtype debugoptimized \
     -Dlibmpv=true -Dlua=luajit \
-    -D{shaderc,spirv-cross,d3d11,libplacebo,libplacebo-next}=enabled
+    -D{shaderc,spirv-cross,d3d11,libplacebo}=enabled
 
 meson compile -C build
 

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -12,7 +12,6 @@ meson setup build            \
   -D libarchive=enabled      \
   -D libbluray=enabled       \
   -D libmpv=true             \
-  -D libplacebo=enabled      \
   -D lua=enabled             \
   -D pdf-build=enabled       \
   -D rubberband=enabled      \
@@ -20,8 +19,7 @@ meson setup build            \
   -D spirv-cross=enabled     \
   -D tests=true              \
   -D uchardet=enabled        \
-  -D vapoursynth=enabled     \
-  -D vulkan=enabled
+  -D vapoursynth=enabled
 meson compile -C build
 cp ./build/player/mpv.com ./build
 ./build/mpv.com -v --no-config

--- a/meson.build
+++ b/meson.build
@@ -929,7 +929,7 @@ if features['jpeg']
     dependencies += jpeg
 endif
 
-libplacebo = dependency('libplacebo', version: '>=4.157.0', required: get_option('libplacebo'))
+libplacebo = dependency('libplacebo', version: '>=6.292.0', required: get_option('libplacebo'))
 features += {'libplacebo': libplacebo.found()}
 if features['libplacebo']
     dependencies += libplacebo

--- a/meson.build
+++ b/meson.build
@@ -934,16 +934,8 @@ features += {'libplacebo': libplacebo.found()}
 if features['libplacebo']
     dependencies += libplacebo
     sources += files('video/out/placebo/ra_pl.c',
-                     'video/out/placebo/utils.c')
-endif
-
-libplacebo_next = get_option('libplacebo-next').require(
-    features['libplacebo'] and libplacebo.version().version_compare('>=5.264.0'),
-    error_message: 'libplacebo v5.264.0+ was not found!',
-)
-features += {'libplacebo-next': libplacebo_next.allowed()}
-if features['libplacebo-next']
-    sources += files('video/out/vo_gpu_next.c',
+                     'video/out/placebo/utils.c',
+                     'video/out/vo_gpu_next.c',
                      'video/out/gpu_next/context.c')
 endif
 
@@ -1779,7 +1771,7 @@ if get_option('tests')
 endif
 
 summary({'d3d11': features['d3d11'],
-         'gpu-next': features['libplacebo-next'],
+         'gpu-next': features['libplacebo'],
          'javascript': features['javascript'],
          'libmpv': get_option('libmpv'),
          'lua': features['lua'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -76,7 +76,6 @@ option('gl-win32', type: 'feature', value: 'auto', description: 'OpenGL Win32 Ba
 option('gl-x11', type: 'feature', value: 'disabled', description: 'OpenGL X11/GLX (deprecated/legacy)')
 option('jpeg', type: 'feature', value: 'auto', description: 'JPEG support')
 option('libplacebo', type: 'feature', value: 'auto', description: 'libplacebo support')
-option('libplacebo-next', type: 'feature', value: 'auto', description: 'gpu-next video output')
 option('rpi', type: 'feature', value: 'disabled', description: 'Raspberry Pi support')
 option('sdl2-video', type: 'feature', value: 'auto', description: 'SDL2 video output')
 option('shaderc', type: 'feature', value: 'auto', description: 'libshaderc SPIR-V compiler')

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -23,9 +23,7 @@
 
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_cuda.h>
-#if HAVE_LIBPLACEBO_NEXT
 #include <libplacebo/vulkan.h>
-#endif
 #include <unistd.h>
 
 #if HAVE_WIN32_DESKTOP
@@ -42,16 +40,9 @@ struct ext_vk {
     CUmipmappedArray mma;
 
     pl_tex pltex;
-#if HAVE_LIBPLACEBO_NEXT
     pl_vulkan_sem vk_sem;
     union pl_handle sem_handle;
     CUexternalSemaphore cuda_sem;
-#else
-    pl_sync sync;
-
-    CUexternalSemaphore ss;
-    CUexternalSemaphore ws;
-#endif
 };
 
 static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
@@ -61,9 +52,6 @@ static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
     struct cuda_mapper_priv *p = mapper->priv;
     CudaFunctions *cu = p_owner->cu;
     int mem_fd = -1;
-#if !HAVE_LIBPLACEBO_NEXT
-    int wait_fd = -1, signal_fd = -1;
-#endif
     int ret = 0;
 
     struct ext_vk *evk = talloc_ptrtype(NULL, evk);
@@ -151,7 +139,6 @@ static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
     if (ret < 0)
         goto error;
 
-#if HAVE_LIBPLACEBO_NEXT
     evk->vk_sem.sem = pl_vulkan_sem_create(gpu, pl_vulkan_sem_params(
         .type = VK_SEMAPHORE_TYPE_TIMELINE,
         .export_handle = HANDLE_TYPE,
@@ -177,47 +164,6 @@ static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
         goto error;
     // CUDA takes ownership of an imported FD *but not* an imported Handle.
     evk->sem_handle.fd = -1;
-#else
-    evk->sync = pl_sync_create(gpu, HANDLE_TYPE);
-    if (!evk->sync) {
-        ret = -1;
-        goto error;
-    }
-
-#if !HAVE_WIN32_DESKTOP
-    wait_fd = dup(evk->sync->wait_handle.fd);
-    signal_fd = dup(evk->sync->signal_handle.fd);
-#endif
-
-    CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC w_desc = {
-#if HAVE_WIN32_DESKTOP
-        .type = CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32,
-        .handle.win32.handle = evk->sync->wait_handle.handle,
-#else
-        .type = CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD,
-        .handle.fd = wait_fd,
-#endif
-    };
-    ret = CHECK_CU(cu->cuImportExternalSemaphore(&evk->ws, &w_desc));
-    if (ret < 0)
-        goto error;
-    wait_fd = -1;
-
-    CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC s_desc = {
-#if HAVE_WIN32_DESKTOP
-        .type = CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32,
-        .handle.win32.handle = evk->sync->signal_handle.handle,
-#else
-        .type = CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD,
-        .handle.fd = signal_fd,
-#endif
-    };
-
-    ret = CHECK_CU(cu->cuImportExternalSemaphore(&evk->ss, &s_desc));
-    if (ret < 0)
-        goto error;
-    signal_fd = -1;
-#endif
 
     return true;
 
@@ -225,19 +171,12 @@ error:
     MP_ERR(mapper, "cuda_ext_vk_init failed\n");
     if (mem_fd > -1)
         close(mem_fd);
-#if HAVE_LIBPLACEBO_NEXT
 #if HAVE_WIN32_DESKTOP
     if (evk->sem_handle.handle != NULL)
         CloseHandle(evk->sem_handle.handle);
 #else
     if (evk->sem_handle.fd > -1)
         close(evk->sem_handle.fd);
-#endif
-#else
-    if (wait_fd > -1)
-        close(wait_fd);
-    if (signal_fd > -1)
-        close(signal_fd);
 #endif
     return false;
 }
@@ -258,7 +197,6 @@ static void cuda_ext_vk_uninit(const struct ra_hwdec_mapper *mapper, int n)
             CHECK_CU(cu->cuDestroyExternalMemory(evk->mem));
             evk->mem = 0;
         }
-#if HAVE_LIBPLACEBO_NEXT
         if (evk->cuda_sem) {
             CHECK_CU(cu->cuDestroyExternalSemaphore(evk->cuda_sem));
             evk->cuda_sem = 0;
@@ -266,17 +204,6 @@ static void cuda_ext_vk_uninit(const struct ra_hwdec_mapper *mapper, int n)
         pl_vulkan_sem_destroy(ra_pl_get(mapper->ra), &evk->vk_sem.sem);
 #if HAVE_WIN32_DESKTOP
         CloseHandle(evk->sem_handle.handle);
-#endif
-#else
-        if (evk->ss) {
-            CHECK_CU(cu->cuDestroyExternalSemaphore(evk->ss));
-            evk->ss = 0;
-        }
-        if (evk->ws) {
-            CHECK_CU(cu->cuDestroyExternalSemaphore(evk->ws));
-            evk->ws = 0;
-        }
-        pl_sync_destroy(ra_pl_get(mapper->ra), &evk->sync);
 #endif
     }
     talloc_free(evk);
@@ -290,7 +217,6 @@ static bool cuda_ext_vk_wait(const struct ra_hwdec_mapper *mapper, int n)
     int ret;
     struct ext_vk *evk = p->ext[n];
 
-#if HAVE_LIBPLACEBO_NEXT
     evk->vk_sem.value += 1;
     ret = pl_vulkan_hold_ex(ra_pl_get(mapper->ra), pl_vulkan_hold_params(
         .tex = evk->pltex,
@@ -310,16 +236,6 @@ static bool cuda_ext_vk_wait(const struct ra_hwdec_mapper *mapper, int n)
      };
      ret = CHECK_CU(cu->cuWaitExternalSemaphoresAsync(&evk->cuda_sem,
                                                      &wp, 1, 0));
-#else
-    ret = pl_tex_export(ra_pl_get(mapper->ra),
-                        evk->pltex, evk->sync);
-    if (!ret)
-        return false;
-
-    CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS wp = { 0, };
-    ret = CHECK_CU(cu->cuWaitExternalSemaphoresAsync(&evk->ws,
-                                                     &wp, 1, 0));
-#endif
     return ret == 0;
 }
 
@@ -331,7 +247,6 @@ static bool cuda_ext_vk_signal(const struct ra_hwdec_mapper *mapper, int n)
     int ret;
     struct ext_vk *evk = p->ext[n];
 
-#if HAVE_LIBPLACEBO_NEXT
     evk->vk_sem.value += 1;
     CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS sp = {
         .params = {
@@ -351,11 +266,6 @@ static bool cuda_ext_vk_signal(const struct ra_hwdec_mapper *mapper, int n)
         .qf = VK_QUEUE_FAMILY_EXTERNAL,
         .semaphore = evk->vk_sem,
     ));
-#else
-    CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS sp = { 0, };
-    ret = CHECK_CU(cu->cuSignalExternalSemaphoresAsync(&evk->ss,
-                                                       &sp, 1, 0));
-#endif
     return ret == 0;
 }
 

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -45,17 +45,10 @@ struct ra *ra_create_pl(pl_gpu gpu, struct mp_log *log)
         ra->caps |= RA_CAP_COMPUTE | RA_CAP_NUM_GROUPS;
     if (gpu->limits.compute_queues > gpu->limits.fragment_queues)
         ra->caps |= RA_CAP_PARALLEL_COMPUTE;
-#if PL_API_VER >= 180
     if (gpu->limits.max_variable_comps)
         ra->caps |= RA_CAP_GLOBAL_UNIFORM;
-#else
-    if (gpu->limits.max_variables)
-        ra->caps |= RA_CAP_GLOBAL_UNIFORM;
-#endif
-#if PL_API_VER >= 234
     if (!gpu->limits.host_cached)
         ra->caps |= RA_CAP_SLOW_DR;
-#endif
 
     if (gpu->limits.max_tex_1d_dim)
         ra->caps |= RA_CAP_TEX_1D;
@@ -224,36 +217,7 @@ static bool tex_upload_pl(struct ra *ra, const struct ra_tex_upload_params *para
             };
         }
 
-#if PL_API_VER >= 168
         pl_params.row_pitch = params->stride;
-#else
-        // Older libplacebo uses texel-sized strides, so we have to manually
-        // compensate for possibly misaligned sources (typically rgb24).
-        size_t texel_size = tex->params.format->texel_size;
-        pl_params.stride_w = params->stride / texel_size;
-        size_t stride = pl_params.stride_w * texel_size;
-
-        if (stride != params->stride) {
-            // Fall back to uploading via a staging buffer prepared in CPU
-            int lines = params->rc ? pl_rect_h(pl_params.rc) : tex->params.h;
-            staging = pl_buf_create(gpu, &(struct pl_buf_params) {
-                .size = lines * stride,
-                .memory_type = PL_BUF_MEM_HOST,
-                .host_mapped = true,
-            });
-            if (!staging)
-                return false;
-
-            const uint8_t *src = params->buf ? params->buf->data : params->src;
-            assert(src);
-            for (int y = 0; y < lines; y++)
-                memcpy(staging->data + y * stride, src + y * params->stride, stride);
-
-            pl_params.ptr = NULL;
-            pl_params.buf = staging;
-            pl_params.buf_offset = 0;
-        }
-#endif
     }
 
     bool ok = pl_tex_upload(gpu, &pl_params);
@@ -268,33 +232,10 @@ static bool tex_download_pl(struct ra *ra, struct ra_tex_download_params *params
         .tex = tex,
         .ptr = params->dst,
         .timer = get_active_timer(ra),
+        .row_pitch = params->stride,
     };
 
-#if PL_API_VER >= 168
-    pl_params.row_pitch = params->stride;
     return pl_tex_download(get_gpu(ra), &pl_params);
-#else
-    size_t texel_size = tex->params.format->texel_size;
-    pl_params.stride_w = params->stride / texel_size;
-    size_t stride = pl_params.stride_w * texel_size;
-    uint8_t *staging = NULL;
-    if (stride != params->stride) {
-        staging = talloc_size(NULL, tex->params.h * stride);
-        pl_params.ptr = staging;
-    }
-
-    bool ok = pl_tex_download(get_gpu(ra), &pl_params);
-    if (ok && staging) {
-        for (int y = 0; y < tex->params.h; y++) {
-            memcpy((uint8_t *) params->dst + y * params->stride,
-                   staging + y * stride,
-                   stride);
-        }
-    }
-
-    talloc_free(staging);
-    return ok;
-#endif
 }
 
 static struct ra_buf *buf_create_pl(struct ra *ra,
@@ -520,12 +461,7 @@ static struct ra_renderpass *renderpass_create_pl(struct ra *ra,
         pl_params.vertex_type = PL_PRIM_TRIANGLE_LIST;
         pl_params.vertex_stride = params->vertex_stride;
         pl_params.load_target = !params->invalidate_target;
-
-#if PL_API_VER >= 169
         pl_params.target_format = params->target_format->priv;
-#else
-        pl_params.target_dummy.params.format = params->target_format->priv;
-#endif
 
         if (params->enable_blend) {
             pl_params.blend_params = &blend_params;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -76,7 +76,7 @@ static const struct vo_driver *const video_out_drivers[] =
     &video_out_mediacodec_embed,
 #endif
     &video_out_gpu,
-#if HAVE_LIBPLACEBO_NEXT
+#if HAVE_LIBPLACEBO
     &video_out_gpu_next,
 #endif
 #if HAVE_VDPAU

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -87,6 +87,11 @@ struct user_lut {
     struct pl_custom_lut *lut;
 };
 
+struct frame_info {
+    int count;
+    struct pl_dispatch_info info[VO_PASS_PERF_MAX];
+};
+
 struct priv {
     struct mp_log *log;
     struct mpv_global *global;
@@ -149,7 +154,8 @@ struct priv {
     int num_user_hooks;
 
     // Performance data of last frame
-    struct voctrl_performance_data perf;
+    struct frame_info perf_fresh;
+    struct frame_info perf_redraw;
 
     bool delayed_peak;
     bool inter_preserve;
@@ -753,28 +759,15 @@ static void info_callback(void *priv, const struct pl_render_info *info)
     if (info->index >= VO_PASS_PERF_MAX)
         return; // silently ignore clipped passes, whatever
 
-    struct mp_frame_perf *frame;
+    struct frame_info *frame;
     switch (info->stage) {
-    case PL_RENDER_STAGE_FRAME: frame = &p->perf.fresh; break;
-    case PL_RENDER_STAGE_BLEND: frame = &p->perf.redraw; break;
+    case PL_RENDER_STAGE_FRAME: frame = &p->perf_fresh; break;
+    case PL_RENDER_STAGE_BLEND: frame = &p->perf_redraw; break;
     default: abort();
     }
 
-    int index = info->index;
-    struct mp_pass_perf *perf = &frame->perf[index];
-    const struct pl_dispatch_info *pass = info->pass;
-    static_assert(VO_PERF_SAMPLE_COUNT >= MP_ARRAY_SIZE(pass->samples), "");
-    assert(pass->num_samples <= MP_ARRAY_SIZE(pass->samples));
-
-    perf->count = MPMIN(pass->num_samples, VO_PERF_SAMPLE_COUNT);
-    memcpy(perf->samples, pass->samples, perf->count * sizeof(pass->samples[0]));
-    perf->last = pass->last;
-    perf->peak = pass->peak;
-    perf->avg = pass->average;
-
-    strncpy(frame->desc[index], pass->shader->description, sizeof(frame->desc[index]) - 1);
-    frame->desc[index][sizeof(frame->desc[index]) - 1] = '\0';
-    frame->count = index + 1;
+    frame->count = info->index + 1;
+    pl_dispatch_info_move(&frame->info[info->index], info->pass);
 }
 
 static void update_options(struct vo *vo)
@@ -1318,6 +1311,30 @@ done:
     pl_tex_destroy(gpu, &fbo);
 }
 
+static inline void copy_frame_info_to_mp(struct frame_info *pl,
+                                         struct mp_frame_perf *mp) {
+    static_assert(MP_ARRAY_SIZE(pl->info) == MP_ARRAY_SIZE(mp->perf), "");
+    assert(pl->count <= VO_PASS_PERF_MAX);
+    mp->count = MPMIN(pl->count, VO_PASS_PERF_MAX);
+
+    for (int i = 0; i < mp->count; ++i) {
+        const struct pl_dispatch_info *pass = &pl->info[i];
+
+        static_assert(VO_PERF_SAMPLE_COUNT >= MP_ARRAY_SIZE(pass->samples), "");
+        assert(pass->num_samples <= MP_ARRAY_SIZE(pass->samples));
+
+        struct mp_pass_perf *perf = &mp->perf[i];
+        perf->count = MPMIN(pass->num_samples, VO_PERF_SAMPLE_COUNT);
+        memcpy(perf->samples, pass->samples, perf->count * sizeof(pass->samples[0]));
+        perf->last = pass->last;
+        perf->peak = pass->peak;
+        perf->avg = pass->average;
+
+        strncpy(mp->desc[i], pass->shader->description, sizeof(mp->desc[i]) - 1);
+        mp->desc[i][sizeof(mp->desc[i]) - 1] = '\0';
+    }
+}
+
 static int control(struct vo *vo, uint32_t request, void *data)
 {
     struct priv *p = vo->priv;
@@ -1359,9 +1376,12 @@ static int control(struct vo *vo, uint32_t request, void *data)
         p->want_reset = true;
         return VO_TRUE;
 
-    case VOCTRL_PERFORMANCE_DATA:
-        *(struct voctrl_performance_data *) data = p->perf;
+    case VOCTRL_PERFORMANCE_DATA: {
+        struct voctrl_performance_data *perf = data;
+        copy_frame_info_to_mp(&p->perf_fresh, &perf->fresh);
+        copy_frame_info_to_mp(&p->perf_redraw, &perf->redraw);
         return true;
+    }
 
     case VOCTRL_SCREENSHOT:
         video_screenshot(vo, data);
@@ -1466,6 +1486,11 @@ static void uninit(struct vo *vo)
     }
 
     pl_renderer_destroy(&p->rr);
+
+    for (int i = 0; i < VO_PASS_PERF_MAX; ++i) {
+        pl_shader_info_deref(&p->perf_fresh.info[i].shader);
+        pl_shader_info_deref(&p->perf_redraw.info[i].shader);
+    }
 
     p->ra_ctx = NULL;
     p->pllog = NULL;

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1898,9 +1898,7 @@ static void update_render_options(struct vo *vo)
     p->params.disable_linear_scaling = !opts->linear_downscaling && !opts->linear_upscaling;
     p->params.disable_fbos = opts->dumb_mode == 1;
     p->params.blend_against_tiles = opts->alpha_mode == ALPHA_BLEND_TILES;
-#if PL_API_VER >= 277
     p->params.corner_rounding = p->corner_rounding;
-#endif
 
     // Map scaler options as best we can
     p->params.upscaler = map_scaler(p, SCALER_SCALE);
@@ -1946,7 +1944,6 @@ static void update_render_options(struct vo *vo)
         [TONE_MAPPING_ST2094_10] = &pl_tone_map_st2094_10,
     };
 
-#if PL_API_VER >= 269
     const struct pl_gamut_map_function *gamut_modes[] = {
         [GAMUT_CLIP]            = &pl_gamut_map_clip,
         [GAMUT_PERCEPTUAL]      = &pl_gamut_map_perceptual,
@@ -1959,36 +1956,6 @@ static void update_render_options(struct vo *vo)
         [GAMUT_LINEAR]          = &pl_gamut_map_linear,
     };
 
-    // Back-compat approximation, taken from libplacebo source code
-    static const float hybrid_mix[] = {
-        [TONE_MAP_MODE_RGB]     = 1.0f,
-        [TONE_MAP_MODE_MAX]     = 0.0f,
-        [TONE_MAP_MODE_LUMA]    = 0.0f,
-        [TONE_MAP_MODE_HYBRID]  = 0.20f,
-    };
-#else
-    static const enum pl_gamut_mode gamut_modes[] = {
-        [GAMUT_CLIP]            = PL_GAMUT_CLIP,
-        [GAMUT_WARN]            = PL_GAMUT_WARN,
-        [GAMUT_DESATURATE]      = PL_GAMUT_DESATURATE,
-        [GAMUT_DARKEN]          = PL_GAMUT_DARKEN,
-        // Unsupported
-        [GAMUT_PERCEPTUAL]      = PL_GAMUT_CLIP,
-        [GAMUT_RELATIVE]        = PL_GAMUT_CLIP,
-        [GAMUT_SATURATION]      = PL_GAMUT_CLIP,
-        [GAMUT_ABSOLUTE]        = PL_GAMUT_CLIP,
-        [GAMUT_LINEAR]          = PL_GAMUT_CLIP,
-    };
-
-    static const enum pl_tone_map_mode tone_map_modes[] = {
-        [TONE_MAP_MODE_AUTO]    = PL_TONE_MAP_AUTO,
-        [TONE_MAP_MODE_RGB]     = PL_TONE_MAP_RGB,
-        [TONE_MAP_MODE_MAX]     = PL_TONE_MAP_MAX,
-        [TONE_MAP_MODE_HYBRID]  = PL_TONE_MAP_HYBRID,
-        [TONE_MAP_MODE_LUMA]    = PL_TONE_MAP_LUMA,
-    };
-#endif
-
     p->color_map = pl_color_map_default_params;
     p->color_map.tone_mapping_function = tone_map_funs[opts->tone_map.curve];
     p->color_map.tone_mapping_param = opts->tone_map.curve_param;
@@ -1996,23 +1963,10 @@ static void update_render_options(struct vo *vo)
     if (isnan(p->color_map.tone_mapping_param)) // vo_gpu compatibility
         p->color_map.tone_mapping_param = 0.0;
     p->color_map.visualize_lut = opts->tone_map.visualize;
-
-#if PL_API_VER >= 285
     p->color_map.contrast_recovery = opts->tone_map.contrast_recovery;
     p->color_map.contrast_smoothness = opts->tone_map.contrast_smoothness;
-#endif
-
-#if PL_API_VER >= 269
     if (opts->tone_map.gamut_mode != GAMUT_AUTO)
         p->color_map.gamut_mapping = gamut_modes[opts->tone_map.gamut_mode];
-    if (opts->tone_map.mode != TONE_MAP_MODE_AUTO)
-        p->color_map.hybrid_mix = hybrid_mix[opts->tone_map.mode];
-#else
-    p->color_map.intent = opts->icc_opts->intent;
-    p->color_map.tone_mapping_mode = tone_map_modes[opts->tone_map.mode];
-    if (opts->tone_map.gamut_mode != GAMUT_AUTO)
-        p->color_map.gamut_mode = gamut_modes[opts->tone_map.gamut_mode];
-#endif
 
     switch (opts->dither_algo) {
     case DITHER_NONE:


### PR DESCRIPTION
Also includes the new HDR contrast recovery option. I included it by default in the `gpu-hq` profile.

Question: Should we "downgrade" HDR peak detection from on-by-default to on-in-gpu-hq as well? It's really punishing for slower devices, even after libplacebo v6's optimizations.