### PR TITLE
DOCS/interface-changes: remove redundant change

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -51,7 +51,6 @@ Interface changes
     - rename `--sub-forced-only` to `--sub-forced-events-only`
     - remove `sub-forced-only-cur` property (`--sub-forced-events-only` is a replacement)
     - add `hdr-metadata` property
-    - change `--directory-mode` default to `lazy`
     - remove deprecated `video-aspect` property
     - add `--video-crop`
     - add `video-params/crop-[w,h,x,y]`


### PR DESCRIPTION
directory-mode's default was changed again to auto afterwards.