### PR TITLE
[RFC] meson: support exporting to xcode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1569,6 +1569,14 @@ endif
 
 if swift.allowed()
     subdir('osdep')
+    # Xcode supports mixed targets, so we can add them here.
+    if meson.backend() == 'xcode'
+        add_languages('swift')
+        add_project_arguments(swift_flags, language: 'swift')
+        sources += swift_sources
+        # Include the bridging header, or compiling will fail.
+        sources += bridge
+    endif
 endif
 
 macos_touchbar = get_option('macos-touchbar').require(

--- a/meson.build
+++ b/meson.build
@@ -375,6 +375,10 @@ if features['pthread-debug']
     flags += '-DMP_PTHREAD_DEBUG'
 endif
 
+if meson.backend() == 'xcode'
+    flags += '-DXCODE_BACKEND'
+endif
+
 add_project_arguments(flags, language: 'c')
 add_project_link_arguments(link_flags, language: ['c', 'objc'])
 
@@ -390,12 +394,15 @@ if features['cocoa']
                      'osdep/macosx_application.m',
                      'osdep/macosx_events.m',
                      'osdep/macosx_menubar.m',
-                     'osdep/main-fn-cocoa.c',
                      'osdep/path-macosx.m',
                      'video/out/cocoa_common.m',
                      'video/out/cocoa/events_view.m',
                      'video/out/cocoa/video_view.m',
                      'video/out/cocoa/window.m')
+    # Xcode will use this in its own target.
+    if meson.backend() != 'xcode'
+        sources += files('osdep/main-fn-cocoa.c')
+    endif
 endif
 
 if posix
@@ -1768,11 +1775,13 @@ if get_option('cplayer')
                  rename: 'mpv.svg')
     install_data('etc/mpv-symbolic.svg', install_dir: join_paths(hicolor_dir, 'symbolic', 'apps'))
 
+    # Xcode does not support object-only targets.
     if meson.backend() != 'xcode'
         mpv = executable('mpv', objects: libmpv.extract_all_objects(recursive: true), dependencies: dependencies,
                      win_subsystem: 'windows,6.0', include_directories: includedir, install: true)
     else
-        mpv = executable('mpv', sources, dependencies: dependencies, include_directories: includedir)
+        mpv = executable('mpv', 'osdep/main-fn-cocoa.c', dependencies: dependencies, include_directories: includedir,
+                     link_with: libmpv)
     endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1760,8 +1760,12 @@ if get_option('cplayer')
                  rename: 'mpv.svg')
     install_data('etc/mpv-symbolic.svg', install_dir: join_paths(hicolor_dir, 'symbolic', 'apps'))
 
