### PR TITLE
sdl_gamepad: fix button detection on modern controllers

### DIFF
--- a/input/sdl_gamepad.c
+++ b/input/sdl_gamepad.c
@@ -198,6 +198,8 @@ static void remove_gamepad(struct mp_input_src *src, int id)
 
 static void read_gamepad_thread(struct mp_input_src *src, void *param)
 {
+    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+
     if (SDL_WasInit(SDL_INIT_EVENTS)) {
         MP_ERR(src, "Another component is using SDL already.\n");
         mp_input_src_init_done(src);


### PR DESCRIPTION
When using the Xbox Series X Controller on Windows 11, no button beside the 2 triggers worked..
with this little change it appears to get it working fully and every button is available to be mapped.

However I can't test on Linux or MacOS or wherever else SDL is available to, nor can I test with other controllers, so if you can do that, feel free to.