### PR TITLE
osdep/meson: remove the default_value subproject path

### DIFF
--- a/osdep/meson.build
+++ b/osdep/meson.build
@@ -26,8 +26,7 @@ swift_compile = [swift_prog, swift_flags, '-module-name', 'macOS_swift',
                  '-emit-module-path', '@OUTPUT0@', '-import-objc-header', bridge,
                  '-emit-objc-header-path', '@OUTPUT1@', '-o', '@OUTPUT2@',
                  '@INPUT@', '-I.', '-I' + source_root,
-                 '-I' + libplacebo.get_variable('includedir',
-                            default_value: source_root / 'subprojects' / 'libplacebo' / 'src' / 'include')]
+                 '-I' + libplacebo.get_variable('includedir')]
 
 swift_targets = custom_target('swift_targets',
     input: swift_sources,


### PR DESCRIPTION
Should not be needed.