### PR TITLE
ytdl_hook.lua: set metadata with single tracks

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -517,12 +517,13 @@ local function formats_to_edl(json, formats, use_all_formats)
         end
     end
 
+    local tags = tags_to_edl(json)
+
     -- Merge all tracks into a single virtual file, but avoid EDL if it's
-    -- only a single track (i.e. redundant).
-    if #streams == 1 and single_url then
+    -- only a single track without metadata (i.e. redundant).
+    if #streams == 1 and single_url and not tags then
         res.url = single_url
     elseif #streams > 0 then
-        local tags = tags_to_edl(json)
         if tags then
             -- not a stream; just for the sake of concatenating the EDL string
             streams[#streams + 1] = tags


### PR DESCRIPTION
Use EDL for single tracks with metadata to set the uploader, channel url and description metadata with --ytdl-format=best. Currently, these are only set with the other ytdl formats with video and audio in different streams.

The uploader tag is commonly available in sites other than Youtube too, so it may be simpler to always use EDL with single tracks.