### PR TITLE
external_files: remove duplicate from cover art whitelist

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7222,8 +7222,8 @@ Miscellaneous
 
 ``--cover-art-whitelist=<no|yes>``
     Whether to load files with a filename among "AlbumArt", "Album", "cover",
-    "front", "AlbumArtSmall", "Folder", ".folder", "thumb", "front", and an
-    extension in ``--cover-art-auto-exts``, as cover art. This has no effect is
+    "front", "AlbumArtSmall", "Folder", ".folder", "thumb", and an extension in
+    ``--cover-art-auto-exts``, as cover art. This has no effect if
     ``cover-art-auto`` is ``no``.
 
     Default: ``yes``.

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -43,7 +43,6 @@ static const char *const cover_files[] = {
     "Folder",
     ".folder",
     "thumb",
-    "front",
     NULL
 };
 


### PR DESCRIPTION
I made a mistake in 0070a5820e here because there were 2 separate groups of "front" filenames.