### PR TITLE
DOCS/options: vdpau requires GLX

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1290,7 +1290,8 @@ Video
                 ``--gpu-context=angle`` or ``--gpu-context=dxinterop``
                 (Windows only)
     :dxva2-copy: copies video back to system RAM (Windows only)
-    :vdpau:     requires ``--vo=gpu`` with X11, or ``--vo=vdpau`` (Linux only)
+    :vdpau:     requires ``--vo=gpu`` with ``--gpu-context=x11``, or
+                ``--vo=vdpau`` (Linux only)
     :vdpau-copy: copies video back into system RAM (Linux with some GPUs only)
     :mediacodec: requires ``--vo=gpu --gpu-context=android``
                  or ``--vo=mediacodec_embed`` (Android only)


### PR DESCRIPTION
Only vpdau-copy works with EGL. 2d1d815cc7 already added this to manpage, and 1c8d2246bf removed it again, but that seems to be a mistake because I can only get vdpau to work with GLX, and another user also reported that only vdpau-copy was working for him with the default EGL.