### PR TITLE
Revert "console.lua: hide the cursor when unfocused"

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -384,8 +384,7 @@ function update()
     -- horizontal borders.
     local cheight = opts.font_size * 8
     local cglyph = '{\\r' ..
-                   (mp.get_property_native('focused') == false
-                    and '\\alpha&HFF&' or '\\1a&H44&\\3a&H44&\\4a&H99&') ..
+                   '\\1a&H44&\\3a&H44&\\4a&H99&' ..
                    '\\1c&Heeeeee&\\3c&Heeeeee&\\4c&H000000&' ..
                    '\\xbord0.5\\ybord0\\xshad0\\yshad1\\p4\\pbo24}' ..
                    'm 0 0 l 1 0 l 1 ' .. cheight .. ' l 0 ' .. cheight ..
@@ -1318,7 +1317,6 @@ end)
 mp.observe_property('osd-width', 'native', update)
 mp.observe_property('osd-height', 'native', update)
 mp.observe_property('display-hidpi-scale', 'native', update)
-mp.observe_property('focused', nil, update)
 
 -- Enable log messages. In silent mode, mpv will queue log messages in a buffer
 -- until enable_messages is called again without the silent: prefix.


### PR DESCRIPTION
Apparently it is not safe to call voctrl, there seem to be race condition when vo is initializing. Patch can be reapplied when this issue is resolved.

This reverts commit 28b21e4ab7ca00aecc4246d9185bf77f92db98d2.