### PR TITLE
ao_sndio: use sio_flush() to improve controls responsiveness

### DIFF
--- a/audio/out/ao_sndio.c
+++ b/audio/out/ao_sndio.c
@@ -235,8 +235,13 @@ static void reset(struct ao *ao)
     if (p->playing) {
         p->playing = false;
 
+#if HAVE_SNDIO_1_9
+        if (!sio_flush(p->hdl)) {
+            MP_ERR(ao, "reset: couldn't sio_flush()\n");
+#else
         if (!sio_stop(p->hdl)) {
             MP_ERR(ao, "reset: couldn't sio_stop()\n");
+#endif
         }
         p->delay = 0;
         if (!sio_start(p->hdl)) {

--- a/meson.build
+++ b/meson.build
@@ -857,6 +857,7 @@ endif
 
 sndio = dependency('sndio', required: get_option('sndio'))
 features += {'sndio': sndio.found()}
+features += {'sndio-1-9': sndio.version().version_compare('>= 1.9.0')}
 if features['sndio']
     dependencies += sndio
     sources += files('audio/out/ao_sndio.c')


### PR DESCRIPTION
Use sio_flush() instead of sio_stop() to improve controls responsiveness.