### PR TITLE
vo_gpu_next: don't add 0 width/height sub bitmaps to pl_overlay

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -294,6 +294,8 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
         entry->num_parts = 0;
         for (int i = 0; i < item->num_parts; i++) {
             const struct sub_bitmap *b = &item->parts[i];
+            if (b->dw == 0 || b->dh == 0)
+                continue;
             uint32_t c = b->libass.color;
             struct pl_overlay_part part = {
                 .src = { b->src_x, b->src_y, b->src_x + b->w, b->src_y + b->h },


### PR DESCRIPTION
Previously, libplacebo would fail to render the image since mpv was feeding it bogus bitmaps with 0 width/height. An easy way to encounter this would be to set sub-scale to 0 with bitmap/image subs.