### PR TITLE
msg: print all messages to one stream

### DIFF
--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -117,12 +117,6 @@ struct encode_lavc_context *encode_lavc_init(struct mpv_global *global)
     if (!strcmp(filename, "-"))
         filename = "pipe:1";
 
-    if (filename && (
-            !strcmp(filename, "/dev/stdout") ||
-            !strcmp(filename, "pipe:") ||
-            !strcmp(filename, "pipe:1")))
-        mp_msg_force_stderr(global, true);
-
     encode_lavc_discontinuity(ctx);
 
     p->muxer = avformat_alloc_context();
@@ -944,6 +938,19 @@ fail:
     MP_ERR(p, "error encoding at %s\n",
            frame ? av_ts2timestr(frame->pts, &p->encoder->time_base) : "EOF");
     return false;
+}
+
+void encoder_update_log(struct mpv_global *global)
+{
+    struct encode_opts *options = mp_get_config_group(NULL, global, &encode_config);
+    if (options->file && (!strcmp(options->file, "-") ||
+                          !strcmp(options->file, "/dev/stdout") ||
+                          !strcmp(options->file, "pipe:") ||
+                          !strcmp(options->file, "pipe:1")))
+    {
+        mp_msg_force_stderr(global, true);
+    }
+    talloc_free(options);
 }
 
 // vim: ts=4 sw=4 et

--- a/common/encode_lavc.h
+++ b/common/encode_lavc.h
@@ -111,4 +111,6 @@ bool encoder_encode(struct encoder_context *p, AVFrame *frame);
 // Caller needs to acquire encode_lavc_context.lock (or call it from on_ready).
 AVRational encoder_get_mux_timebase_unlocked(struct encoder_context *p);
 
+void encoder_update_log(struct mpv_global *global);
+
 #endif

--- a/common/msg.c
+++ b/common/msg.c
@@ -195,8 +195,7 @@ int mp_msg_level(struct mp_log *log)
 
 static inline int term_msg_fileno(struct mp_log_root *root, int lev)
 {
-    return (root->force_stderr || lev == MSGL_STATUS || lev == MSGL_FATAL ||
-            lev == MSGL_ERR || lev == MSGL_WARN) ? STDERR_FILENO : STDOUT_FILENO;
+    return root->force_stderr ? STDERR_FILENO : STDOUT_FILENO;
 }
 
 // Reposition cursor and clear lines for outputting the status line. In certain

--- a/player/main.c
+++ b/player/main.c
@@ -44,6 +44,7 @@
 #include "options/m_option.h"
 #include "options/m_property.h"
 #include "common/common.h"
+#include "common/encode_lavc.h"
 #include "common/msg.h"
 #include "common/msg_control.h"
 #include "common/stats.h"
@@ -139,6 +140,9 @@ void mp_update_logging(struct MPContext *mpctx, bool preinit)
 
     if (enabled && !preinit && mpctx->opts->consolecontrols)
         terminal_setup_getch(mpctx->input);
+
+    if (enabled)
+        encoder_update_log(mpctx->global);
 }
 
 void mp_print_version(struct mp_log *log, int always)


### PR DESCRIPTION
This change allows stdout to remain free for encoder output or similar tasks like vo=tct.

Before commit 4939570e17, all messages were printed to stdout, except status messages, which were printed to stderr. This approach was reasonable because one could redirect the stream to a file with messages or status output.

After commit 4939570e17, however, some messages started being printed to stderr, while others continued to be output to stdout. This inconsistency involved two output streams printing related messages.

After this change, messages are printed to stderr always, keeping stdout open for all other tasks.

This adjustment also fixes the issue of status messages being printed to both streams after commit 82451bdf04.