### PR TITLE
lua: remove a ton of unneeded parenthesis

### DIFF
--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -175,7 +175,7 @@ function mp.flush_keybindings()
 end
 
 local function add_binding(attrs, key, name, fn, rp)
-    if (type(name) ~= "string") and (name ~= nil) then
+    if type(name) ~= "string" and name ~= nil then
         rp = fn
         fn = name
         name = nil
@@ -226,7 +226,7 @@ local function add_binding(attrs, key, name, fn, rp)
             end
             if is_mouse and (event == "u" or event == "p") then
                 fn()
-            elseif (not is_mouse) and (event == "d" or event == "r" or event == "p") then
+            elseif not is_mouse and (event == "d" or event == "r" or event == "p") then
                 fn()
             end
         end
@@ -316,7 +316,7 @@ end
 local function get_next_timer()
     local best = nil
     for t, _ in pairs(timers) do
-        if (best == nil) or (t.next_deadline < best.next_deadline) then
+        if best == nil or t.next_deadline < best.next_deadline then
             best = t
         end
     end
@@ -598,7 +598,7 @@ mp.register_event("hook", function(ev)
     if fn then
         fn(hookobj)
     end
-    if (not hookobj._defer) and hookobj._id ~= nil then
+    if not hookobj._defer and hookobj._id ~= nil then
         hookobj:cont()
     end
 end)

--- a/player/lua/options.lua
+++ b/player/lua/options.lua
@@ -12,7 +12,7 @@ local function typeconv(desttypeval, val)
             val = nil
         end
     elseif type(desttypeval) == "number" then
-        if not (tonumber(val) == nil) then
+        if tonumber(val) ~= nil then
             val = tonumber(val)
         else
             msg.error("Error: Can't convert '" .. val .. "' to number!")

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -280,7 +280,7 @@ function get_slider_value(element)
 end
 
 function countone(val)
-    if not (user_opts.iamaprogrammer) then
+    if not user_opts.iamaprogrammer then
         val = val + 1
     end
     return val
@@ -301,7 +301,7 @@ end
 
 function add_area(name, x1, y1, x2, y2)
     -- create area if needed
-    if (osc_param.areas[name] == nil) then
+    if osc_param.areas[name] == nil then
         osc_param.areas[name] = {}
     end
     table.insert(osc_param.areas[name], {x1=x1, y1=y1, x2=x2, y2=y2})
@@ -356,7 +356,7 @@ function update_tracklist()
     tracks_mpv = {}
     tracks_mpv.video, tracks_mpv.audio, tracks_mpv.sub = {}, {}, {}
     for n = 1, #tracktable do
-        if not (tracktable[n].type == "unknown") then
+        if tracktable[n].type ~= "unknown" then
             local type = tracktable[n].type
             local mpv_id = tonumber(tracktable[n].id)
 
@@ -379,9 +379,9 @@ function get_tracklist(type)
         for n = 1, #tracks_osc[type] do
             local track = tracks_osc[type][n]
             local lang, title, selected = "unknown", "", "○"
-            if not(track.lang == nil) then lang = track.lang end
-            if not(track.title == nil) then title = track.title end
-            if (track.id == tonumber(mp.get_property(type))) then
+            if track.lang ~= nil then lang = track.lang end
+            if track.title ~= nil then title = track.title end
+            if track.id == tonumber(mp.get_property(type)) then
                 selected = "●"
             end
             msg = msg.."\n"..selected.." "..n..": ["..lang.."] "..title
@@ -394,7 +394,7 @@ end
     --(+1 -> next, -1 -> previous)
 function set_track(type, next)
     local current_track_mpv, current_track_osc
-    if (mp.get_property(type) == "no") then
+    if mp.get_property(type) == "no" then
         current_track_osc = 0
     else
         current_track_mpv = tonumber(mp.get_property(type))
@@ -410,7 +410,7 @@ function set_track(type, next)
 
     mp.commandv("set", type, new_track_mpv)
 
