### PR TITLE
language-posix: as a fallback, treat "C" as "en"

### DIFF
--- a/osdep/language-posix.c
+++ b/osdep/language-posix.c
@@ -33,6 +33,7 @@ char **mp_get_user_langs(void)
 
     size_t nb = 0;
     char **ret = NULL;
+    bool has_c = false;
 
     // Prefer anything we get from LANGUAGE first
     for (const char *langList = getenv("LANGUAGE"); langList && *langList;) {
@@ -49,9 +50,19 @@ char **mp_get_user_langs(void)
         const char *envval = getenv(list[i]);
         if (envval && *envval) {
             size_t len = strcspn(envval, ".@");
+            if (!strncmp("C", envval, len)) {
+                has_c = true;
+                continue;
+            }
+
             MP_TARRAY_GROW(NULL, ret, nb);
             ret[nb++] = talloc_strndup(ret, envval, len);
         }
+    }
+
+    if (has_c && !nb) {
+        MP_TARRAY_GROW(NULL, ret, nb);
+        ret[nb++] = talloc_strdup(ret, "en");
     }
 
     // Null-terminate the list


### PR DESCRIPTION
If we see "C" in one of the language vars we check, don't treat it as a language tag. Once we've checked everything, if we don't have any languages, but saw "C" anywhere, fall back on "en".