### PR TITLE
demux/codec_tags: add jxl/jpegxl extension mapping to image codecs

### DIFF
--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -230,6 +230,7 @@ static const char *const type_to_codec[][2] = {
     { "xface",          "xface" },
     { "xwd",            "xwd" },
     { "svg",            "svg" },
+    { "jxl",            "jpegxl" },
     {0}
 };
 


### PR DESCRIPTION
Add .jxl as a file extension that maps to an image codec. Note that this will include animated JXL files, but .gif is also on that list so they are not different in that regard