### PR TITLE
osc.lua: fix calculation for slider's midpoint

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -818,7 +818,7 @@ function render_elements(master_ass)
                             elseif (sliderpos > (s_max - 3)) then
                                 an = an + 1
                             end
-                        elseif (sliderpos > (s_max-s_min)/2) then
+                        elseif (sliderpos > (s_max+s_min)/2) then
                             an = an + 1
                             tx = tx - 5
                         else


### PR DESCRIPTION
The midpoint of two numbers is given by their sum divided by two.

It's gone unnoticed because `s_min` is basically always zero. The only reason I noticed it is because I've been messing around with the slider's min and max values.