### PR TITLE
TOOLS/lua/autoload: fix specify loading only one type of files

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -184,7 +184,7 @@ function scan_dir(path, current_file, dir_mode, separator, dir_depth, total_file
         if ext == nil then
             return false
         end
-        return EXTENSIONS[string.lower(ext)]
+        return EXTENSIONS_TARGET[string.lower(ext)]
     end)
     table.filter(dirs, function(d)
         return not ((o.ignore_hidden and string.match(d, "^%.")))


### PR DESCRIPTION
Fixes: https://github.com/mpv-player/mpv/commit/5100e7acbabd52b7ebc996e1c73df059e7664018

This was missed there: https://github.com/mpv-player/mpv/pull/11292