### PR TITLE
version.h.in: bump copyright year

### DIFF
--- a/common/version.h.in
+++ b/common/version.h.in
@@ -1,5 +1,5 @@
 #define VERSION "@VERSION@"
-#define MPVCOPYRIGHT "Copyright © 2000-2023 mpv/MPlayer/mplayer2 projects"
+#define MPVCOPYRIGHT "Copyright © 2000-2024 mpv/MPlayer/mplayer2 projects"
 #ifndef NO_BUILD_TIMESTAMPS
 #define BUILDDATE __DATE__ " " __TIME__
 #else


### PR DESCRIPTION
Copyright year update speed ranking to fill PR space:

2020: wm4 committed 2019/12/31 11:10 (https://github.com/mpv-player/mpv/commit/934f8e102682901d77e0990aa594f46d745e0396)
2014: wm4 committed 2013/12/31 18:00 (https://github.com/mpv-player/mpv/commit/66fe4f571371b06b84c9e9cd684df9f7fc90b53f)
2015: wm4 committed 2014/12/31 18:00 (https://github.com/mpv-player/mpv/commit/39548ad9e961794e023aef0e281089064dd41f36)
2016: wm4 committed 2015/12/31 18:18 (https://github.com/mpv-player/mpv/commit/de0523ba7b4f76a1c51cc3924b3fcace51fc8e16)
2017: wm4 committed 2017/01/01 13:09 (https://github.com/mpv-player/mpv/commit/8e41f314f19d97849204ff4a7e9ca0fc4e9a8904)
2018: wm4 authored and wiiaboo committed 2018/01/01 16:05 (https://github.com/mpv-player/mpv/commit/a90abe05462a689e55280bc78af2999aa1f3823e)
2013: wm4 committed 2013/01/04 09:23 (https://github.com/mpv-player/mpv/commit/f394a25e7be6c6d7560b639ea253d747a376c6f6)
2023: Dudemanguy committed 2023/01/04 09:29 (https://github.com/mpv-player/mpv/commit/3a6ef8170551e8eab9ef89143db04e2e0d7ec567)
2022: Dudemanguy committed 2022/01/22 14:22 (https://github.com/mpv-player/mpv/commit/93d77b781d5d2a25f55f79393cbfbdc7b2290acd)
2019: JCount authored and Akemi committed 2019/04/16 14:11 (https://github.com/mpv-player/mpv/commit/7f1d7c38bcadf982e1bf087327cb445de5e20391)
2021: Dudemanguy committed 2021/10/25 11:20 (https://github.com/mpv-player/mpv/commit/12056fdcd4a54dd03d4a88017340d0798e845f09)
