### PR TITLE
miscellaneous cosmetic fixes

### DIFF
--- a/common/msg_control.h
+++ b/common/msg_control.h
@@ -2,6 +2,7 @@
 #define MP_MSG_CONTROL_H
 
 #include <stdbool.h>
+#include "common/msg.h"
 
 struct mpv_global;
 struct MPOpts;

--- a/demux/timeline.h
+++ b/demux/timeline.h
@@ -2,6 +2,7 @@
 #define MP_TIMELINE_H_
 
 #include "common/common.h"
+#include "misc/bstr.h"
 
 // Single segment in a timeline.
 struct timeline_part {

--- a/filters/f_async_queue.h
+++ b/filters/f_async_queue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include "filter.h"
 
 // A thread safe queue, which buffers a configurable number of frames like a

--- a/filters/f_decoder_wrapper.h
+++ b/filters/f_decoder_wrapper.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "filter.h"
 

--- a/filters/f_lavfi.h
+++ b/filters/f_lavfi.h
@@ -31,6 +31,7 @@ struct mp_lavfi *mp_lavfi_create_filter(struct mp_filter *parent,
                                         char **graph_opts,
                                         const char *filter, char **filter_opts);
 
+struct mp_log;
 // Print libavfilter list for --vf/--af
 void print_lavfi_help_list(struct mp_log *log, int media_type);
 

--- a/misc/thread_pool.h
+++ b/misc/thread_pool.h
@@ -1,6 +1,7 @@
 #ifndef MPV_MP_THREAD_POOL_H
 #define MPV_MP_THREAD_POOL_H
 
+#include <stdbool.h>
 struct mp_thread_pool;
 
 // Create a thread pool with the given number of worker threads. This can return

--- a/player/command.h
+++ b/player/command.h
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 
 #include "libmpv/client.h"
+#include "osdep/compiler.h"
 
 struct MPContext;
 struct mp_cmd;

--- a/sub/ass_mp.h
+++ b/sub/ass_mp.h
@@ -42,6 +42,7 @@ struct MPOpts;
 struct mpv_global;
 struct mp_osd_res;
 struct osd_style_opts;
+struct mp_log;
 
 void mp_ass_flush_old_events(ASS_Track *track, long long ts);
 void mp_ass_set_style(ASS_Style *style, double res_y,

--- a/sub/ass_mp.h
+++ b/sub/ass_mp.h
@@ -26,8 +26,10 @@
 #include <ass/ass.h>
 #include <ass/ass_types.h>
 
-// This is probably arbitrary.
-// sd_lavc_conv might indirectly still assume this PlayResY, though.
+// These PlayResX and PlayResY values are arbitrary and taken from lavc.
+// lavc assumes these values when converting to ass generally. Moreover, these
+// values are also used by default in VSFilter, so it isn't that arbitrary.
+#define MP_ASS_FONT_PLAYRESX 384
 #define MP_ASS_FONT_PLAYRESY 288
 
 #define MP_ASS_RGBA(r, g, b, a) \

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -85,8 +85,8 @@ static void mp_ass_add_default_styles(ASS_Track *track, struct mp_subtitle_opts 
 
     if (track->n_styles == 0) {
         if (!track->PlayResY) {
+            track->PlayResX = MP_ASS_FONT_PLAYRESX;
             track->PlayResY = MP_ASS_FONT_PLAYRESY;
-            track->PlayResX = track->PlayResY * 4 / 3;
         }
         track->Kerning = true;
         int sid = ass_alloc_style(track);
@@ -220,8 +220,8 @@ static void assobjects_init(struct sd *sd)
     ctx->ass_track->track_type = TRACK_TYPE_ASS;
 
     ctx->shadow_track = ass_new_track(ctx->ass_library);
-    ctx->shadow_track->PlayResX = 384;
-    ctx->shadow_track->PlayResY = 288;
+    ctx->shadow_track->PlayResX = MP_ASS_FONT_PLAYRESX;
+    ctx->shadow_track->PlayResY = MP_ASS_FONT_PLAYRESY;
     mp_ass_add_default_styles(ctx->shadow_track, opts);
 
     char *extradata = sd->codec->extradata;
@@ -436,7 +436,7 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
 #endif
     ass_set_selective_style_override_enabled(priv, set_force_flags);
     ASS_Style style = {0};
-    mp_ass_set_style(&style, 288, opts->sub_style);
+    mp_ass_set_style(&style, MP_ASS_FONT_PLAYRESY, opts->sub_style);
     ass_set_selective_style_override(priv, &style);
     free(style.FontName);
     if (converted && track->default_style < track->n_styles) {
@@ -473,7 +473,7 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
             track->PlayResX = track->PlayResY * (double)vidw / MPMAX(vidh, 1);
             // ffmpeg and mpv use a default PlayResX of 384 when it is not known,
             // this comes from VSFilter.
-            double fix_margins = track->PlayResX / 384.0;
+            double fix_margins = track->PlayResX / (double)MP_ASS_FONT_PLAYRESX;
             track->styles->MarginL = round(track->styles->MarginL * fix_margins);
             track->styles->MarginR = round(track->styles->MarginR * fix_margins);
         }


### PR DESCRIPTION
Mostly to silence clangd, but the sd_ass integer division is actually a bug fix for subtitles with unknown durations