### PR TITLE
m_option: make m_rect_apply center based

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1834,6 +1834,14 @@ Video
     this can break on streams not encoded by x264, or if a stream encoded by a
     newer x264 version contains no version info.
 
+``--vd-apply-cropping``
+    Certain video codecs support cropping, meaning that only a sub-rectangle of
+    the decoded frame is intended for display. This option controls how cropping
+    is handled by libavcodec. Cropping during decoding has certain limitations
+    with regards to alignment and hardware decoding. If this option is enabled,
+    decoder will apply the crop. Disabled by default, VO will apply the crop in
+    a more robust way.
+
 ``--swapchain-depth=<N>``
     Allow up to N in-flight frames. This essentially controls the frame
     latency. Increasing the swapchain depth can improve pipelining and prevent

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1571,7 +1571,7 @@ Video
     applied to the source video rectangle (before anamorphic stretch) by the VO.
     A crop rectangle that is not within the video rectangle will be ignored.
     This works with hwdec, unlike the equivalent 'lavfi-crop'. Setting the crop
-    to '0x0' disables it.
+    to '0' disables it. When offset is omitted, the central area will be cropped.
 
 ``--video-zoom=<value>``
     Adjust the video display scale factor by the given value. The parameter is

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1570,8 +1570,11 @@ Video
     Crop the video by starting at the x, y offset for w, h pixels. The crop is
     applied to the source video rectangle (before anamorphic stretch) by the VO.
     A crop rectangle that is not within the video rectangle will be ignored.
-    This works with hwdec, unlike the equivalent 'lavfi-crop'. Setting the crop
-    to '0' disables it. When offset is omitted, the central area will be cropped.
+    This works with hwdec, unlike the equivalent 'lavfi-crop'. When offset is
+    omitted, the central area will be cropped. Setting the crop to empty one
+    ``--video-crop=0x0+0+0`` overrides container crop and disables cropping.
+    Setting the crop to ``--video-crop=0`` disables manual cropping and restores
+    the container crop if it's specified.
 
 ``--video-zoom=<value>``
     Adjust the video display scale factor by the given value. The parameter is

--- a/TOOLS/lua/autocrop.lua
+++ b/TOOLS/lua/autocrop.lua
@@ -124,9 +124,11 @@ end
 
 function remove_filter(label)
     if options.use_vo_crop and label == labels.crop then
-        local ro = mp.get_property_native("video-out-params")
-        mp.command(string.format("%s set video-crop 0", command_prefix))
-        return ro and ro["crop-w"] and ro["crop-w"] > 0
+        if mp.get_property('video-crop') ~= '0x0' then
+            mp.command(string.format("%s set video-crop 0", command_prefix))
+            return true
+        end
+        return false
     end
 
     if is_filter_present(label) then

--- a/TOOLS/lua/autocrop.lua
+++ b/TOOLS/lua/autocrop.lua
@@ -72,7 +72,7 @@ local options = {
     detect_min_ratio = 0.5,
     detect_seconds = 1,
     suppress_osd = false,
-    use_vo_crop = false,
+    use_vo_crop = true,
 }
 read_options(options)
 

--- a/TOOLS/lua/autocrop.lua
+++ b/TOOLS/lua/autocrop.lua
@@ -142,7 +142,10 @@ function cleanup()
 
     -- Remove all existing filters.
     for key, value in pairs(labels) do
-        remove_filter(value)
+        -- No need to remove initial crop in vo_crop mode
+        if not (options.use_vo_crop and value == labels.crop) then
+            remove_filter(value)
+        end
     end
 
     -- Kill all timers.

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2381,20 +2381,16 @@ const m_option_type_t m_option_type_size_box = {
     .equal = geometry_equal,
 };
 
-void m_rect_apply(struct mp_rect *rc, int scrw, int scrh, struct m_geometry *gm)
+void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm)
 {
-    *rc = (struct mp_rect){0};
-    m_geometry_apply(&rc->x0, &rc->y0, &rc->x1, &rc->y1, scrw, scrh, gm);
+    *rc = (struct mp_rect){0, 0, w, h};
+    m_geometry_apply(&rc->x0, &rc->y0, &rc->x1, &rc->y1, w, h, gm);
     if (!gm->xy_valid && gm->wh_valid && rc->x1 == 0 && rc->y1 == 0)
         return;
-    if (!gm->xy_valid) {
-        rc->x0 = 0;
-        rc->y0 = 0;
-    }
     if (!gm->wh_valid || rc->x1 == 0 || rc->x1 == INT_MIN)
-        rc->x1 = scrw - rc->x0;
+        rc->x1 = w - rc->x0;
     if (!gm->wh_valid || rc->y1 == 0 || rc->y1 == INT_MIN)
-        rc->y1 = scrh - rc->y0;
+        rc->y1 = h - rc->y0;
     rc->x1 += rc->x0;
     rc->y1 += rc->y0;
 }

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2384,6 +2384,8 @@ const m_option_type_t m_option_type_size_box = {
 void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm)
 {
     *rc = (struct mp_rect){0, 0, w, h};
+    if (!w || !h)
+        return;
     m_geometry_apply(&rc->x0, &rc->y0, &rc->x1, &rc->y1, w, h, gm);
     if (!gm->xy_valid && gm->wh_valid && rc->x1 == 0 && rc->y1 == 0)
         return;

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -105,7 +105,7 @@ struct m_geometry {
 
 void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
                       int scrw, int scrh, struct m_geometry *gm);
-void m_rect_apply(struct mp_rect *rc, int scrw, int scrh, struct m_geometry *gm);
+void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm);
 
 struct m_channels {
     bool set : 1;

--- a/player/command.c
+++ b/player/command.c
@@ -2332,8 +2332,12 @@ static struct mp_image_params get_video_out_params(struct MPContext *mpctx)
 
     struct mp_image_params o_params = mpctx->vo_chain->filter->output_params;
     if (mpctx->video_out) {
-        m_rect_apply(&o_params.crop, o_params.w, o_params.h,
-                     &mpctx->video_out->opts->video_crop);
+        struct m_geometry *gm = &mpctx->video_out->opts->video_crop;
+        if (gm->xy_valid || (gm->wh_valid && (gm->w > 0 || gm->w_per > 0 ||
+                                              gm->h > 0 || gm->h_per > 0)))
+        {
+            m_rect_apply(&o_params.crop, o_params.w, o_params.h, gm);
+        }
     }
 
     return o_params;

--- a/player/command.c
+++ b/player/command.c
@@ -2280,6 +2280,7 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
             (desc.flags & MP_IMGFLAG_ALPHA) ? MP_ALPHA_STRAIGHT : MP_ALPHA_AUTO;
     }
 
