### PR TITLE
10bit formats with EGL hwdec_drmprime

### DIFF
--- a/video/out/hwdec/dmabuf_interop_gl.c
+++ b/video/out/hwdec/dmabuf_interop_gl.c
@@ -186,6 +186,7 @@ static bool vaapi_gl_map(struct ra_hwdec_mapper *mapper,
                 format[2] = DRM_FORMAT_R8;
                 break;
             case DRM_FORMAT_P010:
+            case DRM_FORMAT_P210:
 #ifdef DRM_FORMAT_P030 /* Format added in a newer libdrm version than minimum */
             case DRM_FORMAT_P030:
 #endif

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -132,6 +132,8 @@ static int init(struct ra_hwdec *hw)
     MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_NV12);
     MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_420P);
     MP_TARRAY_APPEND(p, p->formats, num_formats, pixfmt2imgfmt(AV_PIX_FMT_NV16));
+    MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_P010);
+    MP_TARRAY_APPEND(p, p->formats, num_formats, pixfmt2imgfmt(AV_PIX_FMT_P210));
 
     for (int i = 0; i < MP_ARRAY_SIZE(forked_pix_fmt_names); i++) {
         enum AVPixelFormat fmt = av_get_pix_fmt(forked_pix_fmt_names[i]);


### PR DESCRIPTION
This PR allows mpv to accept AV_PIX_FMT_P010 and AV_PIX_FMT_P210 thorugh EGL.

Tested with rockchip rk3588 and https://github.com/nyanmisaka/ffmpeg-rockchip, since currently no V4L interface supports proper 10bit formats.

Full documentation is here: https://github.com/hbiyik/ffmpeg-rockchip/wiki/Rendering#mpv