### PR TITLE
Revert "ci/msys2: double down on running meson through python3.11"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,9 +234,10 @@ jobs:
             libjpeg-turbo:p
             libplacebo:p
             lua51:p
+            meson:p
             ninja:p
             pkgconf:p
-            python3.11:p
+            python:p
             rst2pdf:p
             rubberband:p
             shaderc:p
@@ -258,7 +259,6 @@ jobs:
       - name: Run meson tests
         id: tests
         run: |
-          source ./venv/bin/activate
           meson test -C build
 
       - name: Print meson test log

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -1,8 +1,5 @@
 #!/bin/sh -e
 
-python3.11 -m venv venv
-source ./venv/bin/activate
-python -m pip install meson
 meson setup build            \
   -D cdda=enabled            \
   -D d3d-hwaccel=enabled     \


### PR DESCRIPTION
Python 3.11 will be released soon as default Python package, and actually python3.11 package already disappeared from the repository.

This reverts commit c637beb5223b0af5a671c8829a0e1a42e7e9a411.