### PR TITLE
test: refactor libmpv test into separate binaries

### DIFF
--- a/test/libmpv_lavfi_complex.c
+++ b/test/libmpv_lavfi_complex.c
@@ -1,0 +1,65 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libmpv_test_utils.h"
+
+static void test_lavfi_complex(mpv_handle *ctx, char *file)
+{
+    const char *cmd[] = {"loadfile", file, NULL};
+    check_api_error(mpv_command(ctx, cmd));
+    int finished = 0;
+    int loaded = 0;
+    while (!finished) {
+        mpv_event *event = mpv_wait_event(ctx, 0);
+        switch (event->event_id) {
+        case MPV_EVENT_FILE_LOADED:
+            // Add file as external and toggle lavfi-complex on.
+            if (!loaded) {
+                check_api_error(mpv_set_property_string(ctx, "external-files", file));
+                const char *add_cmd[] = {"video-add", file, "auto", NULL};
+                check_api_error(mpv_command(ctx, add_cmd));
+                check_api_error(mpv_set_property_string(ctx, "lavfi-complex", "[vid1] [vid2] vstack [vo]"));
+            }
+            loaded = 1;
+            break;
+        case MPV_EVENT_END_FILE:
+            if (loaded)
+                finished = 1;
+            break;
+        }
+    }
+    if (!finished)
+        fail(ctx, "Lavfi complex failed!\n");
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2)
+        return 1;
+
+    mpv_handle *ctx = mpv_create();
+    if (!ctx)
+        return 1;
+
+    // Use tct for all video-related stuff.
+    check_api_error(mpv_set_property_string(ctx, "vo", "tct"));
+    check_api_error(mpv_initialize(ctx));
+    test_lavfi_complex(ctx, argv[1]);
+
+    mpv_destroy(ctx);
+    return 0;
+}

--- a/test/libmpv_load_file.c
+++ b/test/libmpv_load_file.c
@@ -1,0 +1,59 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libmpv_test_utils.h"
+
+static void test_file_loading(mpv_handle *ctx, char *file)
+{
+    const char *cmd[] = {"loadfile", file, NULL};
+    check_api_error(mpv_command(ctx, cmd));
+    int loaded = 0;
+    int finished = 0;
+    while (!finished) {
+        mpv_event *event = mpv_wait_event(ctx, 0);
+        switch (event->event_id) {
+        case MPV_EVENT_FILE_LOADED:
+            // make sure it loads before exiting
+            loaded = 1;
+            break;
+        case MPV_EVENT_END_FILE:
+            if (loaded)
+                finished = 1;
+            break;
+        }
+    }
+    if (!finished)
+        fail(ctx, "Unable to load test file!\n");
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2)
+        return 1;
+
+    mpv_handle *ctx = mpv_create();
+    if (!ctx)
+        return 1;
+
+    // Use tct for all video-related stuff.
+    check_api_error(mpv_set_property_string(ctx, "vo", "tct"));
+    check_api_error(mpv_initialize(ctx));
+    test_file_loading(ctx, argv[1]);
+
+    mpv_destroy(ctx);
+    return 0;
+}

--- a/test/libmpv_test_utils.c
+++ b/test/libmpv_test_utils.c
@@ -1,0 +1,43 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libmpv_test_utils.h"
+
+MP_NORETURN PRINTF_ATTRIBUTE(2, 3)
+void fail(mpv_handle *ctx, const char *fmt, ...)
+{
+	if (fmt) {
+		va_list va;
+		va_start(va, fmt);
+		vfprintf(stderr, fmt, va);
+		va_end(va);
+	}
+    if (ctx)
+	    mpv_destroy(ctx);
+    exit(1);
+}
+
+void check_api_error(int status)
+{
+    if (status < 0)
+        fail(NULL, "mpv API error: %s\n", mpv_error_string(status));
+}
+

--- a/test/libmpv_test_utils.h
+++ b/test/libmpv_test_utils.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libmpv/client.h>
+
+// Stolen from osdep/compiler.h
+#ifdef __GNUC__
+#define PRINTF_ATTRIBUTE(a1, a2) __attribute__ ((format(printf, a1, a2)))
+#define MP_NORETURN __attribute__((noreturn))
+#else
+#define PRINTF_ATTRIBUTE(a1, a2)
+#define MP_NORETURN
+#endif
+
+// Broken crap with __USE_MINGW_ANSI_STDIO
+#if defined(__MINGW32__) && defined(__GNUC__) && !defined(__clang__)
+#undef PRINTF_ATTRIBUTE
+#define PRINTF_ATTRIBUTE(a1, a2) __attribute__ ((format (gnu_printf, a1, a2)))
+#endif
+
+
+MP_NORETURN PRINTF_ATTRIBUTE(2, 3)
+void fail(mpv_handle *ctx, const char *fmt, ...);
+void check_api_error(int status);

--- a/test/meson.build
+++ b/test/meson.build
@@ -98,10 +98,18 @@ paths = executable('paths', 'paths.c', include_directories: incdir,
 test('paths', paths)
 
 if get_option('libmpv')
-    libmpv_test = executable('libmpv-test', 'libmpv_test.c',
-                             include_directories: incdir, link_with: libmpv)
+    libmpv_test_utils = static_library('libmpv-test-utils', 'libmpv_test_utils.c',
+                                       include_directories: incdir, link_with: libmpv)
+    libmpv_lavfi_complex = executable('libmpv-lavfi-complex', 'libmpv_lavfi_complex.c',
+                                      include_directories: incdir, link_with: libmpv_test_utils)
+    libmpv_load_file = executable('libmpv-load-file', 'libmpv_load_file.c',
+                                  include_directories: incdir, link_with: libmpv_test_utils)
+    libmpv_options = executable('libmpv-options', 'libmpv_options.c',
+                                include_directories: incdir, link_with: libmpv_test_utils)
     file = join_paths(source_root, 'etc', 'mpv-icon-8bit-16x16.png')
-    test('libmpv', libmpv_test, args: file)
+    test('libmpv-lavfi-complex-test', libmpv_lavfi_complex, args: file)
+    test('libmpv-load-file-test', libmpv_load_file, args: file)
+    test('libmpv-options-test', libmpv_options, args: file)
 endif
 
 # Minimum required libavutil version that works with these tests.


### PR DESCRIPTION
It turns out that msys can occasionally be really slow when loading files (greater than 10 seconds) which causes part of the libmpv test to fail. There's several possible ways to deal with this, but let's go with splitting the big libmpv test into three separate binaries since there's really three separate tests going on here. To do that, refactor the shared bits into libmpv_test_utils and then split the rest into separate files and link them with that. Now, the options test, loading file test, and lavfi complex test all run separately and we don't have to worry about one part of the test taking so long that it blocks other stuff. If we somehow run into meson's default time limit (30 seconds), that individual test's time can always just be adjusted later.