### PR TITLE
demux_playlist: default to --directory-mode=lazy

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -52,6 +52,7 @@ Interface changes
     - rename `--sub-forced-only` to `--sub-forced-events-only`
     - remove `sub-forced-only-cur` property (`--sub-forced-events-only` is a replacement)
     - add `hdr-metadata` property
+    - change `--directory-mode` default to `lazy`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3965,12 +3965,9 @@ Demuxer
     libarchive opens all volumes anyway when playing the main file, even though
     mpv iterated no archive entries yet.
 
-``--directory-mode=<recursive|lazy|ignore>``
-    When opening a directory, open subdirectories recursively, lazily or not at
-    all (default: recursive).
-
-    Values other then ``recursive`` can lead to problems with resuming playlists
-    (`RESUMING PLAYBACK`_) and possibly other things.
+``--directory-mode=<lazy|recursive|ignore>``
+    When opening a directory, open subdirectories lazily, recursively or not at
+    all (default: lazy).
 
 Input
 -----

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -37,8 +37,8 @@
 #define PROBE_SIZE (8 * 1024)
 
 enum dir_mode {
-    DIR_RECURSIVE,
     DIR_LAZY,
+    DIR_RECURSIVE,
     DIR_IGNORE,
 };
 
@@ -50,14 +50,14 @@ struct demux_playlist_opts {
 struct m_sub_options demux_playlist_conf = {
     .opts = (const struct m_option[]) {
         {"directory-mode", OPT_CHOICE(dir_mode,
-            {"recursive", DIR_RECURSIVE},
             {"lazy", DIR_LAZY},
+            {"recursive", DIR_RECURSIVE},
             {"ignore", DIR_IGNORE})},
         {0}
     },
     .size = sizeof(struct demux_playlist_opts),
     .defaults = &(const struct demux_playlist_opts){
-        .dir_mode = DIR_RECURSIVE,
+        .dir_mode = DIR_LAZY,
     },
 };
 


### PR DESCRIPTION
64959c450d solved the problems with resuming playback, so default to --directory-mode=lazy because it's faster, especially on slow drives, and results in smaller playlists.