### PR TITLE
ytdl_hook: propogate ytdl.path out so that mp.get_opt can see it

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -956,6 +956,9 @@ function run_ytdl_hook(url)
             if ytdl_cmd then
                 msg.verbose("Found youtube-dl at: " .. ytdl_cmd)
                 ytdl.path = ytdl_cmd
+                if mp.get_opt("ytdl_hook-ytdl_path") == nil then
+                    mp.commandv('no-osd', 'change-list', 'script-opts', 'append', 'ytdl_hook-ytdl_path=' .. ytdl.path)
+                end
                 command[1] = ytdl.path
                 result = exec(command)
                 break
@@ -968,6 +971,9 @@ function run_ytdl_hook(url)
                 else
                     msg.verbose("Found youtube-dl with path " .. path .. " in PATH")
                     ytdl.path = path
+                    if mp.get_opt("ytdl_hook-ytdl_path") == nil then
+                        mp.commandv('no-osd', 'change-list', 'script-opts', 'append', 'ytdl_hook-ytdl_path=' .. ytdl.path)
+                    end
                     break
                 end
             end


### PR DESCRIPTION
Allows other scripts to use ytdl.path without having to discover it themselves.