### PR TITLE
builtin.conf: unset default languages in libmpv and encode profiles

### DIFF
--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -28,6 +28,9 @@ input-default-bindings=no
 input-vo-keyboard=no
 # OSX/Cocoa global input hooks
 input-media-keys=no
+vlang=
+alang=
+slang=
 
 [encoding]
 vo=lavc
@@ -39,6 +42,9 @@ resume-playback=no
 load-scripts=no
 osc=no
 framedrop=no
+vlang=
+alang=
+slang=
 
 [gpu-hq]
 scale=spline36


### PR DESCRIPTION
The `auto` behavior doesn't really make sense in these contexts.