### PR TITLE
screenshot: remove artificial limit on the number of screenshots taken

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -166,7 +166,7 @@ static char *create_fname(struct MPContext *mpctx, char *template,
                 goto error_exit;
             char fmtstr[] = {'%', '0', digits, 'd', '\0'};
             res = talloc_asprintf_append(res, fmtstr, *frameno);
-            if (*frameno < 100000 - 1) {
+            if (*frameno < INT_MAX - 1) {
                 (*frameno) += 1;
                 (*sequence) += 1;
             }


### PR DESCRIPTION
This allows taking more than 99999 screenshots in a single session, and also for the case when a sequence of 99999 screenshots already exists on the filesystem.
