### PR TITLE
OSC: fix indentation and stray whitespace between L342-L451

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -410,10 +410,10 @@ function set_track(type, next)
 
     mp.commandv("set", type, new_track_mpv)
 
-        if new_track_osc == 0 then
+    if new_track_osc == 0 then
         show_message(nicetypes[type] .. " Track: none")
     else
-        show_message(nicetypes[type]  .. " Track: "
+        show_message(nicetypes[type] .. " Track: "
             .. new_track_osc .. "/" .. #tracks_osc[type]
             .. " [".. (tracks_osc[type][new_track_osc].lang or "unknown") .."] "
             .. (tracks_osc[type][new_track_osc].title or ""))


### PR DESCRIPTION
Read this before you submit this pull request:
- [x] https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

----

Just trying to fix a few things I noticed while making changes to my local `osc.lua`

I don't really know Lua, but the indentation for the conditional statement seems off - unless there is some very obscure technique used here.

There are some other (minor) issues with `osc.lua`, mainly inconsistent whitespace around the `..` operator, for example.
But hey, got to leave this for future contributions.

