### PR TITLE
lua: don't return a second value from successful format_json

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -1184,11 +1184,11 @@ static int script_format_json(lua_State *L, void *tmp)
     char *dst = talloc_strdup(tmp, "");
     if (json_write(&dst, &node) >= 0) {
         lua_pushstring(L, dst);
-        lua_pushnil(L);
-    } else {
-        lua_pushnil(L);
-        lua_pushstring(L, "error");
+        return 1;
     }
+
+    lua_pushnil(L);
+    lua_pushstring(L, "error");
     return 2;
 }
 


### PR DESCRIPTION
Even for successful calls, utils.format_json returns nil as the second return value. This doesn't have any purpose and is not documented, and it is inconvenient for passing JSON to script-message, because

mp.commandv('script-message', 'foo', utils.format_json(...))

errors because mp.commandv receives nil as the fourth argument.

This commit makes format_json return only one value in case of success to fix this.