### PR TITLE
defaults.lua: add an inactive parameter to timer constructors

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -438,17 +438,21 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     that are equal to the ``fn`` parameter. This uses normal Lua ``==``
     comparison, so be careful when dealing with closures.
 
-``mp.add_timeout(seconds, fn)``
+``mp.add_timeout(seconds, fn [, disabled])``
     Call the given function fn when the given number of seconds has elapsed.
     Note that the number of seconds can be fractional. For now, the timer's
     resolution may be as low as 50 ms, although this will be improved in the
     future.
 
+    If the ``disabled`` argument is set to ``true`` or a truthy value, the
+    timer will wait to be manually started with a call to its ``resume()``
+    method.
+
     This is a one-shot timer: it will be removed when it's fired.
 
     Returns a timer object. See ``mp.add_periodic_timer`` for details.
 
-``mp.add_periodic_timer(seconds, fn)``
+``mp.add_periodic_timer(seconds, fn [, disabled])``
     Call the given function periodically. This is like ``mp.add_timeout``, but
     the timer is re-added after the function fn is run.
 

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -265,20 +265,22 @@ local timers = {}
 local timer_mt = {}
 timer_mt.__index = timer_mt
 
-function mp.add_timeout(seconds, cb)
-    local t = mp.add_periodic_timer(seconds, cb)
+function mp.add_timeout(seconds, cb, disabled)
+    local t = mp.add_periodic_timer(seconds, cb, disabled)
     t.oneshot = true
     return t
 end
 
-function mp.add_periodic_timer(seconds, cb)
+function mp.add_periodic_timer(seconds, cb, disabled)
     local t = {
         timeout = seconds,
         cb = cb,
         oneshot = false,
     }
     setmetatable(t, timer_mt)
-    t:resume()
+    if not disabled then
+        t:resume()
+    end
     return t
 end
 


### PR DESCRIPTION
Added to the functions `mp.add_timeout` and `mp.add_periodic_timer`.

If the `inactive` argument is set to `true` or a truthy value, the timer will wait to be manually started with a call to its `resume()` method.