### PR TITLE
sub: fix sub-seek and sub-step -1 with unknown duration subs

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -603,11 +603,6 @@ static struct sub_bitmaps *get_bitmaps(struct sd *sd, struct mp_osd_res dim,
         ass_set_storage_size(renderer, 0, 0);
     }
     long long ts = find_timestamp(sd, pts);
-    if (ctx->duration_unknown && pts != MP_NOPTS_VALUE) {
-        mp_ass_flush_old_events(track, ts);
-        ctx->num_seen_packets = 0;
-        sd->preload_ok = false;
-    }
 
     if (no_ass)
         fill_plaintext(sd, pts);
@@ -814,7 +809,7 @@ static void fill_plaintext(struct sd *sd, double pts)
 static void reset(struct sd *sd)
 {
     struct sd_ass_priv *ctx = sd->priv;
-    if (sd->opts->sub_clear_on_seek || ctx->duration_unknown || ctx->clear_once) {
+    if (sd->opts->sub_clear_on_seek || ctx->clear_once) {
         ass_flush_events(ctx->ass_track);
         ctx->num_seen_packets = 0;
         sd->preload_ok = false;


### PR DESCRIPTION
f9cefbfec4 made it so mp_ass_flush_old_events() is continously called on subtitles with unknown duration, without explaining why, breaking sub-seek/step -1 with a VO (the issue does not occur when showing subtitles in the terminal because get_bitmaps() is not called). I don't experience any issue after removing the call, so delete it to fix these commands.

After removing that, you can sub-seek -1 once after regular playback, but not after seeking and thus not multiple times in a row. This is caused by a714f8e928 which fixed subtitles with unknown duration being duplicated when seeking with a VO (it does not happen in the terminal) by clearing old lines on seeks, which broke sub-seek -1 and sub-step -1 in a second way after any seek. The proper fix is to remove the line ctx->num_seen_packets = 0 for subtitles with unknown duration instead, which lets decode() return early when a line has already been shown.

Having removed these 2 lines, I also removed sd->preload_ok = false, and thus the whole conditional, since according to sub/sd.h preload_ok only needs to be set to false when old subtitles are discarded, and they are no longer discarded,

The bug can be reproduced with mpv --sub-file=<(curl 'https://music.xianqiao.wang/neteaseapiv2/lyric?id=1399616170' | jq -r .lrc.lyric) 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
