### PR TITLE
OSC: Separate OSC title and window CSD text.

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1159,7 +1159,8 @@ function window_controls(topbar)
     -- Window Title
     ne = new_element("wctitle", "button")
     ne.content = function ()
-        local title = mp.command_native({"expand-text", user_opts.title})
+        local title = mp.get_property_native("title")
+        title = mp.command_native({"expand-text", title})
         -- escape ASS, and strip newlines and trailing slashes
         title = title:gsub("\\n", " "):gsub("\\$", ""):gsub("{","\\{")
         return not (title == "") and title or "mpv"


### PR DESCRIPTION
These properties were tied together but it seems like it could be useful to have these be separate properties so they can be separately customized to show different information, as both may be on screen at once.

in reference to my issue https://github.com/mpv-player/mpv/issues/13295 I decided to try to fix it myself.  I dunno what other changes should be made or if i did it in a sensible way.  it might be kinda dumb.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.