### PR TITLE
vd_lavc: enable hwdec auto-safe by default

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -60,6 +60,7 @@ Interface changes
     - add `--icc-3dlut-size=auto` and make it the default
     - add `--scale=ewa_lanczos4sharpest`
     - remove `--scale-wblur`, `--cscale-wblur`, `--dscale-wblur`, `--tscale-wblur`
+    - change to `--hwdec=auto-safe` by default
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1255,8 +1255,8 @@ Video
     This option accepts a comma delimited list of ``api`` types, along with certain
     special values:
 
-    :no:        always use software decoding (default)
-    :auto-safe: enable any whitelisted hw decoder (see below)
+    :no:        always use software decoding
+    :auto-safe: enable any whitelisted hw decoder (default) (see below)
     :auto:      forcibly enable any hw decoder found (see below)
     :yes:       exactly the same as ``auto-safe``
     :auto-copy: enable best hw decoder with copy-back (see below)

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -140,7 +140,7 @@ const struct m_sub_options vd_lavc_conf = {
         .skip_frame = AVDISCARD_DEFAULT,
         .framedrop = AVDISCARD_NONREF,
         .dr = -1,
-        .hwdec_api = (char *[]){"no", NULL,},
+        .hwdec_api = (char *[]){"auto-safe", NULL,},
         .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;


### PR DESCRIPTION
In most of the cases hardware decoding is preferable for power consumption.