### PR TITLE
sdl_gamepad: add version check for SDL_HINT_JOYSTICK_THREAD

### DIFF
--- a/input/sdl_gamepad.c
+++ b/input/sdl_gamepad.c
@@ -200,7 +200,9 @@ static void remove_gamepad(struct mp_input_src *src, int id)
 
 static void read_gamepad_thread(struct mp_input_src *src, void *param)
 {
+#if SDL_VERSION_ATLEAST(2, 0, 14)
     SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+#endif
 
     if (SDL_WasInit(SDL_INIT_EVENTS)) {
         MP_ERR(src, "Another component is using SDL already.\n");


### PR DESCRIPTION
Requires SDL version 2.0.14.
