### PR TITLE
ao_pipewire: revert media role handling

### DIFF
--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -34,8 +34,6 @@ enum aocontrol {
     AOCONTROL_SET_MUTE,
     // Has char* as argument, which contains the desired stream title.
     AOCONTROL_UPDATE_STREAM_TITLE,
-    // Has enum aocontrol_media_role* argument, which contains the current media role
-    AOCONTROL_UPDATE_MEDIA_ROLE,
 };
 
 // If set, then the queued audio data is the last. Note that after a while, new
@@ -58,11 +56,6 @@ enum {
     AO_INIT_STREAM_SILENCE = 1 << 2,
     // Force exclusive mode, i.e. lock out the system mixer.
     AO_INIT_EXCLUSIVE = 1 << 3,
-};
-
-enum aocontrol_media_role {
-    AOCONTROL_MEDIA_ROLE_MUSIC,
-    AOCONTROL_MEDIA_ROLE_MOVIE,
 };
 
 struct ao_device_desc {

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -553,6 +553,7 @@ static int init(struct ao *ao)
     struct pw_properties *props = pw_properties_new(
         PW_KEY_MEDIA_TYPE, "Audio",
         PW_KEY_MEDIA_CATEGORY, "Playback",
+        PW_KEY_MEDIA_ROLE, "Movie",
         PW_KEY_NODE_NAME, ao->client_name,
         PW_KEY_NODE_DESCRIPTION, ao->client_name,
         PW_KEY_APP_NAME, ao->client_name,
@@ -677,8 +678,7 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
         }
         case AOCONTROL_SET_VOLUME:
         case AOCONTROL_SET_MUTE:
-        case AOCONTROL_UPDATE_STREAM_TITLE:
-        case AOCONTROL_UPDATE_MEDIA_ROLE: {
+        case AOCONTROL_UPDATE_STREAM_TITLE: {
             int ret;
 
             pw_thread_loop_lock(p->loop);
@@ -709,26 +709,6 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
                     char *title = arg;
                     struct spa_dict_item items[1];
                     items[0] = SPA_DICT_ITEM_INIT(PW_KEY_MEDIA_NAME, title);
-                    ret = CONTROL_RET(pw_stream_update_properties(p->stream, &SPA_DICT_INIT(items, MP_ARRAY_SIZE(items))));
-                    break;
-                }
-                case AOCONTROL_UPDATE_MEDIA_ROLE: {
-                    enum aocontrol_media_role *role = arg;
-                    struct spa_dict_item items[1];
-                    const char *role_str;
-                    switch (*role) {
-                        case AOCONTROL_MEDIA_ROLE_MOVIE:
-                            role_str = "Movie";
-                            break;
-                        case AOCONTROL_MEDIA_ROLE_MUSIC:
-                            role_str = "Music";
-                            break;
-                        default:
-                            MP_WARN(ao, "Unknown media role %d\n", *role);
-                            role_str = "";
-                            break;
-                    }
-                    items[0] = SPA_DICT_ITEM_INIT(PW_KEY_MEDIA_ROLE, role_str);
                     ret = CONTROL_RET(pw_stream_update_properties(p->stream, &SPA_DICT_INIT(items, MP_ARRAY_SIZE(items))));
                     break;
                 }

--- a/player/audio.c
+++ b/player/audio.c
@@ -190,30 +190,6 @@ void update_playback_speed(struct MPContext *mpctx)
     update_speed_filters(mpctx);
 }
 
-static bool has_video_track(struct MPContext *mpctx)
-{
-    if (mpctx->vo_chain && mpctx->vo_chain->is_coverart)
-        return false;
-
-    for (int n = 0; n < mpctx->num_tracks; n++) {
-        struct track *track = mpctx->tracks[n];
-        if (track->type == STREAM_VIDEO && !track->attached_picture && !track->image)
-            return true;
-    }
-
-    return false;
-}
-
-void audio_update_media_role(struct MPContext *mpctx)
-{
-    if (!mpctx->ao)
-        return;
-
-    enum aocontrol_media_role role = has_video_track(mpctx) ?
-        AOCONTROL_MEDIA_ROLE_MOVIE : AOCONTROL_MEDIA_ROLE_MUSIC;
-    ao_control(mpctx->ao, AOCONTROL_UPDATE_MEDIA_ROLE, &role);
-}
-
 static void ao_chain_reset_state(struct ao_chain *ao_c)
 {
     ao_c->last_out_pts = MP_NOPTS_VALUE;
@@ -498,8 +474,6 @@ static int reinit_audio_filters_and_output(struct MPContext *mpctx)
     ao_chain_set_ao(ao_c, mpctx->ao);
 
     audio_update_volume(mpctx);
-
-    audio_update_media_role(mpctx);
 
     // Almost nonsensical hack to deal with certain format change scenarios.
     if (mpctx->audio_status == STATUS_PLAYING)

--- a/player/command.c
+++ b/player/command.c
@@ -6779,9 +6779,6 @@ static void command_event(struct MPContext *mpctx, int event, void *arg)
     if (event == MP_EVENT_WIN_STATE2)
         ctx->cached_window_scale = 0;
 
-    if (event == MPV_EVENT_FILE_LOADED)
-        audio_update_media_role(mpctx);
-
     if (event == MP_EVENT_METADATA_UPDATE) {
         struct playlist_entry *const pe = mpctx->playing;
         if (!pe->title) {

--- a/player/core.h
+++ b/player/core.h
@@ -488,7 +488,6 @@ int init_audio_decoder(struct MPContext *mpctx, struct track *track);
 void reinit_audio_chain_src(struct MPContext *mpctx, struct track *track);
 void audio_update_volume(struct MPContext *mpctx);
 void audio_update_balance(struct MPContext *mpctx);
-void audio_update_media_role(struct MPContext *mpctx);
 void reload_audio_output(struct MPContext *mpctx);
 void audio_start_ao(struct MPContext *mpctx);
 


### PR DESCRIPTION
The dynamic approach is racy.

For more details see the commit messages.

Potential successor: #11253
Fixes: #12041