### PR TITLE
vo_gpu_next: improve updating overlays

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6919,8 +6919,6 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
             }
         }
         osd_changed(mpctx->osd);
-        if (mpctx->video_out)
-            vo_control_async(mpctx->video_out, VOCTRL_OSD_CHANGED, NULL);
         if (flags & (UPDATE_SUB_FILT | UPDATE_SUB_HARD))
             mp_force_video_refresh(mpctx);
         mp_wakeup_core(mpctx);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -683,7 +683,6 @@ void vo_control_async(struct vo *vo, int request, void *data)
         break;
     case VOCTRL_KILL_SCREENSAVER:
     case VOCTRL_RESTORE_SCREENSAVER:
-    case VOCTRL_OSD_CHANGED:
         break;
     default:
         abort(); // requires explicit support

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -72,9 +72,6 @@ enum mp_voctrl {
     // you could install your own listener.
     VOCTRL_VO_OPTS_CHANGED,
 
-    // Triggered by any change to the OSD (e.g. OSD style changes)
-    VOCTRL_OSD_CHANGED,
-
     /* private to vo_gpu */
     VOCTRL_LOAD_HWDEC_API,
 


### PR DESCRIPTION
fbe154831a8addfc18a4f81e1c4b9284c31acace added a new VOCTRL to signal when the OSD changed for gpu-next's handling of subtitles, but this is both not necessary and actually incomplete. The VOCTRL would signal OSD changes, but not all subtitle changes (like selecting another non-external sub track for example). VOCTRL_OSD_CHANGED was used to increment p->osd_sync which would then redraw the blended subtitles if the player was paused.

But there's already a VOCTRL_PAUSE and VOCTRL_RESUME. Plus, the sub_bitmap_list object will have items in it if it changed in any way, so we don't need the VOCTRL_OSD_CHANGED method at all. That can be removed.

The check that fp->osd_sync < p->osd_sync stays in place since that's an optimization while the video is playing, but we also check the pause state as well since the VO can know this. If we're paused, then always do update_overlays since core must be signalling a redraw to us if we get a draw_frame call here. Additionally in update_overlays itself, the p->osd_sync counter is incremented if we have any items since the frame signature will need that. As for the actual bug that is fixed, changing subtitle tracks while paused with blended subtitles now correctly works. Previously, it was never updated so the old subtitle stayed there forever until you deselected it (since VOCTRL_OSD_CHANGED triggered there).

Also include some cosmetic code fixes that were noticed.