### PR TITLE
video: adjust avsync when draining audio

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -343,7 +343,7 @@ static void adjust_sync(struct MPContext *mpctx, double v_pts, double frame_time
 {
     struct MPOpts *opts = mpctx->opts;
 
-    if (mpctx->audio_status != STATUS_PLAYING)
+    if (mpctx->audio_status == STATUS_EOF)
         return;
 
     mpctx->delay -= frame_time;


### PR DESCRIPTION
The full revert in b0e6ac380f was actually not needed, doing so causes a single frame to drop when mpv is draining audio after a discontinuity (e.g. seek). Calculating A-V sync change while draining audio actually makes sense in hindsight, and probably should've been the original commit.

This actually gets us the benefits of cb2b579f61 without breaking files where the audio doesn't start together with the video.

Fixes: b0e6ac380f ("Revert "player/video: loosen logic checks for adjust_sync"")

