### PR TITLE
TOOLS/macos-sdk-version: use packaging instead of distutils for version

### DIFF
--- a/TOOLS/macos-sdk-version.py
+++ b/TOOLS/macos-sdk-version.py
@@ -8,7 +8,7 @@ import re
 import os
 import string
 import sys
-from distutils.version import StrictVersion
+from packaging import version
 from shutil import which
 from subprocess import check_output
 
@@ -56,7 +56,7 @@ def find_macos_sdk():
         sdk_version = '10.10.0'
 
     # pick the higher version, always pick sdk over build if newer
-    if StrictVersion(build_version) > StrictVersion(sdk_version):
+    if version.parse(build_version) > version.parse(sdk_version):
         return sdk,build_version
     else:
         return sdk,sdk_version


### PR DESCRIPTION
Python 3.10 deprecated disutils and then removed it in 3.12. The macos sdk check uses the version compare from there, so it needs to be replaced with something else. So instead use the API from the packaging module which is also widely available and a fit replacement.

Might need to install python-packaging for the CI. Let's see.

Edit: evidently not.