### PR TITLE
demux_mkv: fix few issues found during developing fuzzers

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -406,6 +406,8 @@ static bstr demux_mkv_decode(struct mp_log *log, mkv_track_t *track,
         talloc_free(src);
     if (!size)
         dest = NULL;
+    if (!dest)
+        size = 0;
     return (bstr){dest, size};
 }
 
@@ -2073,6 +2075,8 @@ static void probe_x264_garbage(demuxer_t *demuxer)
 
         bstr sblock = {block->laces[0]->data, block->laces[0]->size};
         bstr nblock = demux_mkv_decode(demuxer->log, track, sblock, 1);
+        if (!nblock.len)
+            continue;
 
         sh->codec->first_packet = new_demux_packet_from(nblock.start, nblock.len);
         talloc_steal(mkv_d, sh->codec->first_packet);
@@ -2835,6 +2839,8 @@ static int handle_block(demuxer_t *demuxer, struct block_info *block_info)
 
             bstr block = {data->data, data->size};
             bstr nblock = demux_mkv_decode(demuxer->log, track, block, 1);
+            if (!nblock.len)
+                break;
 
             if (block.start != nblock.start || block.len != nblock.len) {
                 // (avoidable copy of the entire data)

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2980,20 +2980,22 @@ static int read_next_block_into_queue(demuxer_t *demuxer)
                 if (end > mkv_d->cluster_end)
                     goto find_next_cluster;
                 int res = read_block_group(demuxer, end, &block);
-                if (res < 0)
-                    goto find_next_cluster;
                 if (res > 0)
                     goto add_block;
+                free_block(&block);
+                if (res < 0)
+                    goto find_next_cluster;
                 break;
             }
 
             case MATROSKA_ID_SIMPLEBLOCK: {
                 block = (struct block_info){ .simple = true };
                 int res = read_block(demuxer, mkv_d->cluster_end, &block);
-                if (res < 0)
-                    goto find_next_cluster;
                 if (res > 0)
                     goto add_block;
+                free_block(&block);
+                if (res < 0)
+                    goto find_next_cluster;
                 break;
             }
 

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -390,6 +390,10 @@ static bstr demux_mkv_decode(struct mp_log *log, mkv_track_t *track,
             }
             size = dstlen - out_avail;
         } else if (enc->comp_algo == 3) {
+            if (enc->comp_settings_len == 0 || !enc->comp_settings) {
+                mp_warn(log, "missing comp_settings, unable to reconstruct the data.\n");
+                goto error;
+            }
             dest = talloc_size(track->parser_tmp, size + enc->comp_settings_len);
             memcpy(dest, enc->comp_settings, enc->comp_settings_len);
             memcpy(dest + enc->comp_settings_len, src, size);

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -3404,15 +3404,21 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
         if (r == 0) {
             r = parse_obj_settings(log, name, op, &param, ol, dst ? &res : NULL);
         }
-        if (r < 0)
+        if (r < 0) {
+            free_obj_settings_list(&res);
             return r;
+        }
         if (param.len > 0) {
             const char sep[2] = {OPTION_LIST_SEPARATOR, 0};
-            if (!bstr_eatstart0(&param, sep))
+            if (!bstr_eatstart0(&param, sep)) {
+                free_obj_settings_list(&res);
                 return M_OPT_INVALID;
+            }
             if (param.len == 0) {
-                if (!ol->allow_trailer)
+                if (!ol->allow_trailer) {
+                    free_obj_settings_list(&res);
                     return M_OPT_INVALID;
+                }
                 if (dst) {
                     m_obj_settings_t item = {
                         .name = talloc_strdup(NULL, ""),
@@ -3427,6 +3433,7 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
         if (op == OP_APPEND) {
             mp_err(log, "Option %.*s: -append takes only 1 filter (no ',').\n",
                    BSTR_P(name));
+            free_obj_settings_list(&res);
             return M_OPT_INVALID;
         }
         mp_warn(log, "Passing more than 1 argument to %.*s is deprecated!\n",


### PR DESCRIPTION
It is possible to have data with empty block that contains additions. In which case the block would not be added and the additions would leak.

Found by fuzzing.