### PR TITLE
DOCS/options: fix typo in hdr-peak-percentile

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6697,7 +6697,7 @@ them.
     distribution is progressively cut off. Setting this too low will cause
     clipping of very bright details, but can improve the dynamic brightness
     range of scenes with very bright isolated highlights. Values other than 100
-    come with a small performance penalty. (Only for ``--vo=gpu-next`)
+    come with a small performance penalty. (Only for ``--vo=gpu-next``)
 
 ``--hdr-peak-decay-rate=<1.0..1000.0>``
     The decay rate used for the HDR peak detection algorithm (default: 100.0).


### PR DESCRIPTION
Commit 45e95311b83560d6e716f6cbc9fc8506f828c4cc added `hdr-peak-percentile` to the docs, but the mention of `-vo=gpu-next` was missing a second `, causing a warning message to be displayed.

![image](https://github.com/FreeTheTech101/mpv/assets/7614507/83ec5b31-eac6-4f80-b26b-69dbdbc59071)