### PR TITLE
x11_common: handle window dragging in ButtonPress event

### DIFF
--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -137,9 +137,6 @@ struct vo_x11_state {
     Atom dnd_requested_action;
     Window dnd_src_window;
 
-    /* dragging the window */
-    bool win_drag_button1_down;
-
     Atom icc_profile_property;
 };
 


### PR DESCRIPTION
Begin the `_NET_WM_MOVERESIZE` window dragging in `ButtonPress` event to match the behavior of win32 and wayland, simplify logic by dropping the `win_drag_button1_down` hack required by the old method, and fix a race condition described in commit 19f101db680f966a6e56035a16784541be390982, which happens when moving the mouse and releasing the button at the same time.

The race condition can be easily triggered when using a touch screen (tested with libinput driver), where a tap is translated to `MotionNotify`, `ButtonPress`, `MotionNotify`, and `ButtonRelease` in sequence, with the last 2 events having the same timestamp. This has caused some window managers to not stop dragging after the `ButtonRelease`, resulting in window being stuck in dragging state after a single tap.
