### PR TITLE
TOOLS/lua/autoload: skip loading when playback is aborted

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -211,6 +211,12 @@ function scan_dir(path, current_file, dir_mode, separator, dir_depth, total_file
 end
 
 function find_and_add_entries()
+    local aborted = mp.get_property_native("playback-abort")
+    if aborted then
+        msg.debug("stopping: playback aborted")
+        return
+    end
+
     local path = mp.get_property("path", "")
     local dir, filename = utils.split_path(path)
     msg.trace(("dir: %s, filename: %s"):format(dir, filename))


### PR DESCRIPTION
> Quickly going through a directory with too many loadable files causes the autoload tasks to pile up and exiting the player will take forever. Avoid this by skipping loading when playback is aborted.

Not sure if it's the best way to do it but it does speed up exiting when there are too many autoload tasks queued (happens to me when I'm going through a folder with thousands of images).

EDIT:

Related: https://github.com/mpv-player/mpv/issues/12563. I think what @Obegg really meant seems to be the same as what I've described here.

`autoload.lua` can block quitting when it can't catch up with the incoming `start-file` events. Checking the `playback-abort` property ensures at most one autoload task is really executed on quitting and it seems to keep the script's behavior in normal cases. A smarter approach might be to check the number of queued `start-file` events or receive a preemptive signal about player exiting, but there doesn't seem to be an API available for this.