### PR TITLE
console.lua: make completion case-insensitive

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -158,6 +158,11 @@ Configurable Options
 
     Set the font border size used for the REPL and the console.
 
+``case_sensitive``
+    Default: no on Windows, yes on other platforms.
+
+    Whether Tab completion is case sensitive. Only works with ASCII characters.
+
 ``history_dedup``
     Default: true
 


### PR DESCRIPTION
This is useful for completing files and more rarely for profiles. It will also be useful to third-party scripts interacting with the console once the API to do it is merged.