### PR TITLE
build: fix build when disabling cocoa-cb

### DIFF
--- a/osdep/macosx_application.m
+++ b/osdep/macosx_application.m
@@ -33,7 +33,7 @@
 #if HAVE_MACOS_TOUCHBAR
 #import "osdep/macosx_touchbar.h"
 #endif
-#if HAVE_MACOS_COCOA_CB
+#if HAVE_SWIFT
 #include "osdep/macOS_swift.h"
 #endif
 

--- a/osdep/macosx_events.m
+++ b/osdep/macosx_events.m
@@ -38,7 +38,7 @@
 
 #include "config.h"
 
-#if HAVE_MACOS_COCOA_CB
+#if HAVE_SWIFT
 #include "osdep/macOS_swift.h"
 #endif
 


### PR DESCRIPTION
the swift obj-c bridging header is only included when cocoa-cb is enabled. cocoa-cb is not the only swift feature anymore and disabling cocoa-cb leads to a runtime error that specific swift classes could not be found.

include the swift obj-c bridging header in the case swift features are enabled.