### PR TITLE
video/out/hwdec/hwdec_vaapi: Remove unnecessary explicit synchronization

### DIFF
--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -288,9 +288,6 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
         close_file_descriptors(desc);
         goto err;
     }
-    vaSyncSurface(display, va_surface_id(mapper->src));
-    // No need to error out if sync fails, but good to know if it did.
-    CHECK_VA_STATUS(mapper, "vaSyncSurface()");
     p->surface_acquired = true;
 
     // We use AVDRMFrameDescriptor to store the dmabuf so we need to copy the


### PR DESCRIPTION
Implicit synchronization will handle that.
Extra explicit synchronization here would bring some overheads.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.