### PR TITLE
vo: change vo_frame duration to double

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -1252,7 +1252,7 @@ void write_video(struct MPContext *mpctx)
         diff /= mpctx->video_speed;
         if (mpctx->time_frame < 0)
             diff += mpctx->time_frame;
-        frame->duration = MPCLAMP(diff, 0, 10) * 1e9;
+        frame->duration = MP_TIME_S_TO_NS(MPCLAMP(diff, 0, 10));
     }
 
     mpctx->video_pts = mpctx->next_frames[0]->pts;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -211,7 +211,7 @@ struct vo_frame {
     // If 0, present immediately.
     int64_t pts;
     // Approximate frame duration, in ns.
-    int duration;
+    double duration;
     // Realtime of estimated distance between 2 vsync events.
     double vsync_interval;
     // "ideal" display time within the vsync


### PR DESCRIPTION
32-bit signed integer can hold ~2.1s stored as nanoseconds. While frame duration doesn't make sense to be this long, the existing clamp is to 10s. Change type to double, which is consistent with other fields in vo_frame.