### PR TITLE
cocoa-cb: render on main queue instead of dedicated queue

### DIFF
--- a/video/out/mac/gl_layer.swift
+++ b/video/out/mac/gl_layer.swift
@@ -82,8 +82,6 @@ class GLLayer: CAOpenGLLayer {
     enum Draw: Int { case normal = 1, atomic, atomicEnd }
     var draw: Draw = .normal
 
-    let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue.draw")
-
     var needsICCUpdate: Bool = false {
         didSet {
             if needsICCUpdate == true {
@@ -239,7 +237,7 @@ class GLLayer: CAOpenGLLayer {
 
     func update(force: Bool = false) {
         if force { forceDraw = true }
-        queue.async {
+        DispatchQueue.main.async {
             if self.forceDraw || !self.inLiveResize {
                 self.needsFlip = true
                 self.display()


### PR DESCRIPTION
lets see how this pans out. Apple changed a lot regarding layer handling and opengl. a lot of the issues got fixed a lot of new issues occurred. i couldn't reproduce any of the issues anymore that were fixed with the dedicated render queue, though can reproduce the new issues that we have.

related old commit 965ba23303d980c239e2b0191488766cfa7b0f75