### PR TITLE
 osdep: fix clang warnings with `_FORTIFY_SOURCE`

### DIFF
--- a/osdep/subprocess-posix.c
+++ b/osdep/subprocess-posix.c
@@ -134,7 +134,7 @@ static pid_t spawn_process(const char *path, struct mp_subprocess_opts *opts,
         as_execvpe(path, opts->exe, opts->args, opts->env ? opts->env : environ);
 
     child_failed:
-        write(p[1], &(char){1}, 1); // shouldn't be able to fail
+        (void)write(p[1], &(char){1}, 1); // shouldn't be able to fail
         _exit(1);
     }
 

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -435,7 +435,7 @@ static void *terminal_thread(void *ptr)
         }
         if (fds[1].revents & POLLIN) {
             int8_t c = -1;
-            read(stop_cont_pipe[0], &c, 1);
+            (void)read(stop_cont_pipe[0], &c, 1);
             if (c == PIPE_STOP)
                 do_deactivate_getch2();
             else if (c == PIPE_CONT)


### PR DESCRIPTION
This fixes warnings generated for `unused-result` since read/write
functions are declared with the `warn_unused_result` attribute when mpv
is build with `-O1 -D_FORTIFY_SOURCE=1` with clang. Cast to avoid to
avoid these warnings.