### PR TITLE
vo_gpu: fix fragment coordinate calculation when dithering and drawing checkerboard

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2727,7 +2727,7 @@ void gl_video_set_fb_depth(struct gl_video *p, int fb_depth)
     p->fb_depth = fb_depth;
 }
 
-static void pass_dither(struct gl_video *p)
+static void pass_dither(struct gl_video *p, const struct ra_fbo *fbo)
 {
     // Assume 8 bits per component if unknown.
     int dst_depth = p->fb_depth > 0 ? p->fb_depth : 8;
@@ -2860,7 +2860,9 @@ static void pass_dither(struct gl_video *p)
 
     gl_sc_uniform_texture(p->sc, "dither", p->dither_texture);
 
-    GLSLF("vec2 dither_pos = gl_FragCoord.xy * 1.0/%d.0;\n", dither_size);
+    GLSLF("vec2 dither_coord = vec2(gl_FragCoord.x, %d.0 + %f * gl_FragCoord.y);",
+          fbo->flip ? p->dst_rect.y1 : 0, fbo->flip ? -1.0 : 1.0);
+    GLSLF("vec2 dither_pos = dither_coord * 1.0/%d.0;\n", dither_size);
 
     if (p->opts.temporal_dither) {
         int phase = (p->frames_rendered / p->opts.temporal_dither_period) % 8u;
@@ -3097,7 +3099,7 @@ static void pass_draw_to_screen(struct gl_video *p, const struct ra_fbo *fbo, in
     pass_opt_hook_point(p, "OUTPUT", NULL);
 
     if (flags & RENDER_SCREEN_COLOR)
-        pass_dither(p);
+        pass_dither(p, fbo);
     pass_describe(p, "output to screen");
     finish_pass_fbo(p, fbo, false, &p->dst_rect);
 }


### PR DESCRIPTION
This fixes the below rendering glitches when redrawing cached frames while the fbo texture needs to be flipped, typically `--vo=gpu --gpu-api=opengl`:

Checkerboard, notice that the pattern is changed when toggling between playing and pausing. 
https://github.com/mpv-player/mpv/assets/130121847/fc653cea-22dd-40d9-8e1a-ffe2434afd8e

Dithering (`--dither-depth=1`), notice that the pattern is different when toggling between playing and pausing. 
https://github.com/mpv-player/mpv/assets/130121847/57fc1b33-732b-457b-95ea-d9e8707816ba

