### PR TITLE
filters: add ---deinterlace-field-parity option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -28,6 +28,7 @@ Interface changes
 
  --- mpv 0.38.0 ---
     - add `begin-vo-dragging` command
+    - add `--deinterlace-field-parity` option
     - add `--volume-gain`, `--volume-gain-min`, and `--volume-gain-max` options
     - add `current-gpu-context` property
     - add `--secondary-sub-ass-override` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1676,6 +1676,17 @@ Video
     inserted deinterlacing filters, and that this will make video look worse if
     it's not actually interlaced.
 
+``--deinterlace-field-parity=<tff|bff|auto>``
+    Specify the field parity/order when deinterlacing(default: auto)
+    Each frame of an interlaced video is divided into two fields, which are
+    then separately transmitted. Top field represents even lines while bottom
+    field represents odd lines. When deinterlacing the deinterlacer needs to
+    know the correct temporal order of the fields else the video will appear
+    jittery.
+
+    ``auto`` will automatically try to detect the field order of the video,
+    ``tff`` forces top field first while ``bff`` forces bottom field first.
+
 ``--frames=<number>``
     Play/convert only first ``<number>`` video frames, then quit.
 

--- a/filters/f_auto_filters.c
+++ b/filters/f_auto_filters.c
@@ -88,12 +88,14 @@ static void deint_process(struct mp_filter *f)
 
     bool has_filter = true;
     if (img->imgfmt == IMGFMT_VDPAU) {
-        char *args[] = {"deint", "yes", NULL};
+        char *args[] = {"deint", "yes", 
+                        "parity", field_parity, NULL};
         p->sub.filter =
             mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "vdpaupp", args);
     } else if (img->imgfmt == IMGFMT_D3D11) {
+        char *args[] = {"parity", field_parity, NULL};
         p->sub.filter =
-            mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "d3d11vpp", NULL);
+            mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "d3d11vpp", args);
     } else if (img->imgfmt == IMGFMT_CUDA) {
         char *args[] = {"mode", "send_field",
                         "parity", field_parity, NULL};
@@ -106,7 +108,8 @@ static void deint_process(struct mp_filter *f)
             mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "bwdif_vulkan", args);
     } else if (img->imgfmt == IMGFMT_VAAPI) {
         char *args[] = {"deint", "motion-adaptive",
-                        "interlaced-only", "yes", NULL};
+                        "interlaced-only", "yes", 
+                        "parity", field_parity, NULL};
         p->sub.filter =
             mp_create_user_filter(f, MP_OUTPUT_CHAIN_VIDEO, "vavpp", args);
     } else {

--- a/options/options.c
+++ b/options/options.c
@@ -42,6 +42,7 @@
 #include "input/event.h"
 #include "stream/stream.h"
 #include "video/csputils.h"
+#include "video/filter/refqueue.h"
 #include "video/hwdec.h"
 #include "video/image_writer.h"
 #include "sub/osd.h"
@@ -440,9 +441,16 @@ const struct m_sub_options filter_conf = {
     .opts = (const struct m_option[]){
         {"deinterlace", OPT_CHOICE(deinterlace,
             {"no", 0}, {"yes", 1}, {"auto", -1})},
+        {"deinterlace-field-parity", OPT_CHOICE(field_parity, 
+            {"tff", MP_FIELD_PARITY_TFF}, 
+            {"bff", MP_FIELD_PARITY_BFF}, 
+            {"auto", MP_FIELD_PARITY_AUTO})},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),
+    .defaults = &(const struct filter_opts){
+        .field_parity = MP_FIELD_PARITY_AUTO,
+    },
     .change_flags = UPDATE_IMGPAR,
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -399,6 +399,7 @@ struct dvd_opts {
 
 struct filter_opts {
     int deinterlace;
+    int field_parity;
 };
 
 extern const struct m_sub_options vo_sub_opts;

--- a/video/filter/refqueue.h
+++ b/video/filter/refqueue.h
@@ -29,6 +29,10 @@ enum {
     MP_MODE_INTERLACED_ONLY = (1 << 2), // only deinterlace marked frames
 };
 
+#define MP_FIELD_PARITY_AUTO -1
+#define MP_FIELD_PARITY_TFF 0
+#define MP_FIELD_PARITY_BFF 1
+
 void mp_refqueue_set_mode(struct mp_refqueue *q, int flags);
 bool mp_refqueue_should_deint(struct mp_refqueue *q);
 bool mp_refqueue_is_top_field(struct mp_refqueue *q);

--- a/video/filter/refqueue.h
+++ b/video/filter/refqueue.h
@@ -34,6 +34,7 @@ enum {
 #define MP_FIELD_PARITY_BFF 1
 
 void mp_refqueue_set_mode(struct mp_refqueue *q, int flags);
+void mp_refqueue_set_parity(struct mp_refqueue *q, int parity);
 bool mp_refqueue_should_deint(struct mp_refqueue *q);
 bool mp_refqueue_is_top_field(struct mp_refqueue *q);
 bool mp_refqueue_top_field_first(struct mp_refqueue *q);

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -46,6 +46,7 @@ struct opts {
     bool deint_enabled;
     bool interlaced_only;
     int mode;
+    int field_parity;
 };
 
 struct priv {
@@ -469,6 +470,7 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
         (p->opts->deint_enabled ? MP_MODE_DEINT : 0) |
         MP_MODE_OUTPUT_FIELDS |
         (p->opts->interlaced_only ? MP_MODE_INTERLACED_ONLY : 0));
+    mp_refqueue_set_parity(p->queue, p->opts->field_parity);
 
     return f;
 
@@ -488,6 +490,10 @@ static const m_option_t vf_opts_fields[] = {
         {"mocomp", D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_MOTION_COMPENSATION},
         {"ivctc", D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_INVERSE_TELECINE},
         {"none", 0})},
+    {"parity", OPT_CHOICE(field_parity,
+        {"tff", MP_FIELD_PARITY_TFF},
+        {"bff", MP_FIELD_PARITY_BFF},
+        {"auto", MP_FIELD_PARITY_AUTO})},
     {0}
 };
 
@@ -499,6 +505,7 @@ const struct mp_user_filter_entry vf_d3d11vpp = {
         .priv_defaults = &(const OPT_BASE_STRUCT) {
             .deint_enabled = true,
             .mode = D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_BOB,
+            .field_parity = MP_FIELD_PARITY_AUTO,
         },
         .options = vf_opts_fields,
     },

--- a/video/filter/vf_vavpp.c
+++ b/video/filter/vf_vavpp.c
@@ -51,6 +51,7 @@ struct pipeline {
 
 struct opts {
     int deint_type;
+    int field_parity;
     bool interlaced_only;
     bool reversal_bug;
 };
@@ -143,11 +144,13 @@ static void update_pipeline(struct mp_filter *vf)
         (p->do_deint ? MP_MODE_DEINT : 0) |
         (p->opts->deint_type >= 2 ? MP_MODE_OUTPUT_FIELDS : 0) |
         (p->opts->interlaced_only ? MP_MODE_INTERLACED_ONLY : 0));
+    mp_refqueue_set_parity(p->queue, p->opts->field_parity);
     return;
 
 nodeint:
     mp_refqueue_set_refs(p->queue, 0, 0);
     mp_refqueue_set_mode(p->queue, 0);
+    mp_refqueue_set_parity(p->queue, p->opts->field_parity);
 }
 
 static struct mp_image *alloc_out(struct mp_filter *vf)
@@ -485,6 +488,10 @@ static const m_option_t vf_opts_fields[] = {
         {"motion-compensated", 5})},
     {"interlaced-only", OPT_BOOL(interlaced_only)},
     {"reversal-bug", OPT_BOOL(reversal_bug)},
