### PR TITLE
Update ytdl_hook.lua: Fix yt-dlp's Incomplete data received error which is rather non-critical to catch

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -871,6 +871,10 @@ function run_ytdl_hook(url)
     elseif json then
         json, parse_err = utils.parse_json(json)
     end
+    
+    if result.status ~= 0 then
+        msg.error("result.status != 0 but JSON parsed successfully")
+    end
 
     if (json == nil) then
         msg.verbose("status:", result.status)

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -874,6 +874,10 @@ function run_ytdl_hook(url)
     
     if result.status ~= 0 then
         msg.error("result.status != 0 but JSON parsed successfully")
+        msg.verbose("status:", result.status)
+        msg.verbose("reason:", result.error_string)
+        msg.verbose("stdout:", result.stdout)
+        msg.verbose("stderr:", result.stderr)
     end
 
     if (json == nil) then

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -872,8 +872,9 @@ function run_ytdl_hook(url)
         json, parse_err = utils.parse_json(json)
     end
     
-    if result.status ~= 0 then
-        msg.error("result.status != 0 but JSON parsed successfully")
+    if result.status ~= 0 and json then
+        msg.warn("exit status isn't zero but the JSON still parsed successfully")
+        msg.warn(result.stderr:match("^%s*(.*)%s*$"))
         msg.verbose("status:", result.status)
         msg.verbose("reason:", result.error_string)
         msg.verbose("stdout:", result.stdout)

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -866,7 +866,7 @@ function run_ytdl_hook(url)
     local json = result.stdout
     local parse_err = nil
 
-    if result.status ~= 0 or json == "" then
+    if json == "" then
         json = nil
     elseif json then
         json, parse_err = utils.parse_json(json)


### PR DESCRIPTION
Because `Incomplete data received` isn't critical, should only check if json is blank.

Currently if you open a playlist with MPV, it's throwing this error:
```
mpv https://www.youtube.com/playlist?list=PLVM1qRtVEeErISdPLpYEc53XEHU5m34cl
[ytdl_hook] ERROR: Incomplete data received
[ytdl_hook] youtube-dl failed: unexpected error occurred
Failed to recognize file format.
```

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.