### PR TITLE
build: remove unneeded libdl requirement for vaapi

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1418,8 +1418,8 @@ if features['vaapi-x11']
     sources += files('video/out/vo_vaapi.c')
 endif
 
-vaapi = get_option('vaapi').require(libva.found() and features['libdl'] and
-    (features['vaapi-drm'] or features['vaapi-wayland'] or features['vaapi-x11']))
+vaapi = get_option('vaapi').require(libva.found() and (features['vaapi-drm'] or
+                                    features['vaapi-wayland'] or features['vaapi-x11']))
 features += {'vaapi': vaapi.allowed()}
 
 if features['vaapi']


### PR DESCRIPTION
Curiously, vaapi requiring libdl has always existed ever since support was added to mpv (2827295703c74e3c119df9a435aa856e268c2ea9). After some investigation in IRC from uau and JEEB, it was concluded that the libdl requirement was blindly copied from the vdpau check above it. At the time, the vdpau code actually used dlsym so it was needed. The check was later dropped when waf support was added
(7e2edad8efea55e8df1faa695d1389ef4e326d7c). However, the requirement in vaapi lived on, and actually it was never needed. libva does use dl when building its libraries unsurprisingly, but this isn't relevant to mpv in any way. Just drop it.