### PR TITLE
threads: unbreak mpv on builds without asserts

### DIFF
--- a/osdep/threads-posix.h
+++ b/osdep/threads-posix.h
@@ -122,6 +122,7 @@ static inline int mp_mutex_init_type_internal(mp_mutex *mutex, enum mp_mutex_typ
     pthread_mutexattr_settype(&attr, mutex_type);
     ret = pthread_mutex_init(mutex, &attr);
     pthread_mutexattr_destroy(&attr);
+    assert(!ret);
     return ret;
 }
 

--- a/osdep/threads-win32.h
+++ b/osdep/threads-win32.h
@@ -51,9 +51,6 @@ static inline int mp_mutex_init_type_internal(mp_mutex *mutex, enum mp_mutex_typ
     return 0;
 }
 
-#define mp_mutex_init_type(mutex, mtype) \
-    assert(!mp_mutex_init_type_internal(mutex, mtype))
-
 static inline int mp_mutex_destroy(mp_mutex *mutex)
 {
     if (mutex->use_cs)

--- a/osdep/threads.h
+++ b/osdep/threads.h
@@ -12,7 +12,7 @@ enum mp_mutex_type {
     mp_mutex_init_type(mutex, MP_MUTEX_NORMAL)
 
 #define mp_mutex_init_type(mutex, mtype) \
-    assert(!mp_mutex_init_type_internal(mutex, mtype))
+    mp_mutex_init_type_internal(mutex, mtype)
 
 #if HAVE_WIN32_THREADS
 #include "threads-win32.h"


### PR DESCRIPTION
Also remove duplicated macro.

Fixes: #12818 #12820