### PR TITLE
x11_common: support `--title-bar`

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3236,7 +3236,7 @@ Window
     default, use ``--no-border`` to disable the standard window decorations.
 
 ``--title-bar``, ``--no-title-bar``
-    (Windows only)
+    (Windows and X11 only)
     Play video with the window title bar. Since this is on by default,
     use --no-title-bar to hide the title bar. The --no-border option takes
     precedence.


### PR DESCRIPTION
Some X11 window managers support controlling the title bar independently from other window decorations with `_MOTIF_WM_HINTS`. This allows hiding the title bar while keeping other decorations like the resizing borders.

Let mpv respect the `--title-bar` option on X11 so `--no-title-bar` can hide the title bar only like on win32.
