### PR TITLE
win32: signal VO_EVENT_DPI on dpi changes

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -563,6 +563,7 @@ static void update_dpi(struct vo_w32_state *w32)
 
     w32->dpi = dpi;
     w32->dpi_scale = w32->opts->hidpi_window_scale ? w32->dpi / 96.0 : 1.0;
+    signal_events(w32, VO_EVENT_DPI);
 }
 
 static void update_display_info(struct vo_w32_state *w32)


### PR DESCRIPTION
The win32 code already updates itself on dpi changes. However, it never signalled mpv's core when this happened which meant that the display-hidpi-scale property never changed. Simply send the VO_EVENT_DPI event when appropriate. Fixes #12081.