### PR TITLE
osc: add scrolling to the seekbar

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -85,6 +85,7 @@ seekbar
 
     =============   ================================================
     left-click      seek to position
+    mouse wheel     seek forward/backward
     =============   ================================================
 
 time left

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2085,6 +2085,10 @@ function osc_init()
             "absolute-percent", "exact") end
     ne.eventresponder["reset"] =
         function (element) element.state.lastseek = nil end
+    ne.eventresponder["wheel_up_press"] =
+        function () mp.commandv("osd-auto", "seek",  10) end
+    ne.eventresponder["wheel_down_press"] =
+        function () mp.commandv("osd-auto", "seek", -10) end
 
 
     -- tc_left (current pos)


### PR DESCRIPTION
the osc currently allows for changing volume via scrolling when on top of the volume icon. this does the same thing for the seekbar by allowing seeking via scroll.
