### PR TITLE
input.conf: bind `Ctrl+WHEEL_UP/DOWN` to `video-zoom`

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -218,7 +218,7 @@ Alt+LEFT, Alt+RIGHT, Alt+UP, Alt+DOWN
     Move the video rectangle (panning).
 
 Alt++ and Alt+-
-    Combining ``Alt`` with the ``+`` or ``-`` keys changes video zoom.
+    Change video zoom.
 
 Alt+BACKSPACE
     Reset the pan/zoom settings.
@@ -281,7 +281,7 @@ PREVIOUS and NEXT
     Seek backward/forward 1 minute.
 
 ZOOMIN and ZOOMOUT
-    Changes video zoom.
+    Change video zoom.
 
 If you miss some older key bindings, look at ``etc/restore-old-bindings.conf``
 in the mpv git repository.
@@ -304,6 +304,8 @@ Wheel up/down
 Wheel left/right
     Seek forward/backward 10 seconds.
 
+Ctrl+Wheel up/down
+    Change video zoom.
 
 USAGE
 =====

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -65,6 +65,8 @@
 #ZOOMIN    add video-zoom   0.1         # zoom in
 #Alt+-     add video-zoom  -0.1         # zoom out
 #ZOOMOUT   add video-zoom  -0.1         # zoom out
+#Ctrl+WHEEL_UP   add video-zoom  0.1    # zoom in
+#Ctrl+WHEEL_DOWN add video-zoom -0.1    # zoom out
 #Alt+BS set video-zoom 0 ; set video-pan-x 0 ; set video-pan-y 0 # reset zoom and pan settings
 #PGUP add chapter 1                     # seek to the next chapter
 #PGDWN add chapter -1                   # seek to the previous chapter


### PR DESCRIPTION
There are good reasons to bind `Ctrl+WHEEL_UP/WHEEL_DOWN` to `video-zoom`:

- They are ubiquitous and familiar key bindings to represent zooming operations, which are used in all popular web browsers, document viewers, and document editors.
- Because `WHEEL_UP/WHEEL_DOWN` are scaled with high-resolution scrolling input devices like touchpads, this allows smooth zooming.
- This makes "pinch to zoom" with touchpads and touchscreens work out of box on Windows, since by default applications receive these key inputs for pinch gesture.
- It had been considered to bind these keys to `window-scale` instead. However, this results in horrible UX as the keybinds work only when the mouse pointer is over the mpv window, and if the window shrinks during this operation, the window below mpv now receives these keybinds, resulting in unwanted zooming for that window, which violates the principle of least surprise.
