### PR TITLE
command: don't flush the status line from the run command

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5770,7 +5770,6 @@ static void cmd_run(void *p)
     char **args = talloc_zero_array(NULL, char *, cmd->num_args + 1);
     for (int n = 0; n < cmd->num_args; n++)
         args[n] = cmd->args[n].v.s;
-    mp_msg_flush_status_line(mpctx->log);
     struct mp_subprocess_opts opts = {
         .exe = args[0],
         .args = args,


### PR DESCRIPTION
This line does nothing useful, and in fact subprocess with detach does the same thing as run without flushing the status line. Past commits don't describe its purpose either.

Since 24270b8587 run flushes the status line even when mpv is backgrounded after setting really-quiet at runtime, so if you e.g. background mpv and run notify-send ${media-title} on file-loaded, an unrelated terminal line is cleared when changing playlist position, which garbles the output of any open TUI program.