### PR TITLE
Revert "input.conf: swap wheel up/down with wheel left/right"

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -37,10 +37,10 @@
 # Mouse wheels, touchpad or other input devices that have axes
 # if the input devices supports precise scrolling it will also scale the
 # numeric value accordingly
-#WHEEL_UP      add volume 2
-#WHEEL_DOWN    add volume -2
-#WHEEL_LEFT    seek -10         # seek 10 seconds backward
-#WHEEL_RIGHT   seek 10          # seek 10 seconds forward
+#WHEEL_UP      seek 10          # seek 10 seconds forward
+#WHEEL_DOWN    seek -10         # seek 10 seconds backward
+#WHEEL_LEFT    add volume -2
+#WHEEL_RIGHT   add volume 2
 
 ## Seek units are in seconds, but note that these are limited by keyframes
 #RIGHT seek  5                          # seek 5 seconds forward


### PR DESCRIPTION
This reverts commit 981a9372ff0034178a986f8bc1ec1ad6b973bb6c (#12290)

<hr>

I've been meaning to create this PR earlier but I unintentionally gave the changes a try after rebuilding mpv and let's say there was more than one instance of me being confused after scrolling did not seek in the video.

I argue that:
* changing this behavior after it's been this way so long is bad: 023e5ccd02609c8a2fdcf63ee0a87025beeb79f0 (mpv v0.1.0, 10 years ago)
  * consider the recent subtitle selection change which likely affected less users but was still eventually reverted 
* it's hard to quantify what is "intuitive" for the scroll wheel to do in a media player and how many people really adjust their input.conf in this regard
* "users can trivially undo this" is an alright justification if the new behavior is somehow objectively better, in this case it's just a different preference
* this cuts off 99% of users from convenient seeking using only the mouse
  * I'm implying here that people more often seek than they change the volume
  * even as someone with a gaming mouse I do not have the ability to scroll horizontally
  * (moving your mouse to the OSC and doing it there is not considered convenient)
* seek scrolling is an easily discoverable feature, many users are likely to know it -> large potential impact