### PR TITLE
player/command: adjust offsets when sub seeking/stepping

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -49,8 +49,9 @@
 #include "demux/demux.h"
 #include "demux/stheader.h"
 #include "common/playlist.h"
-#include "sub/osd.h"
 #include "sub/dec_sub.h"
+#include "sub/osd.h"
+#include "sub/sd.h"
 #include "options/m_option.h"
 #include "options/m_property.h"
 #include "options/m_config_frontend.h"
@@ -5410,11 +5411,10 @@ static void cmd_sub_step_seek(void *p)
                                                &mpctx->opts->subs_rend->sub_delay);
                 show_property_osd(mpctx, "sub-delay", cmd->on_osd);
             } else {
-                // We can easily get stuck by failing to seek to the video
-                // frame which actually shows the sub first (because video
-                // frame PTS and sub PTS rarely match exactly). Add some
-                // rounding for the mess of it.
-                a[0] += 0.01 * (a[1] >= 0 ? 1 : -1);
+                // We can easily seek/step to the wrong subtitle line (because
+                // video frame PTS and sub PTS rarely match exactly). Add an
+                // arbitrary forward offset as a workaround.
+                a[0] += SUB_SEEK_OFFSET;
                 mark_seek(mpctx);
                 queue_seek(mpctx, MPSEEK_ABSOLUTE, a[0], MPSEEK_EXACT,
                            MPSEEK_FLAG_DELAY);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -9,6 +9,8 @@
 #define SUB_GAP_THRESHOLD 0.210
 // don't change timings if durations are smaller
 #define SUB_GAP_KEEP 0.4
+// slight offset when sub seeking or sub stepping
+#define SUB_SEEK_OFFSET 0.01
 
 struct sd {
     struct mpv_global *global;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -844,7 +844,8 @@ static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
         long long res = ass_step_sub(ctx->ass_track, ts, a[1]);
         if (!res)
             return false;
-        a[0] += res / 1000.0;
+        // Try to account for overlapping durations
+        a[0] += res / 1000.0 + SUB_SEEK_OFFSET;
         return true;
     }
     case SD_CTRL_SET_VIDEO_PARAMS:


### PR DESCRIPTION
In the sub seek code path, there was an arbitrary small offset added to the pts before the seek. However when seeking backwards, the offset was an additional subtraction. de6eace6e984be3cd2515e9be6362a0cf04b7457 added this logic 10 years ago and perhaps it made sense then, but the additional subtraction when seeking backwards causes the subtitle seek to go too far to the previous subtitle if the durations overlaps. This should always be an addition to work correctly. Additionally, the sub stepping code path also could use this offset for the same reason (duration overlaps). Let's always add the offset to refpts to account for both cases and update the comment to be a little more relevant. Fixes #11445.