### PR TITLE
console: fix crash for long suggestion strings

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -214,8 +214,9 @@ function format_table(list, width_max, rows_max)
         for column = 1, column_count do
             local i = row + (column - 1) * row_count
             if i > #list then break end
+            -- more then 99 leads to 'invalid format (width or precision too long)'
             local format_string = column == column_count and '%s'
-                                  or '%-' .. column_widths[column] .. 's'
+                                  or '%-' .. math.min(column_widths[column], 99) .. 's'
             columns[column] = string.format(format_string, list[i])
         end
         -- first row is at the bottom


### PR DESCRIPTION
String formatting of Lua crashes with widths greater then 99, so limit the value to that.

A nicer solution would be to create our own string padding function that can handle bigger widths, but such long  suggestions aren't common enough to be worth the effort.