### PR TITLE
osxbundle: activate Game Mode with App bundle

### DIFF
--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -188,6 +188,8 @@
     <string>${VERSION}</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
     <key>LSEnvironment</key>
     <dict>
       <key>MallocNanoZone</key>


### PR DESCRIPTION
this is a somewhat weird change. i have no idea if it actually improves things or if it's just some placebo Apple marketing.
Game Mode 'documentation' lol: https://support.apple.com/en-us/105118

mpv isn't really a game and categorising our App bundle as game seems counterintuitive. though as a video player it does have some similarities, possibly needing considerably CPU and GPU resources and low presentation latencies.

the macOS Game Mode promises exactly that, it gives App the highest priority access to CPU and GPU resources and lowers usage for background tasks.

sadly the Game Mode can only be activated by categorising the App as a game and that is only possible with an App bundle and not as a command line tool.