### PR TITLE
x11 hidpi scaling fixes

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -667,6 +667,15 @@ static bool vo_x11_get_xft_dpi_scale(struct vo_x11_state *x11)
     return success;
 }
 
+static void vo_x11_get_dpi_scale(struct vo_x11_state *x11)
+{
+    if (x11->opts->hidpi_window_scale) {
+        if (!vo_x11_get_xft_dpi_scale(x11))
+            vo_x11_get_x11_screen_dpi_scale(x11);
+    }
+    x11->pending_vo_events |= VO_EVENT_DPI;
+}
+
 bool vo_x11_init(struct vo *vo)
 {
     char *dispName;
@@ -731,10 +740,7 @@ bool vo_x11_init(struct vo *vo)
            x11->ws_width, x11->ws_height, dispName,
            x11->display_is_local ? "local" : "remote");
 
-    if (x11->opts->hidpi_window_scale) {
-        if (!vo_x11_get_xft_dpi_scale(x11))
-            vo_x11_get_x11_screen_dpi_scale(x11);
-    }
+    vo_x11_get_dpi_scale(x11);
 
     x11->wm_type = vo_wm_detect(vo);
 
@@ -2077,6 +2083,8 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
                 vo_x11_fullscreen(vo);
             if (opt == &opts->ontop)
                 vo_x11_setlayer(vo, opts->ontop);
+            if (opt == &opts->hidpi_window_scale)
+                vo_x11_set_geometry(vo);
             if (opt == &opts->border || opt == &opts->title_bar)
                 vo_x11_decoration(vo, opts->border, opts->title_bar);
             if (opt == &opts->all_workspaces)

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -669,10 +669,8 @@ static bool vo_x11_get_xft_dpi_scale(struct vo_x11_state *x11)
 
 static void vo_x11_get_dpi_scale(struct vo_x11_state *x11)
 {
-    if (x11->opts->hidpi_window_scale) {
-        if (!vo_x11_get_xft_dpi_scale(x11))
-            vo_x11_get_x11_screen_dpi_scale(x11);
-    }
+    if (!vo_x11_get_xft_dpi_scale(x11))
+        vo_x11_get_x11_screen_dpi_scale(x11);
     x11->pending_vo_events |= VO_EVENT_DPI;
 }
 
@@ -2109,16 +2107,16 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
         int *s = arg;
         if (!x11->window || x11->parent)
             return VO_FALSE;
-        s[0] = (x11->fs ? RC_W(x11->nofsrc) : RC_W(x11->winrc)) / x11->dpi_scale;
-        s[1] = (x11->fs ? RC_H(x11->nofsrc) : RC_H(x11->winrc)) / x11->dpi_scale;
+        s[0] = x11->fs ? RC_W(x11->nofsrc) : RC_W(x11->winrc);
+        s[1] = x11->fs ? RC_H(x11->nofsrc) : RC_H(x11->winrc);
         return VO_TRUE;
     }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
         int *s = arg;
         if (!x11->window || x11->parent)
             return VO_FALSE;
-        int w = s[0] * x11->dpi_scale;
-        int h = s[1] * x11->dpi_scale;
+        int w = s[0];
+        int h = s[1];
         struct mp_rect rc = x11->winrc;
         rc.x1 = rc.x0 + w;
         rc.y1 = rc.y0 + h;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1405,6 +1405,7 @@ void vo_x11_check_events(struct vo *vo)
             }
             if (Event.type == x11->xrandr_event) {
                 xrandr_read(x11);
+                vo_x11_get_dpi_scale(x11);
                 vo_x11_update_geometry(vo);
             }
             break;


### PR DESCRIPTION
Some general things I noticed since the subject came up. 

1. 4981690fb63ca2b30fad1cf424e6a11234e34fa8 technically regresses the `display-hidpi-scale` property by always making it 1 if `--no-hidpi-window-scale` is used. imo this is undesirable because the console uses that and you always want text to be scaled regardless if the window is or not. Fix this by removing the option checks and unneeded `x11->dpi_scale` multiplications/divisions.
2. The x11 backend never sent `VO_EVENT_DPI` nor did it recalculate dpi after a randr event. It's niche but `Xft.dpi` can technically change at runtime.