### PR TITLE
[RFC] Revert "player/loadfile: remove blank line on exit"

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1901,6 +1901,7 @@ terminate_playback:
                mpv_error_string(end_event.error), end_event.reason);
     if (end_event.error == MPV_ERROR_UNKNOWN_FORMAT)
         MP_ERR(mpctx, "Failed to recognize file format.\n");
+    MP_INFO(mpctx, "\n");
 
     if (mpctx->playing)
         playlist_entry_unref(mpctx->playing);


### PR DESCRIPTION
This reverts commit 051ba909b4107240d643e4793efa2ceb714fd1b4.

Apparently it is very important feature for some, I found it ugly, especially with `--msg-time`.