### PR TITLE
timer-linux: prefer CLOCK_BOOTTIME if defined

### DIFF
--- a/osdep/timer-linux.c
+++ b/osdep/timer-linux.c
@@ -36,7 +36,11 @@ uint64_t mp_raw_time_ns(void)
 {
     struct timespec tp = {0};
     int ret = -1;
-#if defined(CLOCK_MONOTONIC_RAW)
+#if defined(CLOCK_BOOTTIME)
+    // avoid linux's CLOCK_MONOTONIC{_RAW} issue of not counting
+    // system suspension time
+    ret = clock_gettime(CLOCK_BOOTTIME, &tp);
+#elif defined(CLOCK_MONOTONIC_RAW)
     ret = clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 #endif
     if (ret)


### PR DESCRIPTION
this is mainly just to unify the behavior between linux and BSDs where linux's `CLOCK_MONOTONIC{_RAW}` doesn't count time during system suspension. this likely doesn't matter much in practice given `CLOCK_MONOTONIC*` was used for a long time but it doesn't hurt unifying the behavior.

ref: https://github.com/mpv-player/mpv/pull/12764#discussion_r1375228918