### PR TITLE
msg: simplify the line_skip calculation

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -269,6 +269,7 @@ void mp_msg_flush_status_line(struct mp_log *log, bool clear)
     }
 
 done:
+    log->root->status_line.len = 0;
     mp_mutex_unlock(&log->root->lock);
 }
 


### PR DESCRIPTION
Make it more straightforward by always calculating top offset first instead of having two branches, that tries to calc it directly.

This also fixes missing negative check before `\033[%dA` which was in practice only problem on macOS which was handling negative values, while in fact it shouldn't.

Fixes: #13484