### PR TITLE
osxbundle: avoid running `codesign` with deprecated `--deep` argument

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -40,7 +40,13 @@ def apply_plist_template(plist_file, version):
         print(line.rstrip().replace('${VERSION}', version))
 
 def sign_bundle(binary_name):
-    sh('codesign --force --deep -s - ' + bundle_path(binary_name))
+    sign_directories = ['Contents/Frameworks', 'Contents/MacOS']
+    for dir in sign_directories:
+        resolved_dir = os.path.join(bundle_path(binary_name), dir)
+        for root, _dirs, files in os.walk(resolved_dir):
+            for f in files:
+                sh('codesign --force -s - ' + os.path.join(root, f))
+    sh('codesign --force -s - ' + bundle_path(binary_name))
 
 def bundle_version(src_path):
     version = 'UNKNOWN'


### PR DESCRIPTION
`--deep` is deprecated as of macos 13.0.
It is also not supported by alternative `codesign` implementations like
[sigtool](https://github.com/thefloweringash/sigtool).

Related: https://github.com/NixOS/nixpkgs/pull/270691

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.