### PR TITLE
vo_gpu_next: fix blur and taper values being zero

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1801,8 +1801,10 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
     }
 
     par->config.clamp = cfg->clamp;
-    par->config.blur = cfg->kernel.blur;
-    par->config.taper = cfg->kernel.taper;
+    if (cfg->kernel.blur > 0.0)
+        par->config.blur = cfg->kernel.blur;
+    if (cfg->kernel.taper > 0.0)
+        par->config.taper = cfg->kernel.taper;
     if (cfg->radius > 0.0) {
         if (par->config.kernel->resizable) {
 #if PL_API_VER >= 303


### PR DESCRIPTION
This would always apply the config blur and taper values to the kernel, even if it was zero because the user didn't specify any.

Fixes #12415 