### PR TITLE
github/workflows: use macos-13 host for freebsd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
           cat ./build/meson-logs/testlog.txt
 
   freebsd:
-    runs-on: macos-12 # until https://github.com/actions/runner/issues/385
+    runs-on: macos-13 # until https://github.com/actions/runner/issues/385
     timeout-minutes: 20 # avoid any weirdness with the VM
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Maybe macos-13 runners will be more stable?