### PR TITLE
command: fix property time-remaining returning -0.000000 in rare cases

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -813,7 +813,7 @@ static bool time_remaining(MPContext *mpctx, double *remaining)
     if (playback == MP_NOPTS_VALUE || len <= 0)
         return false;
 
-    *remaining = len - playback;
+    *remaining = MPMAX(len - playback, 0);
 
     return len >= 0;
 }


### PR DESCRIPTION
I’m not sure if this is the right fix, but it works. The fix can be tested with this file: https://send.ephemeral.land/download/1643644c0c2b471e/#vE9wwIGVQxXPMiktjcdV2g (Go to the end, without the fix the osc should now show as remaining time "--00:00:00", notice the double minus.)

I have used this script to check the property:
```lua
mp.add_key_binding("q", "osc-test", function()
    mp.msg.log("info", mp.get_property("time-remaining"))
end)
```