### PR TITLE
win32: fix window maximized state after setting window size

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -185,6 +185,7 @@ struct vo_w32_state {
     BOOL win_arranging;
 
     bool conversion_mode_init;
+    bool unmaximize;
 };
 
 static void adjust_window_rect(struct vo_w32_state *w32, HWND hwnd, RECT *rc)
@@ -1080,6 +1081,19 @@ static void update_window_state(struct vo_w32_state *w32)
     SetWindowPos(w32->window, w32->opts->ontop ? HWND_TOPMOST : HWND_NOTOPMOST,
                  wr.left, wr.top, rect_w(wr), rect_h(wr),
                  SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOOWNERZORDER);
+
+    // Unmaximize the window if a size change is requested because SetWindowPos
+    // doesn't change the window maximized state.
+    // ShowWindow(SW_SHOWNOACTIVATE) can't be used here because it tries to
+    // "restore" the window to its size before it's maximized.
+    if (w32->unmaximize) {
+        WINDOWPLACEMENT wp = { .length = sizeof wp };
+        GetWindowPlacement(w32->window, &wp);
+        wp.showCmd = SW_SHOWNOACTIVATE;
+        wp.rcNormalPosition = wr;
+        SetWindowPlacement(w32->window, &wp);
+        w32->unmaximize = false;
+    }
 
     // Show the window if it's not yet visible
     if (!is_visible(w32->window)) {
@@ -2084,6 +2098,9 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
             } else if (changed_option == &vo_opts->geometry || changed_option == &vo_opts->autofit ||
                 changed_option == &vo_opts->autofit_smaller || changed_option == &vo_opts->autofit_larger)
             {
+                if (w32->opts->window_maximized) {
+                    w32->unmaximize = true;
+                }
                 window_reconfig(w32, true);
             }
         }
@@ -2120,6 +2137,9 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         RECT *rc = w32->current_fs ? &w32->prev_windowrc : &w32->windowrc;
         resize_and_move_rect(w32, rc, s[0], s[1]);
 
+        if (w32->opts->window_maximized) {
+            w32->unmaximize = true;
+        }
         w32->fit_on_screen = true;
         reinit_window_state(w32);
         return VO_TRUE;


### PR DESCRIPTION
With runtime geometry change, currently it only results in a `SetWindowPos` call to resize the window. However, `SetWindowPos` doesn't change the window maximized state, so Windows still thinks that the window is maximized even though it no longer covers the whole workspace. This results in visual glitches, and if the window is dragged afterwards it's "restored" again.

Fix this by unmaximize the window in this case, which also matches the behavior of X11 and Wayland.

Also update maximized state when leaving fullscreen. Fixes https://github.com/mpv-player/mpv/issues/10687.