### PR TITLE
ao_wasapi: address premature buffer fills in exclusive mode

### DIFF
--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -348,7 +348,7 @@ static int thread_control_exclusive(struct ao *ao, enum aocontrol cmd, void *arg
     case AOCONTROL_GET_VOLUME:
         IAudioEndpointVolume_GetMasterVolumeLevelScalar(
             state->pEndpointVolume, &volume);
-        *(float *)arg = volume;
+        *(float *)arg = volume * 100.f;
         return CONTROL_OK;
     case AOCONTROL_SET_VOLUME:
         volume = (*(float *)arg) / 100.f;
@@ -378,7 +378,7 @@ static int thread_control_shared(struct ao *ao, enum aocontrol cmd, void *arg)
     switch(cmd) {
     case AOCONTROL_GET_VOLUME:
         ISimpleAudioVolume_GetMasterVolume(state->pAudioVolume, &volume);
-        *(float *)arg = volume;
+        *(float *)arg = volume * 100.f;
         return CONTROL_OK;
     case AOCONTROL_SET_VOLUME:
         volume = (*(float *)arg) / 100.f;

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -180,19 +180,17 @@ static void thread_resume(struct ao *ao)
     }
 }
 
-static void thread_wakeup(void *ptr)
-{
-    struct ao *ao = ptr;
-    struct wasapi_state *state = ao->priv;
-    SetEvent(state->hWake);
-}
-
-static void set_thread_state(struct ao *ao,
-                             enum wasapi_thread_state thread_state)
+static void set_state_and_wakeup_thread(struct ao *ao,
+                                        enum wasapi_thread_state thread_state)
 {
     struct wasapi_state *state = ao->priv;
     atomic_store(&state->thread_state, thread_state);
-    thread_wakeup(ao);
+    SetEvent(state->hWake);
+}
+
+static void thread_process_dispatch(void *ptr)
+{
+    set_state_and_wakeup_thread(ptr, WASAPI_THREAD_DISPATCH);
 }
 
 static DWORD __stdcall AudioThread(void *lpParameter)
@@ -212,14 +210,15 @@ static DWORD __stdcall AudioThread(void *lpParameter)
         if (WaitForSingleObject(state->hWake, INFINITE) != WAIT_OBJECT_0)
             MP_ERR(ao, "Unexpected return value from WaitForSingleObject\n");
 
-        mp_dispatch_queue_process(state->dispatch, 0);
-
         int thread_state = atomic_load(&state->thread_state);
         switch (thread_state) {
         case WASAPI_THREAD_FEED:
             // fill twice on under-full buffer (see comment in thread_feed)
             if (thread_feed(ao) && thread_feed(ao))
                 MP_ERR(ao, "Unable to fill buffer fast enough\n");
+            break;
+        case WASAPI_THREAD_DISPATCH:
+            mp_dispatch_queue_process(state->dispatch, 0);
             break;
         case WASAPI_THREAD_RESET:
             thread_reset(ao);
@@ -250,7 +249,7 @@ static void uninit(struct ao *ao)
     MP_DBG(ao, "Uninit wasapi\n");
     struct wasapi_state *state = ao->priv;
     if (state->hWake)
-        set_thread_state(ao, WASAPI_THREAD_SHUTDOWN);
+        set_state_and_wakeup_thread(ao, WASAPI_THREAD_SHUTDOWN);
 
     if (state->hAudioThread &&
         WaitForSingleObject(state->hAudioThread, INFINITE) != WAIT_OBJECT_0)
@@ -301,7 +300,7 @@ static int init(struct ao *ao)
     }
 
     state->dispatch = mp_dispatch_create(state);
-    mp_dispatch_set_wakeup_fn(state->dispatch, thread_wakeup, ao);
+    mp_dispatch_set_wakeup_fn(state->dispatch, thread_process_dispatch, ao);
 
     state->init_ok = false;
     state->hAudioThread = CreateThread(NULL, 0, &AudioThread, ao, 0, NULL);
@@ -456,12 +455,12 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 
 static void audio_reset(struct ao *ao)
 {
-    set_thread_state(ao, WASAPI_THREAD_RESET);
+    set_state_and_wakeup_thread(ao, WASAPI_THREAD_RESET);
 }
 
 static void audio_resume(struct ao *ao)
 {
-    set_thread_state(ao, WASAPI_THREAD_RESUME);
+    set_state_and_wakeup_thread(ao, WASAPI_THREAD_RESUME);
 }
 
 static void hotplug_uninit(struct ao *ao)

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -48,6 +48,7 @@ void wasapi_change_uninit(struct ao* ao);
 
 enum wasapi_thread_state {
     WASAPI_THREAD_FEED = 0,
+    WASAPI_THREAD_DISPATCH,
     WASAPI_THREAD_RESUME,
     WASAPI_THREAD_RESET,
     WASAPI_THREAD_SHUTDOWN


### PR DESCRIPTION
This is also meant to fix #12615 but with more conservative changes to hopefully have an earlier merge into upstream (I know it's bad manner and practice, but the issue has been bugging me for quite some time 🥲, and it is actually very easily triggered). Different from #13434, the buffer space checks using `IAudioClient_GetCurrentPadding` and logic for resolving cascading buffer underruns are kept in case there are older Windows versions that behave differently.

To test, add for example the following key binding:
```
v set ao-volume 50
```
Press `v` while in playback with `--ao=wasapi` and `--audio-exclusive=yes` and notice the glitches and slowly accumulating A/V desync without this patch.