### PR TITLE
vo_dmabuf_wayland: reject formats not supported by the gpu

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1375,8 +1375,8 @@ static void format_table(void *data,
     close(fd);
 
     if (map != MAP_FAILED) {
-        wl->format_map = map;
-        wl->format_size = size;
+        wl->compositor_format_map = map;
+        wl->compositor_format_size = size;
     }
 }
 
@@ -2858,7 +2858,7 @@ void vo_wayland_uninit(struct vo *vo)
     if (wl->display)
         wl_display_disconnect(wl->display);
 
-    munmap(wl->format_map, wl->format_size);
+    munmap(wl->compositor_format_map, wl->compositor_format_size);
 
     for (int n = 0; n < 2; n++)
         close(wl->wakeup_pipe[n]);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -106,8 +106,11 @@ struct vo_wayland_state {
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
 
     /* linux-dmabuf */
+    dev_t main_device_id;
     struct zwp_linux_dmabuf_v1 *dmabuf;
     struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
+    uint32_t *gpu_formats;
+    uint32_t gpu_format_count;
     wayland_format *format_map;
     uint32_t format_size;
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -26,7 +26,7 @@ typedef struct {
     uint32_t format;
     uint32_t padding;
     uint64_t modifier;
-} wayland_format;
+} compositor_format;
 
 struct wayland_opts {
     int configure_bounds;
@@ -111,8 +111,8 @@ struct vo_wayland_state {
     struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
     uint32_t *gpu_formats;
     uint32_t gpu_format_count;
-    wayland_format *format_map;
-    uint32_t format_size;
+    compositor_format *compositor_format_map;
+    uint32_t compositor_format_size;
 
     /* presentation-time */
     struct wp_presentation  *presentation;

--- a/video/out/wldmabuf/ra_wldmabuf.c
+++ b/video/out/wldmabuf/ra_wldmabuf.c
@@ -34,6 +34,19 @@ bool ra_compatible_format(struct ra* ra, uint32_t drm_format, uint64_t modifier)
     struct vo_wayland_state *wl = p->vo->wl;
     const wayland_format *formats = wl->format_map;
 
+    // First check if the gpu/drivers support the format.
+    bool supported_gpu_format = false;
+    for (int i = 0; i < wl->gpu_format_count; i++) {
+        if (drm_format == wl->gpu_formats[i]) {
+            supported_gpu_format = true;
+            break;
+        }
+    }
+
+    if (!supported_gpu_format)
+        return false;
+
+    // Now check if the compositor supports the format.
     for (int i = 0; i < wl->format_size / sizeof(wayland_format); i++) {
         if (drm_format == formats[i].format && modifier == formats[i].modifier)
             return true;

--- a/video/out/wldmabuf/ra_wldmabuf.c
+++ b/video/out/wldmabuf/ra_wldmabuf.c
@@ -32,7 +32,7 @@ bool ra_compatible_format(struct ra* ra, uint32_t drm_format, uint64_t modifier)
 {
     struct priv* p = ra->priv;
     struct vo_wayland_state *wl = p->vo->wl;
-    const wayland_format *formats = wl->format_map;
+    const compositor_format *formats = wl->compositor_format_map;
 
     // First check if the gpu/drivers support the format.
     bool supported_gpu_format = false;
@@ -47,7 +47,7 @@ bool ra_compatible_format(struct ra* ra, uint32_t drm_format, uint64_t modifier)
         return false;
 
     // Now check if the compositor supports the format.
-    for (int i = 0; i < wl->format_size / sizeof(wayland_format); i++) {
+    for (int i = 0; i < wl->compositor_format_size / sizeof(compositor_format); i++) {
         if (drm_format == formats[i].format && modifier == formats[i].modifier)
             return true;
     }


### PR DESCRIPTION
The best way to test is to have trash hardware that doesn't support NV12 (yes really).

We probe compositor-supported formats for dmabuf_wayland but we do not check what the gpu supports. If the gpu doesn't support the format, then we should reject it as well. This is still a WIP in progress because although mpv's auto converter does work with this, I have to specify `--hwdec` otherwise it will fail. Looks like it tries to go directly to yuv420p -> vaapi[bgr0] instead of the two step process of yuv420p -> bgr0 then brg0 -> vaapi[bgr0].