### PR TITLE
[RFC] hidpi-window-scale changes

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -47,6 +47,7 @@ Interface changes
     - remove `--vo=rpi`, `--gpu-context=rpi`, and `--hwdec=mmal`
     - add `auto` choice to `--deinterlace`
     - change `--teletext-page` default from 100 to 0 ("subtitle" in lavc)
+    - change `--hidpi-window-scale` default to `no`
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3458,7 +3458,7 @@ Window
 
 ``--hidpi-window-scale``, ``--no-hidpi-window-scale``
     Scale the window size according to the backing DPI scale factor from the OS
-    (default: yes). For example, if the OS DPI scaling is set to 200%, mpv's window
+    (default: no). For example, if the OS DPI scaling is set to 200%, mpv's window
     size will be multiplied by 2.
 
 ``--native-fs``, ``--no-native-fs``

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3457,10 +3457,9 @@ Window
         - ``--monitoraspect=16:9`` or ``--monitoraspect=1.7777``
 
 ``--hidpi-window-scale``, ``--no-hidpi-window-scale``
-    (macOS, Windows, X11, and Wayland only)
-    Scale the window size according to the backing scale factor (default: yes).
-    On regular HiDPI resolutions the window opens with double the size but appears
-    as having the same size as on non-HiDPI resolutions.
+    Scale the window size according to the backing DPI scale factor from the OS
+    (default: yes). For example, if the OS DPI scaling is set to 200%, mpv's window
+    size will be multiplied by 2.
 
 ``--native-fs``, ``--no-native-fs``
     (macOS only)

--- a/options/options.c
+++ b/options/options.c
@@ -236,7 +236,6 @@ const struct m_sub_options vo_sub_opts = {
         .auto_window_resize = true,
         .keepaspect = true,
         .keepaspect_window = true,
-        .hidpi_window_scale = true,
         .native_fs = true,
         .taskbar_progress = true,
         .border = true,

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -618,7 +618,7 @@ static void update_dpi(struct vo_w32_state *w32)
     }
 
     w32->dpi = dpi;
-    w32->dpi_scale = w32->opts->hidpi_window_scale ? w32->dpi / 96.0 : 1.0;
+    w32->dpi_scale = w32->dpi / 96.0;
     signal_events(w32, VO_EVENT_DPI);
 }
 
@@ -2092,8 +2092,8 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
             return VO_FALSE;
 
         RECT *rc = w32->current_fs ? &w32->prev_windowrc : &w32->windowrc;
-        s[0] = rect_w(*rc) / w32->dpi_scale;
-        s[1] = rect_h(*rc) / w32->dpi_scale;
+        s[0] = rect_w(*rc);
+        s[1] = rect_h(*rc);
         return VO_TRUE;
     }
     case VOCTRL_SET_UNFS_WINDOW_SIZE: {
@@ -2101,9 +2101,6 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
 
         if (!w32->window_bounds_initialized)
             return VO_FALSE;
-
-        s[0] *= w32->dpi_scale;
-        s[1] *= w32->dpi_scale;
 
         RECT *rc = w32->current_fs ? &w32->prev_windowrc : &w32->windowrc;
         resize_and_move_rect(w32, rc, s[0], s[1]);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2177,8 +2177,6 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
                 set_input_region(wl, opts->cursor_passthrough);
             if (opt == &opts->fullscreen)
                 toggle_fullscreen(wl);
-            if (opt == &opts->hidpi_window_scale)
-                set_geometry(wl, true);
             if (opt == &opts->window_maximized)
                 toggle_maximized(wl);
             if (opt == &opts->window_minimized)


### PR DESCRIPTION
Follow up to #13470.

Apparently wayland behaves differently here than other backends, but I would argue it's better and more intuitive so I made x11 and win32 (untested) match it. I don't know how macOS works but I would guess it needs to be changed to be brought in line the changes in this PR (cc @Akemi).

So to sum it up:
1. The DPI scale factor should not be taken into account when setting the window scale. It is unintuitive and adds extra complexity for no benefit. When a user sets a window scale to 1, they reasonably expect the scale to actually be 1. Not 1 multiplied by some other random number. This was mentioned in #9437 and I agree with the user.
2. The DPI scale still needs to be accurately reported to the `display-hidpi-scale` property regardless of the value of `hidpi-window-scale`. It's not like the DPI of the monitor magically goes away. It has actual practical use as well: e.g. text in the console.
3. Add a method for runtime updating of `hidpi-window-scale`. Wayland was the only one that attempted it, but it's bugged. It's much easier to do it centrally however since this is quite literally the same as a window scale. All you have to do is pick the right factor first.
4. Make `hidpi-window-scale` default to no. Everyone that has chimed in #13465 apparently dislikes that it currently defaults to `yes` (aside from the one thumbs down presumably). I would say that a 1920x1080 should always open as that regardless of the OS DPI setting and it makes no sense to scale it, but this particular one I won't insist on if people actually do like this for some reason.
