### PR TITLE
github/workflows: remove macOS 11 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,6 @@ jobs:
         cc:
           - "clang"
         os:
-          - "macos-11"
           - "macos-12"
           - "macos-13"
     steps:


### PR DESCRIPTION
Homebrew has finally given up supporting macOS 11, and all updated dependencies are being built locally. Additionally, python3.12 - being a dependency of libass in Homebrew - seems to completely fail under cairo's meson usage on macOS 11, even if we let it build.

Thus, finally remove macOS 11 from our macOS build matrix, leaving 12 and 13.

ref: Homebrew/brew#16019