### PR TITLE
zsh-completion: use --no-config

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -150,7 +150,7 @@ function _mpv_generate_arguments {
 function _mpv_generate_protocols {
   _mpv_completion_protocols=()
   local list_protos_line
-  for list_protos_line in "${(@f)$($~words[1] --list-protocols)}"; do
+  for list_protos_line in "${(@f)$($~words[1] --no-config --list-protocols)}"; do
     if [[ $list_protos_line =~ $'^[ \t]+(.*)' ]]; then
       _mpv_completion_protocols+="$match[1]"
     fi
@@ -211,7 +211,7 @@ case $state in
     esac
     local -a values
     local current
-    for current in "${(@f)$($~words[1] --${option_name}=help)}"; do
+    for current in "${(@f)$($~words[1] --no-config --${option_name}=help)}"; do
       [[ $current =~ $pattern ]] || continue;
       local name=${match[name_group]//:/\\:} desc=${match[desc_group]}
       if [[ -n $desc ]]; then

--- a/etc/mpv.bash-completion
+++ b/etc/mpv.bash-completion
@@ -42,7 +42,7 @@ _mpv_get_args()
         _filedir 2>/dev/null || COMPREPLY=($(compgen -f))
         return 0
       else
-        candidates=($(mpv $1=help | grep -v ':' | awk '{print $1;}'))
+        candidates=($(mpv --no-config $1=help | grep -v ':' | awk '{print $1;}'))
         candidates+=("help")
       fi
       ;;
@@ -50,16 +50,16 @@ _mpv_get_args()
       candidates=("yes" "no" "help")
       ;;
     Choices:|Object)
-      candidates=($(mpv $1=help | grep -v ':' | awk '{print $1;}'))
+      candidates=($(mpv --no-config $1=help | grep -v ':' | awk '{print $1;}'))
       candidates+=("help")
       ;;
     Image)
-      candidates=($(mpv $1=help))
+      candidates=($(mpv --no-config $1=help))
       candidates=("${candidates[@]:2}")
       candidates+=("help")
       ;;
     Profile)
-      candidates=($(mpv $1= | grep -v ':' | awk '{print $1;}'))
+      candidates=($(mpv --no-config $1= | grep -v ':' | awk '{print $1;}'))
       ;;
     *)
       # There are other categories; some of which we could do something smarter


### PR DESCRIPTION
Avoids tab completion parsing the mpv.conf file. Fixes printing warnings when pressing tab if `mpv.conf` contains errors, for example. Also avoids spending unnecessary time reading from disk and potentially loading profiles, user scripts etc.