### PR TITLE
fix sub-seek without a video

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5445,6 +5445,14 @@ static void cmd_sub_step_seek(void *p)
                     track_ind == 0 ? "sub-delay" : "secondary-sub-delay",
                     cmd->on_osd);
             } else {
+                // We can easily seek/step to the wrong subtitle line (because
+                // video frame PTS and sub PTS rarely match exactly).
+                // sub/sd_ass.c adds SUB_SEEK_OFFSET as a workaround, and we
+                // need an even bigger offset without a video.
+                if (!mpctx->current_track[0][STREAM_VIDEO] ||
+                    mpctx->current_track[0][STREAM_VIDEO]->image) {
+                    a[0] += SUB_SEEK_WITHOUT_VIDEO_OFFSET - SUB_SEEK_OFFSET;
+                }
                 mark_seek(mpctx);
                 queue_seek(mpctx, MPSEEK_ABSOLUTE, a[0], MPSEEK_EXACT,
                            MPSEEK_FLAG_DELAY);

--- a/player/command.c
+++ b/player/command.c
@@ -5445,10 +5445,6 @@ static void cmd_sub_step_seek(void *p)
                     track_ind == 0 ? "sub-delay" : "secondary-sub-delay",
                     cmd->on_osd);
             } else {
-                // We can easily seek/step to the wrong subtitle line (because
-                // video frame PTS and sub PTS rarely match exactly). Add an
-                // arbitrary forward offset as a workaround.
-                a[0] += SUB_SEEK_OFFSET;
                 mark_seek(mpctx);
                 queue_seek(mpctx, MPSEEK_ABSOLUTE, a[0], MPSEEK_EXACT,
                            MPSEEK_FLAG_DELAY);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -11,6 +11,7 @@
 #define SUB_GAP_KEEP 0.4
 // slight offset when sub seeking or sub stepping
 #define SUB_SEEK_OFFSET 0.01
+#define SUB_SEEK_WITHOUT_VIDEO_OFFSET 0.1
 
 struct sd {
     struct mpv_global *global;


### PR DESCRIPTION
commit 1: command: don't add SUB_SEEK_OFFSET twice with sub-seek

The name SD_CTRL_SUB_STEP is misleading, but it is also used for sub-seek, and sub/sd_ass.c already adds SUB_SEEK_OFFSET with it.

commit 2: command: fix sub-seek while paused without a video

When using sub-seek without a video track while paused, adding the 0.01 SUB_SEEK_OFFSET to the new timestamp is not enough to show the new subtitle line. Add 0.1 instead to fix it. 0.01 is already enough for sub-step.