### PR TITLE
win32: add more values for monitor refresh rate detection

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -550,6 +550,10 @@ static double get_refresh_rate_from_gdi(const wchar_t *device)
         case  95:
         case 119:
         case 143:
+        case 164:
+        case 239:
+        case 359:
+        case 479:
             rv = (rv + 1) / 1.001;
     }
 


### PR DESCRIPTION
Not sure how often `get_refresh_rate_from_gdi()` is actually called but just in case. 