### PR TITLE
DOCS/lua: update read_options example

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -680,13 +680,13 @@ with values found in the config-file and the command-line (in that order).
 
 Example implementation::
 
-    require 'mp.options'
     local options = {
         optionA = "defaultvalueA",
         optionB = -0.5,
         optionC = true,
     }
-    read_options(options, "myscript")
+
+    require "mp.options".read_options(options, "myscript")
     print(options.optionA)
 
 


### PR DESCRIPTION
This still shows the old way of calling read_options even though it was deprecated 8 years in ago 327b091909e.