### PR TITLE
input: fix double click handling

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -740,6 +740,7 @@ static void mp_input_feed_key(struct input_ctx *ictx, int code, double scale,
             now - ictx->last_doubleclick_time < opts->doubleclick_time / 1000.0)
         {
             if (code >= MP_MBTN_LEFT && code <= MP_MBTN_RIGHT) {
+                now = 0;
                 interpret_key(ictx, code - MP_MBTN_BASE + MP_MBTN_DBL_BASE,
                               1, 1);
             }


### PR DESCRIPTION
On practically all platforms and GUI toolkits, a triggered double click event clears the mouse input buffer so that the next click won't trigger another double click event. mpv doesn't do this, so a third click results in another double click event.

Fix this by resetting the double click timer after a double click event is triggered which achieves the same effect.

This also fixes https://github.com/mpv-player/mpv/issues/12214.
