### PR TITLE
osd_libass: update the OSD bar's dent and border size

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4269,7 +4269,7 @@ OSD
     Size of the border of the OSD bar in scaled pixels (see ``--sub-font-size``
     for details).
 
-    Default: 1.2.
+    Default: 0.5.
 
 ``--osd-back-color=<color>``
     See ``--sub-color``. Color used for OSD text background.

--- a/options/options.c
+++ b/options/options.c
@@ -372,7 +372,7 @@ const struct m_sub_options mp_osd_render_sub_opts = {
         .osd_bar_align_y = 0.5,
         .osd_bar_w = 75.0,
         .osd_bar_h = 3.125,
-        .osd_bar_border_size = 1.2,
+        .osd_bar_border_size = 0.5,
         .osd_scale = 1,
         .osd_scale_by_window = true,
     },

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -466,7 +466,7 @@ static void update_progbar(struct osd_state *osd, struct osd_object *obj)
     // chapter marks
     for (int n = 0; n < obj->progbar_state.num_stops; n++) {
         float s = obj->progbar_state.stops[n] * width;
-        float dent = border * 1.3;
+        float dent = MPMAX(border * 1.3, 1.6);
 
         if (s > dent && s < width - dent) {
             ass_draw_move_to(d, s + dent, 0);


### PR DESCRIPTION
Make the OSD bar markers bigger so we can default to a smaller, better-looking border size, without sacrificing markers' visibility.