### PR TITLE
meson: declare libmpv as a dependency and override it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1740,6 +1740,10 @@ if get_option('libmpv')
     headers = ['libmpv/client.h', 'libmpv/render.h',
                'libmpv/render_gl.h', 'libmpv/stream_cb.h']
     install_headers(headers, subdir: 'mpv')
+
+    # Allow projects to build with libmpv by cloning into ./subprojects/mpv
+    libmpv_dep = declare_dependency(link_with: libmpv)
+    meson.override_dependency('mpv', libmpv_dep)
 endif
 
 if get_option('cplayer')


### PR DESCRIPTION
This allows libmpv users to build it as a subproject easily, i.e. meson setup build --force-fallback-for=mpv -Dmpv:libmpv=true, if the mpv source is in the subprojects directory. Mainly useful for development.

For an easy test, take this meson.build file and drop in the mpv-examples [simple](https://github.com/mpv-player/mpv-examples/tree/master/libmpv/simple) directory.
```
project('simple', 'c')
mpv = executable('simple', 'simple.c', dependencies: dependency('mpv'))
```
Place the mpv source directory within a subprojects folder in simple however you like (symlink or just a copy). If you do: `meson setup build --force-fallback-for=mpv -Dmpv:libmpv=true`, the subproject fallback will work with this branch but not on master.