### PR TITLE
add --sub-ass-horizontal-scaling-compat option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -40,6 +40,7 @@ Interface changes
       You can disable this with `--no-term-remaining-playtime`.
     - add `playlist-path` and `playlist/N/playlist-path` properties
     - add `--x11-wid-title` option
+    - add the '--sub-ass-horizontal-scaling-compat' option
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2454,6 +2454,23 @@ Subtitles
     Renamed from ``--sub-ass-use-margins``. To place ASS subtitles in the borders
     too (like the old option did), also add ``--sub-ass-force-margins``.
 
+``--sub-ass-horizontal-scaling-compat``
+    Override the PlayResX to attempt to mimic old x-axis scaling behavior from
+    libass versions 0.16.0 or older. This fixes borders and shadows being too
+    thick or too thin, if a crop filter is inserted, depending on the crop
+    dimensions.
+
+    This option works by setting PlayResX = PlayResY * Display Aspect Ratio, if
+    the display aspect ratio is not the same as storage aspect ratio (e.g. a crop
+    filter is inserted), and automatically reverting back to the old PlayResX
+    if e.g. the filter is removed and the display resolution matches the script
+    resolution again.
+
+    Note that it will break signs due to explicit vector coordinates changing,
+    so use with care.
+
+    Default: no.
+
 ``--sub-ass-vsfilter-aspect-compat=<yes|no>``
     Stretch SSA/ASS subtitles when playing anamorphic videos for compatibility
     with traditional VSFilter behavior. This switch has no effect when the

--- a/options/options.c
+++ b/options/options.c
@@ -276,6 +276,8 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-ass-line-spacing", OPT_FLOAT(ass_line_spacing),
             M_RANGE(-1000, 1000)},
         {"sub-use-margins", OPT_BOOL(sub_use_margins)},
+        {"sub-ass-horizontal-scaling-compat",
+            OPT_BOOL(ass_horizontal_scaling_compat)},
         {"sub-ass-force-margins", OPT_BOOL(ass_use_margins)},
         {"sub-ass-vsfilter-aspect-compat", OPT_BOOL(ass_vsfilter_aspect_compat)},
         {"sub-ass-vsfilter-color-compat", OPT_CHOICE(ass_vsfilter_color_compat,

--- a/options/options.h
+++ b/options/options.h
@@ -102,6 +102,7 @@ struct mp_subtitle_opts {
     bool ass_vsfilter_aspect_compat;
     int ass_vsfilter_color_compat;
     bool ass_vsfilter_blur_compat;
+    bool ass_horizontal_scaling_compat;
     bool use_embedded_fonts;
     char **ass_force_style_list;
     char *ass_styles_file;

--- a/player/sub.c
+++ b/player/sub.c
@@ -88,9 +88,12 @@ static bool update_subtitle(struct MPContext *mpctx, double video_pts,
         return true;
 
     if (mpctx->vo_chain) {
-        struct mp_image_params params = mpctx->vo_chain->filter->input_params;
-        if (params.imgfmt)
-            sub_control(dec_sub, SD_CTRL_SET_VIDEO_PARAMS, &params);
+        struct mp_image_params video_params = mpctx->vo_chain->filter->input_params;
+        if (video_params.imgfmt)
+            sub_control(dec_sub, SD_CTRL_SET_VIDEO_PARAMS, &video_params);
+        struct mp_image_params out_params = mpctx->vo_chain->filter->output_params;
+        if (out_params.imgfmt)
+            sub_control(dec_sub, SD_CTRL_SET_OUT_PARAMS, &out_params);
     }
 
     if (track->demuxer->fully_read && sub_can_preload(dec_sub)) {

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -20,6 +20,7 @@ enum sd_ctrl {
     SD_CTRL_SET_TOP,
     SD_CTRL_SET_VIDEO_DEF_FPS,
     SD_CTRL_UPDATE_OPTS,
+    SD_CTRL_SET_OUT_PARAMS,
 };
 
 enum sd_text_type {

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -454,6 +454,15 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     if (converted)
         ass_track_set_feature(track, ASS_FEATURE_WRAP_UNICODE, 1);
 #endif
+    if (!converted && opts->ass_horizontal_scaling_compat) {
+        if (ctx->out_params.w != ctx->video_params.w &&
+            ctx->out_params.h != ctx->video_params.h) {
+            track->PlayResX = track->PlayResY *
+                ((double)ctx->out_params.w / ctx->out_params.h);
+        } else {
+            track->PlayResX = ctx->PlayResX;
+        }
+    }
     if (converted) {
         bool override_playres = true;
         char **ass_force_style_list = opts->ass_force_style_list;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -59,6 +59,7 @@ struct sd_ass_priv {
     int64_t *seen_packets;
     int num_seen_packets;
     bool duration_unknown;
+    int PlayResX;
 };
 
 static void mangle_colors(struct sd *sd, struct sub_bitmaps *parts);
@@ -230,8 +231,10 @@ static void assobjects_init(struct sd *sd)
         extradata = lavc_conv_get_extradata(ctx->converter);
         extradata_size = extradata ? strlen(extradata) : 0;
     }
-    if (extradata)
+    if (extradata) {
         ass_process_codec_private(ctx->ass_track, extradata, extradata_size);
+        ctx->PlayResX = ctx->ass_track->PlayResX;
+    }
 
     mp_ass_add_default_styles(ctx->ass_track, opts);
 

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -54,6 +54,7 @@ struct sd_ass_priv {
     struct sub_bitmap_copy_cache *copy_cache;
     char last_text[500];
     struct mp_image_params video_params;
+    struct mp_image_params out_params;
     struct mp_image_params last_params;
     struct mp_osd_res osd;
     int64_t *seen_packets;
@@ -852,6 +853,9 @@ static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
     }
     case SD_CTRL_SET_VIDEO_PARAMS:
         ctx->video_params = *(struct mp_image_params *)arg;
+        return CONTROL_OK;
+    case SD_CTRL_SET_OUT_PARAMS:
+        ctx->out_params = *(struct mp_image_params *)arg;
         return CONTROL_OK;
     case SD_CTRL_SET_TOP:
         ctx->on_top = *(bool *)arg;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -481,12 +481,10 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         // and/or different source formats which would be exposed over time.
         // Make these adjustments only if the user didn't set PlayResX.
         if (override_playres) {
-            int vidw = dim->w - (dim->ml + dim->mr);
-            int vidh = dim->h - (dim->mt + dim->mb);
-            track->PlayResX = track->PlayResY * (double)vidw / MPMAX(vidh, 1);
-            // ffmpeg and mpv use a default PlayResX of 384 when it is not known,
-            // this comes from VSFilter.
-            double fix_margins = track->PlayResX / 384.0;
+            track->PlayResX = track->PlayResY *
+                ((double)ctx->out_params.w / ctx->out_params.h);
+            // Divide the new PlayResX by the old PlayResX
+            double fix_margins = track->PlayResX / (double)ctx->PlayResX;
             track->styles->MarginL = round(track->styles->MarginL * fix_margins);
             track->styles->MarginR = round(track->styles->MarginR * fix_margins);
         }


### PR DESCRIPTION
With a crop filter inserted, [--sub-ass-horizontal-scaling-compat=no](https://github.com/mpv-player/mpv/assets/6298234/6e87074d-be9a-4028-aff4-8d213b7fd3ee) and [--sub-ass-horizontal-scaling-compat=yes](https://github.com/mpv-player/mpv/assets/6298234/792dfd86-3714-4e7e-8dd6-976146b6137b)

See individual commit messages. Also not sold on the option name, please let me know if anyone has better ideas.