### PR TITLE
demux_mf: detect svg

### DIFF
--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -337,6 +337,7 @@ static const struct {
     { "qoi",            "qoi" },
     { "xface",          "xface" },
     { "xwd",            "xwd" },
+    { "svg",            "svg" },
     {0}
 };
 


### PR DESCRIPTION
This allows playing svgs without having to specify --demuxer-lavf-format=svg_pipe.