### PR TITLE
various: replace dead links in comments

### DIFF
--- a/demux/codec_tags.c
+++ b/demux/codec_tags.c
@@ -48,8 +48,8 @@ static const char *lookup_tag(int type, uint32_t tag)
 /*
  * As seen in the following page:
  *
- * https://web.archive.org/web/20220406060153/
- * http://dream.cs.bath.ac.uk/researchdev/wave-ex/bformat.html
+ * <https://web.archive.org/web/20220406060153/
+ * http://dream.cs.bath.ac.uk/researchdev/wave-ex/bformat.html>
  *
  * Note that the GUID struct in the above citation has its
  * integers encoded in little-endian format, which means that

--- a/misc/rendezvous.c
+++ b/misc/rendezvous.c
@@ -28,7 +28,7 @@ struct waiter {
  * of _all_ waiters in the process, and temporarily wakes up _all_ waiters on
  * each second call).
  *
- * This is inspired by: http://9atom.org/magic/man2html/2/rendezvous */
+ * This is inspired by: https://man.cat-v.org/plan_9/2/rendezvous */
 intptr_t mp_rendezvous(void *tag, intptr_t value)
 {
     struct waiter wait = { .tag = tag, .value = &value };

--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -377,7 +377,8 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
     // Get pointers to the arrays in lpReserved2. This is an undocumented data
     // structure used by MSVCRT (and other frameworks and runtimes) to emulate
     // FD inheritance. The format is unofficially documented here:
-    // https://www.catch22.net/tuts/undocumented-createprocess
+    // <https://web.archive.org/web/20221014190010/
+    // https://www.catch22.net/tuts/undocumented-createprocess>
     si.StartupInfo.cbReserved2 = sizeof(int) + crt_fd_count * (1 + sizeof(intptr_t));
     si.StartupInfo.lpReserved2 = talloc_size(tmp, si.StartupInfo.cbReserved2);
     char *crt_buf_flags = si.StartupInfo.lpReserved2 + sizeof(int);
@@ -402,7 +403,8 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
     // Specify which handles are inherited by the subprocess. If this isn't
     // specified, the subprocess inherits all inheritable handles, which could
     // include handles created by other threads. See:
-    // http://blogs.msdn.com/b/oldnewthing/archive/2011/12/16/10248328.aspx
+    // <https://web.archive.org/web/20121127222200/
+    // http://blogs.msdn.com/b/oldnewthing/archive/2011/12/16/10248328.aspx>
     si.lpAttributeList = create_handle_list(tmp, share_hndls, share_hndl_count);
 
     // If we have a console, the subprocess will automatically attach to it so

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -5,10 +5,10 @@
  * (https://github.com/glumpy/glumpy/blob/master/glumpy/library/build-spatial-filters.py)
  *
  * Also see:
- * - http://vector-agg.cvs.sourceforge.net/viewvc/vector-agg/agg-2.5/include/agg_image_filters.h
+ * - https://sourceforge.net/p/agg/svn/HEAD/tree/agg-2.4/include/agg_image_filters.h
  * - Vapoursynth plugin fmtconv (WTFPL Licensed), which is based on
  *   dither plugin for avisynth from the same author:
- *   https://github.com/vapoursynth/fmtconv/tree/master/src/fmtc
+ *   https://gitlab.com/EleonoreMizo/fmtconv/-/tree/master/src/fmtc
  * - Paul Heckbert's "zoom"
  * - XBMC: ConvolutionKernels.cpp etc.
  *

--- a/video/out/gpu/error_diffusion.c
+++ b/video/out/gpu/error_diffusion.c
@@ -227,7 +227,8 @@ void pass_error_diffusion(struct gl_shader_cache *sc,
 }
 
 // Different kernels for error diffusion.
-// Patterns are from http://www.efg2.com/Lab/Library/ImageProcessing/DHALF.TXT
+// Patterns are from <https://web.archive.org/web/20181031005427/
+// http://www.efg2.com/Lab/Library/ImageProcessing/DHALF.TXT>
 const struct error_diffusion_kernel mp_error_diffusion_kernels[] = {
     {
         .name = "simple",

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -254,7 +254,7 @@ void pass_compute_polar(struct gl_shader_cache *sc, struct scaler *scaler,
 static void bicubic_calcweights(struct gl_shader_cache *sc, const char *t, const char *s)
 {
     // Explanation of how bicubic scaling with only 4 texel fetches is done:
-    //   http://www.mate.tue.nl/mate/pdfs/10318.pdf
+    //   <https://web.archive.org/web/20180720154854/http://www.mate.tue.nl/mate/pdfs/10318.pdf>
     //   'Efficient GPU-Based Texture Interpolation using Uniform B-Splines'
     // Explanation why this algorithm normally always blurs, even with unit
     // scaling:

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -347,8 +347,8 @@ static void clear_keyboard_buffer(void)
 
     // Use the method suggested by Michael Kaplan to clear any pending dead
     // keys from the current keyboard layout. See:
-    // https://web.archive.org/web/20101004154432/http://blogs.msdn.com/b/michkap/archive/2006/04/06/569632.aspx
-    // https://web.archive.org/web/20100820152419/http://blogs.msdn.com/b/michkap/archive/2007/10/27/5717859.aspx
+    // <https://web.archive.org/web/20101004154432/http://blogs.msdn.com/b/michkap/archive/2006/04/06/569632.aspx>
+    // <https://web.archive.org/web/20100820152419/http://blogs.msdn.com/b/michkap/archive/2007/10/27/5717859.aspx>
     do {
         ret = ToUnicode(vkey, scancode, keys, buf, MP_ARRAY_SIZE(buf), 0);
     } while (ret < 0);
@@ -359,7 +359,7 @@ static int to_unicode(UINT vkey, UINT scancode, const BYTE keys[256])
     // This wraps ToUnicode to be stateless and to return only one character
 
     // Make the buffer 10 code units long to be safe, same as here:
-    // https://web.archive.org/web/20101013215215/http://blogs.msdn.com/b/michkap/archive/2006/03/24/559169.aspx
+    // <https://web.archive.org/web/20101013215215/http://blogs.msdn.com/b/michkap/archive/2006/03/24/559169.aspx>
     wchar_t buf[10] = { 0 };
 
     // Dead keys aren't useful for key shortcuts, so clear the keyboard state
@@ -1501,7 +1501,8 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         }
         // Windows can send spurious mouse events, which would make the mpv
         // core unhide the mouse cursor on completely unrelated events. See:
-        //  https://blogs.msdn.com/b/oldnewthing/archive/2003/10/01/55108.aspx
+        // <https://web.archive.org/web/20100821161603/
+        // https://blogs.msdn.com/b/oldnewthing/archive/2003/10/01/55108.aspx>
         int x = GET_X_LPARAM(lParam);
         int y = GET_Y_LPARAM(lParam);
         if (x != w32->mouse_x || y != w32->mouse_y) {


### PR DESCRIPTION
Replace various dead links with live replacements or archives. Less friction for anyone who wants to look up these references.
