### PR TITLE
meson: limit vk-khr-display to posix systems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1287,8 +1287,9 @@ if features['vulkan'] and features['x11']
      sources += files('video/out/vulkan/context_xlib.c')
 endif
 
-features += {'vk-khr-display': cc.has_function('vkCreateDisplayPlaneSurfaceKHR', prefix: '#include <vulkan/vulkan_core.h>',
-                                               dependencies: [vulkan])}
+features += {'vk-khr-display': features['posix'] and
+    cc.has_function('vkCreateDisplayPlaneSurfaceKHR', prefix: '#include <vulkan/vulkan_core.h>',
+                    dependencies: [vulkan])}
 if features['vk-khr-display']
     sources += files('video/out/vulkan/context_display.c')
 endif


### PR DESCRIPTION
This only works on DRM anyway, even if the vulkan header exists