-        if (new_track_osc == 0) then
+        if new_track_osc == 0 then
         show_message(nicetypes[type] .. " Track: none")
     else
         show_message(nicetypes[type]  .. " Track: "
@@ -457,7 +457,7 @@ function prepare_elements()
     -- remove elements without layout or invisible
     local elements2 = {}
     for n, element in pairs(elements) do
-        if not (element.layout == nil) and (element.visible) then
+        if element.layout ~= nil and element.visible then
             table.insert(elements2, element)
         end
     end
@@ -492,14 +492,14 @@ function prepare_elements()
         local static_ass = assdraw.ass_new()
 
 
-        if (element.type == "box") then
+        if element.type == "box" then
             --draw box
             static_ass:draw_start()
             ass_draw_rr_h_cw(static_ass, 0, 0, elem_geo.w, elem_geo.h,
                              element.layout.box.radius, element.layout.box.hexagon)
             static_ass:draw_stop()
 
-        elseif (element.type == "slider") then
+        elseif element.type == "slider" then
             --draw static slider parts
 
             local r1 = 0
@@ -509,13 +509,13 @@ function prepare_elements()
             local foV = slider_lo.border + slider_lo.gap
 
             -- calculate positions of min and max points
-            if (slider_lo.stype ~= "bar") then
+            if slider_lo.stype ~= "bar" then
                 r1 = elem_geo.h / 2
                 element.slider.min.ele_pos = elem_geo.h / 2
                 element.slider.max.ele_pos = elem_geo.w - (elem_geo.h / 2)
-                if (slider_lo.stype == "diamond") then
+                if slider_lo.stype == "diamond" then
                     r2 = (elem_geo.h - 2 * slider_lo.border) / 2
-                elseif (slider_lo.stype == "knob") then
+                elseif slider_lo.stype == "knob" then
                     r2 = r1
                 end
             else
@@ -543,45 +543,45 @@ function prepare_elements()
                               r2, slider_lo.stype == "diamond")
 
             -- marker nibbles
-            if not (element.slider.markerF == nil) and (slider_lo.gap > 0) then
+            if element.slider.markerF ~= nil and slider_lo.gap > 0 then
                 local markers = element.slider.markerF()
                 for _,marker in pairs(markers) do
-                    if (marker > element.slider.min.value) and
-                        (marker < element.slider.max.value) then
+                    if marker > element.slider.min.value and
+                        marker < element.slider.max.value then
 
                         local s = get_slider_ele_pos_for(element, marker)
 
-                        if (slider_lo.gap > 1) then -- draw triangles
+                        if slider_lo.gap > 1 then -- draw triangles
 
                             local a = slider_lo.gap / 0.5 --0.866
 
                             --top
-                            if (slider_lo.nibbles_top) then
-                                static_ass:move_to(s - (a/2), slider_lo.border)
-                                static_ass:line_to(s + (a/2), slider_lo.border)
+                            if slider_lo.nibbles_top then
+                                static_ass:move_to(s - (a / 2), slider_lo.border)
+                                static_ass:line_to(s + (a / 2), slider_lo.border)
                                 static_ass:line_to(s, foV)
                             end
 
                             --bottom
