### PR TITLE
mac: add support for window-id property

### DIFF
--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -562,6 +562,13 @@ class Common: NSObject {
             let fps = data!.assumingMemoryBound(to: CDouble.self)
             fps.pointee = currentFps()
             return VO_TRUE
+        case VOCTRL_GET_WINDOW_ID:
+            guard let window = window else {
+                return VO_NOTAVAIL
+            }
+            let wid = data!.assumingMemoryBound(to: Int64.self)
+            wid.pointee = unsafeBitCast(window, to: Int64.self)
+            return VO_TRUE
         case VOCTRL_GET_HIDPI_SCALE:
             let scaleFactor = data!.assumingMemoryBound(to: CDouble.self)
             let screen = getCurrentScreen()


### PR DESCRIPTION
tested with the [cocoabasic](https://github.com/mpv-player/mpv-examples/blob/master/libmpv/cocoa/cocoabasic.m) example with:

```
int64_t win;
mpv_get_property(mpv, "window-id", MPV_FORMAT_INT64, &win);
NSWindow *window = (NSWindow *)win;
printf("window height: %f width: %f\n", window.frame.size.height, window.frame.size.width);

---------prints
event: start-file
event: file-loaded
event: video-reconfig
event: video-reconfig
event: playback-restart
window height: 1038.000000 width: 1920.000000
event: video-reconfig
event: end-file
event: video-reconfig
event: idle
```