### PR TITLE
meson: fix ios-gl hwdec build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1449,7 +1449,7 @@ videotoolbox_pl = get_option('videotoolbox-pl').require(
     error_message: 'vulkan or CV metal support could be found!',
 )
 features += {'videotoolbox-pl': videotoolbox_pl.allowed()}
-if features['videotoolbox-gl'] or features['videotoolbox-pl']
+if features['videotoolbox-gl'] or features['videotoolbox-pl'] or features['ios-gl']
     sources += files('video/out/hwdec/hwdec_vt.c')
 endif
 if features['videotoolbox-gl']


### PR DESCRIPTION
It's a bit inconsistent. meson.build suggests that videotoolbox-gl could be used in pair with ios-gl. But this then includes macos specific files later on.

Without this fix, 0.37 now causes _ra_hwdec_videotoolbox symbol not found when ran on hardware cause hwdec_vt is never included. 0.36 worked correctly so I guess placebo related refactor of meson.build caused this regression.
