### PR TITLE
ao: not start AO when receiving EOF data.

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -656,10 +656,14 @@ static bool ao_play_data(struct ao *ao)
         MP_STATS(ao, "end ao fill");
 
         if (!p->streaming) {
-            MP_VERBOSE(ao, "starting AO\n");
-            ao->driver->start(ao);
-            p->streaming = true;
-            state.playing = true;
+            if (got_eof) {
+                MP_WARN(ao, "Error starting AO with EOF data.\n");
+            } else {
+                MP_VERBOSE(ao, "starting AO\n");
+                ao->driver->start(ao);
+                p->streaming = true;
+                state.playing = true;
+            }
         }
     }
 


### PR DESCRIPTION
When mpv resumes audio from underrun state, if the first audio data contains EOF. mpv may get stuck in an infinite loop. `ao->buffer_state->playing` is true and does not change anymore, repeat `blocked, waiting for old audio to play` on the function fill_audio_out_buffers().
Pulse Audio continues to request data and calls stream_request_cb(). pa_stream_writable_size() continues to increase. mpv hangs and cannot play video, until `Failed to allocate buffer`.

buffer.c: To resolve this issue, not start AO when receiving EOF data.

Fixes: #13242

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.