### PR TITLE
win32: opt in to the windows segment heap

### DIFF
--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -13,6 +13,7 @@
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
             <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
             <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+            <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
         </windowsSettings>
     </application>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">


### PR DESCRIPTION
ref: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#heaptype

The speed of releasing the demuxer cache has been greatly improved, from more than 10 seconds down to 1 second. (tested on win11 22h2 with `--demuxer-max-bytes=16384MiB`)