### PR TITLE
win32: add option to change backdrop style

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7126,6 +7126,16 @@ Miscellaneous
 
     This is a key/value list option. See `List Options`_ for details.
 
+``--backdrop-type=<auto|none|mica|acrylic|mica-alt>``
+    (Windows only)
+    Controls the backdrop/border style.
+
+    :auto: Default Windows behavior
+    :none: The backdrop will be black or white depending on the system's theme settings.
+    :mica: Enables the Mica style, which is the default on Windows 11.
+    :acrylic: Enables the Acrylic style (frosted glass look).
+    :mica-alt: Same as Mica, except reversed.
+
 ``--window-affinity=<default|excludefromcmcapture|monitor>``
     (Windows only)
     Controls the window affinity behavior of mpv.

--- a/options/options.c
+++ b/options/options.c
@@ -188,14 +188,23 @@ static const m_option_t mp_vo_opt_list[] = {
         {"photo", 1}, {"video", 2}, {"game", 3})},
 #endif
 #if HAVE_WIN32_DESKTOP
-    {"window-affinity", OPT_CHOICE(window_affinity, {"default", WDA_NONE},
-        {"excludefromcapture", WDA_EXCLUDEFROMCAPTURE}, {"monitor", WDA_MONITOR})},
-    {"vo-mmcss-profile", OPT_STRING(mmcss_profile)},
 // For old MinGW-w64 compatibility
 #define DWMWCP_DEFAULT 0
 #define DWMWCP_DONOTROUND 1
 #define DWMWCP_ROUND 2
 #define DWMWCP_ROUNDSMALL 3
+
+#define DWMSBT_AUTO 0
+#define DWMSBT_NONE 1
+#define DWMSBT_MAINWINDOW 2
+#define DWMSBT_TRANSIENTWINDOW 3
+#define DWMSBT_TABBEDWINDOW 4
+
+    {"backdrop-type", OPT_CHOICE(backdrop_type, {"auto", DWMSBT_AUTO}, {"none", DWMSBT_NONE},
+        {"mica", DWMSBT_MAINWINDOW}, {"acrylic", DWMSBT_TRANSIENTWINDOW}, {"mica-alt", DWMSBT_TABBEDWINDOW})},
+    {"window-affinity", OPT_CHOICE(window_affinity, {"default", WDA_NONE},
+        {"excludefromcapture", WDA_EXCLUDEFROMCAPTURE}, {"monitor", WDA_MONITOR})},
+    {"vo-mmcss-profile", OPT_STRING(mmcss_profile)},
     {"window-corners", OPT_CHOICE(window_corners,
         {"default", DWMWCP_DEFAULT},
         {"donotround", DWMWCP_DONOTROUND},

--- a/options/options.h
+++ b/options/options.h
@@ -64,6 +64,7 @@ typedef struct mp_vo_opts {
     bool force_render;
     bool force_window_position;
 
+    int backdrop_type;
     int window_affinity;
     char *mmcss_profile;
     int window_corners;


### PR DESCRIPTION
Adds the ability to change the style of the backdrop to mica (alt), none or acrylic.

This is a Windows 11 only feature, I can't test this on 10 and it's most likely not gonna work on 7 at all, but since we only support 10+ it doesn't matter.
Feel free to test on fully updated 10 and report back.

The backdrop style mainly affects the Top bar/border because we have no other GUI elements where the backdrop is visible, e.g no button popup windows or anything.

As far as I can tell, Mica is transparent to the desktop background only, same as mica-alt, while acrylic is transparent to the windows/objects directly behind it.

While we're at it, should we set acrylic to be the default? or just let windows handle it, idk.. RFC on that.

Another question, but to my code, is the enum mapping fine? I can't think of a prettier solution other than having lots of conditionals in the update function itself.. I can't have the enum values directly in OPT_CHOICE since it's not supported afaik.

EDIT: had to force-push leftover debug out.

Here's a comparison of the available styles:
![image](https://github.com/mpv-player/mpv/assets/1492505/bf41cdae-fc8f-4567-8f26-a24a67b9ee1f)
