### PR TITLE
loadfile: avoid infinite playlist loading loops

### DIFF
--- a/player/core.h
+++ b/player/core.h
@@ -275,6 +275,8 @@ typedef struct MPContext {
     struct playlist_entry *playing; // currently playing file
     char *filename; // immutable copy of playing->filename (or NULL)
     char *stream_open_filename;
+    char **playlist_paths; // used strictly for playlist validation
+    int playlist_paths_len;
     enum stop_play_reason stop_play;
     bool playback_initialized; // playloop can be run/is running
     int error_playing;


### PR DESCRIPTION
A playlist with the first entry referring to itself will cause mpv to loop forever trying to open it. Obviously there's no reason to ever actually do this, but we can gracefully error out in this case since it's simple to detect. ~~Note that doing a ping-pong loop with something like m3u files referring to each other will still "work" (i.e. loop forever). There's nothing we can really do about that so the solution is still "don't do that".~~ Fixes #3967.

Edit: Now should work for any self referential playlist.