### PR TITLE
input: add `--input-preprocess-wheel` option 

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -30,6 +30,7 @@ Interface changes
     - add `--volume-gain`, `--volume-gain-min`, and `--volume-gain-max` options
     - add `current-gpu-context` property
     - add `--secondary-sub-ass-override` option
+    - add `--input-preprocess-wheel` option
     - remove shared-script-properties (user-data is a replacement)
     - add `--secondary-sub-delay`, decouple secondary subtitles from
       `--sub-delay`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4181,6 +4181,20 @@ Input
     implemented. Whether media keys work when the mpv window is focused is
     implementation-defined.
 
+``--input-preprocess-wheel=<yes|no>``
+    Preprocess ``WHEEL_*`` events so that while scrolling on the horizontal
+    or vertical direction, the events aren't generated for another direction
+    even when the two directions are scrolled together (default: yes).
+
+    This preprocessing can be beneficial for preventing accidentally seeking
+    while changing the volume by scrolling on a touchpad with the default
+    keybind. Due to the deadzone mechanism used, disabling the preprocessing
+    allows for diagonal scrolling (such as panning) and potentially reduces
+    input latency.
+
+    Note that disabling the preprocessing does not affect any filtering done
+    by the OS/driver before these events are delivered to mpv, if any.
+
 ``--input-right-alt-gr``, ``--no-input-right-alt-gr``
     (macOS and Windows only)
     Use the right Alt key as Alt Gr to produce special characters. If disabled,

--- a/input/input.c
+++ b/input/input.c
@@ -179,6 +179,7 @@ struct input_opts {
     bool vo_key_input;
     bool test;
     bool allow_win_drag;
+    bool preprocess_wheel;
 };
 
 const struct m_sub_options input_config = {
@@ -198,6 +199,7 @@ const struct m_sub_options input_config = {
         {"input-cursor", OPT_BOOL(enable_mouse_movements)},
         {"input-vo-keyboard", OPT_BOOL(vo_key_input)},
         {"input-media-keys", OPT_BOOL(use_media_keys)},
+        {"input-preprocess-wheel", OPT_BOOL(preprocess_wheel)},
 #if HAVE_SDL2_GAMEPAD
         {"input-gamepad", OPT_BOOL(use_gamepad)},
 #endif
@@ -217,6 +219,7 @@ const struct m_sub_options input_config = {
         .builtin_bindings = true,
         .vo_key_input = true,
         .allow_win_drag = true,
+        .preprocess_wheel = true,
     },
     .change_flags = UPDATE_INPUT,
 };
@@ -731,7 +734,7 @@ static void mp_input_feed_key(struct input_ctx *ictx, int code, double scale,
     if (!force_mouse && opts->doubleclick_time && MP_KEY_IS_MOUSE_BTN_DBL(unmod))
         return;
     int units = 1;
-    if (MP_KEY_IS_WHEEL(unmod) && !process_wheel(ictx, unmod, &scale, &units))
+    if (MP_KEY_IS_WHEEL(unmod) && opts->preprocess_wheel && !process_wheel(ictx, unmod, &scale, &units))
         return;
     interpret_key(ictx, code, scale, units);
     if (code & MP_KEY_STATE_DOWN) {


### PR DESCRIPTION
Fixes https://github.com/mpv-player/mpv/issues/11175.
Fixes https://github.com/mpv-player/mpv/issues/11851. Note that while the issue was poorly conveyed, the concern of the preprocessing causing input delay is valid. See the description of the second undesirable behavior in the commit message for details. 
