### PR TITLE
 ytdl_hook: support thumbnails

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -942,6 +942,13 @@ Program Behavior
         ``all_formats`` is set to 'no', and the stream selection as done by
         youtube-dl (via ``--ytdl-format``) is used.
 
+    ``thumbnails=<all|best|none>``
+        Add thumbnails as video tracks (default: none).
+
+        Thumbnails get downloaded when they are added as tracks, so 'all' can
+        have a noticable impact on how long it takes to open the video when
+        there are a lot of thumbnails.
+
     ``use_manifests=<yes|no>``
         Make mpv use the master manifest URL for formats like HLS and DASH,
         if available, allowing for video/audio selection in runtime (default:

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -759,6 +759,7 @@ local function add_single_video(json)
     if (o.thumbnails == 'all' or o.thumbnails == 'best') and not (json.thumbnails == nil) then
         local thumb = nil
         local thumb_height = -1
+        local thumb_preference = nil
 
         for _, thumb_info in ipairs(json.thumbnails) do
             if not (thumb_info.url == nil) then
@@ -766,9 +767,11 @@ local function add_single_video(json)
                     msg.verbose("adding thumbnail")
                     mp.commandv("video-add", thumb_info.url, "auto")
                     thumb_height = 0
-                elseif ((thumb_info.height or 0) > thumb_height) then
+                elseif (thumb_preference ~= nil and thumb_info.preference > thumb_preference) or
+                    (thumb_preference == nil and ((thumb_info.height or 0) > thumb_height)) then
                     thumb = thumb_info.url
                     thumb_height = thumb_info.height or 0
+                    thumb_preference = thumb_info.preference
                 end
             end
         end

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -761,7 +761,8 @@ local function add_single_video(json)
         local thumb_height = -1
         local thumb_preference = nil
 
-        for _, thumb_info in ipairs(json.thumbnails) do
+        for i = #json.thumbnails, 1, -1 do
+            local thumb_info = json.thumbnails[i]
             if not (thumb_info.url == nil) then
                 if (o.thumbnails == 'all') then
                     msg.verbose("adding thumbnail")


### PR DESCRIPTION
Successor to #7848

Doing it this way has the downside that all added thumbnails get downloaded. This could be avoided if they were added like formats when `all_formats=yes` is used, but that can be changed some other time.