### PR TITLE
wayland: set current_output on surface leave if applicable

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -904,12 +904,12 @@ static void surface_handle_leave(void *data, struct wl_surface *wl_surface,
 
     struct vo_wayland_output *o;
     wl_list_for_each(o, &wl->output_list, link) {
-        if (o->output == output) {
+        if (o->output == output)
             o->has_surface = false;
-            wl->pending_vo_events |= VO_EVENT_WIN_STATE;
-            return;
-        }
+        if (o->output != output && o->has_surface)
+            wl->current_output = o;
     }
+    wl->pending_vo_events |= VO_EVENT_WIN_STATE;
 }
 
 #ifdef HAVE_WAYLAND_1_22


### PR DESCRIPTION
When the mpv surface leaves the output, we no longer mark it as the current output. However, this implicitly depends on there being a preceding surface entrance event to a different output. This is not necessarily the case. Consider moving the window from monitor 1, to monitor 1-2, and then back to 1 again. mpv gets the entrance event to monitor 2 and sets that as the current output to work off of. Then when you move back to only monitor 1, it removes monitor 2 from the current output. However, monitor 1 is not updated again as the current output because there is not a new surface entrance event in this case (the window never left). So the numbers that mpv's core is using are incorrect and for the wrong monitor. Luckily, we already keep track of what outputs the mpv surface is currently on no matter how many there are so it is simply a matter of setting current output again in the leave event if we have a different output that has the mpv surface.

Ref: https://github.com/swaywm/sway/issues/7932