### PR TITLE
demux_mkv: PAR should be calculated after applying crop

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1510,22 +1510,22 @@ static int demux_mkv_open_video(demuxer_t *demuxer, mkv_track_t *track)
     sh_v->disp_w = track->v_width;
     sh_v->disp_h = track->v_height;
 
-    int dw = track->v_dwidth_set ? track->v_dwidth : track->v_width;
-    int dh = track->v_dheight_set ? track->v_dheight : track->v_height;
-    struct mp_image_params p = {.w = track->v_width, .h = track->v_height};
-    mp_image_params_set_dsize(&p, dw, dh);
-    sh_v->par_w = p.p_w;
-    sh_v->par_h = p.p_h;
-
-    sh_v->stereo_mode = track->stereo_mode;
-    sh_v->color = track->color;
-
     sh_v->crop.x0 = track->v_crop_left_set ? track->v_crop_left : 0;
     sh_v->crop.y0 = track->v_crop_top_set ? track->v_crop_top : 0;
     sh_v->crop.x1 = track->v_width -
                         (track->v_crop_right_set ? track->v_crop_right : 0);
     sh_v->crop.y1 = track->v_height -
                         (track->v_crop_bottom_set ? track->v_crop_bottom : 0);
+
+    int dw = track->v_dwidth_set ? track->v_dwidth : mp_rect_w(sh_v->crop);
+    int dh = track->v_dheight_set ? track->v_dheight : mp_rect_h(sh_v->crop);
+    struct mp_image_params p = {.w = mp_rect_w(sh_v->crop), .h = mp_rect_h(sh_v->crop)};
+    mp_image_params_set_dsize(&p, dw, dh);
+    sh_v->par_w = p.p_w;
+    sh_v->par_h = p.p_h;
+
+    sh_v->stereo_mode = track->stereo_mode;
+    sh_v->color = track->color;
 
     if (track->v_projection_pose_roll_set) {
         int rotate = lrintf(fmodf(fmodf(track->v_projection_pose_roll, 360) + 360, 360));

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1141,6 +1141,11 @@ struct AVFrame *mp_image_to_av_frame(struct mp_image *src)
     dst->width = src->w;
     dst->height = src->h;
 
+    dst->crop_left = src->params.crop.x0;
+    dst->crop_top = src->params.crop.y0;
+    dst->crop_right = dst->width - src->params.crop.x1;
+    dst->crop_bottom = dst->height - src->params.crop.y1;
+
     dst->sample_aspect_ratio.num = src->params.p_w;
     dst->sample_aspect_ratio.den = src->params.p_h;
 


### PR DESCRIPTION
DisplayWidth/DisplayHeight applies to the video frame after cropping (PixelCrop* Elements).