### PR TITLE
player/main: don't set the main thread name

### DIFF
--- a/player/main.c
+++ b/player/main.c
@@ -419,7 +419,6 @@ int mp_initialize(struct MPContext *mpctx, char **options)
 
 int mpv_main(int argc, char *argv[])
 {
-    mp_thread_set_name("mpv");
     struct MPContext *mpctx = mp_create();
     if (!mpctx)
         return 1;


### PR DESCRIPTION
98a27b3cd1e6af743af67699318df1946ce5bf8f changed this to mpv but that's kind of pointless since the binary is already named mpv so that will be the default thread name. Evidently, people rename/symlink the binary to something else so might as well make them happier. Fixes #13469.