### PR TITLE
console.lua: exit with with Ctrl+[

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -11,7 +11,7 @@ Keybindings
 \`
     Show the console.
 
-ESC
+ESC and Ctrl+[
     Hide the console.
 
 ENTER, Ctrl+J and Ctrl+M

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -830,6 +830,7 @@ end
 function get_bindings()
     local bindings = {
         { 'esc',         function() set_active(false) end       },
+        { 'ctrl+[',      function() set_active(false) end       },
         { 'enter',       handle_enter                           },
         { 'kp_enter',    handle_enter                           },
         { 'shift+enter', function() handle_char_input('\n') end },


### PR DESCRIPTION
This binding commonly closes similar input buffers like vim's Command-line mode and dmenu.