### PR TITLE
console.lua: style log lines in the terminal

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -922,9 +922,10 @@ REPL.
 ``input.terminate()``
     Close the console.
 
-``input.log(message, style)``
+``input.log(message, style, terminal_style)``
     Add a line to the log buffer. ``style`` can contain additional ASS tags to
-    apply to ``message``.
+    apply to ``message``, and ``terminal_style`` can contain escape sequences
+    that are used when the console is displayed in the terminal.
 
 ``input.log_error(message)``
     Helper to add a line to the log buffer with the same color as the one the
@@ -933,7 +934,8 @@ REPL.
 ``input.set_log(log)``
     Replace the entire log buffer.
 
-    ``log`` is a table of strings, or tables with ``text`` and ``style`` keys.
+    ``log`` is a table of strings, or tables with ``text``, ``style`` and
+    ``terminal_style`` keys.
 
     Example:
 
@@ -941,7 +943,11 @@ REPL.
 
         input.set_log({
             "regular text",
-            { style = "{\\c&H7a77f2&}", text = "error text" }
+            {
+                text = "error text",
+                style = "{\\c&H7a77f2&}",
+                terminal_style = "\027[31m",
+            }
         })
 
 Events

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -675,9 +675,12 @@ mp.input = {
     terminate: function () {
         mp.commandv("script-message-to", "console", "disable");
     },
-    log: function (message, style) {
-        mp.commandv("script-message-to", "console", "log",
-                    JSON.stringify({ text: message, style: style }));
+    log: function (message, style, terminal_style) {
+        mp.commandv("script-message-to", "console", "log", JSON.stringify({
+                        text: message,
+                        style: style,
+                        terminal_style: terminal_style,
+                   }));
     },
     log_error: function (message) {
         mp.commandv("script-message-to", "console", "log",

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -49,9 +49,12 @@ function input.terminate()
     mp.commandv("script-message-to", "console", "disable")
 end
 
-function input.log(message, style)
-    mp.commandv("script-message-to", "console", "log",
-                utils.format_json({ text = message, style = style }))
+function input.log(message, style, terminal_style)
+    mp.commandv("script-message-to", "console", "log", utils.format_json({
+                   text = message,
+                   style = style,
+                   terminal_style = terminal_style,
+               }))
 end
 
 function input.log_error(message)


### PR DESCRIPTION
When running the console in the terminal, style log lines with the same escape sequences as msg.c.

This system will be more useful to third party scripts interacting with the console e.g. a script to select a playlist entry can invert the color of the selection.

Also add a missing newline to help's error message.