### PR TITLE
player/command: make show-progress work regardless of osd prefix

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -758,7 +758,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 ``show-text <text> [<duration>|-1 [<level>]]``
     Show text on the OSD. The string can contain properties, which are expanded
     as described in `Property Expansion`_. This can be used to show playback
-    time, filename, and so on.
+    time, filename, and so on. ``no-osd`` has no effect on this command.
 
     <duration>
         The time in ms to show the message for. By default, it uses the same
@@ -786,7 +786,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
 ``show-progress``
     Show the progress bar, the elapsed time and the total duration of the file
-    on the OSD.
+    on the OSD. ``no-osd`` has no effect on this command.
 
 ``write-watch-later-config``
     Write the resume config file that the ``quit-watch-later`` command writes,

--- a/player/command.c
+++ b/player/command.c
@@ -5640,6 +5640,10 @@ static void cmd_show_progress(void *p)
     mpctx->add_osd_seek_info |=
             (cmd->msg_osd ? OSD_SEEK_INFO_TEXT : 0) |
             (cmd->bar_osd ? OSD_SEEK_INFO_BAR : 0);
+
+    // If we got neither (i.e. no-osd) force both like osd-auto.
+    if (!mpctx->add_osd_seek_info)
+        mpctx->add_osd_seek_info |= OSD_SEEK_INFO_TEXT | OSD_SEEK_INFO_BAR;
     mpctx->osd_force_update = true;
     mp_wakeup_core(mpctx);
 }


### PR DESCRIPTION
Having the show-progress command obey no-osd is nonsensical and
unintuitive. The show-text command already ignores no-osd, so there's
precedence for this. Fixes #5662.