### PR TITLE
mac: remove mpv-bundle symlink to allow code signing

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -38,10 +38,6 @@ def apply_plist_template(plist_file, version):
     for line in fileinput.input(plist_file, inplace=1):
         print(line.rstrip().replace('${VERSION}', version))
 
-def create_bundle_symlink(binary_name, symlink_name):
-    os.symlink(os.path.basename(binary_name),
-               os.path.join(target_directory(binary_name), symlink_name))
-
 def bundle_version():
     if os.path.exists('VERSION'):
         x = open('VERSION')
@@ -72,8 +68,6 @@ def main():
     copy_bundle(binary_name)
     print("> copying binary")
     copy_binary(binary_name)
-    print("> create bundle symlink")
-    create_bundle_symlink(binary_name, "mpv-bundle")
     print("> generating Info.plist")
     apply_plist_template(target_plist(binary_name), version)
 

--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -173,7 +173,7 @@
       </dict>
     </array>
     <key>CFBundleExecutable</key>
-    <string>mpv-bundle</string>
+    <string>mpv</string>
     <key>CFBundleIconFile</key>
     <string>icon</string>
     <key>CFBundleIdentifier</key>
@@ -192,6 +192,8 @@
     <dict>
       <key>MallocNanoZone</key>
       <string>0</string>
+      <key>MPVBUNDLE</key>
+      <string>true</string>
     </dict>
     <key>CFBundleURLTypes</key>
     <array>

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -312,12 +312,6 @@ static void init_cocoa_application(bool regular)
     });
 }
 
-static bool bundle_started_from_finder(char **argv)
-{
-    NSString *binary_path = [NSString stringWithUTF8String:argv[0]];
-    return [binary_path hasSuffix:@"mpv-bundle"];
-}
-
 static bool is_psn_argument(char *arg_to_check)
 {
     NSString *arg = [NSString stringWithUTF8String:arg_to_check];
@@ -340,7 +334,6 @@ static void setup_bundle(int *argc, char *argv[])
                                                     @"/opt/local/bin",
                                                     @"/opt/local/sbin"];
     setenv("PATH", [path_new UTF8String], 1);
-    setenv("MPVBUNDLE", "true", 1);
 }
 
 int cocoa_main(int argc, char *argv[])
@@ -353,7 +346,9 @@ int cocoa_main(int argc, char *argv[])
         ctx.argc     = &argc;
         ctx.argv     = &argv;
 
-        if (bundle_started_from_finder(argv)) {
+        NSString* bundle = [[[NSProcessInfo processInfo] environment] objectForKey:@"MPVBUNDLE"];
+
+        if ([bundle isEqual:@"true"]) {
             setup_bundle(&argc, argv);
             init_cocoa_application(true);
         } else {


### PR DESCRIPTION
Apps on Apple silicon have to be codesigned to run, but [you can't codesign bundles that have a symlink for the main executable](https://github.com/mpv-player/mpv/issues/8533#issuecomment-774575210) like `mpv-bundle`.

The `mpv-bundle` symlink is used as the bundle's main executable because it makes the execution name of the binary different, [letting us detect mpv is started from the bundle](https://github.com/mpv-player/mpv/commit/77021cf6fe6a1813b832c8927c288e958b6f6845). Launch Services runs `Info.plist`'s `CFBundleExecutable` when launching a bundle, so you can check if that's how the binary was launched by [comparing the execution name to the name of the symlink](https://github.com/mpv-player/mpv/blob/dfbdf7516586427083a868307a77c35bab8bc764/osdep/macosx_application.m#L317-L318).
 
After some digging, it turns out there's another key in `Info.plist` we can use to replace this. Launch Services will set what's in [`LSEnvironment`](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW9) as environment variables before launching a bundle. [`MPVBUNDLE`](https://github.com/mpv-player/mpv/blob/13c6e060e2316d12e34d2983dcc15eecef645900/osdep/macosx_application.m#L343) already gets set for this exact reason, so moving that into `LSEnvironment` lets us check for it instead of checking for the symlink.

I've tested switching videos via Finder, and it works fine on my end (macOS 13.5). Totally understand if this isn't the way you guys want to go about this though.

Apparently, macOS will sometimes cache Info.plist files, so you might have to run
`/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -seed`