### PR TITLE
aspect: add output-pan-x/y options

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -56,6 +56,7 @@ Interface changes
     - add `--video-crop`
     - add `video-params/crop-[w,h,x,y]`
     - remove `--tone-mapping-mode`
+    - add `output-pan-x` and `output-pan-y` property
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1556,6 +1556,16 @@ Video
 
     This option is disabled if the ``--no-keepaspect`` option is used.
 
+``--output-pan-x=<value>``, ``--output-pan-y=<value>``
+    Same as ``--video-pan-x`` and ``--video-pan-y`` except unit of the value is
+    in fractions of the size of the destination rectangle.
+
+    For example, displaying a video fullscreen on a 1920x1080 screen with
+    ``--output-pan-x=-0.1`` would move the video 192 pixels to the left and
+    ``--output-pan-y=-0.1`` would move the video 108 pixels up.
+
+    This options is disabled if the ``--no-keepaspect`` option is used.
+
 ``--video-rotate=<0-359|no>``
     Rotate the video clockwise, in degrees. If ``no`` is given, the video is
     never rotated, even if the file has rotation metadata. (The rotation value

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1550,9 +1550,10 @@ Video
     full size, even if parts of the video are not visible due to panscan or
     other options).
 
-    For example, displaying a video fullscreen on a 1920x1080 screen with
-    ``--video-pan-x=-0.1`` would move the video 192 pixels to the left and
-    ``--video-pan-y=-0.1`` would move the video 108 pixels up.
+    For example, displaying a video scaled to 1920x1080 due to video-zoom or
+    other options on a 1280x720 mpv window, with ``--video-pan-x=-0.1`` would
+    move the video 192 pixels to the left and ``--video-pan-y=-0.1`` would move
+    the video 108 pixels up.
 
     This option is disabled if the ``--no-keepaspect`` option is used.
 
@@ -1560,9 +1561,10 @@ Video
     Same as ``--video-pan-x`` and ``--video-pan-y`` except unit of the value is
     in fractions of the size of the destination rectangle.
 
-    For example, displaying a video fullscreen on a 1920x1080 screen with
-    ``--output-pan-x=-0.1`` would move the video 192 pixels to the left and
-    ``--output-pan-y=-0.1`` would move the video 108 pixels up.
+    For example, displaying a video scaled to 1920x1080 due to video-zoom or
+    other options on a 1280x720 mpv window, with ``--output-pan-x=-0.1`` would
+    move the video 128 pixels to the left and ``--output-pan-y=-0.1`` would move
+    the video 72 pixels up.
 
     This options is disabled if the ``--no-keepaspect`` option is used.
 

--- a/options/options.c
+++ b/options/options.c
@@ -142,6 +142,8 @@ static const m_option_t mp_vo_opt_list[] = {
     {"video-zoom", OPT_FLOAT(zoom), M_RANGE(-20.0, 20.0)},
     {"video-pan-x", OPT_FLOAT(pan_x)},
     {"video-pan-y", OPT_FLOAT(pan_y)},
+    {"output-pan-x", OPT_FLOAT(outpan_x)},
+    {"output-pan-y", OPT_FLOAT(outpan_y)},
     {"video-align-x", OPT_FLOAT(align_x), M_RANGE(-1.0, 1.0)},
     {"video-align-y", OPT_FLOAT(align_y), M_RANGE(-1.0, 1.0)},
     {"video-scale-x", OPT_FLOAT(scale_x), M_RANGE(0, 10000.0)},

--- a/options/options.h
+++ b/options/options.h
@@ -39,6 +39,7 @@ typedef struct mp_vo_opts {
     float panscan;
     float zoom;
     float pan_x, pan_y;
+    float outpan_x, outpan_y;
     float align_x, align_y;
     float scale_x, scale_y;
     float margin_x[2];

--- a/video/out/aspect.c
+++ b/video/out/aspect.c
@@ -77,7 +77,8 @@ static void clamp_size(int size, int *start, int *end)
 
 static void src_dst_split_scaling(int src_size, int dst_size,
                                   int scaled_src_size,
-                                  float zoom, float align, float pan, float scale,
+                                  float zoom, float align,
+                                  float pan, float outpan, float scale,
                                   int *src_start, int *src_end,
                                   int *dst_start, int *dst_end,
                                   int *osd_margin_a, int *osd_margin_b)
@@ -86,7 +87,8 @@ static void src_dst_split_scaling(int src_size, int dst_size,
     scaled_src_size = MPMAX(scaled_src_size, 1);
     align = (align + 1) / 2;
 
-    *dst_start = (dst_size - scaled_src_size) * align + pan * scaled_src_size;
+    *dst_start = (dst_size - scaled_src_size) * align +
+                  pan * scaled_src_size + outpan * dst_size;
     *dst_end = *dst_start + scaled_src_size;
 
     // Distance of screen frame to video
@@ -174,12 +176,12 @@ void mp_get_src_dst_rects(struct mp_log *log, struct mp_vo_opts *opts,
                             vid_window_w, vid_window_h, monitor_par,
                             &scaled_width, &scaled_height);
         src_dst_split_scaling(src_w, vid_window_w, scaled_width,
-                              opts->zoom, opts->align_x, opts->pan_x, opts->scale_x,
-                              &src.x0, &src.x1, &dst.x0, &dst.x1,
+                              opts->zoom, opts->align_x, opts->pan_x, opts->outpan_x,
+                              opts->scale_x, &src.x0, &src.x1, &dst.x0, &dst.x1,
                               &osd.ml, &osd.mr);
         src_dst_split_scaling(src_h, vid_window_h, scaled_height,
-                              opts->zoom, opts->align_y, opts->pan_y, opts->scale_y,
-                              &src.y0, &src.y1, &dst.y0, &dst.y1,
+                              opts->zoom, opts->align_y, opts->pan_y, opts->outpan_y,
+                              opts->scale_y, &src.y0, &src.y1, &dst.y0, &dst.y1,
                               &osd.mt, &osd.mb);
     }
 


### PR DESCRIPTION
There are way too many preexisting scripts that rely on this behavior for video panning, like for example scripts that allow you to use mpv as an image viewer. If this behavior is desired then it may be better to add a new option for panning relative to the destination instead.

The restriction of video-pan-x/y being clamped to {-3, 3} also results in the video being impossible to pan if it was zoomed in beyond a certain degree.

This reverts commit 7d6f9e37397ed57be0f1375afe8fddfc451aa152.