### PR TITLE
player: don't remove all selected sub tracks in mp_dselect_track

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -835,6 +835,8 @@ void mp_deselect_track(struct MPContext *mpctx, struct track *track)
 {
     if (track && track->selected) {
         for (int t = 0; t < num_ptracks[track->type]; t++) {
+            if (mpctx->current_track[t][track->type] != track)
+                continue;
             mp_switch_track_n(mpctx, t, track->type, NULL, 0);
             mark_track_selection(mpctx, t, track->type, -1); // default
         }


### PR DESCRIPTION
fix secondary sub disappear after sub-reload, sub-remove.