### PR TITLE
player: remove shared-script-properties property

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -26,6 +26,8 @@ Interface changes
 
 ::
 
+ --- mpv 0.38.0 ---
+    - remove shared-script-properties (user-data is a replacement)
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3328,35 +3328,11 @@ Property list
 ``current-ao``
     Current audio output driver (name as used with ``--ao``).
 
-``shared-script-properties`` (RW)
-    This is a key/value map of arbitrary strings shared between scripts for
-    general use. The player itself does not use any data in it (although some
-    builtin scripts may). The property is not preserved across player restarts.
-
-    This is very primitive, inefficient, and annoying to use. It's a makeshift
-    solution which could go away any time (for example, when a better solution
-    becomes available). This is also why this property has an annoying name. You
-    should avoid using it, unless you absolutely have to.
-
-    Lua scripting has helpers starting with ``utils.shared_script_property_``.
-    They are undocumented because you should not use this property. If you still
-    think you must, you should use the helpers instead of the property directly.
-
-    You are supposed to use the ``change-list`` command to modify the contents.
-    Reading, modifying, and writing the property manually could data loss if two
-    scripts update different keys at the same time due to lack of
-    synchronization. The Lua helpers take care of this.
-
-    (There is no way to ensure synchronization if two scripts try to update the
-    same key at the same time.)
-
 ``user-data`` (RW)
     This is a recursive key/value map of arbitrary nodes shared between clients for
     general use (i.e. scripts, IPC clients, host applications, etc).
     The player itself does not use any data in it (although some builtin scripts may).
     The property is not preserved across player restarts.
-
-    This is a more powerful replacement for ``shared-script-properties``.
 
     Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
     read, written, or observed.

--- a/player/command.c
+++ b/player/command.c
@@ -111,7 +111,6 @@ struct command_ctx {
     mpv_node udata;
 
     double cached_window_scale;
-    bool shared_script_warning;
 };
 
 static const struct m_option script_props_type = {
@@ -3624,32 +3623,6 @@ static int mp_property_bindings(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-
-static int mp_property_script_props(void *ctx, struct m_property *prop,
-                                    int action, void *arg)
-{
-    MPContext *mpctx = ctx;
-    struct command_ctx *cmd = mpctx->command_ctx;
-    if (!cmd->shared_script_warning) {
-        MP_WARN(mpctx, "The shared-script-properties property is deprecated and will "
-                "be removed in the future. Use the user-data property instead.\n");
-        cmd->shared_script_warning = true;
-    }
-    switch (action) {
-    case M_PROPERTY_GET_TYPE:
-        *(struct m_option *)arg = script_props_type;
-        return M_PROPERTY_OK;
-    case M_PROPERTY_GET:
-        m_option_copy(&script_props_type, arg, &cmd->script_props);
-        return M_PROPERTY_OK;
-    case M_PROPERTY_SET:
-        m_option_copy(&script_props_type, &cmd->script_props, arg);
-        mp_notify_property(mpctx, prop->name);
-        return M_PROPERTY_OK;
-    }
-    return M_PROPERTY_NOT_IMPLEMENTED;
-}
-
 static int do_list_udata(int item, int action, void *arg, void *ctx);
 
 struct udata_ctx {
@@ -4020,7 +3993,6 @@ static const struct m_property mp_properties_base[] = {
     {"command-list", mp_property_commands},
     {"input-bindings", mp_property_bindings},
 
-    {"shared-script-properties", mp_property_script_props},
     {"user-data", mp_property_udata},
 
     M_PROPERTY_ALIAS("video", "vid"),

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -177,28 +177,6 @@ mp.abort_async_command = function abort_async_command(id) {
         mp._abort_async_command(id);
 }
 
-// shared-script-properties - always an object, even if without properties
-function shared_script_property_set(name, val) {
-    if (arguments.length > 1)
-        return mp.commandv("change-list", "shared-script-properties", "append", "" + name + "=" + val);
-    else
-        return mp.commandv("change-list", "shared-script-properties", "remove", name);
-}
-
-function shared_script_property_get(name) {
-    return mp.get_property_native("shared-script-properties")[name];
-}
-
-function shared_script_property_observe(name, cb) {
-    return mp.observe_property("shared-script-properties", "native",
-        function shared_props_cb(_name, val) { cb(name, val[name]) }
-    );
-}
-
-mp.utils.shared_script_property_set = shared_script_property_set;
-mp.utils.shared_script_property_get = shared_script_property_get;
-mp.utils.shared_script_property_observe = shared_script_property_observe;
-
 // osd-ass
 var next_assid = 1;
 mp.create_osd_overlay = function create_osd_overlay(format) {

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -809,28 +809,4 @@ function mp_utils.subprocess_detached(t)
     mp.commandv("run", unpack(t.args))
 end
 
-function mp_utils.shared_script_property_set(name, value)
-    if value ~= nil then
-        -- no such thing as change-list with mpv_node, so build a string value
-        mp.commandv("change-list", "shared-script-properties", "append",
-                    name .. "=" .. value)
-    else
-        mp.commandv("change-list", "shared-script-properties", "remove", name)
-    end
-end
-
-function mp_utils.shared_script_property_get(name)
-    local map = mp.get_property_native("shared-script-properties")
-    return map and map[name]
-end
-
--- cb(name, value) on change and on init
-function mp_utils.shared_script_property_observe(name, cb)
-    -- it's _very_ wasteful to observe the mpv core "super" property for every
-    -- shared sub-property, but then again you shouldn't use this
-    mp.observe_property("shared-script-properties", "native", function(_, val)
-        cb(name, val and val[name])
-    end)
-end
-
 return {}


### PR DESCRIPTION
If we really want to go through a proper deprecation period, we can, but the manual has stated for a long time that "It's a makeshift solution which could go away any time (for example, when a better solution becomes available)" which is exactly what happened with the `user-data` addition. So I figure just screw it and delete the code.