### PR TITLE
mac: update geometry/autofit opts on runtime

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3394,7 +3394,6 @@ Window
     be the default behavior. Currently only affects X11 and SDL VOs.
 
 ``--auto-window-resize=<yes|no>``
-    (Wayland, Win32, and X11)
     By default, mpv will automatically resize itself if the video's size changes
     (i.e. advancing forward in a playlist). Setting this to ``no`` disables this
     behavior so the window size never changes automatically. This option does

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -64,7 +64,7 @@ class CocoaCB: Common {
         mpv?.vo = vo
         if backendState == .needsInit {
             DispatchQueue.main.sync { self.initBackend(vo) }
-        } else {
+        } else if mpv?.opts.auto_window_resize ?? true {
             DispatchQueue.main.async {
                 self.updateWindowSize(vo)
                 self.layer?.update(force: true)

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -553,6 +553,14 @@ class Common: NSObject {
                     DispatchQueue.main.async {
                         self.window?.setMaximized(Bool(mpv.opts.window_maximized))
                     }
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.geometry): fallthrough
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.autofit): fallthrough
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.autofit_smaller): fallthrough
+                case MPVHelper.getPointer(&mpv.optsPtr.pointee.autofit_larger):
+                    DispatchQueue.main.async {
+                        let (_, _, wr) = self.getInitProperties(vo)
+                        self.window?.updateFrame(wr)
+                    }
                 default:
                     break
                 }

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -342,21 +342,19 @@ class Window: NSWindow, NSWindowDelegate {
 
     func updateFrame(_ rect: NSRect) {
         if rect != frame {
-            let cRect = frameRect(forContentRect: rect)
             unfsContentFrame = rect
-            setFrame(cRect, display: true)
-            common.windowDidUpdateFrame()
+            if !isInFullscreen {
+                let cRect = frameRect(forContentRect: rect)
+                setFrame(cRect, display: true)
+                common.windowDidUpdateFrame()
+            }
         }
     }
 
     func updateSize(_ size: NSSize) {
         if let currentSize = contentView?.frame.size, size != currentSize {
             let newContentFrame = centeredContentSize(for: frame, size: size)
-            if !isInFullscreen {
-                updateFrame(newContentFrame)
-            } else {
-                unfsContentFrame = newContentFrame
-            }
+            updateFrame(newContentFrame)
         }
     }
 

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -58,7 +58,9 @@ class MacCommon: Common {
                 initWindowState()
             }
 
-            if !NSEqualSizes(window?.unfsContentFramePixel.size ?? NSZeroSize, wr.size) {
+            if !NSEqualSizes(window?.unfsContentFramePixel.size ?? NSZeroSize, wr.size) &&
+               mpv?.opts.auto_window_resize ?? true
+            {
                 window?.updateSize(wr.size)
             }
 


### PR DESCRIPTION
related issue #8379, after that only windows seems to be missing. when merged the mac label can be removed