### PR TITLE
mac/input: move input related function into new class, cleanup and optimisations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1513,6 +1513,7 @@ features += {'swift': swift.allowed()}
 swift_sources = []
 if features['cocoa'] and features['swift']
     swift_sources += files('osdep/mac/libmpv_helper.swift',
+                           'osdep/mac/input_helper.swift',
                            'osdep/mac/log_helper.swift',
                            'osdep/mac/mpv_helper.swift',
                            'osdep/mac/menu_bar.swift',

--- a/osdep/mac/application.m
+++ b/osdep/mac/application.m
@@ -115,7 +115,7 @@ static void terminate_cocoa_application(void)
 
 - (void)sendEvent:(NSEvent *)event
 {
-    if ([self modalWindow] || ![_eventsResponder processKeyEvent:event])
+    if ([self modalWindow] || ![_eventsResponder.inputHelper processKeyWithEvent:event])
         [super sendEvent:event];
     [_eventsResponder.inputHelper wakeup];
 }

--- a/osdep/mac/application.m
+++ b/osdep/mac/application.m
@@ -117,7 +117,7 @@ static void terminate_cocoa_application(void)
 {
     if ([self modalWindow] || ![_eventsResponder processKeyEvent:event])
         [super sendEvent:event];
-    [_eventsResponder wakeup];
+    [_eventsResponder.inputHelper wakeup];
 }
 
 - (id)init
@@ -162,7 +162,6 @@ static const char mac_icon[] =
 - (NSTouchBar *)makeTouchBar
 {
     TouchBar *tBar = [[TouchBar alloc] init];
-    [tBar setApp:self];
     tBar.delegate = tBar;
     tBar.customizationIdentifier = customID;
     tBar.defaultItemIdentifiers = @[play, previousItem, nextItem, seekBar];
@@ -202,17 +201,6 @@ static const char mac_icon[] =
     return &vo_sub_opts;
 }
 
-- (void)queueCommand:(char *)cmd
-{
-    [_eventsResponder queueCommand:cmd];
-}
-
-- (void)stopMPV:(char *)cmd
-{
-    if (![_eventsResponder queueCommand:cmd])
-        terminate_cocoa_application();
-}
-
 - (void)applicationWillFinishLaunching:(NSNotification *)notification
 {
     NSAppleEventManager *em = [NSAppleEventManager sharedAppleEventManager];
@@ -225,7 +213,8 @@ static const char mac_icon[] =
 - (void)handleQuitEvent:(NSAppleEventDescriptor *)event
          withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
-    [self stopMPV:"quit"];
+    if (![_eventsResponder.inputHelper command:@"quit"])
+        terminate_cocoa_application();
 }
 
 - (void)getUrl:(NSAppleEventDescriptor *)event
@@ -240,7 +229,7 @@ static const char mac_icon[] =
                      range:NSMakeRange(0, [MPV_PROTOCOL length])];
 
     url = [url stringByRemovingPercentEncoding];
-    [_eventsResponder handleFilesArray:@[url]];
+    [_eventsResponder.inputHelper openWithFiles:@[url]];
 }
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames
@@ -249,14 +238,10 @@ static const char mac_icon[] =
         mpv_shared_app().openCount--;
         return;
     }
-    [self openFiles:filenames];
-}
 
-- (void)openFiles:(NSArray *)filenames
-{
     SEL cmpsel = @selector(localizedStandardCompare:);
     NSArray *files = [filenames sortedArrayUsingSelector:cmpsel];
-    [_eventsResponder handleFilesArray:files];
+    [_eventsResponder.inputHelper openWithFiles:files];
 }
 @end
 
@@ -357,7 +342,7 @@ int cocoa_main(int argc, char *argv[])
         }
 
         mp_thread_create(&playback_thread_id, playback_thread, &ctx);
-        [[EventsResponder sharedInstance] waitForInputContext];
+        [[EventsResponder sharedInstance].inputHelper wait];
         cocoa_run_runloop();
 
         // This should never be reached: cocoa_run_runloop blocks until the

--- a/osdep/mac/application_objc.h
+++ b/osdep/mac/application_objc.h
@@ -27,9 +27,6 @@ struct mpv_handle;
 
 - (NSImage *)getMPVIcon;
 - (void)processEvent:(struct mpv_event *)event;
-- (void)queueCommand:(char *)cmd;
-- (void)stopMPV:(char *)cmd;
-- (void)openFiles:(NSArray *)filenames;
 - (void)initCocoaCb:(struct mpv_handle *)ctx;
 + (const struct m_sub_options *)getMacOSConf;
 + (const struct m_sub_options *)getVoSubConf;

--- a/osdep/mac/events.h
+++ b/osdep/mac/events.h
@@ -24,9 +24,6 @@
 struct input_ctx;
 struct mpv_handle;
 
-void cocoa_put_key(int keycode);
-void cocoa_put_key_with_modifiers(int keycode, int modifiers);
-
 void cocoa_init_media_keys(void);
 void cocoa_uninit_media_keys(void);
 

--- a/osdep/mac/events.h
+++ b/osdep/mac/events.h
@@ -19,7 +19,6 @@
 
 #ifndef MAC_EVENTS
 #define MAC_EVENTS
-#include "input/keycodes.h"
 
 struct input_ctx;
 struct mpv_handle;

--- a/osdep/mac/events.m
+++ b/osdep/mac/events.m
@@ -17,21 +17,12 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Carbon header is included but Carbon is NOT linked to mpv's binary. This
-// file only needs this include to use the keycode definitions in keymap.
-#import <Carbon/Carbon.h>
-
-// Media keys definitions
-#import <IOKit/hidsystem/ev_keymap.h>
 #import <Cocoa/Cocoa.h>
 
 #include "mpv_talloc.h"
 #include "input/event.h"
 #include "input/input.h"
 #include "player/client.h"
-#include "input/keycodes.h"
-// doesn't make much sense, but needed to access keymap functionality
-#include "video/out/vo.h"
 
 #import "osdep/mac/events_objc.h"
 #import "osdep/mac/application_objc.h"
@@ -48,76 +39,12 @@
     BOOL _is_application;
 }
 
-- (NSEvent *)handleKey:(NSEvent *)event;
 - (BOOL)setMpvHandle:(struct mpv_handle *)ctx;
 - (void)initCocoaCb;
 - (void)readEvents;
 - (void)startMediaKeys;
 - (void)stopMediaKeys;
-- (int)mapKeyModifiers:(int)cocoaModifiers;
-- (int)keyModifierMask:(NSEvent *)event;
 @end
