### PR TITLE
wayland: improve wl_output guessing before mpv window is mapped

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3005,6 +3005,13 @@ Window
         explicitly. It's also possible that the window manager provides native
         features to control which screens application windows should use.
 
+    .. admonition:: Note (Wayland)
+
+        This option does not actually work on wayland since window placement is
+        not allowed. However setting this option does influence mpv's initial
+        guess at finding an output which may be useful for options like
+        ``--geometry`` or ``--autofit`` which depend on the monitor resolution.
+
     See also ``--fs-screen``.
 
 ``--screen-name=<string>``

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1620,8 +1620,9 @@ static void guess_focus(struct vo_wayland_state *wl)
 static struct vo_wayland_output *find_output(struct vo_wayland_state *wl)
 {
     int index = 0;
-    int screen_id = wl->vo_opts->fsscreen_id;
-    char *screen_name = wl->vo_opts->fsscreen_name;
+    struct mp_vo_opts *opts = wl->vo_opts;
+    int screen_id = opts->fullscreen ? opts->fsscreen_id : opts->screen_id;
+    char *screen_name = opts->fullscreen ? opts->fsscreen_name : opts->screen_name;
     struct vo_wayland_output *output = NULL;
     struct vo_wayland_output *fallback_output = NULL;
     wl_list_for_each(output, &wl->output_list, link) {
@@ -1639,9 +1640,9 @@ static struct vo_wayland_output *find_output(struct vo_wayland_state *wl)
     if (!fallback_output) {
         MP_ERR(wl, "No screens could be found!\n");
         return NULL;
-    } else if (wl->vo_opts->fsscreen_id >= 0) {
+    } else if (screen_id >= 0) {
         MP_WARN(wl, "Screen index %i not found/unavailable! Falling back to screen 0!\n", screen_id);
-    } else if (wl->vo_opts->fsscreen_name) {
+    } else if (screen_name && screen_name[0]) {
         MP_WARN(wl, "Screen name %s not found/unavailable! Falling back to screen 0!\n", screen_name);
     }
     return fallback_output;


### PR DESCRIPTION
There's some geometry-related things that mpv has to calculate before the window is actually mapped onto the screen in wayland. But there's no way to know which output the window will end up on before it happens, so it's possible to calculate it using the wrong values. mpv corrects itself later when the surface event happens, but making the initial guess work better can help in certain cases.

find_output is the only thing that needs to be changed here. Its main purpose is to grab the right output based on user settings when we're trying to full screen and giving a fallback in case we don't have wl->current_output yet. The x11 code already does something similar, so we're basically just copying it. Allow user settings like --screen and --screen-name to influence the initial wl_output guess. Those options won't actually place the window on that specific screen since we can't do that in wayland, but if the user knows where the window will end up beforehand it makes sense to listen to the arguments they pass. If something goes wrong, then we just fallback to 0 like before.

cc @llyyr 