### PR TITLE
mac/vulkan: set NSView as layer delegate like recommended by MoltenVK

### DIFF
--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -142,6 +142,7 @@ class Common: NSObject {
         view.layer = layer
         view.wantsLayer = true
         view.layerContentsPlacement = .scaleProportionallyToFit
+        layer.delegate = view
     }
 
     func initWindowState() {

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -17,7 +17,7 @@
 
 import Cocoa
 
-class View: NSView {
+class View: NSView, CALayerDelegate {
     unowned var common: Common
     var mpv: MPVHelper? { get { return common.mpv } }
 


### PR DESCRIPTION
from the moltenvk docs. imo kinda dumb that this is 'needed', since the layer delegate functions are on the view now, even if not used. though if they ever need to be used there is no clear distinction between view and layer functionality because of this.

> When creating a CAMetalLayer to underpin the Vulkan surface to render to, it is strongly recommended that you ensure the delegate of the CAMetalLayer is the NSView/UIView in which the layer is contained, to ensure correct and optimized Vulkan swapchain and refresh timing behavior across multiple display screens that might have different properties.