### PR TITLE
win32: add support for --input-cursor-passthrough option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4149,7 +4149,6 @@ Input
     Support depends on the VO in use.
 
 ``--input-cursor-passthrough``, ``--no-input-cursor-passthrough``
-    (X11, Wayland and macOS only)
     Tell the backend windowing system to allow pointer events to passthrough
     the mpv window. This allows windows under mpv to instead receive pointer
     events as if the mpv window was never there.

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1202,6 +1202,23 @@ static void update_backdrop(const struct vo_w32_state *w32)
                           &backdropType, sizeof(backdropType));
 }
 
+static void update_cursor_passthrough(const struct vo_w32_state *w32)
+{
+    if (w32->parent)
+        return;
+
+    LONG_PTR exstyle = GetWindowLongPtrW(w32->window, GWL_EXSTYLE);
+    if (exstyle) {
+        if (w32->opts->cursor_passthrough) {
+            SetWindowLongPtrW(w32->window, GWL_EXSTYLE, exstyle | WS_EX_LAYERED | WS_EX_TRANSPARENT);
+            // This is required, otherwise the titlebar disappears.
+            SetLayeredWindowAttributes(w32->window, 0, 255, LWA_ALPHA);
+        } else {
+            SetWindowLongPtrW(w32->window, GWL_EXSTYLE, exstyle & ~(WS_EX_LAYERED | WS_EX_TRANSPARENT));
+        }
+    }
+}
+
 static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
                                 LPARAM lParam)
 {
@@ -1800,6 +1817,8 @@ static MP_THREAD_VOID gui_thread(void *ptr)
         update_affinity(w32);
     if (w32->opts->backdrop_type)
         update_backdrop(w32);
+    if (w32->opts->cursor_passthrough)
+        update_cursor_passthrough(w32);
 
     if (SUCCEEDED(OleInitialize(NULL))) {
         ole_ok = true;
@@ -1980,6 +1999,8 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
                 update_window_state(w32);
             } else if (changed_option == &vo_opts->backdrop_type) {
                 update_backdrop(w32);
+            } else if (changed_option == &vo_opts->cursor_passthrough) {
+                update_cursor_passthrough(w32);
             } else if (changed_option == &vo_opts->border ||
                        changed_option == &vo_opts->title_bar)
             {


### PR DESCRIPTION
This completes the support for all supported desktop platforms.

Related: https://github.com/mpv-player/mpv/issues/8701, addresses the click through part.
