### PR TITLE
win32: improve loading files from long paths

### DIFF
--- a/osdep/io.h
+++ b/osdep/io.h
@@ -79,8 +79,11 @@ void mp_flush_wakeup_pipe(int pipe_end);
 
 #ifdef _WIN32
 #include <wchar.h>
+#include "options/path.h"
 wchar_t *mp_from_utf8(void *talloc_ctx, const char *s);
 char *mp_to_utf8(void *talloc_ctx, const wchar_t *s);
+wchar_t *mp_get_absolute_path(void *talloc_ctx, const char *path, const wchar_t *prefix);
+wchar_t *mp_resolve_path(void *talloc_ctx, const char *path);
 #endif
 
 #ifdef __CYGWIN__


### PR DESCRIPTION
Long path support on Windows in MPV didn't work in all scenarios:
- If long path was given on command line or added via script/IPC in non-UNC format it failed to open
- autoload.lua failed to process files that exceeded MAX_PATH (#11539)

To fix that, function that converts to UNC path when needed was added. It appends `\\?\` and converts `/` to `\`. It is used to convert file path before passing it to `CreateFileW`.
Lua and JS `mp.utils.split_path` returns directory with trailing slash. `mp.utils.readdir` used simple string append which caused double slash in path. UNC paths do not support this, so `mp_path_join` was used instead.