### PR TITLE
stats.lua: fixes and unification

### DIFF
--- a/DOCS/interface-changes/term-size.txt
+++ b/DOCS/interface-changes/term-size.txt
@@ -1,0 +1,1 @@
+add `term-size` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2804,6 +2804,19 @@ Property list
     Any of these properties may be unavailable or set to dummy values if the
     VO window is not created or visible.
 
+``term-size``
+    The current terminal size.
+
+    This has two sub-properties.
+
+    ``term-size/w``
+        width of the terminal in cells
+    ``term-size/h``
+        height of the terminal in cells
+
+    This property is not observable. Reacting to size changes requires
+    polling.
+
 ``window-id``
     Read-only - mpv's window id. May not always be available, i.e due to window
     not being opened yet or not being supported by the VO.

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -85,6 +85,18 @@ Configurable Options
     respective duration. This can result in overlapping text when multiple
     scripts decide to print text at the same time.
 
+``term_width_limit``
+    Default: -1
+
+    Sets the terminal width.
+    A value of 0 means the width is infinite, -1 means it's automatic.
+
+``term_height_limit``
+    Default: -1
+
+    Sets the terminal height.
+    A value of 0 means the height is infinite, -1 means it's automatic.
+
 ``plot_perfdata``
     Default: yes
 

--- a/player/command.c
+++ b/player/command.c
@@ -74,6 +74,7 @@
 
 #include "osdep/io.h"
 #include "osdep/subprocess.h"
+#include "osdep/terminal.h"
 
 #include "core.h"
 
@@ -2886,6 +2887,23 @@ static int mp_property_osd_ass(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
+static int mp_property_term_size(void *ctx, struct m_property *prop,
+                                  int action, void *arg)
+{
+    int w = -1, h = -1;
+    terminal_get_size(&w, &h);
+    if (w == -1 || h == -1)
+        return M_PROPERTY_UNAVAILABLE;
+
+    struct m_sub_property props[] = {
+        {"w",      SUB_PROP_INT(w)},
+        {"h",      SUB_PROP_INT(h)},
+        {0}
+    };
+
+    return m_property_read_sub(props, action, arg);
+}
+
 static int mp_property_mouse_pos(void *ctx, struct m_property *prop,
                                     int action, void *arg)
 {
@@ -4092,6 +4110,7 @@ static const struct m_property mp_properties_base[] = {
     {"input-bindings", mp_property_bindings},
 
     {"user-data", mp_property_udata},
+    {"term-size", mp_property_term_size},
 
     M_PROPERTY_ALIAS("video", "vid"),
     M_PROPERTY_ALIAS("audio", "aid"),

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -29,12 +29,9 @@ local o = {
     persistent_overlay = false,      -- whether the stats can be overwritten by other output
     print_perfdata_passes = false,   -- when true, print the full information about all passes
     filter_params_max_length = 100,  -- a filter list longer than this many characters will be shown one filter per line instead
-<<<<<<< HEAD
     show_frame_info = false,          -- whether to show the current frame info
-=======
     term_width_limit = -1,           -- overwrites the terminal width
     term_height_limit = -1,          -- overwrites the terminal height
->>>>>>> 89493c38fb (stats.lua: truncate long lines for the terminal)
     debug = false,
 
     -- Graph options and style
@@ -291,6 +288,12 @@ local function sorted_keys(t, comp_fn)
     return keys
 end
 
+local function scroll_hint()
+    local hint = format("(hint: scroll with %s/%s)", o.key_scroll_up, o.key_scroll_down)
+    if not o.use_ass then return " " .. hint end
+    return format(" {\\fs%s}%s{\\fs%s}", o.font_size * 0.66, hint, o.font_size)
+end
+
 local function append_perfdata(header, s, dedicated_page, print_passes)
     local vo_p = mp.get_property_native("vo-passes")
     if not vo_p then
@@ -333,11 +336,11 @@ local function append_perfdata(header, s, dedicated_page, print_passes)
     -- ensure that the fixed title is one element and every scrollable line is
     -- also one single element.
     local h = dedicated_page and header or s
-    h[#h+1] = format("%s%s%s%s{\\fs%s}%s%s{\\fs%s}",
+    h[#h+1] = format("%s%s%s%s{\\fs%s}%s{\\fs%s}%s",
                      dedicated_page and "" or o.nl, dedicated_page and "" or o.indent,
                      b("Frame Timings:"), o.prefix_sep, o.font_size * 0.66,
-                     "(last/average/peak μs)",
-                     dedicated_page and " (hint: scroll with ↑↓)" or "", o.font_size)
+                     "(last/average/peak μs)", o.font_size,
+                     dedicated_page and scroll_hint() or "")
 
     for _,frame in ipairs(sorted_keys(vo_p)) do  -- ensure fixed display order
         local data = vo_p[frame]
@@ -1113,9 +1116,7 @@ local function keybinding_info(after_scroll, bindlist)
     local page = pages[o.key_page_4]
     eval_ass_formatting()
     add_header(header)
-    append(header, "", {prefix=format("%s: {\\fs%s}%s{\\fs%s}", page.desc,
-           o.font_size * 0.66, "(hint: scroll with ↑↓)", o.font_size), nl="",
-           indent=""})
+    append(header, "", {prefix=format("%s:%s", page.desc, scroll_hint()), nl="", indent=""})
     header = {table.concat(header)}
 
     if not kbinfo_lines or not after_scroll then
@@ -1130,7 +1131,7 @@ local function perf_stats()
     eval_ass_formatting()
     add_header(header)
     local page = pages[o.key_page_0]
-    append(header, "", {prefix=page.desc .. ":", nl="", indent=""})
+    append(header, "", {prefix=format("%s:%s", page.desc, scroll_hint()), nl="", indent=""})
     append_general_perfdata(content)
     header = {table.concat(header)}
     return finalize_page(header, content, true)

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1065,8 +1065,9 @@ end
 -- content     : table of the content where each entry is one line
 -- apply_scroll: scroll the content
 local function finalize_page(header, content, apply_scroll)
-    local term_width = o.term_width_limit or 80
-    local term_height = o.term_height_limit or 24
+    local term_size = mp.get_property_native("term-size", {})
+    local term_width = o.term_width_limit or term_size.w or 80
+    local term_height = o.term_height_limit or term_size.h or 24
     local from, to = 1, #content
     if apply_scroll and term_height > 0 then
         -- Up to 40 lines for libass because it can put a big performance toll on
@@ -1483,7 +1484,7 @@ if o.bindlist ~= "no" then
     mp.add_timeout(0, function()  -- wait for all other scripts to finish init
         o.ass_formatting = false
         o.no_ass_indent = " "
-        o.term_size.w = width
+        o.term_size = { w = width , h = 0}
         io.write(keybinding_info(false, true) .. "\n")
         mp.command("quit")
     end)


### PR DESCRIPTION
Fixes scrolling for page 0 in the terminal and unifies the scrolling implementation.
Also introduces a new line shortening function for the terminal that is used by all scrollable pages now.