### PR TITLE
cocoa-cb: lock CGLContext on uninit and manual redraw

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -209,7 +209,9 @@ class CocoaCB: Common {
         uninit()
         uninitCommon()
 
+        layer?.lockCglContext()
         libmpv.deinitRender()
+        layer?.unlockCglContext()
         libmpv.deinitMPV(destroy)
     }
 

--- a/video/out/mac/gl_layer.swift
+++ b/video/out/mac/gl_layer.swift
@@ -199,6 +199,14 @@ class GLLayer: CAOpenGLLayer {
         }
     }
 
+    func lockCglContext() {
+        CGLLockContext(cglContext)
+    }
+
+    func unlockCglContext() {
+        CGLUnlockContext(cglContext)
+    }
+
     override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj {
         return cglPixelFormat
     }
@@ -219,10 +227,12 @@ class GLLayer: CAOpenGLLayer {
         super.display()
         CATransaction.flush()
         if isUpdate && needsFlip {
+            lockCglContext()
             CGLSetCurrentContext(cglContext)
             if libmpv.isRenderUpdateFrame() {
                 libmpv.drawRender(NSZeroSize, bufferDepth, cglContext, skip: true)
             }
+            unlockCglContext()
         }
         displayLock.unlock()
     }


### PR DESCRIPTION
i could never reproduce this issue so i can't really confirm it fixed. though thanks to @low-batt thorough investigation on #11681 and https://github.com/iina/iina/pull/3581 the fix is rather obvious.