### PR TITLE
vo: replace some magic numbers with timer macros

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -1257,7 +1257,7 @@ void vo_drm_wait_events(struct vo *vo, int64_t until_time_ns)
     struct vo_drm_state *drm = vo->drm;
     if (drm->vt_switcher_active) {
         int64_t wait_ns = until_time_ns - mp_time_ns();
-        int64_t timeout_ns = MPCLAMP(wait_ns, 1e6, 1e10);
+        int64_t timeout_ns = MPCLAMP(wait_ns, 0, MP_TIME_S_TO_NS(10));
         vt_switcher_poll(&drm->vt_switcher, timeout_ns);
     } else {
         vo_wait_default(vo, until_time_ns);

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -523,7 +523,10 @@ static void wakeup(struct vo *vo)
 static void wait_events(struct vo *vo, int64_t until_time_ns)
 {
     int64_t wait_ns = until_time_ns - mp_time_ns();
-    int timeout_ms = MPCLAMP(wait_ns / 1e6, 1, 10000);
+    // Round-up to 1ms for short timeouts (100us, 1000us]
+    if (wait_ns > MP_TIME_US_TO_NS(100))
+        wait_ns = MPMAX(wait_ns, MP_TIME_MS_TO_NS(1));
+    int timeout_ms = MPCLAMP(wait_ns / MP_TIME_MS_TO_NS(1), 0, 10000);
     SDL_Event ev;
 
     while (SDL_WaitEventTimeout(&ev, timeout_ms)) {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2611,7 +2611,7 @@ void vo_wayland_wait_events(struct vo *vo, int64_t until_time_ns)
     struct vo_wayland_state *wl = vo->wl;
 
     int64_t wait_ns = until_time_ns - mp_time_ns();
-    int64_t timeout_ns = MPCLAMP(wait_ns, 1e6, 1e10);
+    int64_t timeout_ns = MPCLAMP(wait_ns, 0, MP_TIME_S_TO_NS(10));
 
     wayland_dispatch_events(wl, 2, timeout_ns);
 }

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2178,7 +2178,7 @@ void vo_x11_wait_events(struct vo *vo, int64_t until_time_ns)
         { .fd = x11->wakeup_pipe[0], .events = POLLIN },
     };
     int64_t wait_ns = until_time_ns - mp_time_ns();
-    int64_t timeout_ns = MPCLAMP(wait_ns, 1e6, 1e10);
+    int64_t timeout_ns = MPCLAMP(wait_ns, 0, MP_TIME_S_TO_NS(10));
 
     mp_poll(fds, 2, timeout_ns);
 


### PR DESCRIPTION
Most importantly, the wait_until addition was missed while doing the unit conversions to nanoseconds which meant mpv woke up roughly every second since not nearly enough time was added. It was meant to be 1000 seconds (1e9 in microseconds). Use a macro so it's more readable. Also put some other wild 1e9 calculations inside of a macro as well.

Fixes a899e14bccb667af243f8fce454160e17ae45c2a.