### PR TITLE
builtin.conf: modernize internal profiles

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -66,6 +66,8 @@ Interface changes
     - enable `--correct-downscaling`, `--linear-downscaling`, `--sigmoid-upscaling`
     - `--cscale` defaults to `--scale` if not defined
     - change `--tscale` default to `oversample`
+    - change `--dither-depth` to `auto`
+    - deprecate `--profile=gpu-hq`, add `--profile=<fast|high-quality>`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -64,6 +64,7 @@ Interface changes
     - rename `--cache-dir` and `--cache-unlink-files` to `--demuxer-cache-dir` and
       `--demuxer-cache-unlink-files`
     - enable `--correct-downscaling`, `--linear-downscaling`, `--sigmoid-upscaling`
+    - `--cscale` defaults to `--scale` if not defined
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -65,6 +65,7 @@ Interface changes
       `--demuxer-cache-unlink-files`
     - enable `--correct-downscaling`, `--linear-downscaling`, `--sigmoid-upscaling`
     - `--cscale` defaults to `--scale` if not defined
+    - change `--tscale` default to `oversample`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -63,6 +63,7 @@ Interface changes
     - remove `bcspline` filter (`bicubic` is now the same as `bcspline`)
     - rename `--cache-dir` and `--cache-unlink-files` to `--demuxer-cache-dir` and
       `--demuxer-cache-unlink-files`
+    - enable `--correct-downscaling`, `--linear-downscaling`, `--sigmoid-upscaling`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5293,7 +5293,7 @@ them.
         Catmull-Rom. A Cubic filter in the same vein as ``mitchell``, where
         the ``B`` and ``C`` parameters are ``0.0`` and ``0.5`` respectively.
         This filter is sharper than ``mitchell``, but it results in mild
-        ringing. Like ``mitchell``, this filter is good at downscaling (see 
+        ringing. Like ``mitchell``, this filter is good at downscaling (see
         ``--dscale``).
 
     ``oversample``
@@ -5438,6 +5438,7 @@ them.
 ``--correct-downscaling``
     When using convolution based filters, extend the filter size when
     downscaling. Increases quality, but reduces performance while downscaling.
+    Enabled by default.
 
     This will perform slightly sub-optimally for anamorphic video (but still
     better than without it) since it will extend the size to match only the
@@ -5448,7 +5449,7 @@ them.
 ``--linear-downscaling``
     Scale in linear light when downscaling. It should only be used with a
     ``--fbo-format`` that has at least 16 bit precision. This option
-    has no effect on HDR content.
+    has no effect on HDR content. Enabled by default.
 
 ``--linear-upscaling``
     Scale in linear light when upscaling. Like ``--linear-downscaling``, it
@@ -5459,7 +5460,7 @@ them.
 
 ``--sigmoid-upscaling``
     When upscaling, use a sigmoidal color transform to avoid emphasizing
-    ringing artifacts. This is incompatible with and replaces
+    ringing artifacts. Enabled by default. This is incompatible with and replaces
     ``--linear-upscaling``. (Note that sigmoidization also requires
     linearization, so the ``LINEAR`` rendering step fires in both cases)
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5325,7 +5325,7 @@ them.
     The filter used for interpolating the temporal axis (frames). This is only
     used if ``--interpolation`` is enabled. The only valid choices for
     ``--tscale`` are separable convolution filters (use ``--tscale=help`` to
-    get a list). The default is ``mitchell``.
+    get a list). The default is ``oversample``.
 
     Common ``--tscale`` choices include ``oversample``, ``linear``,
     ``catmull_rom``, ``mitchell``, ``gaussian``, or ``bicubic``. These are

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5252,17 +5252,16 @@ them.
     The filter function to use when upscaling video.
 
     ``bilinear``
-        Bilinear hardware texture filtering (fastest, very low quality). This
-        is the default for compatibility reasons.
+        Bilinear hardware texture filtering (fastest, very low quality). This is
+        the default when using the ``fast`` profile.
 
     ``spline36``
-        Mid quality and speed. This is the default when using ``gpu-hq``.
+        Mid quality and speed.
 
     ``lanczos``
-        Lanczos scaling. Provides mid quality and speed. Generally worse than
-        ``spline36``, but it results in a slightly sharper image which is good
-        for some content types. The number of taps can be controlled with
-        ``scale-radius``, but is best left unchanged.
+        Lanczos scaling. Provides good balance between quality and performance.
+        This is the default for ``scale``. The number of taps can be controlled
+        with ``scale-radius``, but is best left unchanged.
 
         (This filter is an alias for ``sinc``-windowed ``sinc``)
 
@@ -5275,8 +5274,8 @@ them.
         (This filter is an alias for ``jinc``-windowed ``jinc``)
 
     ``ewa_lanczossharp``
-        A slightly sharpened version of ewa_lanczos. If your hardware can run
-        it, this is probably what you should use by default.
+        A slightly sharpened version of ewa_lanczos. This is the default when
+        using the ``high-quality`` profile.
 
     ``ewa_lanczos4sharpest``
         Very sharp scaler, but also slightly slower than ``ewa_lanczossharp``.
@@ -5287,7 +5286,7 @@ them.
     ``mitchell``
         Mitchell-Netravali. The ``B`` and ``C`` parameters can be set with
         ``--scale-param1`` and ``--scale-param2``. This filter is very good at
-        downscaling (see ``--dscale``).
+        downscaling. This is the default for ``--dscale``.
 
     ``catmull_rom``
         Catmull-Rom. A Cubic filter in the same vein as ``mitchell``, where
