### PR TITLE
DOCS/options: correct language

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -601,7 +601,7 @@ Playback Control
     Tuning:
 
     - Remove all ``--vf``/``--af`` filters you have set. Disable hardware
-      decoding. Disable idiotic nonsense like SPDIF passthrough.
+      decoding. Disable functions like SPDIF passthrough.
 
     - Increasing ``--video-reversal-buffer`` might help if reversal queue
       overflow is reported, which may happen in high bitrate video, or video


### PR DESCRIPTION
I know this is a very tiny pull request without too much impact. I just noticed this while reading the reference guide and thought this might not be very nice. There are people that need SPDIF passthrough and it's also no idiotic nonsense. So don´t be rude... Just say "disable functions like" instead of "Disable idiotic nonsense" :)