### PR TITLE
sub: add `--sub-lavc-o` option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2313,6 +2313,13 @@ Subtitles
     Force subtitle demuxer type for ``--sub-file``. Give the demuxer name as
     printed by ``--sub-demuxer=help``.
 
+``--sub-lavc-o=<key>=<value>[,<key>=<value>[,...]]``
+    Pass AVOptions to libavcodec decoder. Note, a patch to make the o=
+    unneeded and pass all unknown options through the AVOption system is
+    welcome. A full list of AVOptions can be found in the FFmpeg manual.
+
+    This is a key/value list option. See `List Options`_ for details.
+
 ``--sub-delay=<sec>``
     Delays primary subtitles by ``<sec>`` seconds. Can be negative.
 

--- a/options/options.c
+++ b/options/options.c
@@ -321,6 +321,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"teletext-page", OPT_INT(teletext_page), M_RANGE(1, 999)},
         {"sub-past-video-end", OPT_BOOL(sub_past_video_end)},
         {"sub-ass-force-style", OPT_REPLACED("sub-ass-style-overrides")},
+        {"sub-lavc-o", OPT_KEYVALUELIST(sub_avopts)},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),

--- a/options/options.h
+++ b/options/options.h
@@ -113,6 +113,7 @@ struct mp_subtitle_opts {
     bool sub_clear_on_seek;
     int teletext_page;
     bool sub_past_video_end;
+    char **sub_avopts;
 };
 
 // Options for both primary and secondary subs.

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -96,6 +96,9 @@ static int init(struct sd *sd)
     ctx = avcodec_alloc_context3(sub_codec);
     if (!ctx)
         goto error;
+
+    mp_set_avopts(sd->log, ctx, sd->opts->sub_avopts);
+
     priv->avpkt = av_packet_alloc();
     if (!priv->avpkt)
         goto error;


### PR DESCRIPTION
 We have `--vd-lavc-o` and `--ad-lavc-o`, but no equivalent option for
 subtitles.