### PR TITLE
options: add --sub-ass-colorspace option

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -63,6 +63,7 @@ Interface changes
     - add `--border-background` option
     - add `video-target-params` property
     - add `hdr10plus` sub-parameter to `format` video filter
+    - add `--sub-ass-colorspace` option
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2528,6 +2528,21 @@ Subtitles
 
     Default: yes.
 
+``--sub-ass-colorspace=<auto|video|sdr>``
+    Specify the RGB primaries and transfer function to use when rendering
+    ASS subtitles.
+
+    :auto:  Follow the ASS specification. This is currently equivalent to
+            ``video``. This behavior may change in the future. (default)
+    :video: Assume that ASS subtitles are in the video's colorspace. Match the
+            color primaries and transfer function of the ASS subtitles to those
+            of the associated video.
+    :sdr:   Assume that ASS subtitles are SDR. Match them to the video's
+            colorspace in SDR mode. If the video is HDR, fall back to sRGB.
+
+    This option affects ``--vo=gpu-next``, ``--vo=gpu`` always assume sRGB
+    colorspace for subtitles.
+
 ``--sub-ass-vsfilter-aspect-compat=<yes|no>``
     Stretch SSA/ASS subtitles when playing anamorphic videos for compatibility
     with traditional VSFilter behavior. This switch has no effect when the

--- a/options/options.c
+++ b/options/options.c
@@ -325,6 +325,8 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"sub-past-video-end", OPT_BOOL(sub_past_video_end)},
         {"sub-ass-force-style", OPT_REPLACED("sub-ass-style-overrides")},
         {"sub-lavc-o", OPT_KEYVALUELIST(sub_avopts)},
+        {"sub-ass-colorspace", OPT_CHOICE(ass_colorspace,
+            {"auto", 0}, {"video", 1}, {"sdr", 2})},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),

--- a/options/options.h
+++ b/options/options.h
@@ -113,6 +113,7 @@ struct mp_subtitle_opts {
     bool sub_clear_on_seek;
     int teletext_page;
     bool sub_past_video_end;
+    int ass_colorspace;
     char **sub_avopts;
 };
 


### PR DESCRIPTION
Option to control what colorspace subtitle should be converted to before drawing them. Upstream ASS specification says that all subtitles should be rendered with color primaries and transfer matching their associated video.

This has certain limitations in the case of HDR/WCG content. See the discussion in libass/libass#297.

To mitigate current situation add an option for users to control the render target of subtitles.

This could be also accomplished with --blend-subtitles to some degree, but I don't want to mux options that are not really clear to affect this certain case.

See-Also: https://github.com/libass/libass/blob/649a7c2e1fc6f4188ea1a89968560715800b883d/libass/ass_types.h#L233-L237
See-Also: https://github.com/libass/libass/issues/297
See-Also: https://github.com/mpv-player/mpv/issues/13381
Fixes: https://github.com/mpv-player/mpv/issues/13673

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.