### PR TITLE
github/workflows: don't install angleproject on msys2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,6 @@ jobs:
           update: true
           install: git
           pacboy: >-
-            angleproject:p
             ca-certificates:p
             cc:p
             diffutils:p

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -7,8 +7,6 @@ meson setup build            \
   -D d3d-hwaccel=enabled     \
   -D d3d11=enabled           \
   -D dvdnav=enabled          \
-  -D egl-angle-lib=enabled   \
-  -D egl-angle-win32=enabled \
   -D jpeg=enabled            \
   -D lcms2=enabled           \
   -D libarchive=enabled      \


### PR DESCRIPTION
This package isn't available for i686 anymore, and not worth the hassle to only install it for win64 since it isn't particularly useful.

See: https://github.com/msys2/MINGW-packages/commit/fff2fa3711e3cf1c9b65b12784ab3d9428a779f1