### PR TITLE
playloop: enable the screensaver with --image-display-duration=inf

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2173,7 +2173,7 @@ Property list
 ``core-idle``
     Whether the playback core is paused. This can differ from ``pause`` in
     special situations, such as when the player pauses itself due to low
-    network cache.
+    network cache or when displaying an image without advancing automatically.
 
     This also returns ``yes``/true if playback is restarting or if nothing is
     playing at all. In other words, it's only ``no``/false if there's actually

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -134,7 +134,8 @@ void update_core_idle_state(struct MPContext *mpctx)
     bool eof = mpctx->video_status == STATUS_EOF &&
                mpctx->audio_status == STATUS_EOF;
     bool active = !mpctx->paused && mpctx->restart_complete &&
-                  !mpctx->stop_play && mpctx->in_playloop && !eof;
+                  !mpctx->stop_play && mpctx->in_playloop && !eof &&
+                  mpctx->time_frame < INFINITY;
 
     if (mpctx->playback_active != active) {
         mpctx->playback_active = active;


### PR DESCRIPTION
This sets core-idle to true when an image is kept open forever, because conceptually that is like being paused. The advantage is enabling the screensaver with --image-display-duration=inf, --pause=no and --stop-screensaver=yes, without having to manually set pause when viewing images without advancing automatically. You can still disable the screensaver in this case with --stop-screensaver=always.