+    bool has_crop = mp_rect_w(p.crop) > 0 && mp_rect_h(p.crop) > 0;
     const char *aspect_name = get_aspect_ratio_name(d_w / (double)d_h);
     struct m_sub_property props[] = {
         {"pixelformat",     SUB_PROP_STR(mp_imgfmt_to_name(p.imgfmt))},
@@ -2291,10 +2292,10 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
         {"h",               SUB_PROP_INT(p.h)},
         {"dw",              SUB_PROP_INT(d_w)},
         {"dh",              SUB_PROP_INT(d_h)},
-        {"crop-x",          SUB_PROP_INT(p.crop.x0)},
-        {"crop-y",          SUB_PROP_INT(p.crop.y0)},
-        {"crop-w",          SUB_PROP_INT(mp_rect_w(p.crop))},
-        {"crop-h",          SUB_PROP_INT(mp_rect_h(p.crop))},
+        {"crop-x",          SUB_PROP_INT(p.crop.x0), .unavailable = !has_crop},
+        {"crop-y",          SUB_PROP_INT(p.crop.y0), .unavailable = !has_crop},
+        {"crop-w",          SUB_PROP_INT(mp_rect_w(p.crop)), .unavailable = !has_crop},
+        {"crop-h",          SUB_PROP_INT(mp_rect_h(p.crop)), .unavailable = !has_crop},
         {"aspect",          SUB_PROP_FLOAT(d_w / (double)d_h)},
         {"aspect-name",     SUB_PROP_STR(aspect_name), .unavailable = !aspect_name},
         {"par",             SUB_PROP_FLOAT(p.p_w / (double)p.p_h)},

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -80,6 +80,7 @@ struct vd_lavc_params {
     int threads;
     bool bitexact;
     bool old_x264;
+    bool apply_cropping;
     bool check_hw_profile;
     int software_fallback;
     char **avopts;
@@ -120,6 +121,7 @@ const struct m_sub_options vd_lavc_conf = {
         {"vd-lavc-o", OPT_KEYVALUELIST(avopts)},
         {"vd-lavc-dr", OPT_CHOICE(dr,
             {"auto", -1}, {"no", 0}, {"yes", 1})},
+        {"vd-apply-cropping", OPT_BOOL(apply_cropping)},
         {"hwdec", OPT_STRINGLIST(hwdec_api),
             .help = hwdec_opt_help,
             .flags = M_OPT_OPTIONAL_PARAM | UPDATE_HWDEC},
@@ -772,6 +774,7 @@ static void init_avctx(struct mp_filter *vd)
     avctx->skip_loop_filter = lavc_param->skip_loop_filter;
     avctx->skip_idct = lavc_param->skip_idct;
     avctx->skip_frame = lavc_param->skip_frame;
+    avctx->apply_cropping = lavc_param->apply_cropping;
 
     if (lavc_codec->id == AV_CODEC_ID_H264 && lavc_param->old_x264)
         av_opt_set(avctx, "x264_build", "150", AV_OPT_SEARCH_CHILDREN);

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -522,6 +522,7 @@ void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
     dst->params.color = src->params.color;
     dst->params.chroma_location = src->params.chroma_location;
     dst->params.alpha = src->params.alpha;
+    dst->params.crop = src->params.crop;
     dst->nominal_fps = src->nominal_fps;
 
     // ensure colorspace consistency
@@ -1011,6 +1012,11 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
 
     dst->pict_type = src->pict_type;
 
+    dst->params.crop.x0 = src->crop_left;
+    dst->params.crop.y0 = src->crop_top;
+    dst->params.crop.x1 = src->width - src->crop_right;
+    dst->params.crop.y1 = src->height - src->crop_bottom;
+
     dst->fields = 0;
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 7, 100)
     if (src->flags & AV_FRAME_FLAG_INTERLACED)
@@ -1042,6 +1048,7 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
         // Might be incorrect if colorspace changes.
         dst->params.color.light = p->color.light;
         dst->params.alpha = p->alpha;
+        dst->params.crop = p->crop;
     }
 
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_DISPLAYMATRIX);


### PR DESCRIPTION
This makes it easier to apply crops without need to manually calc the offset. I wanted for it to be top-left corner based, but maybe it was not that good idea in retrospect.

Also rename scrw/scrh, since they don't refer to screen. It was copied form m_geometry apply.