### PR TITLE
osdep/io: add `mp_unlink()`

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -621,6 +621,14 @@ int mp_mkdir(const char *path, int mode)
     return res;
 }
 
+int mp_unlink(const char *path)
+{
+    wchar_t *wpath = mp_from_utf8(NULL, path);
+    int res = _wunlink(wpath);
+    talloc_free(wpath);
+    return res;
+}
+
 char *mp_win32_getcwd(char *buf, size_t size)
 {
     if (size >= SIZE_MAX / 3 - 1) {

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -116,6 +116,7 @@ DIR *mp_opendir(const char *path);
 struct dirent *mp_readdir(DIR *dir);
 int mp_closedir(DIR *dir);
 int mp_mkdir(const char *path, int mode);
+int mp_unlink(const char *path);
 char *mp_win32_getcwd(char *buf, size_t size);
 char *mp_getenv(const char *name);
 
@@ -183,6 +184,7 @@ void mp_globfree(mp_glob_t *pglob);
 #define readdir(...) mp_readdir(__VA_ARGS__)
 #define closedir(...) mp_closedir(__VA_ARGS__)
 #define mkdir(...) mp_mkdir(__VA_ARGS__)
+#define unlink(...) mp_unlink(__VA_ARGS__)
 #define getcwd(...) mp_win32_getcwd(__VA_ARGS__)
 #define getenv(...) mp_getenv(__VA_ARGS__)
 


### PR DESCRIPTION
`unlink()` was never wrapped in win32, so all usages of it were referring the ANSI version of the function. This doesn't work properly for Windows versions before 1903 (where the UTF-8 codepage is requested).

Fix this by adding `mp_unlink()` which wraps over `_wunlink()`.
