### PR TITLE
vd_lavc: repeatedly attempt to fallback if hwdec fails in reinit

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -659,8 +659,11 @@ static void reinit(struct mp_filter *vd)
 
     bool use_hwdec = ctx->use_hwdec;
     init_avctx(vd);
-    if (!ctx->avctx && use_hwdec)
-        force_fallback(vd);
+    if (!ctx->avctx && use_hwdec) {
+        do {
+            force_fallback(vd);
+        } while (!ctx->avctx);
+    }
 }
 
 static void init_avctx(struct mp_filter *vd)


### PR DESCRIPTION
In the same way that fallback in receive_frame() needs to be repeated until we get a working decoder, we have to do the same thing in reinit(). Calling force_fallback() only once can still yield a non functional decoder.

The reason why we have these multiple paths which each require their own fallback logic is that we can fail at different stages:
* hwdec init
* decoder init <- repeated fallback was missing here
* frame decoding

Fixes #12084