### PR TITLE
osc: allow disabling special mouse wheel behavior

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -211,6 +211,13 @@ Configurable Options
 
     Alpha of the seekable ranges, 0 (opaque) to 255 (fully transparent).
 
+``scrollcontrols``
+    Default: yes
+
+    By default, going up or down with the mouse wheel can trigger certain
+    actions (such as seeking) if the mouse is hovering an OSC element.
+    Set to ``no`` to disable any special mouse wheel behavior.
+
 ``deadzonesize``
     Default: 0.5
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -38,6 +38,7 @@ local user_opts = {
     seekrangeseparate = true,   -- whether the seekranges overlay on the bar-style seekbar
     seekrangealpha = 200,       -- transparency of seekranges
     seekbarkeyframes = true,    -- use keyframes when dragging the seekbar
+    scrollcontrols = true,      -- allow scrolling when hovering certain OSC elements
     title = "${media-title}",   -- string compatible with property-expansion
                                 -- to be shown as OSC title
     tooltipborder = 1,          -- border of tooltip in bottom/topbar
@@ -1937,10 +1938,13 @@ function osc_init()
         function () set_track("audio", -1) end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () show_message(get_tracklist("audio"), 2) end
-    ne.eventresponder["wheel_down_press"] =
-        function () set_track("audio", 1) end
-    ne.eventresponder["wheel_up_press"] =
-        function () set_track("audio", -1) end
+
+    if user_opts.scrollcontrols then
+        ne.eventresponder["wheel_down_press"] =
+            function () set_track("audio", 1) end
+        ne.eventresponder["wheel_up_press"] =
+            function () set_track("audio", -1) end
+    end
 
     --cy_sub
     ne = new_element("cy_sub", "button")
@@ -1960,10 +1964,13 @@ function osc_init()
         function () set_track("sub", -1) end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () show_message(get_tracklist("sub"), 2) end
-    ne.eventresponder["wheel_down_press"] =
-        function () set_track("sub", 1) end
-    ne.eventresponder["wheel_up_press"] =
-        function () set_track("sub", -1) end
+
+    if user_opts.scrollcontrols then
+        ne.eventresponder["wheel_down_press"] =
+            function () set_track("sub", 1) end
+        ne.eventresponder["wheel_up_press"] =
+            function () set_track("sub", -1) end
+    end
 
     --tog_fs
     ne = new_element("tog_fs", "button")
@@ -2053,10 +2060,13 @@ function osc_init()
             "absolute-percent", "exact") end
     ne.eventresponder["reset"] =
         function (element) element.state.lastseek = nil end
-    ne.eventresponder["wheel_up_press"] =
-        function () mp.commandv("osd-auto", "seek",  10) end
-    ne.eventresponder["wheel_down_press"] =
-        function () mp.commandv("osd-auto", "seek", -10) end
+
+    if user_opts.scrollcontrols then
+        ne.eventresponder["wheel_up_press"] =
+            function () mp.commandv("osd-auto", "seek",  10) end
+        ne.eventresponder["wheel_down_press"] =
+            function () mp.commandv("osd-auto", "seek", -10) end
+    end
 
 
     -- tc_left (current pos)
@@ -2140,10 +2150,12 @@ function osc_init()
     ne.eventresponder["mbtn_left_up"] =
         function () mp.commandv("cycle", "mute") end
 
-    ne.eventresponder["wheel_up_press"] =
-        function () mp.commandv("osd-auto", "add", "volume", 5) end
-    ne.eventresponder["wheel_down_press"] =
-        function () mp.commandv("osd-auto", "add", "volume", -5) end
+    if user_opts.scrollcontrols then
+        ne.eventresponder["wheel_up_press"] =
+            function () mp.commandv("osd-auto", "add", "volume", 5) end
+        ne.eventresponder["wheel_down_press"] =
+            function () mp.commandv("osd-auto", "add", "volume", -5) end
+    end
 
 
     -- load layout


### PR DESCRIPTION
Not everyone necessarily wants this feature as it can interfere with whatever they already have the scroll wheel configured to in input.conf. Add an option for this. Fixes #13096.