### PR TITLE
[RFC] f_auto_filters: change fallback deinterlace to bwdif

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -41,6 +41,7 @@ Interface changes
     - added the `mp.input` scripting API to query the user for textual input
     - add `forced` choice to `subs-with-matching-audio`
     - remove `--term-remaining-playtime` option
+    - change fallback deinterlace to bwdif
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1667,7 +1667,7 @@ Video
 ``--deinterlace=<yes|no>``
     Enable or disable interlacing (default: no).
     Interlaced video shows ugly comb-like artifacts, which are visible on
-    fast movement. Enabling this typically inserts the yadif video filter in
+    fast movement. Enabling this typically inserts the bwdif video filter in
     order to deinterlace the video, or lets the video output apply deinterlacing
     if supported.
 

--- a/DOCS/mplayer-changes.rst
+++ b/DOCS/mplayer-changes.rst
@@ -135,7 +135,7 @@ Miscellaneous
 * Support for precise scrolling which scales the parameter of commands. If the
   input doesn't support precise scrolling the scale factor stays 1.
 * Allow changing/adjusting video filters at runtime. (This is also used to make
-  the ``D`` key insert vf_yadif if deinterlacing is not supported otherwise).
+  the ``D`` key insert vf_bwdif if deinterlacing is not supported otherwise).
 * Improved support for .cue files.
 
 Mac OS X

--- a/TOOLS/lua/autodeint.lua
+++ b/TOOLS/lua/autodeint.lua
@@ -8,7 +8,7 @@
 -- telecined and the interlacing field dominance.
 --
 -- Based on this information, it may set mpv's ``deinterlace`` property (which
--- usually inserts the yadif filter), or insert the ``pullup`` filter if the
+-- usually inserts the bwdif filter), or insert the ``pullup`` filter if the
 -- content is telecined.  It also sets field dominance with lavfi setfield.
 --
 -- OPTIONS:

--- a/filters/f_auto_filters.c
+++ b/filters/f_auto_filters.c
@@ -107,7 +107,7 @@ static void deint_process(struct mp_filter *f)
         struct mp_autoconvert *ac = mp_autoconvert_create(subf);
         if (ac) {
             filters[0] = ac->f;
-            // We know vf_yadif does not support hw inputs.
+            // We know vf_bwdif does not support hw inputs.
             mp_autoconvert_add_all_sw_imgfmts(ac);
 
             if (!mp_autoconvert_probe_input_video(ac, img)) {
@@ -121,7 +121,7 @@ static void deint_process(struct mp_filter *f)
 
         char *args[] = {"mode", "send_field", NULL};
         filters[1] =
-            mp_create_user_filter(subf, MP_OUTPUT_CHAIN_VIDEO, "yadif", args);
+            mp_create_user_filter(subf, MP_OUTPUT_CHAIN_VIDEO, "bwdif", args);
 
         mp_chain_filters(subf->ppins[0], subf->ppins[1], filters, 2);
         p->sub.filter = subf;


### PR DESCRIPTION
I don't actually deinterlace ever but allegedly this is better than yadif, and there's no real reason to not have this be the fallback deinterlace when we're not using hw frames. Also change various mentions of yadif to bwdif. Ref #12835.