### PR TITLE
terminal-unix: don't set `SA_RESETHAND` for quit request signals

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -492,8 +492,8 @@ void terminal_setup_getch(struct input_ctx *ictx)
     }
 
     setsigaction(SIGINT,  quit_request_sighandler, SA_RESETHAND, false);
-    setsigaction(SIGQUIT, quit_request_sighandler, SA_RESETHAND, false);
-    setsigaction(SIGTERM, quit_request_sighandler, SA_RESETHAND, false);
+    setsigaction(SIGQUIT, quit_request_sighandler, 0, true);
+    setsigaction(SIGTERM, quit_request_sighandler, 0, true);
 }
 
 void terminal_uninit(void)


### PR DESCRIPTION
This can cause mpv to abruptly quit without following the proper uninit
process when a second `SIGTERM` or `SIGQUIT` is sent and mpv
didn't quit on the first one already. This is because the default action
for these signals is to terminate the program immediately, similar to
`SIGKILL`, and `SA_RESETHAND` resets the `quit_request_sighandler` to
`SIG_DFL` for the default action.

Also keep the `SA_RESETHAND` flag for SIGINT because the current
behavior is to quit after receiving two Ctrl+C no matter what, this is
probably convenient and worth keeping.

This change is because it was too easy to send multiple quit requests
accidentally or before mpv is prepared to handle these signals during
preinit.

An easy way to reproduce is with `timeout 1 mpv [...]` where mpv would
quit abruptly anywhere from half the time to once every 50 attempts
depending on your luck.
