### PR TITLE
DOCS/ao: change wrong note on which driver is preferred

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -12,9 +12,8 @@ in the list.
 
 .. note::
 
-    See ``--ao=help`` for a list of compiled-in audio output drivers. The
-    driver ``--ao=alsa`` is preferred. ``--ao=pulse`` is preferred on systems
-    where PulseAudio is used. On BSD systems, ``--ao=oss`` is preferred.
+    See ``--ao=help`` for a list of compiled-in audio output drivers sorted by
+    autoprobe order.
 
 Available audio output drivers are:
 


### PR DESCRIPTION
--ao=pipewire has been preferred on Linux for a long time, and this note even makes it sound like alsa is preferred on any system. Just say that the print order is the order in which the drivers are tried so this note won't have to be updated again in the future, like --gpu-context's documentation does.