### PR TITLE
test: update ffmpeg format refs

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -118,7 +118,7 @@ endif
 
 # Minimum required libavutil version that works with these tests.
 # Will need to be manually updated when ffmpeg adds/removes more formats in the future.
-if libavutil.version().version_compare('>= 57.39.101')
+if libavutil.version().version_compare('>= 58.27.100')
 
 # The CI can randomly fail if libavutil isn't explicitly linked again here.
     img_format = executable('img-format', 'img_format.c', include_directories: incdir,

--- a/test/ref/draw_bmp.txt
+++ b/test/ref/draw_bmp.txt
@@ -42,6 +42,8 @@ gbrap10     = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=u
 gbrap10be   = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
 gbrap12     = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
 gbrap12be   = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
+gbrap14     = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
+gbrap14be   = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
 gbrap16     = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
 gbrap16be   = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
 gbrapf32    = align=1:1 ov=unknown, ov_f=gbrapf32, v_f=gbrapf32, a=unknown, ca=unknown, ca_f=unknown
@@ -99,10 +101,14 @@ p016        = align=2:2 ov=yuva420p, ov_f=yuva420pf, v_f=yuv420pf, a=gray, ca=gr
 p016be      = align=2:2 ov=yuva420p, ov_f=yuva420pf, v_f=yuv420pf, a=gray, ca=gray, ca_f=grayf32
 p210        = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
 p210be      = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
+p212        = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
+p212be      = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
 p216        = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
 p216be      = align=2:1 ov=yuva422p, ov_f=yuva422pf, v_f=yuv422pf, a=gray, ca=gray, ca_f=grayf32
 p410        = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
 p410be      = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
+p412        = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
+p412be      = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
 p416        = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
 p416be      = align=1:1 ov=yuva444p, ov_f=yuva444pf, v_f=yuv444pf, a=unknown, ca=unknown, ca_f=unknown
 pal8        = no

--- a/test/ref/img_formats.txt
+++ b/test/ref/img_formats.txt
@@ -436,6 +436,37 @@ gbrap12be: [GENERIC] fcsp=rgb ctype=uint
     1: p=0  st=2  o=0  sh=0  d=12
     2: p=1  st=2  o=0  sh=0  d=12
     3: p=3  st=2  o=0  sh=0  d=12
+gbrap14: [GENERIC] fcsp=rgb ctype=uint
+  Basic desc: [ba][bb][a][rgb][le][uint]
+    planes=4, chroma=0:0 align=1:1
+    {16/[0:0] 16/[0:0] 16/[0:0] 16/[0:0] }
+    0: 16bits {} {0:16/-2} {} {}
+    1: 16bits {} {} {0:16/-2} {}
+    2: 16bits {0:16/-2} {} {} {}
+    3: 16bits {} {} {} {0:16/-2}
+  Regular: planes=4 compbytes=2 bitpad=-2 chroma=1x1 ctype=uint
+    0: {2}
+    1: {3}
+    2: {1}
+    3: {4}
+  AVD: name=gbrap14le chroma=0:0 flags=0xb0 [planar][rgb][alpha]
+    0: p=2  st=2  o=0  sh=0  d=14
+    1: p=0  st=2  o=0  sh=0  d=14
+    2: p=1  st=2  o=0  sh=0  d=14
+    3: p=3  st=2  o=0  sh=0  d=14
+gbrap14be: [GENERIC] fcsp=rgb ctype=uint
+  Basic desc: [ba][bb][a][rgb][be][uint]
+    planes=4, chroma=0:0 align=1:1
+    {16/[0:0] 16/[0:0] 16/[0:0] 16/[0:0] }
+    0: 16bits endian_bytes=2 {} {0:16/-2} {} {}
+    1: 16bits endian_bytes=2 {} {} {0:16/-2} {}
+    2: 16bits endian_bytes=2 {0:16/-2} {} {} {}
+    3: 16bits endian_bytes=2 {} {} {} {0:16/-2}
+  AVD: name=gbrap14be chroma=0:0 flags=0xb1 [be][planar][rgb][alpha]
+    0: p=2  st=2  o=0  sh=0  d=14
+    1: p=0  st=2  o=0  sh=0  d=14
+    2: p=1  st=2  o=0  sh=0  d=14
+    3: p=3  st=2  o=0  sh=0  d=14
 gbrap16: [GENERIC] fcsp=rgb ctype=uint
   Basic desc: [ba][bb][a][rgb][le][uint]
     planes=4, chroma=0:0 align=1:1
@@ -1058,6 +1089,29 @@ p210be: [GENERIC] ctype=uint
     0: p=0  st=2  o=0  sh=6  d=10
     1: p=1  st=4  o=0  sh=6  d=10
     2: p=1  st=4  o=2  sh=6  d=10
+p212: [GENERIC] ctype=uint
+  Basic desc: [ba][bb][nv][yuv][le][uint]
+    planes=2, chroma=1:0 align=2:1
+    {16/[0:0] 32/[1:0] }
+    0: 16bits {0:16/4} {} {} {}
+    1: 32bits {} {0:16/4} {16:16/4} {}
+  Regular: planes=2 compbytes=2 bitpad=4 chroma=2x1 ctype=uint
+    0: {1}
+    1: {2, 3}
+  AVD: name=p212le chroma=1:0 flags=0x10 [planar]
+    0: p=0  st=2  o=0  sh=4  d=12
+    1: p=1  st=4  o=0  sh=4  d=12
+    2: p=1  st=4  o=2  sh=4  d=12
+p212be: [GENERIC] ctype=uint
+  Basic desc: [ba][bb][nv][yuv][be][uint]
+    planes=2, chroma=1:0 align=2:1
+    {16/[0:0] 32/[1:0] }
+    0: 16bits endian_bytes=2 {0:16/4} {} {} {}
+    1: 32bits endian_bytes=2 {} {0:16/4} {16:16/4} {}
+  AVD: name=p212be chroma=1:0 flags=0x11 [be][planar]
+    0: p=0  st=2  o=0  sh=4  d=12
+    1: p=1  st=4  o=0  sh=4  d=12
+    2: p=1  st=4  o=2  sh=4  d=12
 p216: [GENERIC] ctype=uint
   Basic desc: [ba][bb][nv][yuv][le][uint]
     planes=2, chroma=1:0 align=2:1
@@ -1104,6 +1158,29 @@ p410be: [GENERIC] ctype=uint
     0: p=0  st=2  o=0  sh=6  d=10
     1: p=1  st=4  o=0  sh=6  d=10
     2: p=1  st=4  o=2  sh=6  d=10
+p412: [GENERIC] ctype=uint
+  Basic desc: [ba][bb][nv][yuv][le][uint]
+    planes=2, chroma=0:0 align=1:1
+    {16/[0:0] 32/[0:0] }
+    0: 16bits {0:16/4} {} {} {}
+    1: 32bits {} {0:16/4} {16:16/4} {}
+  Regular: planes=2 compbytes=2 bitpad=4 chroma=1x1 ctype=uint
+    0: {1}
+    1: {2, 3}
+  AVD: name=p412le chroma=0:0 flags=0x10 [planar]
+    0: p=0  st=2  o=0  sh=4  d=12
+    1: p=1  st=4  o=0  sh=4  d=12
+    2: p=1  st=4  o=2  sh=4  d=12
+p412be: [GENERIC] ctype=uint
+  Basic desc: [ba][bb][nv][yuv][be][uint]
+    planes=2, chroma=0:0 align=1:1
+    {16/[0:0] 32/[0:0] }
+    0: 16bits endian_bytes=2 {0:16/4} {} {} {}
+    1: 32bits endian_bytes=2 {} {0:16/4} {16:16/4} {}
+  AVD: name=p412be chroma=0:0 flags=0x11 [be][planar]
+    0: p=0  st=2  o=0  sh=4  d=12
+    1: p=1  st=4  o=0  sh=4  d=12
+    2: p=1  st=4  o=2  sh=4  d=12
 p416: [GENERIC] ctype=uint
   Basic desc: [ba][bb][nv][yuv][le][uint]
     planes=2, chroma=0:0 align=1:1
@@ -1406,7 +1483,7 @@ videotoolbox: ctype=unknown
     planes=0, chroma=0:0 align=1:1
     {}
   AVD: name=videotoolbox_vld chroma=0:0 flags=0x8 [hw]
-vulkan: [GENERIC] ctype=unknown
+vulkan: ctype=unknown
   Basic desc: [le][be][hw]
     planes=0, chroma=0:0 align=1:1
     {}

--- a/test/ref/repack.txt
+++ b/test/ref/repack.txt
@@ -77,6 +77,9 @@ gbrap10be       => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
 gbrap12         => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
 gbrap12be       => [pa] [un] gbrap12         | a=1:1
 gbrap12be       => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
+gbrap14         => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
+gbrap14be       => [pa] [un] gbrap14         | a=1:1
+gbrap14be       => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
 gbrap16         => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
 gbrap16be       => [pa] [un] gbrap16         | a=1:1
 gbrap16be       => [pa] [un] gbrapf32        | a=1:1 [planar-f32]
@@ -158,6 +161,10 @@ p210            => [pa] [un] yuv422p16       | a=2:1
 p210            => [pa] [un] yuv422pf        | a=2:1 [planar-f32]
 p210be          => [pa] [un] yuv422p16       | a=2:1
 p210be          => [pa] [un] yuv422pf        | a=2:1 [planar-f32]
+p212            => [pa] [un] yuv422p16       | a=2:1
+p212            => [pa] [un] yuv422pf        | a=2:1 [planar-f32]
+p212be          => [pa] [un] yuv422p16       | a=2:1
+p212be          => [pa] [un] yuv422pf        | a=2:1 [planar-f32]
 p216            => [pa] [un] yuv422p16       | a=2:1
 p216            => [pa] [un] yuv422pf        | a=2:1 [planar-f32]
 p216be          => [pa] [un] yuv422p16       | a=2:1
@@ -166,6 +173,10 @@ p410            => [pa] [un] yuv444p16       | a=1:1
 p410            => [pa] [un] yuv444pf        | a=1:1 [planar-f32]
 p410be          => [pa] [un] yuv444p16       | a=1:1
 p410be          => [pa] [un] yuv444pf        | a=1:1 [planar-f32]
+p412            => [pa] [un] yuv444p16       | a=1:1
+p412            => [pa] [un] yuv444pf        | a=1:1 [planar-f32]
+p412be          => [pa] [un] yuv444p16       | a=1:1
+p412be          => [pa] [un] yuv444pf        | a=1:1 [planar-f32]
 p416            => [pa] [un] yuv444p16       | a=1:1
 p416            => [pa] [un] yuv444pf        | a=1:1 [planar-f32]
 p416be          => [pa] [un] yuv444p16       | a=1:1

--- a/test/ref/zimg_formats.txt
+++ b/test/ref/zimg_formats.txt
@@ -42,6 +42,8 @@
       gbrap10be    Zin   Zout  SWSin  SWSout |
         gbrap12    Zin   Zout  SWSin  SWSout |
       gbrap12be    Zin   Zout  SWSin  SWSout |
+        gbrap14    Zin   Zout  SWSin  SWSout |
+      gbrap14be    Zin   Zout  SWSin  SWSout |
         gbrap16    Zin   Zout  SWSin  SWSout |
       gbrap16be    Zin   Zout  SWSin  SWSout |
        gbrapf32    Zin   Zout  SWSin  SWSout |
@@ -99,10 +101,14 @@
          p016be    Zin   Zout  SWSin  SWSout |
            p210    Zin   Zout  SWSin  SWSout |
          p210be    Zin   Zout  SWSin  SWSout |
+           p212    Zin   Zout  SWSin  SWSout |
+         p212be    Zin   Zout  SWSin  SWSout |
            p216    Zin   Zout  SWSin  SWSout |
          p216be    Zin   Zout  SWSin  SWSout |
            p410    Zin   Zout  SWSin  SWSout |
          p410be    Zin   Zout  SWSin  SWSout |
+           p412    Zin   Zout  SWSin  SWSout |
+         p412be    Zin   Zout  SWSin  SWSout |
            p416    Zin   Zout  SWSin  SWSout |
          p416be    Zin   Zout  SWSin  SWSout |
            pal8    Zin         SWSin         |

--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -187,7 +187,7 @@ static void mapper_unmap(struct ra_hwdec_mapper *mapper)
     AVVkFrame *vkf = p->vkf;
 
     int num_images;
-    for (num_images = 0; (vkf->img[num_images] != NULL); num_images++);
+    for (num_images = 0; (vkf->img[num_images] != VK_NULL_HANDLE); num_images++);
 
     for (int i = 0; (p->tex[i] != NULL); i++) {
         pl_tex *tex = &p->tex[i];
@@ -247,7 +247,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     mp_image_set_size(&raw_layout, hwfc->width, hwfc->height);
 
     int num_images;
-    for (num_images = 0; (vkf->img[num_images] != NULL); num_images++);
+    for (num_images = 0; (vkf->img[num_images] != VK_NULL_HANDLE); num_images++);
     const VkFormat *vk_fmt = av_vkfmt_from_pixfmt(hwfc->sw_format);
 
     vkfc->lock_frame(hwfc, vkf);


### PR DESCRIPTION
These tests should really be rewritten to be less stupid so they don't break everytime ffmpeg updates its formats, but that's too much effort right now. Bump the required libavutil version as well.

https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/8e1ef7c38f6906455ae96984d032e57106e11b77