### PR TITLE
github/workflows: use cross-platform-actions for freebsd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,62 +172,52 @@ jobs:
 
   freebsd:
     runs-on: macos-12 # until https://github.com/actions/runner/issues/385
-    timeout-minutes: 20 # randomly bootloops https://github.com/vmactions/freebsd-vm/issues/74
+    timeout-minutes: 20 # avoid any weirdness with the VM
     steps:
     - uses: actions/checkout@v3
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0
+      uses: cross-platform-actions/action@v0.19.1
       with:
-        mem: 8192
-        copyback: false
-        usesh: true
-        prepare: |
-            # Update to latest release channel
-            mkdir -p /usr/local/etc/pkg/repos
-            echo "FreeBSD: { url: "pkg+http://pkg.freebsd.org/\${ABI}/latest" }" \
-                > /usr/local/etc/pkg/repos/FreeBSD.conf
-            pkg update
-            # Requested in ci/build-freebsd.sh
-            pkg install -y \
-                git \
+        operating_system: freebsd
+        version: '13.2'
+        run: |
+            sudo pkg update
+            sudo pkg install -y \
+                alsa-lib \
                 cmake \
                 evdev-proto \
                 ffmpeg \
-                libplacebo \
-                libxkbcommon \
-                libXinerama \
-                libxpresent \
-                luajit \
-                meson \
-                openal-soft \
-                pkgconf \
-                python3 \
-                sdl2 \
-                sndio \
-                vulkan-headers \
-                wayland-protocols \
-                #
-            # Optionally auto-enabled
-            pkg install -y \
-                alsa-lib \
+                git \
+                iconv \
                 jackit \
-                libXv \
                 libarchive \
                 libbluray \
                 libcaca \
                 libcdio-paranoia \
                 libdvdnav \
+                libplacebo \
+                libXinerama \
+                libxkbcommon \
+                libxpresent \
+                libXv \
+                luajit \
+                meson \
                 mujs \
+                openal-soft \
                 pipewire \
+                pkgconf \
                 pulseaudio \
+                python3 \
                 rubberband \
                 sekrit-twc-zimg \
+                sdl2 \
+                sndio \
                 uchardet \
                 v4l_compat \
-                #
-        run: |
-          ./ci/build-freebsd.sh
-          meson test -C build
+                vulkan-headers \
+                wayland-protocols
+            ./ci/build-freebsd.sh
+            meson test -C build
 
   msys2:
     runs-on: windows-latest

--- a/ci/build-freebsd.sh
+++ b/ci/build-freebsd.sh
@@ -9,11 +9,11 @@ meson setup build \
     --werror      \
     -Dlibplacebo:werror=false \
     -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
+    -Diconv=disabled \
     -Dlibmpv=true \
     -Dlua=enabled \
     -Degl-drm=enabled \
     -Dopenal=enabled \
-    -Dsdl2=enabled \
     -Dsndio=enabled \
     -Dtests=true \
     -Dvdpau=enabled \


### PR DESCRIPTION
Since vmactions is basically a bootlooping disaster with no signs of life from upstream, let's try a different action instead and hope it works better.