### PR TITLE
present_sync: allow future timestamps

### DIFF
--- a/video/out/present_sync.c
+++ b/video/out/present_sync.c
@@ -67,12 +67,11 @@ void present_sync_swap(struct mp_present *present)
         present->vsync_duration = ust_passed / msc_passed;
 
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    if (clock_gettime(CLOCK_MONOTONIC, &ts))
         return;
-    }
 
-    uint64_t now_monotonic = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
-    uint64_t ust_mp_time = mp_time_us() - (now_monotonic - ust);
+    int64_t now_monotonic = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
+    int64_t ust_mp_time = mp_time_us() - (now_monotonic - ust);
 
     present->last_queue_display_time = ust_mp_time;
 }


### PR DESCRIPTION
The original OML sync implementation (which is where this calculation originally comes from) made now_monotonic and ust_mp_time unsigned. This is fine except it has the assumption that now_monotonic is always greater than ust. This actually isn't always the case. In wayland, I observed instances where the reported timestamp is in the future. Of course, it's a valid question to wonder if this even makes sense but these UST values are essentially opaque black boxes to us anyways. It's entirely plausible that the gpu is expecting the actual presentation of the last swap to be a bit in the future, the compositor gets this and reports this to us. So we'll consider such stats as valid. Note that xorg doesn't have this problem because it's roughly one swap buffer call behind because of how the event loop works (honestly something that should be fixed).

Of course, the problem with the unsigned type here is that it overflows on the subtraction so make it signed and allow the appropriate negative value to happen if it does. Note that this will simply result in a small addition to mp_time_us() which is exactly what we want here (timestamp slightly in the future). Some small style changes included just because.

Sidenote: DRM actually has future timestamps too but I plan to rewrite so it uses `present_sync` too.