### PR TITLE
ao_coreaudio: signal buffer underruns

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -78,7 +78,14 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
 
     int64_t end = mp_time_ns();
     end += p->hw_latency_ns + ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
-    ao_read_data(ao, planes, frames, end);
+    int samples = ao_read_data(ao, planes, frames, end);
+
+    if (samples == 0)
+        *aflags |= kAudioUnitRenderAction_OutputIsSilence;
+
+    for (int n = 0; n < buffer_list->mNumberBuffers; n++)
+        buffer_list->mBuffers[n].mDataByteSize = samples * ao->sstride;
+
     return noErr;
 }
 


### PR DESCRIPTION
Change the resulting buffer sizes to match the actual amount of samples read, and set a flag in case no samples were read at all.

References: https://github.com/mpv-player/mpv/pull/12643