### PR TITLE
mac: add support for drag-and-drop option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3155,7 +3155,6 @@ Window
     (Windows only) Snap the player window to screen edges.
 
 ``--drag-and-drop=<no|auto|replace|append>``
-    (X11, Wayland and Windows only)
     Controls the default behavior of drag and drop on platforms that support this.
     ``auto`` will obey what the underlying os/platform gives mpv. Typically, holding
     shift during the drag and drop will append the item to the playlist. Otherwise,

--- a/osdep/macOS_swift_bridge.h
+++ b/osdep/macOS_swift_bridge.h
@@ -27,6 +27,7 @@
 #include "options/m_config.h"
 #include "player/core.h"
 #include "input/input.h"
+#include "input/event.h"
 #include "video/out/win_state.h"
 
 #include "osdep/macosx_application_objc.h"

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -81,7 +81,7 @@ class View: NSView {
         if types.contains(.fileURL) || types.contains(.URL) {
             if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
                 let files = urls.map { $0.absoluteString }
-                EventsResponder.sharedInstance().handleFilesArray(files)
+                mpv?.open(files: files)
                 return true
             }
         } else if types.contains(.string) {
@@ -97,7 +97,7 @@ class View: NSView {
                     filesArray.append(path)
                 }
             }
-            EventsResponder.sharedInstance().handleFilesArray(filesArray)
+            mpv?.open(files: filesArray)
             return true
         }
         return false


### PR DESCRIPTION
not sure if we should remove the "(X11, Wayland, Windows and macOS only)" completely since all platforms support it now, though not all backends?