### PR TITLE
mac/vulkan: workaround for MoltenVK problem that causes flicker

### DIFF
--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -23,7 +23,7 @@ class Common: NSObject {
     var log: LogHelper
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue")
 
-    var window: Window?
+    @objc var window: Window?
     var view: View?
     var titleBar: TitleBar?
 

--- a/video/out/mac/metal_layer.swift
+++ b/video/out/mac/metal_layer.swift
@@ -20,6 +20,17 @@ import Cocoa
 class MetalLayer: CAMetalLayer {
     unowned var common: MacCommon
 
+    // workaround for a MoltenVK workaround that sets the drawableSize to 1x1 to forcefully complete
+    // the presentation, this causes flicker and the drawableSize possibly staying at 1x1
+    override var drawableSize: CGSize {
+        get { return super.drawableSize }
+        set {
+            if Int(newValue.width) > 1 && Int(newValue.height) > 1 {
+                super.drawableSize = newValue
+            }
+        }
+    }
+
     init(common com: MacCommon) {
         common = com
         super.init()

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -35,7 +35,7 @@ class Window: NSWindow, NSWindowDelegate {
     let animationLock: NSCondition = NSCondition()
 
     var unfsContentFramePixel: NSRect { get { return convertToBacking(unfsContentFrame ?? NSRect(x: 0, y: 0, width: 160, height: 90)) } }
-    var framePixel: NSRect { get { return convertToBacking(frame) } }
+    @objc var framePixel: NSRect { get { return convertToBacking(frame) } }
 
     var keepAspect: Bool = true {
         didSet {

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -93,12 +93,6 @@ class MacCommon: Common {
         }
     }
 
-    func updateRenderSize(_ size: NSSize) {
-        mpv?.vo.pointee.dwidth = Int32(size.width)
-        mpv?.vo.pointee.dheight = Int32(size.height)
-        flagEvents(VO_EVENT_RESIZE | VO_EVENT_EXPOSE)
-    }
-
     override func displayLinkCallback(_ displayLink: CVDisplayLink,
                                             _ inNow: UnsafePointer<CVTimeStamp>,
                                      _ inOutputTime: UnsafePointer<CVTimeStamp>,
@@ -144,12 +138,7 @@ class MacCommon: Common {
     }
 
     override func windowDidResize() {
-        guard let window = window else {
-            log.sendWarning("No window available on window resize event")
-            return
-        }
-
-        updateRenderSize(window.framePixel.size)
+        flagEvents(VO_EVENT_RESIZE | VO_EVENT_EXPOSE)
     }
 
     override func windowDidChangeScreenProfile() {

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -85,7 +85,14 @@ error:
 
 static bool resize(struct ra_ctx *ctx)
 {
-    return ra_vk_ctx_resize(ctx, ctx->vo->dwidth, ctx->vo->dheight);
+    struct priv *p = ctx->priv;
+
+    if (!p->vo_mac.window) {
+        return false;
+    }
+    CGSize size = p->vo_mac.window.framePixel.size;
+
+    return ra_vk_ctx_resize(ctx, (int)size.width, (int)size.height);
 }
 
 static bool mac_vk_reconfig(struct ra_ctx *ctx)


### PR DESCRIPTION
first commit works around a broken workaround: https://github.com/KhronosGroup/MoltenVK/blame/b56c152a1245a95e7d4e8d64baca8ae42e85ae6a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm#L274-L283

MoltenVK itself tries to work around a supposedly Metal problem that itself causes flicker, black screens or broken rendering. it sets the drawableSize to 1x1 to forcefully complete the presentation. though if 1x1 resolution frame is presented it causes a visual flicker or rather a solid coloured frame. it causes even more problems since sometimes it does not reset the drawableSize to the proper resolution and keeps rendering everything in 1x1.

work around this workaround by discarding drawableSize that are <=1 in any direction.

second commit is just some minor bugfix and optimisation.