### PR TITLE
wayland_common: guard against negative configure sizes

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -890,6 +890,11 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
     struct mp_vo_opts *vo_opts = wl->vo_opts;
     struct mp_rect old_geometry = wl->geometry;
 
+    if (width < 0 || height < 0) {
+        MP_WARN(wl, "Compositor sent negative width/height values. Treating them as zero.\n");
+        width = height = 0;
+    }
+
     int old_toplevel_width = wl->toplevel_width;
     int old_toplevel_height = wl->toplevel_height;
     wl->toplevel_width = width;


### PR DESCRIPTION
Per xdg-shell protocol specification, it's not illegal for compositor to send negative width and height values. But negative values are nonsense to mpv, and can cause protocol error afterwards, like `xdg_surface::set_window_geometry` which doesn't accept negative values. Treat any negative values as zero (client determines size) for now.

Fixes https://github.com/mpv-player/mpv/issues/13301.
