### PR TITLE
input.conf: make `u` toggle between force and yes

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -173,9 +173,9 @@ Shift+g and Shift+f
     Adjust subtitle font size by +/- 10%.
 
 u
-    Switch between applying no style overrides to SSA/ASS subtitles, and
-    overriding them almost completely with the normal subtitle style. See
-    ``--sub-ass-override`` for more info.
+    Switch between applying only ``--sub-ass-*`` overrides (default) to SSA/ASS
+    subtitles, and overriding them almost completely with the normal subtitle
+    style. See ``--sub-ass-override`` for more info.
 
 V
     Toggle subtitle VSFilter aspect compatibility mode. See

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -125,7 +125,7 @@
 #v cycle sub-visibility                 # hide or show the subtitles
 #Alt+v cycle secondary-sub-visibility   # hide or show the secondary subtitles
 #V cycle sub-ass-vsfilter-aspect-compat # toggle stretching SSA/ASS subtitles with anamorphic videos to match the historical renderer
-#u cycle-values sub-ass-override "force" "no" # toggle overriding SSA/ASS subtitle styles with the normal styles
+#u cycle-values sub-ass-override "force" "yes" # toggle overriding SSA/ASS subtitle styles with the normal styles
 #j cycle sub                            # switch subtitle track
 #J cycle sub down                       # switch subtitle track backwards
 #SHARP cycle audio                      # switch audio track


### PR DESCRIPTION
There was a discrepancy in what the keybind was advertised to do in the manual, and what the comment in input.conf described it to be doing. It makes very little sense to add a keybind that changes the default and doesn't allow you to get back to the default. This keybind is much more useful if it toggles between yes/force instead of no/force.