### PR TITLE
build: check for SNDCTL_DSP_HALT for oss-audio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -836,7 +836,7 @@ oss_opt = get_option('oss-audio').require(
     get_option('gpl'),
     error_message: 'the build is not GPL!',
 )
-features += {'oss-audio': cc.has_header_symbol('sys/soundcard.h', 'SNDCTL_DSP_SETPLAYVOL',
+features += {'oss-audio': cc.has_header_symbol('sys/soundcard.h', 'SNDCTL_DSP_HALT',
                                                required: oss_opt)}
 if features['oss-audio']
     sources += files('audio/out/ao_oss.c')


### PR DESCRIPTION
At least NetBSD ossaudio(3) right now has SNDCTL_DSP_SETPLAYVOL support but does not support SNDCTL_DSP_HALT chocking at build time.

NFCI on platforms where oss audio output is supported.
