### PR TITLE
player/sub: avoid wasteful sub redraws

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2761,7 +2761,9 @@ Subtitles
     Matroska-style ASS subtitle packets. It should be unique, and libass
     uses it for fast elimination of duplicates. This option disables caching
     of subtitles across seeks, so after a seek libass can't eliminate subtitle
-    packets with the same ReadOrder as earlier packets.
+    packets with the same ReadOrder as earlier packets. Note that enabling this
+    option can result in broken subtitle behavior if you are not actually
+    playing one of the aforementioned broken mkv files.
 
 ``--teletext-page=<-1-999>``
     Select a teletext page number to decode.

--- a/demux/packet.h
+++ b/demux/packet.h
@@ -59,6 +59,9 @@ typedef struct demux_packet {
     double start, end;              // set to non-NOPTS iff segmented is set
 
     // subtitles only
+    bool animated;
+    bool seen;
+    int seen_pos;
     double sub_duration;
 
     // private

--- a/demux/packet.h
+++ b/demux/packet.h
@@ -58,6 +58,9 @@ typedef struct demux_packet {
     struct mp_codec_params *codec;  // set to non-NULL iff segmented is set
     double start, end;              // set to non-NOPTS iff segmented is set
 
+    // subtitles only
+    double sub_duration;
+
     // private
     struct demux_packet *next;
     struct AVPacket *avpacket;   // keep the buffer allocation and sidedata

--- a/player/core.h
+++ b/player/core.h
@@ -402,6 +402,9 @@ typedef struct MPContext {
     int last_chapter_seek;
     bool last_chapter_flag;
 
+    /* Heuristic for potentially redrawing subs. */
+    bool redraw_subs;
+
     bool paused;            // internal pause state
     bool playback_active;   // not paused, restarting, loading, unloading
     bool in_playloop;
@@ -621,6 +624,7 @@ void mp_load_builtin_scripts(struct MPContext *mpctx);
 int64_t mp_load_user_script(struct MPContext *mpctx, const char *fname);
 
 // sub.c
+void redraw_subs(struct MPContext *mpctx);
 void reset_subtitle_state(struct MPContext *mpctx);
 void reinit_sub(struct MPContext *mpctx, struct track *track);
 void reinit_sub_all(struct MPContext *mpctx);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -419,6 +419,7 @@ static void mp_seek(MPContext *mpctx, struct seek_params seek)
     update_ab_loop_clip(mpctx);
 
     mpctx->current_seek = seek;
+    redraw_subs(mpctx);
 }
 
 // This combines consecutive seek requests.
@@ -665,6 +666,9 @@ static void handle_osd_redraw(struct MPContext *mpctx)
     if (!want_redraw)
         return;
     vo_redraw(mpctx->video_out);
+    // Even though we just redrew, it may need to be done again for certain
+    // cases of subtitles on an image.
+    redraw_subs(mpctx);
 }
 
 static void clear_underruns(struct MPContext *mpctx)

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -312,11 +312,15 @@ static bool update_pkt_cache(struct dec_sub *sub, double video_pts)
     if (next_pts < pts || end_pts < pts) {
         if (sub->cached_pkt_pos + 1 < sub->num_cached_pkts) {
             TA_FREEP(&sub->cached_pkts[sub->cached_pkt_pos]);
+            pkt = NULL;
             sub->cached_pkt_pos++;
         }
         if (next_pts < pts)
             return true;
     }
+
+    if (pkt && pkt->animated)
+        return true;
 
     return false;
 }

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -43,7 +43,8 @@ void sub_destroy(struct dec_sub *sub);
 bool sub_can_preload(struct dec_sub *sub);
 void sub_preload(struct dec_sub *sub);
 void sub_redecode_cached_packets(struct dec_sub *sub);
-bool sub_read_packets(struct dec_sub *sub, double video_pts, bool force);
+void sub_read_packets(struct dec_sub *sub, double video_pts, bool force,
+                      bool *packets_read, bool *sub_updated);
 struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
                                     int format, double pts);
 char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -57,6 +57,8 @@ struct sd_ass_priv {
     struct mp_osd_res osd;
     int64_t *seen_packets;
     int num_seen_packets;
+    bool *packets_animated;
+    int num_packets_animated;
     bool duration_unknown;
 };
 
@@ -280,11 +282,55 @@ static int init(struct sd *sd)
     return 0;
 }
 
+// Check if subtitle has events that would cause it to be animated inside {}
+static bool is_animated(char *s)
+{
+    bool in_tag = false;
+    bool valid_event = false;
+    bool valid_tag = false;
+    while (*s) {
+        if (!in_tag && s[0] == '{')
+            in_tag = true;
+        if (s[0] == '\\') {
+            s++;
+            if (!s[0])
+                break;
+            if (s[0] == 'k' || s[0] == 'K' || s[0] == 't') {
+                valid_event = true;
+                continue;
+            // just bruteforce the multi-letter ones
+            } else if (s[0] == 'f') {
+                if (!strncmp(s, "fad", 3)) {
+                    valid_event = true;
+                    continue;
+                }
+            } else if (s[0] == 'm') {
+                if (!strncmp(s, "move", 4)) {
+                    valid_event = true;
+                    continue;
+                }
+            }
+        }
+        if (in_tag && valid_event && s[0] == '}') {
+            valid_tag = true;
+            break;
+        } else if (s[0] == '}') {
+            in_tag = false;
+            valid_event = false;
+            valid_tag = false;
+        }
+        s++;
+    }
+    return valid_tag;
+}
+
 // Note: pkt is not necessarily a fully valid refcounted packet.
 static void filter_and_add(struct sd *sd, struct demux_packet *pkt)
 {
     struct sd_ass_priv *ctx = sd->priv;
     struct demux_packet *orig_pkt = pkt;
+    ASS_Track *track = ctx->ass_track;
+    int old_n_events = track->n_events;
 
     for (int n = 0; n < ctx->num_filters; n++) {
         struct sd_filter *ft = ctx->filters[n];
@@ -300,6 +346,22 @@ static void filter_and_add(struct sd *sd, struct demux_packet *pkt)
                       llrint(pkt->pts * 1000),
                       llrint(pkt->duration * 1000));
 
+    // This bookkeeping is only ever needed for ASS subs
+    if (!ctx->is_converted) {
+        if (!pkt->seen) {
+            for (int n = track->n_events - 1; n >= 0; n--) {
+                if (n + 1 == old_n_events || pkt->animated)
+                    break;
+                ASS_Event *event = &track->events[n];
+                pkt->animated = (event->Effect && event->Effect[0]) ||
+                                 is_animated(event->Text);
+            }
+            MP_TARRAY_APPEND(ctx, ctx->packets_animated, ctx->num_packets_animated, pkt->animated);
+        } else {
+            pkt->animated = ctx->packets_animated[pkt->seen_pos];
+        }
+    }
+
     if (pkt != orig_pkt)
         talloc_free(pkt);
 }
