### PR TITLE
terminal-unix: signal related fixes

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -257,7 +257,9 @@ void mp_msg_flush_status_line(struct mp_log *log, bool clear)
         goto done;
 
     if (!clear) {
-        fprintf(stderr, TERM_ESC_RESTORE_CURSOR "\n");
+        if (log->root->isatty[STDERR_FILENO])
+            fprintf(stderr, TERM_ESC_RESTORE_CURSOR);
+        fprintf(stderr, "\n");
         log->root->blank_lines = 0;
         log->root->status_lines = 0;
         goto done;

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -424,8 +424,10 @@ static MP_THREAD_VOID terminal_thread(void *ptr)
             (void)read(stop_cont_pipe[0], &c, 1);
             if (c == PIPE_STOP) {
                 do_deactivate_getch2();
-                (void)write(STDERR_FILENO, TERM_ESC_RESTORE_CURSOR,
-                            sizeof(TERM_ESC_RESTORE_CURSOR) - 1);
+                if (isatty(STDERR_FILENO)) {
+                    (void)write(STDERR_FILENO, TERM_ESC_RESTORE_CURSOR,
+                                sizeof(TERM_ESC_RESTORE_CURSOR) - 1);
+                }
                 // trying to reset SIGTSTP handler to default and raise it will
                 // result in a race and there's no other way to invoke the
                 // default handler. so just invoke SIGSTOP since it's

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -465,10 +465,6 @@ void terminal_setup_getch(struct input_ctx *ictx)
 
     if (mp_make_wakeup_pipe(death_pipe) < 0)
         return;
-    if (mp_make_wakeup_pipe(stop_cont_pipe) < 0) {
-        close_sig_pipes();
-        return;
-    }
 
     // Disable reading from the terminal even if stdout is not a tty, to make
     //   mpv ... | less
@@ -549,6 +545,11 @@ void terminal_init(void)
 {
     assert(!getch2_enabled);
     getch2_enabled = 1;
+
+    if (mp_make_wakeup_pipe(stop_cont_pipe) < 0) {
+        getch2_enabled = 0;
+        return;
+    }
 
     tty_in = tty_out = open("/dev/tty", O_RDWR | O_CLOEXEC);
     if (tty_in < 0) {


### PR DESCRIPTION
Some signal handler related fixes. Also incorporates the `isatty` change from https://github.com/mpv-player/mpv/pull/13224.