### PR TITLE
DOCS/options: fix documentation for replaygain-clip

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2011,8 +2011,8 @@ Audio
     (default: 0).
 
 ``--replaygain-clip=<yes|no>``
-    Prevent clipping caused by replaygain by automatically lowering the
-    gain (default). Use ``--replaygain-clip=no`` to disable this.
+    Allow the volume gain to clip (default: no). If this option is not
+    enabled, mpv automatically will prevent clipping by lowering the gain.
 
 ``--replaygain-fallback=<db>``
     Gain in dB to apply if the file has no replay gain tags. This option


### PR DESCRIPTION
f1c4d20e6577f32018e20efc4ab9da7d4e1ab4ac added this option, but the documentation is actually backwards. --replaygain-clip allows clipping. Having it disabled, the default, prevents it. Keep the behavior the same, but change the documentation to reflect reality. Closes #13111.