### PR TITLE
ci/lint: ignore message length for revert commits

### DIFF
--- a/ci/lint-commit-msg.py
+++ b/ci/lint-commit-msg.py
@@ -95,7 +95,8 @@ def no_merge(body):
 
 @lint_rule("Subject line should be shorter than 72 characters")
 def line_too_long(body):
-	return len(body[0]) <= 72
+	revert = re.search(r"^Revert \"(.*)\"", body[0])
+	return True if revert else len(body[0]) <= 72
 
 @lint_rule("Prefix should not include C file extensions (use `vo_gpu: ...` not `vo_gpu.c: ...`)")
 def no_file_exts(body):


### PR DESCRIPTION
The default revert will always add 9 extra characters which means it could go over the 72 character soft limit if the commit being reverted has a long subject. We won't fuss about this so just shut up the lint in this case.