### PR TITLE
player: ensure runtime updates of certain rendering options

### DIFF
--- a/options/m_option.h
+++ b/options/m_option.h
@@ -442,7 +442,8 @@ char *format_file_size(int64_t size);
 #define UPDATE_DVB_PROG         (1 << 21) // some --dvbin-...
 #define UPDATE_SUB_HARD         (1 << 22) // subtitle opts. that need full reinit
 #define UPDATE_SUB_EXTS         (1 << 23) // update internal list of sub exts
-#define UPDATE_OPT_LAST         (1 << 23)
+#define UPDATE_VIDEO            (1 << 24) // force redraw if needed
+#define UPDATE_OPT_LAST         (1 << 24)
 
 // All bits between _FIRST and _LAST (inclusive)
 #define UPDATE_OPTS_MASK \

--- a/player/command.c
+++ b/player/command.c
@@ -7075,6 +7075,13 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (flags & UPDATE_LAVFI_COMPLEX)
         update_lavfi_complex(mpctx);
 
+    if (flags & UPDATE_VIDEO) {
+        if (mpctx->video_out) {
+            vo_set_want_redraw(mpctx->video_out);
+            mp_wakeup_core(mpctx);
+        }
+    }
+
     if (opt_ptr == &opts->vo->android_surface_size) {
         if (mpctx->video_out)
             vo_control(mpctx->video_out, VOCTRL_EXTERNAL_RESIZE, NULL);

--- a/video/csputils.c
+++ b/video/csputils.c
@@ -476,6 +476,7 @@ const struct m_sub_options mp_csp_equalizer_conf = {
         {0}
     },
     .size = sizeof(struct mp_csp_equalizer_opts),
+    .change_flags = UPDATE_VIDEO,
 };
 
 // Copy settings from eq into params.

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -483,6 +483,7 @@ const struct m_sub_options gl_video_conf = {
     },
     .size = sizeof(struct gl_video_opts),
     .defaults = &gl_video_opts_def,
+    .change_flags = UPDATE_VIDEO,
 };
 
 static void uninit_rendering(struct gl_video *p);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1171,6 +1171,16 @@ void vo_redraw(struct vo *vo)
     mp_mutex_unlock(&in->lock);
 }
 
+// Same as vo_redraw but the redraw is delayed until it
+// is detected in the playloop.
+void vo_set_want_redraw(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+    mp_mutex_lock(&in->lock);
+    in->want_redraw = true;
+    mp_mutex_unlock(&in->lock);
+}
+
 bool vo_want_redraw(struct vo *vo)
 {
     struct vo_internal *in = vo->in;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -512,6 +512,7 @@ void vo_wait_frame(struct vo *vo);
 bool vo_still_displaying(struct vo *vo);
 bool vo_has_frame(struct vo *vo);
 void vo_redraw(struct vo *vo);
+void vo_set_want_redraw(struct vo *vo);
 bool vo_want_redraw(struct vo *vo);
 void vo_seek_reset(struct vo *vo);
 void vo_destroy(struct vo *vo);


### PR DESCRIPTION
When adding things like brightness or gamma, the video obviously needs a redraw if paused. This happened to work in the normal case because the OSD notification triggered a redraw, but if you use no-osd the picture won't change. Fix this by adding another option flag, UPDATE_VIDEO, and simplying calling vo_redraw. That way something like "no-osd add gamma 1" actually works.