-
-
-#define NSLeftAlternateKeyMask  (0x000020 | NSEventModifierFlagOption)
-#define NSRightAlternateKeyMask (0x000040 | NSEventModifierFlagOption)
-
-static bool LeftAltPressed(int mask)
-{
-    return (mask & NSLeftAlternateKeyMask) == NSLeftAlternateKeyMask;
-}
-
-static bool RightAltPressed(int mask)
-{
-    return (mask & NSRightAlternateKeyMask) == NSRightAlternateKeyMask;
-}
-
-static const struct mp_keymap keymap[] = {
-    // special keys
-    {kVK_Return, MP_KEY_ENTER}, {kVK_Escape, MP_KEY_ESC},
-    {kVK_Delete, MP_KEY_BACKSPACE}, {kVK_Option, MP_KEY_BACKSPACE},
-    {kVK_Control, MP_KEY_BACKSPACE}, {kVK_Shift, MP_KEY_BACKSPACE},
-    {kVK_Tab, MP_KEY_TAB},
-
-    // cursor keys
-    {kVK_UpArrow, MP_KEY_UP}, {kVK_DownArrow, MP_KEY_DOWN},
-    {kVK_LeftArrow, MP_KEY_LEFT}, {kVK_RightArrow, MP_KEY_RIGHT},
-
-    // navigation block
-    {kVK_Help, MP_KEY_INSERT}, {kVK_ForwardDelete, MP_KEY_DELETE},
-    {kVK_Home, MP_KEY_HOME}, {kVK_End, MP_KEY_END},
-    {kVK_PageUp, MP_KEY_PAGE_UP}, {kVK_PageDown, MP_KEY_PAGE_DOWN},
-
-    // F-keys
-    {kVK_F1, MP_KEY_F + 1}, {kVK_F2, MP_KEY_F + 2}, {kVK_F3, MP_KEY_F + 3},
-    {kVK_F4, MP_KEY_F + 4}, {kVK_F5, MP_KEY_F + 5}, {kVK_F6, MP_KEY_F + 6},
-    {kVK_F7, MP_KEY_F + 7}, {kVK_F8, MP_KEY_F + 8}, {kVK_F9, MP_KEY_F + 9},
-    {kVK_F10, MP_KEY_F + 10}, {kVK_F11, MP_KEY_F + 11}, {kVK_F12, MP_KEY_F + 12},
-    {kVK_F13, MP_KEY_F + 13}, {kVK_F14, MP_KEY_F + 14}, {kVK_F15, MP_KEY_F + 15},
-    {kVK_F16, MP_KEY_F + 16}, {kVK_F17, MP_KEY_F + 17}, {kVK_F18, MP_KEY_F + 18},
-    {kVK_F19, MP_KEY_F + 19}, {kVK_F20, MP_KEY_F + 20},
-
-    // numpad
-    {kVK_ANSI_KeypadPlus, '+'}, {kVK_ANSI_KeypadMinus, '-'},
-    {kVK_ANSI_KeypadMultiply, '*'}, {kVK_ANSI_KeypadDivide, '/'},
-    {kVK_ANSI_KeypadEnter, MP_KEY_KPENTER},
-    {kVK_ANSI_KeypadDecimal, MP_KEY_KPDEC},
-    {kVK_ANSI_Keypad0, MP_KEY_KP0}, {kVK_ANSI_Keypad1, MP_KEY_KP1},
-    {kVK_ANSI_Keypad2, MP_KEY_KP2}, {kVK_ANSI_Keypad3, MP_KEY_KP3},
-    {kVK_ANSI_Keypad4, MP_KEY_KP4}, {kVK_ANSI_Keypad5, MP_KEY_KP5},
-    {kVK_ANSI_Keypad6, MP_KEY_KP6}, {kVK_ANSI_Keypad7, MP_KEY_KP7},
-    {kVK_ANSI_Keypad8, MP_KEY_KP8}, {kVK_ANSI_Keypad9, MP_KEY_KP9},
-
-    {0, 0}
-};
-
-static int convert_key(unsigned key, unsigned charcode)
-{
-    int mpkey = lookup_keymap_table(keymap, key);
-    if (mpkey)
-        return mpkey;
-    return charcode;
-}
 
 void cocoa_init_media_keys(void)
 {
@@ -253,79 +180,6 @@ void cocoa_init_cocoa_cb(void)
 - (void)stopMediaKeys
 {
     [_remoteCommandCenter stop];
-}
-
-- (int)mapKeyModifiers:(int)cocoaModifiers
-{
-    int mask = 0;
-    if (cocoaModifiers & NSEventModifierFlagShift)
-        mask |= MP_KEY_MODIFIER_SHIFT;
-    if (cocoaModifiers & NSEventModifierFlagControl)
-        mask |= MP_KEY_MODIFIER_CTRL;
-    if (LeftAltPressed(cocoaModifiers) ||
-        (RightAltPressed(cocoaModifiers) && ![_inputHelper useAltGr]))
-        mask |= MP_KEY_MODIFIER_ALT;
-    if (cocoaModifiers & NSEventModifierFlagCommand)
-        mask |= MP_KEY_MODIFIER_META;
-    return mask;
-}
-
-- (int)mapTypeModifiers:(NSEventType)type
-{
-    NSDictionary *map = @{
-        @(NSEventTypeKeyDown) : @(MP_KEY_STATE_DOWN),
-        @(NSEventTypeKeyUp)   : @(MP_KEY_STATE_UP),
-    };
-    return [map[@(type)] intValue];
-}
-
-- (int)keyModifierMask:(NSEvent *)event
-{
-    return [self mapKeyModifiers:[event modifierFlags]] |
-        [self mapTypeModifiers:[event type]];
-}
-
--(BOOL)handleMPKey:(int)key withMask:(int)mask
-{
-    if (key > 0) {
-        [_inputHelper putKey:key | mask modifiers:0];
-        if (mask & MP_KEY_STATE_UP)
-            [_inputHelper putKey:MP_INPUT_RELEASE_ALL modifiers:0];
-        return YES;
-    } else {
-        return NO;
-    }
-}
-
-- (NSEvent*)handleKey:(NSEvent *)event
-{
-    if ([event isARepeat]) return nil;
-
-    NSString *chars;
-
-    if ([_inputHelper useAltGr] && RightAltPressed([event modifierFlags])) {
-        chars = [event characters];
-    } else {
-        chars = [event charactersIgnoringModifiers];
-    }
-
-    struct bstr t = bstr0([chars UTF8String]);
-    int key = convert_key([event keyCode], bstr_decode_utf8(t, &t));
-
-    if (key > -1)
-        [self handleMPKey:key withMask:[self keyModifierMask:event]];
-
-    return nil;
-}
-
-- (bool)processKeyEvent:(NSEvent *)event
-{
-    if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp){
-        if (![[NSApp mainMenu] performKeyEquivalent:event])
-            [self handleKey:event];
-        return true;
-    }
-    return false;
 }
 
 @end

--- a/osdep/mac/events_objc.h
+++ b/osdep/mac/events_objc.h
@@ -21,6 +21,7 @@
 #include "osdep/mac/events.h"
 
 @class RemoteCommandCenter;
+@class InputHelper;
 struct input_ctx;
 
 @interface EventsResponder : NSObject
@@ -41,5 +42,6 @@ struct input_ctx;
 - (BOOL)handleMPKey:(int)key withMask:(int)mask;
 
 @property(nonatomic, retain) RemoteCommandCenter *remoteCommandCenter;
+@property(nonatomic, retain) InputHelper *inputHelper;
 
 @end

--- a/osdep/mac/events_objc.h
+++ b/osdep/mac/events_objc.h
@@ -27,16 +27,8 @@ struct input_ctx;
 @interface EventsResponder : NSObject
 
 + (EventsResponder *)sharedInstance;
