### PR TITLE
player/command: truncate anything < 1e-4 in pretty printer

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1028,7 +1028,12 @@ static char *print_double_7g(const m_option_t *opt, const void *val)
     double f = VAL(val);
     if (isnan(f))
         return print_double(opt, val);
-    return talloc_asprintf(NULL, "%.7g", f);
+    // Truncate anything < 1e-4 to avoid switching to scientific notation
+    if (fabs(f) < 1e-4) {
+        return talloc_strdup(NULL, "0");
+    } else {
+        return talloc_asprintf(NULL, "%.7g", f);
+    }
 }
 
 static void add_double(const m_option_t *opt, void *val, double add, bool wrap)

--- a/player/command.c
+++ b/player/command.c
@@ -652,8 +652,8 @@ static int mp_property_avsync(void *ctx, struct m_property *prop,
     if (!mpctx->ao_chain || !mpctx->vo_chain)
         return M_PROPERTY_UNAVAILABLE;
     if (action == M_PROPERTY_PRINT) {
-        // Don't print small values resulting from calculation inaccuracies
-        if (fabs(mpctx->last_av_difference) < 1e-5) {
+        // Truncate anything < 1e-4 to avoid switching to scientific notation
+        if (fabs(mpctx->last_av_difference) < 1e-4) {
             *(char **)arg = talloc_strdup(NULL, "0");
         } else {
             *(char **)arg = talloc_asprintf(NULL, "%+.2g", mpctx->last_av_difference);


### PR DESCRIPTION
To avoid switching to scientific notation. Apparently it is "jarring" for some users.

This preserves status quo from before 9dddfc4f where pretty printer were truncated to 3 decimal places, now it is 4.