### PR TITLE
af_scaletempo2: fix audio-video de-sync caused by speed changes

### DIFF
--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -65,10 +65,13 @@ static void process(struct mp_filter *f)
             int frame_size = mp_aframe_get_size(p->pending);
             uint8_t **planes = mp_aframe_get_data_ro(p->pending);
             int read = mp_scaletempo2_fill_input_buffer(&p->data,
-                planes, frame_size, final, p->speed);
+                planes, frame_size, p->speed);
             mp_aframe_skip_samples(p->pending, read);
         }
-        p->sent_final |= final;
+        if (final && p->pending && !p->sent_final) {
+            mp_scaletempo2_set_final(&p->data);
+            p->sent_final = true;
+        }
 
         if (mp_scaletempo2_frames_available(&p->data, p->speed)) {
             if (eof) {
@@ -80,11 +83,8 @@ static void process(struct mp_filter *f)
             if (eof) {
                 mp_pin_in_write(f->ppins[1], MP_EOF_FRAME);
                 return;
-            } else if (format_change) {
-                // go on with proper reinit on the next iteration
-                p->initialized = false;
-                p->sent_final = false;
             }
+            // for format change go on with proper reinit on the next iteration
         }
     }
 

--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -108,9 +108,8 @@ static void process(struct mp_filter *f)
 
         double pts = mp_aframe_get_pts(p->pending);
         if (pts != MP_NOPTS_VALUE) {
-            double frame_delay = p->data.input_buffer_frames - p->data.search_block_index
-                                 + p->data.num_complete_frames * p->speed
-                                 + out_samples * p->speed;
+            double frame_delay = mp_scaletempo2_get_latency(&p->data, p->speed)
+                + out_samples * p->speed;
             mp_aframe_set_pts(out, pts - frame_delay / mp_aframe_get_effective_rate(out));
         }
 

--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -29,7 +29,7 @@ static void process(struct mp_filter *f)
         return;
 
     while (!p->initialized || !p->pending ||
-           !mp_scaletempo2_frames_available(&p->data))
+           !mp_scaletempo2_frames_available(&p->data, p->speed))
     {
         bool eof = false;
         if (!p->pending || !mp_aframe_get_size(p->pending)) {
@@ -65,12 +65,12 @@ static void process(struct mp_filter *f)
             int frame_size = mp_aframe_get_size(p->pending);
             uint8_t **planes = mp_aframe_get_data_ro(p->pending);
             int read = mp_scaletempo2_fill_input_buffer(&p->data,
-                planes, frame_size, final);
+                planes, frame_size, final, p->speed);
             mp_aframe_skip_samples(p->pending, read);
         }
         p->sent_final |= final;
 
