### PR TITLE
stream/dvbin: add support for delivery system ISDB-T 

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5129,6 +5129,9 @@ DVB
     in the mpv configuration directory (usually ``~/.config/mpv``) with the
     filename ``channels.conf.{sat,ter,cbl,atsc,isdbt}`` (based on your card
     type) or ``channels.conf`` as a last resort.
+    Please note that using specific file name with card type is recommended,
+    since the legacy channel format is not fully standardized
+    so autodetection of the delivery system may fail otherwise.
     For DVB-S/2 cards, a VDR 1.7.x format channel list is recommended
     as it allows tuning to DVB-S2 channels, enabling subtitles and
     decoding the PMT (which largely improves the demuxing).

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5127,8 +5127,8 @@ DVB
 ``--dvbin-file=<filename>``
     Instructs mpv to read the channels list from ``<filename>``. The default is
     in the mpv configuration directory (usually ``~/.config/mpv``) with the
-    filename ``channels.conf.{sat,ter,cbl,atsc}`` (based on your card type) or
-    ``channels.conf`` as a last resort.
+    filename ``channels.conf.{sat,ter,cbl,atsc,isdbt}`` (based on your card
+    type) or ``channels.conf`` as a last resort.
     For DVB-S/2 cards, a VDR 1.7.x format channel list is recommended
     as it allows tuning to DVB-S2 channels, enabling subtitles and
     decoding the PMT (which largely improves the demuxing).

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -447,6 +447,7 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
     switch (delsys) {
     case SYS_DVBT2:
     case SYS_DVBT:
+    case SYS_ISDBT:
         if (freq < 1000000)
             freq *= 1000UL;
         switch (bandwidth) {
@@ -563,6 +564,7 @@ static int tune_it(dvb_priv_t *priv, int fd_frontend, unsigned int delsys,
         break;
     case SYS_DVBT:
     case SYS_DVBT2:
+    case SYS_ISDBT:
         {
             struct dtv_property p[] = {
                 { .cmd = DTV_DELIVERY_SYSTEM, .u.data = delsys },

--- a/stream/dvbin.h
+++ b/stream/dvbin.h
@@ -130,6 +130,7 @@ typedef struct {
         DELSYS_BIT(SYS_ATSC) |                                          \
         DELSYS_BIT(SYS_DVBC_ANNEX_B) |                                  \
         DELSYS_BIT(SYS_DVBT2) |                                         \
+        DELSYS_BIT(SYS_ISDBT) |                                         \
         DELSYS_BIT(SYS_DVBC_ANNEX_C)                                    \
     )
 

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -262,7 +262,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
     char line[CHANNEL_LINE_LEN], *colon;
 
     if (!filename)
-        return NULL;
+        return list;
 
     int fields, cnt, k;
     int has8192, has0;
@@ -283,7 +283,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                filename, get_dvb_delsys(delsys));
     if ((f = fopen(filename, "r")) == NULL) {
         mp_fatal(log, "CAN'T READ CONFIG FILE %s\n", filename);
-        return NULL;
+        return list;
     }
 
     if (list == NULL) {

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -352,14 +352,12 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
                         &num_chars);
 
         bool is_vdr_conf = (num_chars == strlen(&line[k]));
-        mp_verbose(log, "This does look like a VDR style channel config file.\n");
 
         // Special case: DVB-T style ZAP config also has 13 columns.
         // Most columns should have non-numeric content, but some channel list generators insert 0
         // if a value is not used. However, INVERSION_* should always set after frequency.
         if (is_vdr_conf && !strncmp(vdr_par_str, "INVERSION_", 10)) {
             is_vdr_conf = false;
-            mp_verbose(log, "Found INVERSION field after frequency, assuming ZAP style channel config file.\n");
         }
 
         if (is_vdr_conf) {

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -1200,6 +1200,7 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                 if (!DELSYS_IS_SET(delsys_mask[f], delsys))
                     continue; /* Skip unsupported. */
 
+                mp_verbose(log, "Searching channel list for delivery system %s\n", get_dvb_delsys(delsys));
                 switch (delsys) {
                 case SYS_DVBC_ANNEX_A:
                 case SYS_DVBC_ANNEX_C:
@@ -1271,6 +1272,7 @@ dvb_state_t *dvb_get_state(stream_t *stream)
             &delsys_mask, (sizeof(unsigned int) * MAX_FRONTENDS));
         state->adapters[state->adapters_count].list = list;
         state->adapters_count++;
+        mp_verbose(log, "Added adapter with channels to state list, contains %d adapters.\n", state->adapters_count);
     }
 
     if (state->adapters_count == 0) {

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -386,6 +386,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
             case SYS_DVBC_ANNEX_C:
             case SYS_ATSC:
             case SYS_DVBC_ANNEX_B:
+            case SYS_ISDBT:
                 mp_verbose(log, "VDR, %s, NUM: %d, NUM_FIELDS: %d, NAME: %s, "
                            "FREQ: %d, SRATE: %d",
                            get_dvb_delsys(delsys),
@@ -437,6 +438,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
             switch (delsys) {
             case SYS_DVBT:
             case SYS_DVBT2:
+            case SYS_ISDBT:
                 fields = sscanf(&line[k], ter_conf,
                                 &ptr->freq, inv, bw, cr, tmp_lcr, mod,
                                 transm, gi, tmp_hier, vpid_str, apid_str);
@@ -553,6 +555,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
         switch (delsys) {
         case SYS_DVBT:
         case SYS_DVBT2:
+        case SYS_ISDBT:
         case SYS_DVBC_ANNEX_A:
         case SYS_DVBC_ANNEX_C:
             if (!strcmp(inv, "INVERSION_ON")) {
@@ -586,6 +589,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
         switch (delsys) {
         case SYS_DVBT:
         case SYS_DVBT2:
+        case SYS_ISDBT:
         case SYS_DVBC_ANNEX_A:
         case SYS_DVBC_ANNEX_C:
         case SYS_ATSC:
@@ -624,6 +628,7 @@ static dvb_channels_list_t *dvb_get_channels(struct mp_log *log,
         switch (delsys) {
         case SYS_DVBT:
         case SYS_DVBT2:
+        case SYS_ISDBT:
             if (!strcmp(bw, "BANDWIDTH_5_MHZ")) {
                 ptr->bw = BANDWIDTH_5_MHZ;
             } else if (!strcmp(bw, "BANDWIDTH_6_MHZ")) {
@@ -1198,6 +1203,9 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                     break;
                 case SYS_DVBT2:
                     conf_file_name = "channels.conf.ter";
+                    break;
+                case SYS_ISDBT:
+                    conf_file_name = "channels.conf.isdbt";
                     break;
                 case SYS_DVBS:
                     if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBS2))


### PR DESCRIPTION
This adds support for the ISDB-T delivery system (used e.g. in Brazil, Japan), and contains some related DVB fixes:
* Detection and treatment of ISDBT channel config files created by `dvbv5-scan` which look like VDR style config files. 
* Fixes an issue potentially loosing track of a channel list / adapter combination if an adapter supports many delivery systems. 
* A few helpful verbose output messages in case issues pop up in the channel parsing code. 
* Related documentation pieces. 

ISDBT tuning has been tested by @fvp in #12218 (he has the appropriate hardware and reception), and I have tested common existing delivery systems with channel configs are not broken (DVB-S/S2, DVB-T/T2). Thanks for the testing! 

closes #12218 