### PR TITLE
vo_gpu: remove --tone-mapping-mode

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -56,6 +56,7 @@ Interface changes
     - remove deprecated `video-aspect` property
     - add `--video-crop`
     - add `video-params/crop-[w,h,x,y]`
+    - remove `--tone-mapping-mode`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6630,28 +6630,6 @@ them.
     it too high will make dark scenes appear unnaturally bright. (``--vo=gpu``
     only)
 
-``--tone-mapping-mode``
-    Controls how the tone mapping function is applied to colors.
-
-    auto
-        Choose the best mode automatically. (Default)
-    rgb
-        Tone-map per-channel (RGB). Has a tendency to severely distort colors,
-        desaturate highlights, and is generally not very recommended. However,
-        this is the mode used in many displays and TVs (especially early ones),
-        and so sometimes it's needed to reproduce the artistic intent a film
-        was mastered with.
-    max
-        Tone-map on the brightest component in the video. Has a tendency to
-        lead to weirdly oversaturated colors, and loss of dark details.
-    hybrid
-        A hybrid approach that uses linear tone-mapping for midtones and
-        per-channel tone mapping for highlights.
-    luma
-        Luminance-based method from ITU-R BT.2446a, including fixed gamut
-        reductions to account for brightness-related perceptual nonuniformity.
-        (``--vo=gpu-next`` only)
-
 ``--tone-mapping-visualize``
     Display a (PQ-PQ) graph of the active tone-mapping LUT. Intended only for
     debugging purposes. The X axis shows PQ input values, the Y axis shows PQ

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -394,12 +394,6 @@ const struct m_sub_options gl_video_conf = {
         {"inverse-tone-mapping", OPT_BOOL(tone_map.inverse)},
         {"tone-mapping-max-boost", OPT_FLOAT(tone_map.max_boost),
             M_RANGE(1.0, 10.0)},
-        {"tone-mapping-mode", OPT_CHOICE(tone_map.mode,
-            {"auto",        TONE_MAP_MODE_AUTO},
-            {"rgb",         TONE_MAP_MODE_RGB},
-            {"max",         TONE_MAP_MODE_MAX},
-            {"hybrid",      TONE_MAP_MODE_HYBRID},
-            {"luma",        TONE_MAP_MODE_LUMA})},
         {"tone-mapping-visualize", OPT_BOOL(tone_map.visualize)},
         {"gamut-mapping-mode", OPT_CHOICE(tone_map.gamut_mode,
             {"auto",        GAMUT_AUTO},
@@ -499,6 +493,7 @@ const struct m_sub_options gl_video_conf = {
         {"tone-mapping-desaturate", OPT_REMOVED("Replaced by --tone-mapping-mode")},
         {"tone-mapping-desaturate-exponent", OPT_REMOVED("Replaced by --tone-mapping-mode")},
         {"tone-mapping-crosstalk", OPT_REMOVED("Hard-coded as 0.04")},
+        {"tone-mapping-mode", OPT_REMOVED("no replacement")},
         {0}
     },
     .size = sizeof(struct gl_video_opts),
@@ -2673,18 +2668,6 @@ static void pass_colormanage(struct gl_video *p, struct mp_colorspace src,
     default:
         MP_WARN(p, "Tone mapping curve unsupported by vo_gpu, falling back.\n");
         p->opts.tone_map.curve = TONE_MAPPING_AUTO;
-        break;
-    }
-
-    switch (p->opts.tone_map.mode) {
-    case TONE_MAP_MODE_AUTO:
-    case TONE_MAP_MODE_RGB:
-    case TONE_MAP_MODE_MAX:
-    case TONE_MAP_MODE_HYBRID:
-        break;
-    default:
-        MP_WARN(p, "Tone mapping mode unsupported by vo_gpu, falling back.\n");
-        p->opts.tone_map.mode = TONE_MAP_MODE_AUTO;
         break;
     }
 

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -102,14 +102,6 @@ enum tone_mapping {
     TONE_MAPPING_ST2094_10,
 };
 
-enum tone_mapping_mode {
-    TONE_MAP_MODE_AUTO,
-    TONE_MAP_MODE_RGB,
-    TONE_MAP_MODE_MAX,
-    TONE_MAP_MODE_HYBRID,
-    TONE_MAP_MODE_LUMA,
-};
-
 enum gamut_mode {
     GAMUT_AUTO,
     GAMUT_CLIP,
@@ -128,7 +120,6 @@ struct gl_tone_map_opts {
     float curve_param;
     float max_boost;
     bool inverse;
-    int mode;
     int compute_peak;
     float decay_rate;
     float scene_threshold_low;

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -818,25 +818,12 @@ static void pass_tone_map(struct gl_shader_cache *sc,
         abort();
     }
 
-    switch (opts->mode) {
-    case TONE_MAP_MODE_RGB:
-        GLSL(color.rgb = sig;)
-        break;
-    case TONE_MAP_MODE_MAX:
-        GLSL(color.rgb *= sig[sig_idx] / sig_orig;)
-        break;
-    case TONE_MAP_MODE_AUTO:
-    case TONE_MAP_MODE_HYBRID:
-        GLSLF("float coeff = max(sig[sig_idx] - %f, 1e-6) / \n"
-              "              max(sig[sig_idx], 1.0);        \n"
-              "coeff = %f * pow(coeff / %f, %f);            \n"
-              "color.rgb *= sig[sig_idx] / sig_orig;        \n"
-              "color.rgb = mix(color.rgb, %f * sig, coeff); \n",
-              0.18 / dst_scale, 0.90, dst_scale, 0.20, dst_scale);
-        break;
-    default:
-        abort();
-    }
+    GLSLF("float coeff = max(sig[sig_idx] - %f, 1e-6) / \n"
+          "              max(sig[sig_idx], 1.0);        \n"
+          "coeff = %f * pow(coeff / %f, %f);            \n"
+          "color.rgb *= sig[sig_idx] / sig_orig;        \n"
+          "color.rgb = mix(color.rgb, %f * sig, coeff); \n",
+          0.18 / dst_scale, 0.90, dst_scale, 0.20, dst_scale);
 }
 
 // Map colors from one source space to another. These source spaces must be


### PR DESCRIPTION
`--vo=gpu-next` no longer uses this option, being replaced entirely by a luminance-based approach internally. And even for `--vo=gpu`, the values other than 'hybrid' are universally inferior in quality.

In the interest of gradually reducing the amount of option bloat here, remove this mostly-pointless option.