### PR TITLE
DOCS/lua: clarify `repeatable` and `complex` for `add_key_binding`

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -308,16 +308,17 @@ The ``mp`` module is preloaded, although it can be loaded manually with
 
         ``repeatable``
             If set to ``true``, enables key repeat for this specific binding.
+            This option only makes sense when ``complex`` is not set to ``true``.
 
         ``complex``
-            If set to ``true``, then ``fn`` is called on both key up and down
-            events (as well as key repeat, if enabled), with the first
-            argument being a table. This table has the following entries (and
-            may contain undocumented ones):
+            If set to ``true``, then ``fn`` is called on key down, repeat and up
+            events, with the first argument being a table. This table has the
+            following entries (and may contain undocumented ones):
 
                 ``event``
                     Set to one of the strings ``down``, ``repeat``, ``up`` or
-                    ``press`` (the latter if key up/down can't be tracked).
+                    ``press`` (the latter if key up/down/repeat can't be
+                    tracked).
 
                 ``is_mouse``
                     Boolean Whether the event was caused by a mouse button.


### PR DESCRIPTION
### Background
The current documentation lacks clarity regarding the interaction between the `repeatable` and `complex` options. Through an analysis of the source code ([`player/lua/defaults.lua`](https://github.com/mpv-player/mpv/blob/master/player/lua/defaults.lua#L224) and
[`player/js/defaults.js`](https://github.com/mpv-player/mpv/blob/master/player/javascript/defaults.js#L325)), it was observed that the `repeatable` option is only meaningful when the `complex` option is not enabled. Additionally, the `complex` option in the existing documentation is confusing, actually `fn` can be called on key repeat when `complex` is `true` and `repeatable` is not `true`.

### Changes Made
1. Clarified that the `repeatable` option only applies when the complex option is not set to `true`.
2. Revised the description of the `complex` option to specify that `fn` is called on key down, **repeat**, up, and press events.
3. Updated the `event` entry to acknowledge the occurrence of key repeat events.