### PR TITLE
mac: change display name retrieval to localizedName NSScreen property

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -115,6 +115,8 @@ Interface changes
     - add hdr metadata to `video-params` property
     - remove `hdr-metadata` property
     - add `--target-gamut`
+    - change the way display names are retrieved on macOS, usage of options and properties
+      `--fs-screen-name`, `--screen-name` and `display-names` needs to be adjusted
  --- mpv 0.36.0 ---
     - add `--target-contrast`
     - Target luminance value is now also applied when ICC profile is used.

--- a/osdep/macos/swift_extensions.swift
+++ b/osdep/macos/swift_extensions.swift
@@ -28,37 +28,6 @@ extension NSScreen {
             return deviceDescription[.screenNumber] as? CGDirectDisplayID ?? 0
         }
     }
-
-    public var displayName: String? {
-        get {
-            var name: String? = nil
-            var object: io_object_t
-            var iter = io_iterator_t()
-            let matching = IOServiceMatching("IODisplayConnect")
-            let result = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &iter)
-
-            if result != KERN_SUCCESS || iter == 0 { return nil }
-
-            repeat {
-                object = IOIteratorNext(iter)
-                if let info = IODisplayCreateInfoDictionary(object, IOOptionBits(kIODisplayOnlyPreferredName)).takeRetainedValue() as? [String:AnyObject],
-                    (info[kDisplayVendorID] as? UInt32 == CGDisplayVendorNumber(displayID) &&
-                    info[kDisplayProductID] as? UInt32 == CGDisplayModelNumber(displayID) &&
-                    info[kDisplaySerialNumber] as? UInt32 ?? 0 == CGDisplaySerialNumber(displayID))
-                {
-                    if let productNames = info["DisplayProductName"] as? [String:String],
-                       let productName = productNames.first?.value
-                    {
-                        name = productName
-                        break
-                    }
-                }
-            } while object != 0
-
-            IOObjectRelease(iter)
-            return name
-        }
-    }
 }
 
 extension NSColor {

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -411,7 +411,7 @@ class Common: NSObject {
 
     func getScreenBy(name screenName: String?) -> NSScreen? {
         for screen in NSScreen.screens {
-            if screen.displayName == screenName {
+            if screen.localizedName == screenName {
                 return screen
             }
         }
@@ -643,7 +643,7 @@ class Common: NSObject {
             let dnames = data!.assumingMemoryBound(to: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?.self)
             var array: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>? = nil
             var count: Int32 = 0
-            let displayName = getCurrentScreen()?.displayName ?? "Unknown"
+            let displayName = getCurrentScreen()?.localizedName ?? "Unknown"
 
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, ta_xstrdup(nil, displayName))
             SWIFT_TARRAY_STRING_APPEND(nil, &array, &count, nil)


### PR DESCRIPTION
remove the old broken display name retrieval and use the new property introduced in 10.15.