### PR TITLE
options: add --input-commands option

### DIFF
--- a/DOCS/interface-changes/add-input-commands.txt
+++ b/DOCS/interface-changes/add-input-commands.txt
@@ -1,0 +1,1 @@
+add `--input-comands` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4101,6 +4101,21 @@ Input
 ``--input-cmdlist``
     Prints all commands that can be bound to keys.
 
+``--input-commands=<cmd1,cmd2,...>``
+    Define a list of commands for mpv to run. The syntax is the same as format
+    as ``input.conf`` but without the key binding argument at the beginning.
+    When this option is set at startup, the commands will run after audio and
+    video playback are about to begin if applicable (in idle mode with no file,
+    it will run immediately). When changing values at runtime, the commands will
+    also run as soon as possible.
+
+    This is a string list option. See `List Options`_ for details.
+
+    .. admonition:: Example
+
+        ``--input-commands="playlist-play-index 1,set ao-volume 40"``
+            sets the playlist index to 1 and the ao-volume to 40
+
 ``--input-doubleclick-time=<milliseconds>``
     Time in milliseconds to recognize two consecutive button presses as a
     double-click (default: 300).

--- a/options/options.c
+++ b/options/options.c
@@ -853,6 +853,7 @@ static const m_option_t mp_opts[] = {
     {"idle", OPT_CHOICE(player_idle_mode,
         {"no",   0}, {"once", 1}, {"yes",  2})},
 
+    {"input-commands", OPT_STRINGLIST(input_commands)},
     {"input-terminal", OPT_BOOL(consolecontrols), .flags = UPDATE_TERM},
 
     {"input-ipc-server", OPT_STRING(ipc_path), .flags = M_OPT_FILE},

--- a/options/options.h
+++ b/options/options.h
@@ -256,6 +256,7 @@ typedef struct MPOpts {
     char *osd_status_msg;
     char *osd_msg[3];
     int player_idle_mode;
+    char **input_commands;
     bool consolecontrols;
     int playlist_pos;
     struct m_rel_time play_start;

--- a/player/command.c
+++ b/player/command.c
@@ -93,6 +93,8 @@ struct command_ctx {
     char **warned_deprecated;
     int num_warned_deprecated;
 
+    bool command_opts_processed;
+
     struct overlay *overlays;
     int num_overlays;
     // One of these is in use by the OSD; the other one exists so that the
@@ -7129,6 +7131,27 @@ void handle_command_updates(struct MPContext *mpctx)
 
     // Depends on polling demuxer wakeup callback notifications.
     cache_dump_poll(mpctx);
+
+    // Potentially run the commands now (idle) instead of waiting for a file to load.
+    if (mpctx->stop_play == PT_STOP)
+        run_command_opts(mpctx);
+}
+
+void run_command_opts(struct MPContext *mpctx)
+{
+    struct MPOpts *opts = mpctx->opts;
+    struct command_ctx *ctx = mpctx->command_ctx;
+
+    if (!opts->input_commands || ctx->command_opts_processed)
+        return;
+
+    // Take easy way out and add these to the input queue.
+    for (int i = 0; opts->input_commands[i]; i++) {
+        struct mp_cmd *cmd = mp_input_parse_cmd(mpctx->input, bstr0(opts->input_commands[i]),
+                                                "the command line");
+        mp_input_queue_cmd(mpctx->input, cmd);
+    }
+    ctx->command_opts_processed = true;
 }
 
 void mp_notify(struct MPContext *mpctx, int event, void *arg)
@@ -7265,6 +7288,11 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (opt_ptr == &opts->vo->android_surface_size) {
         if (mpctx->video_out)
             vo_control(mpctx->video_out, VOCTRL_EXTERNAL_RESIZE, NULL);
+    }
+
+    if (opt_ptr == &opts->input_commands) {
+        mpctx->command_ctx->command_opts_processed = false;
+        run_command_opts(mpctx);
     }
 
     if (opt_ptr == &opts->playback_speed) {

--- a/player/command.h
+++ b/player/command.h
@@ -70,6 +70,7 @@ void run_command(struct MPContext *mpctx, struct mp_cmd *cmd,
                  struct mp_abort_entry *abort,
                  void (*on_completion)(struct mp_cmd_ctx *cmd),
                  void *on_completion_priv);
+void run_command_opts(struct MPContext *mpctx);
 void mp_cmd_ctx_complete(struct mp_cmd_ctx *cmd);
 PRINTF_ATTRIBUTE(3, 4)
 void mp_cmd_msg(struct mp_cmd_ctx *cmd, int status, const char *msg, ...);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1140,6 +1140,7 @@ static void handle_playback_restart(struct MPContext *mpctx)
         mpctx->hrseek_active = false;
         mpctx->restart_complete = true;
         mpctx->current_seek = (struct seek_params){0};
+        run_command_opts(mpctx);
         handle_playback_time(mpctx);
         mp_notify(mpctx, MPV_EVENT_PLAYBACK_RESTART, NULL);
         update_core_idle_state(mpctx);


### PR DESCRIPTION
Basically a simple way to perform any command/property action from the command line. This takes the exact same syntax as input.conf but not including the key naturally. Potentially useful for weird properties that don't map well to options (like ao-volume).

Another try at fixing #12353.