### PR TITLE
vo_gpu_next: reduce number of requested frames from VO

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1953,11 +1953,11 @@ static void update_render_options(struct vo *vo)
 
     // Request as many frames as required from the decoder, depending on the
     // speed VPS/FPS ratio libplacebo may need more frames. Request frames up to
-    // ratio of 1/4, but only if anti aliasing is enabled.
+    // ratio of 1/2, but only if anti aliasing is enabled.
     int req_frames = 2;
     if (pars->params.frame_mixer) {
         req_frames += ceilf(pars->params.frame_mixer->kernel->radius) *
-                      (pars->params.skip_anti_aliasing ? 1 : 4);
+                      (pars->params.skip_anti_aliasing ? 1 : 2);
     }
     vo_set_queue_params(vo, 0, MPMIN(VO_MAX_REQ_FRAMES, req_frames));
 


### PR DESCRIPTION
This avoids limitation of hwdecs number of frames in-flight.