### PR TITLE
player/video: check for track and decoder existence

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -562,7 +562,7 @@ static bool check_for_hwdec_fallback(struct MPContext *mpctx)
 {
     struct vo_chain *vo_c = mpctx->vo_chain;
 
-    if (!vo_c->filter->failed_output_conversion || !vo_c->track)
+    if (!vo_c->filter->failed_output_conversion || !vo_c->track || !vo_c->track->dec)
         return false;
 
     if (mp_decoder_wrapper_control(vo_c->track->dec,
@@ -576,9 +576,13 @@ static bool check_for_hwdec_fallback(struct MPContext *mpctx)
 static bool check_for_forced_eof(struct MPContext *mpctx)
 {
     struct vo_chain *vo_c = mpctx->vo_chain;
-    struct mp_decoder_wrapper *dec = vo_c->track->dec;
 
+    if (!vo_c->track || !vo_c->track->dec)
+        return false;
+
+    struct mp_decoder_wrapper *dec = vo_c->track->dec;
     bool forced_eof = false;
+
     mp_decoder_wrapper_control(dec, VDCTRL_CHECK_FORCED_EOF, &forced_eof);
     return forced_eof;
 }


### PR DESCRIPTION
The track during lavfi-complex can actually be NULL which meant that ca4192e2df7bcfdb9e18461f19e1bd2dd0ee3c7a regressed lavfi-complex by causing mpv to crash during runtime changes of the filter. Additionally, it's possible for the decoder wrapper to also be NULL. check_framedrop within write_video checks this, but check_for_hwdec_fallback does not. Perhaps, it's impossible for this to happen, but we might as well add the check here to be on the safe side since mp_decoder_wrapper_control is not designed to handle a NULL.