### PR TITLE
Add NV16 support for drmprime hwdec

### DIFF
--- a/video/out/hwdec/dmabuf_interop_gl.c
+++ b/video/out/hwdec/dmabuf_interop_gl.c
@@ -176,6 +176,7 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper,
         if (p_mapper->desc.layers[i].nb_planes > 1) {
             switch (p_mapper->desc.layers[i].format) {
             case DRM_FORMAT_NV12:
+            case DRM_FORMAT_NV16:
                 format[0] = DRM_FORMAT_R8;
                 format[1] = DRM_FORMAT_GR88;
                 break;

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -29,6 +29,7 @@
 
 #include "libmpv/render_gl.h"
 #include "options/m_config.h"
+#include "video/fmt-conversion.h"
 #include "video/out/drm_common.h"
 #include "video/out/gpu/hwdec.h"
 #include "video/out/hwdec/dmabuf_interop.h"
@@ -117,6 +118,7 @@ static int init(struct ra_hwdec *hw)
     int num_formats = 0;
     MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_NV12);
     MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_420P);
+    MP_TARRAY_APPEND(p, p->formats, num_formats, pixfmt2imgfmt(AV_PIX_FMT_NV16));
     MP_TARRAY_APPEND(p, p->formats, num_formats, 0); // terminate it
 
     p->hwctx.hw_imgfmt = IMGFMT_DRMPRIME;


### PR DESCRIPTION
NV16 is the half subsampled version of NV12 format where  it is quarter subsampled.

Decoders which support High 4:2:2 profile of h264, provide the frames in NV16 format to establish richer colorspace.
Similar profiles are also available in HEVC and other popular codecs. This patch allows NV16 frames to be displayed over drmprime layers.

Tested to be working with https://github.com/jernejsk/ffmpeg/tree/v4l2-request-n6.0
You can use High422 Profile h264 file to verify.
Here are some samples:
http://videos.hd-trailers.net/TheLastWitchHunter_TRLR1-1080p-HDTN.mp4
http://videos.hd-trailers.net/Poltergeist_DOM_TrailerD-1080p-HDTN.mp4

if someone else wants to double check. 