### PR TITLE
github/workflows: switch back to luajit for macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 lua@5.1 libass ffmpeg meson libplacebo
+          brew install autoconf automake pkg-config libtool python freetype fribidi little-cms2 luajit libass ffmpeg meson libplacebo
 
       - name: Build with meson
         id: build


### PR DESCRIPTION
Homebrew finally pulled the plug on lua 5.1, and it is no more. So we have to change to a different lua package and the only other choice is luajit (no 5.2 in homebrew). We used to use luajit for the ci, but 649556b2b65207c0d40751fae941223978b04932 switched it to lua 5.1. As explained there, luajit 2.0 was horribly bugged and not usuable for mpv and the build had to do dumb hacks to work around it. I expected 5.1 to last a bit longer than a couple of years, but luckily it seems like luajit in homebrew now pulls a luajit 2.1 version (some rolling release thing or however upstream works). The details don't really matter for us since 2.1 does not have all the awful issues that 2.0 used to have. So just switch to luajit again.