### PR TITLE
demux_lavf: clear original metadata after copying

### DIFF
--- a/common/tags.c
+++ b/common/tags.c
@@ -142,3 +142,10 @@ void mp_tags_copy_from_av_dictionary(struct mp_tags *tags,
     while ((entry = av_dict_get(av_dict, "", entry, AV_DICT_IGNORE_SUFFIX)))
         mp_tags_set_str(tags, entry->key, entry->value);
 }
+
+void mp_tags_move_from_av_dictionary(struct mp_tags *tags,
+                                     struct AVDictionary **av_dict_ptr)
+{
+    mp_tags_copy_from_av_dictionary(tags, *av_dict_ptr);
+    av_dict_free(av_dict_ptr);
+}

--- a/common/tags.h
+++ b/common/tags.h
@@ -25,5 +25,7 @@ void mp_tags_merge(struct mp_tags *tags, struct mp_tags *src);
 struct AVDictionary;
 void mp_tags_copy_from_av_dictionary(struct mp_tags *tags,
                                      struct AVDictionary *av_dict);
+void mp_tags_move_from_av_dictionary(struct mp_tags *tags,
+                                     struct AVDictionary **av_dict_ptr);
 
 #endif


### PR DESCRIPTION
This ensures that when lavf appends metadata
that occurs later in the stream,
it starts from empty each time.

Fixes: <https://github.com/mpv-player/mpv/issues/12559>
