### PR TITLE
vo_dmabuf_wayland: correct full window size calculation

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -526,7 +526,9 @@ static void resize(struct vo *vo)
     vo->opts->pan_x = 0;
     vo->opts->pan_y = 0;
     vo_get_src_dst_rects(vo, &src, &dst, &p->screen_osd_res);
-    wp_viewport_set_destination(wl->viewport, 2 * dst.x0 + mp_rect_w(dst), 2 * dst.y0 + mp_rect_h(dst));
+    int window_w = p->screen_osd_res.ml + p->screen_osd_res.mr + mp_rect_w(dst);
+    int window_h = p->screen_osd_res.mt + p->screen_osd_res.mb + mp_rect_h(dst);
+    wp_viewport_set_destination(wl->viewport, window_w, window_h);
 
     //now we restore pan for video viewport calculation
     vo->opts->pan_x = vo_opts->pan_x;


### PR DESCRIPTION
The current calculation makes the implicit assumption that the margins on both sides are always equal (the 2 times multiplication). This isn't true though. For example, a 720p video fullscreened on a 1680x1050 display will have a top margin of 52 but a bottom margin of 53. The current calculation just multiplies 52 by 2, so it's off by one. Fix this by adding together all the margins together (left + right or top + bottom) then adding that to the dst window size (width or height). This way, we get the full size of the window for the viewport. Fixes #12554.