### PR TITLE
ytdl_hook: fix mixed thumbnail.preference availability

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -768,7 +768,7 @@ local function add_single_video(json)
                     msg.verbose("adding thumbnail")
                     mp.commandv("video-add", thumb_info.url, "auto")
                     thumb_height = 0
-                elseif (thumb_preference ~= nil and thumb_info.preference > thumb_preference) or
+                elseif (thumb_preference ~= nil and (thumb_info.preference or -math.huge) > thumb_preference) or
                     (thumb_preference == nil and ((thumb_info.height or 0) > thumb_height)) then
                     thumb = thumb_info.url
                     thumb_height = thumb_info.height or 0


### PR DESCRIPTION
Apparently twitch provides two thumbnails, one has a `preference` field and the other one does not, which leads to a crash when `--script-opts=ytdl_hook-thumbnails=best` is used. To fix this fall back to `-math.huge` in case there has already been a thumbnail with preference set.