### PR TITLE
DOCS/options: fix documentation for --force-window window size

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3155,7 +3155,7 @@ Window
 ``--force-window=<yes|no|immediate>``
     Create a video output window even if there is no video. This can be useful
     when pretending that mpv is a GUI application. Currently, the window
-    always has the size 640x480, and is subject to ``--geometry``,
+    always has the size 960x540, and is subject to ``--geometry``,
     ``--autofit``, and similar options.
 
     .. warning::


### PR DESCRIPTION
The value has been wrong since ca2b05c0fbc9a51472b1a5a94d016e977c6c87c3, and recent commit 8b4a995a9d7ee7b65a5d2c893d72844d551d9697 still didn't fix it.
