### PR TITLE
osc: add playlist_media_title option

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -424,6 +424,13 @@ Configurable Options
     Whether to display the chapters/playlist at the OSD when left-clicking the
     next/previous OSC buttons, respectively.
 
+``playlist_media_title``
+    Default: yes
+
+    Whether to display playlist entries in media titles. If set to ``no``, file
+    names are used instead. Note that media title of a file is only available
+    once it has been loaded.
+
 ``chapter_fmt``
     Default: ``Chapter: %s``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -57,6 +57,7 @@ local user_opts = {
     livemarkers = true,         -- update seekbar chapter markers on duration change
     chapters_osd = true,        -- whether to show chapters OSD on next/prev
     playlist_osd = true,        -- whether to show playlist OSD on next/prev
+    playlist_media_title = true, -- whether to use media titles as playlist entry names
     chapter_fmt = "Chapter: %s", -- chapter print format for seekbar-hover. "no" to disable
     unicodeminus = false,       -- whether to use the Unicode minus sign character
 }
@@ -913,7 +914,7 @@ function get_playlist()
     for i, v in ipairs(limlist) do
         local title = v.title
         local _, filename = utils.split_path(v.filename)
-        if title == nil then
+        if not user_opts.playlist_media_title or title == nil then
             title = filename
         end
         message = string.format('%s %s %s\n', message,


### PR DESCRIPTION
Showing media titles in the playlist is pointless when sources are ill tagged and media titles contain only garbage (such as below). Being able to opt for file names at least gives us a choice in such cases.

![1](https://github.com/mpv-player/mpv/assets/35950308/80577525-f452-4034-84b1-ce7eb1a74107)
