### PR TITLE
stats.lua: fix incorrect storage aspect ratio value

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2457,6 +2457,12 @@ Property list
     ``video-params/par``
         Pixel aspect ratio.
 
+    ``video-params/sar``
+        Storage aspect ratio.
+
+    ``video-params/sar-name``
+        Storage aspect ratio name as string.
+
     ``video-params/colormatrix``
         The colormatrix in use as string. (Exact values subject to change.)
 

--- a/player/command.c
+++ b/player/command.c
@@ -2299,6 +2299,7 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
 
     bool has_crop = mp_rect_w(p.crop) > 0 && mp_rect_h(p.crop) > 0;
     const char *aspect_name = get_aspect_ratio_name(d_w / (double)d_h);
+    const char *sar_name = get_aspect_ratio_name(p.w / (double)p.h);
     struct m_sub_property props[] = {
         {"pixelformat",     SUB_PROP_STR(mp_imgfmt_to_name(p.imgfmt))},
         {"hw-pixelformat",  SUB_PROP_STR(mp_imgfmt_to_name(p.hw_subfmt)),
@@ -2316,6 +2317,8 @@ static int property_imgparams(struct mp_image_params p, int action, void *arg)
         {"aspect",          SUB_PROP_FLOAT(d_w / (double)d_h)},
         {"aspect-name",     SUB_PROP_STR(aspect_name), .unavailable = !aspect_name},
         {"par",             SUB_PROP_FLOAT(p.p_w / (double)p.p_h)},
+        {"sar",             SUB_PROP_FLOAT(p.w / (double)p.h)},
+        {"sar-name",        SUB_PROP_STR(sar_name), .unavailable = !sar_name},
         {"colormatrix",
             SUB_PROP_STR(m_opt_choice_str(mp_csp_names, p.color.space))},
         {"colorlevels",

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -686,10 +686,16 @@ local function append_resolution(s, r, prefix, w_prop, h_prop, video_res)
     if append(s, r[w_prop], {prefix=prefix}) then
         append(s, r[h_prop], {prefix="x", nl="", indent=" ", prefix_sep=" ",
                            no_prefix_markup=true})
-        if r["aspect"] ~= nil then
+        if r["aspect"] ~= nil and not video_res then
             append(s, format("%.2f:1", r["aspect"]), {prefix="", nl="", indent="",
                                                       no_prefix_markup=true})
             append(s, r["aspect-name"], {prefix="(", suffix=")", nl="", indent=" ",
+                                         prefix_sep="", no_prefix_markup=true})
+        end
+        if r["sar"] ~= nil and video_res then
+            append(s, format("%.2f:1", r["sar"]), {prefix="", nl="", indent="",
+                                                      no_prefix_markup=true})
+            append(s, r["sar-name"], {prefix="(", suffix=")", nl="", indent=" ",
                                          prefix_sep="", no_prefix_markup=true})
         end
         if r["s"] then


### PR DESCRIPTION
The "Resolution" property shows the storage resolution for videos with non-square pixels.

Currently, display aspect ratio is shown for both "Resolution" and "Output Resolution" properties which results in a duplicate, and is incorrect for the "Resolution" property.

The correct aspect ratio is now shown using the `video-params/sar` and `video-params/sar-name` properties.

Related issues: https://github.com/mpv-player/mpv/issues/9100, https://github.com/mpv-player/mpv/issues/9409
