### PR TITLE
win32: increase hires timer resolution

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -490,6 +490,7 @@ if features['win32-desktop']
                           cc.find_library('dwmapi'),
                           cc.find_library('gdi32'),
                           cc.find_library('imm32'),
+                          cc.find_library('ntdll'),
                           cc.find_library('ole32'),
                           cc.find_library('uuid'),
                           cc.find_library('uxtheme'),

--- a/meson.build
+++ b/meson.build
@@ -494,8 +494,7 @@ if features['win32-desktop']
                           cc.find_library('ole32'),
                           cc.find_library('uuid'),
                           cc.find_library('uxtheme'),
-                          cc.find_library('version'),
-                          cc.find_library('winmm')]
+                          cc.find_library('version')]
     dependencies += win32_desktop_libs
     path_source = files('osdep/path-win.c')
     subprocess_source = files('osdep/subprocess-win.c')

--- a/osdep/threads-win32.h
+++ b/osdep/threads-win32.h
@@ -115,7 +115,7 @@ static inline int mp_cond_timedwait(mp_cond *cond, mp_mutex *mutex, int64_t time
     timeout = MPCLAMP(timeout, 0, MP_TIME_MS_TO_NS(INFINITE)) / MP_TIME_MS_TO_NS(1);
 
     int ret = 0;
-    int hrt = mp_start_hires_timers(timeout);
+    int64_t hrt = mp_start_hires_timers(MP_TIME_MS_TO_NS(timeout));
     BOOL bRet;
 
     if (mutex->use_cs) {

--- a/osdep/timer.h
+++ b/osdep/timer.h
@@ -39,11 +39,11 @@ uint64_t mp_raw_time_ns(void);
 void mp_sleep_ns(int64_t ns);
 
 #ifdef _WIN32
-// returns: timer resolution in ms if needed and started successfully, else 0
-int mp_start_hires_timers(int wait_ms);
+// returns: timer resolution in ns if needed and started successfully, else 0
+int64_t mp_start_hires_timers(int64_t wait_ns);
 
 // call unconditionally with the return value of mp_start_hires_timers
-void mp_end_hires_timers(int resolution_ms);
+void mp_end_hires_timers(int64_t resolution_ns);
 #endif  /* _WIN32 */
 
 // Converts time units to nanoseconds (int64_t)

--- a/test/meson.build
+++ b/test/meson.build
@@ -51,6 +51,7 @@ endif
 
 if features['win32-desktop']
     test_utils_deps += cc.find_library('imm32')
+    test_utils_deps += cc.find_library('ntdll')
     test_utils_deps += cc.find_library('winmm')
 endif
 test_utils_objects = libmpv.extract_objects(test_utils_files)

--- a/test/meson.build
+++ b/test/meson.build
@@ -52,7 +52,6 @@ endif
 if features['win32-desktop']
     test_utils_deps += cc.find_library('imm32')
     test_utils_deps += cc.find_library('ntdll')
-    test_utils_deps += cc.find_library('winmm')
 endif
 test_utils_objects = libmpv.extract_objects(test_utils_files)
 test_utils = static_library('test-utils', 'test_utils.c', include_directories: incdir,


### PR DESCRIPTION
`timeBeginPeriod()` and `timeEndPeriod()` internally call `NtSetTimerResolution()` to raise/reset timer resolution on win32/NT platforms.

The latter allows setting the timer resolution to less than 1 ms. Modern x86 platforms (I have tested on Ivy Bridge which is the case, but it's likely also the case on older hardware) support a minimum timer resolution of 0.5 ms, as reported by `NtQueryTimerResolution()`.
