### PR TITLE
DOCS/man: add description of display-names property for wayland

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2683,7 +2683,10 @@ Property list
     in the list will be the one that Windows considers associated with the
     window (as determined by the MonitorFromWindow API.) On macOS these are the
     Display Product Names as used in the System Information and only one display
-    name is returned since a window can only be on one screen.
+    name is returned since a window can only be on one screen. On Wayland, these
+    are the wl_output names if protocol version >= 4 is used
+    (LVDS-1, HDMI-A-1, X11-1, etc.), or the wl_output model reported by the
+    geometry event if protocol version < 4 is used.
 
 ``display-fps``
     The refresh rate of the current display. Currently, this is the lowest FPS


### PR DESCRIPTION
On wayland, depending on the wl_output protocol version used, the display-names property can have different values. Mention this in the documentation, like for other platforms.
