### PR TITLE
vd_lavc: by default enable cropping by decoder

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1840,8 +1840,7 @@ Video
     the decoded frame is intended for display. This option controls how cropping
     is handled by libavcodec. Cropping during decoding has certain limitations
     with regards to alignment and hardware decoding. If this option is enabled,
-    decoder will apply the crop. Disabled by default, VO will apply the crop in
-    a more robust way.
+    decoder will apply the crop, else VO will handle it. Enabled by default.
 
 ``--swapchain-depth=<N>``
     Allow up to N in-flight frames. This essentially controls the frame

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -147,6 +147,7 @@ const struct m_sub_options vd_lavc_conf = {
         // for example, if vo_gpu increases the number of reference surfaces for
         // interpolation, this value has to be increased too.
         .hwdec_extra_frames = 6,
+        .apply_cropping = true,
     },
 };
 


### PR DESCRIPTION
While this resolves limitations of lavc decoder crop, it also introduces artifacts with some of the source files or hwdec.

Depending on chroma sampler it is possible to sample outside the decoder crop area, pulling dirty pixels into the image. Some decoders left them zeroed, not black. To fix that we would need specifc solution during mapping of avframes.

As most of the files require the crop only in bottom/right area, the AVCodecContext::apply_cropping works ok for those.

For all other cases that require more fancy cropping like 1440x1080+240+0 user can manually set `--vd-apply-cropping=no`.

Limitations of the lavc crop are explained here:
https://ffmpeg.org/doxygen/trunk/structAVCodecContext.html#a4745c7455c317272c4e139d6f369936c

Fixes: 826ce82cad315f7a48f9c971d3a5fa005a9eab46