### PR TITLE
ao/coreaudio_exclusive: fix segfault when changing formats

### DIFF
--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -470,7 +470,7 @@ bool ca_change_physical_format_sync(struct ao *ao, AudioStreamID stream,
 
     ca_print_asbd(ao, "setting stream physical format:", &change_format);
 
-    sem_t wakeup;
+    mp_sem_t wakeup;
     if (mp_sem_init(&wakeup, 0, 0)) {
         MP_WARN(ao, "OOM\n");
         return false;


### PR DESCRIPTION
PR #12747 missed updating a variable declaration in `ca_change_physical_format_sync`, which ultimately leads to the thread crashing.  The problem reproduces consistently on AS Macs (I don't have an Intel Mac to test on anymore), and produces stack traces like the following:

```
Thread 3 Crashed:: mpv
0   libsystem_kernel.dylib                     0x18cebd11c __pthread_kill + 8
1   libsystem_pthread.dylib                    0x18cef4cc0 pthread_kill + 288
2   libsystem_c.dylib                          0x18ce04ad4 __abort + 136
3   libsystem_c.dylib                          0x18cdf56c4 __stack_chk_fail + 96
4   mpv                                        0x1026b66d0 ca_change_physical_format_sync + 420
5   mpv                                        0x1026b3b70 init + 1052
6   mpv                                        0x1025c5afc ao_init + 332
7   mpv                                        0x1025c5bec ao_init + 572
8   mpv                                        0x1025c5830 ao_init_best + 1228
9   mpv                                        0x102622fac fill_audio_out_buffers + 1820
10  mpv                                        0x1026450d0 run_playloop + 132
11  mpv                                        0x10263f958 play_current_file + 5116
12  mpv                                        0x10263e4e8 mp_play_files + 452
13  mpv                                        0x102641308 mpv_main + 128
14  mpv                                        0x10269f520 playback_thread + 40
15  libsystem_pthread.dylib                    0x18cef5034 _pthread_start + 136
16  libsystem_pthread.dylib                    0x18ceefe3c thread_start + 8
```

Note that non-exclusive output seems to be unaffected.  To reproduce this problem (and/or test this fix), pass `--audio-exclusive=yes` to mpv.