### PR TITLE
A few vo_vaapi fixes

### DIFF
--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -684,6 +684,10 @@ static void draw_osd(struct vo *vo)
         int rw = mp_rect_w(*rc);
         int rh = mp_rect_h(*rc);
 
+        // reduce width of last slice to prevent overflow
+        if (n == num_mod_rc - 1)
+            rw = w - rc->x0;
+
         void *src = mp_image_pixel_ptr(osd, 0, rc->x0, rc->y0);
         void *dst = vaimg.planes[0] + rc->y0 * vaimg.stride[0] + rc->x0 * 4;
 

--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -792,6 +792,7 @@ static int preinit(struct vo *vo)
     if (!p->image_formats)
         goto fail;
 
+    p->mpvaapi->hwctx.hw_imgfmt = IMGFMT_VAAPI;
     p->pool = mp_image_pool_new(p);
     va_pool_set_allocator(p->pool, p->mpvaapi, VA_RT_FORMAT_YUV420);
 


### PR DESCRIPTION
While use of vo_vaapi is discouraged, as long as it's still part of mpv it should at least work. This PR fixes a segfault in draw_osd and makes hardware decode interop work again.