### PR TITLE
win32: pass window handle to the window-id property

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1868,6 +1868,12 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 
         return VO_TRUE;
     }
+    case VOCTRL_GET_WINDOW_ID: {
+        if (!w32->window)
+            return VO_NOTAVAIL;
+        *(int64_t *)arg = (int64_t)w32->window;
+        return VO_TRUE;
+    }
     case VOCTRL_GET_HIDPI_SCALE: {
         *(double *)arg = w32->dpi_scale;
         return VO_TRUE;


### PR DESCRIPTION
uses the same mechanic as for x11, see: https://github.com/mpv-player/mpv/commit/25b66256d7ff48254b2055a066e29f260414112f#

I've tested it with a basic cplugin, not a C expert, so I'm not sure on the memory stuff, does this cause a memory leak? afaik no, works fine though:
```
__declspec(dllexport) int mpv_open_cplugin(mpv_handle *handle)
{
    printf("Hello world from C plugin '%s'!\n", mpv_client_name(handle));
    int64_t *result = (int64_t *)malloc(sizeof(int64_t));
    if (mpv_get_property(handle, "window-id", MPV_FORMAT_INT64, &result) < 0)
        printf("Error getting property\n");
    else
        printf("result: %p\n", (void *)result);
        HWND hwnd = (HWND)result;
        printf("result: %p\n", hwnd);
        if (hwnd) {
            SetWindowLong(hwnd, GWL_EXSTYLE, GetWindowLong(hwnd, GWL_EXSTYLE) | WS_EX_LAYERED);
            SetLayeredWindowAttributes(hwnd, RGB(255, 255, 255), 128, LWA_ALPHA);
            printf("setting transparent\n");
    }
    return 0;
}
```