-- (void)setInputContext:(struct input_ctx *)ctx;
 - (void)setIsApplication:(BOOL)isApplication;
 
-/// Blocks until inputContext is present.
-- (void)waitForInputContext;
-- (void)wakeup;
-- (void)putKey:(int)keycode;
-- (void)handleFilesArray:(NSArray *)files;
-
-- (bool)queueCommand:(char *)cmd;
 - (bool)processKeyEvent:(NSEvent *)event;
 
 - (BOOL)handleMPKey:(int)key withMask:(int)mask;

--- a/osdep/mac/events_objc.h
+++ b/osdep/mac/events_objc.h
@@ -29,10 +29,6 @@ struct input_ctx;
 + (EventsResponder *)sharedInstance;
 - (void)setIsApplication:(BOOL)isApplication;
 
-- (bool)processKeyEvent:(NSEvent *)event;
-
-- (BOOL)handleMPKey:(int)key withMask:(int)mask;
-
 @property(nonatomic, retain) RemoteCommandCenter *remoteCommandCenter;
 @property(nonatomic, retain) InputHelper *inputHelper;
 

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -85,8 +85,8 @@ class InputHelper: NSObject {
         if modifiers.contains(.command) {
             mask |= MP_KEY_MODIFIER_META
         }
-        if modifiers.rawValue & UInt(NX_DEVICELALTKEYMASK) != 0 ||
-           modifiers.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0 && !mp_input_use_alt_gr(input)
+        if modifiers.contains(.optionLeft) ||
+           modifiers.contains(.optionRight) && !mp_input_use_alt_gr(input)
         {
             mask |= MP_KEY_MODIFIER_ALT
         }

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -27,9 +27,6 @@ class InputHelper: NSObject {
         mp_keymap(from: Int32(kVK_Return), to: MP_KEY_ENTER),
         mp_keymap(from: Int32(kVK_Escape), to: MP_KEY_ESC),
         mp_keymap(from: Int32(kVK_Delete), to: MP_KEY_BACKSPACE),
-        mp_keymap(from: Int32(kVK_Option), to: MP_KEY_BACKSPACE),
-        mp_keymap(from: Int32(kVK_Control), to: MP_KEY_BACKSPACE),
-        mp_keymap(from: Int32(kVK_Shift), to: MP_KEY_BACKSPACE),
         mp_keymap(from: Int32(kVK_Tab), to: MP_KEY_TAB),
 
         // cursor keys

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -16,15 +16,52 @@
  */
 
 class InputHelper: NSObject {
+    var mpv: MPVHelper?
     var lock = NSCondition()
     private var input: OpaquePointer?
 
-    @objc init(_ input: OpaquePointer? = nil) {
+    @objc init(_ input: OpaquePointer? = nil, _ mpv: MPVHelper? = nil) {
         super.init()
         self.input = input
+        self.mpv = mpv
     }
 
-    @objc func command(_ cmd: String) -> Bool {
+    @objc func putKey(_ key: Int32) {
+        lock.withLock {
+            guard let input = input else { return }
+            mp_input_put_key(input, key)
+        }
+    }
+
+    func draggable(at pos: NSPoint) -> Bool {
+        lock.withLock {
+            guard let input = input else { return false }
+            return !mp_input_test_dragging(input, Int32(pos.x), Int32(pos.y))
+        }
+    }
+
+    func mouseEnabled() -> Bool {
+        lock.withLock {
+            guard let input = input else { return true }
+            return mp_input_mouse_enabled(input)
+        }
+    }
+
+    func setMouse(position pos: NSPoint) {
+        lock.withLock {
+            guard let input = input else { return }
+            mp_input_set_mouse_pos(input, Int32(pos.x), Int32(pos.y))
+        }
+    }
+
+    func putAxis(_ mpkey: Int32, modifiers: NSEvent.ModifierFlags, delta: Double) {
+        lock.withLock {
+            guard let input = input else { return }
+            mp_input_put_wheel(input, mpkey | mapModifier(modifiers), delta)
+        }
+    }
+
+    @discardableResult @objc func command(_ cmd: String) -> Bool {
         lock.withLock {
             guard let input = input else { return false }
             let cCmd = UnsafePointer<Int8>(strdup(cmd))
@@ -35,10 +72,42 @@ class InputHelper: NSObject {
         }
     }
 
-    @objc func putKey(_ key: Int32) {
+    private func mapModifier(_ modifiers: NSEvent.ModifierFlags) -> Int32 {
+        var mask: UInt32 = 0;
+        guard let input = input else { return Int32(mask) }
+
+        if modifiers.contains(.shift) {
+            mask |= MP_KEY_MODIFIER_SHIFT
+        }
+        if modifiers.contains(.control) {
+            mask |= MP_KEY_MODIFIER_CTRL
+        }
+        if modifiers.contains(.command) {
+            mask |= MP_KEY_MODIFIER_META
+        }
+        if modifiers.rawValue & UInt(NX_DEVICELALTKEYMASK) != 0 ||
+           modifiers.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0 && !mp_input_use_alt_gr(input)
+        {
+            mask |= MP_KEY_MODIFIER_ALT
+        }
+
+        return Int32(mask)
+    }
+
+    @objc func open(files: [String]) {
         lock.withLock {
             guard let input = input else { return }
-            mp_input_put_key(input, key)
+            if (mpv?.opts.drag_and_drop ?? -1) == -2 { return }
+
+            var action = NSEvent.modifierFlags.contains(.shift) ? DND_APPEND : DND_REPLACE
+            if (mpv?.opts.drag_and_drop ?? -1) >= 0  {
+                action = mp_dnd_action(UInt32(mpv?.opts.drag_and_drop ?? Int32(DND_REPLACE.rawValue)))
+            }
+
+            let filesClean = files.map{ $0.hasPrefix("file:///.file/id=") ? (URL(string: $0)?.path ?? $0) : $0 }
+            var filesPtr = filesClean.map { UnsafeMutablePointer<CChar>(strdup($0)) }
+            mp_event_drop_files(input, Int32(files.count), &filesPtr, action)
+            for charPtr in filesPtr { free(UnsafeMutablePointer(mutating: charPtr)) }
         }
     }
 

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -26,10 +26,10 @@ class InputHelper: NSObject {
         self.mpv = mpv
     }
 
-    @objc func putKey(_ key: Int32) {
+    @objc func putKey(_ key: Int32, modifiers: NSEvent.ModifierFlags = .init(rawValue: 0)) {
         lock.withLock {
             guard let input = input else { return }
-            mp_input_put_key(input, key)
+            mp_input_put_key(input, key | mapModifier(modifiers))
         }
     }
 

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -15,10 +15,79 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Carbon.HIToolbox
+
 class InputHelper: NSObject {
     var mpv: MPVHelper?
     var lock = NSCondition()
     private var input: OpaquePointer?
+
+    let keymap: [mp_keymap] = [
+        // special keys
+        mp_keymap(from: Int32(kVK_Return), to: MP_KEY_ENTER),
+        mp_keymap(from: Int32(kVK_Escape), to: MP_KEY_ESC),
+        mp_keymap(from: Int32(kVK_Delete), to: MP_KEY_BACKSPACE),
+        mp_keymap(from: Int32(kVK_Option), to: MP_KEY_BACKSPACE),
+        mp_keymap(from: Int32(kVK_Control), to: MP_KEY_BACKSPACE),
+        mp_keymap(from: Int32(kVK_Shift), to: MP_KEY_BACKSPACE),
+        mp_keymap(from: Int32(kVK_Tab), to: MP_KEY_TAB),
+
+        // cursor keys
+        mp_keymap(from: Int32(kVK_UpArrow), to: MP_KEY_UP),
+        mp_keymap(from: Int32(kVK_DownArrow), to: MP_KEY_DOWN),
+        mp_keymap(from: Int32(kVK_LeftArrow), to: MP_KEY_LEFT),
+        mp_keymap(from: Int32(kVK_RightArrow), to: MP_KEY_RIGHT),
+
+        // navigation block
+        mp_keymap(from: Int32(kVK_Help), to: MP_KEY_INSERT),
+        mp_keymap(from: Int32(kVK_ForwardDelete), to: MP_KEY_DELETE),
+        mp_keymap(from: Int32(kVK_Home), to: MP_KEY_HOME),
+        mp_keymap(from: Int32(kVK_End), to: MP_KEY_END),
+        mp_keymap(from: Int32(kVK_PageUp), to: MP_KEY_PAGE_UP),
+        mp_keymap(from: Int32(kVK_PageDown), to: MP_KEY_PAGE_DOWN),
+
+        // F-keys
+        mp_keymap(from: Int32(kVK_F1), to: MP_KEY_F + 1),
+        mp_keymap(from: Int32(kVK_F2), to: MP_KEY_F + 2),
+        mp_keymap(from: Int32(kVK_F3), to: MP_KEY_F + 3),
+        mp_keymap(from: Int32(kVK_F4), to: MP_KEY_F + 4),
+        mp_keymap(from: Int32(kVK_F5), to: MP_KEY_F + 5),
+        mp_keymap(from: Int32(kVK_F6), to: MP_KEY_F + 6),
+        mp_keymap(from: Int32(kVK_F7), to: MP_KEY_F + 7),
+        mp_keymap(from: Int32(kVK_F8), to: MP_KEY_F + 8),
+        mp_keymap(from: Int32(kVK_F9), to: MP_KEY_F + 9),
+        mp_keymap(from: Int32(kVK_F10), to: MP_KEY_F + 10),
+        mp_keymap(from: Int32(kVK_F11), to: MP_KEY_F + 11),
+        mp_keymap(from: Int32(kVK_F12), to: MP_KEY_F + 12),
+        mp_keymap(from: Int32(kVK_F13), to: MP_KEY_F + 13),
+        mp_keymap(from: Int32(kVK_F14), to: MP_KEY_F + 14),
+        mp_keymap(from: Int32(kVK_F15), to: MP_KEY_F + 15),
+        mp_keymap(from: Int32(kVK_F16), to: MP_KEY_F + 16),
+        mp_keymap(from: Int32(kVK_F17), to: MP_KEY_F + 17),
+        mp_keymap(from: Int32(kVK_F18), to: MP_KEY_F + 18),
+        mp_keymap(from: Int32(kVK_F19), to: MP_KEY_F + 19),
+        mp_keymap(from: Int32(kVK_F20), to: MP_KEY_F + 20),
+
+        // numpad
+        mp_keymap(from: Int32(kVK_ANSI_KeypadPlus), to: Int32(Character("+").asciiValue ?? 0)),
+        mp_keymap(from: Int32(kVK_ANSI_KeypadMinus), to: Int32(Character("-").asciiValue ?? 0)),
+        mp_keymap(from: Int32(kVK_ANSI_KeypadMultiply), to: Int32(Character("*").asciiValue ?? 0)),
+        mp_keymap(from: Int32(kVK_ANSI_KeypadDivide), to: Int32(Character("/").asciiValue ?? 0)),
+        mp_keymap(from: Int32(kVK_ANSI_KeypadEnter), to: MP_KEY_KPENTER),
+        mp_keymap(from: Int32(kVK_ANSI_KeypadDecimal), to: MP_KEY_KPDEC),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad0), to: MP_KEY_KP0),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad1), to: MP_KEY_KP1),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad2), to: MP_KEY_KP2),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad3), to: MP_KEY_KP3),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad4), to: MP_KEY_KP4),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad5), to: MP_KEY_KP5),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad6), to: MP_KEY_KP6),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad7), to: MP_KEY_KP7),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad8), to: MP_KEY_KP8),
+        mp_keymap(from: Int32(kVK_ANSI_Keypad9), to: MP_KEY_KP9),
+
+        mp_keymap(from: 0, to: 0)
+    ]
 
     @objc init(_ input: OpaquePointer? = nil, _ mpv: MPVHelper? = nil) {
         super.init()
@@ -26,10 +95,50 @@ class InputHelper: NSObject {
         self.mpv = mpv
     }
 
-    @objc func putKey(_ key: Int32, modifiers: NSEvent.ModifierFlags = .init(rawValue: 0)) {
+    @objc func put(
+        key: Int32,
+        modifiers: NSEvent.ModifierFlags = .init(rawValue: 0),
+        type: NSEvent.EventType = .applicationDefined
+    ) {
         lock.withLock {
-            guard let input = input else { return }
-            mp_input_put_key(input, key | mapModifier(modifiers))
+            putKey(key, modifiers: modifiers, type: type)
+        }
+    }
+
+    private func putKey(
+        _ key: Int32,
+        modifiers: NSEvent.ModifierFlags = .init(rawValue: 0),
+        type: NSEvent.EventType = .applicationDefined
+    ) {
+        if key < 1 { return }
+
+        guard let input = input else { return }
+        let code = key | mapModifier(modifiers) | mapType(type)
+        mp_input_put_key(input, code)
+
+        if type == .keyUp {
+            mp_input_put_key(input, MP_INPUT_RELEASE_ALL)
+        }
+    }
+
+    @objc func processKey(event: NSEvent) -> Bool {
+        if event.type != .keyDown && event.type != .keyUp { return false }
+        if NSApp.mainMenu?.performKeyEquivalent(with: event) ?? false || event.isARepeat { return true }
+
+        return lock.withLock {
+            let mpkey = lookup_keymap_table(keymap, Int32(event.keyCode))
+            if mpkey > 0 {
+                putKey(mpkey, modifiers: event.modifierFlags, type: event.type)
+                return true
+            }
+
+            guard let chars = event.characters, let charsNoMod = event.charactersIgnoringModifiers else { return false }
+            let key = (useAltGr() && event.modifierFlags.contains(.optionRight)) ? chars : charsNoMod
+            key.withCString {
+                var bstr = bstr0($0)
+                putKey(bstr_decode_utf8(bstr, &bstr), modifiers: event.modifierFlags, type: event.type)
+            }
+            return true
         }
     }
 
@@ -72,9 +181,17 @@ class InputHelper: NSObject {
         }
     }
 
+    private func mapType(_ type: NSEvent.EventType) -> Int32 {
+        let typeMapping: [NSEvent.EventType:UInt32] = [
+            .keyDown: MP_KEY_STATE_DOWN,
+            .keyUp: MP_KEY_STATE_UP,
+        ]
+
+        return Int32(typeMapping[type] ?? 0);
+    }
+
     private func mapModifier(_ modifiers: NSEvent.ModifierFlags) -> Int32 {
         var mask: UInt32 = 0;
-        guard let input = input else { return Int32(mask) }
 
         if modifiers.contains(.shift) {
             mask |= MP_KEY_MODIFIER_SHIFT
@@ -85,9 +202,7 @@ class InputHelper: NSObject {
         if modifiers.contains(.command) {
             mask |= MP_KEY_MODIFIER_META
         }
-        if modifiers.contains(.optionLeft) ||
-           modifiers.contains(.optionRight) && !mp_input_use_alt_gr(input)
-        {
+        if modifiers.contains(.optionLeft) || modifiers.contains(.optionRight) && !useAltGr() {
             mask |= MP_KEY_MODIFIER_ALT
         }
 
@@ -111,11 +226,9 @@ class InputHelper: NSObject {
         }
     }
 
-    @objc func useAltGr() -> Bool {
-        lock.withLock {
-            guard let input = input else { return false }
-            return mp_input_use_alt_gr(input)
-        }
+    private func useAltGr() -> Bool {
+        guard let input = input else { return false }
+        return mp_input_use_alt_gr(input)
     }
 
     @objc func wakeup() {

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -1,0 +1,69 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class InputHelper: NSObject {
+    var lock = NSCondition()
+    private var input: OpaquePointer?
+
+    @objc init(_ input: OpaquePointer? = nil) {
+        super.init()
+        self.input = input
+    }
+
+    @objc func command(_ cmd: String) -> Bool {
+        lock.withLock {
+            guard let input = input else { return false }
+            let cCmd = UnsafePointer<Int8>(strdup(cmd))
+            let mpvCmd = mp_input_parse_cmd(input, bstr0(cCmd), "")
+            mp_input_queue_cmd(input, mpvCmd)
+            free(UnsafeMutablePointer(mutating: cCmd))
+            return true
+        }
+    }
+
+    @objc func putKey(_ key: Int32) {
+        lock.withLock {
+            guard let input = input else { return }
+            mp_input_put_key(input, key)
+        }
+    }
+
+    @objc func useAltGr() -> Bool {
+        lock.withLock {
+            guard let input = input else { return false }
+            return mp_input_use_alt_gr(input)
+        }
+    }
+
+    @objc func wakeup() {
+        lock.withLock {
+            guard let input = input else { return }
+            mp_input_wakeup(input)
+        }
+    }
+
+    @objc func signal(input: OpaquePointer? = nil) {
+        lock.withLock {
+            self.input = input
+            if input != nil { lock.signal() }
+        }
+    }
+
+    @objc func wait() {
+        lock.withLock { while input == nil { lock.wait() } }
+    }
+}

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -26,6 +26,8 @@ class InputHelper: NSObject {
         // special keys
         .init(kVK_Return, MP_KEY_ENTER),       .init(kVK_Escape, MP_KEY_ESC),
         .init(kVK_Delete, MP_KEY_BACKSPACE),   .init(kVK_Tab, MP_KEY_TAB),
+        .init(kVK_VolumeUp, MP_KEY_VOLUME_UP), .init(kVK_VolumeDown, MP_KEY_VOLUME_DOWN),
+        .init(kVK_Mute, MP_KEY_MUTE),
 
         // cursor keys
         .init(kVK_UpArrow, MP_KEY_UP),     .init(kVK_DownArrow, MP_KEY_DOWN),

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -24,66 +24,40 @@ class InputHelper: NSObject {
 
     let keymap: [mp_keymap] = [
         // special keys
-        mp_keymap(from: Int32(kVK_Return), to: MP_KEY_ENTER),
-        mp_keymap(from: Int32(kVK_Escape), to: MP_KEY_ESC),
-        mp_keymap(from: Int32(kVK_Delete), to: MP_KEY_BACKSPACE),
-        mp_keymap(from: Int32(kVK_Tab), to: MP_KEY_TAB),
+        .init(kVK_Return, MP_KEY_ENTER),       .init(kVK_Escape, MP_KEY_ESC),
+        .init(kVK_Delete, MP_KEY_BACKSPACE),   .init(kVK_Tab, MP_KEY_TAB),
 
         // cursor keys
-        mp_keymap(from: Int32(kVK_UpArrow), to: MP_KEY_UP),
-        mp_keymap(from: Int32(kVK_DownArrow), to: MP_KEY_DOWN),
-        mp_keymap(from: Int32(kVK_LeftArrow), to: MP_KEY_LEFT),
-        mp_keymap(from: Int32(kVK_RightArrow), to: MP_KEY_RIGHT),
+        .init(kVK_UpArrow, MP_KEY_UP),     .init(kVK_DownArrow, MP_KEY_DOWN),
+        .init(kVK_LeftArrow, MP_KEY_LEFT), .init(kVK_RightArrow, MP_KEY_RIGHT),
 
         // navigation block
-        mp_keymap(from: Int32(kVK_Help), to: MP_KEY_INSERT),
-        mp_keymap(from: Int32(kVK_ForwardDelete), to: MP_KEY_DELETE),
-        mp_keymap(from: Int32(kVK_Home), to: MP_KEY_HOME),
-        mp_keymap(from: Int32(kVK_End), to: MP_KEY_END),
-        mp_keymap(from: Int32(kVK_PageUp), to: MP_KEY_PAGE_UP),
-        mp_keymap(from: Int32(kVK_PageDown), to: MP_KEY_PAGE_DOWN),
+        .init(kVK_Help, MP_KEY_INSERT),    .init(kVK_ForwardDelete, MP_KEY_DELETE),
+        .init(kVK_Home, MP_KEY_HOME),      .init(kVK_End, MP_KEY_END),
+        .init(kVK_PageUp, MP_KEY_PAGE_UP), .init(kVK_PageDown, MP_KEY_PAGE_DOWN),
 
         // F-keys
-        mp_keymap(from: Int32(kVK_F1), to: MP_KEY_F + 1),
-        mp_keymap(from: Int32(kVK_F2), to: MP_KEY_F + 2),
-        mp_keymap(from: Int32(kVK_F3), to: MP_KEY_F + 3),
-        mp_keymap(from: Int32(kVK_F4), to: MP_KEY_F + 4),
-        mp_keymap(from: Int32(kVK_F5), to: MP_KEY_F + 5),
-        mp_keymap(from: Int32(kVK_F6), to: MP_KEY_F + 6),
-        mp_keymap(from: Int32(kVK_F7), to: MP_KEY_F + 7),
-        mp_keymap(from: Int32(kVK_F8), to: MP_KEY_F + 8),
-        mp_keymap(from: Int32(kVK_F9), to: MP_KEY_F + 9),
-        mp_keymap(from: Int32(kVK_F10), to: MP_KEY_F + 10),
-        mp_keymap(from: Int32(kVK_F11), to: MP_KEY_F + 11),
-        mp_keymap(from: Int32(kVK_F12), to: MP_KEY_F + 12),
-        mp_keymap(from: Int32(kVK_F13), to: MP_KEY_F + 13),
-        mp_keymap(from: Int32(kVK_F14), to: MP_KEY_F + 14),
-        mp_keymap(from: Int32(kVK_F15), to: MP_KEY_F + 15),
-        mp_keymap(from: Int32(kVK_F16), to: MP_KEY_F + 16),
-        mp_keymap(from: Int32(kVK_F17), to: MP_KEY_F + 17),
-        mp_keymap(from: Int32(kVK_F18), to: MP_KEY_F + 18),
-        mp_keymap(from: Int32(kVK_F19), to: MP_KEY_F + 19),
-        mp_keymap(from: Int32(kVK_F20), to: MP_KEY_F + 20),
+        .init(kVK_F1, MP_KEY_F + 1),   .init(kVK_F2, MP_KEY_F + 2),   .init(kVK_F3, MP_KEY_F + 3),
+        .init(kVK_F4, MP_KEY_F + 4),   .init(kVK_F5, MP_KEY_F + 5),   .init(kVK_F6, MP_KEY_F + 6),
+        .init(kVK_F7, MP_KEY_F + 7),   .init(kVK_F8, MP_KEY_F + 8),   .init(kVK_F9, MP_KEY_F + 9),
+        .init(kVK_F10, MP_KEY_F + 10), .init(kVK_F11, MP_KEY_F + 11), .init(kVK_F12, MP_KEY_F + 12),
+        .init(kVK_F13, MP_KEY_F + 13), .init(kVK_F14, MP_KEY_F + 14), .init(kVK_F15, MP_KEY_F + 15),
+        .init(kVK_F16, MP_KEY_F + 16), .init(kVK_F17, MP_KEY_F + 17), .init(kVK_F18, MP_KEY_F + 18),
+        .init(kVK_F19, MP_KEY_F + 19), .init(kVK_F20, MP_KEY_F + 20),
 
         // numpad
-        mp_keymap(from: Int32(kVK_ANSI_KeypadPlus), to: Int32(Character("+").asciiValue ?? 0)),
-        mp_keymap(from: Int32(kVK_ANSI_KeypadMinus), to: Int32(Character("-").asciiValue ?? 0)),
-        mp_keymap(from: Int32(kVK_ANSI_KeypadMultiply), to: Int32(Character("*").asciiValue ?? 0)),
-        mp_keymap(from: Int32(kVK_ANSI_KeypadDivide), to: Int32(Character("/").asciiValue ?? 0)),
-        mp_keymap(from: Int32(kVK_ANSI_KeypadEnter), to: MP_KEY_KPENTER),
-        mp_keymap(from: Int32(kVK_ANSI_KeypadDecimal), to: MP_KEY_KPDEC),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad0), to: MP_KEY_KP0),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad1), to: MP_KEY_KP1),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad2), to: MP_KEY_KP2),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad3), to: MP_KEY_KP3),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad4), to: MP_KEY_KP4),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad5), to: MP_KEY_KP5),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad6), to: MP_KEY_KP6),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad7), to: MP_KEY_KP7),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad8), to: MP_KEY_KP8),
-        mp_keymap(from: Int32(kVK_ANSI_Keypad9), to: MP_KEY_KP9),
+        .init(kVK_ANSI_KeypadPlus, Int32(Character("+").asciiValue ?? 0)),
+        .init(kVK_ANSI_KeypadMinus, Int32(Character("-").asciiValue ?? 0)),
+        .init(kVK_ANSI_KeypadMultiply, Int32(Character("*").asciiValue ?? 0)),
+        .init(kVK_ANSI_KeypadDivide, Int32(Character("/").asciiValue ?? 0)),
+        .init(kVK_ANSI_KeypadEnter, MP_KEY_KPENTER), .init(kVK_ANSI_KeypadDecimal, MP_KEY_KPDEC),
+        .init(kVK_ANSI_Keypad0, MP_KEY_KP0),         .init(kVK_ANSI_Keypad1, MP_KEY_KP1),
+        .init(kVK_ANSI_Keypad2, MP_KEY_KP2),         .init(kVK_ANSI_Keypad3, MP_KEY_KP3),
+        .init(kVK_ANSI_Keypad4, MP_KEY_KP4),         .init(kVK_ANSI_Keypad5, MP_KEY_KP5),
+        .init(kVK_ANSI_Keypad6, MP_KEY_KP6),         .init(kVK_ANSI_Keypad7, MP_KEY_KP7),
+        .init(kVK_ANSI_Keypad8, MP_KEY_KP8),         .init(kVK_ANSI_Keypad9, MP_KEY_KP9),
 
