### PR TITLE
vo_gpu_next: don't render ASS subtitles at HDR colorspace

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -379,7 +379,7 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
             }
             break;
         case SUBBITMAP_LIBASS:
-            if (src && item->video_color_space)
+            if (src && item->video_color_space && !pl_color_space_is_hdr(&src->params.color))
                 ol->color = src->params.color;
             ol->mode = PL_OVERLAY_MONOCHROME;
             ol->repr.alpha = PL_ALPHA_INDEPENDENT;


### PR DESCRIPTION
Upstream ASS specification says that all subtitles should be rendered with color primaries and transfer matching their associated video. But as expected after further discussion the decision has been made to fallback to SDR mode in case of HDR video.

See-Also: https://github.com/libass/libass/blob/649a7c2e1fc6f4188ea1a89968560715800b883d/libass/ass_types.h#L233-L237
See-Also: libass/libass#297
See-Also: mpv-player#13381
Fixes: mpv-player#13673