### PR TITLE
ad_spdif: handle const buf pointee in avio_alloc_context

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -59,7 +59,11 @@ struct spdifContext {
     struct mp_decoder public;
 };
 
+#if LIBAVCODEC_VERSION_MAJOR < 61
 static int write_packet(void *p, uint8_t *buf, int buf_size)
+#else
+static int write_packet(void *p, const uint8_t *buf, int buf_size)
+#endif
 {
     struct spdifContext *ctx = p;
 

--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -1034,7 +1034,11 @@ static const char *get_avopt_type_name(enum AVOptionType type)
     case AV_OPT_TYPE_VIDEO_RATE:        return "fps";
     case AV_OPT_TYPE_DURATION:          return "duration";
     case AV_OPT_TYPE_COLOR:             return "color";
+#if LIBAVUTIL_VERSION_MAJOR < 59
     case AV_OPT_TYPE_CHANNEL_LAYOUT:    return "channellayout";
+#else
+    case AV_OPT_TYPE_CHLAYOUT:          return "channellayout";
+#endif
     case AV_OPT_TYPE_BOOL:              return "bool";
     case AV_OPT_TYPE_CONST: // fallthrough
     default:


### PR DESCRIPTION
ffmpeg recently changed this field to be const which causes our CI to fail on newer versions.

See: https://github.com/FFmpeg/FFmpeg/commit/2a68d945cd74265bb71c3d38b7a2e7f7d7e87be5