+    {"parity", OPT_CHOICE(field_parity,
+        {"tff", MP_FIELD_PARITY_TFF},
+        {"bff", MP_FIELD_PARITY_BFF},
+        {"auto", MP_FIELD_PARITY_AUTO})},
     {0}
 };
 
@@ -496,6 +503,7 @@ const struct mp_user_filter_entry vf_vavpp = {
         .priv_defaults = &(const OPT_BASE_STRUCT){
             .deint_type = -1,
             .reversal_bug = true,
+            .field_parity = MP_FIELD_PARITY_AUTO,
         },
         .options = vf_opts_fields,
     },

--- a/video/filter/vf_vdpaupp.c
+++ b/video/filter/vf_vdpaupp.c
@@ -43,6 +43,7 @@
 struct opts {
     bool deint_enabled;
     bool interlaced_only;
+    int field_parity;
     struct mp_vdpau_mixer_opts opts;
 };
 
@@ -156,6 +157,8 @@ static struct mp_filter *vf_vdpaupp_create(struct mp_filter *parent, void *optio
         (p->opts->interlaced_only ? MP_MODE_INTERLACED_ONLY : 0) |
         (p->opts->opts.deint >= 2 ? MP_MODE_OUTPUT_FIELDS : 0));
 
+    mp_refqueue_set_parity(p->queue, p->opts->field_parity);
+
     mp_refqueue_add_in_format(p->queue, IMGFMT_VDPAU, 0);
 
     return f;
@@ -180,6 +183,10 @@ static const m_option_t vf_opts_fields[] = {
     {"sharpen", OPT_FLOAT(opts.sharpen), M_RANGE(-1, 1)},
     {"hqscaling", OPT_INT(opts.hqscaling), M_RANGE(0, 9)},
     {"interlaced-only", OPT_BOOL(interlaced_only)},
+    {"parity", OPT_CHOICE(field_parity,
+        {"tff", MP_FIELD_PARITY_TFF},
+        {"bff", MP_FIELD_PARITY_BFF},
+        {"auto", MP_FIELD_PARITY_AUTO})},
     {0}
 };
 
@@ -188,6 +195,9 @@ const struct mp_user_filter_entry vf_vdpaupp = {
         .description = "vdpau postprocessing",
         .name = "vdpaupp",
         .priv_size = sizeof(OPT_BASE_STRUCT),
+        .priv_defaults = &(const OPT_BASE_STRUCT){
+            .field_parity = MP_FIELD_PARITY_AUTO,
+        },
         .options = vf_opts_fields,
     },
     .create = vf_vdpaupp_create,


### PR DESCRIPTION
There was previously no way to set the field parity when using --deinterlace or pressing d. The ffmpeg filters(bwdif, bwdif_vulkan, bwdif_cuda) already have a parity parameter so it was just a matter of passing the option through.

As for the other ones(vdpaupp, vavpp, d3d11vpp), I am still unsure when does the MP_IMGFIELD_TOP_FIRST flag get set on the mp_image that refqueue reads, if it ever gets set at all, since it seems like mp_image always assumes bottom field first? I made the parity options take precedence over the flag but the default "auto" option should work exactly the same as before. Nevertheless the logic could be simplified if this is something that's not used anymore.

Also note that out of the inbuilt hardware ones I only tested d3d11vpp but vdpaupp and vavpp should behave no different since the changes are virtually identical.