-    mpv = executable('mpv', objects: libmpv.extract_all_objects(recursive: true), dependencies: dependencies,
+    if meson.backend() != 'xcode'
+        mpv = executable('mpv', objects: libmpv.extract_all_objects(recursive: true), dependencies: dependencies,
                      win_subsystem: 'windows,6.0', include_directories: includedir, install: true)
+    else
+        mpv = executable('mpv', sources, dependencies: dependencies, include_directories: includedir)
+    endif
 endif
 
 if get_option('tests')

--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -36,7 +36,11 @@
 #import "osdep/macosx_touchbar.h"
 #endif
 #if HAVE_MACOS_COCOA_CB
+#if XCODE_BACKEND
+#import <mpv_2-Swift.h>
+#else
 #include "osdep/macOS_swift.h"
+#endif
 #endif
 
 #define MPV_PROTOCOL @"mpv://"

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -40,7 +40,11 @@
 #include "config.h"
 
 #if HAVE_MACOS_COCOA_CB
+#if XCODE_BACKEND
+#import <mpv_2-Swift.h>
+#else
 #include "osdep/macOS_swift.h"
+#endif
 #endif
 
 @interface EventsResponder ()

--- a/osdep/meson.build
+++ b/osdep/meson.build
@@ -4,8 +4,13 @@ header = join_paths(build_root, 'osdep/macOS_swift.h')
 module = join_paths(build_root, 'osdep/macOS_swift.swiftmodule')
 target = join_paths(build_root, 'osdep/macOS_swift.o')
 
-swift_flags = ['-frontend', '-c', '-sdk', macos_sdk_path,
-               '-enable-objc-interop', '-emit-objc-header', '-parse-as-library']
+# Xcode already uses these flags
+if meson.backend() != 'xcode'
+    swift_flags = ['-frontend', '-c', '-sdk', macos_sdk_path,
+                   '-enable-objc-interop', '-emit-objc-header', '-parse-as-library']
+else
+    swift_flags = []
+endif
 
 if swift_ver.version_compare('>=6.0')
     swift_flags += ['-swift-version', '5']
@@ -30,28 +35,32 @@ endif
 extra_flags = get_option('swift-flags').split()
 swift_flags += extra_flags
 
-swift_compile = [swift_prog, swift_flags, '-module-name', 'macOS_swift',
-                 '-emit-module-path', '@OUTPUT0@', '-import-objc-header', bridge,
-                 '-emit-objc-header-path', '@OUTPUT1@', '-o', '@OUTPUT2@',
-                 '@INPUT@', '-I.', '-I' + source_root]
+# For Xcode, this can be merged into the libmpv target.
+if meson.backend() != 'xcode'
+    swift_compile = [swift_prog, swift_flags, '-module-name', 'macOS_swift',
+                     '-emit-module-path', '@OUTPUT0@', '-import-objc-header', bridge,
+                     '-emit-objc-header-path', '@OUTPUT1@', '-o', '@OUTPUT2@',
+                     '@INPUT@', '-I.', '-I' + source_root]
 
-swift_targets = custom_target('swift_targets',
-    input: swift_sources,
-    output: ['macOS_swift.swiftmodule', 'macOS_swift.h', 'macOS_swift.o'],
-    command: swift_compile,
-)
-sources += swift_targets
+    swift_targets = custom_target('swift_targets',
+        input: swift_sources,
+        output: ['macOS_swift.swiftmodule', 'macOS_swift.h', 'macOS_swift.o'],
+        command: swift_compile,
+    )
+    sources += swift_targets
 
-swift_lib_dir_py = find_program(join_paths(tools_directory, 'macos-swift-lib-directory.py'))
-swift_lib_dir = run_command(swift_lib_dir_py, swift_prog.full_path(), check: true).stdout()
-message('Detected Swift library directory: ' + swift_lib_dir)
+    swift_lib_dir_py = find_program(join_paths(tools_directory, 'macos-swift-lib-directory.py'))
+    swift_lib_dir = run_command(swift_lib_dir_py, swift_prog.full_path(), check: true).stdout()
+    message('Detected Swift library directory: ' + swift_lib_dir)
 
-# linker flags
-swift_link_flags = ['-L' + swift_lib_dir, '-Xlinker', '-rpath',
-                    '-Xlinker', swift_lib_dir, '-rdynamic', '-Xlinker',
-                    '-add_ast_path', '-Xlinker', module]
-if swift_ver.version_compare('>=5.0')
-    swift_link_flags += ['-Xlinker', '-rpath', '-Xlinker',
-                         '/usr/lib/swift', '-L/usr/lib/swift']
+    # linker flags
+    swift_link_flags = ['-L' + swift_lib_dir, '-Xlinker', '-rpath',
+                        '-Xlinker', swift_lib_dir, '-rdynamic', '-Xlinker',
+                        '-add_ast_path', '-Xlinker', module]
+    if swift_ver.version_compare('>=5.0')
+        swift_link_flags += ['-Xlinker', '-rpath', '-Xlinker',
+                             '/usr/lib/swift', '-L/usr/lib/swift']
+    endif
+
+    add_project_link_arguments(swift_link_flags, language: ['c', 'objc'])
 endif
-add_project_link_arguments(swift_link_flags, language: ['c', 'objc'])


### PR DESCRIPTION
Even though Meson supports exporting to Xcode, a few changes are required so that mpv runs successfully on it:

* mpv must have at least one source file to compile, as Xcode does not support object-only targets.
* The sources and bridging header for the custom swift target are added to libmpv sources, but only if Xcode was specified as the backend to use. This is mainly so they show up in the IDE itself, which should make development on macOS easier.

Right now, Meson's Xcode backend is in need of repairs (see [mesonbuild#12056](https://github.com/mesonbuild/meson/pull/12056)). At best, mpv will not be able to take advantage of this until Meson 1.3.0 is released.