### PR TITLE
[RFC] TOOLS/lua/autoload: add ignore_patterns option

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -28,7 +28,7 @@ additional_audio_exts=list,of,ext
 ignore_hidden=yes
 same_type=yes
 directory_mode=recursive
-ignore_patterns=^~,^bak-,%.bak%.mp4$
+ignore_patterns=^~,^bak-,%.bak$
 
 --]]
 


### PR DESCRIPTION
Why? Sometimes you want to ignore thumbnails, auto-generated backups or just unwanted files. And here is a non-exhaustive list of real-world examples:
- user backup files: `%.bak%.mp4$` or `^bak-`;
- telegram-desktop chat export thumbnails: `_thumb%.jpg$`;
- a krita graphics editor backup suffix: `^~`

But it's an RFC because... there is little point in a single pattern. It would be better if we could configure a list of patterns. But... Should we just split by commas or write a custom parser for `ignore_pattern` that allows to escape commas? Maybe something else?