### PR TITLE
demux_lavf: always find stream info for avif files

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -510,6 +510,10 @@ static int lavf_check_file(demuxer_t *demuxer, enum demux_check check)
                 break;
             }
 
+            // AVIF always needs to find stream info
+            if (bstrcasecmp0(ext, "avif") == 0)
+                priv->format_hack.skipinfo = false;
+
             if (score >= lavfdopts->probescore)
                 break;
 


### PR DESCRIPTION
avif files will commonly be probed as "mov,mp4,m4a,3gp,3g2,mj2" by ffmpeg, but demux_lavf currently has some logic to skip avformat_find_stream_info for these kinds of files. It was introduced in 6f8c953042a7a964686e5923f5c61025ef6b842e. Presumably, the optimization of mentioned in that commit is still valid however for avif we specifically need to do the avformat_find_stream_info call. Without it, several codec proprieties like width, height, etc. are unavailable. So just check the extension type and disable the skipinfo optimization.