### PR TITLE
restore-old-bindings.conf: remove unusable bindings

### DIFF
--- a/etc/restore-old-bindings.conf
+++ b/etc/restore-old-bindings.conf
@@ -18,16 +18,14 @@
 
 # changed in mpv 0.26.0
 
-h cycle tv-channel -1                  # previous channel
-k cycle tv-channel +1                  # next channel
-H cycle dvb-channel-name -1            # previous channel
-K cycle dvb-channel-name +1            # next channel
+H cycle dvbin-channel-switch-offset up
+K cycle dvbin-channel-switch-offset down
 
 I show-text "${filename}"              # display filename in osd
 
 # changed in mpv 0.24.0
 
-L cycle-values loop "inf" "no"
+L cycle-values loop-playlist "inf" "no"
 
 # changed in mpv 0.10.0
 
@@ -51,11 +49,6 @@ RIGHT seek  10
 LEFT  seek -10
 + add audio-delay 0.100
 - add audio-delay -0.100
-( add balance -0.1
-) add balance 0.1
 F cycle sub-forced-events-only
-TAB cycle program
-A cycle angle
 U stop
-o osd
-I show-text "${filename}"
+o cycle-values osd-level


### PR DESCRIPTION
Remove keybindings for properties that have been removed because they can no longer be used even if you restore them.

Fix the L keybinding: it was bound to cycle-values loop when loop was an alias for loop-playlist, but now it's an alias for loop-file.

"osd" was a command that cycles osd-level from 0 to 3.

Keep only the newest I show-text "${filename}" from mpv 0.26, the mpv 0.5 line for it is a mistake because it was bound to that in input.conf from a749c61437 (2012) until 2e84934be7 (2017), while mpv 0.5 is from 2014.