### PR TITLE
Revert "vo_gpu: remove --scaler-lut-size"

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5469,6 +5469,14 @@ them.
         Scale parameter (t). Increasing this makes the window wider. Defaults
         to 1.
 
+``--scaler-lut-size=<4..10>``
+    Set the size of the lookup texture for scaler kernels (default: 6). The
+    actual size of the texture is ``2^N`` for an option value of ``N``. So the
+    lookup texture with the default setting uses 64 samples.
+
+    All weights are linearly interpolated from those samples, so increasing
+    the size of lookup table might improve the accuracy of scaler.
+
 ``--scaler-resizes-only``
     Disable the scaler if the video image is not resized. In that case,
     ``bilinear`` is used instead of whatever is set with ``--scale``. Bilinear

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -55,6 +55,7 @@ scale=ewa_lanczossharp
 hdr-peak-percentile=99.995
 hdr-contrast-recovery=0.30
 deband=yes
+scaler-lut-size=8
 
 # Deprecated alias
 [gpu-hq]

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -311,6 +311,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .correct_downscaling = true,
     .linear_downscaling = true,
     .sigmoid_upscaling = true,
+    .scaler_lut_size = 6,
     .interpolation_threshold = 0.01,
     .alpha_mode = ALPHA_BLEND_TILES,
     .background = {0, 0, 0, 255},
@@ -425,7 +426,7 @@ const struct m_sub_options gl_video_conf = {
         SCALER_OPTS("dscale", SCALER_DSCALE),
         SCALER_OPTS("cscale", SCALER_CSCALE),
         SCALER_OPTS("tscale", SCALER_TSCALE),
-        {"scaler-lut-size", OPT_REMOVED("hard-coded as 8")},
+        {"scaler-lut-size", OPT_INT(scaler_lut_size), M_RANGE(4, 10)},
         {"scaler-resizes-only", OPT_BOOL(scaler_resizes_only)},
         {"correct-downscaling", OPT_BOOL(correct_downscaling)},
         {"linear-downscaling", OPT_BOOL(linear_downscaling)},
@@ -1787,16 +1788,17 @@ static void reinit_scaler(struct gl_video *p, struct scaler *scaler,
     int stride = width * num_components;
     assert(size <= stride);
 
-    static const int lut_size = 256;
-    float *weights = talloc_array(NULL, float, lut_size * stride);
-    mp_compute_lut(scaler->kernel, lut_size, stride, weights);
+    scaler->lut_size = 1 << p->opts.scaler_lut_size;
+
+    float *weights = talloc_array(NULL, float, scaler->lut_size * stride);
+    mp_compute_lut(scaler->kernel, scaler->lut_size, stride, weights);
 
     bool use_1d = scaler->kernel->polar && (p->ra->caps & RA_CAP_TEX_1D);
 
     struct ra_tex_params lut_params = {
         .dimensions = use_1d ? 1 : 2,
-        .w = use_1d ? lut_size : width,
-        .h = use_1d ? 1 : lut_size,
+        .w = use_1d ? scaler->lut_size : width,
+        .h = use_1d ? 1 : scaler->lut_size,
         .d = 1,
         .format = fmt,
         .render_src = true,

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -52,6 +52,7 @@ struct scaler {
     struct ra_tex *lut;
     struct ra_tex *sep_fbo;
     bool insufficient;
+    int lut_size;
 
     // kernel points here
     struct filter_kernel kernel_storage;
@@ -132,6 +133,7 @@ struct gl_tone_map_opts {
 struct gl_video_opts {
     int dumb_mode;
     struct scaler_config scaler[4];
+    int scaler_lut_size;
     float gamma;
     bool gamma_auto;
     int target_prim;

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -41,7 +41,7 @@ static void pass_sample_separated_get_weights(struct gl_shader_cache *sc,
                                               struct scaler *scaler)
 {
     gl_sc_uniform_texture(sc, "lut", scaler->lut);
-    GLSLF("float ypos = LUT_POS(fcoord, %d.0);\n", scaler->lut->params.h);
+    GLSLF("float ypos = LUT_POS(fcoord, %d.0);\n", scaler->lut_size);
 
     int N = scaler->kernel->size;
     int width = (N + 3) / 4; // round up
@@ -123,10 +123,10 @@ static void polar_sample(struct gl_shader_cache *sc, struct scaler *scaler,
     // get the weight for this pixel
     if (scaler->lut->params.dimensions == 1) {
         GLSLF("w = tex1D(lut, LUT_POS(d * 1.0/%f, %d.0)).r;\n",
-              radius, scaler->lut->params.w);
+              radius, scaler->lut_size);
     } else {
         GLSLF("w = texture(lut, vec2(0.5, LUT_POS(d * 1.0/%f, %d.0))).r;\n",
-              radius, scaler->lut->params.h);
+              radius, scaler->lut_size);
     }
     GLSL(wsum += w;)
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1935,6 +1935,7 @@ static void update_render_options(struct vo *vo)
     struct priv *p = vo->priv;
     pl_options pars = p->pars;
     const struct gl_video_opts *opts = p->opts_cache->opts;
+    pars->params.lut_entries = 1 << opts->scaler_lut_size;
     pars->params.antiringing_strength = opts->scaler[0].antiring;
     pars->params.background_color[0] = opts->background.r / 255.0;
     pars->params.background_color[1] = opts->background.g / 255.0;


### PR DESCRIPTION
This reverts commit 44cf6288c73b71d22a98870cb08b1daf9da5e048.

Fixes issue: #13273 
`scaler-lut-size=8` causes a performance regression on my machine, therefore it'd be a good idea to keep the default at `6` and add it to `profile=high-quality`