### PR TITLE
mac/vulkan: remove old deprecated VK_MVK_macos_surface extension remains

### DIFF
--- a/video/out/vulkan/common.h
+++ b/video/out/vulkan/common.h
@@ -23,7 +23,6 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
 #if HAVE_COCOA
-#define VK_USE_PLATFORM_MACOS_MVK
 #define VK_USE_PLATFORM_METAL_EXT
 #endif
 

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -56,7 +56,7 @@ static bool mac_vk_init(struct ra_ctx *ctx)
         goto error;
 
     VkMetalSurfaceCreateInfoEXT mac_info = {
-        .sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK,
+        .sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
         .pNext = NULL,
         .flags = 0,
         .pLayer = p->vo_mac.layer,


### PR DESCRIPTION
i totally forgot about this after the initial PR was just sitting there for an eternity.