### PR TITLE
stats.lua: display the current GPU context

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,7 @@ Interface changes
 
  --- mpv 0.38.0 ---
     - add `--volume-gain`, `--volume-gain-min`, and `--volume-gain-max` options
+    - add `current-gpu-context` property
     - add `--secondary-sub-ass-override` option
     - remove shared-script-properties (user-data is a replacement)
     - add `--secondary-sub-delay`, decouple secondary subtitles from

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3332,6 +3332,10 @@ Property list
 ``current-vo``
     Current video output driver (name as used with ``--vo``).
 
+``current-gpu-context``
+    Current GPU context of video output driver (name as used with ``--gpu-context``).
+    Valid for ``--vo=gpu`` and ``--vo=gpu-next``.
+
 ``current-ao``
     Current audio output driver (name as used with ``--ao``).
 

--- a/player/command.c
+++ b/player/command.c
@@ -1781,8 +1781,7 @@ static int mp_property_audio_devices(void *ctx, struct m_property *prop,
 static int mp_property_ao(void *ctx, struct m_property *p, int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    return m_property_strdup_ro(action, arg,
-                                    mpctx->ao ? ao_get_name(mpctx->ao) : NULL);
+    return m_property_strdup_ro(action, arg, mpctx->ao ? ao_get_name(mpctx->ao) : NULL);
 }
 
 /// Audio delay (RW)
@@ -2762,15 +2761,15 @@ static int mp_property_perf_info(void *ctx, struct m_property *p, int action,
 static int mp_property_vo(void *ctx, struct m_property *p, int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    return m_property_strdup_ro(action, arg,
-                    mpctx->video_out ? mpctx->video_out->driver->name : NULL);
+    return m_property_strdup_ro(action, arg, mpctx->video_out ?
+                                mpctx->video_out->driver->name : NULL);
 }
 
 static int mp_property_gpu_context(void *ctx, struct m_property *p, int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    return m_property_strdup_ro(action, arg,
-                    mpctx->video_out ? mpctx->video_out->context_name : NULL);
+    return m_property_strdup_ro(action, arg, mpctx->video_out ?
+                                mpctx->video_out->context_name : NULL);
 }
 
 static int mp_property_osd_dim(void *ctx, struct m_property *prop,

--- a/player/command.c
+++ b/player/command.c
@@ -2766,6 +2766,13 @@ static int mp_property_vo(void *ctx, struct m_property *p, int action, void *arg
                     mpctx->video_out ? mpctx->video_out->driver->name : NULL);
 }
 
+static int mp_property_gpu_context(void *ctx, struct m_property *p, int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    return m_property_strdup_ro(action, arg,
+                    mpctx->video_out ? mpctx->video_out->context_name : NULL);
+}
+
 static int mp_property_osd_dim(void *ctx, struct m_property *prop,
                                int action, void *arg)
 {
@@ -3923,6 +3930,7 @@ static const struct m_property mp_properties_base[] = {
     {"vo-passes", mp_property_vo_passes},
     {"perf-info", mp_property_perf_info},
     {"current-vo", mp_property_vo},
+    {"current-gpu-context", mp_property_gpu_context},
     {"container-fps", mp_property_fps},
     {"estimated-vf-fps", mp_property_vf_fps},
     {"video-aspect-override", mp_property_video_aspect_override},

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -855,6 +855,8 @@ local function add_video_out(s)
     append(s, vo, {prefix_sep="", nl="", indent=""})
     append_property(s, "display-names", {prefix_sep="", prefix="(", suffix=")",
                                          no_prefix_markup=true, nl="", indent=" "})
+    append(s, mp.get_property_native("current-gpu-context"),
+           {prefix="Context:", nl="", indent=o.prefix_sep .. o.prefix_sep})
     append_property(s, "avsync", {prefix="A-V:"})
     append_fps(s, "display-fps", "estimated-display-fps")
     if append_property(s, "decoder-frame-drop-count",

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -208,6 +208,7 @@ struct ra_ctx *ra_ctx_create(struct vo *vo, struct ra_ctx_opts opts)
         MP_VERBOSE(ctx, "Initializing GPU context '%s'\n", ctx->fns->name);
         if (contexts[i]->init(ctx)) {
             vo->probing = old_probing;
+            vo->context_name = ctx->fns->name;
             return ctx;
         }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -494,6 +494,9 @@ struct vo {
     int dwidth;
     int dheight;
     float monitor_par;
+
+    // current GPU context (--vo=gpu and --vo=gpu-next only)
+    const char *context_name;
 };
 
 struct mpv_global;


### PR DESCRIPTION
This displays the current GPU context when `--vo=gpu` or `--vo=gpu-next` is used, which shows the platform and backend information of the vo which are previously not available.

The name of the GPU context is available as `current-gpu-context` property. 