### PR TITLE
path-unix: Only accept absolute paths

### DIFF
--- a/osdep/path-darwin.c
+++ b/osdep/path-darwin.c
@@ -35,7 +35,7 @@ static void path_init(void)
     char *home = getenv("HOME");
     char *xdg_config = getenv("XDG_CONFIG_HOME");
 
-    if (xdg_config && xdg_config[0]) {
+    if (xdg_config && xdg_config[0] == '/') {
         snprintf(mpv_home, sizeof(mpv_home), "%s/mpv", xdg_config);
     } else if (home && home[0]) {
         snprintf(mpv_home, sizeof(mpv_home), "%s/.config/mpv", home);

--- a/osdep/path-unix.c
+++ b/osdep/path-unix.c
@@ -44,7 +44,7 @@ static void path_init(void)
     char *xdg_state = getenv("XDG_STATE_HOME");
 
     bool err = false;
-    if (xdg_config && xdg_config[0]) {
+    if (xdg_config && xdg_config[0] == '/') {
         err = err || MKPATH(mpv_home, "%s/mpv", xdg_config);
     } else if (home && home[0]) {
         err = err || MKPATH(mpv_home, "%s/.config/mpv", home);
@@ -56,20 +56,20 @@ static void path_init(void)
         err = err || MKPATH(old_cache, "%s/.mpv/cache", home);
     }
 
-    if (xdg_cache && xdg_cache[0]) {
+    if (xdg_cache && xdg_cache[0] == '/') {
         err = err || MKPATH(mpv_cache, "%s/mpv", xdg_cache);
     } else if (home && home[0]) {
         err = err || MKPATH(mpv_cache, "%s/.cache/mpv", home);
     }
 
-    if (xdg_state && xdg_state[0]) {
+    if (xdg_state && xdg_state[0] == '/') {
         err = err || MKPATH(mpv_state, "%s/mpv", xdg_state);
     } else if (home && home[0]) {
         err = err || MKPATH(mpv_state, "%s/.local/state/mpv", home);
     }
 
     char xdg_user_dirs[CONF_MAX];
-    if (xdg_config && xdg_config[0]) {
+    if (xdg_config && xdg_config[0] == '/') {
         err = err || MKPATH(xdg_user_dirs, "%s/user-dirs.dirs", xdg_config);
     } else if (home && home[0]) {
         err = err || MKPATH(xdg_user_dirs, "%s/.config/user-dirs.dirs", home);


### PR DESCRIPTION
The XDG Base Directory specification says “All paths set in these environment variables must be absolute. If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.”