### PR TITLE
ad_spdif: change deprecated FF_PROFILE to AV_PROFILE

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -22,6 +22,7 @@
 
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
+#include <libavcodec/defs.h>
 #include <libavutil/opt.h>
 
 #include "audio/aframe.h"
@@ -90,7 +91,7 @@ static void determine_codec_params(struct mp_filter *da, AVPacket *pkt,
                                    int *out_profile, int *out_rate)
 {
     struct spdifContext *spdif_ctx = da->priv;
-    int profile = FF_PROFILE_UNKNOWN;
+    int profile = AV_PROFILE_UNKNOWN;
     AVCodecContext *ctx = NULL;
     AVFrame *frame = NULL;
 
@@ -115,7 +116,7 @@ static void determine_codec_params(struct mp_filter *da, AVPacket *pkt,
         av_parser_close(parser);
     }
 
-    if (profile != FF_PROFILE_UNKNOWN || spdif_ctx->codec_id != AV_CODEC_ID_DTS)
+    if (profile != AV_PROFILE_UNKNOWN || spdif_ctx->codec_id != AV_CODEC_ID_DTS)
         return;
 
     const AVCodec *codec = avcodec_find_decoder(spdif_ctx->codec_id);
@@ -145,7 +146,7 @@ done:
     av_frame_free(&frame);
     avcodec_free_context(&ctx);
 
-    if (profile == FF_PROFILE_UNKNOWN)
+    if (profile == AV_PROFILE_UNKNOWN)
         MP_WARN(da, "Failed to parse codec profile.\n");
 }
 
@@ -155,7 +156,7 @@ static int init_filter(struct mp_filter *da)
 
     AVPacket *pkt = spdif_ctx->avpkt;
 
-    int profile = FF_PROFILE_UNKNOWN;
+    int profile = AV_PROFILE_UNKNOWN;
     int c_rate = 0;
     determine_codec_params(da, pkt, &profile, &c_rate);
     MP_VERBOSE(da, "In: profile=%d samplerate=%d\n", profile, c_rate);
@@ -208,15 +209,15 @@ static int init_filter(struct mp_filter *da)
         num_channels                    = 2;
         break;
     case AV_CODEC_ID_DTS: {
-        bool is_hd = profile == FF_PROFILE_DTS_HD_HRA ||
-                     profile == FF_PROFILE_DTS_HD_MA  ||
-                     profile == FF_PROFILE_UNKNOWN;
+        bool is_hd = profile == AV_PROFILE_DTS_HD_HRA ||
+                     profile == AV_PROFILE_DTS_HD_MA  ||
+                     profile == AV_PROFILE_UNKNOWN;
 
         // Apparently, DTS-HD over SPDIF is specified to be 7.1 (8 channels)
         // for DTS-HD MA, and stereo (2 channels) for DTS-HD HRA. The bit
         // streaming rate as well as the signaled channel count are defined
         // based on this value.
-        int dts_hd_spdif_channel_count = profile == FF_PROFILE_DTS_HD_HRA ?
+        int dts_hd_spdif_channel_count = profile == AV_PROFILE_DTS_HD_HRA ?
                                          2 : 8;
         if (spdif_ctx->use_dts_hd && is_hd) {
             av_dict_set_int(&format_opts, "dtshd_rate",


### PR DESCRIPTION
Change the FF_PROFILE defines that are deprecated to the new AV_PROFILE found in defs.h


FF_PROFILE is deprecated => https://github.com/FFmpeg/FFmpeg/commit/8238bc0b5e3dba271217b1223a901b3f9713dc6e

The "doc/APIchanges" says
```
2023-09-07 - xxxxxxxxxx - lavc 60.26.100 - defs.h
  Add AV_PROFILE_* and AV_LEVEL_* replacements in defs.h for the
  defines from avcodec.h. The latter are deprecated.
```

This commit also raises the question of the minimal lavc version... No idea if it's worth raising it to a git version from 2023-09-07 just for that... Other question - are there users that build mpv against "older" ffmpeg versions?

Anyways, maybe consider this one in the future...
