### PR TITLE
ci/lint: allow the first word to be all caps

### DIFF
--- a/ci/lint-commit-msg.py
+++ b/ci/lint-commit-msg.py
@@ -74,6 +74,9 @@ def subsystem_prefix(body):
 def description_lowercase(body):
 	if re.search(NO_PREFIX_WHITELIST, body[0]):
 		return True
+	# Allow all caps for acronyms and such
+	if re.search(r":\s[A-Z]{2,}\s", body[0]):
+		return True
 	return re.search(r":\s+[a-z0-9]", body[0])
 
 @lint_rule("Subject line must not end with a full stop")


### PR DESCRIPTION
Otherwise acronyms and such would fail the lint, and it doesn't make any sense to enforce it here. Also make sure that the length of the word is greater than 1 to avoid something like "foo: A blah blah" from passing.