### PR TITLE
csputils: add pl_hdr_metadata to mp_colorspace and deprecate sig_peak

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -113,6 +113,7 @@ Interface changes
     - `--demuxer-hysteresis-secs` now respects `--cache-secs` and/or
       `--demuxer-readahead-secs` as well
     - add hdr metadata to `video-params` property
+    - remove `hdr-metadata` property
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -112,6 +112,7 @@ Interface changes
     - drop support for `-del` syntax for list options
     - `--demuxer-hysteresis-secs` now respects `--cache-secs` and/or
       `--demuxer-readahead-secs` as well
+    - add hdr metadata to `video-params` property
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2476,7 +2476,7 @@ Property list
     ``video-params/gamma``
         The gamma function in use as string. (Exact values subject to change.)
 
-    ``video-params/sig-peak``
+    ``video-params/sig-peak`` (deprecated)
         The video file's tagged signal peak as float.
 
     ``video-params/light``
@@ -2496,6 +2496,33 @@ Property list
         Alpha type. If the format has no alpha channel, this will be unavailable
         (but in future releases, it could change to ``no``). If alpha is
         present, this is set to ``straight`` or ``premul``.
+
+    ``video-params/min-luma``
+        Minimum luminance, as reported by HDR10 metadata (in cd/m²)
+
+    ``video-params/max-luma``
+        Maximum luminance, as reported by HDR10 metadata (in cd/m²)
+
+    ``video-params/max-cll``
+        Maximum content light level, as reported by HDR10 metadata (in cd/m²)
+
+    ``video-params/max-fall``
+        Maximum frame average light level, as reported by HDR10 metadata (in cd/m²)
+
+    ``video-params/scene-max-r``
+        MaxRGB of a scene for R component, as reported by HDR10+ metadata (in cd/m²)
+
+    ``video-params/scene-max-g``
+        MaxRGB of a scene for G component, as reported by HDR10+ metadata (in cd/m²)
+
+    ``video-params/scene-max-b``
+        MaxRGB of a scene for B component, as reported by HDR10+ metadata (in cd/m²)
+
+    ``video-params/max-pq-y``
+        Maximum PQ luminance of a frame, as reported by peak detection (in PQ, 0-1)
+
+    ``video-params/avg-pq-y``
+        Average PQ luminance of a frame, as reported by peak detection (in PQ, 0-1)
 
     When querying the property with the client API using ``MPV_FORMAT_NODE``,
     or with Lua ``mp.get_property_native``, this will return a mpv_node with
@@ -2526,6 +2553,7 @@ Property list
 
 ``hdr-metadata``
     Video HDR metadata per frame, including peak detection result.
+    If supported the same information is also included in ``video-out-params``.
     This has a number of sub-properties:
 
     ``hdr-metadata/min-luma``

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2550,55 +2550,15 @@ Property list
             "stereo-in"         MPV_FORMAT_STRING
             "average-bpp"       MPV_FORMAT_INT64
             "alpha"             MPV_FORMAT_STRING
