### PR TITLE
demux: clarify the meaning of still_image

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -367,7 +367,7 @@ struct demux_stream {
     bool eager;             // try to keep at least 1 packet queued
                             // if false, this stream is disabled, or passively
                             // read (like subtitles)
-    bool still_image;       // stream has still video images
+    bool still_image;       // stream consists of multiple sparse still images
     bool refreshing;        // finding old position after track switches
     bool eof;               // end of demuxed stream? (true if no more packets)
 

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -49,7 +49,7 @@ struct sh_stream {
     bool visual_impaired_track; // container flag
     bool hearing_impaired_track;// container flag
     bool image;                 // video stream is an image
-    bool still_image;           // video stream contains still images
+    bool still_image;           // video consists of multiple sparse still images
     int hls_bitrate;
     int program_id;
 


### PR DESCRIPTION
Clarify that ffmpeg sets AV_DISPOSITION_STILL_IMAGE for sparse videos like https://s3.amazonaws.com/tmm1/music-choice.ts, not for images.