### PR TITLE
ta: remove MPV_LEAK_REPORT

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1535,13 +1535,6 @@ behavior of mpv.
     This is an integer, and the resulting verbosity corresponds to the number
     of ``--v`` options passed to the command line.
 
-``MPV_LEAK_REPORT``
-    If set to ``1``, enable internal talloc leak reporting. If set to another
-    value, disable leak reporting. If unset, use the default, which normally is
-    ``0``. If mpv was built with ``--enable-ta-leak-report``, the default is
-    ``1``. If leak reporting was disabled at compile time (``NDEBUG`` in
-    custom ``CFLAGS``), this environment variable is ignored.
-
 ``LADSPA_PATH``
     Specifies the search path for LADSPA plugins. If it is unset, fully
     qualified path names must be used.

--- a/DOCS/tech-overview.txt
+++ b/DOCS/tech-overview.txt
@@ -64,13 +64,6 @@ ta.h & ta.c:
     least talloc_steal()). A talloc allocation that is used as parent is often
     called a talloc context.
 
-    One very useful feature of talloc is fast tracking of memory leaks. ("Fast"
-    as in it doesn't require valgrind.) You can enable it by setting the
-    MPV_LEAK_REPORT environment variable to "1":
-        export MPV_LEAK_REPORT=1
-    Or permanently by building with --enable-ta-leak-report.
-    This will list all unfree'd allocations on exit.
-
     Documentation can be found here:
         http://git.samba.org/?p=samba.git;a=blob;f=lib/talloc/talloc.h;hb=HEAD
 

--- a/meson.build
+++ b/meson.build
@@ -351,8 +351,6 @@ if not features['build-date']
     flags += '-DNO_BUILD_TIMESTAMPS'
 endif
 
-features += {'ta-leak-report': get_option('ta-leak-report')}
-
 libdl = dependency('dl', required: false)
 features += {'libdl': libdl.found()}
 if features['libdl']

--- a/meson.options
+++ b/meson.options
@@ -5,9 +5,6 @@ option('libmpv', type: 'boolean', value: false, description: 'libmpv library')
 option('build-date', type: 'boolean', value: true, description: 'include compile timestamp in binary')
 option('tests', type: 'boolean', value: false, description: 'meson unit tests')
 option('fuzzers', type: 'boolean', value: false, description: 'fuzzer binaries')
-# Reminder: normally always built, but enabled by MPV_LEAK_REPORT.
-# Building it can be disabled only by defining NDEBUG through CFLAGS.
-option('ta-leak-report', type: 'boolean', value: false, description: 'enable ta leak report by default (development only)')
 
 # misc features
 option('cdda', type: 'feature', value: 'disabled', description: 'cdda support (libcdio)')

--- a/player/main.c
+++ b/player/main.c
@@ -258,12 +258,6 @@ struct MPContext *mp_create(void)
         return NULL;
     }
 
-    char *enable_talloc = getenv("MPV_LEAK_REPORT");
-    if (!enable_talloc)
-        enable_talloc = HAVE_TA_LEAK_REPORT ? "1" : "0";
-    if (strcmp(enable_talloc, "1") == 0)
-        talloc_enable_leak_report();
-
     mp_time_init();
     mp_rand_seed(0);
 

--- a/ta/ta.h
+++ b/ta/ta.h
@@ -177,7 +177,6 @@ static inline char *ta_oom_s(char *s)
 // Generic pointer
 #define ta_oom_g(ptr) (TA_TYPEOF(ptr))ta_oom_p(ptr)
 
-void ta_enable_leak_report(void);
 void *ta_dbg_set_loc(void *ptr, const char *name);
 void *ta_dbg_mark_as_string(void *ptr);
 

--- a/ta/ta_talloc.h
+++ b/ta/ta_talloc.h
@@ -38,7 +38,6 @@
 #define talloc_realloc_size             ta_xrealloc_size
 #define talloc_new                      ta_xnew_context
 #define talloc_set_destructor           ta_set_destructor
-#define talloc_enable_leak_report       ta_enable_leak_report
 #define talloc_size                     ta_xalloc_size
 #define talloc_zero_size                ta_xzalloc_size
 #define talloc_get_size                 ta_get_size


### PR DESCRIPTION
The ta code had some basic leak checking/reporting. This was always mainly for development usage, but it's pretty obsolete. Nowadays with a couple of meson flags, you can enable ASAN which is much smarter and will catch everything (not just stuff allocated with talloc). There's really no reason to keep supporting this so cut the bloat.