### PR TITLE
vo_gpu/vo_gpu_next: fix transparency in glx

### DIFF
--- a/video/out/gpu_next/context.c
+++ b/video/out/gpu_next/context.c
@@ -107,12 +107,10 @@ err_out:
 }
 #endif // HAVE_D3D11
 
-struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct gl_video_opts *gl_opts)
+struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct ra_ctx_opts *ctx_opts)
 {
     struct gpu_ctx *ctx = talloc_zero(NULL, struct gpu_ctx);
     ctx->log = vo->log;
-
-    struct ra_ctx_opts *ctx_opts = mp_get_config_group(ctx, vo->global, &ra_ctx_conf);
     ctx->ra_ctx = ra_ctx_create(vo, *ctx_opts);
     if (!ctx->ra_ctx)
         goto err_out;

--- a/video/out/gpu_next/context.h
+++ b/video/out/gpu_next/context.h
@@ -21,8 +21,8 @@
 
 struct mp_log;
 struct ra_ctx;
+struct ra_ctx_opts;
 struct vo;
-struct gl_video_opts;
 
 struct gpu_ctx {
     struct mp_log *log;
@@ -35,6 +35,6 @@ struct gpu_ctx {
     void *priv;
 };
 
-struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct gl_video_opts *gl_opts);
+struct gpu_ctx *gpu_ctx_create(struct vo *vo, struct ra_ctx_opts *ctx_opts);
 bool gpu_ctx_resize(struct gpu_ctx *ctx, int w, int h);
 void gpu_ctx_destroy(struct gpu_ctx **ctxp);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1477,17 +1477,17 @@ static inline void copy_frame_info_to_mp(struct frame_info *pl,
     }
 }
 
-static void update_ra_ctx_options(struct vo *vo)
+static void update_ra_ctx_options(struct vo *vo, struct ra_ctx_opts *ctx_opts)
 {
     struct priv *p = vo->priv;
     struct gl_video_opts *gl_opts = p->opts_cache->opts;
     bool border_alpha = (p->next_opts->border_background == BACKGROUND_COLOR &&
                          gl_opts->background_color.a != 255) ||
                          p->next_opts->border_background == BACKGROUND_NONE;
-    p->ra_ctx->opts.want_alpha = (gl_opts->background == BACKGROUND_COLOR &&
-                                  gl_opts->background_color.a != 255) ||
-                                  gl_opts->background == BACKGROUND_NONE ||
-                                  border_alpha;
+    ctx_opts->want_alpha = (gl_opts->background == BACKGROUND_COLOR &&
+                            gl_opts->background_color.a != 255) ||
+                            gl_opts->background == BACKGROUND_NONE ||
+                            border_alpha;
 }
 
 static int control(struct vo *vo, uint32_t request, void *data)
@@ -1505,7 +1505,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
 
     case VOCTRL_UPDATE_RENDER_OPTS: {
         m_config_cache_update(p->opts_cache);
-        update_ra_ctx_options(vo);
+        update_ra_ctx_options(vo, &p->ra_ctx->opts);
         if (p->ra_ctx->fns->update_render_opts)
             p->ra_ctx->fns->update_render_opts(p->ra_ctx);
         update_render_options(vo);
@@ -1825,7 +1825,10 @@ static int preinit(struct vo *vo)
     p->log = vo->log;
 
     struct gl_video_opts *gl_opts = p->opts_cache->opts;
-    p->context = gpu_ctx_create(vo, gl_opts);
+    struct ra_ctx_opts *ctx_opts = mp_get_config_group(vo, vo->global, &ra_ctx_conf);
+    update_ra_ctx_options(vo, ctx_opts);
+    p->context = gpu_ctx_create(vo, ctx_opts);
+    talloc_free(ctx_opts);
     if (!p->context)
         goto err_out;
     // For the time being
@@ -1838,7 +1841,6 @@ static int preinit(struct vo *vo)
         .global = p->global,
         .ra_ctx = p->ra_ctx,
     };
-    update_ra_ctx_options(vo);
 
     vo->hwdec_devs = hwdec_devices_create();
     hwdec_devices_set_loader(vo->hwdec_devs, load_hwdec_api, vo);


### PR DESCRIPTION
It seems that GLX requires us to explicitly set opts.want alpha before ra_ctx_create is called. b7fd232524bc213df91fa77ca0261ff514fad1e4 rearranged the function calls in a way made this not work. Fix this by rearranging ti again so the value is set before ra_ctx is created.