@@ -5318,8 +5317,7 @@ them.
     the filter implied by ``--scale`` will be applied.
 
 ``--dscale=<filter>``
-    Like ``--scale``, but apply these filters on downscaling instead. If this
-    option is unset, the filter implied by ``--scale`` will be applied.
+    Like ``--scale``, but apply these filters on downscaling instead.
 
 ``--tscale=<filter>``
     The filter used for interpolating the temporal axis (frames). This is only
@@ -5445,7 +5443,7 @@ them.
     better than without it) since it will extend the size to match only the
     milder of the scale factors between the axes.
 
-    Note: this option is ignored when using bilinear downscaling (the default).
+    Note: this option is ignored when using bilinear downscaling with ``--vo=gpu``.
 
 ``--linear-downscaling``
     Scale in linear light when downscaling. It should only be used with a
@@ -5528,7 +5526,7 @@ them.
     might be slower or cause latency issues.
 
 ``--dither-depth=<N|no|auto>``
-    Set dither target depth to N. Default: no.
+    Set dither target depth to N. Default: auto.
 
     no
         Disable any dithering done by mpv.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5314,7 +5314,8 @@ them.
 
 ``--cscale=<filter>``
     As ``--scale``, but for interpolating chroma information. If the image is
-    not subsampled, this option is ignored entirely.
+    not subsampled, this option is ignored entirely. If this option is unset,
+    the filter implied by ``--scale`` will be applied.
 
 ``--dscale=<filter>``
     Like ``--scale``, but apply these filters on downscaling instead. If this

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -46,18 +46,26 @@ vlang=
 alang=
 slang=
 
-[gpu-hq]
-scale=spline36
-cscale=spline36
-dscale=mitchell
-dither-depth=auto
+[fast]
+scale=bilinear
+dscale=bilinear
+dither=no
+correct-downscaling=no
+linear-downscaling=no
+sigmoid-upscaling=no
+hdr-compute-peak=no
+
+[high-quality]
+scale=ewa_lanczossharp
 hdr-peak-percentile=99.995
 hdr-contrast-recovery=0.30
 allow-delayed-peak-detect=no
-correct-downscaling=yes
-linear-downscaling=yes
-sigmoid-upscaling=yes
 deband=yes
+scaler-lut-size=8
+
+# Deprecated alias
+[gpu-hq]
+profile=high-quality
 
 [low-latency]
 audio-buffer=0          # minimize extra audio buffer (can lead to dropouts)

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -313,6 +313,9 @@ static const struct gl_video_opts gl_video_opts_def = {
          .clamp = 1, }, // tscale
     },
     .scaler_resizes_only = true,
+    .correct_downscaling = true,
+    .linear_downscaling = true,
+    .sigmoid_upscaling = true,
     .scaler_lut_size = 6,
     .interpolation_threshold = 0.01,
     .alpha_mode = ALPHA_BLEND_TILES,

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -309,8 +309,7 @@ static const struct gl_video_opts gl_video_opts_def = {
          .cutoff = 0.001}, // dscale
         {{NULL, .params={NAN, NAN}}, {.params = {NAN, NAN}},
          .cutoff = 0.001}, // cscale
-        {{"mitchell", .params={NAN, NAN}}, {.params = {NAN, NAN}},
-         .clamp = 1, }, // tscale
+        {{"oversample", .params={NAN, NAN}}, {.params = {NAN, NAN}}}, // tscale
     },
     .scaler_resizes_only = true,
     .correct_downscaling = true,

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -295,7 +295,6 @@ struct gl_video {
 
 static const struct gl_video_opts gl_video_opts_def = {
     .dither_algo = DITHER_FRUIT,
-    .dither_depth = -1,
     .dither_size = 6,
     .temporal_dither_period = 1,
     .error_diffusion = "sierra-lite",
@@ -303,9 +302,9 @@ static const struct gl_video_opts gl_video_opts_def = {
     .sigmoid_center = 0.75,
     .sigmoid_slope = 6.5,
     .scaler = {
-        {{"bilinear", .params={NAN, NAN}}, {.params = {NAN, NAN}},
+        {{"lanczos", .params={NAN, NAN}}, {.params = {NAN, NAN}},
          .cutoff = 0.001}, // scale
-        {{NULL,       .params={NAN, NAN}}, {.params = {NAN, NAN}},
+        {{"mitchell", .params={NAN, NAN}}, {.params = {NAN, NAN}},
          .cutoff = 0.001}, // dscale
         {{NULL, .params={NAN, NAN}}, {.params = {NAN, NAN}},
          .cutoff = 0.001}, // cscale

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1740,7 +1740,9 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
 
     const struct gl_video_opts *opts = p->opts_cache->opts;
     const struct scaler_config *cfg = &opts->scaler[unit];
-    if (unit == SCALER_DSCALE && (!cfg->kernel.name || !strcmp(cfg->kernel.name, "")))
+    if (unit == SCALER_DSCALE && (!cfg->kernel.name || !cfg->kernel.name[0]))
+        cfg = &opts->scaler[SCALER_SCALE];
+    if (unit == SCALER_CSCALE && (!cfg->kernel.name || !cfg->kernel.name[0]))
         cfg = &opts->scaler[SCALER_SCALE];
 
     for (int i = 0; fixed_presets[i].name; i++) {


### PR DESCRIPTION
It's confusing that the mid-quality option is in the gpu-hq profile, while the recommended filter is not. Also prefer the sharper catmull-rom for dscale, as it produces better results.

It's time to retire Spline36.