-        if (mp_scaletempo2_frames_available(&p->data)) {
+        if (mp_scaletempo2_frames_available(&p->data, p->speed)) {
             if (eof) {
                 mp_pin_out_repeat_eof(p->in_pin); // drain more next time
             }
@@ -89,7 +89,7 @@ static void process(struct mp_filter *f)
     }
 
     assert(p->pending);
-    if (mp_scaletempo2_frames_available(&p->data)) {
+    if (mp_scaletempo2_frames_available(&p->data, p->speed)) {
         struct mp_aframe *out = mp_aframe_new_ref(p->cur_format);
         int out_samples = p->data.ola_hop_size;
         if (mp_aframe_pool_allocate(p->out_pool, out, out_samples) < 0) {

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -720,7 +720,7 @@ void mp_scaletempo2_destroy(struct mp_scaletempo2 *p)
 void mp_scaletempo2_reset(struct mp_scaletempo2 *p)
 {
     p->input_buffer_frames = 0;
-    p->output_time = 0.0;
+    p->output_time = p->search_block_center_offset;
     p->search_block_index = 0;
     p->target_block_index = 0;
     // Clear the queue of decoded packets.
@@ -741,7 +741,6 @@ static void get_symmetric_hanning_window(int window_length, float* window)
 void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate)
 {
     p->muted_partial_frame = 0;
-    p->output_time = 0;
     p->search_block_center_offset = 0;
     p->search_block_index = 0;
     p->num_complete_frames = 0;
@@ -782,6 +781,8 @@ void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate)
     p->transition_window = realloc(p->transition_window,
         sizeof(float) * p->ola_window_size * 2);
     get_symmetric_hanning_window(2 * p->ola_window_size, p->transition_window);
+
+    p->output_time = p->search_block_center_offset;
 
     p->wsola_output_size = p->ola_window_size + p->ola_hop_size;
     p->wsola_output = realloc_2d(p->wsola_output, p->channels, p->wsola_output_size);

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -492,7 +492,7 @@ int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
         memcpy(p->input_buffer[i] + p->input_buffer_frames,
             planes[i], read * sizeof(float));
         for (int j = read; j < total_fill; ++j) {
-            p->input_buffer[p->input_buffer_frames + j] = 0;
+            p->input_buffer[i][p->input_buffer_frames + j] = 0.0f;
         }
     }
 

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -810,8 +810,8 @@ void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate)
 {
     p->muted_partial_frame = 0;
     p->output_time = 0;
-    p->search_block_center_offset = 0;
     p->search_block_index = 0;
+    p->target_block_index = 0;
     p->num_complete_frames = 0;
     p->wsola_output_started = false;
     p->channels = channels;

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -702,7 +702,15 @@ int mp_scaletempo2_fill_buffer(struct mp_scaletempo2 *p,
     // Optimize the most common |playback_rate| ~= 1 case to use a single copy
     // instead of copying frame by frame.
     if (p->ola_window_size <= faster_step && slower_step >= p->ola_window_size) {
-        p->wsola_output_started = false;
+
+        if (p->wsola_output_started) {
+            p->wsola_output_started = false;
+
+            // sync audio precisely again
+            set_output_time(p, p->target_block_index + p->search_block_center_offset);
+            remove_old_input_frames(p);
+        }
+
         return read_input_buffer(p, dest_size, dest);
     }
 

--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -694,6 +694,12 @@ int mp_scaletempo2_fill_buffer(struct mp_scaletempo2 *p,
     return rendered_frames;
 }
 
+double mp_scaletempo2_get_latency(struct mp_scaletempo2 *p, double playback_rate)
+{
+    return p->input_buffer_frames - p->search_block_index
+        + p->num_complete_frames * playback_rate;
+}
+
 bool mp_scaletempo2_frames_available(struct mp_scaletempo2 *p)
 {
     return can_perform_wsola(p) || p->num_complete_frames > 0;

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -112,6 +112,13 @@ struct mp_scaletempo2 {
     float **input_buffer;
     int input_buffer_size;
     int input_buffer_frames;
+    // How many frames in |input_buffer| need to be flushed by padding with
+    // silence to process the final packet. While this is nonzero, the filter
+    // appends silence to |input_buffer| until these frames are processed.
+    int input_buffer_final_frames;
+    // How many additional frames of silence have been added to |input_buffer|
+    // for padding after the final packet.
+    int input_buffer_added_silence;
     float *energy_candidate_blocks;
 };
 
@@ -120,7 +127,8 @@ void mp_scaletempo2_reset(struct mp_scaletempo2 *p);
 void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate);
 double mp_scaletempo2_get_latency(struct mp_scaletempo2 *p, double playback_rate);
 int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
-    uint8_t **planes, int frame_size, bool final, double playback_rate);
+    uint8_t **planes, int frame_size, double playback_rate);
+void mp_scaletempo2_set_final(struct mp_scaletempo2 *p);
 int mp_scaletempo2_fill_buffer(struct mp_scaletempo2 *p,
     float **dest, int dest_size, double playback_rate);
 bool mp_scaletempo2_frames_available(struct mp_scaletempo2 *p, double playback_rate);

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -64,7 +64,8 @@ struct mp_scaletempo2 {
     double output_time;
     // The offset of the center frame of |search_block| w.r.t. its first frame.
     int search_block_center_offset;
-    // Index of the beginning of the |search_block|, in frames.
+    // Index of the beginning of the |search_block|, in frames. This may be
+    // negative, which is handled by |peek_audio_with_zero_prepend|.
     int search_block_index;
     // Number of Blocks to search to find the most similar one to the target
     // frame.

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -53,14 +53,14 @@ struct mp_scaletempo2 {
     int samples_per_second;
     // If muted, keep track of partial frames that should have been skipped over.
     double muted_partial_frame;
-    // Book keeping of the current time of generated audio, in frames. This
-    // should be appropriately updated when out samples are generated, regardless
-    // of whether we push samples out when fill_buffer() is called or we store
-    // audio in |wsola_output| for the subsequent calls to fill_buffer().
-    // Furthermore, if samples from |audio_buffer| are evicted then this
-    // member variable should be updated based on |playback_rate|.
-    // Note that this member should be updated ONLY by calling update_output_time(),
-    // so that |search_block_index| is update accordingly.
+    // Book keeping of the current time of generated audio, in frames.
+    // Corresponds to the center of |search_block|. This is increased in
+    // intervals of |ola_hop_size| multiplied by the current playback_rate,
+    // for every WSOLA iteration. This tracks the number of advanced frames as
+    // a double to achieve accurate playback rates beyond the integer precision
+    // of |search_block_index|.
+    // Needs to be adjusted like any other index when frames are evicted from
+    // |input_buffer|.
     double output_time;
     // The offset of the center frame of |search_block| w.r.t. its first frame.
     int search_block_center_offset;
@@ -119,7 +119,7 @@ void mp_scaletempo2_reset(struct mp_scaletempo2 *p);
 void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate);
 double mp_scaletempo2_get_latency(struct mp_scaletempo2 *p, double playback_rate);
 int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
-    uint8_t **planes, int frame_size, bool final);
+    uint8_t **planes, int frame_size, bool final, double playback_rate);
 int mp_scaletempo2_fill_buffer(struct mp_scaletempo2 *p,
-    float **dest, int dest_size, float playback_rate);
-bool mp_scaletempo2_frames_available(struct mp_scaletempo2 *p);
+    float **dest, int dest_size, double playback_rate);
+bool mp_scaletempo2_frames_available(struct mp_scaletempo2 *p, double playback_rate);

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -80,6 +80,9 @@ struct mp_scaletempo2 {
     // them and can be copied to output if fill_buffer() is called. It also
     // specifies the index where the next WSOLA window has to overlap-and-add.
     int num_complete_frames;
+    // Whether |wsola_output| contains an additional |ola_hop_size| of overlap
+    // frames for the next iteration.
+    bool wsola_output_started;
     // Overlap-and-add window.
     float *ola_window;
     // Transition window, used to update |optimal_block| by a weighted sum of

--- a/audio/filter/af_scaletempo2_internals.h
+++ b/audio/filter/af_scaletempo2_internals.h
@@ -114,6 +114,7 @@ struct mp_scaletempo2 {
 void mp_scaletempo2_destroy(struct mp_scaletempo2 *p);
 void mp_scaletempo2_reset(struct mp_scaletempo2 *p);
 void mp_scaletempo2_init(struct mp_scaletempo2 *p, int channels, int rate);
+double mp_scaletempo2_get_latency(struct mp_scaletempo2 *p, double playback_rate);
 int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
     uint8_t **planes, int frame_size, bool final);
 int mp_scaletempo2_fill_buffer(struct mp_scaletempo2 *p,


### PR DESCRIPTION
Update: Apologies for how big this PR has gotten. It turns out there were a lot of unnoticed issues in scaletempo2, which are fixed here. There are detailed commit messages, but see my [comment](https://github.com/mpv-player/mpv/pull/12052#issuecomment-1685231794) for a summary.

Original text:

This is what I came up with to fix #12028. It calculates the scaletempo2 delay based on the current buffer positions.

My testing consisted of the process described in #12028. With normal settings, the audio seems fine both with the new code, and without delay calculation (by removing the pts adjustment altogether as described in the issue). I find it impossible to notice the differences _during_ speed changes in any case.

### window-size delay

There was an additional issue that audio was always delayed by half the configured search-interval. Include `ola_hop_size` in the delay to compensate for that.

I noticed that by increasing the search-interval and window-size to impractically large values:

```
--af=scaletempo2=search-interval=100:window-size=1000
```

(Note: With these settings, repeated speed changes result in very inconsistent output with both the old and new calculation, but it helps to test the delay during constant replay.)

In the original code, I found that the audio was played back about half the search-interval too late (i.e 0.5s with the above settings) even without changing playback speed. The fix was to adjust by `ola_hop_size` in the calculation.

I'm not sure where the `ola_hop_size` delay comes from. It's either the `out` buffer, or from the overlap in the scaletempo2 internals.

### Additional notes

Here are some things I observed. If any of these are wrong, it may mean there is an issue in the new delay calculation:
- Every WSOLA iteration advances the input buffer by _some amount_, and produces data in the output buffer always of size `ola_hop_size`.
- `mp_scaletempo2_fill_buffer` is always called with `ola_hop_size`
- Thus, the rendered frames are always cleared immediately after processing, and `num_complete_frames` is 0 in the delay calculation.
- The input buffer expression makes sense as the header comment states, `|target_block| is the "natural" continuation of the output`. The delay comes from the length of audio that the filter is holding back.
- The factors contributing to delay are:
  - the pending samples in the input buffer,
  - the pending rendered samples in the output buffer, and
  - an amount of `ola_hop_size`

The `frame_delay` code looked like that of the rubberband filter, which might not work for scaletempo2. Sometimes a different amount of input audio was consumed by scaletempo2 than expected. It may have been caused by speed changes being a more dynamic process in scaletempo2. This can be seen by where `playback_rate` is used in `run_one_wsola_iteration`: `playback_rate` is only referenced after the iteration, when updating the time and removing old data from buffers.

In scaletempo2, the playback speed is applied by changing the amount the search window is moved. That apparently averages out correctly at constant playback speed, but when the speed changes, the error in this assumption probably spikes. This error accumulated across all speed changes because of the persistent `frame_delay` value.

With the removal of the persistent `frame_delay`, there should be no way for the audio to drift off. By deriving the delay from filter buffer positions, and the buffers are filled only as much as needed, the delay always stays within buffer bounds.
