### PR TITLE
test: bump libmpv test timeout

### DIFF
--- a/test/libmpv_test.c
+++ b/test/libmpv_test.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 // Stolen from osdep/compiler.h
 #ifdef __GNUC__
@@ -151,10 +150,7 @@ static void test_file_loading(char *file)
     check_api_error(mpv_command(ctx, cmd));
     int loaded = 0;
     int finished = 0;
-    time_t end = time(NULL) + 10;
-    while (time(NULL) < end) {
-        if (finished)
-            break;
+    while (!finished) {
         mpv_event *event = mpv_wait_event(ctx, 0);
         switch (event->event_id) {
         case MPV_EVENT_FILE_LOADED:
@@ -177,10 +173,7 @@ static void test_lavfi_complex(char *file)
     check_api_error(mpv_command(ctx, cmd));
     int finished = 0;
     int loaded = 0;
-    time_t end = time(NULL) + 10;
-    while (time(NULL) < end) {
-        if (finished)
-            break;
+    while (!finished) {
         mpv_event *event = mpv_wait_event(ctx, 0);
         switch (event->event_id) {
         case MPV_EVENT_FILE_LOADED:

--- a/test/meson.build
+++ b/test/meson.build
@@ -101,7 +101,7 @@ if get_option('libmpv')
     libmpv_test = executable('libmpv-test', 'libmpv_test.c',
                              include_directories: incdir, link_with: libmpv)
     file = join_paths(source_root, 'etc', 'mpv-icon-8bit-16x16.png')
-    test('libmpv', libmpv_test, args: file)
+    test('libmpv', libmpv_test, args: file, timeout: 60)
 endif
 
 # Minimum required libavutil version that works with these tests.


### PR DESCRIPTION
Get rid of the time during the while loop and just let this run forever in case of a failure and also bump the timeout in meson to 60 seconds since we know it is possible for msys to take a very long time on occasion. That should be plenty of time for it to finish.