### PR TITLE
vo_gpu: allow deband-iterations to be 0

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6061,7 +6061,7 @@ them.
     virtually always an improvement - the only reason to disable it would be
     for performance.
 
-``--deband-iterations=<1..16>``
+``--deband-iterations=<0..16>``
     The number of debanding steps to perform per sample. Each step reduces a
     bit more banding, but takes time to compute. Note that the strength of each
     step falls off very quickly, so high numbers (>4) are practically useless.

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -950,7 +950,7 @@ const struct deband_opts deband_opts_def = {
 #define OPT_BASE_STRUCT struct deband_opts
 const struct m_sub_options deband_conf = {
     .opts = (const m_option_t[]) {
-        {"iterations", OPT_INT(iterations), M_RANGE(1, 16)},
+        {"iterations", OPT_INT(iterations), M_RANGE(0, 16)},
         {"threshold", OPT_FLOAT(threshold), M_RANGE(0.0, 4096.0)},
         {"range", OPT_FLOAT(range), M_RANGE(1.0, 64.0)},
         {"grain", OPT_FLOAT(grain), M_RANGE(0.0, 4096.0)},


### PR DESCRIPTION
This allows adding grain without debanding. libplacebo already supported this, so no changes are required there.