### PR TITLE
vo: fully replace draw_image with draw_frame

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -968,11 +968,7 @@ static bool render_frame(struct vo *vo)
 
         stats_time_start(in->stats, "video-draw");
 
-        if (vo->driver->draw_frame) {
-            vo->driver->draw_frame(vo, frame);
-        } else {
-            vo->driver->draw_image(vo, mp_image_new_ref(frame->current));
-        }
+        vo->driver->draw_frame(vo, frame);
 
         stats_time_end(in->stats, "video-draw");
 
@@ -1065,14 +1061,7 @@ static void do_redraw(struct vo *vo)
     frame->duration = -1;
     pthread_mutex_unlock(&in->lock);
 
-    if (vo->driver->draw_frame) {
-        vo->driver->draw_frame(vo, frame);
-    } else if ((full_redraw || vo->driver->control(vo, VOCTRL_REDRAW_FRAME, NULL) < 1)
-               && frame->current)
-    {
-        vo->driver->draw_image(vo, mp_image_new_ref(frame->current));
-    }
-
+    vo->driver->draw_frame(vo, frame);
     vo->driver->flip_page(vo);
 
     if (frame != &dummy)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -78,11 +78,6 @@ enum mp_voctrl {
     /* private to vo_gpu */
     VOCTRL_LOAD_HWDEC_API,
 
-    // Redraw the image previously passed to draw_image() (basically, repeat
-    // the previous draw_image call). If this is handled, the OSD should also
-    // be updated and redrawn. Optional; emulated if not available.
-    VOCTRL_REDRAW_FRAME,
-
     // Only used internally in vo_libmpv
     VOCTRL_PREINIT,
     VOCTRL_UNINIT,
@@ -382,17 +377,6 @@ struct vo_driver {
      */
     struct mp_image *(*get_image_ts)(struct vo *vo, int imgfmt, int w, int h,
                                      int stride_align, int flags);
-
-    /*
-     * Render the given frame to the VO's backbuffer. This operation will be
-     * followed by a draw_osd and a flip_page[_timed] call.
-     * mpi belongs to the VO; the VO must free it eventually.
-     *
-     * This also should draw the OSD.
-     *
-     * Deprecated for draw_frame. A VO should have only either callback set.
-     */
-    void (*draw_image)(struct vo *vo, struct mp_image *mpi);
 
     /* Render the given frame. Note that this is also called when repeating
      * or redrawing frames.

--- a/video/out/vo_caca.c
+++ b/video/out/vo_caca.c
@@ -111,13 +111,15 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     return resize(vo);
 }
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *priv = vo->priv;
+    struct mp_image *mpi = frame->current;
+    if (!mpi)
+        return;
     memcpy_pic(priv->dither_buffer, mpi->planes[0], priv->image_width * depth, priv->image_height,
                priv->image_width * depth, mpi->stride[0]);
     caca_dither_bitmap(priv->canvas, 0, 0, priv->screen_w, priv->screen_h, priv->dither, priv->dither_buffer);
-    talloc_free(mpi);
 }
 
 static void flip_page(struct vo *vo)
@@ -305,7 +307,7 @@ const struct vo_driver video_out_caca = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .uninit = uninit,
     .priv_size = sizeof(struct priv),

--- a/video/out/vo_image.c
+++ b/video/out/vo_image.c
@@ -87,20 +87,19 @@ static bool checked_mkdir(struct vo *vo, const char *buf)
 
 static int reconfig(struct vo *vo, struct mp_image_params *params)
 {
-    struct priv *p = vo->priv;
-    mp_image_unrefp(&p->current);
-
     return 0;
 }
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *p = vo->priv;
+    if (!frame->current)
+        return;
 
-    p->current = mpi;
+    p->current = frame->current;
 
     struct mp_osd_res dim = osd_res_from_image_params(vo->params);
-    osd_draw_on_image(vo->osd, dim, mpi->pts, OSD_DRAW_SUB_ONLY, p->current);
+    osd_draw_on_image(vo->osd, dim, frame->current->pts, OSD_DRAW_SUB_ONLY, p->current);
 }
 
 static void flip_page(struct vo *vo)
@@ -122,7 +121,6 @@ static void flip_page(struct vo *vo)
     write_image(p->current, p->opts->opts, filename, vo->global, vo->log);
 
     talloc_free(t);
-    mp_image_unrefp(&p->current);
 }
 
 static int query_format(struct vo *vo, int fmt)
@@ -134,9 +132,6 @@ static int query_format(struct vo *vo, int fmt)
 
 static void uninit(struct vo *vo)
 {
-    struct priv *p = vo->priv;
-
-    mp_image_unrefp(&p->current);
 }
 
 static int preinit(struct vo *vo)
@@ -163,7 +158,7 @@ const struct vo_driver video_out_image =
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .uninit = uninit,
     .global_opts = &vo_image_conf,

--- a/video/out/vo_null.c
+++ b/video/out/vo_null.c
@@ -32,9 +32,8 @@ struct priv {
     double cfg_fps;
 };
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
-    talloc_free(mpi);
 }
 
 static void flip_page(struct vo *vo)
@@ -93,7 +92,7 @@ const struct vo_driver video_out_null = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .uninit = uninit,
     .priv_size = sizeof(struct priv),

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -869,7 +869,7 @@ static int query_format(struct vo *vo, int format)
     return 0;
 }
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *vc = vo->priv;
 
@@ -879,20 +879,16 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
 
     SDL_SetTextureBlendMode(vc->tex, SDL_BLENDMODE_NONE);
 
-    if (mpi) {
-        vc->osd_pts = mpi->pts;
+    if (frame->current) {
+        vc->osd_pts = frame->current->pts;
 
         mp_image_t texmpi;
-        if (!lock_texture(vo, &texmpi)) {
-            talloc_free(mpi);
+        if (!lock_texture(vo, &texmpi))
             return;
-        }
 
-        mp_image_copy(&texmpi, mpi);
+        mp_image_copy(&texmpi, frame->current);
 
         SDL_UnlockTexture(vc->tex);
-
-        talloc_free(mpi);
     }
 
     SDL_Rect src, dst;
@@ -940,9 +936,6 @@ static int control(struct vo *vo, uint32_t request, void *data)
         }
         return 1;
     }
-    case VOCTRL_REDRAW_FRAME:
-        draw_image(vo, NULL);
-        return 1;
     case VOCTRL_SET_PANSCAN:
         force_resize(vo);
         return VO_TRUE;
@@ -987,7 +980,7 @@ const struct vo_driver video_out_sdl = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .uninit = uninit,
     .flip_page = flip_page,
     .wait_events = wait_events,

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -242,13 +242,14 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     return 0;
 }
 
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *p = vo->priv;
-    struct mp_image src = *mpi;
+    struct mp_image *src = frame->current;
+    if (!src)
+        return;
     // XXX: pan, crop etc.
-    mp_sws_scale(p->sws, p->frame, &src);
-    talloc_free(mpi);
+    mp_sws_scale(p->sws, p->frame, src);
 }
 
 static void flip_page(struct vo *vo)
@@ -326,7 +327,7 @@ const struct vo_driver video_out_tct = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .uninit = uninit,
     .priv_size = sizeof(struct priv),

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -168,10 +168,6 @@ static void freeMyXImage(struct priv *p, int foo)
 
 static int reconfig(struct vo *vo, struct mp_image_params *fmt)
 {
-    struct priv *p = vo->priv;
-
-    mp_image_unrefp(&p->original_image);
-
     vo_x11_config_vo_window(vo);
 
     if (!resize(vo))
@@ -327,8 +323,7 @@ static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
         present_sync_get_info(x11->present, info);
 }
 
-// Note: REDRAW_FRAME can call this with NULL.
-static void draw_image(struct vo *vo, mp_image_t *mpi)
+static void draw_frame(struct vo *vo, struct vo_frame *frame)
 {
     struct priv *p = vo->priv;
 
@@ -339,29 +334,27 @@ static void draw_image(struct vo *vo, mp_image_t *mpi)
 
     struct mp_image *img = &p->mp_ximages[p->current_buf];
 
-    if (mpi) {
+    if (frame->current) {
         mp_image_clear_rc_inv(img, p->dst);
 
-        struct mp_image src = *mpi;
+        struct mp_image *src = frame->current;
         struct mp_rect src_rc = p->src;
-        src_rc.x0 = MP_ALIGN_DOWN(src_rc.x0, src.fmt.align_x);
-        src_rc.y0 = MP_ALIGN_DOWN(src_rc.y0, src.fmt.align_y);
-        mp_image_crop_rc(&src, src_rc);
+        src_rc.x0 = MP_ALIGN_DOWN(src_rc.x0, src->fmt.align_x);
+        src_rc.y0 = MP_ALIGN_DOWN(src_rc.y0, src->fmt.align_y);
+        mp_image_crop_rc(src, src_rc);
 
         struct mp_image dst = *img;
         mp_image_crop_rc(&dst, p->dst);
 
-        mp_sws_scale(p->sws, &dst, &src);
+        mp_sws_scale(p->sws, &dst, src);
     } else {
         mp_image_clear(img, 0, 0, img->w, img->h);
     }
 
-    osd_draw_on_image(vo->osd, p->osd, mpi ? mpi->pts : 0, 0, img);
+    osd_draw_on_image(vo->osd, p->osd, frame->current ? frame->current->pts : 0, 0, img);
 
-    if (mpi != p->original_image) {
-        talloc_free(p->original_image);
-        p->original_image = mpi;
-    }
+    if (frame->current != p->original_image)
+        p->original_image = frame->current;
 }
 
 static int query_format(struct vo *vo, int format)
@@ -381,8 +374,6 @@ static void uninit(struct vo *vo)
         freeMyXImage(p, 1);
     if (p->gc)
         XFreeGC(vo->x11->display, p->gc);
-
-    talloc_free(p->original_image);
 
     vo_x11_uninit(vo);
 }
@@ -424,15 +415,11 @@ error:
 
 static int control(struct vo *vo, uint32_t request, void *data)
 {
-    struct priv *p = vo->priv;
     switch (request) {
     case VOCTRL_SET_PANSCAN:
         if (vo->config_ok)
             resize(vo);
         return VO_TRUE;
-    case VOCTRL_REDRAW_FRAME:
-        draw_image(vo, p->original_image);
-        return true;
     }
 
     int events = 0;
@@ -451,7 +438,7 @@ const struct vo_driver video_out_x11 = {
     .query_format = query_format,
     .reconfig = reconfig,
     .control = control,
-    .draw_image = draw_image,
+    .draw_frame = draw_frame,
     .flip_page = flip_page,
     .get_vsync = get_vsync,
     .wakeup = vo_x11_wakeup,


### PR DESCRIPTION
0739cfc20934ac7772ab71dbae7ecba4ba10fda4 added the draw_frame API
deprecated draw_image internally. VOs that still used draw_image were
around, but really there's no reason to not just "upgrade" them anyway.
draw_frame is what the "real" VOs that people care about (gpu/gpu-next)
use. So we can just simplfy the code a bit now. VOCTRL_REDRAW_FRAME is
also no longer needed so that can be completely deleted as well. Note
that several of these VOs are legacy crap anyway (e.g. vaapi) and maybe
should just be deleted but whatever. vo_direct3d was also completely
untested (not that anyone should ever use it).
