### PR TITLE
osc: add osc-windowcontrols_title option

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -400,6 +400,13 @@ Configurable Options
     Supports ``left`` and ``right`` which will place the controls on those
     respective sides.
 
+``windowcontrols_title``
+    Default: ${media-title}
+
+    String that supports property expansion that will be displayed as the
+    windowcontrols title.
+    ASS tags are escaped, and newlines and trailing slashes are stripped.
+
 ``greenandgrumpy``
     Default: no
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -52,6 +52,7 @@ local user_opts = {
     boxvideo = false,           -- apply osc_param.video_margins to video
     windowcontrols = "auto",    -- whether to show window controls
     windowcontrols_alignment = "right", -- which side to show window controls on
+    windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
     greenandgrumpy = false,     -- disable santa hat
     livemarkers = true,         -- update seekbar chapter markers on duration change
     chapters_osd = true,        -- whether to show chapters OSD on next/prev
@@ -1160,7 +1161,7 @@ function window_controls(topbar)
     -- Window Title
     ne = new_element("wctitle", "button")
     ne.content = function ()
-        local title = mp.command_native({"expand-text", user_opts.title})
+        local title = mp.command_native({"expand-text", user_opts.windowcontrols_title})
         -- escape ASS, and strip newlines and trailing slashes
         title = title:gsub("\\n", " "):gsub("\\$", ""):gsub("{","\\{")
         return not (title == "") and title or "mpv"


### PR DESCRIPTION
This allows the title shown with the windowcontrols to be controlled separately from the normal osc title. Fixes #13295.