### PR TITLE
osdep: fix infinite loop when cancelling subprocess

### DIFF
--- a/osdep/subprocess-posix.c
+++ b/osdep/subprocess-posix.c
@@ -281,7 +281,7 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
                     if (pid)
                         kill(pid, SIGKILL);
                     killed_by_us = true;
-                    break;
+                    goto break_poll;
                 }
                 struct mp_subprocess_fd *fd = &opts->fds[n];
                 if (fd->on_read) {
@@ -315,6 +315,8 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
             }
         }
     }
+
+break_poll:
 
     // Note: it can happen that a child process closes the pipe, but does not
     //       terminate yet. In this case, we would have to run waitpid() in


### PR DESCRIPTION
Note: I'm not 100% sure how this happens but I have a local reproducer with wl-copy and the fix definitely works.