### PR TITLE
meson: set default options for libplacebo if using subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Example:
     meson compile -C build
     meson install -C build
 
+For libplacebo, meson can use a git check out as a subproject for a convenient
+way to compile mpv if a sufficient libplacebo version is not easily available
+in the build environment. It will be statically linked with mpv. Example:
+
+    mkdir -p subprojects
+    git clone https://code.videolan.org/videolan/libplacebo.git --depth=1 --recursive subprojects/libplacebo
+
 Essential dependencies (incomplete list):
 
 - gcc or clang

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,8 @@ libavutil = dependency('libavutil', version: '>= 56.70.100')
 libswresample = dependency('libswresample', version: '>= 3.9.100')
 libswscale = dependency('libswscale', version: '>= 5.9.100')
 
-libplacebo = dependency('libplacebo', version: '>=6.338.2')
+libplacebo = dependency('libplacebo', version: '>=6.338.2',
+                default_options: ['default_library=static', 'demos=false'])
 
 libass = dependency('libass', version: '>= 0.12.2')
 


### PR DESCRIPTION
This will prevent building demos and link statically with libplacebo by default if system libplacebo is not found.

@sfan5 