### PR TITLE
some vaapi build changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1405,13 +1405,13 @@ if features['vaapi']
 endif
 
 vaapi_drm = dependency('libva-drm', version: '>= 1.1.0', required: get_option('vaapi-drm').require(features['vaapi']))
-features += {'vaapi-drm': features['vaapi'] and egl_drm.allowed() and vaapi_drm.found()}
+features += {'vaapi-drm': features['vaapi'] and vaapi_drm.found()}
 if features['vaapi-drm']
     dependencies += vaapi_drm
 endif
 
 vaapi_wayland = dependency('libva-wayland', version: '>= 1.1.0', required: get_option('vaapi-wayland').require(features['vaapi']))
-features += {'vaapi-wayland': features['vaapi'] and features['egl-wayland'] and vaapi_wayland.found()}
+features += {'vaapi-wayland': features['vaapi'] and vaapi_wayland.found()}
 if features['vaapi-wayland']
     dependencies += vaapi_wayland
 endif

--- a/meson.build
+++ b/meson.build
@@ -1424,7 +1424,7 @@ if features['vaapi-x11']
 endif
 
 features += {'vaapi-x-egl': features['vaapi-x11'] and egl_x11.allowed()}
-features += {'vaapi-egl': features['vaapi-x11'] or features['vaapi-wayland'] or features['vaapi-drm']}
+features += {'vaapi-egl': (features['vaapi-x11'] or features['vaapi-wayland'] or features['vaapi-drm']) and features['egl']}
 features += {'vaapi-libplacebo': features['vaapi'] and libplacebo.found()}
 
 if features['vaapi-egl'] or features['vaapi-libplacebo']

--- a/meson.build
+++ b/meson.build
@@ -1423,7 +1423,6 @@ if features['vaapi-x11']
     sources += files('video/out/vo_vaapi.c')
 endif
 
-features += {'vaapi-x-egl': features['vaapi-x11'] and egl_x11.allowed()}
 features += {'vaapi-egl': (features['vaapi-x11'] or features['vaapi-wayland'] or features['vaapi-drm']) and features['egl']}
 features += {'vaapi-libplacebo': features['vaapi'] and libplacebo.found()}
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -86,7 +86,7 @@ option('plain-gl', type: 'feature', value: 'auto', description: 'OpenGL without 
 option('vdpau', type: 'feature', value: 'auto', description: 'VDPAU acceleration')
 option('vdpau-gl-x11', type: 'feature', value: 'auto', description: 'VDPAU with OpenGL/X11')
 option('vaapi', type: 'feature', value: 'auto', description: 'VAAPI acceleration')
-option('vaapi-drm', type: 'feature', value: 'auto', description: 'VAAPI (DRM/EGL support)')
+option('vaapi-drm', type: 'feature', value: 'auto', description: 'VAAPI (DRM support)')
 option('vaapi-wayland', type: 'feature', value: 'auto', description: 'VAAPI (Wayland support)')
 option('vaapi-x11', type: 'feature', value: 'auto', description: 'VAAPI (X11 support)')
 option('vaapi-x-egl', type: 'feature', value: 'auto', description: 'VAAPI EGL on X11')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -89,7 +89,7 @@ option('vaapi', type: 'feature', value: 'auto', description: 'VAAPI acceleration
 option('vaapi-drm', type: 'feature', value: 'auto', description: 'VAAPI (DRM support)')
 option('vaapi-wayland', type: 'feature', value: 'auto', description: 'VAAPI (Wayland support)')
 option('vaapi-x11', type: 'feature', value: 'auto', description: 'VAAPI (X11 support)')
-option('vaapi-x-egl', type: 'feature', value: 'auto', description: 'VAAPI EGL on X11')
+option('vaapi-egl', type: 'feature', value: 'auto', description: 'VAAPI (EGL support)')
 option('vulkan', type: 'feature', value: 'auto', description: 'Vulkan context support')
 option('wayland', type: 'feature', value: 'auto', description: 'Wayland')
 option('x11', type: 'feature', value: 'auto', description: 'X11')


### PR DESCRIPTION
Noticed this when I was playing with compiling mpv without GL (-Dgl=disabled). vaapi-drm and vaapi-wayland work just fine with vulkan/libplacebo, they don't need egl.