### PR TITLE
win32: support `--alpha=yes`

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -512,6 +512,11 @@ error:
     return false;
 }
 
+static void d3d11_update_render_opts(struct ra_ctx *ctx)
+{
+    vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
+}
+
 IDXGISwapChain *ra_d3d11_ctx_get_swapchain(struct ra_ctx *ra)
 {
     if (ra->swapchain->fns != &d3d11_swapchain)
@@ -535,10 +540,11 @@ bool ra_d3d11_ctx_prefer_8bit_output_format(struct ra_ctx *ra)
 }
 
 const struct ra_ctx_fns ra_ctx_d3d11 = {
-    .type     = "d3d11",
-    .name     = "d3d11",
-    .reconfig = d3d11_reconfig,
-    .control  = d3d11_control,
-    .init     = d3d11_init,
-    .uninit   = d3d11_uninit,
+    .type               = "d3d11",
+    .name               = "d3d11",
+    .reconfig           = d3d11_reconfig,
+    .control            = d3d11_control,
+    .update_render_opts = d3d11_update_render_opts,
+    .init               = d3d11_init,
+    .uninit             = d3d11_uninit,
 };

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -479,6 +479,9 @@ static bool d3d11_init(struct ra_ctx *ctx)
     if (!vo_w32_init(ctx->vo))
         goto error;
 
+    if (ctx->opts.want_alpha)
+        vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
+
     UINT usage = DXGI_USAGE_RENDER_TARGET_OUTPUT | DXGI_USAGE_SHADER_INPUT;
     if (ID3D11Device_GetFeatureLevel(p->device) >= D3D_FEATURE_LEVEL_11_0 &&
         p->opts->output_format != DXGI_FORMAT_B8G8R8A8_UNORM)

--- a/video/out/opengl/context_win.c
+++ b/video/out/opengl/context_win.c
@@ -96,8 +96,7 @@ static bool create_dc(struct ra_ctx *ctx)
 
     pfd.iPixelType = PFD_TYPE_RGBA;
     pfd.cColorBits = 24;
-    if (ctx->opts.want_alpha)
-        pfd.cAlphaBits = 8;
+    pfd.cAlphaBits = 8;
     pfd.iLayerType = PFD_MAIN_PLANE;
     int pf = ChoosePixelFormat(hdc, &pfd);
 
@@ -373,11 +372,17 @@ static int wgl_control(struct ra_ctx *ctx, int *events, int request, void *arg)
     return ret;
 }
 
+static void wgl_update_render_opts(struct ra_ctx *ctx)
+{
+    vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
+}
+
 const struct ra_ctx_fns ra_ctx_wgl = {
-    .type           = "opengl",
-    .name           = "win",
-    .init           = wgl_init,
-    .reconfig       = wgl_reconfig,
-    .control        = wgl_control,
-    .uninit         = wgl_uninit,
+    .type               = "opengl",
+    .name               = "win",
+    .init               = wgl_init,
+    .reconfig           = wgl_reconfig,
+    .control            = wgl_control,
+    .update_render_opts = wgl_update_render_opts,
+    .uninit             = wgl_uninit,
 };

--- a/video/out/opengl/context_win.c
+++ b/video/out/opengl/context_win.c
@@ -96,6 +96,8 @@ static bool create_dc(struct ra_ctx *ctx)
 
     pfd.iPixelType = PFD_TYPE_RGBA;
     pfd.cColorBits = 24;
+    if (ctx->opts.want_alpha)
+        pfd.cAlphaBits = 8;
     pfd.iLayerType = PFD_MAIN_PLANE;
     int pf = ChoosePixelFormat(hdc, &pfd);
 
@@ -292,6 +294,9 @@ static bool wgl_init(struct ra_ctx *ctx)
 
     if (!vo_w32_init(ctx->vo))
         goto fail;
+
+    if (ctx->opts.want_alpha)
+        vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
 
     vo_w32_run_on_thread(ctx->vo, create_ctx, ctx);
     if (!p->context)

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -50,6 +50,9 @@ static bool win_init(struct ra_ctx *ctx)
     if (!vo_w32_init(ctx->vo))
         goto error;
 
+    if (ctx->opts.want_alpha)
+        vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
+
     VkWin32SurfaceCreateInfoKHR wininfo = {
          .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
          .hinstance = HINST_THISCOMPONENT,
@@ -96,11 +99,17 @@ static int win_control(struct ra_ctx *ctx, int *events, int request, void *arg)
     return ret;
 }
 
+static void win_update_render_opts(struct ra_ctx *ctx)
+{
+    vo_w32_set_transparency(ctx->vo, ctx->opts.want_alpha);
+}
+
 const struct ra_ctx_fns ra_ctx_vulkan_win = {
-    .type           = "vulkan",
-    .name           = "winvk",
-    .reconfig       = win_reconfig,
-    .control        = win_control,
-    .init           = win_init,
-    .uninit         = win_uninit,
+    .type               = "vulkan",
+    .name               = "winvk",
+    .reconfig           = win_reconfig,
+    .control            = win_control,
+    .update_render_opts = win_update_render_opts,
+    .init               = win_init,
+    .uninit             = win_uninit,
 };

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -2245,3 +2245,24 @@ void vo_w32_run_on_thread(struct vo *vo, void (*cb)(void *ctx), void *ctx)
     struct vo_w32_state *w32 = vo->w32;
     mp_dispatch_run(w32->dispatch, cb, ctx);
 }
+
+void vo_w32_set_transparency(struct vo *vo, bool enable)
+{
+    struct vo_w32_state *w32 = vo->w32;
+    if (w32->parent)
+        return;
+
+    DWM_BLURBEHIND dbb = {0};
+    if (enable) {
+        HRGN rgn = CreateRectRgn(0, 0, -1, -1);
+        dbb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+        dbb.hRgnBlur = rgn;
+        dbb.fEnable = TRUE;
+        DwmEnableBlurBehindWindow(w32->window, &dbb);
+        DeleteObject(rgn);
+    } else {
+        dbb.dwFlags = DWM_BB_ENABLE;
+        dbb.fEnable = FALSE;
+        DwmEnableBlurBehindWindow(w32->window, &dbb);
+    }
+}

--- a/video/out/w32_common.h
+++ b/video/out/w32_common.h
@@ -32,5 +32,6 @@ int vo_w32_control(struct vo *vo, int *events, int request, void *arg);
 void vo_w32_config(struct vo *vo);
 HWND vo_w32_hwnd(struct vo *vo);
 void vo_w32_run_on_thread(struct vo *vo, void (*cb)(void *ctx), void *ctx);
+void vo_w32_set_transparency(struct vo *vo, bool enable);
 
 #endif /* MPLAYER_W32_COMMON_H */


### PR DESCRIPTION
This adds support for `--alpha=yes` for `--gpu-api=d3d11` (with `--d3d11-flip=no`) and `--gpu-api=opengl` on win32. 
