### PR TITLE
DOCS/mpv: the playback position is not remembered after poweroff

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1122,10 +1122,10 @@ commands ``quit-watch-later`` (bound to Shift+Q by default) and
 
 The difference between always quitting with a key bound to ``quit-watch-later``
 and using ``--save-position-on-quit`` is that the latter will save the playback
-position even when mpv is closed with a method other than a keybinding, for
-example if you shutdown your system without closing mpv beforehand, unless of
-course mpv is terminated abruptly and doesn't have the time to save (e.g. with
-the KILL Unix signal).
+position even when mpv is closed with a method other than a keybinding, such as
+clicking the close button in the window title bar. However if mpv is terminated
+abruptly and doesn't have the time to save, then the position will not be saved.
+For example, if you shutdown your system without closing mpv beforehand.
 
 mpv also stores options other than the playback position when they have been
 modified after playback began, for example the volume and selected audio/subtitles,


### PR DESCRIPTION
This doesn't actually work on either Windows or Linux with --terminal. With --no-terminal or --no-input-terminal the SIGTERM handler is never registered, so it definitely can't work.

Just remove the note about signals because it would be complicated to explain that they don't terminate abruptly only with --terminal and only if that signal has a handler, and it wouldn't be of interest to most users.