### PR TITLE
timer: remove MP_START_TIME

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -316,7 +316,7 @@ static void print_terminal_line(struct mp_log *log, int lev,
         set_msg_color(stream, lev);
 
     if (root->show_time)
-        fprintf(stream, "[%10.6f] ", (mp_time_ns() - MP_START_TIME) / 1e9);
+        fprintf(stream, "[%10.6f] ", mp_time_sec());
 
     const char *prefix = log->prefix;
     if ((lev >= MSGL_V) || root->verbose || root->module)
@@ -551,7 +551,7 @@ static void *log_file_thread(void *p)
         if (e) {
             pthread_mutex_unlock(&root->log_file_lock);
             fprintf(root->log_file, "[%8.3f][%c][%s] %s",
-                    (mp_time_ns() - MP_START_TIME) / 1e9,
+                    mp_time_sec(),
                     mp_log_levels[e->level][0], e->prefix, e->text);
             fflush(root->log_file);
             pthread_mutex_lock(&root->log_file_lock);

--- a/osdep/semaphore_osx.c
+++ b/osdep/semaphore_osx.c
@@ -46,7 +46,7 @@ int mp_sem_init(mp_sem_t *sem, int pshared, unsigned int value)
 
 int mp_sem_wait(mp_sem_t *sem)
 {
-    return mp_sem_timedwait(sem, MP_START_TIME - 1);
+    return mp_sem_timedwait(sem, -1);
 }
 
 int mp_sem_trywait(mp_sem_t *sem)
@@ -76,9 +76,9 @@ int mp_sem_timedwait(mp_sem_t *sem, int64_t until)
             return 0;
 
         int timeout = 0;
-        if (until == MP_START_TIME - 1) {
+        if (until == -1) {
             timeout = -1;
-        } else if (until >= MP_START_TIME) {
+        } else if (until >= 0) {
             timeout = (until - mp_time_ns()) / MP_TIME_MS_TO_NS(1);
             timeout = MPCLAMP(timeout, 0, INT_MAX);
         } else {

--- a/osdep/timer.c
+++ b/osdep/timer.c
@@ -36,10 +36,7 @@ static void do_timer_init(void)
     mp_raw_time_init();
     mp_rand_seed(mp_raw_time_ns());
     raw_time_offset = mp_raw_time_ns();
-    // Arbitrary additional offset to avoid confusing relative/absolute times.
-    // Also,we rule that the timer never returns 0 (so default-initialized
-    // time values will be always in the past).
-    raw_time_offset -= MP_START_TIME;
+    assert(raw_time_offset > 0);
 }
 
 void mp_time_init(void)
@@ -49,10 +46,7 @@ void mp_time_init(void)
 
 int64_t mp_time_ns(void)
 {
-    uint64_t r = mp_raw_time_ns() - raw_time_offset;
-    if (r < MP_START_TIME)
-        r = MP_START_TIME;
-    return r;
+    return mp_raw_time_ns() - raw_time_offset;
 }
 
 double mp_time_sec(void)

--- a/osdep/timer.h
+++ b/osdep/timer.h
@@ -32,6 +32,7 @@ double mp_time_sec(void);
 
 // Provided by OS specific functions (timer-linux.c)
 void mp_raw_time_init(void);
+// ensure this doesn't return 0
 uint64_t mp_raw_time_ns(void);
 
 // Sleep in nanoseconds.
@@ -44,8 +45,6 @@ int mp_start_hires_timers(int wait_ms);
 // call unconditionally with the return value of mp_start_hires_timers
 void mp_end_hires_timers(int resolution_ms);
 #endif  /* _WIN32 */
-
-#define MP_START_TIME 10 * INT64_C(1000000000)
 
 // Converts time units to nanoseconds (int64_t)
 #define MP_TIME_S_TO_NS(s) ((s) * INT64_C(1000000000))


### PR DESCRIPTION
otherwise, it may give wrong/unwanted results due to operator precedence when used in arithmetic expressions.