### PR TITLE
player: normalize paths for resuming playback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -486,6 +486,11 @@ endif
 
 features += {'win32-desktop': win32 and not uwp.found()}
 if features['win32-desktop']
+    pathcch = cc.find_library('pathcch', required: false)
+    features += {'pathcch': pathcch.found()}
+    if features['pathcch']
+        dependencies += pathcch
+    endif
     win32_desktop_libs = [cc.find_library('avrt'),
                           cc.find_library('dwmapi'),
                           cc.find_library('gdi32'),

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -151,10 +151,61 @@ char *mp_getcwd(void *talloc_ctx)
 
 char *mp_normalize_path(void *talloc_ctx, const char *path)
 {
+    if (!path)
+        return NULL;
+
     if (mp_is_url(bstr0(path)))
         return talloc_strdup(talloc_ctx, path);
 
-    return mp_path_join(talloc_ctx, mp_getcwd(talloc_ctx), path);
+    if (!mp_path_is_absolute(bstr0(path))) {
+        char *cwd = mp_getcwd(talloc_ctx);
+        if (!cwd)
+            return NULL;
+        path = mp_path_join(talloc_ctx, cwd, path);
+    }
+
+#if HAVE_DOS_PATHS
+    return talloc_strdup(talloc_ctx, path);
+#else
+    char *result = talloc_strdup(talloc_ctx, "");
+    const char *next;
+    const char *end = path + strlen(path);
+
+    for (const char *ptr = path; ptr < end; ptr = next + 1) {
+        next = memchr(ptr, '/', end - ptr);
+        if (next == NULL)
+            next = end;
+
+        switch (next - ptr) {
+            case 0:
+                continue;
+            case 1:
+                if (ptr[0] == '.')
+                    continue;
+                break;
+            case 2:
+                // Normalizing symlink/.. results in a wrong path: if the
+                // current working directory is /tmp/foo, and it is a symlink to
+                // /usr/bin, mpv ../file.mkv opens /usr/file.mkv, so we can't
+                // normalize the path to /tmp/file.mkv. Resolve symlinks to fix
+                // this. Otherwise we don't use realpath so users can use
+                // symlinks e.g. to hide how media files are distributed over
+                // real storage and move them while still resuming playback as
+                // long as the symlinked path doesn't change.
+                if (ptr[0] == '.' && ptr[1] == '.') {
+                    char *tmp_result = realpath(path, NULL);
+                    result = talloc_strdup(talloc_ctx, tmp_result);
+                    free(tmp_result);
+                    return result;
+                }
+        }
+
+        result = talloc_strdup_append_buffer(result, "/");
+        result = talloc_strndup_append_buffer(result, ptr, next - ptr);
+    }
+
+    return result;
+#endif
 }
 
 bool mp_path_exists(const char *path)

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -209,20 +209,16 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     struct MPOpts *opts = mpctx->opts;
     char *res = NULL;
     void *tmp = talloc_new(NULL);
-    const char *realpath = fname;
-    bstr bfname = bstr0(fname);
-    if (!mp_is_url(bfname)) {
-        if (opts->ignore_path_in_watch_later_config) {
-            realpath = mp_basename(fname);
-        } else {
-            char *cwd = mp_getcwd(tmp);
-            if (!cwd)
-                goto exit;
-            realpath = mp_path_join(tmp, cwd, fname);
-        }
+    const char *path = NULL;
+    if (opts->ignore_path_in_watch_later_config && !mp_is_url(bstr0(path))) {
+        path = mp_basename(fname);
+    } else {
+        path = mp_normalize_path(tmp, fname);
+        if (!path)
+            goto exit;
     }
     uint8_t md5[16];
-    av_md5_sum(md5, realpath, strlen(realpath));
+    av_md5_sum(md5, path, strlen(path));
     char *conf = talloc_strdup(tmp, "");
     for (int i = 0; i < 16; i++)
         conf = talloc_asprintf_append(conf, "%02X", md5[i]);
@@ -312,6 +308,8 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
         goto exit;
 
     char *path = mp_normalize_path(ctx, cur->filename);
+    if (!path)
+        goto exit;
 
     struct demuxer *demux = mpctx->demuxer;
 
@@ -391,26 +389,19 @@ exit:
 
 void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file)
 {
-    if (!file) {
-        struct playlist_entry *cur = mpctx->playing;
-        if (!cur)
-            return;
-        file = cur->filename;
-        if (!file)
-            return;
-    }
+    void *ctx = talloc_new(NULL);
+    char *path = mp_normalize_path(ctx, file ? file : mpctx->filename);
+    if (!path)
+        goto exit;
 
-    char *fname = mp_get_playback_resume_config_filename(mpctx, file);
+    char *fname = mp_get_playback_resume_config_filename(mpctx, path);
     if (fname) {
         unlink(fname);
         talloc_free(fname);
     }
 
-    if (mp_is_url(bstr0(file)) || mpctx->opts->ignore_path_in_watch_later_config)
-        return;
-
-    void *ctx = talloc_new(NULL);
-    char *path = mp_normalize_path(ctx, file);
+    if (mp_is_url(bstr0(path)) || mpctx->opts->ignore_path_in_watch_later_config)
+        goto exit;
 
     bstr dir = mp_dirname(path);
     while (dir.len > 1 && dir.len < strlen(path)) {
@@ -424,6 +415,7 @@ void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file)
         dir = mp_dirname(path);
     }
 
+exit:
     talloc_free(ctx);
 }
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -53,6 +53,9 @@ endif
 if features['win32-desktop']
     test_utils_deps += cc.find_library('imm32')
     test_utils_deps += cc.find_library('ntdll')
+    if features['pathcch']
+        test_utils_deps += cc.find_library('pathcch')
+    endif
 endif
 test_utils_objects = libmpv.extract_objects(test_utils_files)
 test_utils = static_library('test-utils', 'test_utils.c', include_directories: incdir,


### PR DESCRIPTION
Paths like foo.mkv, ./foo.mkv .//foo.mkv, ../"$(basename "$PWD")"/foo.mkv, and C:\foo.mkv and C:/foo.mkv on Windows, use different config files for resuming playback, so if you quit-watch-later and later play the same file with a different path mpv does not resume playback. This commit normalizes the paths to fix this.

References https://github.com/mpv-player/mpv/pull/495

Someone needs to fix the code for Windows, and also test if the performance impact of calling `GetFullPathNameW` on thousands of playlist entries is acceptable. On Linux `realpath` is actually much slower than this normalizing function. The loop in `mp_check_playlist_resume` with 2330 images takes 0.012 seconds before this patch, 0.014 with it, and if I make it use `realpath` with `/dir/../dir/*` it takes 0.038 seconds.