### PR TITLE
path-{darwin,unix}: save cache to subdir when using non-XDG path

### DIFF
--- a/osdep/path-darwin.c
+++ b/osdep/path-darwin.c
@@ -28,6 +28,7 @@ static pthread_once_t path_init_once = PTHREAD_ONCE_INIT;
 static char mpv_home[512];
 static char old_home[512];
 static char mpv_cache[512];
+static char old_cache[512];
 
 static void path_init(void)
 {
@@ -41,8 +42,10 @@ static void path_init(void)
     }
 
     // Maintain compatibility with old ~/.mpv
-    if (home && home[0])
+    if (home && home[0]) {
         snprintf(old_home, sizeof(old_home), "%s/.mpv", home);
+        snprintf(old_cache, sizeof(old_cache), "%s/.mpv/cache", home);
+    }
 
     if (home && home[0])
         snprintf(mpv_cache, sizeof(mpv_cache), "%s/Library/Caches/io.mpv", home);
@@ -51,8 +54,9 @@ static void path_init(void)
     // config dir only.
     if (mp_path_exists(old_home) && !mp_path_exists(mpv_home)) {
         snprintf(mpv_home, sizeof(mpv_home), "%s", old_home);
-        snprintf(mpv_cache, sizeof(mpv_cache), "%s", old_home);
+        snprintf(mpv_cache, sizeof(mpv_cache), "%s", old_cache);
         old_home[0] = '\0';
+        old_cache[0] = '\0';
     }
 }
 

--- a/osdep/path-unix.c
+++ b/osdep/path-unix.c
@@ -29,6 +29,7 @@ static pthread_once_t path_init_once = PTHREAD_ONCE_INIT;
 static char mpv_home[CONF_MAX];
 static char old_home[CONF_MAX];
 static char mpv_cache[CONF_MAX];
+static char old_cache[CONF_MAX];
 static char mpv_state[CONF_MAX];
 #define MKPATH(BUF, ...) (snprintf((BUF), CONF_MAX, __VA_ARGS__) >= CONF_MAX)
 
@@ -47,8 +48,10 @@ static void path_init(void)
     }
 
     // Maintain compatibility with old ~/.mpv
-    if (home && home[0])
+    if (home && home[0]) {
         err = err || MKPATH(old_home, "%s/.mpv", home);
+        err = err || MKPATH(old_cache, "%s/.mpv/cache", home);
+    }
 
     if (xdg_cache && xdg_cache[0]) {
         err = err || MKPATH(mpv_cache, "%s/mpv", xdg_cache);
@@ -66,9 +69,10 @@ static void path_init(void)
     // config dir only. Also do not use any other XDG directories.
     if (mp_path_exists(old_home) && !mp_path_exists(mpv_home)) {
         err = err || MKPATH(mpv_home, "%s", old_home);
-        err = err || MKPATH(mpv_cache, "%s", old_home);
+        err = err || MKPATH(mpv_cache, "%s", old_cache);
         err = err || MKPATH(mpv_state, "%s", old_home);
         old_home[0] = '\0';
+        old_cache[0] = '\0';
     }
 
     if (err) {


### PR DESCRIPTION
mpv saves cache by default nowadays, but vo_gpu is pretty spammy and saves a bunch of files per shader. If someone is using the non-XDG config directory, this all gets dumped directly into ~/.mpv which isn't so nice. Save it to a sub directory called "cache" instead (or alternatively submit to your XDG overlords). For unfortunate reasons, macOS uses XDG_CONFIG_HOME and has the same legacy fallback mechanism, so this applies to it too.