### PR TITLE
demux_lavf: set duration to -1 if unknown

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1153,8 +1153,8 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
     // We initially prefer track durations over container durations because they
     // have a higher degree of precision over the container duration which are
     // only accurate to the 6th decimal place. This is probably a lavf bug.
-    double total_duration = 0;
-    double av_duration = 0;
+    double total_duration = -1;
+    double av_duration = -1;
     for (int n = 0; n < priv->avfc->nb_streams; n++) {
         AVStream *st = priv->avfc->streams[n];
         if (st->duration <= 0)
@@ -1166,7 +1166,7 @@ static int demux_open_lavf(demuxer_t *demuxer, enum demux_check check)
             av_duration = MPMAX(av_duration, f_duration);
     }
     double duration = av_duration > 0 ? av_duration : total_duration;
-    if (duration == 0 && priv->avfc->duration > 0)
+    if (duration <= 0 && priv->avfc->duration > 0)
         duration = (double)priv->avfc->duration / AV_TIME_BASE;
     demuxer->duration = duration;
 


### PR DESCRIPTION
`demux->duration` is set to -1 on initialization, and some checks rely on it being -1 when unknown. Before this commit, we set `demux->duration` to 0 when unknown. This is incorrect and breaks rtsp logic for disabling seeking outside of cached regions.

To fix these issues, initialize `total_duration` and `av_duration` at -1. They're only changed if a real duration is detected, so in cases where the duration is unknown, demux->duration is set to -1 correctly.

Fixes: e6afc53e7c ("demux_lavf: get total duration from track durations")
Fixes #12454