### PR TITLE
Revert "video: remove another redundant wakeup"

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -1160,10 +1160,8 @@ void write_video(struct MPContext *mpctx)
     struct mp_image_params *p = &mpctx->next_frames[0]->params;
     if (!vo->params || !mp_image_params_equal(p, vo->params)) {
         // Changing config deletes the current frame; wait until it's finished.
-        if (vo_still_displaying(vo)) {
-            vo_request_wakeup_on_done(vo);
+        if (vo_still_displaying(vo))
             return;
-        }
 
         const struct vo_driver *info = mpctx->video_out->driver;
         char extra[20] = {0};

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1182,16 +1182,9 @@ void vo_seek_reset(struct vo *vo)
 bool vo_still_displaying(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
-    pthread_mutex_lock(&vo->in->lock);
-    int64_t now = mp_time_us();
-    int64_t frame_end = 0;
-    if (in->current_frame) {
-        frame_end = in->current_frame->pts + MPMAX(in->current_frame->duration, 0);
-        if (in->current_frame->display_synced)
-            frame_end = in->current_frame->num_vsyncs > 0 ? INT64_MAX : 0;
-    }
-    bool working = now < frame_end || in->rendering || in->frame_queued;
-    pthread_mutex_unlock(&vo->in->lock);
+    pthread_mutex_lock(&in->lock);
+    bool working = in->rendering || in->frame_queued;
+    pthread_mutex_unlock(&in->lock);
     return working && in->hasframe;
 }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -495,7 +495,6 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts);
 void vo_queue_frame(struct vo *vo, struct vo_frame *frame);
 void vo_wait_frame(struct vo *vo);
 bool vo_still_displaying(struct vo *vo);
-void vo_request_wakeup_on_done(struct vo *vo);
 bool vo_has_frame(struct vo *vo);
 void vo_redraw(struct vo *vo);
 bool vo_want_redraw(struct vo *vo);


### PR DESCRIPTION
vo_still_displaying() is racey with vo_request_wakeup_on_done() and above that it doesn't work as expected. VO can run out of work and go to sleep for 1000s, while the play thread still returns on vo_still_displaying() check, because of a check `now < frame_end` so it never advances and go to sleep itself.

This fixes dead lock that we have when image parameters changes during playback.

This reverts commit 0c9ac5835be70ae26e4aa875e833fe2c7b3b3bf3.

Fixes: #12575