### PR TITLE
sd_ass: enable sub-start and sub-end with unknown duration subs

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -748,7 +748,7 @@ static struct sd_times get_times(struct sd *sd, double pts)
     ASS_Track *track = ctx->ass_track;
     struct sd_times res = { .start = MP_NOPTS_VALUE, .end = MP_NOPTS_VALUE };
 
-    if (pts == MP_NOPTS_VALUE || ctx->duration_unknown)
+    if (pts == MP_NOPTS_VALUE)
         return res;
 
     long long ipts = find_timestamp(sd, pts);


### PR DESCRIPTION
The function called to get sub-start and sub-end returns early when the subtitle's duration is unknown, but by just removing this check the properties work fine. The final sub line has a very large sub-end, but that is much better than not having the properties work at all.