### PR TITLE
vo_gpu_next: fix win32 io wrap

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -36,6 +36,7 @@
 #include "options/m_config.h"
 #include "options/options.h"
 #include "options/path.h"
+#include "osdep/io.h"
 #include "osdep/threads.h"
 #include "stream/stream.h"
 #include "video/fmt-conversion.h"


### PR DESCRIPTION
Fixes 84015959cc5d36d8973b2f07ece066902bbbdbe7
