### PR TITLE
ao_wasapi: various fixes and improvements

### DIFF
--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -48,6 +48,7 @@ void wasapi_change_uninit(struct ao* ao);
 
 enum wasapi_thread_state {
     WASAPI_THREAD_FEED = 0,
+    WASAPI_THREAD_DISPATCH,
     WASAPI_THREAD_RESUME,
     WASAPI_THREAD_RESET,
     WASAPI_THREAD_SHUTDOWN

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -74,6 +74,7 @@ typedef struct wasapi_state {
     IMMDevice *pDevice;
     IAudioClient *pAudioClient;
     IAudioRenderClient *pRenderClient;
+    bool client_started;
 
     // WASAPI internal clock information, for estimating delay
     IAudioClock *pAudioClock;


### PR DESCRIPTION
> It turns out the A/V desync problem in https://github.com/mpv-player/mpv/issues/12615 is caused by incorrect usage of `IAudioClient::GetCurrentPadding` with `--ao=wasapi` and `--audio-exclusive=yes`. Current logic uses `GetCurrentPadding` to determine the available free buffer space before writing audio data in both shared mode and exclusive mode, but the return value of `GetCurrentPadding` is meaningless for exclusive, event-driven streams: The result is fixed to `bufferFrameCount`, even if *NO* audio data has ever been written. (MS only clarified the return value for *push-based* exclusive mode; the exact definition for *event-driven* exclusive streams is missing. Also, they are relying solely on OS generated events to fill buffers in their exclusive event-driven demo. See [1] and [2].)
> 
> That said, the buffer space checks in `thread_feed` will always get passed. Most `thread_feed` calls are triggered by events generated by the OS (which happens on a stable `bufferDuration` interval), but opening a new file in the playlist after continuous playback also wakes up the AO thread, leading to a premature buffer fill. Each time this happens, an *irreversible* error is accumulated to `sample_count` as long as there is no AO reset due to manual seek or audio format change. Eventually, there will be noticeable A/V desync.
> 
> As a fix to the issue, don't rely on `GetCurrentPadding` for buffer space calculation in exclusive mode. Also, only let the OS wake up the AO thread to call `thread_feed` if we are in exclusive mode. The relevant code was first introduced as part of the solution to cascading buffer underruns, but since the logic is broken in the first place, it should be safe to revert it.
> 
> [1] https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-getcurrentpadding
> [2] https://learn.microsoft.com/en-us/windows/win32/coreaudio/exclusive-mode-streams

Nice desync test clip: [23.98_2s.zip](https://github.com/mpv-player/mpv/files/14199583/23.98_2s.zip)

Loop it for ~30s with `--ao=wasapi` and `--audio-exclusive=yes` and the desync should be noticeable without this patch. The key is to have sufficiently many file opens without AO resets to let the error in `sample_count` build up.

EDIT:

Added another commit to initialize shared mode stream as MS dictates.

EDIT AGAIN:

Also removed unnecessary stream reset to mitigate #13391 (see below for detailed discussion).