### PR TITLE
meson: check for libplacebo subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -934,7 +934,9 @@ if features['jpeg']
     dependencies += jpeg
 endif
 
-libplacebo = dependency('libplacebo', version: '>=6.292.0', required: get_option('libplacebo'))
+libplacebo_ver = '>=6.292.0'
+subproject('libplacebo', default_options: ['demos=false'], required: false, version: libplacebo_ver)
+libplacebo = dependency('libplacebo', version: libplacebo_ver, required: get_option('libplacebo'))
 features += {'libplacebo': libplacebo.found()}
 if features['libplacebo']
     dependencies += libplacebo


### PR DESCRIPTION
This allows us to build /subprojects/libplacebo and link with that build instead of the system libplacebo if the libplacebo subproject exists.

This is mostly useful for statically linking with libplacebo master for testing and debugging without messing with the system libs