### PR TITLE
Fix headers for OpenBSD compilation

### DIFF
--- a/osdep/threads-posix.h
+++ b/osdep/threads-posix.h
@@ -23,6 +23,11 @@
 
 #include "common/common.h"
 #include "config.h"
+// We make use of NON-POSIX pthreads functions and certain systems 
+// require this header to build without issues. (ex: OpenBSD)
+#if HAVE_BSD_THREAD_NAME
+#include <pthread_np.h>
+#endif
 #include "osdep/compiler.h"
 #include "timer.h"
 


### PR DESCRIPTION
In OpenBSD the compilation fail because `osdep/threads-posix.h` need include `pthread_np.h `

This change fix the issue.

```
[3/199] Compiling C object libmpv.so.2.2.0.p/audio_out_ao_lavc.c.o
FAILED: libmpv.so.2.2.0.p/audio_out_ao_lavc.c.o
/usr/local/llvm16/bin/../libexec/ccc-analyzer -Ilibmpv.so.2.2.0.p -I. -I.. -Icommon -
Ietc -Iplayer/javascript -Iplayer/lua -Isub -I/usr/local/include -I/usr/X11R6/include
 -I/usr/local/include/harfbuzz -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.
0/include -I/usr/local/include/fribidi -I/usr/X11R6/include/freetype2 -I/usr/local/in
clude/libxml2 -I/usr/local/include/lua-5.1 -I/usr/X11R6/include/libdrm -fvisibility=h
idden -fdiagnostics-color=always -Wall -Winvalid-pch -std=c11 -O2 -g -D_FILE_OFFSET_B
ITS=64 -Werror=implicit-function-declaration -Wempty-body -Wdisabled-optimization -Ws
trict-prototypes -Wno-format-zero-length -Wno-redundant-decls -Wvla -Wimplicit-fallt$
rough -fno-math-errno -Wformat -Werror=format-security -Wno-logical-op-parentheses -W
no-switch -Wno-tautological-compare -Wno-pointer-sign -Wno-tautological-constant-out-
of-range-compare -D_GNU_SOURCE -fPIC -D_REENTRANT -pthread -MD -MQ libmpv.so.2.2.0.p/
audio_out_ao_lavc.c.o -MF libmpv.so.2.2.0.p/audio_out_ao_lavc.c.o.d -o libmpv.so.2.2.
0.p/audio_out_ao_lavc.c.o -c ../audio/out/ao_lavc.c
In file included from ../audio/out/ao_lavc.c:44:
In file included from ../common/encode_lavc.h:35:
In file included from ../osdep/threads.h:20:
../osdep/threads-posix.h:232:5: error: call to undeclared function 'pthread_set_name_
np'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimpli
cit-function-declaration]
    pthread_set_name_np(pthread_self(), name);
    ^
../osdep/threads-posix.h:232:5: note: did you mean 'mp_thread_set_name'?
../osdep/threads-posix.h:223:20: note: 'mp_thread_set_name' declared here
static inline void mp_thread_set_name(const char *name)
                   ^
1 error generated.
```