### PR TITLE
player: make all autoload extensions configurable

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -42,6 +42,7 @@ Interface changes
     - add `--x11-wid-title` option
     - add `--libplacebo-opts` option
     - change `--video-pan-x/y` to be relative to the destination rectangle
+    - add `--audio-file-exts`, `--cover-art-auto-exts`, and `--sub-auto-exts`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2187,6 +2187,11 @@ Audio
     :all:   Load all audio files in the current and ``--audio-file-paths``
             directories.
 
+``--audio-file-auto-exts=ext1,ext2,...``
+    Audio file extentions to try and match when using ``audio-file-auto``.
+
+    This is a string list option. See `List Options`_ for details.
+
 ``--audio-file-paths=<path1:path2:...>``
     Equivalent to ``--sub-file-paths`` option, but for auto-loaded audio files.
 
@@ -2565,6 +2570,13 @@ Subtitles
             language suffixes (default).
     :fuzzy: Load all subs containing the media filename.
     :all:   Load all subs in the current and ``--sub-file-paths`` directories.
+
+``--sub-auto-exts=ext1,ext2,...``
+    Subtitle extentions to try and match when using ``--sub-auto``. Note that
+    modifying this list will also affect what mpv recognizes as subtitles when
+    using drag and drop.
+
+    This is a string list option. See `List Options`_ for details.
 
 ``--sub-codepage=<codepage>``
     You can use this option to specify the subtitle codepage. uchardet will be
@@ -7190,6 +7202,11 @@ Miscellaneous
 
     See ``--audio-display`` how to control display of cover art (this can be
     used to disable cover art that is part of the file).
+
+``--cover-art-auto-exts=ext1,ext2,...``
+    Cover art extentions to try and match when using ``cover-art-auto``.
+
+    This is a string list option. See `List Options`_ for details.
 
 ``--cover-art-whitelist=<no|yes>``
     Whether to load filenames in an internal whitelist, such as ``cover.jpg``,

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -433,7 +433,8 @@ char *format_file_size(int64_t size);
 #define UPDATE_HWDEC            (1 << 20) // --hwdec
 #define UPDATE_DVB_PROG         (1 << 21) // some --dvbin-...
 #define UPDATE_SUB_HARD         (1 << 22) // subtitle opts. that need full reinit
-#define UPDATE_OPT_LAST         (1 << 22)
+#define UPDATE_SUB_EXTS         (1 << 23) // update internal list of sub exts
+#define UPDATE_OPT_LAST         (1 << 23)
 
 // All bits between _FIRST and _LAST (inclusive)
 #define UPDATE_OPTS_MASK \

--- a/options/options.c
+++ b/options/options.c
@@ -615,10 +615,13 @@ static const m_option_t mp_opts[] = {
 
     {"sub-auto", OPT_CHOICE(sub_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
+    {"sub-auto-exts", OPT_STRINGLIST(sub_auto_exts), .flags = UPDATE_SUB_EXTS},
     {"audio-file-auto", OPT_CHOICE(audiofile_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
+    {"audio-file-auto-exts", OPT_STRINGLIST(audiofile_auto_exts)},
     {"cover-art-auto", OPT_CHOICE(coverart_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
+    {"cover-art-auto-exts", OPT_STRINGLIST(coverart_auto_exts)},
     {"cover-art-whitelist", OPT_BOOL(coverart_whitelist)},
 
     {"", OPT_SUBSTRUCT(subs_rend, mp_subtitle_sub_opts)},
@@ -1055,6 +1058,58 @@ static const struct MPOpts mp_default_opts = {
     .osd_bar_visible = true,
     .screenshot_template = "mpv-shot%n",
     .play_dir = 1,
+
+    .audiofile_auto_exts = (char *[]){
+        "aac",
+        "ac3",
+        "dts",
+        "eac3",
+        "flac",
+        "m4a",
+        "mka",
+        "mp3",
+        "ogg",
+        "opus",
+        "thd",
+        "wav",
+        "wv",
+        NULL
+    },
+
+    .coverart_auto_exts = (char *[]){
+        "avif",
+        "bmp",
+        "gif",
+        "jpeg",
+        "jpg",
+        "jxl",
+        "png",
+        "tif",
+        "tiff",
+        "webp",
+        NULL
+    },
+
+    .sub_auto_exts = (char *[]){
+        "ass",
+        "idx",
+        "lrc",
+        "mks",
+        "pgs",
+        "rt",
+        "sbv",
+        "scc",
+        "smi",
+        "srt",
+        "ssa",
+        "sub",
+        "sup",
+        "utf",
+        "utf-8",
+        "utf8",
+        "vtt",
+        NULL
+    },
 
     .audio_output_channels = {
         .set = 1,

--- a/options/options.h
+++ b/options/options.h
@@ -309,8 +309,11 @@ typedef struct MPOpts {
     char **external_files;
     bool autoload_files;
     int sub_auto;
+    char **sub_auto_exts;
     int audiofile_auto;
+    char **audiofile_auto_exts;
     int coverart_auto;
+    char **coverart_auto_exts;
     bool coverart_whitelist;
     bool osd_bar_visible;
 

--- a/player/command.c
+++ b/player/command.c
@@ -33,6 +33,7 @@
 
 #include "mpv_talloc.h"
 #include "client.h"
+#include "external_files.h"
 #include "common/av_common.h"
 #include "common/codecs.h"
 #include "common/msg.h"
@@ -6945,6 +6946,9 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 
     if (flags & UPDATE_INPUT)
         mp_input_update_opts(mpctx->input);
+
+    if (flags & UPDATE_SUB_EXTS)
+        mp_update_subtitle_exts(mpctx->opts);
 
     if (init || opt_ptr == &opts->ipc_path || opt_ptr == &opts->ipc_client) {
         mp_uninit_ipc(mpctx->ipc_ctx);

--- a/player/external_files.h
+++ b/player/external_files.h
@@ -33,5 +33,6 @@ struct subfn *find_external_files(struct mpv_global *global, const char *fname,
                                   struct MPOpts *opts);
 
 bool mp_might_be_subtitle_file(const char *filename);
+void mp_update_subtitle_exts(struct MPOpts *opts);
 
 #endif /* MPLAYER_FINDFILES_H */


### PR DESCRIPTION
--audio-file-auto, --cover-art-auto, and --sub-auto all work by using an internally hardcoded list that determine what file extensions get recognized. This is fine and people periodically update it, but we can actually expose this as a stringlist option instead. This way users can add or remove any file extension for any type. For the most part, this is pretty pretty easy and involves making sub_exts, etc. the defaults for the new options (--audio-file-auto-exts, --cover-art-auto-exts, and --sub-auto-exts). There's actually one slight complication however. The input code uses mp_might_be_subtitle_file which guesses if the file drag and dropped file is a subtitle. The input ctx has no access to mpctx so we have to be clever here.

For this, the trick is to recognize that we can leverage the m_option_change_callback. We add a new flag, UPDATE_SUB_EXTS, which fires when the player starts up. Then in the callback, we can set the value of sub_exts in external_files to opts->sub_auto_exts. Whenever the option updates, the callback is fired again and sub_exts updates. That way mp_might_be_subtitle_file can just operate off of this global variable instead of trying to mess with the core mpv state directly.

Fixes #12000.