### PR TITLE
drm: use present_sync mechanism for presentation feedback

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -40,11 +40,12 @@
 
 #include "common/common.h"
 #include "common/msg.h"
+#include "misc/ctype.h"
 #include "options/m_config.h"
 #include "osdep/io.h"
 #include "osdep/poll_wrapper.h"
 #include "osdep/timer.h"
-#include "misc/ctype.h"
+#include "present_sync.h"
 #include "video/out/vo.h"
 
 #define EVT_RELEASE 1
@@ -912,55 +913,12 @@ err:
 static void drm_pflip_cb(int fd, unsigned int msc, unsigned int sec,
                          unsigned int usec, void *data)
 {
-    struct drm_pflip_cb_closure *closure = data;
+    struct vo_drm_state *drm = data;
 
-    struct drm_vsync_tuple *vsync = closure->vsync;
-    // frame_vsync->ust is the timestamp of the pageflip that happened just before this flip was queued
-    // frame_vsync->msc is the sequence number of the pageflip that happened just before this flip was queued
-    // frame_vsync->sbc is the sequence number for the frame that was just flipped to screen
-    struct drm_vsync_tuple *frame_vsync = closure->frame_vsync;
-    struct vo_vsync_info *vsync_info = closure->vsync_info;
-
-    const bool ready =
-        (vsync->msc != 0) &&
-        (frame_vsync->ust != 0) && (frame_vsync->msc != 0);
-
-    const uint64_t ust = (sec * 1000000LL) + usec;
-
-    const unsigned int msc_since_last_flip = msc - vsync->msc;
-    if (ready && msc == vsync->msc) {
-        // Seems like some drivers only increment msc every other page flip when
-        // running in interlaced mode (I'm looking at you nouveau). Obviously we
-        // can't work with this, so shame the driver and bail.
-        mp_err(closure->log,
-               "Got the same msc value twice: (msc: %u, vsync->msc: %u). This shouldn't happen. Possibly broken driver/interlaced mode?\n",
-               msc, vsync->msc);
-        goto fail;
-    }
-
-    vsync->ust = ust;
-    vsync->msc = msc;
-
-    if (ready) {
-        // Convert to mp_time
-        struct timespec ts;
-        if (clock_gettime(CLOCK_MONOTONIC, &ts))
-            goto fail;
-        int64_t now_monotonic = MP_TIME_S_TO_NS(ts.tv_sec) + ts.tv_nsec;
-        int64_t ust_mp_time = mp_time_ns() - (now_monotonic - vsync->ust * 1000);
-
-        const uint64_t     ust_since_enqueue = vsync->ust - frame_vsync->ust;
-        const unsigned int msc_since_enqueue = vsync->msc - frame_vsync->msc;
-        const unsigned int sbc_since_enqueue = vsync->sbc - frame_vsync->sbc;
-
-        vsync_info->vsync_duration = ust_since_enqueue * 1000 / msc_since_enqueue;
-        vsync_info->skipped_vsyncs = msc_since_last_flip - 1; // Valid iff swap_buffers is called every vsync
-        vsync_info->last_queue_display_time = ust_mp_time + (sbc_since_enqueue * vsync_info->vsync_duration);
-    }
-
-fail:
-    *closure->waiting_for_flip = false;
-    talloc_free(closure);
+    int64_t ust = MP_TIME_S_TO_NS(sec) + MP_TIME_US_TO_NS(usec);
+    present_sync_update_values(drm->present, ust, msc);
+    present_sync_swap(drm->present);
+    drm->waiting_for_flip = false;
 }
 
 int vo_drm_control(struct vo *vo, int *events, int request, void *arg)
@@ -985,10 +943,7 @@ int vo_drm_control(struct vo *vo, int *events, int request, void *arg)
         return VO_TRUE;
     case VOCTRL_RESUME:
         drm->paused = false;
-        drm->vsync_info.last_queue_display_time = -1;
-        drm->vsync_info.skipped_vsyncs = 0;
-        drm->vsync.ust = 0;
-        drm->vsync.msc = 0;
+        present_sync_clear_values(drm->present);
         return VO_TRUE;
     }
     return VO_NOTIMPL;
@@ -1075,10 +1030,7 @@ bool vo_drm_init(struct vo *vo)
 
     drm->ev.version = DRM_EVENT_CONTEXT_VERSION;
     drm->ev.page_flip_handler = &drm_pflip_cb;
