### PR TITLE
wayland: don't press keys again when releasing modifiers

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -536,6 +536,12 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
             mp_input_put_key_utf8(wl->vo->input_ctx, state | wl->mpmod, bstr0(s));
         } else {
             // Assume a modifier was pressed and handle it in the mod event instead.
+            // If a modifier is released before a regular key, also release that
+            // key to not activate it again by accident.
+            if (state == MP_KEY_STATE_UP) {
+                wl->mpkey = 0;
+                mp_input_put_key(wl->vo->input_ctx, MP_INPUT_RELEASE_ALL);
+            }
             return;
         }
     }


### PR DESCRIPTION
Since 1f8013ff3f, if you release a modifier before a regular key on Wayland, that key gets pressed again because keyboard_handle_modifiers() calls mp_input_put_key() regardless of whether a modifier is pressed or released, e.g. if you press Shift+s it easy to take an another screenshot with s by accident. Fix this by releasing keys when releasing modifiers, matching the other VOs' behavior.

Ideally, releasing the modifier should input the key alone after --input-ar-delay, while this patch disables it forever, e.g. on X11 if you type something in the console, hold Ctrl+h, and release Ctrl, it starts typing h instead of deleting characters. This doesn't work because keyboard_handle_key() is only called when you first press a key, while on X11 KeyPress keeps getting sent as you hold down the key. But this works on X11 and not on Wayland for several other GTK and Qt applications too, so I guess this is acceptable.