### PR TITLE
vo_gpu_next: update for new ICC profile API

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -57,6 +57,7 @@ Interface changes
     - add `video-params/crop-[w,h,x,y]`
     - remove `--tone-mapping-mode`
     - change `--subs-fallback-forced` so that it works alongside `--slang`
+    - add `--icc-3dlut-size=auto` and make it the default
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6812,9 +6812,10 @@ them.
     3
         absolute colorimetric
 
-``--icc-3dlut-size=<r>x<g>x<b>``
-    Size of the 3D LUT generated from the ICC profile in each dimension.
-    Default is 64x64x64. Sizes may range from 2 to 512.
+``--icc-3dlut-size=<auto|RxGxB>``
+    Size of the 3D LUT generated from the ICC profile in each dimension. The
+    default of ``auto`` means to pick the size automatically based on internal
+    heuristics. Sizes may range from 2 to 512.
 
 ``--icc-force-contrast=<no|0-1000000|inf>``
     Override the target device's detected contrast ratio by a specific value.

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -326,6 +326,12 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
     if (!gl_lcms_has_profile(p))
         return false;
 
+    // For simplicity, default to 65x65x65, which is large enough to cover
+    // typical profiles with good accuracy while not being too wasteful
+    s_r = s_r ? s_r : 65;
+    s_g = s_g ? s_g : 65;
+    s_b = s_b ? s_b : 65;
+
     void *tmp = talloc_new(NULL);
     uint16_t *output = talloc_array(tmp, uint16_t, s_r * s_g * s_b * 4);
     struct lut3d *lut = NULL;
@@ -514,7 +520,7 @@ const struct m_sub_options mp_icc_conf = {
     },
     .size = sizeof(struct mp_icc_opts),
     .defaults = &(const struct mp_icc_opts) {
-        .size_str = "64x64x64",
+        .size_str = "auto",
         .intent = MP_INTENT_RELATIVE_COLORIMETRIC,
         .use_embedded = true,
         .cache = true,

--- a/video/out/gpu/lcms.h
+++ b/video/out/gpu/lcms.h
@@ -44,6 +44,10 @@ bool gl_lcms_has_changed(struct gl_lcms *p, enum mp_csp_prim prim,
 
 static inline bool gl_parse_3dlut_size(const char *arg, int *p1, int *p2, int *p3)
 {
+    if (!strcmp(arg, "auto")) {
+        *p1 = *p2 = *p3 = 0;
+        return true;
+    }
     if (sscanf(arg, "%dx%dx%d", p1, p2, p3) != 3)
         return false;
     for (int n = 0; n < 3; n++) {


### PR DESCRIPTION
Upstream has moved from passing struct pl_icc_profile to directly
attaching a managed pl_icc_object, plus providing a new function
pl_icc_update to update the ICC profile object parameters (if needed).
    
To facilitate this move, pull our ICC params back out of pl_options and
update the target ICC object directly.