### PR TITLE
demux: fix erroneous condition in lazy_stream_needs_wait

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2153,7 +2153,7 @@ static bool lazy_stream_needs_wait(struct demux_stream *ds)
     struct demux_internal *in = ds->in;
     // Attempt to read until force_read_until was reached, or reading has
     // stopped for some reason (true EOF, queue overflow).
-    return !ds->eager && !ds->reader_head && !in->back_demuxing &&
+    return !ds->eager && !in->back_demuxing &&
            !in->eof && ds->force_read_until != MP_NOPTS_VALUE &&
            (in->demux_ts == MP_NOPTS_VALUE ||
             in->demux_ts <= ds->force_read_until);


### PR DESCRIPTION
Yeah another try at this. So when inspecting lazy_stream_needs_wait, I realized it had a curious !ds->reader_head condition. Actually, this is what is messing everything up. This was originally added in cf2b7a4997299ff9e0ff91d4273cd294686b001f for showing large negative sub delay values correctly. It worked because the packet will eventually be discarded during playback causing ds->reader_head not exist and thus the next one will correctly be read ahead as needed.

But for the "switching subtitle tracks while paused" case, this is actually bad. As the stream is read, eventually you'll find a packet and set the reader_head. But it's not going to be the correct packet (unless you're looking for the very first one), so you need to read more. This won't happen because of the !ds->reader_head check and unlike the sub delay case, nothing will eventually discard that packet since playback isn't occuring. So read_packet exits earlier than it should and isn't tried again, so the subtitle that you want won't show since the returned packet has the wrong pts. All that needs to be done here is to delete this one condition. There's already checks in place to make sure that it's not read past the desired timestamp and for the sub delay case (the only other time this logic is used), it makes no difference since you won't read past the specified pts in the first place.

Hopefully I don't break something again...