### PR TITLE
builtin.conf: restore options of the old gpu-hq profile

### DIFF
--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -56,9 +56,13 @@ hdr-contrast-recovery=0.30
 allow-delayed-peak-detect=no
 deband=yes
 
-# Deprecated alias
+# Deprecated
 [gpu-hq]
-profile=high-quality
+scale=spline36
+hdr-peak-percentile=99.995
+hdr-contrast-recovery=0.30
+allow-delayed-peak-detect=no
+deband=yes
 
 [low-latency]
 audio-buffer=0          # minimize extra audio buffer (can lead to dropouts)


### PR DESCRIPTION
Let mpv still have the exact same behavior when using the deprecated `gpu-hq` profile, instead of setting it as an alias of the new `high-quality`.

I have no objections to having the old `gpu-hq` as the new default (apart from `--deband=yes`) - likely majority of users are using `profile=gpu-hq` in their config files for years. It is also good to have a new higher tier profile. However, in my humble opinion, there is no good reason to change the behavior of `gpu-hq` when deprecating it, especially given the new `high-quality` profile is computationally much more intensive, the change may surprise users, e.g. issue #12564.

Typically, deprecation shouldn't break things. I believe we can serve users better by keeping the old behavior (for now).