-        mp_keymap(from: 0, to: 0)
+        .init(0, 0)
     ]
 
     @objc init(_ input: OpaquePointer? = nil, _ mpv: MPVHelper? = nil) {

--- a/osdep/mac/menu_bar.swift
+++ b/osdep/mac/menu_bar.swift
@@ -318,9 +318,7 @@ class MenuBar: NSObject {
 
     @objc func quit(_ menuItem: MenuItem) {
         guard let menuConfig = menuItem.config else { return }
-        menuConfig.command.withCString {
-            (NSApp as? Application)?.stopMPV(UnsafeMutablePointer<CChar>(mutating: $0))
-        }
+        EventsResponder.sharedInstance().inputHelper.command(menuConfig.command)
     }
 
     @objc func openFiles() {
@@ -329,7 +327,7 @@ class MenuBar: NSObject {
         panel.canChooseDirectories = true
 
         if panel.runModal() == .OK {
-            (NSApp as? Application)?.openFiles(panel.urls.map { $0.path })
+            EventsResponder.sharedInstance().inputHelper.open(files: panel.urls.map { $0.path })
         }
     }
 
@@ -337,9 +335,7 @@ class MenuBar: NSObject {
         let panel = NSOpenPanel()
 
         if panel.runModal() == .OK, let url = panel.urls.first {
-            "loadlist \"\(url.path)\"".withCString {
-                EventsResponder.sharedInstance().queueCommand(UnsafeMutablePointer<CChar>(mutating: $0))
-            }
+            EventsResponder.sharedInstance().inputHelper.command("loadlist \"\(url.path)\"")
         }
     }
 
@@ -359,15 +355,13 @@ class MenuBar: NSObject {
         }
 
         if alert.runModal() == .alertFirstButtonReturn && input.stringValue.count > 0 {
-            (NSApp as? Application)?.openFiles([input.stringValue])
+            EventsResponder.sharedInstance().inputHelper.open(files: [input.stringValue])
         }
     }
 
     @objc func command(_ menuItem: MenuItem) {
         guard let menuConfig = menuItem.config else { return }
-        menuConfig.command.withCString {
-            EventsResponder.sharedInstance().queueCommand(UnsafeMutablePointer<CChar>(mutating: $0))
-        }
+        EventsResponder.sharedInstance().inputHelper.command(menuConfig.command)
     }
 
     @objc func url(_ menuItem: MenuItem) {

--- a/osdep/mac/remote_command_center.swift
+++ b/osdep/mac/remote_command_center.swift
@@ -165,11 +165,8 @@ class RemoteCommandCenter: NSObject {
             return .commandFailed
         }
 
-        let success = String(format: "seek %.02f absolute", posEvent.positionTime).withCString {
-            EventsResponder.sharedInstance().queueCommand(UnsafeMutablePointer<Int8>(mutating: $0))
-        }
-
-        return success ? .success : .commandFailed
+        let cmd = String(format: "seek %.02f absolute", posEvent.positionTime)
+        return EventsResponder.sharedInstance().inputHelper.command(cmd) ? .success : .commandFailed
     }
 
     @objc func processEvent(_ event: UnsafeMutablePointer<mpv_event>) {

--- a/osdep/mac/remote_command_center.swift
+++ b/osdep/mac/remote_command_center.swift
@@ -155,7 +155,7 @@ class RemoteCommandCenter: NSObject {
             self.configs[event.command]?.state = state
         }
 
-        EventsResponder.sharedInstance().handleMPKey(config.key, withMask: Int32(state))
+        EventsResponder.sharedInstance().inputHelper.put(key: config.key | Int32(state))
 
         return .success
     }

--- a/osdep/mac/swift_bridge.h
+++ b/osdep/mac/swift_bridge.h
@@ -28,6 +28,7 @@
 #include "player/core.h"
 #include "input/input.h"
 #include "input/event.h"
+#include "input/keycodes.h"
 #include "video/out/win_state.h"
 
 #include "osdep/mac/application_objc.h"

--- a/osdep/mac/swift_extensions.swift
+++ b/osdep/mac/swift_extensions.swift
@@ -16,6 +16,7 @@
  */
 
 import Cocoa
+import IOKit.hidsystem
 
 extension NSDeviceDescriptionKey {
     static let screenNumber = NSDeviceDescriptionKey("NSScreenNumber")
@@ -39,6 +40,11 @@ extension NSColor {
 
         self.init(calibratedRed: red, green: green, blue: blue, alpha: alpha)
     }
+}
+
+extension NSEvent.ModifierFlags {
+    public static var optionLeft: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICELALTKEYMASK))
+    public static var optionRight: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICERALTKEYMASK))
 }
 
 extension Bool {

--- a/osdep/mac/swift_extensions.swift
+++ b/osdep/mac/swift_extensions.swift
@@ -47,6 +47,12 @@ extension NSEvent.ModifierFlags {
     public static var optionRight: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICERALTKEYMASK))
 }
 
