### PR TITLE
cocoa-cb: remove pre-allocation and initialise only when used

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -183,10 +183,12 @@ static const char macosx_icon[] =
     }
 }
 
-- (void)setMpvHandle:(struct mpv_handle *)ctx
+- (void)initCocoaCb:(struct mpv_handle *)ctx
 {
 #if HAVE_MACOS_COCOA_CB
-    [NSApp setCocoaCB:[[CocoaCB alloc] init:ctx]];
+    if (!_cocoa_cb) {
+        [NSApp setCocoaCB:[[CocoaCB alloc] init:ctx]];
+    }
 #endif
 }
 

--- a/osdep/macosx_application_objc.h
+++ b/osdep/macosx_application_objc.h
@@ -30,7 +30,7 @@ struct mpv_handle;
 - (void)queueCommand:(char *)cmd;
 - (void)stopMPV:(char *)cmd;
 - (void)openFiles:(NSArray *)filenames;
-- (void)setMpvHandle:(struct mpv_handle *)ctx;
+- (void)initCocoaCb:(struct mpv_handle *)ctx;
 + (const struct m_sub_options *)getMacOSConf;
 + (const struct m_sub_options *)getVoSubConf;
 

--- a/osdep/macosx_events.h
+++ b/osdep/macosx_events.h
@@ -32,5 +32,6 @@ void cocoa_uninit_media_keys(void);
 
 void cocoa_set_input_context(struct input_ctx *input_context);
 void cocoa_set_mpv_handle(struct mpv_handle *ctx);
+void cocoa_init_cocoa_cb(void);
 
 #endif

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -52,6 +52,7 @@
 
 - (NSEvent *)handleKey:(NSEvent *)event;
 - (BOOL)setMpvHandle:(struct mpv_handle *)ctx;
+- (void)initCocoaCb;
 - (void)readEvents;
 - (void)startMediaKeys;
 - (void)stopMediaKeys;
@@ -166,6 +167,11 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
     }
 }
 
+void cocoa_init_cocoa_cb(void)
+{
+    [[EventsResponder sharedInstance] initCocoaCb];
+}
+
 @implementation EventsResponder
 
 @synthesize remoteCommandCenter = _remoteCommandCenter;
@@ -252,14 +258,20 @@ void cocoa_set_mpv_handle(struct mpv_handle *ctx)
 - (BOOL)setMpvHandle:(struct mpv_handle *)ctx
 {
     if (_is_application) {
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            _ctx = ctx;
-            [NSApp setMpvHandle:ctx];
-        });
+        _ctx = ctx;
         return YES;
-    } else {
-        mpv_destroy(ctx);
-        return NO;
+    }
+
+    mpv_destroy(ctx);
+    return NO;
+}
+
+- (void)initCocoaCb
+{
+    if (_is_application) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [NSApp initCocoaCb:_ctx];
+        });
     }
 }
 

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -27,6 +27,10 @@
 
 #include "libmpv.h"
 
+#if HAVE_MACOS_COCOA_CB
+#include "osdep/macosx_events.h"
+#endif
+
 /*
  * mpv_render_context is managed by the host application - the host application
  * can access it any time, even if the VO is destroyed (or not created yet).
@@ -705,7 +709,9 @@ static void uninit(struct vo *vo)
 
 static int preinit(struct vo *vo)
 {
-#if !HAVE_MACOS_COCOA_CB
+#if HAVE_MACOS_COCOA_CB
+    cocoa_init_cocoa_cb();
+#else
     if (vo->probing)
         return -1;
 #endif


### PR DESCRIPTION
this is something that bothered me for a long time and i think this is an even bigger problem than before all the moltenvk changes, the added support of a vulkan backend on macOS and making gpu(-next) the default vo on macOS again. back when cocoa-cb was added it was decided against properly initialising cocoa-cb on demand because mac dependent code should be kept out of libmpv. so we were stuck with a suboptimal solution.


cocoa-cb was always pre-allocated in the Application itself because libmpv needs to be set up before usage, an opengl context has to be set and because it was decided mac specific code should be kept out of libmpv.

this means that a completely working libmpv and opengl renderer was set up even if it wasn't used. leading to unnecessary log message, resources being used or reserved on the system that might not be used, triggering of dedicated GPU unnecessarily and many other things.

even if not optimal, this wasn't the biggest problem since we only had that one working vo on macOS. though now that we have a vulkan gpu(-next) backend on macOS that was made the default, we always have that dangling cocoa-cb instance, which is completely unnecessary.

move the cocoa-cb initialisation into libmpv preinit function and only init cocoa-cb when we are a standalone App and cocoa-cb support is build into.