### PR TITLE
centralize VO dragging

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -27,6 +27,7 @@ Interface changes
 ::
 
  --- mpv 0.38.0 ---
+    - add `begin-vo-dragging` command
     - add `--volume-gain`, `--volume-gain-min`, and `--volume-gain-max` options
     - add `current-gpu-context` property
     - add `--secondary-sub-ass-override` option

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1478,6 +1478,13 @@ Input Commands that are Possibly Subject to Change
     This command has an even more uncertain future than ``ab-loop-dump-cache``
     and might disappear without replacement if the author decides it's useless.
 
+``begin-vo-dragging``
+    Begin window dragging if supported by the current VO. This command should
+    only be called while a mouse button is being pressed, otherwise it will
+    be ignored. The exact effect of this command depends on the VO implementation
+    of window dragging. For example, on Windows only the left mouse button can
+    begin window dragging, while X11 and Wayland allow other mouse buttons.
+
 Undocumented commands: ``ao-reload`` (experimental/internal).
 
 List of events

--- a/input/input.c
+++ b/input/input.c
@@ -740,13 +740,17 @@ static void mp_input_feed_key(struct input_ctx *ictx, int code, double scale,
     if (code & MP_KEY_STATE_DOWN) {
         code &= ~MP_KEY_STATE_DOWN;
         if (ictx->last_doubleclick_key_down == code &&
-            now - ictx->last_doubleclick_time < opts->doubleclick_time / 1000.0)
+            now - ictx->last_doubleclick_time < opts->doubleclick_time / 1000.0 &&
+            code >= MP_MBTN_LEFT && code <= MP_MBTN_RIGHT)
         {
-            if (code >= MP_MBTN_LEFT && code <= MP_MBTN_RIGHT) {
-                now = 0;
-                interpret_key(ictx, code - MP_MBTN_BASE + MP_MBTN_DBL_BASE,
-                              1, 1);
-            }
+            now = 0;
+            interpret_key(ictx, code - MP_MBTN_BASE + MP_MBTN_DBL_BASE,
+                          1, 1);
+        } else if (code == MP_MBTN_LEFT) {
+            // This is a mouse left botton down event which isn't part of a doubleclick.
+            // Initialize vo dragging in this case.
+            mp_cmd_t *cmd = mp_input_parse_cmd(ictx, bstr0("begin-vo-dragging"), "<internal>");
+            mp_input_queue_cmd(ictx, cmd);
         }
         ictx->last_doubleclick_key_down = code;
         ictx->last_doubleclick_time = now;

--- a/player/command.c
+++ b/player/command.c
@@ -6502,6 +6502,16 @@ static void cmd_dump_cache_ab(void *p)
                  cmd->args[0].v.s);
 }
 
+static void cmd_begin_vo_dragging(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+    struct vo *vo = mpctx->video_out;
+
+    if (vo)
+        vo_control(vo, VOCTRL_BEGIN_DRAGGING, NULL);
+}
+
 /* This array defines all known commands.
  * The first field the command name used in libmpv and input.conf.
  * The second field is the handler function (see mp_cmd_def.handler and
@@ -6969,6 +6979,8 @@ const struct mp_cmd_def mp_cmds[] = {
     },
 
     { "ab-loop-align-cache", cmd_align_cache_ab },
+
+    { "begin-vo-dragging", cmd_begin_vo_dragging },
 
     {0}
 };

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -122,6 +122,9 @@ enum mp_voctrl {
 
     /* private to vo_gpu and vo_gpu_next */
     VOCTRL_EXTERNAL_RESIZE,
+
+    // Begin VO dragging.
+    VOCTRL_BEGIN_DRAGGING,
 };
 
 // Helper to expose what kind of content is currently playing to the VO.

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -474,7 +474,8 @@ static bool handle_char(struct vo_w32_state *w32, WPARAM wc, bool decode)
 
 static void begin_dragging(struct vo_w32_state *w32)
 {
-    if (mp_input_test_dragging(w32->input_ctx, w32->mouse_x, w32->mouse_y))
+    if (w32->current_fs ||
+        mp_input_test_dragging(w32->input_ctx, w32->mouse_x, w32->mouse_y))
         return;
     // Window dragging hack
     ReleaseCapture();

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -498,13 +498,6 @@ static bool handle_mouse_down(struct vo_w32_state *w32, int btn, int x, int y)
 {
     btn |= mod_state(w32);
     mp_input_put_key(w32->input_ctx, btn | MP_KEY_STATE_DOWN);
-
-    if (btn == MP_MBTN_LEFT) {
-        begin_dragging(w32);
-        // Indicate the message was handled, so DefWindowProc won't be called
-        return true;
-    }
-
     SetCapture(w32->window);
     return false;
 }

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -181,6 +181,7 @@ struct vo_w32_state {
 
     bool cleared;
     bool dragging;
+    bool start_dragging;
     BOOL win_arranging;
 
     bool conversion_mode_init;
@@ -1262,6 +1263,12 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         mp_dispatch_queue_process(w32->dispatch, 0);
         w32->in_dispatch = false;
     }
+    // Start window dragging if the flag is set by the voctrl.
+    // This is processed here to avoid blocking the dispatch queue.
+    if (w32->start_dragging) {
+        w32->start_dragging = false;
+        begin_dragging(w32);
+    }
 
     switch (message) {
     case WM_ERASEBKGND:
@@ -2165,7 +2172,7 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         *(bool *)arg = w32->focused;
         return VO_TRUE;
     case VOCTRL_BEGIN_DRAGGING:
-        begin_dragging(w32);
+        w32->start_dragging = true;
         return VO_TRUE;
     }
     return VO_NOTIMPL;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -22,6 +22,8 @@
 #include "input/event.h"
 #include "vo.h"
 
+struct vo_wayland_seat;
+
 typedef struct {
     uint32_t format;
     uint32_t padding;
@@ -155,6 +157,7 @@ struct vo_wayland_state {
     struct wl_surface      *cursor_surface;
     bool                    cursor_visible;
     int                     allocated_cursor_scale;
+    struct vo_wayland_seat *last_button_seat;
 };
 
 bool vo_wayland_check_visible(struct vo *vo);

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1333,8 +1333,6 @@ void vo_x11_check_events(struct vo *vo)
             long msg[4] = {XEMBED_REQUEST_FOCUS};
             vo_x11_xembed_send_message(x11, msg);
             x11->last_button_event = Event;
-            if (Event.xbutton.button == 1)
-                vo_x11_begin_dragging(vo);
             break;
         case ButtonRelease:
             if (Event.xbutton.button - 1 >= MP_KEY_MOUSE_BTN_COUNT)

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -138,6 +138,8 @@ struct vo_x11_state {
     Window dnd_src_window;
 
     Atom icc_profile_property;
+
+    XEvent last_button_event;
 };
 
 bool vo_x11_init(struct vo *vo);


### PR DESCRIPTION
This removes all hardcoded VO dragging logic in win32, x11, and wayland, and handle them centrally in the input system, which now issues the new `begin-vo-dragging` command to start VO dragging for VOs which implement `VOCTRL_BEGIN_DRAGGING`.

The new command also allows scripts to initialize VO dragging with other mouse buttons.

Because the VO dragging is now centralized, it's possible to make further improvements, such as a deadzone mechanism to fix the conflict with `MBTN_LEFT` mouse bind.

Fixes https://github.com/mpv-player/mpv/pull/13457#issuecomment-1965068837.