### PR TITLE
console.lua: simplify the condition to print to the terminal

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -257,14 +257,9 @@ end
 function update()
     pending_update = false
 
-    -- Print to the terminal when there is no VO. Check both vo-configured so
-    -- it works with --force-window --idle and no video tracks, and whether
-    -- there is a video track so that the condition doesn't become true while
-    -- switching VO at runtime, making mp.osd_message() print to the VO's OSD.
-    -- This issue does not happen when switching VO without any video track
-    -- regardless of the condition used.
-    if not mp.get_property_native('vo-configured')
-       and not mp.get_property('current-tracks/video') then
+    -- Unlike vo-configured, current-vo doesn't become falsy while switching VO,
+    -- which would print the log to the OSD.
+    if not mp.get_property('current-vo') then
         print_to_terminal()
         return
     end


### PR DESCRIPTION
This was a simpler fix to not print the console log to the OSD while switching VO.