### PR TITLE
vo_gpu/vo_gpu_next: overhaul alpha related options

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -57,6 +57,7 @@ Interface changes
     - move the `options` argument of the `loadfile` command from the third
       parameter to the fourth (after `index`)
     - add `--drag-and-drop=insert-next` option
+    - rename `--background` to `--background-color`
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -58,6 +58,8 @@ Interface changes
       parameter to the fourth (after `index`)
     - add `--drag-and-drop=insert-next` option
     - rename `--background` to `--background-color`
+    - remove `--alpha` and reintroduce `--background` option for better control
+      over blending alpha components into specific background types
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -60,6 +60,7 @@ Interface changes
     - rename `--background` to `--background-color`
     - remove `--alpha` and reintroduce `--background` option for better control
       over blending alpha components into specific background types
+    - add `--border-background` option
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6921,34 +6921,30 @@ them.
                  softsubbed ASS signs to match the video colors, but may cause
                  SRT subtitles or similar to look slightly off.
 
-``--alpha=<blend-tiles|blend|yes|no>``
-    Decides what to do if the input has an alpha component.
+``--background=<none|color|tiles>``
+    If the frame has an alpha component, decide what kind of background, if any,
+    to blend it with. This does nothing if there is no alpha component.
 
-    blend-tiles
+    color
+        Blend the frame against the background color (``--background-color``,
+        normally black).
+    tiles
         Blend the frame against a 16x16 gray/white tiles background (default).
-    blend
-        Blend the frame against the background color (``--background``, normally
-        black).
-    yes
-        Try to create a framebuffer with alpha component. This only makes sense
-        if the video contains alpha information (which is extremely rare) or if
-        you make the background color transparent. May not be supported on all
-        platforms. If alpha framebuffers are unavailable, it silently falls
-        back on a normal framebuffer. Note that if you set the ``--fbo-format``
-        option to a non-default value, a format with alpha must be specified,
-        or this won't work. Whether this really works depends on the windowing
-        system and desktop environment.
-    no
-        Ignore alpha component.
+    none
+        Do not blend the frame and leave the alpha as is.
+
+    Before mpv 0.38.0, this option used to accept a color value specifying the
+    background color. This is now done by the ``--background-color`` option.
+    Use that instead.
+
+``--background-color=<color>``
+    Color used to draw parts of the mpv window not covered by video. See the
+    ``--sub-color`` option for how colors are defined.
 
 ``--opengl-rectangle-textures``
     Force use of rectangle textures (default: no). Normally this shouldn't have
     any advantages over normal textures. Note that hardware decoding overrides
     this flag. Could be removed any time.
-
-``--background-color=<color>``
-    Color used to draw parts of the mpv window not covered by video. See the
-    ``--sub-color`` option for how colors are defined.
 
 ``--gpu-tex-pad-x``, ``--gpu-tex-pad-y``
     Enlarge the video source textures by this many pixels. For debugging only

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6946,7 +6946,7 @@ them.
     any advantages over normal textures. Note that hardware decoding overrides
     this flag. Could be removed any time.
 
-``--background=<color>``
+``--background-color=<color>``
     Color used to draw parts of the mpv window not covered by video. See the
     ``--sub-color`` option for how colors are defined.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6941,6 +6941,10 @@ them.
     Color used to draw parts of the mpv window not covered by video. See the
     ``--sub-color`` option for how colors are defined.
 
+``--border-background=<none|color|tiles>``
+    Same as ``--background`` but only applies to the black bar/border area of
+    the window. ``vo=gpu-next`` only. Defaults to ``color``.
+
 ``--opengl-rectangle-textures``
     Force use of rectangle textures (default: no). Normally this shouldn't have
     any advantages over normal textures. Note that hardware decoding overrides

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -313,7 +313,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .sigmoid_upscaling = true,
     .interpolation_threshold = 0.01,
     .alpha_mode = ALPHA_BLEND_TILES,
