### PR TITLE
ci/msys2: don't error out when subprojects dir already exists

### DIFF
--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -1,19 +1,7 @@
 #!/bin/sh -e
 
-mkdir subprojects
-cat > subprojects/libplacebo.wrap <<EOF
-[wrap-git]
-url = https://code.videolan.org/videolan/libplacebo.git
-revision = v6.338.1
-depth = 1
-clone-recursive = true
-EOF
-
 meson setup build            \
   --werror                   \
-  -Dlibplacebo:werror=false  \
-  -Dlibplacebo:demos=false   \
-  -Dlibplacebo:default_library=static \
   -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
   -D cdda=enabled            \
   -D d3d-hwaccel=enabled     \


### PR DESCRIPTION
Facilitates local rebuilding.
