### PR TITLE
meson: generate .com in the same place as the .exe if possible

### DIFF
--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -280,7 +280,7 @@ meson compile -C $build
 if [ "$2" = pack ]; then
     mkdir -p artifact/tmp
     echo "Copying:"
-    cp -pv $build/player/mpv.com $build/mpv.exe artifact/
+    cp -pv $build/mpv.com $build/mpv.exe artifact/
     # copy everything we can get our hands on
     cp -p "$prefix_dir/bin/"*.dll artifact/tmp/
     shopt -s nullglob

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -35,5 +35,4 @@ meson setup build            \
   -D uchardet=enabled        \
   -D vapoursynth=enabled
 meson compile -C build
-cp ./build/player/mpv.com ./build
 ./build/mpv.com -v --no-config

--- a/meson.build
+++ b/meson.build
@@ -1686,6 +1686,13 @@ features += {'libmpv-' + get_option('default_library'): get_option('libmpv')}
 
 # build targets
 if win32
+    # Older meson versions generate this in the player subdirectory.
+    if get_option('cplayer') and meson.version().version_compare('>= 1.3.0')
+        wrapper_sources= 'osdep/win32-console-wrapper.c'
+        executable('mpv', wrapper_sources, c_args: '-municode', link_args: '-municode',
+                   name_suffix: 'com', install: true)
+    endif
+
     windows = import('windows')
     res_flags = ['--codepage=65001']
 

--- a/player/meson.build
+++ b/player/meson.build
@@ -1,10 +1,11 @@
 subdir('javascript')
 subdir('lua')
 
-# Meson doesn't allow having multiple build targets with the same name in the same file.
-# Just generate the com in here for windows builds.
-if win32 and get_option('cplayer')
+# Older versions of meson don't allow multiple build targets with the same name in the same
+# file. Generate it here for compatibility reasons for windows.
+if win32 and get_option('cplayer') and meson.version().version_compare('< 1.3.0')
     wrapper_sources= '../osdep/win32-console-wrapper.c'
     executable('mpv', wrapper_sources, c_args: '-municode', link_args: '-municode',
                name_suffix: 'com', install: true)
+    warning('mpv.com executable will be generated in the player subdirectory.')
 endif


### PR DESCRIPTION
This always bothered me, but it will finally be possible to do this in the next meson version. So this is blocked until 1.3.0 comes out and mingw updates to it. Leaving it here so I don't forget about it later.