### PR TITLE
sub: don't busy loop if the player is paused for cache

### DIFF
--- a/player/sub.c
+++ b/player/sub.c
@@ -204,7 +204,8 @@ void reinit_sub(struct MPContext *mpctx, struct track *track)
     // When paused we have to wait for packets to be available.
     // So just retry until we get a packet in this case.
     if (mpctx->playback_initialized)
-        while (!update_subtitles(mpctx, mpctx->playback_pts) && mpctx->paused);
+        while (!update_subtitles(mpctx, mpctx->playback_pts) &&
+               mpctx->paused && !mpctx->paused_for_cache);
 }
 
 void reinit_sub_all(struct MPContext *mpctx)


### PR DESCRIPTION
When updating subtitles while paused, mpv waits until a packet is available. However in the case of a network stream, it is possible that mpv will pause itself when buffering for cache reasons. This makes that particular loop do a busy loop and can take a long time depending on network streams. Simply just don't do the loop here if we are paused for cache reasons. Fixes #13077.

cc @sfan5