### PR TITLE
javascript: use --js-memory-report option instead of MPV_LEAK_REPORT

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -107,6 +107,8 @@ Interface changes
     - rename `--screenshot-directory` to `--screenshot-dir`
     - rename `--watch-later-directory` to `--watch-later-dir`
     - rename `--play-dir` to `--play-direction`
+    - `--js-memory-report` is now used for enabling memory reporting for javascript
+      scripts
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -993,6 +993,12 @@ Program Behavior
         - ``--ytdl-raw-options=proxy=[http://127.0.0.1:3128]``
         - ``--ytdl-raw-options-append=proxy=http://127.0.0.1:3128``
 
+``--js-memory-report=<yes|no>``
+    Enable memory reporting for javascript scripts in the stats overlay.
+    This is disabled by default because it has an overhead and increases
+    memory usage. This option will only work if it is enabled before mpv is
+    started.
+
 ``--load-stats-overlay=<yes|no>``
     Enable the builtin script that shows useful playback information on a key
     binding (default: yes). By default, the ``i`` key is used (``I`` to make

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -225,8 +225,8 @@ are missing.
 Memory usage is approximate and does not reflect internal fragmentation.
 
 JS scripts memory reporting is disabled by default because collecting the data
-at the JS side has an overhead. It can be enabled by exporting the env var
-``MPV_LEAK_REPORT=1`` before starting mpv, and will increase JS memory usage.
+at the JS side has an overhead and will increase memory usage. It can be
+enabled by setting the ``--js-memory-report`` option before starting mpv.
 
 If entries have ``/time`` and ``/cpu`` variants, the former gives the real time
 (monotonic clock), while the latter the thread CPU time (only if the

--- a/options/options.c
+++ b/options/options.c
@@ -490,6 +490,9 @@ static const m_option_t mp_opts[] = {
     {"script-opts", OPT_KEYVALUELIST(script_opts)},
     {"load-scripts", OPT_BOOL(auto_load_scripts)},
 #endif
+#if HAVE_JAVASCRIPT
+    {"js-memory-report", OPT_BOOL(js_memory_report)},
+#endif
 #if HAVE_LUA
     {"osc", OPT_BOOL(lua_load_osc), .flags = UPDATE_BUILTIN_SCRIPTS},
     {"ytdl", OPT_BOOL(lua_load_ytdl), .flags = UPDATE_BUILTIN_SCRIPTS},

--- a/options/options.h
+++ b/options/options.h
@@ -157,6 +157,7 @@ typedef struct MPOpts {
     char **reset_options;
     char **script_files;
     char **script_opts;
+    bool js_memory_report;
     bool lua_load_osc;
     bool lua_load_ytdl;
     char *lua_ytdl_format;

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -535,8 +535,7 @@ static int s_load_javascript(struct mp_script_args *args)
     js_Alloc alloc_fn = NULL;
     void *actx = NULL;
 
-    char *mem_report = getenv("MPV_LEAK_REPORT");
-    if (mem_report && strcmp(mem_report, "1") == 0) {
+    if (args->mpctx->opts->js_memory_report) {
         alloc_fn = mp_js_alloc;
         actx = ctx;
     }


### PR DESCRIPTION
The MPV_LEAK_REPORT environment variable was previously read in order to determine whether or not to enable memory reporting for javascript scripts. This is kind of weird and deviates from the norm of exposing an option to the user. So let's just add --js-memory-report and disable it by default instead.

Based on discussion from here: https://github.com/mpv-player/mpv/pull/12571#discussion_r1371922356