### PR TITLE
github/workflows: add macOS 13 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 lua@5.1 libass ffmpeg meson
+          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 lua@5.1 libass ffmpeg meson libplacebo
 
       - name: Build with meson
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         os:
           - "macos-11"
           - "macos-12"
+          - "macos-13"
     steps:
       - uses: actions/checkout@v3
 

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -14,7 +14,7 @@ PKG_CONFIG_PATH="${FFMPEG_SYSROOT}/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build \
     -Dprefix="${MPV_INSTALL_PREFIX}" \
     -D{libmpv,tests}=true \
-    -D{gl,iconv,lcms2,lua,jpeg,plain-gl,zlib}=enabled \
+    -D{gl,iconv,lcms2,libplacebo,lua,jpeg,plain-gl,zlib}=enabled \
     -D{cocoa,coreaudio,gl-cocoa,macos-cocoa-cb,macos-touchbar,videotoolbox-gl}=enabled
 
 meson compile -C build -j4


### PR DESCRIPTION
Apparently it is available in public beta since late April.

ref https://github.com/actions/runner-images/issues/6426