### PR TITLE
try fixing sd_lavc stuff again.

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -398,7 +398,8 @@ static struct sub *get_current(struct sd_lavc_priv *priv, double pts)
         if (!sub->valid)
             continue;
         if (pts == MP_NOPTS_VALUE ||
-            (sub->pts == MP_NOPTS_VALUE || pts + 1e-6 >= sub->pts))
+            ((sub->pts == MP_NOPTS_VALUE || pts + 1e-6 >= sub->pts) &&
+             (sub->endpts == MP_NOPTS_VALUE || pts < sub->endpts)))
         {
             // Ignore "trailing" subtitles with unknown length after 1 minute.
             if (sub->endpts == MP_NOPTS_VALUE && pts >= sub->pts + 60)

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -398,8 +398,8 @@ static struct sub *get_current(struct sd_lavc_priv *priv, double pts)
         if (!sub->valid)
             continue;
         if (pts == MP_NOPTS_VALUE ||
-            ((sub->pts == MP_NOPTS_VALUE || pts + 1e-6 >= sub->pts) &&
-             (sub->endpts == MP_NOPTS_VALUE || pts < sub->endpts)))
+            ((sub->pts == MP_NOPTS_VALUE || pts + SUB_GAP_THRESHOLD >= sub->pts) &&
+             (sub->endpts == MP_NOPTS_VALUE || pts - SUB_GAP_THRESHOLD <= sub->endpts)))
         {
             // Ignore "trailing" subtitles with unknown length after 1 minute.
             if (sub->endpts == MP_NOPTS_VALUE && pts >= sub->pts + 60)


### PR DESCRIPTION
02a80f850b5403da89fefed7b32b3f3dfb82f647 isn't a good fix and I found instances where subs lingered far too long on the screen. So instead, I tried to use `SUB_GAP_THRESHOLD` which seems to do the trick.