### PR TITLE
vo: move libmpv back to the bottom in the auto-probing order

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -31,7 +31,11 @@ API changes
 ===========
 
 ::
-
+ --- mpv 0.38.0 ---
+ 2.3    - partially revert the changes from API version 1.27, remove libmpv as the default VO and
+          move it to the bottom of the auto-probing order. this restores the behaviour prior API
+          version 1.27 on all platforms other than macOS, but still auto selects libmpv/cocoa-cb
+          on macOS if it was built with support for cocoa-cb.
  --- mpv 0.37.0 ---
  2.2    - add mpv_time_ns()
  --- mpv 0.36.0 ---

--- a/libmpv/client.h
+++ b/libmpv/client.h
@@ -248,7 +248,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 2)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 3)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -69,7 +69,6 @@ extern const struct vo_driver video_out_kitty;
 
 static const struct vo_driver *const video_out_drivers[] =
 {
-    &video_out_libmpv,
 #if HAVE_ANDROID
     &video_out_mediacodec_embed,
 #endif
@@ -99,6 +98,7 @@ static const struct vo_driver *const video_out_drivers[] =
 #if HAVE_X11
     &video_out_x11,
 #endif
+    &video_out_libmpv,
     &video_out_null,
     // should not be auto-selected
     &video_out_image,

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -705,6 +705,11 @@ static void uninit(struct vo *vo)
 
 static int preinit(struct vo *vo)
 {
+#if !HAVE_MACOS_COCOA_CB
+    if (vo->probing)
+        return -1;
+#endif
+
     struct vo_priv *p = vo->priv;
 
     struct mpv_render_context *ctx =


### PR DESCRIPTION
~this basically reverts commit 7b5a258. this was done for macOS since the only working vo was cocoa-cb (libmpv) and it would otherwise always use the deprecated opengl cocoa backend.~

~we now have a working vulkan gpu/gpu-next backend on macOS which should be the new default vo. vo=libmpv has to be explicitly set now to use cocoa-cb.~

@Dudemanguy @jeeb 

i am not sure if it's a problem that libmpv won't be used as a fallback like this and `vo=libmpv` has to be explicitly set to use it? we will probably get a few issues in the future when mpv is not build with vulkan support and without moltenvk, since it won't playback anything even if cocoa-cb is included in the build.
also should this probing check be reverted too, i am not sure what exactly it is for? https://github.com/mpv-player/mpv/commit/7b5a2588bd33d5cf532a1c83d79dba20a3f26bc5#diff-f7289f81cef5c1b17fc94b82798c1364fa3eff40bbcab6776611e892880cf7d1L557-R558

[edit]
this partially reverts commit 7b5a258. back then the only properly working vo on macOS was cocoa-cb (libmpv). it would always use the deprecated opengl cocoa backend or no vo at all. because of that libmpv was moved to the top of the auto-probing order, so the preferred vo was used on macOS only.

we now have a working vulkan gpu/gpu-next backend on macOS which should be the new default vo. though disabling the auto-probing again for libmpv would probably cause the undesired behaviour on macOS that cocoa-cb would never be auto selected again. especially if not build with vulkan support or without vulkan driver on macOS, this would lead to no video output at all. so instead of completely reverting the mentioned commit, we instead move libmpv to the bottom of the auto-probing order but only auto select it when mpv was built with cocoa-cb support. this restores the previous behaviour on all other platforms besides macOS, but also lets us auto select cocoa-cb if supported.