### PR TITLE
wayland_common: Don't double close file handle

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2539,10 +2539,8 @@ void vo_wayland_uninit(struct vo *vo)
     wl_list_for_each_safe(output, tmp, &wl->output_list, link)
         remove_output(output);
 
-    if (wl->display) {
-        close(wl_display_get_fd(wl->display));
+    if (wl->display)
         wl_display_disconnect(wl->display);
-    }
 
     munmap(wl->format_map, wl->format_size);
 


### PR DESCRIPTION
wl_display_disconnect closes the file handle, so remove the call which closes it immediately prior. This is an important fix when using libmpv as the second close can be on another newly opened file handle.
