### PR TITLE
subprocess-posix: add fallback $PATH

### DIFF
--- a/osdep/subprocess-posix.c
+++ b/osdep/subprocess-posix.c
@@ -172,7 +172,7 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
     int cancel_fd = -1;
     char *path = getenv("PATH");
     if (!path)
-        path = ""; // failure, who cares
+        path = "/usr/local/bin:/bin:/usr/bin"; // fallback to sensible default
 
     *res = (struct mp_subprocess_result){0};
 


### PR DESCRIPTION
from POSIX manpage:

> If $PATH isn't defined, the path list defaults to a list that
> includes the directories returned by `confstr(_CS_PATH)` which
> typically returns the value "/bin:/usr/bin"

confstr() isn't used as it's missing on android (see bf6afbc29). the "/usr/local/bin" part is taken from musl.