### PR TITLE
vo_gpu_next: respect d3d11 swapchain output format preference

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5762,6 +5762,11 @@ them.
         from Windows 10. Thus on older systems it will only automatically
         utilize the rgba8 output format.
 
+    .. note::
+
+        For ``--vo=gpu-next``, this is used as a best-effort hint and
+        libplacebo has the last say on which format is utilized.
+
 ``--d3d11-output-csp=<auto|srgb|linear|pq|bt.2020>``
     Select a specific D3D11 output color space to utilize for D3D11 rendering.
     "auto" is the default, which will select the color space of the desktop

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -521,6 +521,16 @@ IDXGISwapChain *ra_d3d11_ctx_get_swapchain(struct ra_ctx *ra)
     return p->swapchain;
 }
 
+bool ra_d3d11_ctx_prefer_8bit_output_format(struct ra_ctx *ra)
+{
+    if (ra->swapchain->fns != &d3d11_swapchain)
+        return false;
+
+    struct priv *p = ra->priv;
+
+    return p->opts->output_format == DXGI_FORMAT_R8G8B8A8_UNORM;
+}
+
 const struct ra_ctx_fns ra_ctx_d3d11 = {
     .type     = "d3d11",
     .name     = "d3d11",

--- a/video/out/d3d11/context.h
+++ b/video/out/d3d11/context.h
@@ -7,3 +7,7 @@
 // Get the underlying D3D11 swap chain from an RA context. The returned swap chain is
 // refcounted and must be released by the caller.
 IDXGISwapChain *ra_d3d11_ctx_get_swapchain(struct ra_ctx *ra);
+
+// Returns true if an 8-bit output format is explicitly requested for
+// d3d11-output-format for an RA context.
+bool ra_d3d11_ctx_prefer_8bit_output_format(struct ra_ctx *ra);

--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -88,6 +88,7 @@ static bool d3d11_pl_init(struct vo *vo, struct gpu_ctx *ctx,
     ctx->swapchain = pl_d3d11_create_swapchain(d3d11,
         pl_d3d11_swapchain_params(
             .swapchain = swapchain,
+            .disable_10bit_sdr = ra_d3d11_ctx_prefer_8bit_output_format(ctx->ra_ctx),
         )
     );
     if (!ctx->swapchain) {


### PR DESCRIPTION
Currently, libplacebo always tries to reconfigure the d3d11 swapchain to a 10-bit output format because disable_10bit_sdr isn't set to true, even when an 8-bit format is explicitly requested via `--d3d11-output-format`.

Fix this by passing the requested output format preference to libplacebo.
