### PR TITLE
sd_ass: don't wrongly recognize \pos as \p

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -724,7 +724,7 @@ static void ass_to_plaintext(struct buf *b, const char *in)
             if (in[0] == '}') {
                 in += 1;
                 in_tag = false;
-            } else if (in[0] == '\\' && in[1] == 'p') {
+            } else if (in[0] == '\\' && in[1] == 'p' && in[2] != 'o') {
                 in += 2;
                 // Skip text between \pN and \p0 tags. A \p without a number
                 // is the same as \p0, and leading 0s are also allowed.


### PR DESCRIPTION
An ass event like `{\p1\pos{1,1}}m 0 0 l -3 -7 l 11 -7 l 11 -2` ends the drawing mode started with `\p1` due to `\pos` gets confused with `\p`, and thus that line is wrongly considered to be visible text.

Fixes https://github.com/christoph-heinrich/mpv-subtitle-lines/issues/5