### PR TITLE
wayland_common: require WAYLAND_DISPLAY to be set for initialization

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2425,6 +2425,9 @@ bool vo_wayland_init(struct vo *vo)
     vo->wl = talloc_zero(NULL, struct vo_wayland_state);
     struct vo_wayland_state *wl = vo->wl;
 
+    if (!getenv("WAYLAND_DISPLAY"))
+        goto err;
+
     *wl = (struct vo_wayland_state) {
         .display = wl_display_connect(NULL),
         .vo = vo,


### PR DESCRIPTION
Currently, Wayland is above X11 and DRM in probe order. The success of automatic probing depends on the fact that unsuitable backends would fail to initialize. For example, X11 backend (which uses Xlib) fails to initialize if DISPLAY environment variable is not set, so starting mpv in VT console will pick the DRM backend as expected, even when an X server is running in another VT.

However, libwayland-client used by the Wayland backend has the "helpful" behavior of falling back to "wayland-0" if WAYLAND_DISPLAY is not set. This breaks autoprobing if mpv is started from X server or VT console while a running Wayland compositor running in another VT (or even running as an X client) is using "wayland-0" for protocol socket name: mpv will start playing in the Wayland compsitor instead of using the X11 or DRM backends.

Similar to DISPLAY for X server, We should consider exporting WAYLAND_DISPLAY to child processes the responsibility of Wayland compositors, and any compositor not doing this should be considered broken. Thus we now require WAYLAND_DISPLAY to be set for the backend initialization to succeed to make sure that autoprobing works as intended.
