### PR TITLE
player/command: reselect track after UPDATE_SUB_HARD

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6980,6 +6980,8 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
                                       (void *)(uintptr_t)flags);
                 if (ret == CONTROL_OK && flags & (UPDATE_SUB_FILT | UPDATE_SUB_HARD))
                     sub_redecode_cached_packets(sub);
+                if (track->selected)
+                    reselect_demux_stream(mpctx, track, true);
             }
         }
         osd_changed(mpctx->osd);


### PR DESCRIPTION
The lingering cache needs to be cleared so the packets don't stay forever on the screen past their welcome. Do this by simply refreshing the stream. Fixes #13148.