### PR TITLE
DOCS/options: add catmull_rom as an example for --scale

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5286,6 +5286,13 @@ them.
         ``--scale-param1`` and ``--scale-param2``. This filter is very good at
         downscaling (see ``--dscale``).
 
+    ``catmull_rom``
+        Catmull-Rom. A Cubic filter in the same vein as ``mitchell``, where
+        the ``B`` and ``C`` parameters are ``0.0`` and ``0.5`` respectively.
+        This filter is sharper than ``mitchell``, but it results in mild
+        ringing. Like ``mitchell``, this filter is good at downscaling (see 
+        ``--dscale``).
+
     ``oversample``
         A version of nearest neighbour that (naively) oversamples pixels, so
         that pixels overlapping edges get linearly interpolated instead of


### PR DESCRIPTION
Adds `catmull_rom` as an example for `--scale` in the user manual, alongside a brief description of the filter.

`catmull_rom` was only exposed to users as an available filter through `--scale=help`. However, `catmull_rom` is very often aliased as "Bicubic" in other applications such as GIMP and VapourSynth, and is a relatively popular resizing filter. The documentation lacked any description of `catmull_rom`, outside of a brief mention of it in the `--tscale` section.