### PR TITLE
ad_spdif: fix DTS 44.1khz passthrough playback

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -226,7 +226,7 @@ static int init_filter(struct mp_filter *da)
             num_channels                = dts_hd_spdif_channel_count;
         } else {
             sample_format               = AF_FORMAT_S_DTS;
-            samplerate                  = 48000;
+            samplerate                  = c_rate > 44100 ? 48000 : 44100;
             num_channels                = 2;
         }
         break;


### PR DESCRIPTION
There is an issue with the DTS passthrough playback of 44.1khz content. With the current implementation, every DTS core content (regardless of sample rate) is passed to the AVR in a 2ch@48Khz manner. This is only fine for 48Khz and 24/96 content, but not for 44.1khz content, that could be found on some DVD-Audio discs. In this case, this leads to mangled audio or no audio at all.

This commit fixes the issue. The issue is also described here:
https://github.com/mpv-player/mpv/issues/12078
https://github.com/mpv-player/mpv/issues/6651

The fix also takes into account that there are some DTS variants with a samplerate of 96khz (e.g. DTS 24/96), somehow they are recognized wrongly as 48khz by the code. Don´t rely on this "bug", do it correctly. Now every DTS core samplerate above 44.1Khz is correctly treated as 48khz for the passthrough logic and 44.1khz files are treated as 44.1khz for bitstreaming.

The fix uses the sample_rate (c_rate) enumeration that was introduced in this commit: https://github.com/mpv-player/mpv/commit/c522d0dfbd9b9663c4e084261a353ee45991fd86

The fix was tested by a user (https://github.com/mpv-player/mpv/issues/12078#issuecomment-1905185122) and is known to be working. I could only test it in a dry run and it was also working there.