### PR TITLE
af_lavcac3enc: don't use deprecated `avcodec_close`

### DIFF
--- a/audio/filter/af_lavcac3enc.c
+++ b/audio/filter/af_lavcac3enc.c
@@ -103,7 +103,15 @@ static bool reinit(struct mp_filter *f)
     if (!bit_rate && chmap.num < AC3_MAX_CHANNELS + 1)
         bit_rate = default_bit_rate[chmap.num];
 
-    avcodec_close(s->lavc_actx);
+    avcodec_free_context(&s->lavc_actx);
+    s->lavc_actx = avcodec_alloc_context3(s->lavc_acodec);
+    if (!s->lavc_actx) {
+        MP_ERR(f, "Audio LAVC, couldn't reallocate context!\n");
+        return false;
+    }
+
+    if (mp_set_avopts(f->log, s->lavc_actx, s->opts->avopts) < 0)
+        return false;
 
     // Put sample parameters
     s->lavc_actx->sample_fmt = af_to_avformat(format);

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -906,7 +906,7 @@ bool encoder_init_codec_and_muxer(struct encoder_context *p,
     return true;
 
 fail:
-    avcodec_close(p->encoder);
+    avcodec_free_context(&p->encoder);
     return false;
 }
 


### PR DESCRIPTION
See: https://github.com/FFmpeg/FFmpeg/commit/1cc24d749569a42510399a29b034f7a77bdec34e
