### PR TITLE
playloop: use a 16:9 ratio with --force-window

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1030,8 +1030,12 @@ int handle_force_window(struct MPContext *mpctx, bool force)
                 break;
             }
         }
+
+        // Use a 16:9 aspect ratio so that fullscreen on a 16:9 screen will not
+        // have vertical margins, which can lead to a different size or position
+        // of subtitles than with 16:9 videos.
         int w = 960;
-        int h = 480;
+        int h = 540;
         struct mp_image_params p = {
             .imgfmt = config_format,
             .w = w,   .h = h,


### PR DESCRIPTION
ca2b05c0fb changed the window size with --force-window and no video tracks to be closer to 16:9, but I don't see why we shouldn't have an actual 16:9 ratio. The advantage is that subtitles with fullscreen and no video tracks will have the same size and position (depending on the values of --sub-scale-with-window and --sub-use-margins) as with 16:9 videos, because there will be no (invisible) black bars.