### PR TITLE
terminal-unix: enable the cursor after ctrl+z

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -358,6 +358,8 @@ static void stop_sighandler(int signum)
 {
     int saved_errno = errno;
     (void)write(stop_cont_pipe[1], &(char){PIPE_STOP}, 1);
+    (void)write(STDERR_FILENO, TERM_ESC_RESTORE_CURSOR,
+                sizeof(TERM_ESC_RESTORE_CURSOR) - 1);
     errno = saved_errno;
 
     // note: for this signal, we use SA_RESETHAND but do NOT mask signals


### PR DESCRIPTION
24270b8587 disabled the cursor while mpv is running, but if you send mpv to the background, it is not re-enabled until you run bg, and not even after that if mpv is paused. Fix this by enabling the cursor from the SIGTSTP handler.