### PR TITLE
external_files: base cover-art-whitelist on cover-art-auto-exts

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7218,9 +7218,10 @@ Miscellaneous
     This is a string list option. See `List Options`_ for details.
 
 ``--cover-art-whitelist=<no|yes>``
-    Whether to load filenames in an internal whitelist, such as ``cover.jpg``,
-    as cover art. If ``cover-art-auto`` is set to ``no``, the whitelisted
-    filenames are never loaded even if this option is set to ``yes``.
+    Whether to load files with a filename among "AlbumArt", "Album", "cover",
+    "front", "AlbumArtSmall", "Folder", ".folder", "thumb", "front", and an
+    extension in ``--cover-art-auto-exts``, as cover art. This has no effect is
+    ``cover-art-auto`` is ``no``.
 
     Default: ``yes``.
 

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -35,46 +35,15 @@
 // Stolen from: vlc/-/blob/master/modules/meta_engine/folder.c#L40
 // sorted by priority (descending)
 static const char *const cover_files[] = {
-    "AlbumArt.jpg",
-    "AlbumArt.webp",
-    "AlbumArt.jxl",
-    "AlbumArt.avif",
-    "Album.jpg",
-    "Album.webp",
-    "Album.jxl",
-    "Album.avif",
-    "cover.jpg",
-    "cover.png",
-    "cover.webp",
-    "cover.jxl",
-    "cover.avif",
-    "front.jpg",
-    "front.png",
-    "front.webp",
-    "front.jxl",
-    "front.avif",
-
-    "AlbumArtSmall.jpg",
-    "AlbumArtSmall.webp",
-    "AlbumArtSmall.jxl",
-    "AlbumArtSmall.avif",
-    "Folder.jpg",
-    "Folder.png",
-    "Folder.webp",
-    "Folder.jxl",
-    "Folder.avif",
-    ".folder.png",
-    ".folder.webp",
-    ".folder.jxl",
-    ".folder.avif",
-    "thumb.jpg",
-    "thumb.webp",
-    "thumb.jxl",
-    "thumb.avif",
-
-    "front.bmp",
-    "front.gif",
-    "cover.gif",
+    "AlbumArt",
+    "Album",
+    "cover",
+    "front",
+    "AlbumArtSmall",
+    "Folder",
+    ".folder",
+    "thumb",
+    "front",
     NULL
 };
 
@@ -267,7 +236,7 @@ static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
             prio |= 2; // contains the movie name
 
         if (type == STREAM_VIDEO && opts->coverart_whitelist && prio == 0)
-            prio = test_cover_filename(dename);
+            prio = test_cover_filename(tmp_fname_trim);
 
         // doesn't contain the movie name
         // don't try in the mplayer subtitle directory


### PR DESCRIPTION
Combine the cover art whitelist with the extensions in --cover-art-auto-exts instead of hardcoding them. This is shorter, checks for more extensions, saves us from updating the whitelist everytime we add a new image extension, and since the whitelist had gotten so big and the priority is calculated as
MP_ARRAY_SIZE(cover_files) - n, files like cover.jpg were taking priority over cover art loaded by --cover-art-auto=exact.