### PR TITLE
codepage improvements

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -97,6 +97,7 @@ Interface changes
     - add `--window-affinity` option
     - `--config-dir` no longer forces cache and state files to also reside in there
     - deprecate `--demuxer-cue-codepage` in favor of `--metadata-codepage`
+    - change the default of `metadata-codepage` to `auto`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -96,6 +96,7 @@ Interface changes
     - add `--backdrop-type` option
     - add `--window-affinity` option
     - `--config-dir` no longer forces cache and state files to also reside in there
+    - deprecate `--demuxer-cue-codepage` in favor of `--metadata-codepage`
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7315,10 +7315,9 @@ Miscellaneous
     filters.
 
 ``--metadata-codepage=<codepage>``
-    Codepage for various input metadata (default: ``utf-8``). This affects how
-    file tags, chapter titles, etc. are interpreted. You can for example set
-    this to ``auto`` to enable autodetection of the codepage. (This is not the
-    default because non-UTF-8 codepages are an obscure fringe use-case.)
+    Codepage for various input metadata (default: ``auto``). This affects how
+    file tags, chapter titles, etc. are interpreted. In most cases, this merely
+    evaluates to UTF-8 as non-UTF-8 codepages are obscure.
 
     See ``--sub-codepage`` option on how codepages are specified and further
     details regarding autodetection and codepage conversion. (The underlying

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3792,9 +3792,6 @@ Demuxer
 ``--demuxer-rawvideo-size=<value>``
     Frame size in bytes when using ``--demuxer=rawvideo``.
 
-``--demuxer-cue-codepage=<codepage>``
-    Specify the CUE sheet codepage. (See ``--sub-codepage`` for details.)
-
 ``--demuxer-max-bytes=<bytesize>``
     This controls how much the demuxer is allowed to buffer ahead. The demuxer
     will normally try to read ahead as much as necessary, or as much is

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2629,9 +2629,6 @@ Subtitles
     subtitles are interpreted as UTF-8 with "Latin 1" as fallback for bytes
     which are not valid UTF-8 sequences. iconv is never involved in this mode.
 
-    This option changed in mpv 0.23.0. Support for the old syntax was fully
-    removed in mpv 0.24.0.
-
     .. note::
 
         This works for text subtitle files only. Other types of subtitles (in

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -142,7 +142,7 @@ const struct m_sub_options demux_conf = {
             [STREAM_VIDEO] = 1,
             [STREAM_AUDIO] = 10,
         },
-        .meta_cp = "utf-8",
+        .meta_cp = "auto",
     },
     .get_sub_options = get_demux_sub_opts,
 };

--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -101,18 +101,6 @@ static const char *mp_uchardet(void *talloc_ctx, struct mp_log *log, bstr buf)
 const char *mp_charset_guess(void *talloc_ctx, struct mp_log *log,  bstr buf,
                              const char *user_cp, int flags)
 {
-    if (strcasecmp(user_cp, "enca") == 0 || strcasecmp(user_cp, "guess") == 0 ||
-        strcasecmp(user_cp, "uchardet") == 0 || strchr(user_cp, ':'))
-    {
-        mp_err(log, "This syntax for the --sub-codepage option was deprecated "
-                    "and has been removed.\n");
-        if (strncasecmp(user_cp, "utf8:", 5) == 0) {
-            user_cp = user_cp + 5;
-        } else {
-            user_cp = "";
-        }
-    }
-
     if (user_cp[0] == '+') {
         mp_verbose(log, "Forcing charset '%s'.\n", user_cp + 1);
         return user_cp + 1;

--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -114,7 +114,8 @@ const char *mp_charset_guess(void *talloc_ctx, struct mp_log *log,  bstr buf,
 
     int r = bstr_validate_utf8(buf);
     if (r >= 0 || (r > -8 && (flags & MP_ICONV_ALLOW_CUTOFF))) {
-        mp_verbose(log, "Data looks like UTF-8, ignoring user-provided charset.\n");
+        if (strcmp(user_cp, "auto") != 0 && !mp_charset_is_utf8(user_cp))
+            mp_verbose(log, "Data looks like UTF-8, ignoring user-provided charset.\n");
         return "utf-8";
     }
 


### PR DESCRIPTION
1. Use `--metadata-codepage` in stream_lavf.
2. Remove ancient crap.
3. Make demux_cue use `--metadata-codepage` instead of its own duplicate option.
4. Set the default of `--metadata-codepage` to `auto`.