### PR TITLE
github/workflows: use ubuntu-latest host for freebsd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,8 +171,8 @@ jobs:
           cat ./build/meson-logs/testlog.txt
 
   freebsd:
-    runs-on: macos-13 # until https://github.com/actions/runner/issues/385
-    timeout-minutes: 20 # avoid any weirdness with the VM
+    runs-on: ubuntu-latest # until https://github.com/actions/runner/issues/385
+    timeout-minutes: 30 # avoid any weirdness with the VM
     steps:
     - uses: actions/checkout@v3
     - name: Test in FreeBSD VM


### PR DESCRIPTION
In the pursuit of stability.

It is slower, qemu based, but if this is not stable, I don't know what
will be...

Bump timeout to 30 minutes, just in case. It seems to take 12-15
minutes to finish.