### PR TITLE
sub/osd: signal osd_changed on resize

### DIFF
--- a/sub/osd.c
+++ b/sub/osd.c
@@ -253,6 +253,7 @@ static void check_obj_resize(struct osd_state *osd, struct mp_osd_res res,
 {
     if (!osd_res_equals(res, obj->vo_res)) {
         obj->vo_res = res;
+        obj->osd_changed = true;
         mp_client_broadcast_event_external(osd->global->client_api,
                                            MP_EVENT_WIN_RESIZE, NULL);
     }


### PR DESCRIPTION
We should update the osd when the window is resized, previously we weren't signalling for an update.

Fixes #12228