-    .background = {0, 0, 0, 255},
+    .background_color = {0, 0, 0, 255},
     .gamma = 1.0f,
     .tone_map = {
         .curve = TONE_MAPPING_AUTO,
@@ -453,7 +453,7 @@ const struct m_sub_options gl_video_conf = {
             {"blend", ALPHA_BLEND},
             {"blend-tiles", ALPHA_BLEND_TILES})},
         {"opengl-rectangle-textures", OPT_BOOL(use_rectangle)},
-        {"background", OPT_COLOR(background)},
+        {"background-color", OPT_COLOR(background_color)},
         {"interpolation", OPT_BOOL(interpolation)},
         {"interpolation-threshold", OPT_FLOAT(interpolation_threshold)},
         {"blend-subtitles", OPT_CHOICE(blend_subs,
@@ -3088,7 +3088,7 @@ static void pass_draw_to_screen(struct gl_video *p, const struct ra_fbo *fbo, in
             GLSL(color.a = 1.0;)
         } else if (p->opts.alpha_mode == ALPHA_BLEND) {
             // Blend into background color (usually black)
-            struct m_color c = p->opts.background;
+            struct m_color c = p->opts.background_color;
             GLSLF("vec4 background = vec4(%f, %f, %f, %f);\n",
                   c.r / 255.0, c.g / 255.0, c.b / 255.0, c.a / 255.0);
             GLSL(color.rgb += background.rgb * (1.0 - color.a);)
@@ -3864,7 +3864,7 @@ static void check_gl_features(struct gl_video *p)
             .fbo_format = p->opts.fbo_format,
             .alpha_mode = p->opts.alpha_mode,
             .use_rectangle = p->opts.use_rectangle,
-            .background = p->opts.background,
+            .background_color = p->opts.background_color,
             .dither_algo = p->opts.dither_algo,
             .dither_depth = p->opts.dither_depth,
             .dither_size = p->opts.dither_size,
@@ -4115,7 +4115,7 @@ static void reinit_from_options(struct gl_video *p)
     p->opts = *(struct gl_video_opts *)p->opts_cache->opts;
 
     if (!p->force_clear_color)
-        p->clear_color = p->opts.background;
+        p->clear_color = p->opts.background_color;
 
     check_gl_features(p);
     uninit_rendering(p);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3091,6 +3091,7 @@ static void pass_draw_to_screen(struct gl_video *p, const struct ra_fbo *fbo, in
             GLSLF("vec4 background = vec4(%f, %f, %f, %f);\n",
                   c.r / 255.0, c.g / 255.0, c.b / 255.0, c.a / 255.0);
             GLSL(color += background * (1.0 - color.a);)
+            GLSL(color.rgb *= vec3(color.a););
         }
     }
 
@@ -3314,6 +3315,9 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
 
     struct m_color c = p->clear_color;
     float clear_color[4] = {c.r / 255.0, c.g / 255.0, c.b / 255.0, c.a / 255.0};
+    clear_color[0] *= clear_color[3];
+    clear_color[1] *= clear_color[3];
+    clear_color[2] *= clear_color[3];
     p->ra->fns->clear(p->ra, fbo->tex, clear_color, &target_rc);
 
     if (p->hwdec_overlay) {

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -72,11 +72,10 @@ enum dither_algo {
     DITHER_ERROR_DIFFUSION,
 };
 
-enum alpha_mode {
-    ALPHA_NO = 0,
-    ALPHA_YES,
-    ALPHA_BLEND,
-    ALPHA_BLEND_TILES,
+enum background_type {
+    BACKGROUND_NONE = 0,
+    BACKGROUND_COLOR,
+    BACKGROUND_TILES,
 };
 
 enum blend_subs_mode {
@@ -155,7 +154,7 @@ struct gl_video_opts {
     int temporal_dither_period;
     char *error_diffusion;
     char *fbo_format;
-    int alpha_mode;
+    int background;
     bool use_rectangle;
     struct m_color background_color;
     bool interpolation;

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -157,7 +157,7 @@ struct gl_video_opts {
     char *fbo_format;
     int alpha_mode;
     bool use_rectangle;
-    struct m_color background;
+    struct m_color background_color;
     bool interpolation;
     float interpolation_threshold;
     int blend_subs;

--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -113,7 +113,6 @@ struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct gl_video_opts *gl_opts)
     ctx->log = vo->log;
 
     struct ra_ctx_opts *ctx_opts = mp_get_config_group(ctx, vo->global, &ra_ctx_conf);
-    ctx_opts->want_alpha = gl_opts->alpha_mode == ALPHA_YES;
     ctx->ra_ctx = ra_ctx_create(vo, *ctx_opts);
     if (!ctx->ra_ctx)
         goto err_out;

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -172,10 +172,9 @@ static void get_and_update_ambient_lighting(struct gpu_priv *p)
 static void update_ra_ctx_options(struct vo *vo)
 {
     struct gpu_priv *p = vo->priv;
-
-    /* Only the alpha option has any runtime toggle ability. */
     struct gl_video_opts *gl_opts = mp_get_config_group(p->ctx, vo->global, &gl_video_conf);
     p->ctx->opts.want_alpha = gl_opts->alpha_mode == 1;
+    talloc_free(gl_opts);
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)
@@ -285,16 +284,14 @@ static int preinit(struct vo *vo)
     p->log = vo->log;
 
     struct ra_ctx_opts *ctx_opts = mp_get_config_group(vo, vo->global, &ra_ctx_conf);
-    struct gl_video_opts *gl_opts = mp_get_config_group(vo, vo->global, &gl_video_conf);
     struct ra_ctx_opts opts = *ctx_opts;
-    opts.want_alpha = gl_opts->alpha_mode == 1;
     p->ctx = ra_ctx_create(vo, opts);
     talloc_free(ctx_opts);
-    talloc_free(gl_opts);
     if (!p->ctx)
         goto err_out;
     assert(p->ctx->ra);
     assert(p->ctx->swapchain);
+    update_ra_ctx_options(vo);
 
     p->renderer = gl_video_init(p->ctx->ra, vo->log, vo->global);
     gl_video_set_osd_source(p->renderer, vo->osd);

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -173,7 +173,9 @@ static void update_ra_ctx_options(struct vo *vo)
 {
     struct gpu_priv *p = vo->priv;
     struct gl_video_opts *gl_opts = mp_get_config_group(p->ctx, vo->global, &gl_video_conf);
-    p->ctx->opts.want_alpha = gl_opts->alpha_mode == 1;
+    p->ctx->opts.want_alpha = (gl_opts->background == BACKGROUND_COLOR &&
+                               gl_opts->background_color.a != 255) ||
+                               gl_opts->background == BACKGROUND_NONE;
     talloc_free(gl_opts);
 }
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2092,7 +2092,18 @@ static void update_render_options(struct vo *vo)
     pars->params.skip_anti_aliasing = !opts->correct_downscaling;
     pars->params.disable_linear_scaling = !opts->linear_downscaling && !opts->linear_upscaling;
     pars->params.disable_fbos = opts->dumb_mode == 1;
+
+#if PL_API_VER >= 346
+    enum pl_clear_mode map_background_types[3][2] = {
+        { BACKGROUND_NONE,  PL_CLEAR_SKIP  },
+        { BACKGROUND_COLOR, PL_CLEAR_COLOR },
+        { BACKGROUND_TILES, PL_CLEAR_TILES },
+    };
+    pars->params.background = map_background_types[opts->background][1];
+#else
     pars->params.blend_against_tiles = opts->background == BACKGROUND_TILES;
+#endif
+
     pars->params.corner_rounding = p->next_opts->corner_rounding;
     pars->params.correct_subpixel_offsets = !opts->scaler_resizes_only;
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1454,6 +1454,13 @@ static inline void copy_frame_info_to_mp(struct frame_info *pl,
     }
 }
 
+static void update_ra_ctx_options(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+    struct gl_video_opts *gl_opts = p->opts_cache->opts;
+    p->ra_ctx->opts.want_alpha = gl_opts->alpha_mode == ALPHA_YES;
+}
+
 static int control(struct vo *vo, uint32_t request, void *data)
 {
     struct priv *p = vo->priv;
@@ -1469,8 +1476,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
 
     case VOCTRL_UPDATE_RENDER_OPTS: {
         m_config_cache_update(p->opts_cache);
-        const struct gl_video_opts *opts = p->opts_cache->opts;
-        p->ra_ctx->opts.want_alpha = opts->alpha_mode == ALPHA_YES;
+        update_ra_ctx_options(vo);
         if (p->ra_ctx->fns->update_render_opts)
             p->ra_ctx->fns->update_render_opts(p->ra_ctx);
         update_render_options(vo);
@@ -1803,6 +1809,7 @@ static int preinit(struct vo *vo)
         .global = p->global,
         .ra_ctx = p->ra_ctx,
     };
+    update_ra_ctx_options(vo);
 
     vo->hwdec_devs = hwdec_devices_create();
     hwdec_devices_set_loader(vo->hwdec_devs, load_hwdec_api, vo);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1458,7 +1458,9 @@ static void update_ra_ctx_options(struct vo *vo)
 {
     struct priv *p = vo->priv;
     struct gl_video_opts *gl_opts = p->opts_cache->opts;
-    p->ra_ctx->opts.want_alpha = gl_opts->alpha_mode == ALPHA_YES;
+    p->ra_ctx->opts.want_alpha = (gl_opts->background == BACKGROUND_COLOR &&
+                                  gl_opts->background_color.a != 255) ||
+                                  gl_opts->background == BACKGROUND_NONE;
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)
@@ -2090,7 +2092,7 @@ static void update_render_options(struct vo *vo)
     pars->params.skip_anti_aliasing = !opts->correct_downscaling;
     pars->params.disable_linear_scaling = !opts->linear_downscaling && !opts->linear_upscaling;
     pars->params.disable_fbos = opts->dumb_mode == 1;
-    pars->params.blend_against_tiles = opts->alpha_mode == ALPHA_BLEND_TILES;
+    pars->params.blend_against_tiles = opts->background == BACKGROUND_TILES;
     pars->params.corner_rounding = p->next_opts->corner_rounding;
     pars->params.correct_subpixel_offsets = !opts->scaler_resizes_only;
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2083,10 +2083,10 @@ static void update_render_options(struct vo *vo)
     pl_options pars = p->pars;
     const struct gl_video_opts *opts = p->opts_cache->opts;
     pars->params.antiringing_strength = opts->scaler[0].antiring;
-    pars->params.background_color[0] = opts->background.r / 255.0;
-    pars->params.background_color[1] = opts->background.g / 255.0;
-    pars->params.background_color[2] = opts->background.b / 255.0;
-    pars->params.background_transparency = 1.0 - opts->background.a / 255.0;
+    pars->params.background_color[0] = opts->background_color.r / 255.0;
+    pars->params.background_color[1] = opts->background_color.g / 255.0;
+    pars->params.background_color[2] = opts->background_color.b / 255.0;
+    pars->params.background_transparency = 1 - opts->background_color.a / 255.0;
     pars->params.skip_anti_aliasing = !opts->correct_downscaling;
     pars->params.disable_linear_scaling = !opts->linear_downscaling && !opts->linear_upscaling;
     pars->params.disable_fbos = opts->dumb_mode == 1;


### PR DESCRIPTION
A spiritual successor to #9621 but it also implements vo_gpu_next support. This depends on this libplacebo [MR](https://code.videolan.org/videolan/libplacebo/-/merge_requests/640).

This splits `--alpha` into two options: `--alpha` and `--blend`. `alpha` strictly controls whether or not draw the framebuffer with the alpha component if possible (default yes). `blend` is what controls blending the alpha component into either tiles, the background color, or nothing. This makes it possible to blend with a partially transparent background color e.g. something like `mpv --background=0.5/0.5 --blend=background image.png`.

TODO:
- [x] The vo_gpu colors are wrong when blending with transparency for some reason. It kind of works (which is better than not working at all), but haven't figured out what I'm missing. Fixed.

Edit: Nevermind. The alpha component in `--background` is bugged in `vo_gpu` period. `--background=0.5/0.0` is not fully transparent and has a light grayish color for whatever reason. It's fully transparent in `vo_gpu_next` as expected. ~Probably won't bother fixing `vo_gpu` here but if someone wants to, feel free.~ Should work now.