### PR TITLE
video: reset `display_sync_error` when resetting state

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -119,6 +119,7 @@ void reset_video_state(struct MPContext *mpctx)
     mpctx->mistimed_frames_total = 0;
     mpctx->drop_message_shown = 0;
     mpctx->display_sync_drift_dir = 0;
+    mpctx->display_sync_error = 0;
 
     mpctx->video_status = mpctx->vo_chain ? STATUS_SYNCING : STATUS_EOF;
 }

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -878,9 +878,6 @@ static bool render_frame(struct vo *vo)
         frame->duration = -1;
     }
 
-    if (in->paused)
-        frame->vsync_offset = 0;
-
     int64_t now = mp_time_ns();
     int64_t pts = frame->pts;
     int64_t duration = frame->duration;


### PR DESCRIPTION
This would cause mpv to, in some very specific scenarios, have a negative vsync_offset after seeking which would result in mpv requesting a pts before the first frame to libplacebo.

Fix it by setting it to 0 when we reset state, such as after seeking.

Fixes: https://github.com/mpv-player/mpv/issues/12813