### PR TITLE
update subtitles on mkvs with an image track

### DIFF
--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -233,6 +233,17 @@ static const char *const type_to_codec[][2] = {
     {0}
 };
 
+bool mp_codec_is_image(const char *codec)
+{
+    if (codec) {
+        for (int n = 0; type_to_codec[n][0]; n++) {
+            if (strcasecmp(type_to_codec[n][1], codec) == 0)
+                return true;
+        }
+    }
+    return false;
+}
+
 const char *mp_map_type_to_image_codec(const char *type)
 {
     if (type) {

--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -180,6 +180,70 @@ void mp_set_pcm_codec(struct mp_codec_params *c, bool sign, bool is_float,
     c->codec = talloc_strdup(c, codec);
 }
 
+// map file extension/type to an image codec name
+static const char *const type_to_codec[][2] = {
+    { "bmp",            "bmp" },
+    { "dpx",            "dpx" },
+    { "j2c",            "jpeg2000" },
+    { "j2k",            "jpeg2000" },
+    { "jp2",            "jpeg2000" },
+    { "jpc",            "jpeg2000" },
+    { "jpeg",           "mjpeg" },
+    { "jpg",            "mjpeg" },
+    { "jps",            "mjpeg" },
+    { "jls",            "ljpeg" },
+    { "thm",            "mjpeg" },
+    { "db",             "mjpeg" },
+    { "pcd",            "photocd" },
+    { "pfm",            "pfm" },
+    { "phm",            "phm" },
+    { "hdr",            "hdr" },
+    { "pcx",            "pcx" },
+    { "png",            "png" },
+    { "pns",            "png" },
+    { "ptx",            "ptx" },
+    { "tga",            "targa" },
+    { "tif",            "tiff" },
+    { "tiff",           "tiff" },
+    { "sgi",            "sgi" },
+    { "sun",            "sunrast" },
+    { "ras",            "sunrast" },
+    { "rs",             "sunrast" },
+    { "ra",             "sunrast" },
+    { "im1",            "sunrast" },
+    { "im8",            "sunrast" },
+    { "im24",           "sunrast" },
+    { "im32",           "sunrast" },
+    { "sunras",         "sunrast" },
+    { "xbm",            "xbm" },
+    { "pam",            "pam" },
+    { "pbm",            "pbm" },
+    { "pgm",            "pgm" },
+    { "pgmyuv",         "pgmyuv" },
+    { "ppm",            "ppm" },
+    { "pnm",            "ppm" },
+    { "gif",            "gif" },
+    { "pix",            "brender_pix" },
+    { "exr",            "exr" },
+    { "pic",            "pictor" },
+    { "qoi",            "qoi" },
+    { "xface",          "xface" },
+    { "xwd",            "xwd" },
+    { "svg",            "svg" },
+    {0}
+};
+
+const char *mp_map_type_to_image_codec(const char *type)
+{
+    if (type) {
+        for (int n = 0; type_to_codec[n][0]; n++) {
+            if (strcasecmp(type_to_codec[n][0], type) == 0)
+                return type_to_codec[n][1];
+        }
+    }
+    return NULL;
+};
+
 static const char *const mimetype_to_codec[][2] = {
     {"image/apng",      "apng"},
     {"image/avif",      "av1"},

--- a/demux/codec_tags.h
+++ b/demux/codec_tags.h
@@ -28,6 +28,7 @@ void mp_set_codec_from_tag(struct mp_codec_params *c);
 void mp_set_pcm_codec(struct mp_codec_params *c, bool sign, bool is_float,
                       int bits, bool is_be);
 
+bool mp_codec_is_image(const char *codec);
 const char *mp_map_type_to_image_codec(const char *type);
 const char *mp_map_mimetype_to_video_codec(const char *mimetype);
 

--- a/demux/codec_tags.h
+++ b/demux/codec_tags.h
@@ -28,6 +28,7 @@ void mp_set_codec_from_tag(struct mp_codec_params *c);
 void mp_set_pcm_codec(struct mp_codec_params *c, bool sign, bool is_float,
                       int bits, bool is_be);
 
+const char *mp_map_type_to_image_codec(const char *type);
 const char *mp_map_mimetype_to_video_codec(const char *mimetype);
 
 #endif

--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -284,63 +284,6 @@ static bool demux_mf_read_packet(struct demuxer *demuxer,
     return true;
 }
 
-// map file extension/type to a codec name
-
-static const struct {
-    const char *type;
-    const char *codec;
-} type2format[] = {
-    { "bmp",            "bmp" },
-    { "dpx",            "dpx" },
-    { "j2c",            "jpeg2000" },
-    { "j2k",            "jpeg2000" },
-    { "jp2",            "jpeg2000" },
-    { "jpc",            "jpeg2000" },
-    { "jpeg",           "mjpeg" },
-    { "jpg",            "mjpeg" },
-    { "jps",            "mjpeg" },
-    { "jls",            "ljpeg" },
-    { "thm",            "mjpeg" },
-    { "db",             "mjpeg" },
-    { "pcd",            "photocd" },
-    { "pfm",            "pfm" },
-    { "phm",            "phm" },
-    { "hdr",            "hdr" },
-    { "pcx",            "pcx" },
-    { "png",            "png" },
-    { "pns",            "png" },
-    { "ptx",            "ptx" },
-    { "tga",            "targa" },
-    { "tif",            "tiff" },
-    { "tiff",           "tiff" },
-    { "sgi",            "sgi" },
-    { "sun",            "sunrast" },
-    { "ras",            "sunrast" },
-    { "rs",             "sunrast" },
-    { "ra",             "sunrast" },
-    { "im1",            "sunrast" },
-    { "im8",            "sunrast" },
-    { "im24",           "sunrast" },
-    { "im32",           "sunrast" },
-    { "sunras",         "sunrast" },
-    { "xbm",            "xbm" },
-    { "pam",            "pam" },
-    { "pbm",            "pbm" },
-    { "pgm",            "pgm" },
-    { "pgmyuv",         "pgmyuv" },
-    { "ppm",            "ppm" },
-    { "pnm",            "ppm" },
-    { "gif",            "gif" }, // usually handled by demux_lavf
-    { "pix",            "brender_pix" },
-    { "exr",            "exr" },
-    { "pic",            "pictor" },
-    { "qoi",            "qoi" },
-    { "xface",          "xface" },
-    { "xwd",            "xwd" },
-    { "svg",            "svg" },
-    {0}
-};
-
 static const char *probe_format(mf_t *mf, char *type, enum demux_check check)
 {
     if (check > DEMUX_CHECK_REQUEST)
@@ -351,10 +294,9 @@ static const char *probe_format(mf_t *mf, char *type, enum demux_check check)
         if (p)
             type = p + 1;
     }
-    for (int i = 0; type2format[i].type; i++) {
-        if (type && strcasecmp(type, type2format[i].type) == 0)
-            return type2format[i].codec;
-    }
+    const char *codec = mp_map_type_to_image_codec(type);
+    if (codec)
+        return codec;
     if (check == DEMUX_CHECK_REQUEST) {
         if (!org_type) {
             MP_ERR(mf, "file type was not set! (try --mf-type=ext)\n");

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1489,6 +1489,10 @@ static int demux_mkv_open_video(demuxer_t *demuxer, mkv_track_t *track)
     }
 
     const char *codec = sh_v->codec ? sh_v->codec : "";
+    if (mp_codec_is_image(codec)) {
+        sh->still_image = true;
+        sh->image = true;
+    }
     if (!strcmp(codec, "mjpeg")) {
         sh_v->codec_tag = MKTAG('m', 'j', 'p', 'g');
         track->require_keyframes = true;

--- a/player/sub.c
+++ b/player/sub.c
@@ -116,7 +116,7 @@ static bool update_subtitle(struct MPContext *mpctx, double video_pts,
     if (mpctx->video_out && mpctx->video_status == STATUS_EOF &&
         (mpctx->opts->subs_rend->sub_past_video_end ||
          !mpctx->current_track[0][STREAM_VIDEO] ||
-         mpctx->current_track[0][STREAM_VIDEO]->attached_picture)) {
+         mpctx->current_track[0][STREAM_VIDEO]->image)) {
         if (osd_get_force_video_pts(mpctx->osd) != video_pts) {
             osd_set_force_video_pts(mpctx->osd, video_pts);
             osd_query_and_reset_want_redraw(mpctx->osd);


### PR DESCRIPTION
Basically a way to fix #12387. I know I could have left the logic completely in `demux_mkv`, but reusing the list in `demux_mf` seemed better to me than making yet another mapping of things we consider images.