### PR TITLE
playlist: correctly populate playlist-path with the --playlist option

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -391,6 +391,7 @@ struct playlist *playlist_parse_file(const char *file, struct mp_cancel *cancel,
     struct playlist *ret = NULL;
     if (d && d->playlist) {
         ret = talloc_zero(NULL, struct playlist);
+        playlist_populate_playlist_path(d->playlist, file);
         playlist_transfer_entries(ret, d->playlist);
         if (d->filetype && strcmp(d->filetype, "hls") == 0) {
             mp_warn(log, "This might be a HLS stream. For correct operation, "

--- a/options/parse_commandline.c
+++ b/options/parse_commandline.c
@@ -201,7 +201,6 @@ int m_config_parse_mp_command_line(m_config_t *config, struct playlist *files,
                     goto err_out;
                 }
                 playlist_transfer_entries(files, pl);
-                playlist_populate_playlist_path(files, param0);
                 talloc_free(param0);
                 talloc_free(pl);
                 continue;


### PR DESCRIPTION
When using the --playlist option on the commandline, it would mark all entries on the command as having the playlist-path of the value of that passed option, not just the ones that were expanded from it. Fix this by moving the playlist_populate_playlist_path to the same place where the playlist file gets expanded.

Ref https://github.com/mpv-player/mpv/issues/13075#issuecomment-1852179164