### PR TITLE
vo_dmabuf_wayland: support osd rendering when there's no video

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1034,6 +1034,7 @@ int handle_force_window(struct MPContext *mpctx, bool force)
             .imgfmt = config_format,
             .w = w,   .h = h,
             .p_w = 1, .p_h = 1,
+            .force_window = true,
         };
         if (vo_reconfig(vo, &p) < 0)
             goto err;

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -835,6 +835,7 @@ bool mp_image_params_equal(const struct mp_image_params *p1,
            p1->hw_subfmt == p2->hw_subfmt &&
            p1->w == p2->w && p1->h == p2->h &&
            p1->p_w == p2->p_w && p1->p_h == p2->p_h &&
+           p1->force_window == p2->force_window &&
            mp_colorspace_equal(p1->color, p2->color) &&
            p1->chroma_location == p2->chroma_location &&
            p1->rotate == p2->rotate &&

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -46,6 +46,7 @@ struct mp_image_params {
     enum mp_imgfmt hw_subfmt;   // underlying format for some hwaccel pixfmts
     int w, h;                   // image dimensions
     int p_w, p_h;               // define pixel aspect ratio (undefined: 0/0)
+    bool force_window;          // fake image created by handle_force_window
     struct mp_colorspace color;
     enum mp_chroma_location chroma_location;
     // The image should be rotated clockwise (0-359 degrees).

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2239,9 +2239,8 @@ bool vo_wayland_init(struct vo *vo)
         goto err;
 
     if (wl->subcompositor) {
-        wl->osd_subsurface = wl_subcompositor_get_subsurface(wl->subcompositor, wl->osd_surface, wl->video_surface);
         wl->video_subsurface = wl_subcompositor_get_subsurface(wl->subcompositor, wl->video_surface, wl->surface);
-        wl_subsurface_set_desync(wl->video_subsurface);
+        wl->osd_subsurface = wl_subcompositor_get_subsurface(wl->subcompositor, wl->osd_surface, wl->surface);
     }
 
 #if HAVE_WAYLAND_PROTOCOLS_1_27


### PR DESCRIPTION
The osd support was originally written with the requirement that we have
actual frames getting delivered to the VO. This isn't always the case
though. If you force a window on a blank audio file for example, then
there will be no frame thus draw_frame did nothing. Since the previous
commit allows us to reliably detect this, we can rearrange the code
around a little bit to make this possible. A key change is to make the
osd_subsurface have wl->surface as the parent. This is seemingly
required otherwise the osd_surface buffers are never visible above the
empty video_surface when we have a black window. Also nuke the desync
call since it's completely pointless. Fixes https://github.com/mpv-player/mpv/issues/12429.