### PR TITLE
demux_playlist: simplify ini parsing

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -283,6 +283,7 @@ static int parse_ref_init(struct pl_parser *p)
         pl_free_line(p, line);
         return -1;
     }
+    pl_free_line(p, line);
 
     // ASF http streaming redirection - this is needed because ffmpeg http://
     // and mmsh:// can not automatically switch automatically between each
@@ -301,11 +302,11 @@ static int parse_ref_init(struct pl_parser *p)
 
     while (!pl_eof(p)) {
         line = pl_get_line(p);
-        bstr line_dup = line;
-        if (bstr_case_startswith(line_dup, bstr0("Ref"))) {
-            bstr_split_tok(line, "=", &(bstr){0}, &line_dup);
-            if (line_dup.len)
-                pl_add(p, line_dup);
+        bstr value;
+        if (bstr_case_startswith(line, bstr0("Ref"))) {
+            bstr_split_tok(line, "=", &(bstr){0}, &value);
+            if (value.len)
+                pl_add(p, value);
         }
         pl_free_line(p, line);
     }
@@ -326,11 +327,11 @@ static int parse_ini_thing(struct pl_parser *p, const char *header,
         pl_free_line(p, line);
         return 0;
     }
+    pl_free_line(p, line);
     while (!pl_eof(p)) {
         line = pl_get_line(p);
-        bstr line_dup = line;
         bstr key, value;
-        if (bstr_split_tok(line_dup, "=", &key, &value) &&
+        if (bstr_split_tok(line, "=", &key, &value) &&
             bstr_case_startswith(key, bstr0(entry)))
         {
             value = bstr_strip(value);


### PR DESCRIPTION
In acac614032529997e0a8d89d35a8613b505e04fb, I sort of cargoculted what I had to do for m3u, but it's actually not needed. bstr_split_tok unexpectedly doesn't modify the original string. So the line_dup business in the ini parsing is not needed. Remove it. The part in parse_ref_init isn't wrong but naming the variable "line_dup" instead of "value" is stupid so adjust that. And finally, you can actually force a codepage in mpv (add "+" before the codepage) which will cause every line to be allocated memory including the header lines even though those are obviously valid utf8 that should never need conversion. This wasn't taken into account so add an extra pl_free_line in a couple of places to make sure they are freed.