### PR TITLE
vo: move vo_gpu_next above vo_gpu in probe order

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -16,8 +16,8 @@ This is an object settings list option. See `List Options`_ for details.
 
     See ``--vo=help`` for a list of compiled-in video output drivers.
 
-    The recommended output driver is ``--vo=gpu``, which is the default. All
-    other drivers are for compatibility or special purposes. If the default
+    The recommended output driver is ``--vo=gpu-next``, which is the default.
+    All other drivers are for compatibility or special purposes. If the default
     does not work, it will fallback to other drivers (in the same order as
     listed by ``--vo=help``).
 
@@ -26,6 +26,17 @@ This is an object settings list option. See `List Options`_ for details.
     rendering API), it must be explicitly specified.
 
 Available video output drivers are:
+
+``gpu-next``
+    Video renderer based on ``libplacebo``. This supports almost the same set
+    of features as ``--vo=gpu``. See `GPU renderer options`_ for a list.
+
+    Should generally be faster and higher quality, while also implementing some
+    features specific to ``gpu-next``, but some features may be intentionally
+    omitted or there may be functional differences to ``--vo=gpu``.
+    See here for a list of known differences:
+
+    https://github.com/mpv-player/mpv/wiki/GPU-Next-vs-GPU
 
 ``gpu``
     General purpose, customizable, GPU-accelerated video output driver. It
@@ -56,17 +67,6 @@ Available video output drivers are:
     support, and some macOS setups being very slow with ``rgb16`` but fast
     with ``rgb32f``. If you have problems, you can also try enabling the
     ``--gpu-dumb-mode=yes`` option.
-
-``gpu-next``
-    Experimental video renderer based on ``libplacebo``. This supports almost
-    the same set of features as ``--vo=gpu``. See `GPU renderer options`_ for a
-    list.
-
-    Should generally be faster and higher quality, but some features may still
-    be missing or misbehave. Expect (and report!) bugs. See here for a list of
-    known differences and bugs:
-
-    https://github.com/mpv-player/mpv/wiki/GPU-Next-vs-GPU
 
 ``xv`` (X11 only)
     Uses the XVideo extension to enable hardware-accelerated display. This is

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -70,8 +70,8 @@ extern const struct vo_driver video_out_kitty;
 static const struct vo_driver *const video_out_drivers[] =
 {
     // high-quality and well-supported VOs first:
-    &video_out_gpu,
     &video_out_gpu_next,
+    &video_out_gpu,
 
 #if HAVE_VDPAU
     &video_out_vdpau,


### PR DESCRIPTION
Opening a PR to track discussion on this instead of retreading the same topics repeatedly each time we discuss it.

`vo_gpu_next` is already much better than the default `vo_gpu`, and the latter doesn't receive many bug fixes or testing from maintainers making changes elsewhere in the codebase. It doesn't make much sense to keep a default that doesn't receive much or any testing at all due to almost none of the mpv contributors using it. 

There are multiple steps to doing this:

1) Just move gpu-next above gpu in the probe order and change nothing else as this PR is doing. Receive user testing and feedback before the next step.

2) Rename `gpu-next` to `gpu`, rename `gpu` to `gpu-legacy` or `gpu-old`, alias `gpu-next` to `gpu`. And deprecate `gpu-legacy`.


Potential show stoppers:

High Priority: https://github.com/mpv-player/mpv/issues/13108, https://github.com/mpv-player/mpv/issues/11499

Medium Priority: ~~https://github.com/mpv-player/mpv/issues/11925~~, ~~https://github.com/mpv-player/mpv/issues/9551~~ (~~https://github.com/mpv-player/mpv/issues/13303~~ / ~~https://github.com/mpv-player/mpv/issues/12517~~)

Low Priority: https://github.com/mpv-player/mpv/issues/12462

[Various other issues](https://github.com/mpv-player/mpv/milestone/4) 
