### PR TITLE
ao_wasapi: handle potential race condition

### DIFF
--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -48,21 +48,22 @@ void wasapi_change_uninit(struct ao* ao);
 
 enum wasapi_thread_state {
     WASAPI_THREAD_FEED = 0,
-    WASAPI_THREAD_DISPATCH,
     WASAPI_THREAD_RESUME,
     WASAPI_THREAD_RESET,
-    WASAPI_THREAD_SHUTDOWN
+    WASAPI_THREAD_SHUTDOWN,
+    WASAPI_THREAD_DISPATCH_BASE
 };
 
 typedef struct wasapi_state {
     struct mp_log *log;
 
-    bool init_ok;            // status of init phase
+    bool init_ok;             // status of init phase
     // Thread handles
-    HANDLE hInitDone;        // set when init is complete in audio thread
-    HANDLE hAudioThread;     // the audio thread itself
-    HANDLE hWake;            // thread wakeup event
-    atomic_int thread_state; // enum wasapi_thread_state (what to do on wakeup)
+    HANDLE hInitDone;         // set when init is complete in audio thread
+    HANDLE hAudioThread;      // the audio thread itself
+    HANDLE hWake;             // thread wakeup event
+    atomic_uint thread_state; // enum wasapi_thread_state (what to do on wakeup)
+    atomic_uint dispatch_seq; // incremented each time AO control is called
     struct mp_dispatch_queue *dispatch; // for volume/mute/session display
 
     // for setting the audio thread priority


### PR DESCRIPTION
The race condition can be triggered by stressing AO control, for example with a script like
```lua
function stress_ao_control()
    while true do
        mp.command("set ao-volume 10")
    end
end

mp.add_forced_key_binding("v", "stress-ao-control", stress_ao_control)
```

It was noticed when I was messing with the AO and some newly added debug log in the renderer loop made it more easily triggered. I have never run into it in normal usage though, nor has any issue been opened about it. A more robust approach might be to move all non-rendering tasks out of the renderer thread (including AO control handling and device position checking; see https://github.com/mpv-player/mpv/pull/13434#issuecomment-1932809770), but before anyone has the time/intention to work on that this patch can serve as a temporary solution.