### PR TITLE
hwdec_drmprime: try and declare support for weird forked ffmpeg formats

### DIFF
--- a/filters/f_hwtransfer.c
+++ b/filters/f_hwtransfer.c
@@ -94,10 +94,12 @@ static bool select_format(struct priv *p, int input_fmt,
     if (!input_fmt)
         return false;
 
-    // If the input format is a hw format, then we shouldn't be doing this
-    // format selection here at all.
+    // If the input format is a hw format, then we won't be doing any sort of
+    // conversion. Just assume that it will pass-through successfully.
     if (IMGFMT_IS_HWACCEL(input_fmt)) {
-        return false;
+        *out_hw_input_fmt = input_fmt;
+        *out_hw_output_fmt = input_fmt;
+        return true;
     }
 
     // If there is no capability to do uploads or conversions during uploads,


### PR DESCRIPTION
As a result of the work I did the explicitly check for formats supported by the vo in the f_autoconvert logic, I introduced a regression in the handling of the rpi4_8 and rpi4_10 formats. These require special handling because they only exist in the rpi forks and not upstream ffmpeg, which means they don't have stable pix fmt values that we can use directly.

Previously, we simply didn't declare them as supported, which was ok, as nothing was really enforcing the list of supported formats, but that has changed.

As we still can't simply use the pix fmts, I had to do a slightly ridiculous dance to look them up by name, and if they exist, then register them as supported.

Good times.