### PR TITLE
vo_dmabuf_wayland: support 90 degree rotations

### DIFF
--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -92,21 +92,6 @@ static const struct m_sub_options adec_queue_conf = {
 #undef OPT_BASE_STRUCT
 #define OPT_BASE_STRUCT struct dec_wrapper_opts
 
-struct dec_wrapper_opts {
-    double movie_aspect;
-    int aspect_method;
-    double force_fps;
-    bool correct_pts;
-    int video_rotate;
-    char *audio_decoders;
-    char *video_decoders;
-    char *audio_spdif;
-    struct dec_queue_opts *vdec_queue_opts;
-    struct dec_queue_opts *adec_queue_opts;
-    int64_t video_reverse_size;
-    int64_t audio_reverse_size;
-};
-
 static int decoder_list_help(struct mp_log *log, const m_option_t *opt,
                              struct bstr name);
 

--- a/options/options.h
+++ b/options/options.h
@@ -377,6 +377,21 @@ typedef struct MPOpts {
     int cuda_device;
 } MPOpts;
 
+struct dec_wrapper_opts {
+    double movie_aspect;
+    int aspect_method;
+    double force_fps;
+    bool correct_pts;
+    int video_rotate;
+    char *audio_decoders;
+    char *video_decoders;
+    char *audio_spdif;
+    struct dec_queue_opts *vdec_queue_opts;
+    struct dec_queue_opts *adec_queue_opts;
+    int64_t video_reverse_size;
+    int64_t audio_reverse_size;
+};
+
 struct dvd_opts {
     int angle;
     int speed;

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -672,6 +672,8 @@ done:
     if (!vo_wayland_reconfig(vo))
         return VO_ERROR;
 
+    wl_surface_set_buffer_transform(vo->wl->video_surface, img->params.rotate / 90);
+
     // Immediately destroy all buffers if params change.
     destroy_buffers(vo);
     return 0;
@@ -831,6 +833,7 @@ err:
 const struct vo_driver video_out_dmabuf_wayland = {
     .description = "Wayland dmabuf video output",
     .name = "dmabuf-wayland",
+    .caps = VO_CAP_ROTATE90,
     .preinit = preinit,
     .query_format = query_format,
     .reconfig2 = reconfig,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -850,6 +850,16 @@ static void surface_handle_preferred_buffer_transform(void *data,
                                                       struct wl_surface *wl_surface,
                                                       uint32_t transform)
 {
+    struct vo_wayland_state *wl = data;
+    // Don't handle any of the flipped/reflected variants.
+    if (transform <= 3) {
+        struct m_config_cache *opts_cache = m_config_cache_alloc(NULL, wl->vo->global,
+                                                                 &dec_wrapper_conf);
+        struct dec_wrapper_opts *opts = opts_cache->opts;
+        opts->video_rotate = transform * 90;
+        m_config_cache_write_opt(opts_cache, &opts->video_rotate);
+        talloc_free(opts_cache);
+    }
 }
 #endif
 


### PR DESCRIPTION
`video-rotate` will now actually work in `vo_dmabuf_wayland` in 90 degree steps.

@rmader: I also made mpv listen to the `surface_handle_preferred_buffer_transform` event in the second commit, but do you know if any compositor actually uses this? It should work, but I'd like to test it.