### PR TITLE
demux: prepend some cache options with demuxer

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -61,6 +61,8 @@ Interface changes
     - add `--scale=ewa_lanczos4sharpest`
     - remove `--scale-wblur`, `--cscale-wblur`, `--dscale-wblur`, `--tscale-wblur`
     - remove `bcspline` filter (`bicubic` is now the same as `bcspline`)
+    - rename `--cache-dir` and `--cache-unlink-files` to `--demuxer-cache-dir` and
+      `--demuxer-cache-unlink-files`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4905,7 +4905,7 @@ Cache
     media is closed. If the option is disabled and enabled again, it will
     continue to use the cache file that was opened first.
 
-``--cache-dir=<path>``
+``--demuxer-cache-dir=<path>``
     Directory where to create temporary files. Cache is stored in the system's
     cache directory (usually ``~/.cache/mpv``) if this is unset.
 
@@ -4939,7 +4939,7 @@ Cache
 
     This option also triggers when playback is restarted after seeking.
 
-``--cache-unlink-files=<immediate|whendone|no>``
+``--demuxer-cache-unlink-files=<immediate|whendone|no>``
     Whether or when to unlink cache files (default: immediate). This affects
     cache files which are inherently temporary, and which make no sense to
     remain on disk after the player terminates. This is a debugging option.

--- a/demux/cache.c
+++ b/demux/cache.c
@@ -40,10 +40,12 @@ struct demux_cache_opts {
 
 const struct m_sub_options demux_cache_conf = {
     .opts = (const struct m_option[]){
-        {"cache-dir", OPT_STRING(cache_dir), .flags = M_OPT_FILE},
-        {"cache-unlink-files", OPT_CHOICE(unlink_files,
+        {"demuxer-cache-dir", OPT_STRING(cache_dir), .flags = M_OPT_FILE},
+        {"demuxer-cache-unlink-files", OPT_CHOICE(unlink_files,
             {"immediate", 2}, {"whendone", 1}, {"no", 0}),
         },
+        {"cache-dir", OPT_REPLACED("demuxer-cache-dir")},
+        {"cache-unlink-files", OPT_REPLACED("demuxer-cache-unlink-files")},
         {0}
     },
     .size = sizeof(struct demux_cache_opts),


### PR DESCRIPTION
This is a horrible name that only causes confusion (e.g. see #12418). Maybe some other cache options should also be prepended with --demuxer for consistency, but this one is the only one that has an unintuitive meaning.