### PR TITLE
loadfile: make get_audio_lang function static

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -579,7 +579,7 @@ static char **process_langs(char **in)
     return out;
 }
 
-const char *get_audio_lang(struct MPContext *mpctx)
+static const char *get_audio_lang(struct MPContext *mpctx)
 {
     // If we have a single current audio track, this is simple.
     if (mpctx->current_track[0][STREAM_AUDIO])


### PR DESCRIPTION
This fixes a build warning about missing prototypes