### PR TITLE
ao_audiotrack features & fixes

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -33,6 +33,7 @@ Interface changes
     - change `--subs-fallback` default from `no` to `default`
     - add the `--hdr-peak-percentile` option
     - include `--hdr-peak-percentile` in the `gpu-hq` profile
+    - change `--audiotrack-pcm-float` default from `no` to `yes`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -575,8 +575,7 @@ static void *playthread(void *arg)
             ts += (read_samples / (double)(ao->samplerate)) * 1e6;
             ts += AudioTrack_getLatency(ao) * 1e6;
             int samples = ao_read_data(ao, &p->chunk, read_samples, ts);
-            int write_samples = read_samples;
-            int ret = AudioTrack_write(ao, write_samples * ao->sstride);
+            int ret = AudioTrack_write(ao, samples * ao->sstride);
             if (ret >= 0) {
                 p->written_frames += ret / ao->sstride;
             } else if (ret == AudioManager.ERROR_DEAD_OBJECT) {

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -841,6 +841,9 @@ const struct ao_driver audio_out_audiotrack = {
     .reset     = stop,
     .start     = start,
     .priv_size = sizeof(struct priv),
+    .priv_defaults = &(const OPT_BASE_STRUCT) {
+        .cfg_pcm_float = 1,
+    },
     .options   = (const struct m_option[]) {
         {"pcm-float", OPT_BOOL(cfg_pcm_float)},
         {"session-id", OPT_INT(cfg_session_id)},

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -332,7 +332,7 @@ static int AudioTrack_New(struct ao *ao)
             p->cfg_session_id
         );
     }
-    if (!audiotrack || MP_JNI_EXCEPTION_LOG(ao) < 0) {
+    if (MP_JNI_EXCEPTION_LOG(ao) < 0 || !audiotrack) {
         MP_FATAL(ao, "AudioTrack Init failed\n");
         return -1;
     }
@@ -709,7 +709,7 @@ static int init(struct ao *ao)
         p->channel_config,
         p->format
     );
-    if (buffer_size <= 0 || MP_JNI_EXCEPTION_LOG(ao) < 0) {
+    if (MP_JNI_EXCEPTION_LOG(ao) < 0 || buffer_size <= 0) {
         MP_FATAL(ao, "AudioTrack.getMinBufferSize returned an invalid size: %d", buffer_size);
         return -1;
     }
@@ -724,7 +724,7 @@ static int init(struct ao *ao)
     p->chunk = talloc_size(ao, p->size);
 
     jobject timestamp = MP_JNI_NEW(AudioTimestamp.clazz, AudioTimestamp.ctor);
-    if (!timestamp || MP_JNI_EXCEPTION_LOG(ao) < 0) {
+    if (MP_JNI_EXCEPTION_LOG(ao) < 0 || !timestamp) {
         MP_FATAL(ao, "AudioTimestamp could not be created\n");
         return -1;
     }

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -92,7 +92,6 @@ struct JNIAudioTrack {
     jmethodID pause;
     jmethodID write;
     jmethodID writeFloat;
-    jmethodID writeV23;
     jmethodID writeShortV23;
     jmethodID writeBufferV21;
     jmethodID getBufferSizeInFramesV23;
@@ -126,7 +125,6 @@ struct JNIAudioTrack {
     {"android/media/AudioTrack", "pause", "()V", MP_JNI_METHOD, OFFSET(pause), 1},
     {"android/media/AudioTrack", "write", "([BII)I", MP_JNI_METHOD, OFFSET(write), 1},
     {"android/media/AudioTrack", "write", "([FIII)I", MP_JNI_METHOD, OFFSET(writeFloat), 1},
-    {"android/media/AudioTrack", "write", "([BIII)I", MP_JNI_METHOD, OFFSET(writeV23), 0},
     {"android/media/AudioTrack", "write", "([SIII)I", MP_JNI_METHOD, OFFSET(writeShortV23), 0},
     {"android/media/AudioTrack", "write", "(Ljava/nio/ByteBuffer;II)I", MP_JNI_METHOD, OFFSET(writeBufferV21), 1},
     {"android/media/AudioTrack", "getBufferSizeInFrames", "()I", MP_JNI_METHOD, OFFSET(getBufferSizeInFramesV23), 0},

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -684,8 +684,8 @@ static int init(struct ao *ao)
             AudioManager.STREAM_MUSIC
         );
         if (MP_JNI_EXCEPTION_LOG(ao) == 0) {
-            ao->samplerate = samplerate;
             MP_VERBOSE(ao, "AudioTrack.nativeOutputSampleRate = %d\n", samplerate);
+            ao->samplerate = MPMIN(samplerate, ao->samplerate);
         }
     }
     p->samplerate = ao->samplerate;

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -150,12 +150,14 @@ struct JNIAudioTrack {
 struct JNIAudioAttributes {
     jclass clazz;
     jint CONTENT_TYPE_MOVIE;
+    jint CONTENT_TYPE_MUSIC;
     jint USAGE_MEDIA;
     struct MPJniField mapping[];
 } AudioAttributes = {.mapping = {
     #define OFFSET(member) offsetof(struct JNIAudioAttributes, member)
     {"android/media/AudioAttributes", NULL, NULL, MP_JNI_CLASS, OFFSET(clazz), 0},
     {"android/media/AudioAttributes", "CONTENT_TYPE_MOVIE", "I", MP_JNI_STATIC_FIELD_AS_INT, OFFSET(CONTENT_TYPE_MOVIE), 0},
+    {"android/media/AudioAttributes", "CONTENT_TYPE_MUSIC", "I", MP_JNI_STATIC_FIELD_AS_INT, OFFSET(CONTENT_TYPE_MUSIC), 0},
     {"android/media/AudioAttributes", "USAGE_MEDIA", "I", MP_JNI_STATIC_FIELD_AS_INT, OFFSET(USAGE_MEDIA), 0},
     {0}
     #undef OFFSET
@@ -301,7 +303,9 @@ static int AudioTrack_New(struct ao *ao)
         MP_JNI_EXCEPTION_LOG(ao);
         tmp = MP_JNI_CALL_OBJECT(attr_builder, AudioAttributesBuilder.setUsage, AudioAttributes.USAGE_MEDIA);
         MP_JNI_DELETELOCAL(tmp);
-        tmp = MP_JNI_CALL_OBJECT(attr_builder, AudioAttributesBuilder.setContentType, AudioAttributes.CONTENT_TYPE_MOVIE);
+        jint content_type = (ao->init_flags & AO_INIT_MEDIA_ROLE_MUSIC) ?
+            AudioAttributes.CONTENT_TYPE_MUSIC : AudioAttributes.CONTENT_TYPE_MOVIE;
+        tmp = MP_JNI_CALL_OBJECT(attr_builder, AudioAttributesBuilder.setContentType, content_type);
         MP_JNI_DELETELOCAL(tmp);
         jobject attr = MP_JNI_CALL_OBJECT(attr_builder, AudioAttributesBuilder.build);
         MP_JNI_DELETELOCAL(attr_builder);


### PR DESCRIPTION
useful to generate some sample files:
```bash
for rate in 22050 44100 48000 96000; do
	ffmpeg -f lavfi -i aevalsrc="sin(440*2*PI*t):s=$rate:d=5" -c:a pcm_s16le -y s16_$rate.wav
done
for rate in 22050 44100 48000 96000; do
	ffmpeg -f lavfi -i aevalsrc="sin(440*2*PI*t):s=$rate:d=5" -c:a pcm_f32le -y float_$rate.mka
done
for chan in quad 5.1 7.1; do
	ffmpeg -f lavfi -i aevalsrc="sin(440*2*PI*t):c=$chan:d=5" -c:a libvorbis -y layout_$chan.mka
done
```