### PR TITLE
osdep/io: ignore 'x' mode for mp_fopen

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -528,8 +528,7 @@ FILE *mp_fopen(const char *filename, const char *mode)
     for (const char *pos = mode + 1; *pos; pos++) {
         switch (*pos) {
         case '+': rwmode = _O_RDWR;  break;
-        case 'x': oflags |= _O_EXCL; break;
-        // Ignore unknown flags (glibc does too)
+        // Ignore unknown flags
         default: break;
         }
     }


### PR DESCRIPTION
`fopen()` with 'x' mode is a non-portable glibc extension, is currently unused, and should not be used in order to maintain POSIX compatibility. Thus there is no need for the Windows wrapper `mp_fopen()` to support it.
