### PR TITLE
win32: fix display resolution calculation on mulitple monitors

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1848,9 +1848,9 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         *(double*) arg = w32->display_fps;
         return VO_TRUE;
     case VOCTRL_GET_DISPLAY_RES: ;
-        RECT r = get_screen_area(w32);
-        ((int *)arg)[0] = r.right;
-        ((int *)arg)[1] = r.bottom;
+        RECT monrc = get_monitor_info(w32).rcMonitor;
+        ((int *)arg)[0] = monrc.right - monrc.left;
+        ((int *)arg)[1] = monrc.bottom - monrc.top;
         return VO_TRUE;
     case VOCTRL_GET_DISPLAY_NAMES:
         *(char ***)arg = get_disp_names(w32);


### PR DESCRIPTION
It was actually always wrong, and no one ever noticed. This currently returns the size of the entire display area and not one actual monitor. Fix this by calling get_monitor_info and then doing the appropriate subtractions. Checked by @CrendKing and fixes #12172.