### PR TITLE
sub: add `sub-detect-rtl` option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2426,6 +2426,12 @@ Subtitles
         ``--sub-speed=25/23.976`` plays frame based subtitles which have been
         loaded assuming a framerate of 23.976 at 25 FPS.
 
+``--sub-detect-rtl=<yes|no>``
+    Default: no. Set the ``Encoding`` flag to ``-1`` to enable Fribidi's base
+    direction auto detection through libass to render Right to Left (RTL)
+    subtitles correctly. By default, all text is assumed to be Left to Right
+    (LTR) for VSFilter compatibility.
+
 ``--sub-ass-style-overrides=<[Style.]Param=Value[,...]>``
     Override some style or script info parameters.
 

--- a/options/options.c
+++ b/options/options.c
@@ -298,6 +298,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-gray", OPT_BOOL(sub_gray)},
         {"sub-ass", OPT_BOOL(ass_enabled), .flags = UPDATE_SUB_HARD},
         {"sub-scale", OPT_FLOAT(sub_scale), M_RANGE(0, 100)},
+        {"sub-detect-rtl", OPT_BOOL(sub_rtl)},
         {"sub-ass-line-spacing", OPT_FLOAT(ass_line_spacing),
             M_RANGE(-1000, 1000)},
         {"sub-use-margins", OPT_BOOL(sub_use_margins)},

--- a/options/options.h
+++ b/options/options.h
@@ -99,6 +99,7 @@ struct mp_subtitle_opts {
     bool ass_scale_with_window;
     struct osd_style_opts *sub_style;
     float sub_scale;
+    bool sub_rtl;
     float sub_gauss;
     bool sub_gray;
     bool ass_enabled;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -435,6 +435,8 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     if ((converted || opts->ass_style_override) && opts->ass_justify)
         set_force_flags |= ASS_OVERRIDE_BIT_JUSTIFY;
 #endif
+    if (converted && opts->sub_rtl)
+        track->styles->Encoding = -1;
     ass_set_selective_style_override_enabled(priv, set_force_flags);
     ASS_Style style = {0};
     mp_ass_set_style(&style, MP_ASS_FONT_PLAYRESY, opts->sub_style);


### PR DESCRIPTION
libass assumes all text to be left-to-right for compatibility with VSFilter. We can force auto detection by setting Encoding=-1, but it may break older subtitles so don't enable it by default.

Fixes #12978