### PR TITLE
mac: fix build on older swift versions

### DIFF
--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -111,11 +111,11 @@ class MacCommon: Common {
                                          _ flagsOut: UnsafeMutablePointer<CVOptionFlags>) -> CVReturn
     {
         let frameTimer = mpv?.macOpts.macos_render_timer ?? Int32(RENDER_TIMER_CALLBACK)
-        let signalSwap = { [self] in
-            swapLock.lock()
-            swapTime += 1
-            swapLock.signal()
-            swapLock.unlock()
+        let signalSwap = {
+            self.swapLock.lock()
+            self.swapTime += 1
+            self.swapLock.signal()
+            self.swapLock.unlock()
         }
 
         if frameTimer != RENDER_TIMER_SYSTEM {


### PR DESCRIPTION
just some swift compatibility with apparently swift versions older than 5.5. if we drop swift 5 someday this can be reverted.