### PR TITLE
builtin.conf: add --allow-delayed-peak-detect=no to gpu-hq

### DIFF
--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -53,6 +53,7 @@ dscale=mitchell
 dither-depth=auto
 hdr-peak-percentile=99.995
 hdr-contrast-recovery=0.30
+allow-delayed-peak-detect=no
 correct-downscaling=yes
 linear-downscaling=yes
 sigmoid-upscaling=yes


### PR DESCRIPTION
Prevents transient brightness spikes on scene transitions at the cost of sometimes forcing an extra indirect pass (in particular, when downscaling). But on GPUs powerful enough to run gpu-hq, the extra indirect pass shouldn't matter too much. This option mostly exists for weak iGPUs.