### PR TITLE
swresample: stop using deprecated {in,out}_channel_layout options

### DIFF
--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -1035,9 +1035,9 @@ static const char *get_avopt_type_name(enum AVOptionType type)
     case AV_OPT_TYPE_DURATION:          return "duration";
     case AV_OPT_TYPE_COLOR:             return "color";
 #if LIBAVUTIL_VERSION_MAJOR < 59
-    case AV_OPT_TYPE_CHANNEL_LAYOUT:    return "channellayout";
+    case AV_OPT_TYPE_CHANNEL_LAYOUT:    return "ch_layout";
 #else
-    case AV_OPT_TYPE_CHLAYOUT:          return "channellayout";
+    case AV_OPT_TYPE_CHLAYOUT:          return "ch_layout";
 #endif
     case AV_OPT_TYPE_BOOL:              return "bool";
     case AV_OPT_TYPE_CONST: // fallthrough

--- a/filters/f_swresample.c
+++ b/filters/f_swresample.c
@@ -23,6 +23,7 @@
 #include <libswresample/swresample.h>
 
 #include "audio/aframe.h"
+#include "audio/chmap_avchannel.h"
 #include "audio/fmt-conversion.h"
 #include "audio/format.h"
 #include "common/common.h"
@@ -269,14 +270,28 @@ static bool configure_lavrr(struct priv *p, bool verbose)
 
     out_ch_layout = fudge_layout_conversion(p, in_ch_layout, out_ch_layout);
 
+#if HAVE_AV_CHANNEL_LAYOUT
     // Real conversion; output is input to avrctx_out.
+    AVChannelLayout in_layout, out_layout;
+    mp_chmap_to_av_layout(&in_layout, &in_lavc);
+    mp_chmap_to_av_layout(&out_layout, &out_lavc);
+    av_opt_set_chlayout(p->avrctx, "in_chlayout",  &in_layout, 0);
+    av_opt_set_chlayout(p->avrctx, "out_chlayout", &out_layout, 0);
+#else
     av_opt_set_int(p->avrctx, "in_channel_layout",  in_ch_layout, 0);
     av_opt_set_int(p->avrctx, "out_channel_layout", out_ch_layout, 0);
+#endif
     av_opt_set_int(p->avrctx, "in_sample_rate",     p->in_rate, 0);
     av_opt_set_int(p->avrctx, "out_sample_rate",    p->out_rate, 0);
     av_opt_set_int(p->avrctx, "in_sample_fmt",      in_samplefmt, 0);
     av_opt_set_int(p->avrctx, "out_sample_fmt",     out_samplefmtp, 0);
 
+#if HAVE_AV_CHANNEL_LAYOUT
+    AVChannelLayout fake_layout;
+    av_channel_layout_default(&fake_layout, map_out.num);
+    av_opt_set_chlayout(p->avrctx_out, "in_chlayout", &fake_layout, 0);
+    av_opt_set_chlayout(p->avrctx_out, "out_chlayout", &fake_layout, 0);
+#else
     // Just needs the correct number of channels for deplanarization.
     struct mp_chmap fake_chmap;
     mp_chmap_set_unknown(&fake_chmap, map_out.num);
@@ -285,6 +300,7 @@ static bool configure_lavrr(struct priv *p, bool verbose)
         goto error;
     av_opt_set_int(p->avrctx_out, "in_channel_layout",  fake_out_ch_layout, 0);
     av_opt_set_int(p->avrctx_out, "out_channel_layout", fake_out_ch_layout, 0);
+#endif
 
     av_opt_set_int(p->avrctx_out, "in_sample_fmt",      out_samplefmtp, 0);
     av_opt_set_int(p->avrctx_out, "out_sample_fmt",     out_samplefmt, 0);


### PR DESCRIPTION
These options were deprecated with the addition of the channel layout API about a couple of years ago*. Unfortunately, we never saw the deprecation messages so it went unnoticed until they were completely removed with the recent major version bump. Fix this by setting in_chlayout and out_chlayout instead if we have AV_CHANNEL_LAYOUT.

Fixes #13662.

*: https://github.com/FFmpeg/FFmpeg/commit/8a5896ec1f635ccf0d726f7ba7a06649ebeebf25