### PR TITLE
stats.lua: fix page 2 alignment of "Total"

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -350,7 +350,7 @@ local function append_perfdata(s, dedicated_page)
                 s[#s+1] = format(f, o.nl, o.indent, o.indent,
                                  o.font_mono, pp(pass["last"]),
                                  pp(pass["avg"]), pp(pass["peak"]),
-                                 o.prefix_sep .. o.prefix_sep, p(pass["last"], last_s[frame]),
+                                 o.prefix_sep .. "\\h\\h", p(pass["last"], last_s[frame]),
                                  o.font, o.prefix_sep, o.prefix_sep, pass["desc"])
 
                 if o.plot_perfdata and o.use_ass then
@@ -365,8 +365,8 @@ local function append_perfdata(s, dedicated_page)
             -- Print sum of timing values as "Total"
             s[#s+1] = format(f, o.nl, o.indent, o.indent,
                              o.font_mono, pp(last_s[frame]),
-                             pp(avg_s[frame]), pp(peak_s[frame]), "", "", o.font,
-                             o.prefix_sep, o.prefix_sep, b("Total"))
+                             pp(avg_s[frame]), pp(peak_s[frame]),
+                             o.prefix_sep, b("Total"), o.font, "", "", "")
         else
             -- for the simplified view, we just print the sum of each pass
             s[#s+1] = format(f, o.nl, o.indent, o.indent, o.font_mono,


### PR DESCRIPTION
The text didn't line up with with the percentages above it because it didn't use a monospace font.

Instead insert the text at the same position in the template as the percentages and convert one o.prefix_sep from the percentages into hard coded \h\h to ensure alignment even when the user changes o.prefix_sep.