### PR TITLE
command: restore lang after track reload

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5736,6 +5736,10 @@ static void cmd_track_reload(void *p)
     }
 
     struct track *nt = mpctx->tracks[nt_num];
+
+    if (!nt->lang)
+        nt->lang = mp_guess_lang_from_filename(nt, nt->external_filename);
+
     mp_switch_track(mpctx, nt->type, nt, 0);
     print_track_list(mpctx, "Reloaded:");
 }

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -142,6 +142,14 @@ static struct bstr guess_lang_from_filename(struct bstr name, int *fn_start)
     return (struct bstr){name.start + i + 1, n};
 }
 
+char *mp_guess_lang_from_filename(void* ctx, const char *filename)
+{
+    bstr filename_no_ext = bstr_strip_ext(bstr0(filename));
+    int start = 0; // only used in append_dir_subtitles()
+    char *lang = bstrto0(ctx, guess_lang_from_filename(filename_no_ext, &start));
+    return lang;
+}
+
 static void append_dir_subtitles(struct mpv_global *global, struct MPOpts *opts,
                                  struct subfn **slist, int *nsub,
                                  struct bstr path, const char *fname,

--- a/player/external_files.h
+++ b/player/external_files.h
@@ -34,5 +34,6 @@ struct subfn *find_external_files(struct mpv_global *global, const char *fname,
 
 bool mp_might_be_subtitle_file(const char *filename);
 void mp_update_subtitle_exts(struct MPOpts *opts);
+char *mp_guess_lang_from_filename(void *talloc_ctx, const char *filename);
 
 #endif /* MPLAYER_FINDFILES_H */


### PR DESCRIPTION
If a track's language was guessed from its filename, the commands that reload the track, like sub-reload, remove it. Fix this by calling guess_lang_from_filename() again.

Note that backing up t->lang and restoring it if nt->lang is NULL would work incorrectly when lang is in the stream and it is removed before reloading.