### PR TITLE
demux_mkv: increase probing size for still image

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2017,7 +2017,7 @@ static void probe_if_image(demuxer_t *demuxer)
 
         int64_t timecode = -1;
         // Arbitrary restriction on packet reading.
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 1000; i++) {
             int ret = read_next_block_into_queue(demuxer);
             if (ret == 1 && mkv_d->blocks[i].track == track) {
                 if (timecode != mkv_d->blocks[i].timecode)

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2012,7 +2012,7 @@ static void probe_if_image(demuxer_t *demuxer)
         mkv_track_t *track = mkv_d->tracks[n];
         struct sh_stream *sh = track->stream;
 
-        if (!sh || sh->type != STREAM_VIDEO)
+        if (!sh || sh->type != STREAM_VIDEO || sh->image)
             continue;
 
         int64_t timecode = -1;
@@ -2030,10 +2030,8 @@ static void probe_if_image(demuxer_t *demuxer)
         }
 
         // Assume still image
-        if (video_blocks == 1) {
-            sh->still_image = true;
+        if (video_blocks == 1)
             sh->image = true;
-        }
     }
 }
 


### PR DESCRIPTION
Some files, especially with quite a few audio tracks have video blocks further away, which made them false detected as still images.

Fixes: 26a5146