### PR TITLE
timer-linux: fallback to CLOCK_MONOTONIC instead of timespec_get

### DIFF
--- a/osdep/timer-linux.c
+++ b/osdep/timer-linux.c
@@ -35,11 +35,12 @@ void mp_sleep_ns(int64_t ns)
 uint64_t mp_raw_time_ns(void)
 {
     struct timespec tp = {0};
+    int ret = -1;
 #if defined(CLOCK_MONOTONIC_RAW)
-    clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
-#else
-    timespec_get(&tp, TIME_UTC);
+    ret = clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 #endif
+    if (ret)
+        clock_gettime(CLOCK_MONOTONIC, &tp);
     return MP_TIME_S_TO_NS(tp.tv_sec) + tp.tv_nsec;
 }
 


### PR DESCRIPTION
CLOCK_MONOTONIC_RAW is linux-specific and not necessarily available everywhere (like BSDs). It makes sense to prefer it because mpv does a lot of measurements at small intervals (e.g. every frame) so theoretically it should be more accurate. However if the OS doesn't have that, just use CLOCK_MONOTONIC instead which is almost exactly the same. The slight difference probably doesn't matter for us anyway. This does mean that for any POSIX system (minus macOS which has its own stuff), we effectively require CLOCK_MONOTONIC to be available. This clock is technically optional according to POSIX, but the chances of any OS we care about not actually supporting this is probably 0. As a benefit, we know the time returned from this codepath is always monotonic.