-
-``hdr-metadata``
-    Video HDR metadata per frame, including peak detection result.
-    If supported the same information is also included in ``video-out-params``.
-    This has a number of sub-properties:
-
-    ``hdr-metadata/min-luma``
-        Minimum luminance, as reported by HDR10 metadata (in cd/m²)
-
-    ``hdr-metadata/max-luma``
-        Maximum luminance, as reported by HDR10 metadata (in cd/m²)
-
-    ``hdr-metadata/max-cll``
-        Maximum content light level, as reported by HDR10 metadata (in cd/m²)
-
-    ``hdr-metadata/max-fall``
-        Maximum frame average light level, as reported by HDR10 metadata (in cd/m²)
-
-    ``hdr-metadata/scene-max-r``
-        MaxRGB of a scene for R component, as reported by HDR10+ metadata (in cd/m²)
-
-    ``hdr-metadata/scene-max-g``
-        MaxRGB of a scene for G component, as reported by HDR10+ metadata (in cd/m²)
-
-    ``hdr-metadata/scene-max-b``
-        MaxRGB of a scene for B component, as reported by HDR10+ metadata (in cd/m²)
-
-    ``hdr-metadata/max-pq-y``
-        Maximum PQ luminance of a frame, as reported by peak detection (in PQ, 0-1)
-
-    ``hdr-metadata/avg-pq-y``
-        Average PQ luminance of a frame, as reported by peak detection (in PQ, 0-1)
-
-    When querying the property with the client API using ``MPV_FORMAT_NODE``,
-    or with Lua ``mp.get_property_native``, this will return a mpv_node with
-    the following contents:
-
-    ::
-
-        MPV_FORMAT_NODE_MAP
-            "min-luma"     MPV_FORMAT_DOUBLE
-            "max-luma"     MPV_FORMAT_DOUBLE
-            "max-cll"      MPV_FORMAT_DOUBLE
-            "max-fall"     MPV_FORMAT_DOUBLE
-            "scene-max-r"  MPV_FORMAT_DOUBLE
-            "scene-max-g"  MPV_FORMAT_DOUBLE
-            "scene-max-b"  MPV_FORMAT_DOUBLE
-            "max-pq-y"     MPV_FORMAT_DOUBLE
-            "avg-pq-y"     MPV_FORMAT_DOUBLE
+            "min-luma"          MPV_FORMAT_DOUBLE
+            "max-luma"          MPV_FORMAT_DOUBLE
+            "max-cll"           MPV_FORMAT_DOUBLE
+            "max-fall"          MPV_FORMAT_DOUBLE
+            "scene-max-r"       MPV_FORMAT_DOUBLE
+            "scene-max-g"       MPV_FORMAT_DOUBLE
+            "scene-max-b"       MPV_FORMAT_DOUBLE
+            "max-pq-y"          MPV_FORMAT_DOUBLE
+            "avg-pq-y"          MPV_FORMAT_DOUBLE
 
 ``dwidth``, ``dheight``
     Video display size. This is the video size after filters and aspect scaling

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -593,16 +593,58 @@ static void parse_trackcolour(struct demuxer *demuxer, struct mkv_track *track,
                    m_opt_choice_str(mp_csp_levels_names, track->color.levels));
     }
     if (colour->n_max_cll) {
-        track->color.sig_peak = colour->max_cll / MP_REF_WHITE;
+        track->color.hdr.max_cll = colour->max_cll;
+        track->color.sig_peak = track->color.hdr.max_cll / MP_REF_WHITE;
         MP_DBG(demuxer, "|    + MaxCLL: %"PRIu64"\n", colour->max_cll);
     }
