### PR TITLE
vo_gpu: allow --hdr-peak-decay-rate=0.0

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6707,12 +6707,12 @@ them.
     range of scenes with very bright isolated highlights. Values other than 100
     come with a small performance penalty. (Only for ``--vo=gpu-next``)
 
-``--hdr-peak-decay-rate=<1.0..1000.0>``
+``--hdr-peak-decay-rate=<0.0..1000.0>``
     The decay rate used for the HDR peak detection algorithm (default: 100.0).
     This is only relevant when ``--hdr-compute-peak`` is enabled. Higher values
     make the peak decay more slowly, leading to more stable values at the cost
     of more "eye adaptation"-like effects (although this is mitigated somewhat
-    by ``--hdr-scene-threshold``). A value of 1.0 (the lowest possible) disables
+    by ``--hdr-scene-threshold``). A value of 0.0 (the lowest possible) disables
     all averaging, meaning each frame's value is used directly as measured,
     but doing this is not recommended for "noisy" sources since it may lead
     to excessive flicker. (In signal theory terms, this controls the time

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -419,7 +419,7 @@ const struct m_sub_options gl_video_conf = {
         {"hdr-peak-percentile", OPT_FLOAT(tone_map.peak_percentile),
             M_RANGE(0.0, 100.0)},
         {"hdr-peak-decay-rate", OPT_FLOAT(tone_map.decay_rate),
-            M_RANGE(1.0, 1000.0)},
+            M_RANGE(0.0, 1000.0)},
         {"hdr-scene-threshold-low", OPT_FLOAT(tone_map.scene_threshold_low),
             M_RANGE(0, 20.0)},
         {"hdr-scene-threshold-high", OPT_FLOAT(tone_map.scene_threshold_high),

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -644,9 +644,12 @@ static void hdr_update_peak(struct gl_shader_cache *sc,
 
     // Use an IIR low-pass filter to smooth out the detected values, with a
     // configurable decay rate based on the desired time constant (tau)
-    float a = 1.0 - cos(1.0 / opts->decay_rate);
-    float decay = sqrt(a*a + 2*a) - a;
-    GLSLF("  average += %f * (cur - average);\n", decay);
+    if (opts->decay_rate) {
+        float decay = 1.0f - expf(-1.0f / opts->decay_rate);
+        GLSLF("  average += %f * (cur - average);\n", decay);
+    } else {
+        GLSLF("  average = cur;\n");
+    }
 
     // Scene change hysteresis
     float log_db = 10.0 / log(10.0);


### PR DESCRIPTION
This completely disables all smoothing. Despite what the manual claims, a decay rate of 1.0 does *not*.

It's worth pointing out that this depends on the following commit to work properly in --vo=gpu-next, but I don't think working around such a minor detail is worth the trouble, considering people building nightly mpv are probably also building nightly libplacebo it should just work (tm).

See-Also: https://github.com/haasn/libplacebo/commit/1c464baaf4c6228dcfac87f19db1dafc22e328c8
See-Also: https://github.com/haasn/libplacebo/commit/83af2d4ebd5086a56f7b1a2f86628ada3612ee7c