-                            if (slider_lo.nibbles_bottom) then
-                                static_ass:move_to(s - (a/2),
+                            if slider_lo.nibbles_bottom then
+                                static_ass:move_to(s - (a / 2),
                                     elem_geo.h - slider_lo.border)
                                 static_ass:line_to(s,
                                     elem_geo.h - foV)
-                                static_ass:line_to(s + (a/2),
+                                static_ass:line_to(s + (a / 2),
                                     elem_geo.h - slider_lo.border)
                             end
 
                         else -- draw 2x1px nibbles
 
                             --top
-                            if (slider_lo.nibbles_top) then
+                            if slider_lo.nibbles_top then
                                 static_ass:rect_cw(s - 1, slider_lo.border,
                                     s + 1, slider_lo.border + slider_lo.gap);
                             end
 
                             --bottom
-                            if (slider_lo.nibbles_bottom) then
+                            if slider_lo.nibbles_bottom then
                                 static_ass:rect_cw(s - 1,
                                     elem_geo.h -slider_lo.border -slider_lo.gap,
                                     s + 1, elem_geo.h - slider_lo.border);
@@ -597,7 +597,7 @@ function prepare_elements()
 
         -- if the element is supposed to be disabled,
         -- style it accordingly and kill the eventresponders
-        if not (element.enabled) then
+        if not element.enabled then
             element.layout.alpha[1] = 136
             element.eventresponder = nil
         end
@@ -648,18 +648,18 @@ function render_elements(master_ass)
         if element.eventresponder and (state.active_element == n) then
 
             -- run render event functions
-            if not (element.eventresponder.render == nil) then
+            if element.eventresponder.render ~= nil then
                 element.eventresponder.render(element)
             end
 
             if mouse_hit(element) then
                 -- mouse down styling
-                if (element.styledown) then
+                if element.styledown then
                     style_ass:append(osc_styles.elementDown)
                 end
 
-                if (element.softrepeat) and (state.mouse_down_counter >= 15
-                    and state.mouse_down_counter % 5 == 0) then
+                if element.softrepeat and state.mouse_down_counter >= 15
+                    and state.mouse_down_counter % 5 == 0 then
 
                     element.eventresponder[state.active_event_source.."_down"](element)
                 end
@@ -672,11 +672,11 @@ function render_elements(master_ass)
 
         elem_ass:merge(style_ass)
 
-        if not (element.type == "button") then
+        if element.type ~= "button" then
             elem_ass:merge(element.static_ass)
         end
 
-        if (element.type == "slider") then
+        if element.type == "slider" then
 
             local slider_lo = element.layout.slider
             local elem_geo = element.layout.geometry
@@ -794,8 +794,7 @@ function render_elements(master_ass)
             elem_ass:draw_stop()
 
             -- add tooltip
-            if not (element.slider.tooltipF == nil) then
-
+            if element.slider.tooltipF ~= nil then
                 if mouse_hit(element) then
                     local sliderpos = get_slider_value(element)
                     local tooltiplabel = element.slider.tooltipF(sliderpos)
@@ -804,21 +803,21 @@ function render_elements(master_ass)
 
                     local ty
 
-                    if (an == 2) then
+                    if an == 2 then
                         ty = element.hitbox.y1 - slider_lo.border
                     else
-                        ty = element.hitbox.y1 + elem_geo.h/2
+                        ty = element.hitbox.y1 + elem_geo.h / 2
                     end
 
                     local tx = get_virt_mouse_pos()
-                    if (slider_lo.adjust_tooltip) then
-                        if (an == 2) then
-                            if (sliderpos < (s_min + 3)) then
+                    if slider_lo.adjust_tooltip then
+                        if an == 2 then
+                            if sliderpos < (s_min + 3) then
                                 an = an - 1
-                            elseif (sliderpos > (s_max - 3)) then
+                            elseif sliderpos > (s_max - 3) then
                                 an = an + 1
                             end
-                        elseif (sliderpos > (s_max+s_min)/2) then
+                        elseif sliderpos > (s_max+s_min) / 2 then
                             an = an + 1
                             tx = tx - 5
                         else
@@ -838,20 +837,20 @@ function render_elements(master_ass)
                 end
             end
 
-        elseif (element.type == "button") then
+        elseif element.type == "button" then
 
             local buttontext
             if type(element.content) == "function" then
                 buttontext = element.content() -- function objects
-            elseif not (element.content == nil) then
+            elseif element.content ~= nil then
                 buttontext = element.content -- text objects
             end
 
             local maxchars = element.layout.button.maxchars
-            if not (maxchars == nil) and (#buttontext > maxchars) then
+            if maxchars ~= nil and #buttontext > maxchars then
                 local max_ratio = 1.25  -- up to 25% more chars while shrinking
                 local limit = math.max(0, math.floor(maxchars * max_ratio) - 3)
-                if (#buttontext > limit) then
+                if #buttontext > limit then
                     while (#buttontext > limit) do
                         buttontext = buttontext:gsub(".[\128-\191]*$", "")
                     end
@@ -1007,7 +1006,7 @@ function new_element(name, type)
     elements[name].styledown = (type == "button")
     elements[name].state = {}
 
-    if (type == "slider") then
+    if type == "slider" then
         elements[name].slider = {min = {value = 0}, max = {value = 100}}
     end
 
@@ -1016,7 +1015,7 @@ function new_element(name, type)
 end
 
 function add_layout(name)
-    if not (elements[name] == nil) then
+    if elements[name] ~= nil then
         -- new layout
         elements[name].layout = {}
 
@@ -1024,11 +1023,11 @@ function add_layout(name)
         elements[name].layout.layer = 50
         elements[name].layout.alpha = {[1] = 0, [2] = 255, [3] = 255, [4] = 255}
 
-        if (elements[name].type == "button") then
+        if elements[name].type == "button" then
             elements[name].layout.button = {
                 maxchars = nil,
             }
-        elseif (elements[name].type == "slider") then
+        elseif elements[name].type == "slider" then
             -- slider defaults
             elements[name].layout.slider = {
                 border = 1,
@@ -1041,7 +1040,7 @@ function add_layout(name)
                 tooltip_an = 2,
                 alpha = {[1] = 0, [2] = 255, [3] = 88, [4] = 255},
             }
-        elseif (elements[name].type == "box") then
+        elseif elements[name].type == "box" then
             elements[name].layout.box = {radius = 0, hexagon = false}
         end
 
@@ -1196,8 +1195,8 @@ layouts["box"] = function ()
     }
 
     -- make sure the OSC actually fits into the video
-    if (osc_param.playresx < (osc_geo.w + (2 * osc_geo.p))) then
-        osc_param.playresy = (osc_geo.w+(2*osc_geo.p))/osc_param.display_aspect
+    if osc_param.playresx < (osc_geo.w + (2 * osc_geo.p)) then
+        osc_param.playresy = (osc_geo.w + (2 * osc_geo.p)) / osc_param.display_aspect
         osc_param.playresx = osc_param.playresy * osc_param.display_aspect
     end
 
@@ -1371,8 +1370,8 @@ layouts["slimbox"] = function ()
     }
 
     -- make sure the OSC actually fits into the video
-    if (osc_param.playresx < (osc_geo.w)) then
-        osc_param.playresy = (osc_geo.w)/osc_param.display_aspect
+    if osc_param.playresx < (osc_geo.w) then
+        osc_param.playresy = (osc_geo.w) / osc_param.display_aspect
         osc_param.playresx = osc_param.playresy * osc_param.display_aspect
     end
 
@@ -1423,7 +1422,7 @@ layouts["slimbox"] = function ()
     lo.style = osc_styles.box
     lo.alpha[1] = user_opts.boxalpha
     lo.alpha[3] = 0
-    if not (user_opts["seekbarstyle"] == "bar") then
+    if user_opts["seekbarstyle"] ~= "bar" then
         lo.box.radius = osc_geo.r
         lo.box.hexagon = user_opts["seekbarstyle"] == "diamond"
     end
@@ -1505,7 +1504,7 @@ function bar_layout(direction)
         padwc_r = window_control_box_width
     end
 
-    if ((osc_param.display_aspect > 0) and (osc_param.playresx < minW)) then
+    if osc_param.display_aspect > 0 and osc_param.playresx < minW then
         osc_param.playresy = minW / osc_param.display_aspect
         osc_param.playresx = osc_param.playresy * osc_param.display_aspect
     end
@@ -1654,7 +1653,7 @@ function bar_layout(direction)
     lo.style = osc_styles.timecodesBar
     lo.alpha[1] =
         math.min(255, user_opts.boxalpha + (255 - user_opts.boxalpha)*0.8)
-    if not (user_opts["seekbarstyle"] == "bar") then
+    if user_opts["seekbarstyle"] ~= "bar" then
         lo.box.radius = geo.h / 2
         lo.box.hexagon = user_opts["seekbarstyle"] == "diamond"
     end
@@ -1749,7 +1748,7 @@ function osc_init()
     local display_w, display_h, display_aspect = mp.get_osd_size()
     local scale = 1
 
-    if (mp.get_property("video") == "no") then -- dummy/forced window
+    if mp.get_property("video") == "no" then -- dummy/forced window
         scale = user_opts.scaleforcedwindow
     elseif state.fullscreen then
         scale = user_opts.scalefullscreen
@@ -1763,7 +1762,7 @@ function osc_init()
         osc_param.unscaled_y = display_h
     end
     osc_param.playresy = osc_param.unscaled_y / scale
-    if (display_aspect > 0) then
+    if display_aspect > 0 then
         osc_param.display_aspect = display_aspect
     end
     osc_param.playresx = osc_param.playresy * osc_param.display_aspect
@@ -1797,7 +1796,7 @@ function osc_init()
 
     ne.eventresponder["mbtn_left_up"] = function ()
         local title = mp.get_property_osd("media-title")
-        if (have_pl) then
+        if have_pl then
             title = string.format("[%d/%d] %s", countone(pl_pos - 1),
                                   pl_count, title)
         end
@@ -1926,7 +1925,7 @@ function osc_init()
     ne.enabled = (#tracks_osc.audio > 0)
     ne.content = function ()
         local aid = "–"
-        if not (get_track("audio") == 0) then
+        if get_track("audio") ~= 0 then
             aid = get_track("audio")
         end
         return ("\238\132\134" .. osc_styles.smallButtonsLlabel
@@ -1949,7 +1948,7 @@ function osc_init()
     ne.enabled = (#tracks_osc.sub > 0)
     ne.content = function ()
         local sid = "–"
-        if not (get_track("sub") == 0) then
+        if get_track("sub") ~= 0 then
             sid = get_track("sub")
         end
         return ("\238\132\135" .. osc_styles.smallButtonsLlabel
@@ -1969,7 +1968,7 @@ function osc_init()
     --tog_fs
     ne = new_element("tog_fs", "button")
     ne.content = function ()
-        if (state.fullscreen) then
+        if state.fullscreen then
             return ("\238\132\137")
         else
             return ("\238\132\136")
@@ -1981,11 +1980,11 @@ function osc_init()
     --seekbar
     ne = new_element("seekbar", "slider")
 
-    ne.enabled = not (mp.get_property("percent-pos") == nil)
+    ne.enabled = mp.get_property("percent-pos") ~= nil
     state.slider_element = ne.enabled and ne or nil  -- used for forced_title
     ne.slider.markerF = function ()
         local duration = mp.get_property_number("duration", nil)
-        if not (duration == nil) then
+        if duration ~= nil then
             local chapters = mp.get_property_native("chapter-list", {})
             local markers = {}
             for n = 1, #chapters do
@@ -2000,7 +1999,7 @@ function osc_init()
         function () return mp.get_property_number("percent-pos", nil) end
     ne.slider.tooltipF = function (pos)
         local duration = mp.get_property_number("duration", nil)
-        if not ((duration == nil) or (pos == nil)) then
+        if duration ~= nil and pos ~= nil then
             possec = duration * (pos / 100)
             return mp.format_time(possec)
         else
@@ -2016,7 +2015,7 @@ function osc_init()
             return nil
         end
         local duration = mp.get_property_number("duration", nil)
-        if (duration == nil) or duration <= 0 then
+        if duration == nil or duration <= 0 then
             return nil
         end
         local ranges = cache_state["seekable-ranges"]
@@ -2038,8 +2037,8 @@ function osc_init()
             -- sent when the user is done seeking, so we need to throw away
             -- identical seeks
             local seekto = get_slider_value(element)
-            if (element.state.lastseek == nil) or
-                (not (element.state.lastseek == seekto)) then
+            if element.state.lastseek == nil or
+                element.state.lastseek ~= seekto then
                     local flags = "absolute-percent"
                     if not user_opts.seekbarkeyframes then
                         flags = flags .. "+exact"
@@ -2064,7 +2063,7 @@ function osc_init()
     ne = new_element("tc_left", "button")
 
     ne.content = function ()
-        if (state.tc_ms) then
+        if state.tc_ms then
             return (mp.get_property_osd("playback-time/full"))
         else
             return (mp.get_property_osd("playback-time"))
@@ -2080,7 +2079,7 @@ function osc_init()
 
     ne.visible = (mp.get_property_number("duration", 0) > 0)
     ne.content = function ()
-        if (state.rightTC_trem) then
+        if state.rightTC_trem then
             local minus = user_opts.unicodeminus and UNICODE_MINUS or "-"
             local property = user_opts.remaining_playtime and "playtime-remaining"
                                                            or "time-remaining"
@@ -2174,7 +2173,7 @@ function update_margins()
     local margins = osc_param.video_margins
 
     -- Don't use margins if it's visible only temporarily.
-    if (not state.osc_visible) or (get_hidetimeout() >= 0) or
+    if not state.osc_visible or get_hidetimeout() >= 0 or
        (state.fullscreen and not user_opts.showfullscreen) or
        (not state.fullscreen and not user_opts.showwindowed)
     then
@@ -2196,7 +2195,7 @@ function update_margins()
         if not margins_used then
             for _, opt in ipairs(margins_opts) do
                 local v = margins[opt[1]]
-                if (v ~= 0) or state.using_video_margins then
+                if v ~= 0 or state.using_video_margins then
                     mp.set_property_number(opt[2], v)
                     state.using_video_margins = true
                 end
@@ -2229,7 +2228,7 @@ function show_osc()
 
     osc_visible(true)
 
-    if (user_opts.fadeduration > 0) then
+    if user_opts.fadeduration > 0 then
         state.anitype = nil
     end
 end
@@ -2241,8 +2240,8 @@ function hide_osc()
         -- no-op and won't render again to remove the osc, so do that manually.
         state.osc_visible = false
         render_wipe()
-    elseif (user_opts.fadeduration > 0) then
-        if not(state.osc_visible == false) then
+    elseif user_opts.fadeduration > 0 then
+        if state.osc_visible then
             state.anitype = "out"
             request_tick()
         end
@@ -2324,8 +2323,8 @@ function render()
     local now = mp.get_time()
 
     -- check if display changed, if so request reinit
-    if not (state.mp_screen_sizeX == current_screen_sizeX
-        and state.mp_screen_sizeY == current_screen_sizeY) then
+    if state.mp_screen_sizeX ~= current_screen_sizeX
+        or state.mp_screen_sizeY ~= current_screen_sizeY then
 
         request_init_resize()
 
@@ -2355,27 +2354,27 @@ function render()
 
 
     -- fade animation
-    if not(state.anitype == nil) then
+    if state.anitype ~= nil then
 
-        if (state.anistart == nil) then
+        if state.anistart == nil then
             state.anistart = now
         end
 
-        if (now < state.anistart + (user_opts.fadeduration/1000)) then
+        if now < state.anistart + (user_opts.fadeduration / 1000) then
 
-            if (state.anitype == "in") then --fade in
+            if state.anitype == "in" then --fade in
                 osc_visible(true)
                 state.animation = scale_value(state.anistart,
-                    (state.anistart + (user_opts.fadeduration/1000)),
+                    (state.anistart + (user_opts.fadeduration / 1000)),
                     255, 0, now)
-            elseif (state.anitype == "out") then --fade out
+            elseif state.anitype == "out" then --fade out
                 state.animation = scale_value(state.anistart,
-                    (state.anistart + (user_opts.fadeduration/1000)),
+                    (state.anistart + (user_opts.fadeduration / 1000)),
                     0, 255, now)
             end
 
         else
-            if (state.anitype == "out") then
+            if state.anitype == "out" then
                 osc_visible(false)
             end
             kill_animation()
@@ -2413,7 +2412,7 @@ function render()
             state.input_enabled = state.osc_visible
         end
 
-        if (mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2)) then
+        if mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2) then
             mouse_over_osc = true
         end
     end
@@ -2432,7 +2431,7 @@ function render()
                 state.windowcontrols_buttons = state.osc_visible
             end
 
-            if (mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2)) then
+            if mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2) then
                 mouse_over_osc = true
             end
         end
@@ -2440,17 +2439,17 @@ function render()
 
     if osc_param.areas["window-controls-title"] then
         for _,cords in ipairs(osc_param.areas["window-controls-title"]) do
-            if (mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2)) then
+            if mouse_hit_coords(cords.x1, cords.y1, cords.x2, cords.y2) then
                 mouse_over_osc = true
             end
         end
     end
 
     -- autohide
-    if not (state.showtime == nil) and (get_hidetimeout() >= 0) then
-        local timeout = state.showtime + (get_hidetimeout()/1000) - now
+    if state.showtime ~= nil and get_hidetimeout() >= 0 then
+        local timeout = state.showtime + (get_hidetimeout() / 1000) - now
         if timeout <= 0 then
-            if (state.active_element == nil) and not (mouse_over_osc) then
+            if state.active_element == nil and not mouse_over_osc then
                 hide_osc()
             end
         else
@@ -2544,8 +2543,8 @@ function process_event(source, what)
         state.mouse_in_window = true
 
         local mouseX, mouseY = get_virt_mouse_pos()
-        if (user_opts.minmousemove == 0) or
-            (not ((state.last_mouseX == nil) or (state.last_mouseY == nil)) and
+        if user_opts.minmousemove == 0 or
+            ((state.last_mouseX ~= nil and state.last_mouseY ~= nil) and
                 ((math.abs(mouseX - state.last_mouseX) >= user_opts.minmousemove)
                     or (math.abs(mouseY - state.last_mouseY) >= user_opts.minmousemove)
                 )
@@ -2597,9 +2596,9 @@ function tick()
         state.marginsREQ = false
     end
 
-    if (not state.enabled) then return end
+    if not state.enabled then return end
 
-    if (state.idle) then
+    if state.idle then
 
         -- render idle message
         msg.trace("idle message")
@@ -2645,7 +2644,7 @@ function tick()
         end
 
 
-    elseif (state.fullscreen and user_opts.showfullscreen)
+    elseif state.fullscreen and user_opts.showfullscreen
         or (not state.fullscreen and user_opts.showwindowed) then
 
         -- render the OSC
@@ -2708,7 +2707,7 @@ function update_duration_watch()
                        (mp.get_property_number("chapters", 0) or 0) > 0 and
                        true or false  -- ensure it's a boolean
 
-    if (want_watch ~= duration_watched) then
+    if want_watch ~= duration_watched then
         if want_watch then
             mp.observe_property("duration", nil, on_duration)
         else

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1092,7 +1092,7 @@ local function cache_stats()
     append(stats, opt_time(a) .. " - " .. opt_time(b), {prefix = "Packet queue:"})
 
     local r = nil
-    if (a ~= nil) and (b ~= nil) then
+    if a ~= nil and b ~= nil then
         r = b - a
     end
 
@@ -1174,7 +1174,7 @@ local function record_cache_stats()
 
     local a = info["reader-pts"]
     local b = info["cache-end"]
-    if (a ~= nil) and (b ~= nil) then
+    if a ~= nil and b ~= nil then
         graph_add_value(cache_ahead_buf, b - a)
     end
 
@@ -1274,7 +1274,7 @@ local function unbind_scroll()
     end
 end
 local function update_scroll_bindings(k)
-    if (pages[k].scroll) then
+    if pages[k].scroll then
         bind_scroll()
     else
         unbind_scroll()

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -357,7 +357,7 @@ local function join_url(base_url, fragment)
 end
 
 local function edl_track_joined(fragments, protocol, is_live, base)
-    if not (type(fragments) == "table") or not fragments[1] then
+    if type(fragments) ~= "table" or not fragments[1] then
         msg.debug("No fragments to join into EDL")
         return nil
     end
@@ -366,7 +366,7 @@ local function edl_track_joined(fragments, protocol, is_live, base)
     local offset = 1
     local parts = {}
 
-    if (protocol == "http_dash_segments") and not is_live then
+    if protocol == "http_dash_segments" and not is_live then
         msg.debug("Using dash")
         local args = ""
 
@@ -674,7 +674,7 @@ local function add_single_video(json)
             end
         end
 
-        if (not res) and has_requested_formats then
+        if not res and has_requested_formats then
             format_info = "youtube-dl (separate)"
             res = formats_to_edl(json, requested_formats, false)
         end
@@ -721,7 +721,7 @@ local function add_single_video(json)
     end
 
     -- add subtitles
-    if not (json.requested_subtitles == nil) then
+    if json.requested_subtitles ~= nil then
         local subs = {}
         for lang, info in pairs(json.requested_subtitles) do
             subs[#subs + 1] = {lang = lang or "-", info = info}
@@ -733,14 +733,14 @@ local function add_single_video(json)
 
             local sub = nil
 
-            if not (sub_info.data == nil) then
+            if sub_info.data ~= nil then
                 sub = "memory://"..sub_info.data
-            elseif not (sub_info.url == nil) and
+            elseif sub_info.url ~= nil and
                 url_is_safe(sub_info.url) then
                 sub = sub_info.url
             end
 
-            if not (sub == nil) then
+            if sub ~= nil then
                 local edl = "edl://!no_clip;!delay_open,media_type=sub"
                 local codec = map_codec_to_mpv(sub_info.ext)
                 if codec then
@@ -756,15 +756,15 @@ local function add_single_video(json)
     end
 
     -- add thumbnails
-    if (o.thumbnails == 'all' or o.thumbnails == 'best') and not (json.thumbnails == nil) then
+    if (o.thumbnails == 'all' or o.thumbnails == 'best') and json.thumbnails ~= nil then
         local thumb = nil
         local thumb_height = -1
         local thumb_preference = nil
 
         for i = #json.thumbnails, 1, -1 do
             local thumb_info = json.thumbnails[i]
-            if not (thumb_info.url == nil) then
-                if (o.thumbnails == 'all') then
+            if thumb_info.url ~= nil then
+                if o.thumbnails == 'all' then
                     msg.verbose("adding thumbnail")
                     mp.commandv("video-add", thumb_info.url, "auto")
                     thumb_height = 0
@@ -777,10 +777,10 @@ local function add_single_video(json)
             end
         end
 
-        if not (thumb == nil) then
+        if thumb ~= nil then
             msg.verbose("adding thumbnail")
             mp.commandv("video-add", thumb, "auto")
-        elseif (thumb_height == -1) then
+        elseif thumb_height == -1 then
             msg.verbose("No thumbnail url")
         end
     end
@@ -796,12 +796,12 @@ local function add_single_video(json)
             end
             table.insert(chapter_list, {time=chapter.start_time, title=title})
         end
-    elseif not (json.description == nil) and not (json.duration == nil) then
+    elseif json.description ~= nil and json.duration ~= nil then
         chapter_list = extract_chapters(json.description, json.duration)
     end
 
     -- set start time
-    if (json.start_time or json.section_start) and
+    if json.start_time or json.section_start and
         not option_was_set("start") and
         not option_was_set_locally("start") then
         local start_time = json.start_time or json.section_start
@@ -810,7 +810,7 @@ local function add_single_video(json)
     end
 
     -- set end time
-    if (json.end_time or json.section_end) and
+    if json.end_time or json.section_end and
         not option_was_set("end") and
         not option_was_set_locally("end") then
         local end_time = json.end_time or json.section_end
@@ -819,7 +819,7 @@ local function add_single_video(json)
     end
 
     -- set aspect ratio for anamorphic video
-    if not (json.stretched_ratio == nil) and
+    if json.stretched_ratio ~= nil and
         not option_was_set("video-aspect-override") then
         mp.set_property('file-local-options/video-aspect-override', json.stretched_ratio)
     end
@@ -827,7 +827,7 @@ local function add_single_video(json)
     local stream_opts = mp.get_property_native("file-local-options/stream-lavf-o", {})
 
     -- for rtmp
-    if (json.protocol == "rtmp") then
+    if json.protocol == "rtmp" then
         stream_opts = append_libav_opt(stream_opts,
             "rtmp_tcurl", streamurl)
         stream_opts = append_libav_opt(stream_opts,
@@ -869,12 +869,12 @@ local function check_version(ytdl_path)
     local year, month, day = string.match(version_string, "(%d+).(%d+).(%d+)")
 
     -- sanity check
-    if (tonumber(year) < 2000) or (tonumber(month) > 12) or
-        (tonumber(day) > 31) then
+    if tonumber(year) < 2000 or tonumber(month) > 12 or
+        tonumber(day) > 31 then
         return
     end
     local version_ts = os.time{year=year, month=month, day=day}
-    if (os.difftime(os.time(), version_ts) > 60*60*24*90) then
+    if os.difftime(os.time(), version_ts) > 60*60*24*90 then
         msg.warn("It appears that your youtube-dl version is severely out of date.")
     end
 end
@@ -883,7 +883,7 @@ function run_ytdl_hook(url)
     local start_time = os.clock()
 
     -- strip ytdl://
-    if (url:find("ytdl://") == 1) then
+    if url:find("ytdl://") == 1 then
         url = url:sub(8)
     end
 
@@ -900,12 +900,12 @@ function run_ytdl_hook(url)
 
     -- Checks if video option is "no", change format accordingly,
     -- but only if user didn't explicitly set one
-    if (mp.get_property("options/vid") == "no") and (#format == 0) then
+    if mp.get_property("options/vid") == "no" and #format == 0 then
         format = "bestaudio/best"
         msg.verbose("Video disabled. Only using audio")
     end
 
-    if (format == "") then
+    if format == "" then
         format = "bestvideo+bestaudio/best"
     end
 
@@ -916,19 +916,19 @@ function run_ytdl_hook(url)
 
     for param, arg in pairs(raw_options) do
         table.insert(command, "--" .. param)
-        if (arg ~= "") then
+        if arg ~= "" then
             table.insert(command, arg)
         end
         if (param == "sub-lang" or param == "sub-langs" or param == "srt-lang") and (arg ~= "") then
             allsubs = false
-        elseif (param == "proxy") and (arg ~= "") then
+        elseif param == "proxy" and arg ~= "" then
             proxy = arg
-        elseif (param == "yes-playlist") then
+        elseif param == "yes-playlist" then
             use_playlist = true
         end
     end
 
-    if (allsubs == true) then
+    if allsubs == true then
         table.insert(command, "--all-subs")
     end
     if not use_playlist then
@@ -989,7 +989,7 @@ function run_ytdl_hook(url)
         json, parse_err = utils.parse_json(json)
     end
 
-    if (json == nil) then
+    if json == nil then
         msg.verbose("status:", result.status)
         msg.verbose("reason:", result.error_string)
         msg.verbose("stdout:", result.stdout)
@@ -1023,11 +1023,11 @@ function run_ytdl_hook(url)
         -- direct URL, nothing to do
         msg.verbose("Got direct URL")
         return
-    elseif (json["_type"] == "playlist")
-        or (json["_type"] == "multi_video") then
+    elseif json["_type"] == "playlist" or
+           json["_type"] == "multi_video" then
         -- a playlist
 
-        if (#json.entries == 0) then
+        if #json.entries == 0 then
             msg.warn("Got empty playlist, nothing to play.")
             return
         end
@@ -1065,19 +1065,19 @@ function run_ytdl_hook(url)
             -- there might not be subs for the first segment
             local entry_wsubs = nil
             for i, entry in pairs(json.entries) do
-                if not (entry.requested_subtitles == nil) then
+                if entry.requested_subtitles ~= nil then
                     entry_wsubs = i
                     break
                 end
             end
 
-            if not (entry_wsubs == nil) and
-                not (json.entries[entry_wsubs].duration == nil) then
+            if entry_wsubs ~= nil and
+                json.entries[entry_wsubs].duration ~= nil then
                 for j, req in pairs(json.entries[entry_wsubs].requested_subtitles) do
                     local subfile = "edl://"
                     for i, entry in pairs(json.entries) do
-                        if not (entry.requested_subtitles == nil) and
-                            not (entry.requested_subtitles[j] == nil) and
+                        if entry.requested_subtitles ~= nil and
+                            entry.requested_subtitles[j] ~= nil and
                             url_is_safe(entry.requested_subtitles[j].url) then
                             subfile = subfile..edl_escape(entry.requested_subtitles[j].url)
                         else
@@ -1100,7 +1100,7 @@ function run_ytdl_hook(url)
                 local site = entry.url
                 local title = entry.title
 
-                if not (title == nil) then
+                if title ~= nil then
                     title = string.gsub(title, '%s+', ' ')
                     table.insert(playlist, "#EXTINF:0," .. title)
                 end
@@ -1151,11 +1151,11 @@ function run_ytdl_hook(url)
     msg.debug('script running time: '..os.clock()-start_time..' seconds')
 end
 
-if (not o.try_ytdl_first) then
+if not o.try_ytdl_first then
     mp.add_hook("on_load", 10, function ()
         msg.verbose('ytdl:// hook')
         local url = mp.get_property("stream-open-filename", "")
-        if not (url:find("ytdl://") == 1) then
+        if url:find("ytdl://") ~= 1 then
             msg.verbose('not a ytdl:// url')
             return
         end
@@ -1174,7 +1174,7 @@ end)
 mp.add_hook(o.try_ytdl_first and "on_load" or "on_load_fail", 10, function()
     msg.verbose('full hook')
     local url = mp.get_property("stream-open-filename", "")
-    if not (url:find("ytdl://") == 1) and
+    if url:find("ytdl://") ~= 1 and
         not ((url:find("https?://") == 1) and not is_blacklisted(url)) then
         return
     end


### PR DESCRIPTION
For whatever reason, some of the lua code (particularly the osc and ytdl_hook) is full of a bunch of stuff like if (foo), if not (foo == nil), etc. The parenthesis aren't needed in lua and actually just look weird since nobody actually writes lua like this. You can see most of the other conditionals are written normally. So cleanup the style to match when the parenthesis clearly aren't doing anything.

I'm sure I made an oopsie somewhere so someone please double check me.