### PR TITLE
{zsh,bash}-completion: use config when autocompleting profiles

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -192,6 +192,7 @@ case $state in
 
   parse-help-*)
     local option_name=${state#parse-help-}
+    local no_config="--no-config"
     # Can't do non-capturing groups without pcre, so we index the ones we want
     local pattern name_group=1 desc_group=2
     case $option_name in
@@ -203,6 +204,8 @@ case $state in
         # but would break if a profile name contained spaces. This stricter one
         # only breaks if a profile name contains tabs.
         pattern=$'^\t([^\t]*)\t(.*)'
+        # We actually want config so we can autocomplete the user's profiles
+        no_config=""
       ;;
       *)
         pattern=$'^[ \t]+(--'${option_name}$'=)?([^ \t]+)[ \t]*[-:]?[ \t]*(.*)'
@@ -211,7 +214,7 @@ case $state in
     esac
     local -a values
     local current
-    for current in "${(@f)$($~words[1] --no-config --${option_name}=help)}"; do
+    for current in "${(@f)$($~words[1] ${no_config} --${option_name}=help)}"; do
       [[ $current =~ $pattern ]] || continue;
       local name=${match[name_group]//:/\\:} desc=${match[desc_group]}
       if [[ -n $desc ]]; then

--- a/etc/mpv.bash-completion
+++ b/etc/mpv.bash-completion
@@ -26,8 +26,10 @@ _mpv_get_args()
   local partial="$2"
   local type=$(echo "$doc" | awk '{print $2;}')
 
+  # We special-case profiles to ensure we read the config
   if [ "$1" = "--show-profile" ]; then
-    # This is a special case
+    type="ShowProfile"
+  elif [ "$1" = "--profile" ]; then
     type="Profile"
   fi
 
@@ -59,7 +61,11 @@ _mpv_get_args()
       candidates+=("help")
       ;;
     Profile)
-      candidates=($(mpv --no-config $1= | grep -v ':' | awk '{print $1;}'))
+      candidates=($(mpv $1=help | grep -v ':' | awk '{print $1;}'))
+      candidates+=("help")
+      ;;
+    ShowProfile)
+      candidates=($(mpv $1= | grep -v ':' | awk '{print $1;}'))
       ;;
     *)
       # There are other categories; some of which we could do something smarter


### PR DESCRIPTION
We were over-enthusiastic when introducing --no-config into the autocompletions. When autocompleting profiles, you actually need the config, because that's where the profiles come from.

zsh is untested - I don't use it.
