### PR TITLE
options: add --sub-newline-to-space

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2518,6 +2518,14 @@ Subtitles
 
     Default: yes.
 
+``--sub-newline-to-space``
+    Enables replace newline with space in subtitles when they are available,
+    if the subtitles are in a plain text format (or ASS if
+    ``--sub-ass-override``, ``--secondary-sub-ass-override`` is set to strip).
+    Useful when secondary sub postion is adjacent to main subtitle.
+
+    Default: no.
+
 ``--sub-ass-vsfilter-aspect-compat=<yes|no>``
     Stretch SSA/ASS subtitles when playing anamorphic videos for compatibility
     with traditional VSFilter behavior. This switch has no effect when the

--- a/options/options.c
+++ b/options/options.c
@@ -321,6 +321,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"teletext-page", OPT_INT(teletext_page), M_RANGE(1, 999)},
         {"sub-past-video-end", OPT_BOOL(sub_past_video_end)},
         {"sub-ass-force-style", OPT_REPLACED("sub-ass-style-overrides")},
+        {"sub-newline-to-space", OPT_BOOL(sub_newline_to_space)},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),
@@ -337,6 +338,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         .ass_vsfilter_blur_compat = true,
         .ass_shaper = 1,
         .use_embedded_fonts = true,
+        .sub_newline_to_space = false,
     },
     .change_flags = UPDATE_OSD,
 };
@@ -1091,6 +1093,7 @@ static const struct MPOpts mp_default_opts = {
         "sub-visibility",
         "sub-scale",
         "sub-use-margins",
+        "sub-newline-to-space",
         "sub-ass-force-margins",
         "sub-ass-vsfilter-aspect-compat",
         "sub-ass-override",

--- a/options/options.h
+++ b/options/options.h
@@ -113,6 +113,7 @@ struct mp_subtitle_opts {
     bool sub_clear_on_seek;
     int teletext_page;
     bool sub_past_video_end;
+    bool sub_newline_to_space;
 };
 
 // Options for both primary and secondary subs.

--- a/player/command.c
+++ b/player/command.c
@@ -4253,6 +4253,7 @@ static const struct property_osd_display {
     {"secondary-sub-visibility",
      .msg = "Secondary Subtitles ${!secondary-sub-visibility==yes:hidden}"
       "${?secondary-sub-visibility==yes:visible${?secondary-sid==no: (but no secondary subtitles selected)}}"},
+    {"sub-newline-to-space", "Replace newline with space in subtitles"},
     {"sub-forced-events-only", "Forced sub only"},
     {"sub-scale", "Sub Scale"},
     {"sub-ass-vsfilter-aspect-compat", "Subtitle VSFilter aspect compat"},

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -642,7 +642,7 @@ static void append(struct buf *b, char c)
     }
 }
 
-static void ass_to_plaintext(struct buf *b, const char *in)
+static void ass_to_plaintext(struct buf *b, const char *in, bool newline_to_space)
 {
     bool in_tag = false;
     const char *open_tag_pos = NULL;
@@ -668,7 +668,7 @@ static void ass_to_plaintext(struct buf *b, const char *in)
         } else {
             if (in[0] == '\\' && (in[1] == 'N' || in[1] == 'n')) {
                 in += 2;
-                append(b, '\n');
+                append(b, newline_to_space ? ' ' : '\n');
             } else if (in[0] == '\\' && in[1] == 'h') {
                 in += 2;
                 append(b, ' ');
@@ -703,6 +703,7 @@ static bool is_whitespace_only(char *s, int len)
 static char *get_text_buf(struct sd *sd, double pts, enum sd_text_type type)
 {
     struct sd_ass_priv *ctx = sd->priv;
+    struct mp_subtitle_opts *opts = sd->opts;
     ASS_Track *track = ctx->ass_track;
 
     if (pts == MP_NOPTS_VALUE)
@@ -717,7 +718,7 @@ static char *get_text_buf(struct sd *sd, double pts, enum sd_text_type type)
             if (event->Text) {
                 int start = b.len;
                 if (type == SD_TEXT_TYPE_PLAIN) {
-                    ass_to_plaintext(&b, event->Text);
+                    ass_to_plaintext(&b, event->Text, opts->sub_newline_to_space);
                 } else {
                     char *t = event->Text;
                     while (*t)
@@ -1024,7 +1025,7 @@ bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset)
 bstr sd_ass_to_plaintext(char *out, size_t out_siz, const char *in)
 {
     struct buf b = {out, out_siz, 0};
-    ass_to_plaintext(&b, in);
+    ass_to_plaintext(&b, in, false);
     if (b.len < out_siz)
         out[b.len] = 0;
     return (bstr){out, b.len};


### PR DESCRIPTION
Enables replace newline with space in subtitles when they are available, if the subtitles are in a plain text format (or ASS if ``--sub-ass-override``, ``--secondary-sub-ass-override`` is set to strip). Useful when secondary sub postion is adjacent to main subtitle (Default: no).

replace newline with space when display two subtitle at the bottom will have a better user experience, is adding a new option --sub-newline-to-space acceptable? 

    

