### PR TITLE
af_scaletempo2: better defaults

### DIFF
--- a/DOCS/man/af.rst
+++ b/DOCS/man/af.rst
@@ -182,10 +182,10 @@ Available filters are:
         and ``<speed> != 0``. (default: 8.0)
 
     ``search-interval=<amount>``
-        Length in milliseconds to search for best overlap position. (default: 30)
+        Length in milliseconds to search for best overlap position. (default: 40)
 
     ``window-size=<amount>``
-        Length in milliseconds of the overlap-and-add window. (default: 20)
+        Length in milliseconds of the overlap-and-add window. (default: 12)
 
 ``rubberband``
     High quality pitch correction with librubberband. This can be used in place

--- a/audio/filter/af_scaletempo2.c
+++ b/audio/filter/af_scaletempo2.c
@@ -235,8 +235,8 @@ const struct mp_user_filter_entry af_scaletempo2 = {
         .priv_defaults = &(const OPT_BASE_STRUCT) {
             .min_playback_rate = 0.25,
             .max_playback_rate = 8.0,
-            .ola_window_size_ms = 20,
-            .wsola_search_interval_ms = 30,
+            .ola_window_size_ms = 12,
+            .wsola_search_interval_ms = 40,
         },
         .options = (const struct m_option[]) {
             {"search-interval",


### PR DESCRIPTION
### Why a bigger search-interval is required

scaletempo2 doesn't do a good job when the signal contains frequencies less then 1/search_interval.
With a search interval of 30ms that means anything below 33.333Hz sounds bad.

Depending on the genre it's very common for music to contain frequencies down to 30Hz, and sometimes even a little bit below that. Therefore a higher default value is needed to handle such cases.

Based on that an argument can be made for a value of 50, as that should work down to 20Hz, or something even higher because movies sometimes have some infrasonic content.

However the downside of big search intervals is increased CPU usage and intelligibility at higher speeds, as it effectively leads to parts of the audio being skipped.

A value of 40 can handle frequencies down to 25Hz, enough for all music except very rare edge cases, while still providing decent intelligibility.

### Why a smaller window-size is required

Large values reduce intelligibility at high speeds and therefore small values are preferred.

However when values get too small it starts to sound weird (similar to librubberband).

In my testing a value of 10 already works well, but adding a small safety margin seems like a good idea, especially since it made no noticeable difference to intelligibility, which is why 12 was chosen.

### Disclaimer

When testing this you might notice some frequency shift in some edge cases, but there don't seem to be any parameter values where this doesn't happen.

Also the intro music of the Hardware Unboxed YouTube channel is a pathological use-case for scaletempo2. Making that not sound bad requires very large values for `window-size`, which comes at a big cost to intelligibility.