### PR TITLE
win32: resolve dropped shell links (Windows shortcuts)

### DIFF
--- a/osdep/windows_utils.c
+++ b/osdep/windows_utils.c
@@ -24,9 +24,12 @@
 #include <audioclient.h>
 #include <d3d9.h>
 #include <dxgi1_2.h>
+#include <ole2.h>
+#include <shobjidl.h>
 
 #include "common/common.h"
 #include "windows_utils.h"
+#include "mpv_talloc.h"
 
 char *mp_GUID_to_str_buf(char *buf, size_t buf_size, const GUID *guid)
 {
@@ -226,4 +229,23 @@ bool mp_w32_create_anon_pipe(HANDLE *server, HANDLE *client,
 error:
     *server = *client = INVALID_HANDLE_VALUE;
     return false;
+}
+
+wchar_t *mp_w32_get_shell_link_target(wchar_t *path)
+{
+    IShellLink *psl = NULL;
+    IPersistFile *ppf = NULL;
+    wchar_t *buf = talloc_array(NULL, wchar_t, MAX_PATH + 1);
+
+    if (FAILED(CoCreateInstance(&CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, &IID_IShellLinkW, (void**)&psl)) ||
+        FAILED(IShellLinkW_QueryInterface(psl, &IID_IPersistFile, (void**)&ppf)) ||
+        FAILED(IPersistFile_Load(ppf, path, STGM_READ)) ||
+        FAILED(IShellLinkW_GetPath(psl, buf, MAX_PATH, NULL, 0)))
+    {
+        TA_FREEP(&buf);
+    }
+
+    SAFE_RELEASE(psl);
+    SAFE_RELEASE(ppf);
+    return buf;
 }

--- a/osdep/windows_utils.h
+++ b/osdep/windows_utils.h
@@ -46,4 +46,8 @@ struct w32_create_anon_pipe_opts {
 bool mp_w32_create_anon_pipe(HANDLE *server, HANDLE *client,
                              struct w32_create_anon_pipe_opts *opts);
 
+// Returns the target of the shell link in talloc memory if the path is a
+// resolvable shell link, otherwise returns NULL.
+wchar_t *mp_w32_get_shell_link_target(wchar_t *path);
+
 #endif

--- a/video/out/win32/droptarget.c
+++ b/video/out/win32/droptarget.c
@@ -157,8 +157,10 @@ static STDMETHODIMP DropTarget_Drop(IDropTarget *self, IDataObject *pDataObj,
                 wchar_t *buf = talloc_array(NULL, wchar_t, len + 1);
 
                 if (DragQueryFileW(drop, i, buf, len + 1) == len) {
-                    char *fname = mp_to_utf8(files, buf);
+                    wchar_t *target = mp_w32_get_shell_link_target(buf);
+                    char *fname = mp_to_utf8(files, target ? target : buf);
                     files[recvd_files++] = fname;
+                    talloc_free(target);
 
                     MP_VERBOSE(t, "received dropped file: %s\n", fname);
                 } else {


### PR DESCRIPTION
This PR implements shell link resolving and enables it on dropped targets. Closes https://github.com/mpv-player/mpv/issues/8424.

mpv's behavior now matches VLC's behavior with this PR (resolves dropped shell links, but doesn't resolve shell links provided by other means, e.g. commandline). It doesn't match mpc-hc's behavior (resolves all shell links), but that requires touching platform-independent code. A separate PR will address that should such use case arises later. 
