### PR TITLE
options: disable --allow-delayed-peak-detect by default

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -100,6 +100,7 @@ Interface changes
     - add `playlist-next-playlist` and `playlist-prev-playlist` commands
     - change `video-codec` to show description or name, not both
     - deprecate `--cdda-toc-bias` option, offsets are always checked now
+    - disable `--allow-delayed-peak-detect` by default
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6698,7 +6698,7 @@ them.
     frame when beneficial for performance. In particular, this is required to
     avoid an unnecessary FBO indirection when no advanced rendering is required
     otherwise. Has no effect if there already is an indirect pass, such as when
-    advanced scaling is enabled. Defaults to on. (Only affects
+    advanced scaling is enabled. Defaults to no. (Only affects
     ``--vo=gpu-next``, note that ``--vo=gpu`` always delays the peak.)
 
 ``--hdr-peak-percentile=<0.0..100.0>``

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -48,12 +48,12 @@ correct-downscaling=no
 linear-downscaling=no
 sigmoid-upscaling=no
 hdr-compute-peak=no
+allow-delayed-peak-detect=yes
 
 [high-quality]
 scale=ewa_lanczossharp
 hdr-peak-percentile=99.995
 hdr-contrast-recovery=0.30
-allow-delayed-peak-detect=no
 deband=yes
 
 # Deprecated alias

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2217,7 +2217,6 @@ const struct vo_driver video_out_gpu_next = {
     .uninit = uninit,
     .priv_size = sizeof(struct priv),
     .priv_defaults = &(const struct priv) {
-        .delayed_peak = true,
         .inter_preserve = true,
     },
 


### PR DESCRIPTION
Also enable peak detect in fast profile, with delayed peak allowed. This still doesn't require FBO indirection.

Peak detection greatly increases HDR experience. It has been optimized in libplacebo to a point that even on slow Intel iGPU it is safe to use.