### PR TITLE
f_output_chain: prevent double free of child filters

### DIFF
--- a/filters/f_output_chain.c
+++ b/filters/f_output_chain.c
@@ -627,7 +627,7 @@ bool mp_output_chain_update_filters(struct mp_output_chain *c,
 
 error:
     for (int n = 0; n < num_add; n++)
-        talloc_free(add[n]);
+        talloc_free(add[n]->wrapper);
     talloc_free(add);
     talloc_free(used);
     return false;


### PR DESCRIPTION
Fixes https://github.com/mpv-player/mpv/issues/13432.

memcheck log showing the location of the first free:
```
==15178== Thread 1 mpv:
==15178== Invalid read of size 8
==15178==    at 0x3FBFE3: free_obj_settings_list (m_option.c:2978)
==15178==    by 0x3D1AA8: m_option_free (m_option.h:554)
==15178==    by 0x3D2844: destroy_user (f_output_chain.c:226)
==15178==    by 0x3DA1A2: filter_destructor (filter.c:756)
==15178==    by 0x4AEAB2: ta_free (ta.c:242)
==15178==    by 0x3DA140: mp_filter_free_children (filter.c:747)
==15178==    by 0x3DA1AE: filter_destructor (filter.c:759)
==15178==    by 0x4AEAB2: ta_free (ta.c:242)
==15178==    by 0x43A139: vo_chain_uninit (video.c:152)
==15178==    by 0x43A183: uninit_video_chain (video.c:161)
==15178==    by 0x43A6DD: reinit_video_chain_src (video.c:291)
==15178==    by 0x43A328: reinit_video_chain (video.c:210)
==15178==  Address 0x14862888 is 104 bytes inside a block of size 424 free'd
==15178==    at 0x48369AB: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15178==    by 0x4AEAE7: ta_free (ta.c:246)
==15178==    by 0x3D3DB4: mp_output_chain_update_filters (f_output_chain.c:630)
==15178==    by 0x439D9F: recreate_video_filters (video.c:71)
==15178==    by 0x43A667: reinit_video_chain_src (video.c:277)
==15178==    by 0x43A328: reinit_video_chain (video.c:210)
==15178==    by 0x42B7AC: play_current_file (loadfile.c:1764)
==15178==    by 0x42C50A: mp_play_files (loadfile.c:2021)
==15178==    by 0x42D7D0: mpv_main (main.c:432)
==15178==    by 0x4B2696: main (main-fn-unix.c:5)
==15178==  Block was alloc'd at
==15178==    at 0x4837B65: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==15178==    by 0x4AE7DE: ta_zalloc_size (ta.c:156)
==15178==    by 0x3DA499: mp_filter_create_with_params (filter.c:800)
==15178==    by 0x3DA8DF: mp_filter_create (filter.c:852)
==15178==    by 0x3D2875: create_wrapper_filter (f_output_chain.c:241)
==15178==    by 0x3D3793: mp_output_chain_update_filters (f_output_chain.c:561)
==15178==    by 0x439D9F: recreate_video_filters (video.c:71)
==15178==    by 0x43A667: reinit_video_chain_src (video.c:277)
==15178==    by 0x43A328: reinit_video_chain (video.c:210)
==15178==    by 0x42B7AC: play_current_file (loadfile.c:1764)
==15178==    by 0x42C50A: mp_play_files (loadfile.c:2021)
==15178==    by 0x42D7D0: mpv_main (main.c:432)
```