### PR TITLE
ytdl_hook: fix Windows exe search with suffix

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -945,7 +945,7 @@ Program Behavior
         paths should be separated by : on Unix and ; on Windows. mpv looks in
         order for the configured paths in PATH and in mpv's config directory.
         The defaults are "yt-dlp", "yt-dlp_x86" and "youtube-dl". On Windows
-        the suffix extension ".exe" is always appended.
+        the suffix extension is not necessary, but only ".exe" is acceptable.
 
     .. admonition:: Why do the option names mix ``_`` and ``-``?
 

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -834,7 +834,7 @@ function run_ytdl_hook(url)
 
         for _, path in pairs(ytdl.paths_to_search) do
             -- search for youtube-dl in mpv's config dir
-            local exesuf = platform_is_windows() and ".exe" or ""
+            local exesuf = platform_is_windows() and not path:lower():match("%.exe$") and ".exe" or ""
             local ytdl_cmd = mp.find_config_file(path .. exesuf)
             if ytdl_cmd then
                 msg.verbose("Found youtube-dl at: " .. ytdl_cmd)
@@ -847,9 +847,9 @@ function run_ytdl_hook(url)
                 command[1] = path
                 result = exec(command)
                 if result.error_string == "init" then
-                    msg.verbose("youtube-dl with path " .. path .. exesuf .. " not found in PATH or not enough permissions")
+                    msg.verbose("youtube-dl with path " .. path .. " not found in PATH or not enough permissions")
                 else
-                    msg.verbose("Found youtube-dl with path " .. path .. exesuf .. " in PATH")
+                    msg.verbose("Found youtube-dl with path " .. path .. " in PATH")
                     ytdl.path = path
                     break
                 end


### PR DESCRIPTION
Fix the issue where when the given path(s) for yt-dlp/youtube-dl already have ".exe" in it (Like `--script-opts=ytdl_hook-ytdl_path=D:\yt-dlp.exe`), the search for the exe of yt-dlp will fail due to redundant .exe suffix.

Keep in mind since the Lua script will try the original `path` even if the search failed:

https://github.com/mpv-player/mpv/blob/983e8f0100b98bd8aed48e5fe86dd5682174b04e/player/lua/ytdl_hook.lua#L846-L848

So this is more about a minor issue that it causes MPV to print lots of errors in verbose:

```
[ytdl_hook] Video disabled. Only using audio
[global] config path: 'D:\yt-dlp.exe.exe' -/-> 'D:\yt-dlp.exe.exe'
[global] config path: 'D:\yt-dlp.exe.exe' -/-> 'D:\yt-dlp.exe.exe'
[global] config path: 'D:\yt-dlp.exe.exe' -/-> 'D:\yt-dlp.exe.exe'
[ytdl_hook] No youtube-dl found with path D:\yt-dlp.exe.exe in config directories
[ytdl_hook] Running: D:\yt-dlp.exe --no-warnings -J --flat-playlist --sub-format ass/srt/best --format bestaudio/best --all-subs --no-playlist -- https://www.youtube.com/watch?v=jfKfPfyJRdk
[cplayer] Run command: subprocess, flags=64, args=[args="D:\\yt-dlp.exe,--no-warnings,-J,--flat-playlist,--sub-format,ass/srt/best,--format,bestaudio/best,--all-subs,--no-playlist,--,https://www.youtube.com/watch?v=jfKfPfyJRdk", playback_only="yes", capture_size="67108864", capture_stdout="yes", capture_stderr="yes", detach="no", env="", stdin_data="", passthrough_stdin="no"]
```

But it's still nice to get it fixed.