### PR TITLE
DOCS/options: make --scale documentation more consistent

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5337,8 +5337,8 @@ them.
         (This filter is an alias for ``jinc``-windowed ``jinc``)
 
     ``ewa_lanczossharp``
-        A slightly sharpened version of ewa_lanczos. This is the default when
-        using the ``high-quality`` profile.
+        A slightly sharpened version of ``ewa_lanczos``. This is the default
+        when using the ``high-quality`` profile.
 
     ``ewa_lanczos4sharpest``
         Very sharp scaler, but also slightly slower than ``ewa_lanczossharp``.
@@ -5347,8 +5347,10 @@ them.
         built-in anti-ringing, so no extra action needs to be taken.
 
     ``mitchell``
-        Mitchell-Netravali. The ``B`` and ``C`` parameters can be set with
-        ``--scale-param1`` and ``--scale-param2``.
+        Mitchell-Netravali. Piecewise cubic filter with a support of radius 2.0.
+        Provides a balanced compromise of all scaling artifacts. This filter has
+        both ``B`` and ``C`` set to ``1/3``. The ``B`` and ``C`` parameters can
+        be controlled with ``--scale-param1`` and ``--scale-param2``.
 
     ``hermite``
         Hermite spline. Similar to ``bicubic`` but with ``B`` set to ``0.0``.
@@ -5357,10 +5359,9 @@ them.
         default for ``--dscale``.
 
     ``catmull_rom``
-        Catmull-Rom. A Cubic filter in the same vein as ``mitchell``, where
-        the ``B`` and ``C`` parameters are ``0.0`` and ``0.5`` respectively.
-        This filter is sharper than ``mitchell``, but it results in more
-        ringing.
+        Catmull-Rom spline. Similar to ``mitchell``, but with ``B`` and ``C``
+        set to ``0.0`` and ``0.5`` respectively. This filter is sharper than
+        ``mitchell``, but prone to ringing.
 
     ``oversample``
         A version of nearest neighbour that (naively) oversamples pixels, so


### PR DESCRIPTION
Just a couple of consistency changes to the `--scale` documentation in the manual. The formatting and rewording changes are self-explanatory but there's also an expanded description for `mitchell`, because it was almost spline36-levels of useless.

- Define the radius value. The `hermite` example mentions that having a support of radius=1 is special, but why? The reader needs a point of comparison to actually see how hermite is different from other BC-splines.
- Define (B,C) values. `bicubic`, `hermite` and `catmull_rom` have their (B,C) values defined, so the omission here is a bit weird.
- Define the use-case. `mitchell` is generally referred to as a "[satisfactory compromise](https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf)" or an "[ideally](https://github.com/ImageMagick/ImageMagick/blob/92c93c30aded7dbdbc1e5f2ec9b9774da0bf20b9/MagickCore/resize.c#L810) [balanced](https://github.com/ImageMagick/ImageMagick/blob/92c93c30aded7dbdbc1e5f2ec9b9774da0bf20b9/MagickCore/resize.c#L213)" cubic spline. The other scaler examples provide use-cases and resampling artifacts.