### PR TITLE
ci: remove leftover libplacebo subproject options

### DIFF
--- a/ci/build-freebsd.sh
+++ b/ci/build-freebsd.sh
@@ -7,7 +7,6 @@ export LDFLAGS="$LDFLAGS -L/usr/local/lib"
 
 meson setup build \
     --werror      \
-    -Dlibplacebo:werror=false \
     -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
     -Diconv=disabled \
     -Dlibmpv=true \

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -269,7 +269,6 @@ rm -rf $build
 
 meson setup $build --cross-file "$prefix_dir/crossfile" \
     --werror                   \
-    -Dlibplacebo:werror=false  \
     -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
     --buildtype debugoptimized \
     -Dlibmpv=true -Dlua=luajit \

--- a/ci/build-tumbleweed.sh
+++ b/ci/build-tumbleweed.sh
@@ -3,7 +3,6 @@ set -e
 
 meson setup build \
   --werror        \
-  -Dlibplacebo:werror=false \
   -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
   -Db_sanitize=address,undefined \
   -Dcdda=enabled          \

--- a/osdep/meson.build
+++ b/osdep/meson.build
@@ -25,9 +25,7 @@ swift_flags += extra_flags
 swift_compile = [swift_prog, swift_flags, '-module-name', 'macOS_swift',
                  '-emit-module-path', '@OUTPUT0@', '-import-objc-header', bridge,
                  '-emit-objc-header-path', '@OUTPUT1@', '-o', '@OUTPUT2@',
-                 '@INPUT@', '-I.', '-I' + source_root,
-                 '-I' + libplacebo.get_variable('includedir',
-                            default_value: source_root / 'subprojects' / 'libplacebo' / 'src' / 'include')]
+                 '@INPUT@', '-I.', '-I' + source_root]
 
 swift_targets = custom_target('swift_targets',
     input: swift_sources,


### PR DESCRIPTION
486bb93dfa90bf948cff8d77ad685f54d0928531 removed the wrap which made these specific options obsolete.