### PR TITLE
demux: eagerly read subtitle streams when switching tracks while paused

### DIFF
--- a/demux/demux.h
+++ b/demux/demux.h
@@ -284,7 +284,7 @@ void demuxer_feed_caption(struct sh_stream *stream, demux_packet_t *dp);
 
 int demux_read_packet_async(struct sh_stream *sh, struct demux_packet **out_pkt);
 int demux_read_packet_async_until(struct sh_stream *sh, double min_pts,
-                                  struct demux_packet **out_pkt);
+                                  struct demux_packet **out_pkt, bool force_eager);
 bool demux_stream_is_selected(struct sh_stream *stream);
 void demux_set_stream_wakeup_cb(struct sh_stream *sh,
                                 void (*cb)(void *ctx), void *ctx);

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -294,7 +294,7 @@ bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force)
         double min_pts = sub->opts->sub_delay < 0 || force ? video_pts : MP_NOPTS_VALUE;
 
         struct demux_packet *pkt;
-        int st = demux_read_packet_async_until(sub->sh, min_pts, &pkt);
+        int st = demux_read_packet_async_until(sub->sh, min_pts, &pkt, force);
         // Note: "wait" (st==0) happens with non-interleaved streams only, and
         // then we should stop the playloop until a new enough packet has been
         // seen (or the subtitle decoder's queue is full). This usually does not


### PR DESCRIPTION
a323dfae426e43451f4d3e08a9a63cb7d1c1ace9 almost fixed subtitle tracks disappearing when paused but it actually missed one part: the behavior of demux_read_packet_async_until. It's a bit unintuitive, but for subtitle streams, that function would only return the very first packet regardless of whatever pts you pass to it. So the previous commit worked on the very first subtitle, but not actually any of the others (oops). This is because subtitle streams never marked as eager and thus never actually read farther ahead. While the video is playing, this is OK, but if we're paused and switching subtitle tracks then the stream should be eagerly read. Luckily, the logic is already there in the function for this. All we have to do add an extra argument to
demux_read_packet_async_until to force the stream to be read eagerly and then it just works. Actually fixes the bug for real this time.