### PR TITLE
TOOLS/lua/autoload: bump the msg-level of some logging

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -215,10 +215,10 @@ function find_and_add_entries()
     local dir, filename = utils.split_path(path)
     msg.trace(("dir: %s, filename: %s"):format(dir, filename))
     if o.disabled then
-        msg.verbose("stopping: autoload disabled")
+        msg.debug("stopping: autoload disabled")
         return
     elseif #dir == 0 then
-        msg.verbose("stopping: not a local path")
+        msg.debug("stopping: not a local path")
         return
     end
 
@@ -227,7 +227,7 @@ function find_and_add_entries()
     -- check if this is a manually made playlist
     if (pl_count > 1 and autoloaded == nil) or
        (pl_count == 1 and EXTENSIONS[string.lower(this_ext)] == nil) then
-        msg.verbose("stopping: manually made playlist")
+        msg.debug("stopping: manually made playlist")
         return
     else
         if pl_count == 1 then
@@ -263,7 +263,7 @@ function find_and_add_entries()
     end
 
     if next(files) == nil then
-        msg.verbose("no other files or directories in directory")
+        msg.debug("no other files or directories in directory")
         return
     end
 
@@ -298,10 +298,10 @@ function find_and_add_entries()
             -- skip files that are/were already in the playlist
             if not added_entries[file] then
                 if direction == -1 then
-                    msg.info("Prepending " .. file)
+                    msg.verbose("Prepending " .. file)
                     table.insert(append[-1], 1, {file, pl_current + i * direction + 1})
                 else
-                    msg.info("Adding " .. file)
+                    msg.verbose("Adding " .. file)
                     if pl_count > 1 then
                         table.insert(append[1], {file, pl_current + i * direction - 1})
                     else


### PR DESCRIPTION
msg.info for when you're potentially adding hundreds of files is way too spammy and not really useful (autoload loads files, what?). Bump it up to msg.verbose. Also bump up the previously existing msg.verbose logs up to msg.debug to keep the difference in log levels. Fixes #12551.