### PR TITLE
version.py: fix build date

### DIFF
--- a/version.py
+++ b/version.py
@@ -25,21 +25,18 @@ if len(sys.argv) < 2:
     print(version)
     sys.exit()
 
-date = datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
-if date == "":
-    date = datetime.now(timezone.utc).astimezone()
-date_str = date.strftime("%a %b %d %I:%M:%S %Y")
+ts = float(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+date = datetime.fromtimestamp(ts, timezone.utc)
 
-NEW_REVISION = "#define VERSION \"" + version + "\"\n"
 OLD_REVISION = ""
-BUILDDATE = "#define BUILDDATE \"" + date_str + "\"\n"
-MPVCOPYRIGHT = "#define MPVCOPYRIGHT \"Copyright \u00A9 2000-2023 mpv/MPlayer/mplayer2 projects\"" + "\n"
+NEW_REVISION = f'#define VERSION "{version}"'
+BUILDDATE = f'#define BUILDDATE "{date.ctime()}"'
+MPVCOPYRIGHT = f'#define MPVCOPYRIGHT "Copyright © 2000-2023 mpv/MPlayer/mplayer2 projects"'
 
 if os.path.isfile(sys.argv[1]):
     with open(sys.argv[1], "r") as f:
-        OLD_REVISION = f.readline()
+        OLD_REVISION = f.readline().strip()
 
-if NEW_REVISION != OLD_REVISION:
+if NEW_REVISION != OLD_REVISION or NEW_REVISION.endswith('dirty"'):
     with open(sys.argv[1], "w", encoding="utf-8") as f:
-        f.writelines([NEW_REVISION, BUILDDATE, MPVCOPYRIGHT])
-
+        f.writelines(f"{l}{os.linesep}" for l in [NEW_REVISION, BUILDDATE, MPVCOPYRIGHT])


### PR DESCRIPTION
- Use ctime() instead manual format string. Fixes 12-hour format (%I) without AM/PM (%p) specified. It is 24-hours now, as it should be.
- Avoid naive datetime object.
- Fix timestamp type, it is float in Python.
- Remove dummy fallback branch.
- Use f-strings for readability.
- Always rebuild version.h is repository is dirty.

RFC: I actually was thinking about changing the format to `date -u --rfc-email` -> `Sat, 29 Jul 2023 09:19:20 +0000` and probably without tz, so `Sat, 29 Jul 2023 09:19:20`, I find it more readable than ctime... but you will likely not agree, so I didn't include this change.

RFC2: Build time has limited usefulness in the binary. And causes only troubles with build reproducibility and so on. We could just remove it...