### PR TITLE
console.lua: add more completers

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -630,6 +630,13 @@ local function command_list()
     return commands
 end
 
+local function command_list_and_help()
+    local commands = command_list()
+    commands[#commands + 1] = 'help'
+
+    return commands
+end
+
 local function property_list()
     local option_info = {
         'name', 'type', 'set-from-commandline', 'set-locally', 'default-value',
@@ -674,7 +681,8 @@ end
 --           match.
 function build_completers()
     local completers = {
-        { pattern = '^%s*()[%w_-]+$', list = command_list, append = ' ' },
+        { pattern = '^%s*()[%w_-]+$', list = command_list_and_help, append = ' ' },
+        { pattern = '^%s*help%s+()[%w_-]*$', list = command_list },
         { pattern = '^%s*set%s+"?([%w_-]+)"?%s+()%S*$', list = choice_list },
         { pattern = '^%s*set%s+"?([%w_-]+)"?%s+"()%S*$', list = choice_list, append = '"' },
         { pattern = '^%s*cycle[-_]values%s+"?([%w_-]+)"?.-%s+()%S*$', list = choice_list, append = " " },

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -13,7 +13,6 @@
 -- CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 local utils = require 'mp.utils'
-local options = require 'mp.options'
 local assdraw = require 'mp.assdraw'
 
 -- Default options
@@ -56,7 +55,7 @@ else
 end
 
 -- Apply user-set options
-options.read_options(opts)
+require 'mp.options'.read_options(opts)
 
 local styles = {
     -- Colors are stolen from base16 Eighties by Chris Kempson

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -669,6 +669,26 @@ local function profile_list()
     return profiles
 end
 
+local function list_option_list()
+    local options = {}
+
+    -- Don't log errors for renamed and removed properties.
+    -- (Just mp.enable_messages('fatal') still logs them to the terminal.)
+    local msg_level_backup = mp.get_property('msg-level')
+    mp.set_property('msg-level', msg_level_backup == '' and 'cplayer=no'
+                                 or msg_level_backup .. ',cplayer=no')
+
+    for _, option in pairs(mp.get_property_native('options')) do
+        if mp.get_property('option-info/' .. option .. '/type', ''):find(' list$') then
+            options[#options + 1] = option
+        end
+    end
+
+    mp.set_property('msg-level', msg_level_backup)
+
+    return options
+end
+
 local function choice_list(option)
     local info = mp.get_property_native('option-info/' .. option, {})
 
@@ -699,6 +719,8 @@ function build_completers()
         { pattern = '^%s*cycle[-_]values%s+"?([%w_-]+)"?.-%s+"()%S*$', list = choice_list, append = '" ' },
         { pattern = '^%s*apply[-_]profile%s+"()%S*$', list = profile_list, append = '"' },
         { pattern = '^%s*apply[-_]profile%s+()%S*$', list = profile_list },
+        { pattern = '^%s*change[-_]list%s+()[%w_-]*$', list = list_option_list, append = ' ' },
+        { pattern = '^%s*change[-_]list%s+()"[%w_-]*$', list = list_option_list, append = '" ' },
         { pattern = '${()[%w_/-]+$', list = property_list, append = '}' },
     }
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -659,6 +659,16 @@ local function property_list()
     return properties
 end
 
+local function profile_list()
+    local profiles = {}
+
+    for i, profile in ipairs(mp.get_property_native('profile-list')) do
+        profiles[i] = profile.name
+    end
+
+    return profiles
+end
+
 local function choice_list(option)
     local info = mp.get_property_native('option-info/' .. option, {})
 
@@ -687,6 +697,8 @@ function build_completers()
         { pattern = '^%s*set%s+"?([%w_-]+)"?%s+"()%S*$', list = choice_list, append = '"' },
         { pattern = '^%s*cycle[-_]values%s+"?([%w_-]+)"?.-%s+()%S*$', list = choice_list, append = " " },
         { pattern = '^%s*cycle[-_]values%s+"?([%w_-]+)"?.-%s+"()%S*$', list = choice_list, append = '" ' },
+        { pattern = '^%s*apply[-_]profile%s+"()%S*$', list = profile_list, append = '"' },
+        { pattern = '^%s*apply[-_]profile%s+()%S*$', list = profile_list },
         { pattern = '${()[%w_/-]+$', list = property_list, append = '}' },
     }
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -688,6 +688,20 @@ local function list_option_list()
     return options
 end
 
+local function list_option_verb_list(option)
+    local type = mp.get_property('option-info/' .. option .. '/type')
+
+    if type == 'Key/value list' then
+        return {'add', 'append', 'set', 'remove'}
+    end
+
+    if type == 'String list' or type == 'Object settings list' then
+        return {'add', 'append', 'clr', 'pre', 'set', 'remove', 'toggle'}
+    end
+
+    return {}
+end
+
 local function choice_list(option)
     local info = mp.get_property_native('option-info/' .. option, {})
 
@@ -720,6 +734,10 @@ function build_completers()
         { pattern = '^%s*apply[-_]profile%s+()%S*$', list = profile_list },
         { pattern = '^%s*change[-_]list%s+()[%w_-]*$', list = list_option_list, append = ' ' },
         { pattern = '^%s*change[-_]list%s+()"[%w_-]*$', list = list_option_list, append = '" ' },
+        { pattern = '^%s*change[-_]list%s+"?([%w_-]+)"?%s+()%a*$', list = list_option_verb_list, append = ' ' },
+        { pattern = '^%s*change[-_]list%s+"?([%w_-]+)"?%s+"()%a*$', list = list_option_verb_list, append = '" ' },
+        { pattern = '^%s*([av]f)%s+()%a*$', list = list_option_verb_list, append = ' ' },
+        { pattern = '^%s*([av]f)%s+"()%a*$', list = list_option_verb_list, append = '" ' },
         { pattern = '${()[%w_/-]+$', list = property_list, append = '}' },
     }
 


### PR DESCRIPTION
This adds some more completers to console.lua.

Question: do we want to complete `del` with the list option verbs even though it's deprecated or is it one of these things that no one is going to remove without wm4?