### PR TITLE
player: redo --subs-fallback-forced

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -57,6 +57,7 @@ Interface changes
     - add `video-params/crop-[w,h,x,y]`
     - remove `--tone-mapping-mode`
     - add `auto` to `--sub-fix-timing` and make it the default
+    - change `--subs-fallback-forced` so that it works alongside `--slang`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -153,10 +153,11 @@ Track Selection
     Setting this to `default` means that only streams flagged as `default` will be selected.
 
 ``--subs-fallback-forced=<yes|no|always>``
-    When autoselecting a subtitle track, if no tracks match your preferred languages,
-    select a forced track that matches the language of the selected audio track (default: yes).
-    `always` will always select a forced track if possible, regardles if the language matches the
-    selected audio track or not.
+    When autoselecting a subtitle track, the default value of `yes` will prefer using a forced
+    subtitle track if the subtitle language matches the audio language and matches your list of
+    preferred languages. The special value `always` will only select forced subtitle tracks and
+    never fallback on a non-forced track. Conversely, `no` will never select a forced subtitle
+    track.
 
 
 Playback Control


### PR DESCRIPTION
In the never ending quest of trying to satisfy every possible user request for subtitle autoselection, I ended up redoing how --subs-fallback-forced works. The old behavior had it as strictly a fallback-type option when there were no lang matches, but now we can make it an active part of compare_track and it works along with slang to select the desired track. Since it's a three state option, the no option still works to avoid selecting any forced subtitle tracks. The meaning of always slightly changes to mean "only select forced subtitle tracks" and yes remains essentially the same (no special priority given besides the audio matching subtitle language case).

So instead of making yet another option, I opted to change `subs-fallback-forced` instead because it's significantly saner and also it's still capable of doing the same thing `subs-fallback-forced` did. Main difference is that it's not actually a fallback anymore so should the option be renamed possibly? `subs-select-forced-subs`?