### PR TITLE
x11_common: fix compose key handling

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1177,6 +1177,8 @@ void vo_x11_check_events(struct vo *vo)
 
     while (XPending(display)) {
         XNextEvent(display, &Event);
+        if (XFilterEvent(&Event, x11->window))
+            continue;
         MP_TRACE(x11, "XEvent: %d\n", Event.type);
         switch (Event.type) {
         case Expose:
@@ -1579,7 +1581,7 @@ static void vo_x11_create_window(struct vo *vo, XVisualInfo *vis,
 
     if (x11->xim) {
         x11->xic = XCreateIC(x11->xim,
-                             XNInputStyle, XIMPreeditNone | XIMStatusNone,
+                             XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
                              XNClientWindow, x11->window,
                              XNFocusWindow, x11->window,
                              NULL);


### PR DESCRIPTION
Compose key doesn't function in X11 because `XFilterEvent()` isn't called, and `XNInputStyle` is set to a wrong value. This results in `KeyPress` events for the separate keyboard inputs in the compose key input sequence instead of the composed character, making it impossible to input certain characters which require compose key.

Fix this by calling the required `XFilterEvent()` and set `XNInputStyle` to the correct value.

This makes proper the implementation of the feature introduced in https://github.com/mpv-player/mpv/commit/ad455c43.
