### PR TITLE
vf_vapoursynth: set nominal_fps after the filter

### DIFF
--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -280,8 +280,11 @@ static void VS_CC vs_frame_done(void *userData, const VSFrameRef *f, int n,
             if (!err1 && !err2)
                 img.pkt_duration = num / (double)den;
         }
-        if (img.pkt_duration < 0)
+        if (img.pkt_duration < 0) {
             MP_ERR(p, "No PTS after filter at frame %d!\n", n);
+        } else {
+            img.nominal_fps = 1.0 / img.pkt_duration;
+        }
         res = mp_image_new_copy(&img);
         p->vsapi->freeFrame(f);
     }


### PR DESCRIPTION
Fixing consequences of https://github.com/mpv-player/mpv/pull/11224.
W/o this there's no way now to set correct time_base and encoder always do "240 fps".