### PR TITLE
audio: don't block on lock in ao_read_data

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -184,7 +184,8 @@ int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_us)
     struct buffer_state *p = ao->buffer_state;
     assert(!ao->driver->write);
 
-    pthread_mutex_lock(&p->lock);
+    if (pthread_mutex_trylock(&p->lock))
+        return 0;
 
     int pos = read_buffer(ao, data, samples, &(bool){0});
 

--- a/osdep/threads.c
+++ b/osdep/threads.c
@@ -79,3 +79,13 @@ int mp_ptwrap_mutex_init(const char *file, int line, pthread_mutex_t *m,
         pthread_mutexattr_destroy(&m_attr);
     return res;
 }
+
+int mp_ptwrap_mutex_trylock(const char *file, int line, pthread_mutex_t *m)
+{
+    int res = (pthread_mutex_trylock)(m);
+
+    if (res != EBUSY)
+        mp_ptwrap_check(file, line, res);
+
+    return res;
+}

--- a/osdep/threads.h
+++ b/osdep/threads.h
@@ -13,6 +13,7 @@ void mpthread_set_name(const char *name);
 int mp_ptwrap_check(const char *file, int line, int res);
 int mp_ptwrap_mutex_init(const char *file, int line, pthread_mutex_t *m,
                          const pthread_mutexattr_t *attr);
+int mp_ptwrap_mutex_trylock(const char *file, int line, pthread_mutex_t *m);
 
 #ifdef MP_PTHREAD_DEBUG
 
@@ -46,6 +47,7 @@ int mp_ptwrap_mutex_init(const char *file, int line, pthread_mutex_t *m,
 #undef pthread_join
 #undef pthread_mutex_destroy
 #undef pthread_mutex_lock
+#undef pthread_mutex_trylock
 #undef pthread_mutex_unlock
 
 #define pthread_cond_init(...)      MP_PTWRAP(pthread_cond_init, __VA_ARGS__)
@@ -62,6 +64,9 @@ int mp_ptwrap_mutex_init(const char *file, int line, pthread_mutex_t *m,
 
 #define pthread_mutex_init(...) \
     mp_ptwrap_mutex_init(__FILE__, __LINE__, __VA_ARGS__)
+
+#define pthread_mutex_trylock(...) \
+    mp_ptwrap_mutex_trylock(__FILE__, __LINE__, __VA_ARGS__)
 
 #endif
 

--- a/osdep/win32/include/pthread.h
+++ b/osdep/win32/include/pthread.h
@@ -27,6 +27,7 @@
 #define pthread_mutex_destroy m_pthread_mutex_destroy
 #define pthread_mutex_init m_pthread_mutex_init
 #define pthread_mutex_lock m_pthread_mutex_lock
+#define pthread_mutex_trylock m_pthread_mutex_trylock
 #define pthread_mutex_unlock m_pthread_mutex_unlock
 #define pthread_cond_timedwait m_pthread_cond_timedwait
 #define pthread_cond_wait m_pthread_cond_wait
@@ -64,6 +65,7 @@ int pthread_mutex_init(pthread_mutex_t *restrict mutex,
                        const pthread_mutexattr_t *restrict attr);
 
 int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
 int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 #define pthread_cond_t CONDITION_VARIABLE

--- a/osdep/win32/pthread.c
+++ b/osdep/win32/pthread.c
@@ -67,6 +67,15 @@ int pthread_mutex_lock(pthread_mutex_t *mutex)
     return 0;
 }
 
+int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+    if (mutex->use_cs) {
+        return !TryEnterCriticalSection(&mutex->lock.cs);
+    } else {
+        return !TryAcquireSRWLockExclusive(&mutex->lock.srw);
+    }
+}
+
 int pthread_mutex_unlock(pthread_mutex_t *mutex)
 {
     if (mutex->use_cs) {


### PR DESCRIPTION
ao_read_data() is used by pull AOs potentially from threads managed by external libraries.  These threads can be sensitive to blocking. For example the pipewire ao is using a realtime thread for the callbacks.

Note:
I don't have a specific problem this fixes, but it looked like it could be one in theory.