### PR TITLE
win32: clear client area to black early

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1141,8 +1141,10 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
     }
 
     switch (message) {
-    case WM_ERASEBKGND: // no need to erase background separately
-        return 1;
+    case WM_ERASEBKGND:
+        if (!w32->parent && (!w32->opts->border || w32->current_fs))
+            return TRUE;
+        break;
     case WM_PAINT:
         signal_events(w32, VO_EVENT_EXPOSE);
         break;
@@ -1446,6 +1448,7 @@ static void register_window_class(void)
         .hInstance = HINST_THISCOMPONENT,
         .hIcon = LoadIconW(HINST_THISCOMPONENT, L"IDI_ICON1"),
         .hCursor = LoadCursor(NULL, IDC_ARROW),
+        .hbrBackground = (HBRUSH) GetStockObject(BLACK_BRUSH),
         .lpszClassName = L"mpv",
     });
 }


### PR DESCRIPTION
This fixes white background appearing for short period of time before first frame is drawn. Clear to black as this is way less distracting than bright white flash.

Borderless window and fullscreen seems to be initially not drawn/transparent, so no need to clear it to black. Only when decorations are enabled (--border) the issue happens.

Fixes: #12549