### PR TITLE
sd_lavc: account for floating point inaccuracy

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -398,7 +398,7 @@ static struct sub *get_current(struct sd_lavc_priv *priv, double pts)
             continue;
         if (pts == MP_NOPTS_VALUE ||
             ((sub->pts == MP_NOPTS_VALUE || pts + 1e-6 >= sub->pts) &&
-             (sub->endpts == MP_NOPTS_VALUE || pts < sub->endpts)))
+             (sub->endpts == MP_NOPTS_VALUE || pts + 1e-6 < sub->endpts)))
         {
             // Ignore "trailing" subtitles with unknown length after 1 minute.
             if (sub->endpts == MP_NOPTS_VALUE && pts >= sub->pts + 60)


### PR DESCRIPTION
Timestamps are converted from microsecond resolution timestamp, we don't have more precision, so we have to account for that when comparing the floating point values as them will slightly be off.

Fixes: #12327