### PR TITLE
options: restore old default sub selection behavior

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -29,6 +29,8 @@ Interface changes
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.
+    - change `--subs-with-matching-audio` default from `no` to `yes`
+    - change `--subs-fallback` default from `no` to `default`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -140,11 +140,11 @@ Track Selection
 
 ``--subs-with-matching-audio=<yes|no>``
     When autoselecting a subtitle track, select a full/non-forced one even if the selected
-    audio stream matches your preferred subtitle language (default: no).
+    audio stream matches your preferred subtitle language (default: yes).
 
 ``--subs-fallback=<yes|default|no>``
     When autoselecting a subtitle track, if no tracks match your preferred languages,
-    select a full track even if it doesn't match your preferred subtitle language (default: no).
+    select a full track even if it doesn't match your preferred subtitle language (default: default).
     Setting this to `default` means that only streams flagged as `default` will be selected.
 
 ``--subs-fallback-forced=<yes|no>``

--- a/options/options.c
+++ b/options/options.c
@@ -1040,7 +1040,8 @@ static const struct MPOpts mp_default_opts = {
         [STREAM_SUB] = (char *[]){ "auto", NULL },
     },
     .stream_auto_sel = true,
-    .subs_with_matching_audio = false,
+    .subs_with_matching_audio = true,
+    .subs_fallback = 1,
     .subs_fallback_forced = true,
     .audio_display = 1,
     .audio_output_format = 0,  // AF_FORMAT_UNKNOWN


### PR DESCRIPTION
1669c4698d237eb885aa3f9c5b81983de6009418 notably flipped the default of --subs-with-matching-audio from yes to no as part of a series of changes that gave more control over sub selection behavior. While the increased amount of options is definitely nice, changing the default to no results in very unintuitive behavior. For example, setting alang=en and slang=en in your config will not show any subtitles since the audio stream is English as well so --subs-with-matching-audio being no causes the subs to not be be selected. This is very weird for users who reasonably expect slang being set to actually result in showing subs and this is what mpv did for the past decade.

The other case is when a subtitle does not have a language tag but is flagged as default. Because --subs-fallback (a new option), defaults to no, these subtitles also will not be loaded. This is also strange for users since mpv previously loaded these and they would need to change the value of this option. It's also inconsistent because audio tracks that are tagged as default are also loaded by default.

The new behavior seems to have mostly just confused users, and it also regresses their configs for unclear reasons. Let's just set the options to be back in line with the old behavior with is what most users expect. --subs-with-matching-audio goes back to being yes and the new option --subs-fallback should be default. Fixes #11854.