### PR TITLE
player/video: wait for the frames to be fully displayed before reconfig

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -1173,8 +1173,10 @@ void write_video(struct MPContext *mpctx)
     struct mp_image_params *p = &mpctx->next_frames[0]->params;
     if (!vo->params || video_reconfig_needed(*p, *vo->params)) {
         // Changing config deletes the current frame; wait until it's finished.
-        if (vo_still_displaying(vo))
+        if (vo_still_displaying(vo)) {
+            vo_request_wakeup_on_done(vo);
             return;
+        }
 
         const struct vo_driver *info = mpctx->video_out->driver;
         char extra[20] = {0};

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1202,9 +1202,16 @@ void vo_seek_reset(struct vo *vo)
 bool vo_still_displaying(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
-    mp_mutex_lock(&in->lock);
-    bool working = in->rendering || in->frame_queued;
-    mp_mutex_unlock(&in->lock);
+    mp_mutex_lock(&vo->in->lock);
+    int64_t now = mp_time_ns();
+    int64_t frame_end = 0;
+    if (in->current_frame) {
+        frame_end = in->current_frame->pts + MPMAX(in->current_frame->duration, 0);
+        if (in->current_frame->display_synced)
+            frame_end = in->current_frame->num_vsyncs > 0 ? INT64_MAX : 0;
+    }
+    bool working = now < frame_end || in->rendering || in->frame_queued;
+    mp_mutex_unlock(&vo->in->lock);
     return working && in->hasframe;
 }
 

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -134,6 +134,7 @@ struct vo_internal {
     bool want_redraw;               // redraw request from VO to player
     bool send_reset;                // send VOCTRL_RESET
     bool paused;
+    bool wakeup_on_done;
     int queued_events;              // event mask for the user
     int internal_events;            // event mask for us
 
@@ -767,6 +768,41 @@ void vo_wakeup(struct vo *vo)
     mp_mutex_unlock(&in->lock);
 }
 
+static bool still_displaying(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+    int64_t now = mp_time_ns();
+    int64_t frame_end = 0;
+    if (in->current_frame) {
+        frame_end = in->current_frame->pts + MPMAX(in->current_frame->duration, 0);
+        if (in->current_frame->display_synced)
+            frame_end = in->current_frame->num_vsyncs > 0 ? INT64_MAX : 0;
+    }
+    return (now < frame_end || in->rendering || in->frame_queued) && in->hasframe;
+}
+
+// Return true if there is still a frame being displayed (or queued).
+bool vo_still_displaying(struct vo *vo)
+{
+    mp_mutex_lock(&vo->in->lock);
+    bool res = still_displaying(vo);
+    mp_mutex_unlock(&vo->in->lock);
+    return res;
+}
+
+// Make vo issue a wakeup once vo_still_displaying() becomes true.
+void vo_request_wakeup_on_done(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+    mp_mutex_lock(&vo->in->lock);
+    if (still_displaying(vo)) {
+        in->wakeup_on_done = true;
+    } else {
+        wakeup_core(vo);
+    }
+    mp_mutex_unlock(&vo->in->lock);
+}
+
 // Whether vo_queue_frame() can be called. If the VO is not ready yet, the
 // function will return false, and the VO will call the wakeup callback once
 // it's ready.
@@ -925,6 +961,7 @@ static bool render_frame(struct vo *vo)
 
     if (in->dropped_frame) {
         in->drop_count += 1;
+        wakeup_core(vo);
     } else {
         in->rendering = true;
         in->hasframe_rendered = true;
@@ -996,11 +1033,14 @@ static bool render_frame(struct vo *vo)
         more_frames = true;
 
     mp_cond_broadcast(&in->wakeup); // for vo_wait_frame()
-    wakeup_core(vo);
 
 done:
     if (!vo->driver->frame_owner || in->dropped_frame)
         talloc_free(frame);
+    if (in->wakeup_on_done && !still_displaying(vo)) {
+        in->wakeup_on_done = false;
+        wakeup_core(vo);
+    }
     mp_mutex_unlock(&in->lock);
 
     return more_frames;
@@ -1195,24 +1235,6 @@ void vo_seek_reset(struct vo *vo)
     in->send_reset = true;
     wakeup_locked(vo);
     mp_mutex_unlock(&in->lock);
-}
-
-// Return true if there is still a frame being displayed (or queued).
-// If this returns true, a wakeup some time in the future is guaranteed.
-bool vo_still_displaying(struct vo *vo)
-{
-    struct vo_internal *in = vo->in;
-    mp_mutex_lock(&vo->in->lock);
-    int64_t now = mp_time_ns();
-    int64_t frame_end = 0;
-    if (in->current_frame) {
-        frame_end = in->current_frame->pts + MPMAX(in->current_frame->duration, 0);
-        if (in->current_frame->display_synced)
-            frame_end = in->current_frame->num_vsyncs > 0 ? INT64_MAX : 0;
-    }
-    bool working = now < frame_end || in->rendering || in->frame_queued;
-    mp_mutex_unlock(&vo->in->lock);
-    return working && in->hasframe;
 }
 
 // Whether at least 1 frame was queued or rendered since last seek or reconfig.

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -510,6 +510,7 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts);
 void vo_queue_frame(struct vo *vo, struct vo_frame *frame);
 void vo_wait_frame(struct vo *vo);
 bool vo_still_displaying(struct vo *vo);
+void vo_request_wakeup_on_done(struct vo *vo);
 bool vo_has_frame(struct vo *vo);
 void vo_redraw(struct vo *vo);
 void vo_set_want_redraw(struct vo *vo);


### PR DESCRIPTION
This avoids clearing the queued frame and the currently displayed one on VO reconfiguration requests that happen when new frames arrive. Instead, let those frames be fully displayed.

Fixes mf:// playback issues introduced after commit ef11d31c3acfd71307a94e44ad164a4861287675.

We have to wait on the play loop thread; otherwise, the VO thread can be starved because no one would wake it up after the last frame is fully displayed. VO keeps track of queued frames and the current one, but what we care about is the actual on-screen display duration. In this case, VO is already sleeping because the frame is already rendered. Hence, we cannot return from the write_video function and expect the already sleeping VO thread to wake the playback thread and ask for new frames. This issue has been fixed by commit ef11d31c. However, completely removing the frame duration check means that it would clear last ones too fast. This mostly matters only for mf://, which reconfigures VO on every frame.