### PR TITLE
DOCS/lua: note that properties are preferred to getcwd and getpid

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -726,7 +726,7 @@ strictly part of the guaranteed API.
 
 ``utils.getcwd()``
     Returns the directory that mpv was launched from. On error, ``nil, error``
-    is returned.
+    is returned. This merely retrieves the ``working-directory`` property.
 
 ``utils.readdir(path [, filter])``
     Enumerate all entries at the given path on the filesystem, and return them
@@ -830,7 +830,8 @@ strictly part of the guaranteed API.
 
 ``utils.getpid()``
     Returns the process ID of the running mpv process. This can be used to identify
-    the calling mpv when launching (detached) subprocesses.
+    the calling mpv when launching (detached) subprocesses. This merely retrieves
+    the ``pid`` property.
 
 ``utils.get_env_list()``
     Returns the C environment as a list of strings. (Do not confuse this with


### PR DESCRIPTION
This prevents script writers from getting confused over whether to use these functions or the properties, like in
https://github.com/mpv-player/mpv/issues/7975#issuecomment-1875913750

They are moved to the end of the list of utils functions because having the first one in the list be a deprecated one would be weird.