### PR TITLE
input.conf: swap wheel up/down with wheel left/right

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -37,10 +37,10 @@
 # Mouse wheels, touchpad or other input devices that have axes
 # if the input devices supports precise scrolling it will also scale the
 # numeric value accordingly
-#WHEEL_UP      seek 10          # seek 10 seconds forward
-#WHEEL_DOWN    seek -10         # seek 10 seconds backward
-#WHEEL_LEFT    add volume -2
-#WHEEL_RIGHT   add volume 2
+#WHEEL_UP      add volume 2
+#WHEEL_DOWN    add volume -2
+#WHEEL_LEFT    seek -10         # seek 10 seconds backward
+#WHEEL_RIGHT   seek 10          # seek 10 seconds forward
 
 ## Seek units are in seconds, but note that these are limited by keyframes
 #RIGHT seek  5                          # seek 5 seconds forward


### PR DESCRIPTION
Wheel being seek by default is very unintuitive and surprising to a lot of users. It seems to be one of the things most consistently complained about in the default UI. I change this on all of my devices, and so do many others.

It's trivial for users who like the old behavior to change it back.