### PR TITLE
command: add `sub-ass-extradata` property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2679,6 +2679,11 @@ Property list
         coordinates should be ignored when this value is false, because the
         video backends update them only when the pointer hovers the window.
 
+``sub-ass-extradata``
+    The current ASS subtitle track's extradata. There is no formatting done.
+    The extradata is returned as a string as-is. This property is not
+    available for non-ASS subtitle tracks.
+
 ``sub-text``
     The current subtitle text regardless of sub visibility. Formatting is
     stripped. If the subtitle is not text-based (i.e. DVD/BD subtitles), an

--- a/player/command.c
+++ b/player/command.c
@@ -2916,6 +2916,29 @@ static int mp_property_sub_pos(void *ctx, struct m_property *prop,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
+static int mp_property_sub_ass_extradata(void *ctx, struct m_property *prop,
+                                     int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    struct dec_sub *sub = track ? track->d_sub : NULL;
+    if (!sub)
+        return M_PROPERTY_UNAVAILABLE;
+    switch (action) {
+    case M_PROPERTY_GET: {
+        char *data = sub_ass_get_extradata(sub);
+        if (!data)
+            return M_PROPERTY_UNAVAILABLE;
+        *(char **)arg = data;
+        return M_PROPERTY_OK;
+    }
+    case M_PROPERTY_GET_TYPE:
+        *(struct m_option *)arg = (struct m_option){.type = CONF_TYPE_STRING};
+        return M_PROPERTY_OK;
+    }
+    return M_PROPERTY_NOT_IMPLEMENTED;
+}
+
 static int get_sub_text(void *ctx, struct m_property *prop,
                         int action, void *arg, int sub_index)
 {
@@ -3954,6 +3977,7 @@ static const struct m_property mp_properties_base[] = {
     {"sub-delay", mp_property_sub_delay},
     {"sub-speed", mp_property_sub_speed},
     {"sub-pos", mp_property_sub_pos},
+    {"sub-ass-extradata", mp_property_sub_ass_extradata},
     {"sub-text", mp_property_sub_text,
         .priv = (void *)&(const int){SD_TEXT_TYPE_PLAIN}},
     {"secondary-sub-text", mp_property_secondary_sub_text,

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -369,6 +369,15 @@ char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type)
     return text;
 }
 
+char *sub_ass_get_extradata(struct dec_sub *sub)
+{
+    if (strcmp(sub->sd->codec->codec, "ass") != 0)
+        return NULL;
+    char *extradata = sub->sd->codec->extradata;
+    int extradata_size = sub->sd->codec->extradata_size;
+    return talloc_strndup(NULL, extradata, extradata_size);
+}
+
 struct sd_times sub_get_times(struct dec_sub *sub, double pts)
 {
     pthread_mutex_lock(&sub->lock);

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -47,6 +47,7 @@ bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force);
 struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
                                     int format, double pts);
 char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type);
+char *sub_ass_get_extradata(struct dec_sub *sub);
 struct sd_times sub_get_times(struct dec_sub *sub, double pts);
 void sub_reset(struct dec_sub *sub);
 void sub_select(struct dec_sub *sub, bool selected);


### PR DESCRIPTION
Added so I can do what #12157 does through a lua script (with sub-ass-force-style) instead, since it seems there isn't much interest in that PR.

I still prefer that PR for this but it seems mpv don't want too many hacks around libass