### PR TITLE
osc: add scrolling to audio/sub buttons

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -102,6 +102,7 @@ audio and sub
     left-click      cycle audio/sub tracks forward
     right-click     cycle audio/sub tracks backwards
     shift+L-click   show available audio/sub tracks
+    mouse wheel     cycle audio/sub tracks forward/backwards
     =============   ================================================
 
 vol

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1938,6 +1938,10 @@ function osc_init()
         function () set_track("audio", -1) end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () show_message(get_tracklist("audio"), 2) end
+    ne.eventresponder["wheel_down_press"] =
+        function () set_track("audio", 1) end
+    ne.eventresponder["wheel_up_press"] =
+        function () set_track("audio", -1) end
 
     --cy_sub
     ne = new_element("cy_sub", "button")
@@ -1957,6 +1961,10 @@ function osc_init()
         function () set_track("sub", -1) end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () show_message(get_tracklist("sub"), 2) end
+    ne.eventresponder["wheel_down_press"] =
+        function () set_track("sub", 1) end
+    ne.eventresponder["wheel_up_press"] =
+        function () set_track("sub", -1) end
 
     --tog_fs
     ne = new_element("tog_fs", "button")


### PR DESCRIPTION
Consistent with other osc buttons now

Fixes #12377