### PR TITLE
github/workflows: put a 20 minute timeout on the freebsd job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
 
   freebsd:
     runs-on: macos-12 # until https://github.com/actions/runner/issues/385
+    timeout-minutes: 20 # randomly bootloops https://github.com/vmactions/freebsd-vm/issues/74
     steps:
     - uses: actions/checkout@v3
     - name: Test in FreeBSD VM


### PR DESCRIPTION
It bootloops quite often these days which is annoying and clogs up all the macos runners. https://github.com/vmactions/freebsd-vm/issues/74