### PR TITLE
path: don't load any files if --no-config is passed

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -76,10 +76,14 @@ static const char *mp_get_platform_path(void *talloc_ctx,
     assert(talloc_ctx);
 
     if (global->configdir) {
+        // Return NULL for all platform paths if --no-config is passed
+        if (!global->configdir[0])
+            return NULL;
+
         // force all others to NULL, only first returns the path
         for (int n = 0; n < MP_ARRAY_SIZE(config_dirs); n++) {
             if (strcmp(config_dirs[n], type) == 0)
-                return (n == 0 && global->configdir[0]) ? global->configdir : NULL;
+                return (n == 0) ? global->configdir : NULL;
         }
     }
 


### PR DESCRIPTION
--no-config is equivalent to --config-dir="".

Fixes: df758880e26c ("path: don't override "cache" and "state" paths with configdir")
