### PR TITLE
win32: re-enable IME

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -489,6 +489,7 @@ if features['win32-desktop']
     win32_desktop_libs = [cc.find_library('avrt'),
                           cc.find_library('dwmapi'),
                           cc.find_library('gdi32'),
+                          cc.find_library('imm32'),
                           cc.find_library('ole32'),
                           cc.find_library('uuid'),
                           cc.find_library('uxtheme'),

--- a/test/meson.build
+++ b/test/meson.build
@@ -50,6 +50,7 @@ if not features['win32-threads']
 endif
 
 if features['win32-desktop']
+    test_utils_deps += cc.find_library('imm32')
     test_utils_deps += cc.find_library('winmm')
 endif
 test_utils_objects = libmpv.extract_objects(test_utils_files)

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1551,6 +1551,15 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             ((LPNCCALCSIZE_PARAMS) lParam)->rgrc[0].top -= get_title_bar_height(w32);
         }
         break;
+    case WM_IME_STARTCOMPOSITION: {
+        HIMC imc = ImmGetContext(w32->window);
+        if (imc) {
+            COMPOSITIONFORM cf = {.dwStyle = CFS_POINT, .ptCurrentPos = {0, 0}};
+            ImmSetCompositionWindow(imc, &cf);
+            ImmReleaseContext(w32->window, imc);
+        }
+        break;
+    }
     }
 
     if (message == w32->tbtn_created_msg) {

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -457,9 +457,9 @@ static void handle_key_up(struct vo_w32_state *w32, UINT vkey, UINT scancode)
     }
 }
 
-static bool handle_char(struct vo_w32_state *w32, wchar_t wc)
+static bool handle_char(struct vo_w32_state *w32, WPARAM wc, bool decode)
 {
-    int c = decode_utf16(w32, wc);
+    int c = decode ? decode_utf16(w32, wc) : wc;
 
     if (c == 0)
         return true;
@@ -1446,8 +1446,15 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         break;
     case WM_CHAR:
     case WM_SYSCHAR:
-        if (handle_char(w32, wParam))
+        if (handle_char(w32, wParam, true))
             return 0;
+        break;
+    case WM_UNICHAR:
+        if (wParam == UNICODE_NOCHAR) {
+            return TRUE;
+        } else if (handle_char(w32, wParam, false)) {
+            return 0;
+        }
         break;
     case WM_KILLFOCUS:
         mp_input_put_key(w32->input_ctx, MP_INPUT_RELEASE_ALL);


### PR DESCRIPTION
The IME was intentionally disabled 8 years ago because it was "not useful for key-bindings". It also broke Alt+Shift language switching. 
Now that text input is an official part of mpv it's time to re-enable it.

Reverts https://github.com/mpv-player/mpv/commit/bf6b981367e45c3f926d3e667bba3f3ed6e9dc37.
Fixes https://github.com/mpv-player/mpv/issues/9168.
Fixes https://github.com/mpv-player/mpv/issues/9168#issuecomment-1748674241.
