### PR TITLE
osc: remove toggle for forced only subpictures

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1315,14 +1315,6 @@ layouts["box"] = function ()
         {x = posX - pos_offsetX, y = bigbtnrowY, an = 7, w = 70, h = 18}
     lo.style = osc_styles.smallButtonsL
 
-    sub_codec = mp.get_property("current-tracks/sub/codec")
-    if (sub_codec == "dvd_subtitle" or sub_codec == "hdmv_pgs_subtitle") then
-        lo = add_layout("tog_forced_only")
-        lo.geometry =
-        {x = posX - pos_offsetX + 70, y = bigbtnrowY - 1, an = 7, w = 25, h = 18}
-        lo.style = osc_styles.smallButtonsL
-    end
-
     lo = add_layout("tog_fs")
     lo.geometry =
         {x = posX+pos_offsetX - 25, y = bigbtnrowY, an = 4, w = 25, h = 25}
@@ -1628,16 +1620,6 @@ function bar_layout(direction)
     lo = add_layout("volume")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
-
-    -- Forced-subs-only button
-    sub_codec = mp.get_property("current-tracks/sub/codec")
-    if (sub_codec == "dvd_subtitle" or sub_codec == "hdmv_pgs_subtitle") then
-        geo = { x = geo.x - geo.w - padX - 10,
-                y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-        lo = add_layout("tog_forced_only")
-        lo.geometry = geo
-        lo.style = osc_styles.smallButtonsBar
-    end
 
     -- Track selection buttons
     geo = { x = geo.x - tsW - padX, y = geo.y, an = geo.an, w = tsW, h = geo.h }
@@ -1975,27 +1957,6 @@ function osc_init()
         function () set_track("sub", -1) end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () show_message(get_tracklist("sub"), 2) end
-
-    -- tog_forced_only
-    local tog_forced_only = new_element("tog_forced_only", "button")
-    ne = tog_forced_only
-    ne.content = function ()
-        local base_a = tog_forced_only.layout.alpha
-        local alpha = base_a[1]
-        if not mp.get_property_bool("sub-forced-events-only") then
-            alpha = 255
-        end
-        local ret = assdraw.ass_new()
-        ret:append("[")
-        ass_append_alpha(ret, {[1] = alpha, [2] = 1, [3] = base_a[3], [4] = base_a[4]}, 0)
-        ret:append("F")
-        ass_append_alpha(ret, base_a, 0)
-        ret:append("]")
-        return ret.text
-    end
-    ne.eventresponder["mbtn_left_up"] = function ()
-        mp.set_property_bool("sub-forced-events-only", (not mp.get_property_bool("sub-forced-events-only")))
-    end
 
     --tog_fs
     ne = new_element("tog_fs", "button")


### PR DESCRIPTION
DVD/PGS are definitely not common, and ones that make use of the forced subpictures flag even less so. For this button to be useful, the subtitle track would need to be DVD or PGS, the track would need to make use of the forced flag, the user would have to know what forced subpictures are, and the user would need to have the preference of only viewing forced subpictures on a subtitle. The function of this button is too niche to be on the osc, if this behavior is desired the user can simply bind a key in their input.conf. Moreover, this button only adds confusion because there's no intuitive way to show what it does, and there's no explanation for it anywhere in the manuals. osc real-estate is quite limited as it is, so let's not waste any space on buttons with highly questionable utility at best and confusing or bad UX at worst.