### PR TITLE
runtime geometry change fixes

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3358,8 +3358,8 @@ Window
             of the screen width, or higher than 60% of the screen height.
 
 ``--autofit-larger=<[W[xH]]>``
-    This option behaves exactly like ``--autofit``, except the window size is
-    only changed if the window would be larger than the specified size.
+    This option behaves exactly like ``--autofit``, except that it sets the
+    maximum size of the window.
 
     .. admonition:: Example
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1099,13 +1099,11 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
         wl->hidden = is_suspended;
 
     if (vo_opts->fullscreen != is_fullscreen) {
-        wl->state_change = true;
         vo_opts->fullscreen = is_fullscreen;
         m_config_cache_write_opt(wl->vo_opts_cache, &vo_opts->fullscreen);
     }
 
     if (vo_opts->window_maximized != is_maximized) {
-        wl->state_change = true;
         vo_opts->window_maximized = is_maximized;
         m_config_cache_write_opt(wl->vo_opts_cache, &vo_opts->window_maximized);
     }
@@ -2142,7 +2140,6 @@ static int spawn_cursor(struct vo_wayland_state *wl)
 
 static void toggle_fullscreen(struct vo_wayland_state *wl)
 {
-    wl->state_change = true;
     bool specific_screen = wl->vo_opts->fsscreen_id >= 0 || wl->vo_opts->fsscreen_name;
     if (wl->vo_opts->fullscreen && !specific_screen) {
         xdg_toplevel_set_fullscreen(wl->xdg_toplevel, NULL);
@@ -2156,7 +2153,6 @@ static void toggle_fullscreen(struct vo_wayland_state *wl)
 
 static void toggle_maximized(struct vo_wayland_state *wl)
 {
-    wl->state_change = true;
     if (wl->vo_opts->window_maximized) {
         xdg_toplevel_set_maximized(wl->xdg_toplevel);
     } else {
@@ -2314,6 +2310,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
             if (opt == &opts->geometry || opt == &opts->autofit ||
                 opt == &opts->autofit_smaller || opt == &opts->autofit_larger)
             {
+                wl->state_change = true;
                 set_geometry(wl, true);
             }
         }
@@ -2352,6 +2349,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         wl->window_size.x1 = s[0];
         wl->window_size.y1 = s[1];
         if (!wl->vo_opts->fullscreen && !wl->tiled) {
+            wl->state_change = true;
             if (wl->vo_opts->window_maximized) {
                 xdg_toplevel_unset_maximized(wl->xdg_toplevel);
                 wl_display_dispatch_pending(wl->display);

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1161,11 +1161,6 @@ static void vo_x11_check_net_wm_state_change(struct vo *vo)
             XFree(elems);
         }
 
-        if (opts->window_maximized && !is_maximized && x11->geometry_change) {
-            x11->geometry_change = false;
-            vo_x11_config_vo_window(vo);
-        }
-
         opts->window_minimized = is_minimized;
         x11->hidden = is_minimized;
         m_config_cache_write_opt(x11->opts_cache, &opts->window_minimized);
@@ -1801,10 +1796,6 @@ void vo_x11_config_vo_window(struct vo *vo)
 
     assert(x11->window);
 
-    // Don't attempt to change autofit/geometry on maximized windows.
-    if (x11->geometry_change && opts->window_maximized)
-        return;
-
     vo_x11_update_screeninfo(vo);
 
     struct vo_win_geometry geo;
@@ -2098,6 +2089,12 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
             if (opt == &opts->geometry || opt == &opts->autofit ||
                 opt == &opts->autofit_smaller || opt == &opts->autofit_larger)
             {
+                if (opts->window_maximized && !opts->fullscreen) {
+                    x11->opts->window_maximized = false;
+                    m_config_cache_write_opt(x11->opts_cache,
+                            &x11->opts->window_maximized);
+                    vo_x11_maximize(vo);
+                }
                 vo_x11_set_geometry(vo);
             }
         }

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -114,6 +114,7 @@ struct vo_x11_state {
      * stays the same (even if that size is different from the current
      * window size after the user modified the latter). */
     int old_dw, old_dh;
+    int old_x, old_y;
     /* Video size changed during fullscreen when we couldn't tell the new
      * size to the window manager. Must set window size when turning
      * fullscreen off. */


### PR DESCRIPTION
This fixes setting window position on x11 and supports setting geometry on runtime on win32. 

Closes https://github.com/mpv-player/mpv/issues/8379.
Fixes 8e793bde78f00fbb64223db30851c6d080c4abeb.
