### PR TITLE
vo_gpu_next: set max shader cache size back down to 10 MiB

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1661,11 +1661,11 @@ static int preinit(struct vo *vo)
 
     p->shader_cache = pl_cache_create(pl_cache_params(
         .log = p->pllog,
-        .max_total_size  = 50 << 20, // 50 MiB
+        .max_total_size  = 10 << 20, // 10 MiB
     ));
     p->icc_cache = pl_cache_create(pl_cache_params(
         .log = p->pllog,
-        .max_total_size = (1 << 20) * 1024, // 1 GiB
+        .max_total_size = 10 << 20, // 10 MiB
     ));
     pl_gpu_set_cache(p->gpu, p->shader_cache);
 


### PR DESCRIPTION
If you view a ton of files (like images), the cache can grow to massive sizes and slow down quitting the player to a noticeable amount. Turn the max size down to 10 MiB for now as a workaround until we improve the cache saving later.