### PR TITLE
stats.lua: fix blurry graphs when `--osd-blur` is set

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2815,7 +2815,8 @@ Subtitles
     ``--sub-shadow-offset`` to change its size relative to the text.
 
 ``--sub-blur=<0..20.0>``
-    Gaussian blur factor. 0 means no blur applied (default).
+    Gaussian blur factor applied to the sub font border.
+    0 means no blur applied (default).
 
 ``--sub-bold=<yes|no>``
     Format text on bold.
@@ -4336,7 +4337,8 @@ OSD
     See ``--sub-color``. Color used for OSD text background.
 
 ``--osd-blur=<0..20.0>``
-    Gaussian blur factor. 0 means no blur applied (default).
+    Gaussian blur factor applied to the OSD font border.
+    0 means no blur applied (default).
 
 ``--osd-bold=<yes|no>``
     Format text on bold.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -412,7 +412,7 @@ function update()
     -- thin as possible and make it appear to be 1px wide by giving it 0.5px
     -- horizontal borders.
     local cheight = opts.font_size * 8
-    local cglyph = '{\\r' ..
+    local cglyph = '{\\rDefault' ..
                    (mp.get_property_native('focused') == false
                     and '\\alpha&HFF&' or '\\1a&H44&\\3a&H44&\\4a&H99&') ..
                    '\\1c&Heeeeee&\\3c&Heeeeee&\\4c&H000000&' ..

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -222,7 +222,7 @@ local function generate_graph(values, i, len, v_max, v_avg, scale, x_tics)
 
     local bg_box = format("{\\bord0.5}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
                           o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
-    return format("%s{\\r}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
+    return format("%s{\\r}{\\rDefault}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
                   o.prefix_sep, y_offset, bg_box, o.plot_color, table.concat(s), text_style())
 end
 


### PR DESCRIPTION
When `--osd-blur` is set to a nonzero value, the graphs also become blurry. This is because they are rendered by the `osd-overlay` command with the "OSD" style which has OSD blur applied, and are treated no differently from texts. Fix this by using the "Default" style for these graphs which uses the default OSD options.