### PR TITLE
misc: safer strncpy

### DIFF
--- a/audio/out/ao_oss.c
+++ b/audio/out/ao_oss.c
@@ -115,6 +115,7 @@ static void device_descr_get(size_t dev_idx, char *buf, size_t buf_size)
     int fd = open(dev_path, O_RDONLY);
     if (ioctl(fd, SOUND_MIXER_INFO, &mi) == 0) {
         strncpy(buf, mi.name, buf_size - 1);
+        buf[buf_size - 1] = '\0';
         tmp = (buf_size - 1);
     }
     close(fd);

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -322,6 +322,7 @@ static void *ipc_thread(void *p)
 
     ipc_un.sun_family = AF_UNIX,
     strncpy(ipc_un.sun_path, arg->path, sizeof(ipc_un.sun_path) - 1);
+    ipc_un.sun_path[sizeof(ipc_un.sun_path) - 1] = '\0';
 
     unlink(ipc_un.sun_path);
 

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -1599,6 +1599,7 @@ static void save_cached_program(struct ra *ra, struct ra_renderpass *pass,
     };
     memcpy(header.magic, cache_magic, sizeof(header.magic));
     strncpy(header.compiler, spirv->name, sizeof(header.compiler) - 1);
+    header.compiler[sizeof(header.compiler) - 1] = '\0';
 
     struct bstr *prog = &pass->params.cached_program;
     bstr_xappend(pass, prog, (bstr){ (char *) &header, sizeof(header) });

--- a/video/out/gpu/spirv.c
+++ b/video/out/gpu/spirv.c
@@ -58,6 +58,7 @@ bool spirv_compiler_init(struct ra_ctx *ctx)
 
         const char *name = m_opt_choice_str(compiler_choices, i);
         strncpy(ctx->spirv->name, name, sizeof(ctx->spirv->name) - 1);
+        ctx->spirv->name[sizeof(ctx->spirv->name) - 1] = '\0';
         MP_VERBOSE(ctx, "Initializing SPIR-V compiler '%s'\n", name);
         if (ctx->spirv->fns->init(ctx))
             return true;


### PR DESCRIPTION
From the man page:

> The strncpy() function is similar, except that at most n bytes of src are copied.  Warning: If there is no null byte among the first n bytes of src, the string placed in dest will not be null-terminated.