### PR TITLE
make libplacebo a required dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
             pkg update
             # Requested in ci/build-freebsd.sh
             pkg install -y \
+                git \
                 cmake \
                 evdev-proto \
                 ffmpeg \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
       matrix:
         cc:
           - "clang"
+        cxx:
+          - "clang++"
         os:
           - "macos-11"
           - "macos-12"
@@ -105,6 +107,7 @@ jobs:
           ./ci/build-macos.sh
         env:
           CC: "${{ matrix.cc }}"
+          CXX: "${{ matrix.cxx }}"
           TRAVIS_OS_NAME: "${{ matrix.os }}"
 
       - name: Print meson log
@@ -127,12 +130,19 @@ jobs:
     container:
       image: "registry.opensuse.org/home/mia/images/images/mpv-ci:stable-deps"
       env:
-        CC: "${{ matrix.cc }}"
+        CC: "${{ matrix.config.cc }}"
+        CXX: "${{ matrix.config.cxx }}"
     strategy:
       matrix:
-        cc:
-          - "gcc"
-          - "clang"
+        config:
+        - {
+            cc: "gcc",
+            cxx: "g++",
+          }
+        - {
+            cc: "clang",
+            cxx: "clang++",
+          }
     steps:
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/subprojects
+/subprojects/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /subprojects/*
+!/subprojects/libplacebo.wrap

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -14,7 +14,7 @@ PKG_CONFIG_PATH="${FFMPEG_SYSROOT}/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build \
     -Dprefix="${MPV_INSTALL_PREFIX}" \
     -D{libmpv,tests}=true \
-    -D{gl,iconv,lcms2,libplacebo,lua,jpeg,plain-gl,zlib}=enabled \
+    -D{gl,iconv,lcms2,lua,jpeg,plain-gl,zlib}=enabled \
     -D{cocoa,coreaudio,gl-cocoa,macos-cocoa-cb,macos-touchbar,videotoolbox-gl}=enabled
 
 meson compile -C build -j4

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -270,7 +270,7 @@ rm -rf $build
 meson setup $build --cross-file "$prefix_dir/crossfile" \
     --buildtype debugoptimized \
     -Dlibmpv=true -Dlua=luajit \
-    -D{shaderc,spirv-cross,d3d11,libplacebo}=enabled
+    -D{shaderc,spirv-cross,d3d11}=enabled
 
 meson compile -C $build
 

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ libavutil = dependency('libavutil', version: '>= 56.70.100')
 libswresample = dependency('libswresample', version: '>= 3.9.100')
 libswscale = dependency('libswscale', version: '>= 5.9.100')
 
+libplacebo = dependency('libplacebo', version: '>=6.338.0', fallback: ['libplacebo', 'libplacebo'],
+    default_options: ['default_library=static', 'demos=false'])
+
 libass = dependency('libass', version: '>= 0.12.2')
 
 # the dependency order of libass -> ffmpeg is necessary due to
@@ -32,6 +35,7 @@ dependencies = [libass,
                 libavfilter,
                 libavformat,
                 libavutil,
+                libplacebo,
                 libswresample,
                 libswscale]
 
@@ -44,6 +48,7 @@ features = {
     'avif-muxer': libavformat.version().version_compare('>= 59.24.100'),
     'libass': true,
     'threads': true,
+    'libplacebo': true,
 }
 
 
@@ -233,6 +238,12 @@ sources = files(
     'video/out/win_state.c',
     'video/repack.c',
     'video/sws_utils.c',
+
+    ## libplacebo
+    'video/out/placebo/ra_pl.c',
+    'video/out/placebo/utils.c',
+    'video/out/vo_gpu_next.c',
+    'video/out/gpu_next/context.c',
 
     ## osdep
     'osdep/io.c',
@@ -934,16 +945,6 @@ if features['jpeg']
     dependencies += jpeg
 endif
 
-libplacebo = dependency('libplacebo', version: '>=6.292.0', required: get_option('libplacebo'))
-features += {'libplacebo': libplacebo.found()}
-if features['libplacebo']
-    dependencies += libplacebo
-    sources += files('video/out/placebo/ra_pl.c',
-                     'video/out/placebo/utils.c',
-                     'video/out/vo_gpu_next.c',
-                     'video/out/gpu_next/context.c')
-endif
-
 sdl2_video = get_option('sdl2-video').require(
     features['sdl2'],
     error_message: 'sdl2 was not found!',
@@ -1261,7 +1262,7 @@ endif
 # vulkan
 vulkan_opt = get_option('vulkan').require(
     libplacebo.get_variable('pl_has_vulkan', default_value: '0') == '1',
-    error_message: 'libplacebo could not be found!',
+    error_message: 'libplacebo compiled without vulkan support!',
 )
 vulkan = dependency('vulkan', version: '>= 1.1.70', required: vulkan_opt)
 features += {'vulkan': vulkan.found()}
@@ -1334,9 +1335,8 @@ endif
 
 vulkan_interop = get_option('vulkan-interop').require(
     features['vulkan'] and vulkan.version().version_compare('>=1.3.238') and
-    features['libplacebo'] and
     libavutil.version().version_compare('>=58.11.100'),
-    error_message: 'Vulkan Interop requires vulkan headers >= 1.3.238, libplacebo, and libavutil >= 58.11.100',
+    error_message: 'Vulkan Interop requires vulkan headers >= 1.3.238, and libavutil >= 58.11.100',
 )
 features += {'vulkan-interop': vulkan_interop.allowed()}
 if vulkan_interop.allowed()
@@ -1430,26 +1430,15 @@ features += {'vaapi': vaapi.allowed()}
 if features['vaapi']
     dependencies += libva
     sources += files('video/filter/vf_vavpp.c',
-                     'video/vaapi.c')
-endif
-
-features += {'vaapi-egl': features['vaapi'] and features['egl'] and features['drm']}
-features += {'vaapi-libplacebo': features['vaapi'] and libplacebo.found()}
-
-if features['vaapi-egl'] or features['vaapi-libplacebo']
-    sources += files('video/out/hwdec/hwdec_vaapi.c')
+                     'video/vaapi.c',
+                     'video/out/hwdec/hwdec_vaapi.c',
+                     'video/out/hwdec/dmabuf_interop_pl.c')
 endif
 
 dmabuf_interop_gl = features['egl'] and features['drm']
 features += {'dmabuf-interop-gl': dmabuf_interop_gl}
 if features['dmabuf-interop-gl']
     sources += files('video/out/hwdec/dmabuf_interop_gl.c')
-endif
-
-dmabuf_interop_pl = features['vaapi-libplacebo']
-features += {'dmabuf-interop-pl': dmabuf_interop_pl}
-if features['dmabuf-interop-pl']
-    sources += files('video/out/hwdec/dmabuf_interop_pl.c')
 endif
 
 vdpau_opt = get_option('vdpau').require(
@@ -1783,7 +1772,6 @@ if get_option('tests')
 endif
 
 summary({'d3d11': features['d3d11'],
-         'gpu-next': features['libplacebo'],
          'javascript': features['javascript'],
          'libmpv': get_option('libmpv'),
          'lua': features['lua'],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -75,7 +75,6 @@ option('gl-dxinterop', type: 'feature', value: 'auto', description: 'OpenGL/Dire
 option('gl-win32', type: 'feature', value: 'auto', description: 'OpenGL Win32 Backend')
 option('gl-x11', type: 'feature', value: 'disabled', description: 'OpenGL X11/GLX (deprecated/legacy)')
 option('jpeg', type: 'feature', value: 'auto', description: 'JPEG support')
-option('libplacebo', type: 'feature', value: 'auto', description: 'libplacebo support')
 option('rpi', type: 'feature', value: 'disabled', description: 'Raspberry Pi support')
 option('sdl2-video', type: 'feature', value: 'auto', description: 'SDL2 video output')
 option('shaderc', type: 'feature', value: 'auto', description: 'libshaderc SPIR-V compiler')

--- a/player/main.c
+++ b/player/main.c
@@ -26,9 +26,7 @@
 
 #include "config.h"
 
-#if HAVE_LIBPLACEBO
 #include <libplacebo/config.h>
-#endif
 
 #include "mpv_talloc.h"
 
@@ -153,9 +151,7 @@ void mp_print_version(struct mp_log *log, int always)
     mp_msg(log, v, "%s %s\n", mpv_version, mpv_copyright);
     if (strcmp(mpv_builddate, "UNKNOWN"))
         mp_msg(log, v, " built on %s\n", mpv_builddate);
-#if HAVE_LIBPLACEBO
     mp_msg(log, v, "libplacebo version: %s\n", PL_VERSION);
-#endif
     check_library_versions(log, v);
     mp_msg(log, v, "\n");
     // Only in verbose mode.

--- a/subprojects/libplacebo.wrap
+++ b/subprojects/libplacebo.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+
+url = https://code.videolan.org/videolan/libplacebo.git
+revision = v6.338.1
+depth = 1
+clone-recursive = true

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -41,7 +41,7 @@ extern const struct ra_hwdec_driver ra_hwdec_aimagereader;
 extern const struct ra_hwdec_driver ra_hwdec_vulkan;
 
 const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
-#if HAVE_VAAPI_EGL || HAVE_VAAPI_LIBPLACEBO
+#if HAVE_VAAPI
     &ra_hwdec_vaapi,
 #endif
 #if HAVE_VIDEOTOOLBOX_GL || HAVE_IOS_GL

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -55,7 +55,7 @@ const static dmabuf_interop_init interop_inits[] = {
 #if HAVE_DMABUF_INTEROP_GL
     dmabuf_interop_gl_init,
 #endif
-#if HAVE_DMABUF_INTEROP_PL
+#if HAVE_VAAPI
     dmabuf_interop_pl_init,
 #endif
 #if HAVE_DMABUF_WAYLAND

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -128,9 +128,7 @@ const static dmabuf_interop_init interop_inits[] = {
 #if HAVE_DMABUF_INTEROP_GL
     dmabuf_interop_gl_init,
 #endif
-#if HAVE_DMABUF_INTEROP_PL
     dmabuf_interop_pl_init,
-#endif
 #if HAVE_DMABUF_WAYLAND
     dmabuf_interop_wl_init,
 #endif

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -76,9 +76,7 @@ static const struct vo_driver *const video_out_drivers[] =
     &video_out_mediacodec_embed,
 #endif
     &video_out_gpu,
-#if HAVE_LIBPLACEBO
     &video_out_gpu_next,
-#endif
 #if HAVE_VDPAU
     &video_out_vdpau,
 #endif


### PR DESCRIPTION
This works by first checking if the required libplacebo version is available on the system, if it isn't then we'll automatically fallback to the wrap and fetch libplacebo recursively with all its submodules and link statically.

For now, we're only pulling in the latest tagged release instead of master or a specific revision.