### PR TITLE
context_drm_egl: don't free egl properties if they are null

### DIFF
--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -497,9 +497,12 @@ static void drm_egl_uninit(struct ra_ctx *ctx)
 
         eglMakeCurrent(p->egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                        EGL_NO_CONTEXT);
-        eglDestroyContext(p->egl.display, p->egl.context);
-        eglDestroySurface(p->egl.display, p->egl.surface);
-        gbm_surface_destroy(p->gbm.surface);
+        if (p->egl.display) {
+            eglDestroyContext(p->egl.display, p->egl.context);
+            eglDestroySurface(p->egl.display, p->egl.surface);
+        }
+        if (p->gbm.surface)
+            gbm_surface_destroy(p->gbm.surface);
         eglTerminate(p->egl.display);
         gbm_device_destroy(p->gbm.device);
         p->egl.context = EGL_NO_CONTEXT;


### PR DESCRIPTION
If we failed to create a gbm surface, we would call drm_egl_uninit to free up any state we had allocated. However, we would segfault if we tried to cleanup properties there were never initialized. Null checks have been added to guard against this.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.