### PR TITLE
audio: get ao-volume if not set at startup

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -188,8 +188,13 @@ void audio_update_ao_volume(struct MPContext *mpctx)
     struct MPOpts *opts = mpctx->opts;
     struct ao *ao = mpctx->ao;
     float vol = opts->ao_volume;
-    if (!ao || vol < 0)
+    if (!ao)
         return;
+    if (vol < 0) {
+        ao_control(ao, AOCONTROL_GET_VOLUME, &vol);
+        opts->ao_volume = (int) vol;
+        return;
+    }
 
     ao_control(ao, AOCONTROL_SET_VOLUME, &vol);
 }


### PR DESCRIPTION
Commit 58ed620 introduces a bug where if ao-volume is not set at startup the input controls will start changing it from -1. This fixes it by getting the ao-volume value if it's not set during startup.