### PR TITLE
osdep/w32_keyboard: remove duplicated MP_KEY_BACK mapping

### DIFF
--- a/osdep/w32_keyboard.c
+++ b/osdep/w32_keyboard.c
@@ -93,7 +93,6 @@ static const struct keymap appcmd_map[] = {
     {APPCOMMAND_LAUNCH_MAIL,         MP_KEY_MAIL},
     {APPCOMMAND_BROWSER_FAVORITES,   MP_KEY_FAVORITES},
     {APPCOMMAND_BROWSER_SEARCH,      MP_KEY_SEARCH},
-    {APPCOMMAND_BROWSER_BACKWARD,    MP_KEY_BACK},
     {0, 0}
 };
 


### PR DESCRIPTION
MP_MBTN_BACK is already mapped, the appcmd duplicates this.

Fixes: #12768
Fixes: 8301906