### PR TITLE
Save libplacebo.cache file atomically

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -484,6 +484,20 @@ int mp_creat(const char *filename, int mode)
     return mp_open(filename, _O_CREAT | _O_WRONLY | _O_TRUNC, mode);
 }
 
+int mp_rename(const char *oldpath, const char *newpath)
+{
+    wchar_t *woldpath = mp_from_utf8(NULL, oldpath),
+        *wnewpath = mp_from_utf8(NULL, newpath);
+    BOOL ok = MoveFileExW(woldpath, wnewpath, MOVEFILE_REPLACE_EXISTING);
+    talloc_free(woldpath);
+    talloc_free(wnewpath);
+    if (!ok) {
+        set_errno_from_lasterror();
+        return -1;
+    }
+    return 0;
+}
+
 FILE *mp_fopen(const char *filename, const char *mode)
 {
     if (!mode[0]) {

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -98,6 +98,7 @@ int mp_printf(const char *format, ...);
 int mp_fprintf(FILE *stream, const char *format, ...);
 int mp_open(const char *filename, int oflag, ...);
 int mp_creat(const char *filename, int mode);
+int mp_rename(const char *oldpath, const char *newpath);
 FILE *mp_fopen(const char *filename, const char *mode);
 DIR *mp_opendir(const char *path);
 struct dirent *mp_readdir(DIR *dir);
@@ -164,6 +165,7 @@ void mp_globfree(mp_glob_t *pglob);
 #define fprintf(...) mp_fprintf(__VA_ARGS__)
 #define open(...) mp_open(__VA_ARGS__)
 #define creat(...) mp_creat(__VA_ARGS__)
+#define rename(...) mp_rename(__VA_ARGS__)
 #define fopen(...) mp_fopen(__VA_ARGS__)
 #define opendir(...) mp_opendir(__VA_ARGS__)
 #define readdir(...) mp_readdir(__VA_ARGS__)

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -17,6 +17,8 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <unistd.h>
+
 #include <libplacebo/colorspace.h>
 #include <libplacebo/options.h>
 #include <libplacebo/renderer.h>
@@ -1519,51 +1521,49 @@ static void load_cache_files(struct priv *p)
         }
         talloc_free(shader_cache);
     }
-    if (icc_cache) {
-        if (!same_cache) {
-            FILE *cache = fopen(icc_cache, "rb");
-            if (cache) {
-                int ret = pl_cache_load_file(p->icc_cache, cache);
-                fclose(cache);
-                if (ret < 0)
-                    MP_WARN(p, "Failed loading cache from %s\n", icc_cache);
-            }
+    if (icc_cache && !same_cache) {
+        FILE *cache = fopen(icc_cache, "rb");
+        if (cache) {
+            int ret = pl_cache_load_file(p->icc_cache, cache);
+            fclose(cache);
+            if (ret < 0)
+                MP_WARN(p, "Failed loading cache from %s\n", icc_cache);
         }
-        talloc_free(icc_cache);
     }
+    talloc_free(icc_cache);
 }
 
 static void save_cache_files(struct priv *p)
 {
+    void *ta_ctx = talloc_new(NULL);
     char *icc_cache = get_cache_file(p, "icc");
     char *shader_cache = get_cache_file(p, "shader");
+    talloc_steal(ta_ctx, icc_cache);
+    talloc_steal(ta_ctx, shader_cache);
+
     bool same_cache = false;
     if (icc_cache && shader_cache)
         same_cache = strcmp(icc_cache, shader_cache) == 0;
-    if (shader_cache) {
-        FILE *cache = fopen(shader_cache, "wb");
-        if (cache) {
-            int ret = pl_cache_save_file(p->shader_cache, cache);
-            if (same_cache)
-                pl_cache_save_file(p->icc_cache, cache);
-            fclose(cache);
-            if (ret < 0)
-                MP_WARN(p, "Failed saving cache to %s\n", shader_cache);
-        }
-        talloc_free(shader_cache);
+    for (int i = 0; i < 2; i++) {
+        const char *target_file = i == 0 ? shader_cache : icc_cache;
+        pl_cache target_cache = i == 0 ? p->shader_cache : p->icc_cache;
+
+        if (!target_file)
+            continue;
+        FILE *cache = fopen(target_file, "wb");
+        if (!cache)
+            continue;
+        int ret = pl_cache_save_file(target_cache, cache);
+        if (same_cache)
+            ret += pl_cache_save_file(p->icc_cache, cache);
+        fclose(cache);
+        if (ret < 0)
+            MP_WARN(p, "Failed saving cache to %s\n", target_file);
+
+        if (same_cache)
+            break;
     }
-    if (icc_cache) {
-        if (!same_cache) {
-            FILE *cache = fopen(icc_cache, "wb");
-            if (cache) {
-                int ret = pl_cache_save_file(p->icc_cache, cache);
-                fclose(cache);
-                if (ret < 0)
-                    MP_WARN(p, "Failed saving cache to %s\n", icc_cache);
-            }
-        }
-        talloc_free(icc_cache);
-    }
+    talloc_free(ta_ctx);
 }
 
 


### PR DESCRIPTION
context: while I was testing stuff mpv once complained about "Failed loading cache: file seems empty or truncated"
I assumed this must have happened during an mpv crash or while multiple instances were trying to write the file (at the same time) and decided to make these changes.

<s>@<a></a>kasper93 I vaguely remember atomic `rename` for overwriting not working on Windows. Any advice? </s>
Indeed doesn't work, should be fixed now.