-    // if MaxCLL is unavailable, try falling back to the mastering metadata
-    if (!track->color.sig_peak && colour->n_mastering_metadata) {
+    if (colour->n_max_fall) {
+        track->color.hdr.max_fall = colour->max_fall;
+        MP_DBG(demuxer, "|    + MaxFALL: %"PRIu64"\n", colour->max_cll);
+    }
+    if (colour->n_mastering_metadata) {
         struct ebml_mastering_metadata *mastering = &colour->mastering_metadata;
 
+        if (mastering->n_primary_r_chromaticity_x) {
+            track->color.hdr.prim.red.x = mastering->primary_r_chromaticity_x;
+            MP_DBG(demuxer, "|    + PrimaryRChromaticityX: %f\n", track->color.hdr.prim.red.x);
+        }
+        if (mastering->n_primary_r_chromaticity_y) {
+            track->color.hdr.prim.red.y = mastering->primary_r_chromaticity_y;
+            MP_DBG(demuxer, "|    + PrimaryRChromaticityY: %f\n", track->color.hdr.prim.red.y);
+        }
+        if (mastering->n_primary_g_chromaticity_x) {
+            track->color.hdr.prim.green.x = mastering->primary_g_chromaticity_x;
+            MP_DBG(demuxer, "|    + PrimaryGChromaticityX: %f\n", track->color.hdr.prim.green.x);
+        }
+        if (mastering->n_primary_g_chromaticity_y) {
+            track->color.hdr.prim.green.y = mastering->primary_g_chromaticity_y;
+            MP_DBG(demuxer, "|    + PrimaryGChromaticityY: %f\n", track->color.hdr.prim.green.y);
+        }
+        if (mastering->n_primary_b_chromaticity_x) {
+            track->color.hdr.prim.blue.x = mastering->primary_b_chromaticity_x;
+            MP_DBG(demuxer, "|    + PrimaryBChromaticityX: %f\n", track->color.hdr.prim.blue.x);
+        }
+        if (mastering->n_primary_b_chromaticity_y) {
+            track->color.hdr.prim.blue.y = mastering->primary_b_chromaticity_y;
+            MP_DBG(demuxer, "|    + PrimaryBChromaticityY: %f\n", track->color.hdr.prim.blue.y);
+        }
+        if (mastering->n_white_point_chromaticity_x) {
+            track->color.hdr.prim.white.x = mastering->white_point_chromaticity_x;
+            MP_DBG(demuxer, "|    + WhitePointChromaticityX: %f\n", track->color.hdr.prim.white.x);
+        }
+        if (mastering->n_white_point_chromaticity_y) {
+            track->color.hdr.prim.white.y = mastering->white_point_chromaticity_y;
+            MP_DBG(demuxer, "|    + WhitePointChromaticityY: %f\n", track->color.hdr.prim.white.y);
+        }
+        if (mastering->n_luminance_min) {
+            track->color.hdr.min_luma = mastering->luminance_min;
+            MP_DBG(demuxer, "|    + LuminanceMin: %f\n", track->color.hdr.min_luma);
+        }
         if (mastering->n_luminance_max) {
-            track->color.sig_peak = mastering->luminance_max / MP_REF_WHITE;
-            MP_DBG(demuxer, "|    + HDR peak: %f\n", track->color.sig_peak);
+            track->color.hdr.max_luma = mastering->luminance_max;
+            if (!track->color.sig_peak)
+                track->color.sig_peak = track->color.hdr.max_luma / MP_REF_WHITE;
+            MP_DBG(demuxer, "|    + LuminanceMax: %f\n", track->color.hdr.max_luma);
         }
     }
 }

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -594,7 +594,6 @@ static void parse_trackcolour(struct demuxer *demuxer, struct mkv_track *track,
     }
     if (colour->n_max_cll) {
         track->color.hdr.max_cll = colour->max_cll;
-        track->color.sig_peak = track->color.hdr.max_cll / MP_REF_WHITE;
         MP_DBG(demuxer, "|    + MaxCLL: %"PRIu64"\n", colour->max_cll);
     }
     if (colour->n_max_fall) {
@@ -642,8 +641,6 @@ static void parse_trackcolour(struct demuxer *demuxer, struct mkv_track *track,
         }
         if (mastering->n_luminance_max) {
             track->color.hdr.max_luma = mastering->luminance_max;
-            if (!track->color.sig_peak)
-                track->color.sig_peak = track->color.hdr.max_luma / MP_REF_WHITE;
             MP_DBG(demuxer, "|    + LuminanceMax: %f\n", track->color.hdr.max_luma);
         }
     }

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -548,11 +548,6 @@ void mp_decoder_wrapper_set_play_dir(struct mp_decoder_wrapper *d, int dir)
     thread_unlock(p);
 }
 
-static bool is_valid_peak(float sig_peak)
-{
-    return !sig_peak || (sig_peak >= 1 && sig_peak <= 100);
-}
-
 static void fix_image_params(struct priv *p,
                              struct mp_image_params *params)
 {
@@ -622,12 +617,6 @@ static void fix_image_params(struct priv *p,
     }
 
     mp_colorspace_merge(&m.color, &c->color);
-
-    // Sanitize the HDR peak. Sadly necessary
-    if (!is_valid_peak(m.color.sig_peak)) {
-        MP_WARN(p, "Invalid HDR peak in stream: %f\n", m.color.sig_peak);
-        m.color.sig_peak = 0.0;
-    }
 
     // Guess missing colorspace fields from metadata. This guarantees all
     // fields are at least set to legal values afterwards.

--- a/player/command.c
+++ b/player/command.c
@@ -2323,7 +2323,7 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
             SUB_PROP_STR(m_opt_choice_str(mp_csp_prim_names, p.color.primaries))},
         {"gamma",
             SUB_PROP_STR(m_opt_choice_str(mp_csp_trc_names, p.color.gamma))},
