### PR TITLE
Revert "vo_gpu_next: use pl_dispatch_info_move to avoid useless data copy"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -930,8 +930,8 @@ if features['libplacebo']
 endif
 
 libplacebo_next = get_option('libplacebo-next').require(
-    features['libplacebo'] and libplacebo.version().version_compare('>=5.266.0'),
-    error_message: 'libplacebo v5.266.0+ was not found!',
+    features['libplacebo'] and libplacebo.version().version_compare('>=5.264.0'),
+    error_message: 'libplacebo v5.264.0+ was not found!',
 )
 features += {'libplacebo-next': libplacebo_next.allowed()}
 if features['libplacebo-next']


### PR DESCRIPTION
tested with libplacebo 5.264.1-1 (Arch)

the idea is to revert the revert (reapply the original commit) after release