### PR TITLE
player: use audio pts corresponding to playing audio on EOF 

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1085,8 +1085,7 @@ static void handle_playback_time(struct MPContext *mpctx)
     } else if (mpctx->video_status == STATUS_EOF &&
                mpctx->audio_status == STATUS_EOF)
     {
-        double apts =
-            mpctx->ao_chain ? mpctx->ao_chain->last_out_pts : MP_NOPTS_VALUE;
+        double apts = playing_audio_pts(mpctx);
         double vpts = mpctx->video_pts;
         double mpts = MP_PTS_MAX(apts, vpts);
         if (mpts != MP_NOPTS_VALUE)


### PR DESCRIPTION
See each individual commit for more information.

To reproduce each bug, get the sample file from the linked issue and run the following commands.

`mpv --no-config 02\ Kevin\ Penkin\ -\ Old\ Stories.flac --force-window --keep-open --start=421`

When mpv reaches EOF, the time-remaining property will be negative 0. After the first commit in this PR, the time-remaining property will be zero when mpv seeks to EOF while paused. 

However, time-remaining will still be negative 0 when mpv reaches EOF while playing through the audio. This is fixed by clamping to length.

Another issue is that time-pos being a negative number when gapless audio is enabled (default), and mpv is looping the same file. This can be reproduced with this:

`mpv --no-config 02\ Kevin\ Penkin\ -\ Old\ Stories.flac --force-window --loop --no-audio-display --pause --start=421`

Hit play after making sure your osc is visible and displaying decimals, the audio will loop from -0.120 or so, instead of 0.

This is fixed by clamping audio pts to 0.

