### PR TITLE
vulkan: fix listing of vulkan devices on macOS

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -52,6 +52,28 @@ static inline OPT_STRING_VALIDATE_FUNC(vk_validate_dev)
         }
     };
 
+#ifdef VK_KHR_portability_enumeration
+    uint32_t exts_count = 0;
+    vkEnumerateInstanceExtensionProperties(NULL, &exts_count, NULL);
+    VkExtensionProperties *exts = talloc_array_ptrtype(NULL, exts, exts_count);
+    res = vkEnumerateInstanceExtensionProperties(NULL, &exts_count, exts);
+
+    if (res == VK_SUCCESS) {
+        for (int n = 0; n < exts_count; n++) {
+            if (strcmp(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, exts[n].extensionName) == 0) {
+                info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+                info.enabledExtensionCount = 1;
+                info.ppEnabledExtensionNames = (const char*[]) {
+                    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
+                };
+                break;
+            }
+        }
+    }
+
+    talloc_free(exts);
+#endif
+
     VkInstance inst;
     VkPhysicalDevice *devices = NULL;
     uint32_t num = 0;


### PR DESCRIPTION
should this be guarded by a platform check/preprocessor? i am not sure if this could possibly make problems on other platforms?

vkCreateInstance() always returned VK_ERROR_INCOMPATIBLE_DRIVER and listing devices always ended up in option parameter parse error.

from the vulkan macOS docs at least the flag and this one extension is needed to enumerate over the devices, from 1.3.216 onwards.
https://vulkan.lunarg.com/doc/sdk/1.3.275.0/mac/getting_started.html

> Encountered VK_ERROR_INCOMPATIBLE_DRIVER:
> 
> Beginning with the 1.3.216 Vulkan SDK, the Vulkan Loader is strictly enforcing the new VK_KHR_PORTABILITY_subset extension. The most likely cause of this error message on instance creation is failure to adhere to this extension, which prevents applications on all platforms from selecting by default a non-conformant Vulkan implementation without opting in. MoltenVK is currently not fully conformant, and thus supporting this extension is necessary for building robust and portable Vulkan-based applications that are good citizens in the Vulkan ecosystem.
> 
> Opting in is simple. First add the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit to your VkInstanceCreateInfo structure's .flags member, then add two instance extensions to your instance extensions list: VK_KHR_portability_enumeration, and VK_KHR_get_physical_device_properties2.
> ...
> Note that support for the VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME is only required for Vulkan version 1.0.