### PR TITLE
[RFC] video/image_writer: add bgra screenshot support

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4332,6 +4332,7 @@ Screenshot
     :webp:      WebP
     :jxl:       JPEG XL
     :avif:      AVIF
+    :bgra:      BGRA
 
 ``--screenshot-tag-colorspace=<yes|no>``
     Tag screenshots with the appropriate colorspace (default: yes).

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -557,6 +557,8 @@ Available video output drivers are:
             PNG files.
         webp
             WebP files.
+        bgra
+            BGRA files.
 
     ``--vo-image-png-compression=<0-9>``
         PNG compression factor (speed vs. file size tradeoff) (default: 7)

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -75,6 +75,7 @@ const struct m_opt_choice_alternatives mp_image_writer_formats[] = {
     {"jpeg", AV_CODEC_ID_MJPEG},
     {"png",  AV_CODEC_ID_PNG},
     {"webp", AV_CODEC_ID_WEBP},
+    {"bgra", AV_CODEC_ID_RAWVIDEO},
 #if HAVE_JPEGXL
     {"jxl",  AV_CODEC_ID_JPEGXL},
 #endif
@@ -705,6 +706,9 @@ bool write_image(struct mp_image *image, const struct image_writer_opts *opts,
         // We don't want that, so force YUV/YUVA here.
         int alpha = image->fmt.flags & MP_IMGFLAG_ALPHA;
         destfmt = alpha ? pixfmt2imgfmt(AV_PIX_FMT_YUVA420P) : IMGFMT_420P;
+    }
+    if (opts->format == AV_CODEC_ID_RAWVIDEO) {
+        destfmt = IMGFMT_BGRA;
     }
 
     if (!destfmt)


### PR DESCRIPTION
Mostly for use in scripts that will re-use the screenshots in overlay-add like [thumbfast](https://github.com/po5/thumbfast).  
The advantage of this over encode mode (which TheAMM's thumbnailer and thumbfast use) is that we can accurately match the user's tonemapping, and screenshots allow dynamic side data in the filename to solve https://github.com/po5/thumbfast/issues/97 (encode mode output filename can't be updated at runtime)

Not ready for merge as it sometimes initially outputs all 0's on HDR files with gpu-next. Making a 2nd screenshot of the same frame correctly renders it.  
Does anyone know why this is happening?