### PR TITLE
f_lavfi: don't reject dynamic lavfi ins/outs (v2)

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -44,6 +44,12 @@ The exact syntax is:
     the ``lavfi`` filter, which uses a very similar syntax as mpv (MPlayer
     historically) to specify filters and their parameters.
 
+.. note::
+
+    ``--vf`` can only take a single track as input, even if the filter supports
+    dynamic input. Filters that require multiple inputs can't be used.
+    Use ``--lavfi-complex`` for such a use case. This also applies for ``--af``.
+
 Filters can be manipulated at run time. You can use ``@`` labels as described
 above in combination with the ``vf`` command (see `COMMAND INTERFACE`_) to get
 more control over this. Initially disabled filters with ``!`` are useful for

--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -981,9 +981,13 @@ static bool is_usable(const AVFilter *filter, int media_type)
     int nb_inputs  = avfilter_pad_count(filter->inputs),
         nb_outputs = avfilter_pad_count(filter->outputs);
 #endif
-    return nb_inputs == 1 && nb_outputs == 1 &&
-           avfilter_pad_get_type(filter->inputs, 0) == media_type &&
-           avfilter_pad_get_type(filter->outputs, 0) == media_type;
+    bool input_ok = filter->flags & AVFILTER_FLAG_DYNAMIC_INPUTS;
+    bool output_ok = filter->flags & AVFILTER_FLAG_DYNAMIC_OUTPUTS;
+    if (nb_inputs == 1)
+        input_ok = avfilter_pad_get_type(filter->inputs, 0) == media_type;
+    if (nb_outputs == 1)
+        output_ok = avfilter_pad_get_type(filter->outputs, 0) == media_type;
+    return input_ok && output_ok;
 }
 
 bool mp_lavfi_is_usable(const char *name, int media_type)


### PR DESCRIPTION
Ideally, users should be using lavfi-complex instead of lavfi-bridge for such a use case, however currently lavfi-complex doesn't support hwdec. So we can allow filters with dynamic inputs to work with lavfi-bridge, at the cost of them only being able to take in only one input. This should probably be reverted when/if lavfi-complex has hwdec, but for now this allows us to use libplacebo as a video filter with hwdec in mpv again.

Basically the same as #12170 but Github don't let you reopen PRs if you force pushed while it was closed...

I've made the code changes requested by @kasper93, and also added a note about --vf limitations in the docs. I'm not particularly sold on the idea of allowing filters with dynamic in/out in lavfi-bridge, but there are certainly limitations with lavfi-complex that aren't super simple to resolve, so this may have some utility.