### PR TITLE
stats.lua: inherit OSD styles

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -108,7 +108,7 @@ Configurable Options
     Clear data buffers used for drawing graphs when toggling.
 
 ``font``
-    Default: sans-serif
+    Default: same as ``osd-font``
 
     Font name. Should support as many font weights as possible for optimal
     visual experience.
@@ -125,9 +125,9 @@ Configurable Options
     Font size used to render text.
 
 ``font_color``
-    Default: FFFFFF
+    Default: same as ``osd-color``
 
-    Font color.
+    Color of the text.
 
 ``border_size``
     Default: 0.8
@@ -135,14 +135,31 @@ Configurable Options
     Size of border drawn around the font.
 
 ``border_color``
-    Default: 262626
+    Default: same as ``osd-border-color``
 
-    Color of drawn border.
+    Color of the text border.
+
+``shadow_x_offset``
+    Default: 0
+
+    The horizontal distance from the text to position the shadow at.
+
+``shadow_y_offset``
+    Default: 0
+
+    The vertical distance from the text to position the shadow at.
+
+``shadow_color``
+    Default: same as ``osd-shadow-color``
+
+    Color of the text shadow.
 
 ``alpha``
     Default: 11
 
-    Transparency for drawn text.
+    Transparency of text when ``font_color`` is specified, of text borders when
+    ``border_color`` is specified, and of text shadows when ``shadow_color`` is
+    specified.
 
 ``plot_bg_border_color``
     Default: 0000FF

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -45,15 +45,15 @@ local o = {
     plot_color = "FFFFFF",
 
     -- Text style
-    font = "sans-serif",
+    font = "",
     font_mono = "monospace",   -- monospaced digits are sufficient
     font_size = 8,
-    font_color = "FFFFFF",
+    font_color = "",
     border_size = 0.8,
-    border_color = "262626",
+    border_color = "",
     shadow_x_offset = 0.0,
     shadow_y_offset = 0.0,
-    shadow_color = "000000",
+    shadow_color = "",
     alpha = "11",
 
     -- Custom header for ASS tags to style the text output.
@@ -159,13 +159,26 @@ local function text_style()
     if o.custom_header and o.custom_header ~= "" then
         return o.custom_header
     else
-        local has_shadow = mp.get_property('osd-back-color'):sub(2, 3) == '00'
-        return format("{\\r\\an7\\fs%d\\fn%s\\bord%f\\3c&H%s&" ..
-                      "\\1c&H%s&\\1a&H%s&\\3a&H%s&" ..
-                      (has_shadow and "\\4a&H%s&\\xshad%f\\yshad%f\\4c&H%s&}" or "}"),
-                      o.font_size, o.font, o.border_size,
-                      o.border_color, o.font_color, o.alpha, o.alpha, o.alpha,
-                      o.shadow_x_offset, o.shadow_y_offset, o.shadow_color)
+        local style = "{\\r\\an7\\fs" .. o.font_size .. "\\bord" .. o.border_size
+
+        if o.font ~= "" then
+            style = style .. "\\fn" .. o.font
+        end
+
+        if o.font_color ~= "" then
+            style = style .. "\\1c&H" .. o.font_color .. "&\\1a&H" .. o.alpha .. "&"
+        end
+
+        if o.border_color ~= "" then
+            style = style .. "\\3c&H" .. o.border_color .. "&\\3a&H" .. o.alpha .. "&"
+        end
+
+        if o.shadow_color ~= "" then
+            style = style .. "\\4c&H" .. o.shadow_color .. "&\\4a&H" .. o.alpha .. "&"
+        end
+
+        return style .. "\\xshad" .. o.shadow_x_offset ..
+               "\\yshad" .. o.shadow_y_offset .. "}"
     end
 end
 


### PR DESCRIPTION
Avoid having to configure both the OSD and the stats script opts when you change the OSD options, in particular avoid having to convert colors to BGR.

Also document the shadow options.

font_size, border_size and shadow offset defaults are kept because the same values look much bigger in the stats than in the corresponding OSD options.

osd-back-color is now respected without extra checks until you explicitly set a shadow_color.


IMHO `font`, `font_color`, `border_color` and `shadow_color` could just be removed since I don't see why you would want them to be the different from the rest of the OSD.