### PR TITLE
m3u: introduce EXT-MPV to allow specifying per-file parameters

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -27,14 +27,27 @@
 #include "demux/demux.h"
 #include "stream/stream.h"
 
-struct playlist_entry *playlist_entry_new(const char *filename)
+struct playlist_entry *playlist_entry_new_uninitialized()
 {
     struct playlist_entry *e = talloc_zero(NULL, struct playlist_entry);
-    char *local_filename = mp_file_url_to_filename(e, bstr0(filename));
-    e->filename = local_filename ? local_filename : talloc_strdup(e, filename);
+    e->filename = NULL;
     e->stream_flags = STREAM_ORIGIN_DIRECT;
     e->original_index = -1;
     return e;
+}
+
+struct playlist_entry *playlist_entry_init_filename(struct playlist_entry *e, const char *filename)
+{
+    assert(e->filename == NULL);
+    char *local_filename = mp_file_url_to_filename(e, bstr0(filename));
+    e->filename = local_filename ? local_filename : talloc_strdup(e, filename);
+    return e;
+}
+
+struct playlist_entry *playlist_entry_new(const char *filename)
+{
+    struct playlist_entry *e = playlist_entry_new_uninitialized();
+    return playlist_entry_init_filename(e, filename);
 }
 
 void playlist_entry_add_param(struct playlist_entry *e, bstr name, bstr value)

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -79,6 +79,8 @@ void playlist_entry_add_params(struct playlist_entry *e,
                                struct playlist_param *params,
                                int params_count);
 
+struct playlist_entry *playlist_entry_new_uninitialized(void);
+struct playlist_entry *playlist_entry_init_filename(struct playlist_entry *e, const char *filename);
 struct playlist_entry *playlist_entry_new(const char *filename);
 
 void playlist_add(struct playlist *pl, struct playlist_entry *add);


### PR DESCRIPTION
m3u files are handy, but it would be nice to be able to specify per-file parameters. This PR introduces a `#EXT-MPV:param=value` directive that applies to the next file in the playlist. The existing per-file params mechanism is used.

Sample usage:
```
#EXT-MPV:image-display-duration=5
image.jpg
#EXT-MPV:start=120
#EXT-MPV:length=20
foo.mp4
#EXT-MPV:image-display-duration=60
image2.jpg
```

Much of this can already be done via `.edl` files, but edl files (seem to?) require edl to parse all of the contents, which can be prohibitive in case of lots of entries.