### PR TITLE
 sd_ass: add `sub-vsfilter-bidi-compat` to enable vsfilter bidi compat 

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2560,6 +2560,15 @@ Subtitles
     offset scale factor, not what the video filter chain or the video output
     use.
 
+``--sub-vsfilter-bidi-compat=<yes|no>``
+    Set implicit bidi detection to ``ltr`` instead of ``auto`` to match ASS'
+    default. This also disables libass' incompatible extensions. This currently
+    includes bracket pair matching according to the revised Unicode
+    Bidirectional Algorithm introduced in Unicode 6.3, and also affects how BiDi
+    runs are split and processed, as well as soft linewrapping of unicode text.
+
+    This affects plaintext (non-ASS) subtitles only. Default: no.
+
 ``--sub-ass-vsfilter-color-compat=<basic|full|force-601|no>``
     Mangle colors like (xy-)vsfilter do (default: basic). Historically, VSFilter
     was not color space aware. This was no problem as long as the color space

--- a/options/options.c
+++ b/options/options.c
@@ -307,6 +307,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-ass-vsfilter-color-compat", OPT_CHOICE(ass_vsfilter_color_compat,
             {"no", 0}, {"basic", 1}, {"full", 2}, {"force-601", 3})},
         {"sub-ass-vsfilter-blur-compat", OPT_BOOL(ass_vsfilter_blur_compat)},
+        {"sub-vsfilter-bidi-compat", OPT_BOOL(sub_vsfilter_bidi_compat)},
         {"embeddedfonts", OPT_BOOL(use_embedded_fonts), .flags = UPDATE_SUB_HARD},
         {"sub-ass-style-overrides", OPT_STRINGLIST(ass_style_override_list),
             .flags = UPDATE_SUB_HARD},

--- a/options/options.h
+++ b/options/options.h
@@ -104,6 +104,7 @@ struct mp_subtitle_opts {
     bool ass_vsfilter_aspect_compat;
     int ass_vsfilter_color_compat;
     bool ass_vsfilter_blur_compat;
+    bool sub_vsfilter_bidi_compat;
     bool use_embedded_fonts;
     char **ass_style_override_list;
     char *ass_styles_file;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -527,8 +527,16 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     ass_set_hinting(priv, set_hinting);
     ass_set_line_spacing(priv, set_line_spacing);
 #if LIBASS_VERSION >= 0x01600010
-    if (converted)
+    if (converted) {
         ass_track_set_feature(track, ASS_FEATURE_WRAP_UNICODE, 1);
+        if (!opts->sub_vsfilter_bidi_compat) {
+            for (int n = 0; n < track->n_styles; n++) {
+                track->styles[n].Encoding = -1;
+            }
+            ass_track_set_feature(track, ASS_FEATURE_BIDI_BRACKETS, 1);
+            ass_track_set_feature(track, ASS_FEATURE_WHOLE_TEXT_LAYOUT, 1);
+        }
+    }
 #endif
     if (converted) {
         bool override_playres = true;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -510,7 +510,7 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         set_force_flags |= ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
     if (converted)
         set_force_flags |= ASS_OVERRIDE_BIT_ALIGNMENT;
-#ifdef ASS_JUSTIFY_AUTO
+#if LIBASS_VERSION >= 0x01306000
     if ((converted || shared_opts->ass_style_override[sd->order]) && opts->ass_justify)
         set_force_flags |= ASS_OVERRIDE_BIT_JUSTIFY;
 #endif

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -550,12 +550,13 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         if (override_playres) {
             int vidw = dim->w - (dim->ml + dim->mr);
             int vidh = dim->h - (dim->mt + dim->mb);
+            int old_playresx = track->PlayResX;
             track->PlayResX = track->PlayResY * (double)vidw / MPMAX(vidh, 1);
-            // ffmpeg and mpv use a default PlayResX of 384 when it is not known,
-            // this comes from VSFilter.
-            double fix_margins = track->PlayResX / (double)MP_ASS_FONT_PLAYRESX;
-            track->styles->MarginL = round(track->styles->MarginL * fix_margins);
-            track->styles->MarginR = round(track->styles->MarginR * fix_margins);
+            double fix_margins = track->PlayResX / (double)old_playresx;
+            for (int n = 0; n < track->n_styles; n++) {
+                track->styles[n].MarginL = round(track->styles[n].MarginL * fix_margins);
+                track->styles[n].MarginR = round(track->styles[n].MarginR * fix_margins);
+            }
         }
     }
 }


### PR DESCRIPTION
Enable ASS_FEATURE_INCOMPATIBLE_EXTENSIONS and auto base detection
by default, and add an option to disable this if needed.

This currently means auto base direction, changing how bidi runs are
split, bidi bracket matching, and unicode soft line wrapping.

This is strictly an improvement for Webvtt files as they always use
auto base detection. This _fixes_ right-to-left text rendering for
webvtt files which correctly mark rtl/ltr. Webvtt files obtained from
sources which sideload the RTL information through css also see an
improvement due to the auto detection.

Generally SRT files also want this, but some are also written to
workaround VSFilter quirks.
