### PR TITLE
hwtransfer: implement support for hw->hw format conversion

### DIFF
--- a/filters/f_autoconvert.c
+++ b/filters/f_autoconvert.c
@@ -150,7 +150,12 @@ static bool build_image_converter(struct mp_autoconvert *c, struct mp_log *log,
     for (int n = 0; n < p->num_imgfmts; n++) {
         bool samefmt = img->params.imgfmt == p->imgfmts[n];
         bool samesubffmt = img->params.hw_subfmt == p->subfmts[n];
-        if (samefmt && (samesubffmt || !p->subfmts[n])) {
+        /*
+         * In practice, `p->subfmts` is not usually populated today, in which
+         * case we must actively probe formats below to establish if the VO can
+         * accept the subfmt being used by the hwdec.
+         */
+        if (samefmt && samesubffmt) {
             if (p->imgparams_set) {
                 if (!mp_image_params_equal(&p->imgparams, &img->params))
                     break;
@@ -183,26 +188,57 @@ static bool build_image_converter(struct mp_autoconvert *c, struct mp_log *log,
 
     bool dst_all_hw = true;
     bool dst_have_sw = false;
+    bool has_src_hw_fmt = false;
     for (int n = 0; n < num_fmts; n++) {
         bool is_hw = IMGFMT_IS_HWACCEL(fmts[n]);
         dst_all_hw &= is_hw;
         dst_have_sw |= !is_hw;
+        has_src_hw_fmt |= is_hw && fmts[n] == imgpar.imgfmt;
     }
 
     // Source is hw, some targets are sw -> try to download.
     bool hw_to_sw = !imgfmt_is_sw && dst_have_sw;
 
-    if (dst_all_hw && num_fmts > 0) {
+    if (has_src_hw_fmt) {
+        int src_fmt = img->params.hw_subfmt;
+        /*
+         * If the source format is a hardware format, and our output supports
+         * that hardware format, we prioritize preserving the use of that
+         * hardware format. In most cases, the sub format will also be supported
+         * and no conversion will be required, but in some cases, the hwdec
+         * may be able to output formats that the VO cannot display, and
+         * hardware format conversion becomes necessary.
+         */
+        struct mp_hwupload upload = mp_hwupload_create(conv, imgpar.imgfmt,
+                                                       src_fmt,
+                                                       true);
+        if (upload.successful_init) {
+            if (upload.f) {
+                mp_info(log, "Converting %s[%s] -> %s[%s]\n",
+                        mp_imgfmt_to_name(imgpar.imgfmt),
+                        mp_imgfmt_to_name(src_fmt),
+                        mp_imgfmt_to_name(imgpar.imgfmt),
+                        mp_imgfmt_to_name(upload.selected_sw_imgfmt));
+                filters[2] = upload.f;
+            }
+            hw_to_sw = false;
+            need_sws = false;
+        } else {
+            mp_err(log, "Failed to create HW uploader for format %s\n",
+                   mp_imgfmt_to_name(src_fmt));
+        }
+    } else if (dst_all_hw && num_fmts > 0) {
         bool upload_created = false;
         int sw_fmt = imgfmt_is_sw ? img->imgfmt : img->params.hw_subfmt;
 
         for (int i = 0; i < num_fmts; i++) {
             // We can probably use this! Very lazy and very approximate.
-            struct mp_hwupload *upload = mp_hwupload_create(conv, fmts[i]);
-            if (upload) {
+            struct mp_hwupload upload = mp_hwupload_create(conv, fmts[i],
+                                                           sw_fmt, false);
+            if (upload.successful_init) {
                 mp_info(log, "HW-uploading to %s\n", mp_imgfmt_to_name(fmts[i]));
-                filters[2] = upload->f;
-                hwupload_fmt = mp_hwupload_find_upload_format(upload, sw_fmt);
+                filters[2] = upload.f;
+                hwupload_fmt = upload.selected_sw_imgfmt;
                 fmts = &hwupload_fmt;
                 num_fmts = hwupload_fmt ? 1 : 0;
                 hw_to_sw = false;

--- a/filters/f_autoconvert.c
+++ b/filters/f_autoconvert.c
@@ -358,8 +358,8 @@ static void handle_video_frame(struct mp_filter *f)
     }
 
     if (!mp_subfilter_drain_destroy(&p->sub)) {
-        p->in_imgfmt = p->in_subfmt = 0;
-        return;
+        MP_VERBOSE(f, "Sub-filter requires draining but we must destroy it now.\n");
+        mp_subfilter_destroy(&p->sub);
     }
 
     p->in_imgfmt = img->params.imgfmt;

--- a/filters/f_hwtransfer.h
+++ b/filters/f_hwtransfer.h
@@ -4,16 +4,19 @@
 
 // A filter which uploads sw frames to hw. Ignores hw frames.
 struct mp_hwupload {
+    // Indicates if the filter was successfully initialised, or not.
+    // If not, the state of other members is undefined.
+    bool successful_init;
+
+    // The filter to use for uploads. NULL if none is required.
     struct mp_filter *f;
+
+    // The underlying format of uploaded frames
+    int selected_sw_imgfmt;
 };
 
-struct mp_hwupload *mp_hwupload_create(struct mp_filter *parent, int hw_imgfmt);
-
-// Return the best format suited for upload that is supported for a given input
-// imgfmt. This returns the same as imgfmt if the format is natively supported,
-// and otherwise a format that likely results in the least loss.
-// Returns 0 if completely unsupported.
-int mp_hwupload_find_upload_format(struct mp_hwupload *u, int imgfmt);
+struct mp_hwupload mp_hwupload_create(struct mp_filter *parent, int hw_imgfmt,
+                                       int sw_imgfmt, bool src_is_same_hw);
 
 // A filter which downloads sw frames from hw. Ignores sw frames.
 struct mp_hwdownload {

--- a/filters/f_output_chain.c
+++ b/filters/f_output_chain.c
@@ -114,7 +114,11 @@ static void check_in_format_change(struct mp_user_filter *u,
             // But a common case is enabling HW decoding, which
             // might init some support of them in the VO, and update
             // the VO's format list.
-            update_output_caps(p);
+            //
+            // But as this is only relevant to the "convert" filter, don't
+            // do this for the other filters as it is wasted work.
+            if (strcmp(u->name, "convert") == 0)
+                update_output_caps(p);
 
             p->public.reconfig_happened = true;
         }

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -18,6 +18,11 @@ struct mp_hwdec_ctx {
     const int *supported_formats;
     // HW format used by the hwdec
     int hw_imgfmt;
+
+    // The name of this hwdec's matching conversion filter if available.
+    // This will be used for hardware conversion of frame formats.
+    // NULL otherwise.
+    const char *conversion_filter_name;
 };
 
 // Used to communicate hardware decoder device handles from VO to video decoder.

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -23,6 +23,10 @@ struct mp_hwdec_ctx {
     // This will be used for hardware conversion of frame formats.
     // NULL otherwise.
     const char *conversion_filter_name;
+
+    // The libavutil hwconfig to be used when querying constraints for the
+    // conversion filter. Can be NULL if no special config is required.
+    void *conversion_config;
 };
 
 // Used to communicate hardware decoder device handles from VO to video decoder.

--- a/video/out/hwdec/dmabuf_interop_wl.c
+++ b/video/out/hwdec/dmabuf_interop_wl.c
@@ -54,7 +54,8 @@ static bool map(struct ra_hwdec_mapper *mapper,
         return false;
     }
 
-    MP_VERBOSE(mapper, "Supported Wayland display format: '%s(%016lx)'\n",
+    MP_VERBOSE(mapper, "Supported Wayland display format %s: '%s(%016lx)'\n",
+               mp_imgfmt_to_name(mapper->src->params.hw_subfmt),
                mp_tag_str(drm_format), mapper_p->desc.objects[0].format_modifier);
 
     return true;

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -131,6 +131,8 @@ const static dmabuf_interop_init interop_inits[] = {
     NULL
 };
 
+const static char *conversion_filter_name = "scale_vaapi";
+
 static int init(struct ra_hwdec *hw)
 {
     struct priv_owner *p = hw->priv;
@@ -177,6 +179,7 @@ static int init(struct ra_hwdec *hw)
     p->ctx->hwctx.hw_imgfmt = IMGFMT_VAAPI;
     p->ctx->hwctx.supported_formats = p->formats;
     p->ctx->hwctx.driver_name = hw->driver->name;
+    p->ctx->hwctx.conversion_filter_name = conversion_filter_name;
     hwdec_devices_add(hw->devs, &p->ctx->hwctx);
     return 0;
 }

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -113,8 +113,14 @@ struct priv_owner {
 static void uninit(struct ra_hwdec *hw)
 {
     struct priv_owner *p = hw->priv;
-    if (p->ctx)
+    if (p->ctx) {
         hwdec_devices_remove(hw->devs, &p->ctx->hwctx);
+        if (p->ctx->hwctx.conversion_config) {
+            AVVAAPIHWConfig *hwconfig = p->ctx->hwctx.conversion_config;
+            vaDestroyConfig(p->ctx->display, hwconfig->config_id);
+            av_freep(&p->ctx->hwctx.conversion_config);
+        }
+    }
     va_destroy(p->ctx);
 }
 
@@ -131,11 +137,10 @@ const static dmabuf_interop_init interop_inits[] = {
     NULL
 };
 
-const static char *conversion_filter_name = "scale_vaapi";
-
 static int init(struct ra_hwdec *hw)
 {
     struct priv_owner *p = hw->priv;
+    VAStatus vas;
 
     for (int i = 0; interop_inits[i]; i++) {
         if (interop_inits[i](hw, &p->dmabuf_interop)) {
@@ -173,13 +178,23 @@ static int init(struct ra_hwdec *hw)
         return -1;
     }
 
+    VAConfigID config_id;
+    AVVAAPIHWConfig *hwconfig = NULL;
+    vas = vaCreateConfig(p->display, VAProfileNone, VAEntrypointVideoProc, NULL,
+                         0, &config_id);
+    if (vas == VA_STATUS_SUCCESS) {
+        hwconfig = av_hwdevice_hwconfig_alloc(p->ctx->av_device_ref);
+        hwconfig->config_id = config_id;
+    }
+
     // it's now safe to set the display resource
     ra_add_native_resource(hw->ra_ctx->ra, "VADisplay", p->display);
 
     p->ctx->hwctx.hw_imgfmt = IMGFMT_VAAPI;
     p->ctx->hwctx.supported_formats = p->formats;
     p->ctx->hwctx.driver_name = hw->driver->name;
-    p->ctx->hwctx.conversion_filter_name = conversion_filter_name;
+    p->ctx->hwctx.conversion_filter_name = "scale_vaapi";
+    p->ctx->hwctx.conversion_config = hwconfig;
     hwdec_devices_add(hw->devs, &p->ctx->hwctx);
     return 0;
 }


### PR DESCRIPTION
Historically, we have not attempted to support hw->hw format conversion in the autoconvert logic. If a user needed to do these kinds of conversions, they needed to manually insert the hw format's scale filter manually (eg: scale_vaapi).

This was usually fine because the general rule is that any format supported by the hardware can be used as well as any other. ie: You would only need to do conversion if you have a specific goal in mind.

However, we now have two situations where we can find ourselves with a hardware format being produced by a decoder that cannot be accepted by a VO via hwdec-interop:
 * dmabuf-wayland can only accept formats that the Wayland compositor accepts. In the case of GNOME, it can only accept a handful of RGB formats.
 * When decoding via VAAPI on Intel hardware, some of the more unusual video encodings (4:2:2, 10bit 4:4:4) lead to packed frame formats which gpu-next cannot handle, causing rendering to fail.

In both these cases (at least when using VAAPI with dmabuf-wayland), if we could detect the failure case and insert a `scale_vaapi` filter, we could get successful output automatically. For `hwdec=drm`, there is currently not scaling filter, so dmabuf-wayland is still out of luck there.

The basic approach to implementing this is to detect the case where we are evaluating a hardware format where the VO can accept the hardware format itself, but may not accept the underlying sw format. In the current code, we bypass autoconvert as soon as we see the hardware format is compatible.

My first observation is that we actually have logic in autoconvert to detect when the input sw format is not in the list of allowed sw formats passed into the autoconverter. Unfortunately, we never populate this list, and the way you would expect to do that if vo-query-format returned sw format information. We could define an extended vo-query-format-2, but we'd still need to implement the probing logic to fill it in.

On the other hand, we already have the probing logic in the hwupload filter - and most recently I used that logic to implement conversion on upload. So if we could leverage that, we could both detect when hw->hw conversion is required, and pick the best target format.

This exercise is then primarily a one of detecting when we are in this case and letting that code run in a useful way. The hwupload filter is a bit awkward to work with today, and so I refactored a bunch of the set up code to actually make it more encapsulated. Now, instead of the caller instantiating it and then triggering the probe, we probe on creation and instantiate the correct underlying filter (hwupload vs scaler) automatically.