### PR TITLE
drm: bump minimum version to 2.4.105

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -894,7 +894,7 @@ if features['direct3d']
     sources += files('video/out/vo_direct3d.c')
 endif
 
-drm = dependency('libdrm', version: '>= 2.4.75', required: get_option('drm'))
+drm = dependency('libdrm', version: '>= 2.4.105', required: get_option('drm'))
 features += {'drm': drm.found() and (features['vt.h'] or features['consio.h'])}
 if features['drm']
     dependencies += drm
@@ -906,9 +906,6 @@ if features['drm']
                      'video/out/hwdec/hwdec_drmprime_overlay.c',
                      'video/out/vo_drm.c')
 endif
-
-# This can be removed roughly when Debian 12 is released.
-features += {'drm-is-kms': features['drm'] and drm.version().version_compare('>= 2.4.105')}
 
 gbm = dependency('gbm', version: '>=17.1.0', required: get_option('gbm'))
 features += {'gbm': gbm.found()}

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -809,15 +809,11 @@ static int open_card_path(const char *path)
 
 static bool card_supports_kms(const char *path)
 {
-#if HAVE_DRM_IS_KMS
     int fd = open_card_path(path);
     bool ret = fd != -1 && drmIsKMS(fd);
     if (fd != -1)
         close(fd);
     return ret;
-#else
-    return true;
-#endif
 }
 
 static void get_primary_device_path(struct vo_drm_state *drm)


### PR DESCRIPTION
Debian 12 is out, with 2.4.114, and Ubuntu 22.04 has 2.4.110, this
 #ifdef is no longer needed