### PR TITLE
github/workflows improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,14 @@ on:
       - master
       - ci
       - 'release/**'
+    paths-ignore:
+      - 'DOCS/**'
+      - 'TOOLS/lua/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'DOCS/**'
+      - 'TOOLS/lua/**'
 
 jobs:
   mingw:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - master
+      - ci
+      - 'release/**'
+    paths:
+      - 'DOCS/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'DOCS/**'
+
+jobs:
+  commit-msg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: docs
+        run: |
+          sudo apt-get install python3-docutils
+          rst2man --strip-elements-with-class=contents --halt=2 ./DOCS/man/mpv.rst mpv.1


### PR DESCRIPTION
When someone purely changes some documentation or something similar, there's no point in having the bot spam a comment linking to the artifacts. This only is useful if actual source code changes (i.e. so users can test if needed). Add a job that detects changed files and whitelist the file types we care about.

Excuse the bit of testing to make sure this works.