### PR TITLE
ao_pipewire: use native buffersize by default

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -872,7 +872,7 @@ const struct ao_driver audio_out_pipewire = {
         .loop = NULL,
         .stream = NULL,
         .init_state = INIT_STATE_NONE,
-        .options.buffer_msec = 20,
+        .options.buffer_msec = 0,
         .options.volume_mode = VOLUME_MODE_CHANNEL,
     },
     .options_prefix = "pipewire",


### PR DESCRIPTION
Instead of trying to guess the correct number in mpv let the pipewire server choose.

Fixes #9992

@sta-c0000 @AtticFinder65536 Could you check if this solves your issue?