### PR TITLE
wayland: remove gnome-specific idle-inhibit warning

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1372,9 +1372,6 @@ A common problem is that Linux desktop environments ignore the standard
 screensaver APIs on which mpv relies. In particular, mpv uses the Screen Saver
 extension (XSS) on X11, and the idle-inhibit protocol on Wayland.
 
-GNOME in particular still ignores the idle-inhibit protocol, and has its own
-D-Bus interfaces for display power management, which mpv does not support.
-
 Before mpv 0.33.0, the X11 backend ran ``xdg-screensaver reset`` in 10 second
 intervals when not paused in order to support screensaver inhibition in these
 environments. This functionality was removed in 0.33.0, but it is possible to

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2306,10 +2306,6 @@ bool vo_wayland_init(struct vo *vo)
     if (!wl->idle_inhibit_manager) {
         MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
                    zwp_idle_inhibit_manager_v1_interface.name);
-
-        const char *xdg_current_desktop = getenv("XDG_CURRENT_DESKTOP");
-        if (xdg_current_desktop != NULL && strstr(xdg_current_desktop, "GNOME"))
-            MP_WARN(wl, "GNOME's wayland compositor lacks support for the idle inhibit protocol. This means the screen can blank during playback.\n");
     }
 
     wl->opts = mp_get_config_group(wl, wl->vo->global, &wayland_conf);


### PR DESCRIPTION
Unbelievably, mutter actually supports the idle inhibit protocol now after many years of pain*. Let's remove this hacky warning.

*: https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3145

Blocked until the next GNOME release, but I'll leave it here so I don't forget.