### PR TITLE
player: make `--loop-file` gapless

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -874,7 +874,7 @@ static void handle_loop_file(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
 
-    if (mpctx->stop_play != AT_END_OF_FILE)
+    if (mpctx->video_status != STATUS_DRAINING && mpctx->video_status != STATUS_EOF)
         return;
 
     double target = MP_NOPTS_VALUE;


### PR DESCRIPTION
Don't output a black frame in between loop iterations: `write_video`
no longer outputs a frame on `logical_eof`, unless it's draining
existing ones.
Adjust `handle_loop_file` to trigger the seek slightly earlier to
avoid a stutter caused by the last frame displaying slightly too long.

---

Compared to #10748, this preserves all existing functionality (specifically everything related  to timing continues to work as before), and `--loop[-file]` is improved without adding a new option.  
This is my first time messing with mpv code, so please let me know if there's anything I can improve.

Thanks to @llyyr for mentioning #10748 in the feature request I created, #13284.
And thanks to @boxerab for that first take on this, it motivated me to dig into the code!
