### PR TITLE
command: support passing scale to `keypress`

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -827,11 +827,13 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     <double>
         The mouse event represents double-click.
 
-``keypress <name>``
+``keypress <name> [<scale>]``
     Send a key event through mpv's input handler, triggering whatever
     behavior is configured to that key. ``name`` uses the ``input.conf``
-    naming scheme for keys and modifiers. Useful for the client API: key events
-    can be sent to libmpv to handle internally.
+    naming scheme for keys and modifiers. ``scale`` is used to scale numerical
+    change effected by the bound command (same mechanism as precise scrolling).
+    Useful for the client API: key events can be sent to libmpv to handle
+    internally.
 
 ``keydown <name>``
     Similar to ``keypress``, but sets the ``KEYDOWN`` flag so that if the key is

--- a/input/input.c
+++ b/input/input.c
@@ -757,10 +757,12 @@ void mp_input_put_key(struct input_ctx *ictx, int code)
     input_unlock(ictx);
 }
 
-void mp_input_put_key_artificial(struct input_ctx *ictx, int code)
+void mp_input_put_key_artificial(struct input_ctx *ictx, int code, double value)
 {
+    if (value == 0.0)
+        return;
     input_lock(ictx);
-    mp_input_feed_key(ictx, code, 1, true);
+    mp_input_feed_key(ictx, code, value, true);
     input_unlock(ictx);
 }
 

--- a/input/input.h
+++ b/input/input.h
@@ -83,7 +83,8 @@ void mp_input_src_feed_cmd_text(struct mp_input_src *src, char *buf, size_t len)
 void mp_input_put_key(struct input_ctx *ictx, int code);
 
 // Like mp_input_put_key(), but ignore mouse disable option for mouse buttons.
-void mp_input_put_key_artificial(struct input_ctx *ictx, int code);
+// value can be used like with mp_input_put_wheel(), use 1 if not applicable.
+void mp_input_put_key_artificial(struct input_ctx *ictx, int code, double value);
 
 // Like mp_input_put_key(), but process all UTF-8 characters in the given
 // string as key events.

--- a/player/command.c
+++ b/player/command.c
@@ -6216,7 +6216,8 @@ static void cmd_key(void *p)
             cmd->success = false;
             return;
         }
-        mp_input_put_key_artificial(mpctx->input, code | action, 1);
+        double scale = action == 0 ? cmd->args[1].v.d : 1;
+        mp_input_put_key_artificial(mpctx->input, code | action, scale);
     }
 }
 
@@ -6772,7 +6773,8 @@ const struct mp_cmd_def mp_cmds[] = {
                                 .flags = MP_CMD_OPT_ARG}}},
     { "keybind", cmd_key_bind, { {"name", OPT_STRING(v.s)},
                                  {"cmd", OPT_STRING(v.s)} }},
-    { "keypress", cmd_key, { {"name", OPT_STRING(v.s)} },
+    { "keypress", cmd_key, { {"name", OPT_STRING(v.s)},
+                             {"scale", OPT_DOUBLE(v.d), OPTDEF_DOUBLE(1)} },
         .priv = &(const int){0}},
     { "keydown", cmd_key, { {"name", OPT_STRING(v.s)} },
         .priv = &(const int){MP_KEY_STATE_DOWN}},

--- a/player/command.c
+++ b/player/command.c
@@ -6177,7 +6177,7 @@ static void cmd_mouse(void *p)
 
     if (button == -1) {// no button
         if (pre_key)
-            mp_input_put_key_artificial(mpctx->input, pre_key);
+            mp_input_put_key_artificial(mpctx->input, pre_key, 1);
         mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
         return;
     }
@@ -6195,9 +6195,9 @@ static void cmd_mouse(void *p)
     }
     button += dbc ? MP_MBTN_DBL_BASE : MP_MBTN_BASE;
     if (pre_key)
-        mp_input_put_key_artificial(mpctx->input, pre_key);
+        mp_input_put_key_artificial(mpctx->input, pre_key, 1);
     mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
-    mp_input_put_key_artificial(mpctx->input, button);
+    mp_input_put_key_artificial(mpctx->input, button, 1);
 }
 
 static void cmd_key(void *p)
@@ -6208,7 +6208,7 @@ static void cmd_key(void *p)
 
     const char *key_name = cmd->args[0].v.s;
     if (key_name[0] == '\0' && action == MP_KEY_STATE_UP) {
-        mp_input_put_key_artificial(mpctx->input, MP_INPUT_RELEASE_ALL);
+        mp_input_put_key_artificial(mpctx->input, MP_INPUT_RELEASE_ALL, 1);
     } else {
         int code = mp_input_get_key_from_name(key_name);
         if (code < 0) {
@@ -6216,7 +6216,7 @@ static void cmd_key(void *p)
             cmd->success = false;
             return;
         }
-        mp_input_put_key_artificial(mpctx->input, code | action);
+        mp_input_put_key_artificial(mpctx->input, code | action, 1);
     }
 }
 


### PR DESCRIPTION
can be used to emulate precise scrolling from libmpv (and probably other fun things)

test: `keypress Shift+UP 0.2` should seek exactly 1s