### PR TITLE
build: restrict git describe to top level source directory

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -1,5 +1,8 @@
 version_h = vcs_tag(
-    command: ['git', 'describe', '--always', '--tags', '--dirty'],
+    command: ['git',
+        '--git-dir=' + join_paths(source_root, '.git'),
+        '--work-tree=' + source_root,
+        'describe', '--always', '--tags', '--dirty'],
     input: 'version.h.in',
     output: 'version.h',
     replace_string: '@VERSION@',


### PR DESCRIPTION
fix version determination when building mpv from release tarball extracted within another git repository