### PR TITLE
TOOLS/{file2string,matroska}: drop unneeded stdout output

### DIFF
--- a/TOOLS/file2string.py
+++ b/TOOLS/file2string.py
@@ -39,10 +39,6 @@ def file2string(infilename, infile, outfile):
         outfile.write('"' + ''.join(conv[c] for c in line) + '"\n')
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        outfile = sys.stdout
-    else:
-        outfile = open(sys.argv[2], "w")
-
+    outfile = open(sys.argv[2], "w")
     with open(sys.argv[1], 'rb') as infile:
         file2string(sys.argv[1], infile, outfile)

--- a/TOOLS/matroska.py
+++ b/TOOLS/matroska.py
@@ -463,15 +463,10 @@ if __name__ == "__main__":
     def parse_toplevel(s):
         parse_one(s, 0, None, 1 << 63)
 
-    if len(sys.argv) < 3:
-        outfile = sys.stdout
-    else:
-        outfile = open(sys.argv[2], "w")
-
     if sys.argv[1] == '--generate-header':
-        generate_C_header(outfile)
+        generate_C_header(open(sys.argv[2], "w"))
     elif sys.argv[1] == '--generate-definitions':
-        generate_C_definitions(outfile)
+        generate_C_definitions(open(sys.argv[2], "w"))
     else:
         s = open(sys.argv[1], "rb")
         while 1:


### PR DESCRIPTION
This was originally for the waf build, and then later writing the output to a file was added for meson. Since the waf build is no longer around anymore, remove the dead code.