### PR TITLE
player: remove --term-remaining-playtime option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -40,6 +40,7 @@ Interface changes
     - add `--sub-filter-sdh-enclosures` option
     - added the `mp.input` scripting API to query the user for textual input
     - add `forced` choice to `subs-with-matching-audio`
+    - remove `--term-remaining-playtime` option
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4887,10 +4887,6 @@ Terminal
 
     See `Property Expansion`_.
 
-``--term-remaining-playtime``, ``--no-term-remaining-playtime``
-    When printing out the time on the terminal, show the remaining time adjusted by
-    playback speed. Default: ``yes``
-
 ``--term-status-msg=<string>``
     Print out a custom string during playback instead of the standard status
     line. Expands properties. See `Property Expansion`_.

--- a/options/options.c
+++ b/options/options.c
@@ -823,7 +823,6 @@ static const m_option_t mp_opts[] = {
 
     {"term-osd-bar", OPT_BOOL(term_osd_bar), .flags = UPDATE_OSD},
     {"term-osd-bar-chars", OPT_STRING(term_osd_bar_chars), .flags = UPDATE_OSD},
-    {"term-remaining-playtime", OPT_BOOL(term_remaining_playtime), .flags = UPDATE_OSD},
     {"term-title", OPT_STRING(term_title), .flags = UPDATE_OSD},
 
     {"term-playing-msg", OPT_STRING(playing_msg)},
@@ -978,7 +977,6 @@ static const struct MPOpts mp_default_opts = {
     .frame_dropping = 1,
     .term_osd = 2,
     .term_osd_bar_chars = "[-+-]",
-    .term_remaining_playtime = true,
     .consolecontrols = true,
     .playlist_pos = -1,
     .play_frames = -1,

--- a/options/options.h
+++ b/options/options.h
@@ -247,7 +247,6 @@ typedef struct MPOpts {
     int term_osd;
     bool term_osd_bar;
     char *term_osd_bar_chars;
-    bool term_remaining_playtime;
     char *term_title;
     char *playing_msg;
     char *osd_playing_msg;

--- a/player/osd.c
+++ b/player/osd.c
@@ -190,10 +190,9 @@ static char *get_term_status_msg(struct MPContext *mpctx)
     saddf(&line, ": ");
 
     // Playback position
-    double speed = opts->term_remaining_playtime ? mpctx->video_speed : 1;
     sadd_hhmmssff(&line, get_playback_time(mpctx), opts->osd_fractions);
     saddf(&line, " / ");
-    sadd_hhmmssff(&line, get_time_length(mpctx) / speed, opts->osd_fractions);
+    sadd_hhmmssff(&line, get_time_length(mpctx), opts->osd_fractions);
 
     sadd_percentage(&line, get_percent_pos(mpctx));
 


### PR DESCRIPTION
c62b45ec2ab020dad04a95aff3c85aab631b1f32 adjusted the total remaining time, but not the playback position.