### PR TITLE
build: internally rename gl-wayland to egl-wayland

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1197,8 +1197,8 @@ if features['egl-drm']
 endif
 
 egl_wayland = dependency('wayland-egl', version: '>= 9.0.0', required: get_option('egl-wayland'))
-features += {'gl-wayland': features['egl'] and egl_wayland.found() and gl_allowed and features['wayland']}
-if features['gl-wayland']
+features += {'egl-wayland': features['egl'] and egl_wayland.found() and gl_allowed and features['wayland']}
+if features['egl-wayland']
     dependencies += egl_wayland
     features += {'gl': true}
     sources += files('video/out/opengl/context_wayland.c')
@@ -1411,7 +1411,7 @@ if features['vaapi-drm']
 endif
 
 vaapi_wayland = dependency('libva-wayland', version: '>= 1.1.0', required: get_option('vaapi-wayland').require(features['vaapi']))
-features += {'vaapi-wayland': features['vaapi'] and features['gl-wayland'] and vaapi_wayland.found()}
+features += {'vaapi-wayland': features['vaapi'] and features['egl-wayland'] and vaapi_wayland.found()}
 if features['vaapi-wayland']
     dependencies += vaapi_wayland
 endif

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -82,7 +82,7 @@ static const struct ra_ctx_fns *contexts[] = {
 #if HAVE_GL_DXINTEROP
     &ra_ctx_dxgl,
 #endif
-#if HAVE_GL_WAYLAND
+#if HAVE_EGL_WAYLAND
     &ra_ctx_wayland_egl,
 #endif
 #if HAVE_EGL_X11


### PR DESCRIPTION
This has always been a pet peeve of mine and in fact I named the option in meson "egl-wayland" with the intention of finally doing this. We call everything that's egl "egl" internally except for wayland.