### PR TITLE
vo: clear vsync_offset if drawing while paused

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -907,6 +907,9 @@ static bool render_frame(struct vo *vo)
         frame->duration = -1;
     }
 
+    if (in->paused)
+        frame->vsync_offset = 0;
+
     int64_t now = mp_time_us();
     int64_t pts = frame->pts;
     int64_t duration = frame->duration;


### PR DESCRIPTION
I did some digging and vsync_offset being negative is completely normal and happens during typical playback too. It's just the error being the other way around (too early vs too late). So I think the simplest fix is probably to just make vsync_offset 0 if we're paused and trying to render a frame.
cc @haasn