### PR TITLE
options: fix relative time parsing

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2648,17 +2648,18 @@ const m_option_type_t m_option_type_channels = {
 
 static int parse_timestring(struct bstr str, double *time, char endchar)
 {
-    int a, b, len;
-    double d;
+    int h, m, len;
+    double s;
     *time = 0; /* ensure initialization for error cases */
-    if (bstr_sscanf(str, "%d:%d:%lf%n", &a, &b, &d, &len) >= 3)
-        *time = 3600 * a + 60 * b + d;
-    else if (bstr_sscanf(str, "%d:%lf%n", &a, &d, &len) >= 2)
-        *time = 60 * a + d;
-    else if (bstr_sscanf(str, "%lf%n", &d, &len) >= 1)
-        *time = d;
-    else
+    if (bstr_sscanf(str, "%d:%d:%lf%n", &h, &m, &s, &len) >= 3) {
+        *time = 3600 * h + 60 * m + s;
+    } else if (bstr_sscanf(str, "%d:%lf%n", &m, &s, &len) >= 2) {
+        *time = 60 * m + s;
+    } else if (bstr_sscanf(str, "%lf%n", &s, &len) >= 1) {
+        *time = s;
+    } else {
         return 0;  /* unsupported time format */
+    }
     if (len < str.len && str.start[len] != endchar)
         return 0;  /* invalid extra characters at the end */
     if (!isfinite(*time))


### PR DESCRIPTION
Fixes wrong time parsing when the value starts with "-".

**Reproduction steps:**
file length: `00:10:00`

- `mpv --start=-02:30 --pause <file>`  
  expected position: `00:07:30`  
  actual position: `00:08:30`

- `mpv --start=-00:02:30 --pause <file>`  
  expected position: `00:07:30`  
  actual position: `00:02:30`