### PR TITLE
github/workflows: ignore more files from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,21 @@ on:
     paths-ignore:
       - 'DOCS/**'
       - 'TOOLS/lua/**'
+      - '.editorconfig'
+      - '.gitignore'
+      - 'Copyright'
+      - 'README.md'
+      - 'RELEASE_NOTES'
   pull_request:
     branches: [master]
     paths-ignore:
       - 'DOCS/**'
       - 'TOOLS/lua/**'
+      - '.editorconfig'
+      - '.gitignore'
+      - 'Copyright'
+      - 'README.md'
+      - 'RELEASE_NOTES'
 
 jobs:
   mingw:


### PR DESCRIPTION
Exclude more files not participating in the build process, including `README.md`, to achieve the original goal of preventing artifacts comment spam.
