### PR TITLE
wayland_common: properly handle high resolution scrolling

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -436,12 +436,24 @@ static void touch_handle_cancel(void *data, struct wl_touch *wl_touch)
 {
 }
 
+static void touch_handle_shape(void *data, struct wl_touch *wl_touch,
+                               int32_t id, wl_fixed_t major, wl_fixed_t minor)
+{
+}
+
+static void touch_handle_orientation(void *data, struct wl_touch *wl_touch,
+                                     int32_t id, wl_fixed_t orientation)
+{
+}
+
 static const struct wl_touch_listener touch_listener = {
     touch_handle_down,
     touch_handle_up,
     touch_handle_motion,
     touch_handle_frame,
     touch_handle_cancel,
+    touch_handle_shape,
+    touch_handle_orientation,
 };
 
 static void keyboard_handle_keymap(void *data, struct wl_keyboard *wl_keyboard,

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1420,6 +1420,9 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
     }
 
     if (!strcmp(interface, wl_seat_interface.name) && found++) {
+        if (ver < 5)
+            MP_WARN(wl, "Scrolling won't work because the compositor doesn't "
+                        "support version 5 of wl_seat protocol!\n");
 #ifdef HAVE_WAYLAND_1_21
         ver = MPMIN(ver, 8); /* Cap at 8 in case new events are added later. */
 #else

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -295,7 +295,12 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 {
     struct vo_wayland_state *wl = data;
 
-    double val = wl_fixed_to_double(value) < 0 ? -1 : 1;
+    // The axis value is specified in logical coordinates, but the exact value emitted
+    // by one mouse wheel click is unspecified. In practice, most compositors use either
+    // 10 (GNOME, Weston) or 15 (wlroots, same as libinput) as the value.
+    // Divide the value by 10 and clamp it between -1 and 1 so that mouse wheel clicks
+    // work as intended on all compositors while still allowing high resolution trackpads.
+    double val = MPCLAMP(wl_fixed_to_double(value) / 10.0, -1, 1);
     switch (axis) {
     case WL_POINTER_AXIS_VERTICAL_SCROLL:
         if (value > 0)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -151,6 +151,11 @@ struct vo_wayland_state {
     uint32_t keyboard_code;
     int mpkey;
     int mpmod;
+    double axis_value_vertical;
+    int32_t axis_value120_vertical;
+    double axis_value_horizontal;
+    int32_t axis_value120_horizontal;
+    bool axis_value120_scroll;
 
     /* DND */
     struct wl_data_device *dnd_ddev;


### PR DESCRIPTION
Commit f54ad8eb055771a080f079964504cb0f32fc4014 broke high resolution scrolling because one logical mouse click is generated for every scroll event, no matter the magnitude. This makes scrolling on trackpad way too fast.

Revert the axis scaling change in that commit and clamp the resulting value between -1 and 1 to make sure mouse wheel scrolling works as intended on compositors which send a value larger than 10 for these events.
