### PR TITLE
vo_gpu_next: disable libplacebo VPS/FPS estimation

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -920,7 +920,7 @@ static void handle_display_sync_frame(struct MPContext *mpctx,
     frame->vsync_offset = -prev_error;
     frame->ideal_frame_duration = frame_duration;
     frame->ideal_frame_vsync = (-prev_error / frame_duration) * approx_duration;
-    frame->ideal_frame_vsync_duration = approx_duration / num_vsyncs;
+    frame->ideal_frame_vsync_duration = (vsync / frame_duration) * approx_duration;
     frame->num_vsyncs = num_vsyncs;
     frame->display_synced = true;
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -937,6 +937,9 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
                 .pts = frame->current->pts + pts_offset,
                 .radius = pl_frame_mix_radius(&params),
                 .vsync_duration = frame->ideal_frame_vsync_duration,
+#if PL_API_VER >= 342
+                .no_estimate = true,
+#endif
 #if PL_API_VER >= 340
                 .drift_compensation = 0,
 #endif
@@ -965,6 +968,9 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
             .pts = frame->current->pts + pts_offset,
             .radius = pl_frame_mix_radius(&params),
             .vsync_duration = frame->ideal_frame_vsync_duration,
+#if PL_API_VER >= 342
+            .no_estimate = true,
+#endif
             .interpolation_threshold = opts->interpolation_threshold,
 #if PL_API_VER >= 340
             .drift_compensation = 0,

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -936,6 +936,10 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
             pl_queue_update(p->queue, NULL, pl_queue_params(
                 .pts = frame->current->pts + pts_offset,
                 .radius = pl_frame_mix_radius(&params),
+                .vsync_duration = frame->ideal_frame_vsync_duration,
+#if PL_API_VER >= 340
+                .drift_compensation = 0,
+#endif
             ));
         }
         return;
@@ -962,6 +966,9 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
             .radius = pl_frame_mix_radius(&params),
             .vsync_duration = frame->ideal_frame_vsync_duration,
             .interpolation_threshold = opts->interpolation_threshold,
+#if PL_API_VER >= 340
+            .drift_compensation = 0,
+#endif
         );
 
         // mpv likes to generate sporadically jumping PTS shortly after


### PR DESCRIPTION
Rebased on #12873 but separated, because it is blocked by https://code.videolan.org/videolan/libplacebo/-/merge_requests/625 merge. Draft until upstream is updated.