### PR TITLE
TOOLS/macos-sdk-version: remove legacy sdk version retrieval

### DIFF
--- a/TOOLS/macos-sdk-version.py
+++ b/TOOLS/macos-sdk-version.py
@@ -6,6 +6,7 @@
 import re
 import os
 import string
+import subprocess
 import sys
 from shutil import which
 from subprocess import check_output
@@ -13,11 +14,11 @@ from subprocess import check_output
 def find_macos_sdk():
     sdk = os.environ.get('MACOS_SDK', '')
     sdk_version = os.environ.get('MACOS_SDK_VERSION', '0.0')
-    build_version = '0.0'
     xcrun = which('xcrun')
+    xcodebuild = which('xcodebuild')
 
     if not xcrun:
-        return sdk,sdk_version,build_version
+        return sdk,sdk_version
 
     if not sdk:
         sdk = check_output([xcrun, '--sdk', 'macosx', '--show-sdk-path'],
@@ -25,36 +26,20 @@ def find_macos_sdk():
 
     # find macOS SDK paths and version
     if sdk_version == '0.0':
-        # show-sdk-build-version: is not available on older command line tools, but returns a build version (eg 17A360)
-        # show-sdk-version: is always available, but on older dev tools it's only the major version
-        sdk_build_version = check_output([xcrun, '--sdk', 'macosx',
-                                          '--show-sdk-build-version'], encoding="UTF-8")
-
         sdk_version = check_output([xcrun, '--sdk', 'macosx', '--show-sdk-version'],
                                     encoding="UTF-8")
 
-    if sdk:
-        build_version = '10.10.0'
-
-    # convert build version to a version string
-    # first 2 two digits are the major version, starting with 15 which is 10.11 (offset of 4)
-    # 1 char is the minor version, A => 0, B => 1 and ongoing
-    # last digits are bugfix version, which are not relevant for us
-    # eg 16E185 => 10.12.4, 17A360 => 10.13, 18B71 => 10.14.1
-    if sdk_build_version and isinstance(sdk_build_version, str):
-        verRe = re.compile("(\d+)(\D+)(\d+)")
-        version_parts = verRe.search(sdk_build_version)
-        major = int(version_parts.group(1)) - 4
-        minor = string.ascii_lowercase.index(version_parts.group(2).lower())
-        build_version = '10.' + str(major) + '.' + str(minor)
-        # from 20 onwards macOS 11.0 starts
-        if int(version_parts.group(1)) >= 20:
-            build_version = '11.' + str(minor)
+        # use xcode tools when installed, still necessary for xcode versions <12.0
+        try:
+            sdk_version = check_output([xcodebuild, '-sdk', 'macosx', '-version', 'ProductVersion'],
+                                        encoding="UTF-8", stderr=subprocess.DEVNULL)
+        except:
+            pass
 
     if not isinstance(sdk_version, str):
         sdk_version = '10.10.0'
 
-    return sdk,sdk_version,build_version
+    return sdk.strip(),sdk_version.strip()
 
 if __name__ == "__main__":
     sdk_info = find_macos_sdk()

--- a/meson.build
+++ b/meson.build
@@ -1459,10 +1459,8 @@ macos_sdk_path = ''
 macos_sdk_version = '0.0'
 if darwin and macos_sdk_version_py.found()
     macos_sdk_info = run_command(macos_sdk_version_py, check: true).stdout().split(',')
-    macos_sdk_path = macos_sdk_info[0].strip()
-    # Always pick whichever version is higher.
-    macos_sdk_version = macos_sdk_info[1].version_compare('>' + macos_sdk_info[2]) ? \
-                        macos_sdk_info[1] : macos_sdk_info[2]
+    macos_sdk_path = macos_sdk_info[0]
+    macos_sdk_version = macos_sdk_info[1]
 endif
 
 if macos_sdk_path != ''


### PR DESCRIPTION
i checked some of the oldest and newest xcode and command line tools for the problem with the sdk version and the truncated minor version. the only version that still exhibits that problem is xcode older than 12. xcode 12 is the newest version supported on our oldest macOS version supported. since xcode 11 is also still supported on 10.15 i added the sdk version retrieval with an xcode only tool in the case xcode is installed. this can be removed once we drop support for macOS 10.15.

anyway, the very error prone conversion from sdk build version to sdk version can be safely removed now and we get proper sdk version retrieval in all cases now (other than Apple fucking up again).

```
				build-version	version		ProductVersion
CommandLineTools 11.3.1		19B90		10.15.1
CommandLineTools 12.1		19G68		10.15.6
CommandLineTools 12.5.1		20E214		11.3
CommandLineTools 13.4		21E226		12.3
CommandLineTools 14.3.1		22E245		13.3
Xcode 11.3.1			19B90		10.15		10.15.1
Xcode 12.1			19G68		10.15.6		10.15.6
Xcode 12.5.1			20E214		11.3		11.3
Xcode 13.4.1			23A334		14.0		14.0
Xcode 14.3.1			22E245		13.3		13.3
```

[edit]
something related but no relevant anymore since we removed the build version number. maybe helpful for other or in the future. this is how the minor version maps the letter in the build version.
```
A	0
B	1
C	2
D	3
E	4
F	5
G	6

# from xcode 12.2, SDK 11.0 onwards
A	0
B	0
C	1
D	1
E	3
F	3
G	4
H	4
I	5
J	5
```