### PR TITLE
timer: drop ancient macOS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Releases can be found on the [release list][releases].
 
 ## System requirements
 
-- A not too ancient Linux, Windows 10 or later, or macOS 10.8 or later.
+- A not too ancient Linux, Windows 10 or later, or macOS 10.12 or later.
 - A somewhat capable CPU. Hardware decoding might help if the CPU is too slow to
   decode video in realtime, but must be explicitly enabled with the `--hwdec`
   option.

--- a/osdep/timer.c
+++ b/osdep/timer.c
@@ -72,24 +72,10 @@ int64_t mp_time_ns_add(int64_t time_ns, double timeout_sec)
     return time_ns + ti;
 }
 
-static int get_realtime(struct timespec *out_ts)
-{
-#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
-    return clock_gettime(CLOCK_REALTIME, out_ts);
-#else
-    // OSX
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    out_ts->tv_sec = tv.tv_sec;
-    out_ts->tv_nsec = tv.tv_usec * 1000UL;
-    return 0;
-#endif
-}
-
 struct timespec mp_time_ns_to_realtime(int64_t time_ns)
 {
     struct timespec ts = {0};
-    if (get_realtime(&ts) != 0)
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         return ts;
     int64_t time_rel = time_ns - mp_time_ns();
 


### PR DESCRIPTION
macOS didn't support clock_gettime until 10.12 which was released roughly 7 years ago. Since we're breaking support for ancient OSes anyway, we might as well break some old macOS versions for fun. This makes 10.12 the minimum supported macOS version.