-        {"sig-peak", SUB_PROP_FLOAT(p.color.sig_peak)},
+        {"sig-peak", SUB_PROP_FLOAT(p.color.hdr.max_luma * MP_REF_WHITE)},
         {"light",
             SUB_PROP_STR(m_opt_choice_str(mp_csp_light_names, p.color.light))},
         {"chroma-location",

--- a/player/command.c
+++ b/player/command.c
@@ -2710,11 +2710,9 @@ static int mp_property_hdr_metadata(void *ctx, struct m_property *prop,
     if (vo_control(mpctx->video_out, VOCTRL_HDR_METADATA, &data) != VO_TRUE)
         return M_PROPERTY_UNAVAILABLE;
 
-    bool has_hdr10 = data.max_luma;
-    bool has_hdr10plus = data.scene_avg && (data.scene_max[0] ||
-                                            data.scene_max[1] ||
-                                            data.scene_max[2]);
-    bool has_cie_y = data.max_pq_y && data.avg_pq_y;
+    bool has_cie_y     = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_CIE_Y);
+    bool has_hdr10     = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_HDR10);
+    bool has_hdr10plus = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_HDR10PLUS);
 
     struct m_sub_property props[] = {
         {"min-luma",    SUB_PROP_FLOAT(data.min_luma),     .unavailable = !has_hdr10},

--- a/player/command.c
+++ b/player/command.c
@@ -4051,7 +4051,7 @@ static const char *const *const mp_event_property_change[] = {
       "secondary-sub-text", "audio-bitrate", "video-bitrate", "sub-bitrate",
       "decoder-frame-drop-count", "frame-drop-count", "video-frame-info",
       "vf-metadata", "af-metadata", "sub-start", "sub-end", "secondary-sub-start",
-      "secondary-sub-end"),
+      "secondary-sub-end", "video-out-params", "video-dec-params", "video-params"),
     E(MP_EVENT_DURATION_UPDATE, "duration"),
     E(MPV_EVENT_VIDEO_RECONFIG, "video-out-params", "video-params",
       "video-format", "video-codec", "video-bitrate", "dwidth", "dheight",

--- a/player/command.c
+++ b/player/command.c
@@ -2716,42 +2716,6 @@ static int mp_property_vo_passes(void *ctx, struct m_property *prop,
     return M_PROPERTY_OK;
 }
 
-static int mp_property_hdr_metadata(void *ctx, struct m_property *prop,
-                                    int action, void *arg)
-{
-    MPContext *mpctx = ctx;
-    if (!mpctx->video_out)
-        return M_PROPERTY_UNAVAILABLE;
-
-    int valid = m_property_read_sub_validate(ctx, prop, action, arg);
-    if (valid != M_PROPERTY_VALID)
-        return valid;
-
-    struct pl_hdr_metadata data;
-    if (vo_control(mpctx->video_out, VOCTRL_HDR_METADATA, &data) != VO_TRUE)
-        return M_PROPERTY_UNAVAILABLE;
-
-    bool has_cie_y     = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_CIE_Y);
-    bool has_hdr10     = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_HDR10);
-    bool has_hdr10plus = pl_hdr_metadata_contains(&data, PL_HDR_METADATA_HDR10PLUS);
-
-    struct m_sub_property props[] = {
-        {"min-luma",    SUB_PROP_FLOAT(data.min_luma),     .unavailable = !has_hdr10},
-        {"max-luma",    SUB_PROP_FLOAT(data.max_luma),     .unavailable = !has_hdr10},
-        {"max-cll",     SUB_PROP_FLOAT(data.max_cll),      .unavailable = !has_hdr10},
-        {"max-fall",    SUB_PROP_FLOAT(data.max_fall),     .unavailable = !has_hdr10},
-        {"scene-max-r", SUB_PROP_FLOAT(data.scene_max[0]), .unavailable = !has_hdr10plus},
-        {"scene-max-g", SUB_PROP_FLOAT(data.scene_max[1]), .unavailable = !has_hdr10plus},
-        {"scene-max-b", SUB_PROP_FLOAT(data.scene_max[2]), .unavailable = !has_hdr10plus},
-        {"scene-avg",   SUB_PROP_FLOAT(data.scene_avg),    .unavailable = !has_hdr10plus},
-        {"max-pq-y",    SUB_PROP_FLOAT(data.max_pq_y),     .unavailable = !has_cie_y},
-        {"avg-pq-y",    SUB_PROP_FLOAT(data.avg_pq_y),     .unavailable = !has_cie_y},
-        {0}
-    };
-
-    return m_property_read_sub(props, action, arg);
-}
-
 static int mp_property_perf_info(void *ctx, struct m_property *p, int action,
                                  void *arg)
 {
@@ -3963,7 +3927,6 @@ static const struct m_property mp_properties_base[] = {
     {"current-window-scale", mp_property_current_window_scale},
     {"vo-configured", mp_property_vo_configured},
     {"vo-passes", mp_property_vo_passes},
-    {"hdr-metadata", mp_property_hdr_metadata},
     {"perf-info", mp_property_perf_info},
     {"current-vo", mp_property_vo},
     {"container-fps", mp_property_fps},

--- a/player/command.c
+++ b/player/command.c
@@ -2706,7 +2706,7 @@ static int mp_property_hdr_metadata(void *ctx, struct m_property *prop,
     if (valid != M_PROPERTY_VALID)
         return valid;
 
-    struct mp_hdr_metadata data;
+    struct pl_hdr_metadata data;
     if (vo_control(mpctx->video_out, VOCTRL_HDR_METADATA, &data) != VO_TRUE)
         return M_PROPERTY_UNAVAILABLE;
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -934,13 +934,11 @@ local function add_video(s)
     end
     append_img_params(s, r, ro)
 
-    local hdr = mp.get_property_native("hdr-metadata")
-    if not hdr then
-        local hdrpeak = r["sig-peak"] or 0
-        hdr = {["max-cll"]=math.floor(hdrpeak * 203)}
+    if not ro["max-cll"] then
+        ro["max-cll"] = math.floor((ro["sig-peak"] or 0) * 203)
     end
 
-    append_hdr(s, hdr)
+    append_hdr(s, ro)
     append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
     append_filters(s, "vf", "Filters:")
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -933,11 +933,6 @@ local function add_video(s)
         append_fps(s, "container-fps", "estimated-vf-fps")
     end
     append_img_params(s, r, ro)
-
-    if not ro["max-cll"] then
-        ro["max-cll"] = math.floor((ro["sig-peak"] or 0) * 203)
-    end
-
     append_hdr(s, ro)
     append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
     append_filters(s, "vf", "Filters:")

--- a/test/meson.build
+++ b/test/meson.build
@@ -64,6 +64,7 @@ img_utils_files = [
     'video/fmt-conversion.c',
     'video/img_format.c',
     'video/mp_image.c',
+    'video/out/placebo/utils.c',
     'video/sws_utils.c'
 ]
 if features['zimg']

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -1,5 +1,6 @@
 #include <libavutil/common.h>
 
+#include "common/msg.h"
 #include "options/m_option.h"
 #include "options/path.h"
 #include "osdep/subprocess.h"
@@ -98,7 +99,7 @@ void assert_memcmp_impl(const char *file, int line,
 }
 
 /* Stubs: see test_utils.h */
-struct mp_log *mp_null_log;
+struct mp_log *const mp_null_log;
 const char *mp_help_text;
 
 void mp_msg(struct mp_log *log, int lev, const char *format, ...) {};
@@ -106,3 +107,5 @@ int mp_msg_find_level(const char *s) {return 0;};
 int mp_msg_level(struct mp_log *log) {return 0;};
 void mp_write_console_ansi(void) {};
 void mp_set_avdict(AVDictionary **dict, char **kv) {};
+struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,
+                          const char *name) { return NULL; };

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -133,6 +133,7 @@ void mp_colorspace_merge(struct mp_colorspace *orig, struct mp_colorspace *new)
         orig->sig_peak = new->sig_peak;
     if (!orig->light)
         orig->light = new->light;
+    pl_hdr_metadata_merge(&orig->hdr, &new->hdr);
 }
 
 // The short name _must_ match with what vf_stereo3d accepts (if supported).
@@ -912,7 +913,8 @@ bool mp_colorspace_equal(struct mp_colorspace c1, struct mp_colorspace c2)
            c1.primaries == c2.primaries &&
            c1.gamma == c2.gamma &&
            c1.light == c2.light &&
-           c1.sig_peak == c2.sig_peak;
+           c1.sig_peak == c2.sig_peak &&
+           pl_hdr_metadata_equal(&c1.hdr, &c2.hdr);
 }
 
 enum mp_csp_equalizer_param {

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -129,8 +129,6 @@ void mp_colorspace_merge(struct mp_colorspace *orig, struct mp_colorspace *new)
         orig->primaries = new->primaries;
     if (!orig->gamma)
         orig->gamma = new->gamma;
-    if (!orig->sig_peak)
-        orig->sig_peak = new->sig_peak;
     if (!orig->light)
         orig->light = new->light;
     pl_hdr_metadata_merge(&orig->hdr, &new->hdr);
@@ -913,7 +911,6 @@ bool mp_colorspace_equal(struct mp_colorspace c1, struct mp_colorspace c2)
            c1.primaries == c2.primaries &&
            c1.gamma == c2.gamma &&
            c1.light == c2.light &&
-           c1.sig_peak == c2.sig_peak &&
            pl_hdr_metadata_equal(&c1.hdr, &c2.hdr);
 }
 

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -21,6 +21,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <libplacebo/colorspace.h>
+
 #include "options/m_option.h"
 
 /* NOTE: the csp and levels AUTO values are converted to specific ones
@@ -138,24 +140,6 @@ extern const struct m_opt_choice_alternatives mp_stereo3d_names[];
 
 #define MP_STEREO3D_NAME_DEF(x, def) \
     (MP_STEREO3D_NAME(x) ? MP_STEREO3D_NAME(x) : (def))
-
-struct mp_hdr_metadata {
-    // HDR10
-    // Mastering display metadata
-    float min_luma, max_luma;       // min/max luminance (in cd/m²)
-
-    // Content light level
-    float max_cll;                  // max content light level (in cd/m²)
-    float max_fall;                 // max frame average light level (in cd/m²)
-
-    // HDR10+
-    float scene_max[3];             // maxRGB in cd/m² per component (RGB)
-    float scene_avg;                // average of maxRGB in cd/m²
-
-    // CIE Y
-    float max_pq_y;                 // maximum PQ luminance (in PQ, 0-1)
-    float avg_pq_y;                 // averaged PQ luminance (in PQ, 0-1)
-};
 
 struct mp_colorspace {
     enum mp_csp space;

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -147,7 +147,6 @@ struct mp_colorspace {
     enum mp_csp_prim primaries;
     enum mp_csp_trc gamma;
     enum mp_csp_light light;
-    float sig_peak; // highest relative value in signal. 0 = unknown/auto (deprecated)
     struct pl_hdr_metadata hdr;
 };
 

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -147,7 +147,8 @@ struct mp_colorspace {
     enum mp_csp_prim primaries;
     enum mp_csp_trc gamma;
     enum mp_csp_light light;
-    float sig_peak; // highest relative value in signal. 0 = unknown/auto
+    float sig_peak; // highest relative value in signal. 0 = unknown/auto (deprecated)
+    struct pl_hdr_metadata hdr;
 };
 
 // For many colorspace conversions, in particular those involving HDR, an

--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -81,8 +81,10 @@ static void set_params(struct vf_format_opts *p, struct mp_image_params *out,
             out->color.light = MP_CSP_LIGHT_AUTO;
         }
     }
-    if (p->sig_peak)
+    if (p->sig_peak) {
         out->color.sig_peak = p->sig_peak;
+        out->color.hdr.max_cll = p->sig_peak;
+    }
     if (p->light)
         out->color.light = p->light;
     if (p->chroma_location)

--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -77,14 +77,12 @@ static void set_params(struct vf_format_opts *p, struct mp_image_params *out,
             // When changing the gamma function explicitly, also reset stuff
             // related to the gamma function since that information will almost
             // surely be false now and have to be re-inferred
-            out->color.sig_peak = 0.0;
+            out->color.hdr = (struct pl_hdr_metadata){0};
             out->color.light = MP_CSP_LIGHT_AUTO;
         }
     }
-    if (p->sig_peak) {
-        out->color.sig_peak = p->sig_peak;
-        out->color.hdr.max_cll = p->sig_peak;
-    }
+    if (p->sig_peak)
+        out->color.hdr = (struct pl_hdr_metadata){ .max_luma = p->sig_peak * MP_REF_WHITE };
     if (p->light)
         out->color.light = p->light;
     if (p->chroma_location)

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -637,7 +637,7 @@ static struct mp_image *convert_image(struct mp_image *image, int destfmt,
         p.color.primaries = MP_CSP_PRIM_BT_709;
         p.color.gamma = MP_CSP_TRC_AUTO;
         p.color.light = MP_CSP_LIGHT_DISPLAY;
-        p.color.sig_peak = 0;
+        p.color.hdr = (struct pl_hdr_metadata){0};
         if (p.color.space != MP_CSP_RGB) {
             p.color.levels = yuv_levels;
             p.color.space = MP_CSP_BT_601;

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -27,6 +27,7 @@
 #include <libavutil/rational.h>
 #include <libavcodec/avcodec.h>
 #include <libavutil/mastering_display_metadata.h>
+#include <libplacebo/utils/libav.h>
 
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 16, 100)
 # include <libavutil/dovi_meta.h>
@@ -41,6 +42,7 @@
 #include "mp_image.h"
 #include "osdep/threads.h"
 #include "sws_utils.h"
+#include "out/placebo/utils.h"
 
 // Determine strides, plane sizes, and total required size for an image
 // allocation. Returns total size on success, <0 on error. Unused planes
@@ -776,8 +778,6 @@ char *mp_image_params_to_str_buf(char *b, size_t bs,
                         m_opt_choice_str(mp_csp_trc_names, p->color.gamma),
                         m_opt_choice_str(mp_csp_levels_names, p->color.levels),
                         m_opt_choice_str(mp_csp_light_names, p->color.light));
-        if (p->color.sig_peak)
-            mp_snprintf_cat(b, bs, " SP=%f", p->color.sig_peak);
         mp_snprintf_cat(b, bs, " CL=%s",
                         m_opt_choice_str(mp_chroma_names, p->chroma_location));
         if (mp_image_crop_valid(p)) {
@@ -955,20 +955,20 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
         params->color.gamma = MP_CSP_TRC_AUTO;
     }
 
-    if (!params->color.sig_peak) {
+    if (!params->color.hdr.max_luma) {
         if (params->color.gamma == MP_CSP_TRC_HLG) {
-            params->color.sig_peak = 1000 / MP_REF_WHITE; // reference display
+            params->color.hdr.max_luma = 1000; // reference display
         } else {
             // If the signal peak is unknown, we're forced to pick the TRC's
             // nominal range as the signal peak to prevent clipping
-            params->color.sig_peak = mp_trc_nom_peak(params->color.gamma);
+            params->color.hdr.max_luma = mp_trc_nom_peak(params->color.gamma) * MP_REF_WHITE;
         }
     }
 
     if (!mp_trc_is_hdr(params->color.gamma)) {
         // Some clips have leftover HDR metadata after conversion to SDR, so to
         // avoid blowing up the tone mapping code, strip/sanitize it
-        params->color.sig_peak = 1.0;
+        params->color.hdr = pl_hdr_metadata_empty;
     }
 
     if (params->chroma_location == MP_CHROMA_AUTO) {
@@ -1061,20 +1061,14 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
     if (sd)
         dst->icc_profile = sd->buf;
 
-    // Get the content light metadata if available
-    sd = av_frame_get_side_data(src, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
-    if (sd) {
-        AVContentLightMetadata *clm = (AVContentLightMetadata *)sd->data;
-        dst->params.color.sig_peak = clm->MaxCLL / MP_REF_WHITE;
-    }
-
-    // Otherwise, try getting the mastering metadata if available
-    sd = av_frame_get_side_data(src, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-    if (!dst->params.color.sig_peak && sd) {
-        AVMasteringDisplayMetadata *mdm = (AVMasteringDisplayMetadata *)sd->data;
-        if (mdm->has_luminance)
-            dst->params.color.sig_peak = av_q2d(mdm->max_luminance) / MP_REF_WHITE;
-    }
+    AVFrameSideData *mdm = av_frame_get_side_data(src, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+    AVFrameSideData *clm = av_frame_get_side_data(src, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+    AVFrameSideData *dhp = av_frame_get_side_data(src, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);
+    pl_map_hdr_metadata(&dst->params.color.hdr, &(struct pl_av_hdr_metadata) {
+        .mdm = (void *)(mdm ? mdm->data : NULL),
+        .clm = (void *)(clm ? clm->data : NULL),
+        .dhp = (void *)(dhp ? dhp->data : NULL),
+    });
 
     sd = av_frame_get_side_data(src, AV_FRAME_DATA_A53_CC);
     if (sd)
@@ -1189,12 +1183,11 @@ struct AVFrame *mp_image_to_av_frame(struct mp_image *src)
         new_ref->icc_profile = NULL;
     }
 
-    if (src->params.color.sig_peak) {
-        AVContentLightMetadata *clm =
-            av_content_light_metadata_create_side_data(dst);
-        MP_HANDLE_OOM(clm);
-        clm->MaxCLL = src->params.color.sig_peak * MP_REF_WHITE;
-    }
+    pl_avframe_set_color(dst, (struct pl_color_space){
+        .primaries = mp_prim_to_pl(src->params.color.primaries),
+        .transfer = mp_trc_to_pl(src->params.color.gamma),
+        .hdr = src->params.color.hdr,
+    });
 
     {
         AVFrameSideData *sd = av_frame_new_side_data(dst,

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -123,7 +123,7 @@ enum mp_voctrl {
     /* private to vo_gpu and vo_gpu_next */
     VOCTRL_EXTERNAL_RESIZE,
 
