### PR TITLE
console.lua: expand ~/ in file completion

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1001,6 +1001,16 @@ function complete(backwards)
                 completion_start_position = s2
             end
 
+            -- Expand ~ in file completion.
+            if completer.list == file_list and hint:find('^~' .. path_separator) then
+                local home = mp.command_native({'expand-path', '~/'})
+                before_cur = before_cur:sub(1, completion_start_position - #hint - 1) ..
+                             home ..
+                             before_cur:sub(completion_start_position - #hint + 1)
+                hint = home .. hint:sub(2)
+                completion_start_position = completion_start_position + #home - 1
+            end
+
             -- If the completer's pattern found a word, check the completer's
             -- list for possible completions
             local part = before_cur:sub(completion_start_position)


### PR DESCRIPTION
Makes Tab expand loadfile ~/ to loadfile /home/$USER/.

I used expand-path instead of os.getenv('HOME') to make it work on Windows.

If there is a ~ before the file command it will be expanded instead, e.g. print-text ~; loadfile ~/, but this shouldn't happen in real-world usage and would need implementing a command parser to fix.