### PR TITLE
demux_playlist: remove len restriction on headerless m3u

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -207,7 +207,7 @@ static int parse_m3u(struct pl_parser *p)
             char probe[PROBE_SIZE];
             int len = stream_read_peek(p->real_stream, probe, sizeof(probe));
             bstr data = {probe, len};
-            if (ext && data.len > 10 && maybe_text(data)) {
+            if (ext && data.len >= 2 && maybe_text(data)) {
                 const char *exts[] = {"m3u", "m3u8", NULL};
                 for (int n = 0; exts[n]; n++) {
                     if (strcasecmp(ext, exts[n]) == 0)


### PR DESCRIPTION
Discovered by @christoph-heinrich in IRC.
09c701b797c44293dc0e22874b4acf0246b3d148 added a fallback for headerless m3u files. However, it requires that the bstr len be greater than 10. This means that a m3u playlist with a single entry with a very short filename (such as "test.flac") will not be recognized as a playlist since the amount of data is too small. The reason for this restriction is unexplained and really shouldn't matter given that the important thing mpv should be doing is checking if the data is text. Just loosen the check to pass as long as the len is greater than 0.