-    VOCTRL_HDR_METADATA,            // struct mp_hdr_metadata*
+    VOCTRL_HDR_METADATA,            // struct pl_hdr_metadata*
 };
 
 // Helper to expose what kind of content is currently playing to the VO.

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1436,20 +1436,9 @@ static int control(struct vo *vo, uint32_t request, void *data)
         return true;
     }
 
-    case VOCTRL_HDR_METADATA: {
-        struct mp_hdr_metadata *hdr = data;
-        hdr->min_luma = p->last_hdr_metadata.min_luma;
-        hdr->max_luma = p->last_hdr_metadata.max_luma;
-        hdr->max_cll = p->last_hdr_metadata.max_cll;
-        hdr->max_fall = p->last_hdr_metadata.max_fall;
-        hdr->scene_max[0] = p->last_hdr_metadata.scene_max[0];
-        hdr->scene_max[1] = p->last_hdr_metadata.scene_max[1];
-        hdr->scene_max[2] = p->last_hdr_metadata.scene_max[2];
-        hdr->scene_avg = p->last_hdr_metadata.scene_avg;
-        hdr->max_pq_y = p->last_hdr_metadata.max_pq_y;
-        hdr->avg_pq_y = p->last_hdr_metadata.avg_pq_y;
+    case VOCTRL_HDR_METADATA:
+        *(struct pl_hdr_metadata *) data = p->last_hdr_metadata;
         return true;
-    }
 
     case VOCTRL_SCREENSHOT:
         video_screenshot(vo, data);

--- a/video/zimg.c
+++ b/video/zimg.c
@@ -548,8 +548,8 @@ static bool mp_zimg_state_init(struct mp_zimg_context *ctx,
         params.allow_approximate_gamma = 1;
 
     // leave at default for SDR, which means 100 cd/m^2 for zimg
-    if (ctx->dst.color.sig_peak > 0 && mp_trc_is_hdr(ctx->dst.color.gamma))
-        params.nominal_peak_luminance = ctx->dst.color.sig_peak * MP_REF_WHITE;
+    if (ctx->dst.color.hdr.max_luma > 0 && mp_trc_is_hdr(ctx->dst.color.gamma))
+        params.nominal_peak_luminance = ctx->dst.color.hdr.max_luma;
 
     st->graph = zimg_filter_graph_build(&src_fmt, &dst_fmt, &params);
     if (!st->graph) {


### PR DESCRIPTION
Extracted from #12306, since it is stuck in limbo