### PR TITLE
DOCS/options: add example for custom pitch correction filter

### DIFF
--- a/DOCS/man/af.rst
+++ b/DOCS/man/af.rst
@@ -179,7 +179,7 @@ Available filters are:
 
     ``max-speed=<speed>``
         Mute audio if the playback speed is above ``<speed>``
-        and ``<speed> != 0``. (default: 4.0)
+        and ``<speed> != 0``. (default: 8.0)
 
     ``search-interval=<amount>``
         Length in milliseconds to search for best overlap position. (default: 30)

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1848,8 +1848,22 @@ Audio
 
 ``--audio-pitch-correction=<yes|no>``
     If this is enabled (default), playing with a speed different from normal
-    automatically inserts the ``scaletempo2`` audio filter. For details, see
-    audio filter section.
+    automatically inserts the ``scaletempo2`` audio filter. You can insert
+    filters besides ``scaletempo2`` and modify their params using
+    `Conditional auto profiles`:
+
+    ::
+
+        [af_insert]
+        profile-cond=speed ~= 1
+        profile-restore=copy
+        af-add=scaletempo2=search-interval=50 # Insert filter and params here.
+
+    Filters set this way replace the ``scaletempo2`` default, instead of
+    overlapping with it. If there are multiple audio filters inserted that can do
+    pitch correction, then only the last one in the filter chain is used.
+    For details on the specifics of each available filter, see the audio filter
+    section.
 
 ``--audio-device=<name>``
     Use the given audio device. This consists of the audio output name, e.g.

--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -234,7 +234,7 @@ const struct mp_user_filter_entry af_scaletempo2 = {
         .priv_size = sizeof(OPT_BASE_STRUCT),
         .priv_defaults = &(const OPT_BASE_STRUCT) {
             .min_playback_rate = 0.25,
-            .max_playback_rate = 4.0,
+            .max_playback_rate = 8.0,
             .ola_window_size_ms = 20,
             .wsola_search_interval_ms = 30,
         },


### PR DESCRIPTION
Apparently this isn't so obvious. I would know.