### PR TITLE
path: don't treat "hidden" files as extension

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -263,7 +263,8 @@ void mp_path_strip_trailing_separator(char *path)
 char *mp_splitext(const char *path, bstr *root)
 {
     assert(path);
-    const char *split = strrchr(path, '.');
+    int skip = (*path == '.'); // skip leading dot for "hidden" unix files
+    const char *split = strrchr(path + skip, '.');
     if (!split || !split[1] || strchr(split, '/'))
         return NULL;
     if (root)


### PR DESCRIPTION
currently for a filename such as ".file" mpv incorrectly thinks of the entire filename as being an extension. skip leading dots to avoid treating "hidden/dot" files as extension.