### PR TITLE
command: add `load-config-file` and `load-input-conf`

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -43,6 +43,7 @@ Interface changes
     - remove `--term-remaining-playtime` option
     - change fallback deinterlace to bwdif
     - add the command `load-config-file`
+    - add the command `load-input-conf`
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -42,6 +42,7 @@ Interface changes
     - add `forced` choice to `subs-with-matching-audio`
     - remove `--term-remaining-playtime` option
     - change fallback deinterlace to bwdif
+    - add the command `load-config-file`
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1341,6 +1341,11 @@ Input Commands that are Possibly Subject to Change
     was already included, its previous options are not reset before it is
     reparsed.
 
+``load-input-conf <filename>``
+    Load an input configuration file, similar to the ``--input-conf`` option. If
+    the file was already included, its previous bindings are not reset before it
+    is reparsed.
+
 ``load-script <filename>``
     Load a script, similar to the ``--script`` option. Whether this waits for
     the script to finish initialization or not changed multiple times, and the

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1336,6 +1336,11 @@ Input Commands that are Possibly Subject to Change
         relevant mode. Prints a warning if nothing could be done. See
         `Runtime profiles`_ for details.
 
+``load-config-file <filename>``
+    Load a configuration file, similar to the ``--include`` option. If the file
+    was already included, its previous options are not reset before it is
+    reparsed.
+
 ``load-script <filename>``
     Load a script, similar to the ``--script`` option. Whether this waits for
     the script to finish initialization or not changed multiple times, and the

--- a/input/input.c
+++ b/input/input.c
@@ -1395,6 +1395,14 @@ void mp_input_load_config(struct input_ctx *ictx)
     input_unlock(ictx);
 }
 
+bool mp_input_load_config_file(struct input_ctx *ictx, char *file)
+{
+    input_lock(ictx);
+    bool result = parse_config_file(ictx, file);
+    input_unlock(ictx);
+    return result;
+}
+
 static void clear_queue(struct cmd_queue *queue)
 {
     while (queue->first) {

--- a/input/input.c
+++ b/input/input.c
@@ -1276,9 +1276,9 @@ static int parse_config(struct input_ctx *ictx, bool builtin, bstr data,
     return n_binds;
 }
 
-static int parse_config_file(struct input_ctx *ictx, char *file)
+static bool parse_config_file(struct input_ctx *ictx, char *file)
 {
-    int r = 0;
+    bool r = false;
     void *tmp = talloc_new(NULL);
     stream_t *s = NULL;
 
@@ -1295,7 +1295,7 @@ static int parse_config_file(struct input_ctx *ictx, char *file)
         MP_VERBOSE(ictx, "Parsing input config file %s\n", file);
         int num = parse_config(ictx, false, data, file, NULL);
         MP_VERBOSE(ictx, "Input config file %s parsed: %d binds\n", file, num);
-        r = 1;
+        r = true;
     } else {
         MP_ERR(ictx, "Error reading input config file %s\n", file);
     }

--- a/input/input.c
+++ b/input/input.c
@@ -1276,7 +1276,7 @@ static int parse_config(struct input_ctx *ictx, bool builtin, bstr data,
     return n_binds;
 }
 
-static int parse_config_file(struct input_ctx *ictx, char *file, bool warn)
+static int parse_config_file(struct input_ctx *ictx, char *file)
 {
     int r = 0;
     void *tmp = talloc_new(NULL);
@@ -1376,13 +1376,13 @@ void mp_input_load_config(struct input_ctx *ictx)
 
     bool config_ok = false;
     if (ictx->opts->config_file && ictx->opts->config_file[0])
-        config_ok = parse_config_file(ictx, ictx->opts->config_file, true);
+        config_ok = parse_config_file(ictx, ictx->opts->config_file);
     if (!config_ok) {
         // Try global conf dir
         void *tmp = talloc_new(NULL);
         char **files = mp_find_all_config_files(tmp, ictx->global, "input.conf");
         for (int n = 0; files && files[n]; n++)
-            parse_config_file(ictx, files[n], false);
+            parse_config_file(ictx, files[n]);
         talloc_free(tmp);
     }
 

--- a/input/input.h
+++ b/input/input.h
@@ -178,7 +178,11 @@ struct input_ctx *mp_input_init(struct mpv_global *global,
                                 void (*wakeup_cb)(void *ctx),
                                 void *wakeup_ctx);
 
+// Load the configured input.conf files.
 void mp_input_load_config(struct input_ctx *ictx);
+
+// Load a specific input.conf file.
+bool mp_input_load_config_file(struct input_ctx *ictx, char *file);
 
 void mp_input_update_opts(struct input_ctx *ictx);
 

--- a/player/command.c
+++ b/player/command.c
@@ -6288,6 +6288,15 @@ static void cmd_load_config_file(void *p)
     mp_notify_property(mpctx, "profile-list");
 }
 
+static void cmd_load_input_conf(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    char *config_file = cmd->args[0].v.s;
+    cmd->success = mp_input_load_config_file(mpctx->input, config_file);
+}
+
 static void cmd_load_script(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6826,6 +6835,8 @@ const struct mp_cmd_def mp_cmds[] = {
     },
 
     { "load-config-file", cmd_load_config_file, {{"filename", OPT_STRING(v.s)}} },
+
+    { "load-input-conf", cmd_load_input_conf, {{"filename", OPT_STRING(v.s)}} },
 
     { "load-script", cmd_load_script, {{"filename", OPT_STRING(v.s)}} },
 

--- a/player/command.c
+++ b/player/command.c
@@ -55,6 +55,7 @@
 #include "options/m_option.h"
 #include "options/m_property.h"
 #include "options/m_config_frontend.h"
+#include "options/parse_configfile.h"
 #include "osdep/getpid.h"
 #include "video/out/gpu/context.h"
 #include "video/out/vo.h"
@@ -6270,6 +6271,23 @@ static void cmd_apply_profile(void *p)
     }
 }
 
+static void cmd_load_config_file(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    char *config_file = cmd->args[0].v.s;
+    int r = m_config_parse_config_file(mpctx->mconfig, mpctx->global,
+                                       config_file, NULL, 0);
+
+    if (r < 1) {
+        cmd->success = false;
+        return;
+    }
+
+    mp_notify_property(mpctx, "profile-list");
+}
+
 static void cmd_load_script(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6806,6 +6824,8 @@ const struct mp_cmd_def mp_cmds[] = {
         {"mode", OPT_CHOICE(v.i, {"apply", 0}, {"restore", 1}),
             .flags = MP_CMD_OPT_ARG}, }
     },
+
+    { "load-config-file", cmd_load_config_file, {{"filename", OPT_STRING(v.s)}} },
 
     { "load-script", cmd_load_script, {{"filename", OPT_STRING(v.s)}} },
 


### PR DESCRIPTION
This adds the commands `load-config-file` and `load-input-conf`. They can be used to auto reload configuration files, e.g. in vim:

```vim
autocmd BufWritePost ~/.config/mpv/mpv.conf silent !echo load-config-file %:p | socat - /tmp/mpvsocket
autocmd BufWritePost ~/.config/mpv/input.conf silent !echo load-input-conf %:p | socat - /tmp/mpvsocket
```

Partially fixes #6362. This is simpler than spawning a thread to observe changes to these files with inotify and doing the equivalent on each platform, but it relies on users configuring their text editor.