### PR TITLE
vo_gpu/vo_gpu_next: scaler fixes

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1727,6 +1727,12 @@ static void reinit_scaler(struct gl_video *p, struct scaler *scaler,
 
     uninit_scaler(p, scaler);
 
+    if (conf && scaler->index == SCALER_DSCALE && (!conf->kernel.name ||
+        !conf->kernel.name[0]))
+    {
+        conf = &p->opts.scaler[SCALER_SCALE];
+    }
+
     struct filter_kernel bare_window;
     const struct filter_kernel *t_kernel = mp_find_filter_kernel(conf->kernel.name);
     const struct filter_window *t_window = mp_find_filter_window(conf->window.name);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1542,7 +1542,7 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
 
     const struct gl_video_opts *opts = p->opts_cache->opts;
     const struct scaler_config *cfg = &opts->scaler[unit];
-    if (unit == SCALER_DSCALE && !cfg->kernel.name)
+    if (unit == SCALER_DSCALE && (!cfg->kernel.name || !strcmp(cfg->kernel.name, "")))
         cfg = &opts->scaler[SCALER_SCALE];
 
     for (int i = 0; fixed_presets[i].name; i++) {


### PR DESCRIPTION
The first commit fixes #12031. The second commit implements the behavior suggested [here](https://github.com/mpv-player/mpv/issues/12031#issuecomment-1657004574). That is, cscale will use the value of scale if it is unset.