### PR TITLE
video: Added key conversion from other layouts to english one

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3388,6 +3388,15 @@ static struct demuxer *demux_open(struct stream *stream,
     struct demuxer *demuxer = NULL;
     char *force_format = params ? params->force_format : NULL;
 
+    struct parent_stream_info sinfo = {
+        .seekable = stream->seekable,
+        .is_network = stream->is_network,
+        .is_streaming = stream->streaming,
+        .stream_origin = stream->stream_origin,
+        .cancel = cancel,
+        .filename = talloc_strdup(NULL, stream->url),
+    };
+
     if (!force_format)
         force_format = stream->demuxer;
 
@@ -3408,15 +3417,6 @@ static struct demuxer *demux_open(struct stream *stream,
             goto done;
         }
     }
-
-    struct parent_stream_info sinfo = {
-        .seekable = stream->seekable,
-        .is_network = stream->is_network,
-        .is_streaming = stream->streaming,
-        .stream_origin = stream->stream_origin,
-        .cancel = cancel,
-        .filename = talloc_strdup(NULL, stream->url),
-    };
 
     // Test demuxers from first to last, one pass for each check_levels[] entry
     for (int pass = 0; check_levels[pass] != -1; pass++) {

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -376,6 +376,14 @@ static int decode_key(struct vo_w32_state *w32, UINT vkey, UINT scancode)
     }
 
     int c = to_unicode(vkey, scancode, keys);
+    // Find utf-16 key value despite user's layout (only for english letters)
+    if ((vkey >= 65 && vkey <= 90) || (vkey >= 97 && vkey <= 122))
+    {
+        if ((keys[VK_SHIFT] & 0x80) || ((keys[VK_CAPITAL] & 0x01) && !(keys[VK_SHIFT] & 0x80)))
+            c = vkey;
+        else
+            c = vkey + 32;
+    }
 
     // Some shift states prevent ToUnicode from working or cause it to produce
     // control characters. If this is detected, remove modifiers until it


### PR DESCRIPTION
Fixed the bug, described in issue #45. 
Bug: if you have a non-english layout (like Armenian, Arabic or etc.), your key bindings don't work. 
I tested this using 3 layouts (Armenian, Arabic and Russian), and it works well. However, it works only with keys related to English alphabet (lower and upper cases). 