@@ -307,7 +369,7 @@ static void filter_and_add(struct sd *sd, struct demux_packet *pkt)
 // Test if the packet with the given file position (used as unique ID) was
 // already consumed. Return false if the packet is new (and add it to the
 // internal list), and return true if it was already seen.
-static bool check_packet_seen(struct sd *sd, int64_t pos)
+static bool check_packet_seen(struct sd *sd, struct demux_packet *packet)
 {
     struct sd_ass_priv *priv = sd->priv;
     int a = 0;
@@ -315,15 +377,18 @@ static bool check_packet_seen(struct sd *sd, int64_t pos)
     while (a < b) {
         int mid = a + (b - a) / 2;
         int64_t val = priv->seen_packets[mid];
-        if (pos == val)
+        if (packet->pos == val) {
+            packet->seen_pos = mid;
             return true;
-        if (pos > val) {
+        }
+        if (packet->pos > val) {
             a = mid + 1;
         } else {
             b = mid;
         }
     }
-    MP_TARRAY_INSERT_AT(priv, priv->seen_packets, priv->num_seen_packets, a, pos);
+    packet->seen_pos = a;
+    MP_TARRAY_INSERT_AT(priv, priv->seen_packets, priv->num_seen_packets, a, packet->pos);
     return false;
 }
 
@@ -332,13 +397,13 @@ static bool check_packet_seen(struct sd *sd, int64_t pos)
 static void decode(struct sd *sd, struct demux_packet *packet)
 {
     struct sd_ass_priv *ctx = sd->priv;
+    ASS_Track *track = ctx->ass_track;
 
     packet->sub_duration = packet->duration;
 
-    ASS_Track *track = ctx->ass_track;
     if (ctx->converter) {
         if (!sd->opts->sub_clear_on_seek && packet->pos >= 0 &&
-            check_packet_seen(sd, packet->pos))
+            check_packet_seen(sd, packet))
             return;
 
         double sub_pts = 0;
@@ -377,7 +442,9 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         }
     } else {
         // Note that for this packet format, libass has an internal mechanism
-        // for discarding duplicate (already seen) packets.
+        // for discarding duplicate (already seen) packets but we check this
+        // anyways for our purposes for ASS subtitles.
+        packet->seen = check_packet_seen(sd, packet);
         filter_and_add(sd, packet);
     }
 }

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -332,6 +332,9 @@ static bool check_packet_seen(struct sd *sd, int64_t pos)
 static void decode(struct sd *sd, struct demux_packet *packet)
 {
     struct sd_ass_priv *ctx = sd->priv;
+
+    packet->sub_duration = packet->duration;
+
     ASS_Track *track = ctx->ass_track;
     if (ctx->converter) {
         if (!sd->opts->sub_clear_on_seek && packet->pos >= 0 &&

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -327,6 +327,8 @@ static void decode(struct sd *sd, struct demux_packet *packet)
     if (res < 0 || !got_sub)
         return;
 
+    packet->sub_duration = sub.end_display_time;
+
     if (sub.pts != AV_NOPTS_VALUE)
         pts = sub.pts / (double)AV_TIME_BASE;
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1025,7 +1025,9 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
             struct frame_priv *fp = mpi->priv;
             apply_crop(image, p->src, vo->params->w, vo->params->h);
             if (opts->blend_subs) {
-                if (frame->redraw || fp->osd_sync < p->osd_sync) {
+                if (frame->redraw)
+                    p->osd_sync++;
+                if (fp->osd_sync < p->osd_sync) {
                     float rx = pl_rect_w(p->dst) / pl_rect_w(image->crop);
                     float ry = pl_rect_h(p->dst) / pl_rect_h(image->crop);
                     struct mp_osd_res res = {
@@ -1037,9 +1039,6 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
                         .mb = (image->crop.y1 - vo->params->h) * ry,
                         .display_par = 1.0,
                     };
-                    // TODO: fix this doing pointless updates
-                    if (frame->redraw)
-                        p->osd_sync++;
                     update_overlays(vo, res, OSD_DRAW_SUB_ONLY,
                                     PL_OVERLAY_COORDS_DST_CROP,
                                     &fp->subs, image, mpi);


### PR DESCRIPTION
mpv is currently very wasteful when drawing subs when they're being drawn to the terminal or being drawn ontop of a still image. It actually runs on every single loop which spams VOs with tons of completely unneeded redraw calls. We can be smarter here and detect when the subtitle actually changes and signal the redraw only when it's needed instead.