### PR TITLE
github/workflows: revert to github-script@v6

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v6
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION
There is an upstream regression in v7. Use v6 until Node 16 is still available.

See: https://github.com/actions/github-script/issues/448