+extension mp_keymap {
+    init(_ f: Int, _ t: Int32) {
+        self.init(from: Int32(f), to: t)
+    }
+}
+
 extension Bool {
     init(_ int32: Int32) {
         self.init(int32 != 0)

--- a/osdep/mac/touchbar.h
+++ b/osdep/mac/touchbar.h
@@ -16,7 +16,6 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import "osdep/mac/application_objc.h"
 
 #define BASE_ID @"io.mpv.touchbar"
 static NSTouchBarCustomizationIdentifier customID = BASE_ID;
@@ -37,7 +36,6 @@ struct mpv_event;
 
 -(void)processEvent:(struct mpv_event *)event;
 
-@property(nonatomic, retain) Application *app;
 @property(nonatomic, retain) NSDictionary *touchbarItems;
 @property(nonatomic, assign) double duration;
 @property(nonatomic, assign) double position;

--- a/osdep/mac/touchbar.m
+++ b/osdep/mac/touchbar.m
@@ -17,10 +17,16 @@
 
 #include "player/client.h"
 #import "osdep/mac/touchbar.h"
+#import "osdep/mac/events_objc.h"
+
+#include "config.h"
+
+#if HAVE_SWIFT
+#include "osdep/mac/swift.h"
+#endif
 
 @implementation TouchBar
 
-@synthesize app = _app;
 @synthesize touchbarItems = _touchbar_items;
 @synthesize duration = _duration;
 @synthesize position = _position;
@@ -231,7 +237,7 @@
 - (void)buttonAction:(NSButton *)sender
 {
     NSString *identifier = [self getIdentifierFromView:sender];
-    [self.app queueCommand:(char *)[self.touchbarItems[identifier][@"cmd"] UTF8String]];
+    [[EventsResponder sharedInstance].inputHelper command:self.touchbarItems[identifier][@"cmd"]];
 }
 
 - (void)seekbarChanged:(NSSlider *)slider
@@ -239,7 +245,7 @@
     NSString *identifier = [self getIdentifierFromView:slider];
     NSString *seek = [NSString stringWithFormat:
         self.touchbarItems[identifier][@"cmd"], slider.doubleValue];
-    [self.app queueCommand:(char *)[seek UTF8String]];
+    [[EventsResponder sharedInstance].inputHelper command:seek];
 }
 
 - (NSString *)formatTime:(int)time

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -40,6 +40,7 @@ class CocoaCB: Common {
 
     func preinit(_ vo: UnsafeMutablePointer<vo>) {
         mpv = MPVHelper(vo, log)
+        input = InputHelper(vo.pointee.input_ctx, mpv)
 
         if backendState == .uninitialized {
             backendState = .needsInit

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -20,6 +20,7 @@ import IOKit.pwr_mgt
 
 class Common: NSObject {
     var mpv: MPVHelper?
+    var input: InputHelper?
     var log: LogHelper
     let queue: DispatchQueue = DispatchQueue(label: "io.mpv.queue")
 

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -53,7 +53,7 @@ class View: NSView, CALayerDelegate {
         addTrackingArea(tracker!)
 
         if containsMouseLocation() {
-            cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_LEAVE, 0)
+            input?.putKey(SWIFT_KEY_MOUSE_LEAVE)
         }
     }
 
@@ -118,14 +118,14 @@ class View: NSView, CALayerDelegate {
 
     override func mouseEntered(with event: NSEvent) {
         if input?.mouseEnabled() ?? true {
-            cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_ENTER, 0)
+            input?.putKey(SWIFT_KEY_MOUSE_ENTER)
         }
         common.updateCursorVisibility()
     }
 
     override func mouseExited(with event: NSEvent) {
         if input?.mouseEnabled() ?? true {
-            cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_LEAVE, 0)
+            input?.putKey(SWIFT_KEY_MOUSE_LEAVE)
         }
         common.titleBar?.hide()
         common.setCursorVisibility(true)
@@ -202,7 +202,7 @@ class View: NSView, CALayerDelegate {
     func signalMouseEvent(_ event: NSEvent, _ state: UInt32) {
         hasMouseDown = state == MP_KEY_STATE_DOWN
         let mpkey = getMpvButton(event)
-        cocoa_put_key_with_modifiers((mpkey | Int32(state)), Int32(event.modifierFlags.rawValue))
+        input?.putKey((mpkey | Int32(state)), modifiers: event.modifierFlags)
     }
 
     func signalMouseMovement(_ event: NSEvent) {
@@ -250,7 +250,7 @@ class View: NSView, CALayerDelegate {
                 mpkey = deltaX > 0 ? SWIFT_WHEEL_LEFT : SWIFT_WHEEL_RIGHT
             }
 
-            cocoa_put_key_with_modifiers(mpkey, Int32(modifiers.rawValue))
+            input?.putKey(mpkey, modifiers: modifiers)
         }
     }
 

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -20,6 +20,7 @@ import Cocoa
 class View: NSView, CALayerDelegate {
     unowned var common: Common
     var mpv: MPVHelper? { get { return common.mpv } }
+    var input: InputHelper? { get { return common.input } }
 
     var tracker: NSTrackingArea?
     var hasMouseDown: Bool = false
@@ -81,7 +82,7 @@ class View: NSView, CALayerDelegate {
         if types.contains(.fileURL) || types.contains(.URL) {
             if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
                 let files = urls.map { $0.absoluteString }
-                mpv?.open(files: files)
+                input?.open(files: files)
                 return true
             }
         } else if types.contains(.string) {
@@ -97,7 +98,7 @@ class View: NSView, CALayerDelegate {
                     filesArray.append(path)
                 }
             }
-            mpv?.open(files: filesArray)
+            input?.open(files: filesArray)
             return true
         }
         return false
@@ -116,14 +117,14 @@ class View: NSView, CALayerDelegate {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_ENTER, 0)
         }
         common.updateCursorVisibility()
     }
 
     override func mouseExited(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             cocoa_put_key_with_modifiers(SWIFT_KEY_MOUSE_LEAVE, 0)
         }
         common.titleBar?.hide()
@@ -131,51 +132,51 @@ class View: NSView, CALayerDelegate {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseMovement(event)
         }
         common.titleBar?.show()
     }
 
     override func mouseDragged(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseMovement(event)
         }
     }
 
     override func mouseDown(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseDown(event)
         }
     }
 
     override func mouseUp(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseUp(event)
         }
         common.window?.isMoving = false
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseDown(event)
         }
     }
 
     override func rightMouseUp(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseUp(event)
         }
     }
 
     override func otherMouseDown(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseDown(event)
         }
     }
 
     override func otherMouseUp(with event: NSEvent) {
-        if mpv?.mouseEnabled() ?? true {
+        if input?.mouseEnabled() ?? true {
             signalMouseUp(event)
         }
     }
@@ -211,7 +212,7 @@ class View: NSView, CALayerDelegate {
 
         common.window?.updateMovableBackground(point)
         if !(common.window?.isMoving ?? false) {
-            mpv?.setMousePosition(point)
+            input?.setMouse(position: point)
         }
     }
 
@@ -227,11 +228,11 @@ class View: NSView, CALayerDelegate {
             cmd = delta > 0 ? SWIFT_WHEEL_LEFT : SWIFT_WHEEL_RIGHT
         }
 
-        mpv?.putAxis(cmd, modifiers: event.modifierFlags, delta: abs(delta))
+        input?.putAxis(cmd, modifiers: event.modifierFlags, delta: abs(delta))
     }
 
     override func scrollWheel(with event: NSEvent) {
-        if !(mpv?.mouseEnabled() ?? true) {
+        if !(input?.mouseEnabled() ?? true) {
             return
         }
 

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -53,7 +53,7 @@ class View: NSView, CALayerDelegate {
         addTrackingArea(tracker!)
 
         if containsMouseLocation() {
-            input?.putKey(SWIFT_KEY_MOUSE_LEAVE)
+            input?.put(key: SWIFT_KEY_MOUSE_LEAVE)
         }
     }
 
@@ -118,14 +118,14 @@ class View: NSView, CALayerDelegate {
 
     override func mouseEntered(with event: NSEvent) {
         if input?.mouseEnabled() ?? true {
-            input?.putKey(SWIFT_KEY_MOUSE_ENTER)
+            input?.put(key: SWIFT_KEY_MOUSE_ENTER)
         }
         common.updateCursorVisibility()
     }
 
     override func mouseExited(with event: NSEvent) {
         if input?.mouseEnabled() ?? true {
-            input?.putKey(SWIFT_KEY_MOUSE_LEAVE)
+            input?.put(key: SWIFT_KEY_MOUSE_LEAVE)
         }
         common.titleBar?.hide()
         common.setCursorVisibility(true)
@@ -202,7 +202,7 @@ class View: NSView, CALayerDelegate {
     func signalMouseEvent(_ event: NSEvent, _ state: UInt32) {
         hasMouseDown = state == MP_KEY_STATE_DOWN
         let mpkey = getMpvButton(event)
-        input?.putKey((mpkey | Int32(state)), modifiers: event.modifierFlags)
+        input?.put(key: (mpkey | Int32(state)), modifiers: event.modifierFlags)
     }
 
     func signalMouseMovement(_ event: NSEvent) {
@@ -250,7 +250,7 @@ class View: NSView, CALayerDelegate {
                 mpkey = deltaX > 0 ? SWIFT_WHEEL_LEFT : SWIFT_WHEEL_RIGHT
             }
 
-            input?.putKey(mpkey, modifiers: modifiers)
+            input?.put(key: mpkey, modifiers: modifiers)
         }
     }
 

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -556,7 +556,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        cocoa_put_key(MP_KEY_CLOSE_WIN)
+        input?.putKey(MP_KEY_CLOSE_WIN)
         return false
     }
 

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -20,6 +20,7 @@ import Cocoa
 class Window: NSWindow, NSWindowDelegate {
     weak var common: Common! = nil
     var mpv: MPVHelper? { get { return common.mpv } }
+    var input: InputHelper? { get { return common.input } }
 
     var targetScreen: NSScreen?
     var previousScreen: NSScreen?
@@ -335,7 +336,7 @@ class Window: NSWindow, NSWindowDelegate {
 
     func updateMovableBackground(_ pos: NSPoint) {
         if !isInFullscreen {
-            isMovableByWindowBackground = mpv?.canBeDraggedAt(pos) ?? true
+            isMovableByWindowBackground = input?.draggable(at: pos) ?? true
         } else {
             isMovableByWindowBackground = false
         }
@@ -503,12 +504,12 @@ class Window: NSWindow, NSWindowDelegate {
     @objc func setDoubleWindowSize() { setWindowScale(2.0) }
 
     func setWindowScale(_ scale: Double) {
-        mpv?.command("set window-scale \(scale)")
+        input?.command("set window-scale \(scale)")
     }
 
     func addWindowScale(_ scale: Double) {
         if !isInFullscreen {
-            mpv?.command("add window-scale \(scale)")
+            input?.command("add window-scale \(scale)")
         }
     }
 

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -556,7 +556,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        input?.putKey(MP_KEY_CLOSE_WIN)
+        input?.put(key: MP_KEY_CLOSE_WIN)
         return false
     }
 

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -28,6 +28,7 @@ class MacCommon: Common {
         let newlog = mp_log_new(vo, vo.pointee.log, "mac")
         super.init(newlog)
         mpv = MPVHelper(vo, log)
+        input = InputHelper(vo.pointee.input_ctx, mpv)
         timer = PreciseTimer(common: self)
 
         DispatchQueue.main.sync {


### PR DESCRIPTION
this reworks key input management. one big part of the preparations to rewrite the events class into a more generic macOS platform features hub that work independent of a video output.

in further steps and with the swift conversion, functions calls will get less nested/verbose. though for now we have to live with a bit of ugliness for the sake of objective-c.