### PR TITLE
command: fix segfault with playlist-{next,prev}-playlist

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -221,7 +221,7 @@ struct playlist_entry *playlist_get_first_in_next_playlist(struct playlist *pl,
     if (!entry)
         return NULL;
 
-    while (entry && entry->playlist_path &&
+    while (entry && entry->playlist_path && pl->current->playlist_path &&
            strcmp(entry->playlist_path, pl->current->playlist_path) == 0)
         entry = playlist_entry_get_rel(entry, direction);
 

--- a/player/command.c
+++ b/player/command.c
@@ -5335,6 +5335,7 @@ static void cmd_playlist_next_prev_playlist(void *p)
                               : playlist_get_last(mpctx->playlist);
 
         if (entry && entry->playlist_path &&
+            mpctx->playlist->current->playlist_path &&
             strcmp(entry->playlist_path,
                    mpctx->playlist->current->playlist_path) == 0)
             entry = NULL;


### PR DESCRIPTION
This was wrongly assuming that playlist_path is always set for the current playlist entry, but it's only set when a file was added by expanding a playlist.

The crash in playlist_get_first_in_next_playlist can be reproduced with mpv foo.mkv foo.zip, playlist-next, playlist-prev, playlist-next-playlist. You need to run playlist-next, playlist-prev first because foo.zip's playlist_path is NULL until you do that, which makes playlist_get_first_in_next_playlist return immediately.

The crash in cmd_playlist_next_prev_playlist can be replicated with mpv --loop-playlist foo.zip foo.mkv, running playlist-next until foo.mkv, and playlist-play-next. Again, you need to open foo.zip first or its playlist_path is NULL which skips running strcmp(entry->playlist_path, mpctx->playlist->current->playlist_path).

Fixes https://github.com/mpv-player/mpv/issues/12495#issuecomment-1760968608