### PR TITLE
audio: use last_out_pts when deciding whether to start ao

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -845,8 +845,8 @@ void audio_start_ao(struct MPContext *mpctx)
     double pts = MP_NOPTS_VALUE;
     if (!get_sync_pts(mpctx, &pts))
         return;
-    double apts = written_audio_pts(mpctx) - mpctx->delay;
-    if (pts != MP_NOPTS_VALUE && apts != MP_NOPTS_VALUE && pts < apts &&
+    double apts = playing_audio_pts(mpctx); // (basically including mpctx->delay)
+    if (pts != MP_NOPTS_VALUE && apts != MP_NOPTS_VALUE && pts < (apts - 1e9) &&
         mpctx->video_status != STATUS_EOF)
     {
         double diff = (apts - pts) / mpctx->opts->playback_speed;

--- a/player/audio.c
+++ b/player/audio.c
@@ -845,7 +845,7 @@ void audio_start_ao(struct MPContext *mpctx)
     double pts = MP_NOPTS_VALUE;
     if (!get_sync_pts(mpctx, &pts))
         return;
-    double apts = playing_audio_pts(mpctx); // (basically including mpctx->delay)
+    double apts = written_audio_pts(mpctx) - mpctx->delay;
     if (pts != MP_NOPTS_VALUE && apts != MP_NOPTS_VALUE && pts < apts &&
         mpctx->video_status != STATUS_EOF)
     {


### PR DESCRIPTION
This fixes an issue where a frame is dropped on discontinuities on certain AO driver + samplerate combinations. This was made worse by b0e6ac380f6dd1a3196de0b2426f71a3e3f68bff because it could potentially cause `audio_status` to remain at `STATUS_READY` for one frame longer than needed by satisfying `pts < apts` in the condition on the next line. Alternative to this fix, checking `apts - pts >= 1e9` also fixes the issue, but this is probably more correct.

Subtracting `mpctx->delay` is more appropriate for this because `ao_get_delay` only accounts for the internal AO buffer, and all the surrounding code that deals with avsync uses `mpctx->delay` instead of `ao_get_delay`.

Moreover, `ao_get_delay` is currently bugged on all push AOs since b74c09efbf7c6969fc053265f72cc0501b840ce1 (#12322)