-
-    drm->vsync_info.vsync_duration = 0;
-    drm->vsync_info.skipped_vsyncs = -1;
-    drm->vsync_info.last_queue_display_time = -1;
+    drm->present = mp_present_initialize(drm, 8); // max swapchain depth allowed
 
     return true;
 
@@ -1287,12 +1239,6 @@ static int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
 double vo_drm_get_display_fps(struct vo_drm_state *drm)
 {
     return mode_get_Hz(&drm->mode.mode);
-}
-
-void vo_drm_get_vsync(struct vo *vo, struct vo_vsync_info *info)
-{
-    struct vo_drm_state *drm = vo->drm;
-    *info = drm->vsync_info;
 }
 
 void vo_drm_set_monitor_par(struct vo *vo)

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -39,12 +39,6 @@ struct framebuffer {
     uint32_t id;
 };
 
-struct drm_vsync_tuple {
-    uint64_t ust;
-    unsigned int msc;
-    unsigned int sbc;
-};
-
 struct drm_mode {
     drmModeModeInfo mode;
     uint32_t blob_id;
@@ -77,12 +71,11 @@ struct vo_drm_state {
     struct drm_atomic_context *atomic_context;
     struct drm_mode mode;
     struct drm_opts *opts;
-    struct drm_vsync_tuple vsync;
     struct framebuffer *fb;
     struct mp_log *log;
+    struct mp_present *present;
     struct vo *vo;
     struct vt_switcher vt_switcher;
-    struct vo_vsync_info vsync_info;
 
     bool active;
     bool paused;
@@ -99,19 +92,10 @@ struct vo_drm_state {
     uint32_t width;
 };
 
-struct drm_pflip_cb_closure {
-    struct drm_vsync_tuple *frame_vsync; // vsync tuple when the frame that just flipped was queued
-    struct drm_vsync_tuple *vsync; // vsync tuple of the latest page flip. drm_pflip_cb updates this
-    struct vo_vsync_info *vsync_info; // where the drm_pflip_cb routine writes its output
-    bool *waiting_for_flip; // drm_pflip_cb writes false here before returning
-    struct mp_log *log; // Needed to print error messages that shame bad drivers
-};
-
 bool vo_drm_init(struct vo *vo);
 int vo_drm_control(struct vo *vo, int *events, int request, void *arg);
 
 double vo_drm_get_display_fps(struct vo_drm_state *drm);
-void vo_drm_get_vsync(struct vo *vo, struct vo_vsync_info *info);
 void vo_drm_set_monitor_par(struct vo *vo);
 void vo_drm_uninit(struct vo *vo);
 void vo_drm_wait_events(struct vo *vo, int64_t until_time_ns);

--- a/video/out/present_sync.c
+++ b/video/out/present_sync.c
@@ -107,6 +107,15 @@ void present_sync_swap(struct mp_present *present)
     cur->queue_display_time = ust_mp_time;
 }
 
+void present_sync_clear_values(struct mp_present *present)
+{
+    struct mp_present_entry *cur = present->head;
+    while (cur) {
+        *cur = (struct mp_present_entry){0};
+        cur = cur->list_node.next;
+    }
+}
+
 void present_sync_update_values(struct mp_present *present, int64_t ust,
                                 int64_t msc)
 {

--- a/video/out/present_sync.c
+++ b/video/out/present_sync.c
@@ -107,7 +107,7 @@ void present_sync_swap(struct mp_present *present)
     cur->queue_display_time = ust_mp_time;
 }
 
-void present_update_sync_values(struct mp_present *present, int64_t ust,
+void present_sync_update_values(struct mp_present *present, int64_t ust,
                                 int64_t msc)
 {
     struct mp_present_entry *cur = present->head;

--- a/video/out/present_sync.h
+++ b/video/out/present_sync.h
@@ -25,15 +25,23 @@
 /* Generic helpers for obtaining presentation feedback from
  * backend APIs. This requires ust/msc values. */
 
-struct mp_present {
-    int64_t current_ust;
-    int64_t current_msc;
-    int64_t last_ust;
-    int64_t last_msc;
+struct mp_present_entry {
+    int64_t ust;
+    int64_t msc;
     int64_t vsync_duration;
-    int64_t last_skipped_vsyncs;
-    int64_t last_queue_display_time;
+    int64_t skipped_vsyncs;
+    int64_t queue_display_time;
+
+    struct {
+        struct mp_present_entry *next, *prev;
+    } list_node;
 };
+
+struct mp_present {
+    struct mp_present_entry *head, *tail;
+};
+
+struct mp_present *mp_present_initialize(void *talloc_ctx, int entries);
 
 // Used during the get_vsync call to deliver the presentation statistics to the VO.
 void present_sync_get_info(struct mp_present *present, struct vo_vsync_info *info);

--- a/video/out/present_sync.h
+++ b/video/out/present_sync.h
@@ -50,7 +50,7 @@ void present_sync_get_info(struct mp_present *present, struct vo_vsync_info *inf
 void present_sync_swap(struct mp_present *present);
 
 // Called anytime the backend delivers new ust/msc values.
-void present_update_sync_values(struct mp_present *present, int64_t ust,
+void present_sync_update_values(struct mp_present *present, int64_t ust,
                                 int64_t msc);
 
 #endif /* MP_PRESENT_SYNC_H */

--- a/video/out/present_sync.h
+++ b/video/out/present_sync.h
@@ -49,6 +49,9 @@ void present_sync_get_info(struct mp_present *present, struct vo_vsync_info *inf
 // Called after every buffer swap to update presentation statistics.
 void present_sync_swap(struct mp_present *present);
 
+// Zero the entire list but keep the items.
+void present_sync_clear_values(struct mp_present *present);
+
 // Called anytime the backend delivers new ust/msc values.
 void present_sync_update_values(struct mp_present *present, int64_t ust,
                                 int64_t msc);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2282,7 +2282,7 @@ bool vo_wayland_init(struct vo *vo)
         wl->fback_pool->len = 8; // max swapchain depth allowed
         wl->fback_pool->fback = talloc_zero_array(wl->fback_pool, struct wp_presentation_feedback *,
                                                   wl->fback_pool->len);
-        wl->present = talloc_zero(wl, struct mp_present);
+        wl->present = mp_present_initialize(wl, 8); // max swapchain depth allowed
     } else {
         MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
                    wp_presentation_interface.name);
@@ -2560,8 +2560,8 @@ void vo_wayland_wait_frame(struct vo_wayland_state *wl)
      * 3. refresh rate of the output reported by the compositor
      * 4. make up crap if vblank_time is still <= 0 (better than nothing) */
 
-    if (wl->use_present)
-        vblank_time = wl->present->vsync_duration;
+    if (wl->use_present && wl->present->head)
+        vblank_time = wl->present->head->vsync_duration;
 
     if (vblank_time <= 0 && wl->refresh_interval > 0)
         vblank_time = wl->refresh_interval;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1159,7 +1159,7 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
     int64_t sec = (uint64_t) tv_sec_lo + ((uint64_t) tv_sec_hi << 32);
     int64_t ust = MP_TIME_S_TO_NS(sec) + (uint64_t) tv_nsec;
     int64_t msc = (uint64_t) seq_lo + ((uint64_t) seq_hi << 32);
-    present_update_sync_values(wl->present, ust, msc);
+    present_sync_update_values(wl->present, ust, msc);
 }
 
 static void feedback_discarded(void *data, struct wp_presentation_feedback *fback)

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -626,7 +626,7 @@ bool vo_x11_init(struct vo *vo)
 
     x11_error_output = x11->log;
     XSetErrorHandler(x11_errorhandler);
-    x11->present = talloc_zero(x11, struct mp_present);
+    x11->present = mp_present_initialize(x11, 8); // max swapchain depth allowed
 
     dispName = XDisplayName(NULL);
 

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1328,7 +1328,7 @@ void vo_x11_check_events(struct vo *vo)
                 if (cookie->evtype == PresentCompleteNotify) {
                     XPresentCompleteNotifyEvent *present_event;
                     present_event = (XPresentCompleteNotifyEvent *)cookie->data;
-                    present_update_sync_values(x11->present,
+                    present_sync_update_values(x11->present,
                                                present_event->ust * 1000,
                                                present_event->msc);
                 }


### PR DESCRIPTION
I had to enhance `present_sync` a little bit, but this gets drm on the same codepath that x11 and wayland already use in regards to this stuff.