### PR TITLE
player: remove track layout hashing

### DIFF
--- a/player/core.h
+++ b/player/core.h
@@ -301,8 +301,6 @@ typedef struct MPContext {
     struct track **tracks;
     int num_tracks;
 
-    char *track_layout_hash;
-
     // Selected tracks. NULL if no track selected.
     // There can be num_ptracks[type] of the same STREAM_TYPE selected at once.
     // Currently, this is used for the secondary subtitle track only.


### PR DESCRIPTION
Originally introduced in c32082a1a7634e8a5e0bb2551056fe64e357d395. This kept track of whatever the layout of the file was so that if the next file changed; it would reset all track selections (sid/aid/vid) back to the default. This was a bit strange however since it only operated if the user switched the track manually via keybinds.

The reasoning for the commit to avoid "essentially select[ing] random tracks". That might have been the case then, but with the way the track selection is currently structured selecting a track id that doesn't exist can trivially be made to follow the usual autoselection logic. One could argue that selecting a track id that doesn't exist should result in selecting no track at all. It makes logical sense but considering that using --vid would easily lead to cases where no video is selected (probably not desirable), we'll stick to the more user friendly behavior of just using the autodetection.

So the actual change here is to just delete a bunch of code. This track layout stuff and everything associated with it leads to a bunch of weird, unintuitive behavior. Probably someone will complain about this change anyway, but oh well. Fixes #13670.

- [ ] TODO: Actually update the documentation and make sure there's not some weird corner case.