### PR TITLE
add d3d11 backend for the Render API

### DIFF
--- a/libmpv/render.h
+++ b/libmpv/render.h
@@ -421,6 +421,10 @@ typedef enum mpv_render_param_type {
      * See MPV_RENDER_PARAM_SW_STRIDE for alignment requirements.
      */
     MPV_RENDER_PARAM_SW_POINTER = 20,
+    /*
+     * MPV_RENDER_API_TYPE_DXGI only
+     */
+    MPV_RENDER_PARAM_DXGI_INIT_PARAMS = 21,
 } mpv_render_param_type;
 
 /**
@@ -467,6 +471,8 @@ typedef struct mpv_render_param {
 #define MPV_RENDER_API_TYPE_OPENGL "opengl"
 // See section "Software renderer"
 #define MPV_RENDER_API_TYPE_SW "sw"
+// See render_dxgi.h
+#define MPV_RENDER_API_TYPE_DXGI "dxgi"
 
 /**
  * Flags used in mpv_render_frame_info.flags. Each value represents a bit in it.

--- a/libmpv/render_dxgi.h
+++ b/libmpv/render_dxgi.h
@@ -1,0 +1,18 @@
+#ifndef MPV_CLIENT_API_RENDER_DXGI_H_
+#define MPV_CLIENT_API_RENDER_DXGI_H_
+
+#include "render.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct mpv_dxgi_init_params {
+    void *device;
+    void *swapchain;
+} mpv_dxgi_init_params;
+
+#ifdef __cplusplus
+}
+#endif
+#endif // MPV_CLIENT_API_RENDER_DXGI_H_

--- a/meson.build
+++ b/meson.build
@@ -980,7 +980,8 @@ d3d11 = get_option('d3d11').require(
 features += {'d3d11': d3d11.allowed()}
 if features['d3d11']
     sources += files('video/out/d3d11/context.c',
-                     'video/out/d3d11/ra_d3d11.c')
+                     'video/out/d3d11/ra_d3d11.c',
+                     'video/out/d3d11/libmpv_d3d11.c')
 endif
 
 wayland = {
@@ -1724,7 +1725,8 @@ if get_option('libmpv')
                  description: 'mpv media player client library')
 
     headers = ['libmpv/client.h', 'libmpv/render.h',
-               'libmpv/render_gl.h', 'libmpv/stream_cb.h']
+               'libmpv/render_gl.h', 'libmpv/stream_cb.h',
+               'libmpv/render_dxgi.h']
     install_headers(headers, subdir: 'mpv')
 endif
 

--- a/video/out/d3d11/libmpv_d3d11.c
+++ b/video/out/d3d11/libmpv_d3d11.c
@@ -1,0 +1,87 @@
+#include "common/msg.h"
+#include "ra_d3d11.h"
+#include "libmpv/render_dxgi.h"
+#include "video/out/gpu/libmpv_gpu.h"
+#include "osdep/windows_utils.h"
+
+struct priv {
+    struct ra_tex *tex;
+    ID3D11Device *device;
+    IDXGISwapChain *swapchain;
+};
+
+static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
+{
+    MP_VERBOSE(ctx, "Creating libmpv d3d11 context\n");
+    struct priv *p = ctx->priv = talloc_zero(NULL, struct priv);
+
+    mpv_dxgi_init_params *init_params =
+        get_mpv_render_param(params, MPV_RENDER_PARAM_DXGI_INIT_PARAMS, NULL);
+    if (!init_params)
+        return MPV_ERROR_INVALID_PARAMETER;
+
+    p->device = init_params->device;
+    p->swapchain = init_params->swapchain;
+    ID3D11Device_AddRef(p->device);
+    ID3D11Device_AddRef(p->swapchain);
+
+    // initialize a blank ra_ctx to reuse ra_gl_ctx
+    struct ra_ctx *ra_ctx = talloc_zero(p, struct ra_ctx);
+    ra_ctx->log = ctx->log;
+    ra_ctx->global = ctx->global;
+
+    if (!spirv_compiler_init(ra_ctx))
+        return MPV_ERROR_UNSUPPORTED;
+
+    ra_ctx->ra = ra_d3d11_create(p->device, ctx->log, ra_ctx->spirv);
+    if (!ra_ctx->ra)
+        return MPV_ERROR_UNSUPPORTED;    
+
+    ctx->ra_ctx = ra_ctx;
+    return 0;
+}
+
+static int wrap_fbo(struct libmpv_gpu_context *ctx, mpv_render_param *params, struct ra_tex **out)
+{
+    struct priv *p = ctx->priv;
+    ID3D11Resource *backbuffer = NULL;
+
+    if (!p->tex) {
+        HRESULT hr = IDXGISwapChain_GetBuffer(p->swapchain, 0, &IID_ID3D11Texture2D,
+                        (void**)&backbuffer);
+        if (FAILED(hr)) {
+            MP_ERR(ctx, "Couldn't get swapchain image\n");
+            return MPV_ERROR_UNSUPPORTED;
+        }
+        p->tex = ra_d3d11_wrap_tex(ctx->ra_ctx->ra, backbuffer);
+        SAFE_RELEASE(backbuffer);
+    }
+
+    *out = p->tex;
+    return 0;
+}
+
+static void done_frame(struct libmpv_gpu_context *ctx, bool ds)
+{
+    struct priv *p = ctx->priv;
+
+    ra_d3d11_flush(ctx->ra_ctx->ra);
+    ra_tex_free(ctx->ra_ctx->ra, &p->tex);
+}
+
+static void destroy(struct libmpv_gpu_context *ctx)
+{
+    struct priv *p = ctx->priv;
+    if (ctx->ra_ctx->ra)
+        ra_tex_free(ctx->ra_ctx->ra, &p->tex);
+    SAFE_RELEASE(p->swapchain);
+    SAFE_RELEASE(p->device);
+}
+
+const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11 = {
+    .api_name    = MPV_RENDER_API_TYPE_DXGI,
+    .init        = init,
+    .wrap_fbo    = wrap_fbo,
+    .done_frame  = done_frame,
+    .destroy     = destroy,
+};

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -6,6 +6,9 @@
 #include "video/out/libmpv.h"
 
 static const struct libmpv_gpu_context_fns *context_backends[] = {
+#if HAVE_D3D11
+    &libmpv_gpu_context_d3d11,
+#endif
 #if HAVE_GL
     &libmpv_gpu_context_gl,
 #endif

--- a/video/out/gpu/libmpv_gpu.h
+++ b/video/out/gpu/libmpv_gpu.h
@@ -38,3 +38,4 @@ struct libmpv_gpu_context_fns {
 };
 
 extern const struct libmpv_gpu_context_fns libmpv_gpu_context_gl;
+extern const struct libmpv_gpu_context_fns libmpv_gpu_context_d3d11;


### PR DESCRIPTION
add dxgi render api to sovle https://github.com/mpv-player/mpv/issues/5979

1. pass a `ID3D11Device` from host app when init mpv render content
2. pass backBufferResource of `ID3D11Texture2D` during call `mpv_render_context_render`

see demo for using this api https://gist.github.com/dragonflylee/a7764253efb026bd67666542910ec75e