### PR TITLE
vo_gpu_next: make `dither-depth=auto` mean 8 bpc for SDR

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5554,8 +5554,10 @@ them.
     no
         Disable any dithering done by mpv.
     auto
-        Automatic selection. If output bit depth cannot be detected, 8 bits per
-        component are assumed.
+        Automatic selection.
+        On ``vo=gpu``: if output bit depth cannot be detected, 8 bpc is assumed.
+        On ``vo=gpu-next``: with ``gpu-api=d3d11``, real on-the-wire bpc is used.
+        For other ``gpu-api``, 8 bpc is used for SDR content.
     8
         Dither to 8 bit output.
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -841,7 +841,11 @@ static void apply_target_options(struct priv *p, struct pl_frame *target)
     int dither_depth = opts->dither_depth;
     if (dither_depth == 0) {
         struct ra_swapchain *sw = p->ra_ctx->swapchain;
-        dither_depth = sw->fns->color_depth ? sw->fns->color_depth(sw) : 0;
+        if (sw->fns->color_depth) {
+            dither_depth = sw->fns->color_depth(sw);
+        } else if (!pl_color_transfer_is_hdr(target->color.transfer)) {
+            dither_depth = 8;
+        }
     }
     if (dither_depth > 0) {
         struct pl_bit_encoding *tbits = &target->repr.bits;

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -309,11 +309,6 @@ char *ra_vk_ctx_get_device_name(struct ra_ctx *ctx)
     return device_name;
 }
 
-static int color_depth(struct ra_swapchain *sw)
-{
-    return 0; // TODO: implement this somehow?
-}
-
 static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
@@ -363,7 +358,6 @@ static void get_vsync(struct ra_swapchain *sw,
 }
 
 static const struct ra_swapchain_fns vulkan_swapchain = {
-    .color_depth   = color_depth,
     .start_frame   = start_frame,
     .submit_frame  = submit_frame,
     .swap_buffers  = swap_buffers,


### PR DESCRIPTION
Depends on https://github.com/mpv-player/mpv/pull/13646

Fixes the issue described in https://github.com/mpv-player/mpv/issues/11862 for SDR files for non-d3d11 gpu-api. We currently don't have a smarter way to get the real on-the-wire bpc for other APIs, so this is the best that can be done.

Alternative to #13642