### PR TITLE
demux: add a format-name property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3089,6 +3089,11 @@ Property list
     ``track-list/N/demux-par``
         Pixel aspect ratio.
 
+    ``track-list/N/format-name``
+        Short name for format from ffmpeg. If the track is audio, this will be
+        the name of the sample format. If the track is video, this will be the
+        name of the pixel format.
+
     ``track-list/N/audio-channels`` (deprecated)
         Deprecated alias for ``track-list/N/demux-channel-count``.
 

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -29,14 +29,15 @@
 
 #include <libavformat/avformat.h>
 #include <libavformat/avio.h>
+
 #include <libavutil/avutil.h>
 #include <libavutil/avstring.h>
-#include <libavutil/mathematics.h>
-#include <libavutil/replaygain.h>
 #include <libavutil/display.h>
-#include <libavutil/opt.h>
-
 #include <libavutil/dovi_meta.h>
+#include <libavutil/mathematics.h>
+#include <libavutil/opt.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/replaygain.h>
 
 #include "audio/chmap_avchannel.h"
 
@@ -726,6 +727,7 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
 
         sh->codec->samplerate = codec->sample_rate;
         sh->codec->bitrate = codec->bit_rate;
+        sh->codec->format_name = talloc_strdup(sh, av_get_sample_fmt_name(codec->format));
 
         double delay = 0;
         if (codec->sample_rate > 0)
@@ -764,6 +766,7 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
 
         sh->codec->disp_w = codec->width;
         sh->codec->disp_h = codec->height;
+        sh->codec->format_name = talloc_strdup(sh, av_get_pix_fmt_name(codec->format));
         if (st->avg_frame_rate.num)
             sh->codec->fps = av_q2d(st->avg_frame_rate);
         if (is_image(st, sh->attached_picture, priv->avif)) {

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -111,6 +111,7 @@ struct mp_codec_params {
 
     // STREAM_VIDEO + STREAM_AUDIO
     int bits_per_coded_sample;
+    char *format_name;    // pixel format (video) or sample format (audio)
 
     // STREAM_SUB
     double frame_based;   // timestamps are frame-based (and this is the

--- a/player/command.c
+++ b/player/command.c
@@ -2063,6 +2063,7 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
         {"demux-bitrate",  SUB_PROP_INT(p.bitrate), .unavailable = p.bitrate <= 0},
         {"demux-rotation", SUB_PROP_INT(p.rotate),  .unavailable = p.rotate <= 0},
         {"demux-par",      SUB_PROP_DOUBLE(par),    .unavailable = par <= 0},
+        {"format-name", SUB_PROP_STR(p.format_name), .unavailable = !p.format_name},
         {"replaygain-track-peak", SUB_PROP_FLOAT(rg.track_peak),
                         .unavailable = !has_rg},
         {"replaygain-track-gain", SUB_PROP_FLOAT(rg.track_gain),


### PR DESCRIPTION
It can be useful to know the underlying format of any entry in the track list. Only applicable to the lavf demuxer.