### PR TITLE
player: add --write-user-files-in-config-dir option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -63,6 +63,9 @@ Interface changes
     - remove `bcspline` filter (`bicubic` is now the same as `bcspline`)
     - rename `--cache-dir` and `--cache-unlink-files` to `--demuxer-cache-dir` and
       `--demuxer-cache-unlink-files`
+    - add `--write-user-files-in-config-dir` option
+    - `--config-dir` no longer silently saves cache and watch_later files in the same
+      directory. This is controlled by `--write-user-files-in-config-dir`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -765,6 +765,13 @@ Program Behavior
 
     Note that the ``--no-config`` option takes precedence over this option.
 
+``--write-user-files-in-config-dir=<yes|no>``
+    If the default config directory is being overrwritten with ``--config-dir``,
+    also force all user files (such has ``cache`` and ``state``) to be written
+    in this directory as well. This has no effect if ``--config-dir`` isn't used.
+    Note that options like ``--watch-later-directory`` which specifically set
+    a directory for some files will have priority over this if they are set.
+
 ``--dump-stats=<filename>``
     Write certain statistics to the given file. The file is truncated on
     opening. The file will contain raw samples, each with a timestamp. To

--- a/common/global.h
+++ b/common/global.h
@@ -10,6 +10,7 @@ struct mpv_global {
     struct mp_client_api *client_api;
     char *configdir;
     struct stats_base *stats;
+    int force_user_files;
 };
 
 #endif

--- a/options/options.c
+++ b/options/options.c
@@ -443,6 +443,7 @@ static const m_option_t mp_opts[] = {
     {"config", OPT_BOOL(load_config), .flags = CONF_PRE_PARSE},
     {"config-dir", OPT_STRING(force_configdir),
         .flags = CONF_NOCFG | CONF_PRE_PARSE | M_OPT_FILE},
+    {"write-user-files-in-config-dir", OPT_BOOL(write_user_files_in_config_dir)},
     {"reset-on-next-file", OPT_STRINGLIST(reset_options)},
 
 #if HAVE_LUA || HAVE_JAVASCRIPT || HAVE_CPLUGINS

--- a/options/options.h
+++ b/options/options.h
@@ -216,6 +216,7 @@ typedef struct MPOpts {
     bool quiet;
     bool load_config;
     char *force_configdir;
+    bool write_user_files_in_config_dir;
     bool use_filedir_conf;
     int hls_bitrate;
     int edition_id;

--- a/options/path.c
+++ b/options/path.c
@@ -87,8 +87,13 @@ static const char *mp_get_platform_path(void *talloc_ctx,
                 return (n == 0 && global->configdir[0]) ? global->configdir : NULL;
         }
         for (int n = 0; n < MP_ARRAY_SIZE(config_dir_replaces); n++) {
-            if (strcmp(config_dir_replaces[n], type) == 0)
-                return global->configdir[0] ? global->configdir : NULL;
+            if (strcmp(config_dir_replaces[n], type) == 0) {
+                if (global->configdir[0] && global->force_user_files) {
+                    return global->configdir;
+                } else if (!global->configdir[0]) {
+                    return NULL;
+                }
+            }
         }
     }
 
@@ -122,6 +127,7 @@ void mp_init_paths(struct mpv_global *global, struct MPOpts *opts)
         force_configdir = "";
 
     global->configdir = talloc_strdup(global, force_configdir);
+    global->force_user_files = opts->write_user_files_in_config_dir;
 }
 
 char *mp_find_user_file(void *talloc_ctx, struct mpv_global *global,


### PR DESCRIPTION
Right now, the --config-dir option silently causes all watch_later and cache files to be written in the --config-dir as well. This is pretty uninitutive and also not desirable in most cases so make this an explict option and disable it by default. Note that options like --watch-later-directory or --demuxer-cache-dir will take priority over whatever this is set to. Fixes #12418.

@sfan5: does this work for android? The `--config-dir` behavior as it currently is just seems to confuse users.