### PR TITLE
Revert "player/video: loosen logic checks for adjust_sync"

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -343,7 +343,7 @@ static void adjust_sync(struct MPContext *mpctx, double v_pts, double frame_time
 {
     struct MPOpts *opts = mpctx->opts;
 
-    if (mpctx->audio_status == STATUS_EOF)
+    if (mpctx->audio_status != STATUS_PLAYING)
         return;
 
     mpctx->delay -= frame_time;
@@ -388,7 +388,7 @@ static void handle_new_frame(struct MPContext *mpctx)
         }
     }
     mpctx->time_frame += frame_time / mpctx->video_speed;
-    if (frame_time)
+    if (mpctx->video_status >= STATUS_PLAYING)
         adjust_sync(mpctx, pts, frame_time);
     MP_TRACE(mpctx, "frametime=%5.3f\n", frame_time);
 }


### PR DESCRIPTION
This reverts commit cb2b579f61764452652c6cf5c6a94ae5e67c77ed.

This breaks files where the audio starts much later after the video since mpv reads the first audio packet even if it isn't supposed to start yet, resulting in the audio_status being STATUS_READY for the entire time mpv is "waiting" for the first audio packet to be played.