### PR TITLE
Revert "ci/mingw: pin Vulkan version again"

### DIFF
--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -162,7 +162,7 @@ _spirv_cross () {
 _spirv_cross_mark=lib/libspirv-cross-c-shared.dll.a
 
 _vulkan_headers () {
-    [ -d Vulkan-Headers ] || $gitclone https://github.com/KhronosGroup/Vulkan-Headers -b v1.3.276
+    [ -d Vulkan-Headers ] || $gitclone https://github.com/KhronosGroup/Vulkan-Headers
     builddir Vulkan-Headers
     cmake .. "${cmake_args[@]}"
     makeplusinstall
@@ -171,7 +171,7 @@ _vulkan_headers () {
 _vulkan_headers_mark=include/vulkan/vulkan.h
 
 _vulkan_loader () {
-    [ -d Vulkan-Loader ] || $gitclone https://github.com/KhronosGroup/Vulkan-Loader -b v1.3.276
+    [ -d Vulkan-Loader ] || $gitclone https://github.com/KhronosGroup/Vulkan-Loader
     builddir Vulkan-Loader
     cmake .. "${cmake_args[@]}" \
         -DENABLE_WERROR=OFF


### PR DESCRIPTION
No longer needed after commit:
https://github.com/FFmpeg/FFmpeg/commit/e06ce6d2b45edac4a2df04f304e18d4727417d24

This reverts commit 09606b9db9e228ac80cadb5fd7875ad60c9bd178.