### PR TITLE
demux: always update the cache on init

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -4131,7 +4131,7 @@ static void update_cache(struct demux_internal *in)
 
     int64_t now = mp_time_ns();
     int64_t diff = now - in->last_speed_query;
-    bool do_update = diff >= MP_TIME_S_TO_NS(1);
+    bool do_update = diff >= MP_TIME_S_TO_NS(1) || !in->last_speed_query;
 
     // Don't lock while querying the stream.
     mp_mutex_unlock(&in->lock);


### PR DESCRIPTION
cd59ea8afab6381951a3ae19a43e422906d02164 removed an arbitrary start offset added to the timer. However, it turns out that demux secretly depends on this. When updating cache to actually read bytes from the stream, there's a diff >= MP_TIME_S_TO_NS(1) check to make it only update once every second. With the old MP_START_TIME macro, the initial time value would always be at least 1e10, so this would also be true. Since we don't have that offset anymore, now the initial time is less than that so it is not updated and properties like file-size are 0. Just be sure to always update if the last_speed_query is 0 (i.e. we just started the player). Fixes #12869.