### PR TITLE
command: do a normal seek instead of a refresh seek when switching vo

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7054,7 +7054,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
         handle_force_window(mpctx, true);
         reinit_video_chain(mpctx);
         if (track)
-            reselect_demux_stream(mpctx, track, true);
+            queue_seek(mpctx, MPSEEK_RELATIVE, 0.0, MPSEEK_EXACT, 0);
 
         mp_wakeup_core(mpctx);
     }


### PR DESCRIPTION
This avoids dropping the entire cache when vo is changed but tracks stay the same. Only tested on Android.

On Android, the only time that the vo is switched is when you turn off the screen or background the app. In this case, I think that a refresh seek isn't necessary, which is why I changed this line.

It is more of a *hack* than a *fix*, I would be thankful for some feedback on how to make this work on other platforms where you might switch the vo in different contexts.