### PR TITLE
vo: remove VOCTRL_HDR_METADATA

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2372,17 +2372,16 @@ static struct mp_image_params get_video_out_params(struct MPContext *mpctx)
 static int mp_property_vo_imgparams(void *ctx, struct m_property *prop,
                                     int action, void *arg)
 {
+    MPContext *mpctx = ctx;
+    struct vo *vo = mpctx->video_out;
+    if (!vo)
+        return M_PROPERTY_UNAVAILABLE;
+
     int valid = m_property_read_sub_validate(ctx, prop, action, arg);
     if (valid != M_PROPERTY_VALID)
         return valid;
 
-    struct mp_image_params p = get_video_out_params(ctx);
-
-    MPContext *mpctx = ctx;
-    if (mpctx->video_out)
-        vo_control(mpctx->video_out, VOCTRL_HDR_METADATA, &p.color.hdr);
-
-    return property_imgparams(p, action, arg);
+    return property_imgparams(vo_get_current_params(vo), action, arg);
 }
 
 static int mp_property_dec_imgparams(void *ctx, struct m_property *prop,

--- a/player/video.c
+++ b/player/video.c
@@ -1034,6 +1034,19 @@ static void apply_video_crop(struct MPContext *mpctx, struct vo *vo)
     }
 }
 
+static bool video_reconfig_needed(const struct mp_image_params *p1,
+                                  const struct mp_image_params *p2)
+{
+    return p1->imgfmt != p2->imgfmt ||
+           p1->hw_subfmt != p2->hw_subfmt ||
+           p1->w != p2->w || p1->h != p2->h ||
+           p1->p_w != p2->p_w || p1->p_h != p2->p_h ||
+           p1->force_window != p2->force_window ||
+           p1->rotate != p2->rotate ||
+           p1->stereo3d != p2->stereo3d ||
+           !mp_rect_equals(&p1->crop, &p2->crop);
+}
+
 void write_video(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
@@ -1156,7 +1169,7 @@ void write_video(struct MPContext *mpctx)
 
     // Filter output is different from VO input?
     struct mp_image_params *p = &mpctx->next_frames[0]->params;
-    if (!vo->params || !mp_image_params_equal(p, vo->params)) {
+    if (!vo->params || video_reconfig_needed(p, vo->params)) {
         // Changing config deletes the current frame; wait until it's finished.
         if (vo_still_displaying(vo))
             return;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1422,3 +1422,13 @@ int lookup_keymap_table(const struct mp_keymap *map, int key)
         map++;
     return map->to;
 }
+
+struct mp_image_params vo_get_current_params(struct vo *vo)
+{
+    struct mp_image_params p = {0};
+    mp_mutex_lock(&vo->in->lock);
+    if (vo->params)
+        p = *vo->params;
+    mp_mutex_unlock(&vo->in->lock);
+    return p;
+}

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -122,8 +122,6 @@ enum mp_voctrl {
 
     /* private to vo_gpu and vo_gpu_next */
     VOCTRL_EXTERNAL_RESIZE,
-
-    VOCTRL_HDR_METADATA,            // struct pl_hdr_metadata*
 };
 
 // Helper to expose what kind of content is currently playing to the VO.
@@ -535,5 +533,7 @@ void vo_get_src_dst_rects(struct vo *vo, struct mp_rect *out_src,
                           struct mp_rect *out_dst, struct mp_osd_res *out_osd);
 
 struct vo_frame *vo_frame_ref(struct vo_frame *frame);
+
+struct mp_image_params vo_get_current_params(struct vo *vo);
 
 #endif /* MPLAYER_VIDEO_OUT_H */


### PR DESCRIPTION
Currently VOCTRL are completely unusable for frequent data query. Since the HDR parameter addition to video-params, the parameters can change each frame. In which case observe on those parameter would be triggered constantly. The problem is that quering those parameters involves VOCTRL which in turn involves whole render cycle of delay.

I'm not quite happy with this solution, but don't see better one without changing observe/notify logic significantly. And even than for metadata that changes each frame, we would need to still have some kind of cache to not wait for VOCTRL again...

Fixes: 84de84b
Fixes: #12825