### PR TITLE
terminal: support mouse input

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -341,12 +341,12 @@ static void do_activate_getch2(void)
     enable_kx(true);
 
     struct termios tio_new;
-    tcgetattr(tty_in,&tio_new);
+    tcgetattr(tty_in, &tio_new);
 
     tio_new.c_lflag &= ~(ICANON|ECHO); /* Clear ICANON and ECHO. */
     tio_new.c_cc[VMIN] = 1;
     tio_new.c_cc[VTIME] = 0;
-    tcsetattr(tty_in,TCSANOW,&tio_new);
+    tcsetattr(tty_in, TCSANOW, &tio_new);
 
     getch2_active = 1;
 }

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -240,6 +240,13 @@ static void process_input(struct input_ctx *input_ctx, bool timeout)
             int mods = 0;
             if (buf.b[0] == '\033') {
                 if (buf.len > 1 && buf.b[1] == '[') {
+                    // Throw away unrecognized mouse CSI sequences.
+                    // Cannot be handled by the loop below since the bytes
+                    // afterwards can be out of that range.
+                    if (buf.len > 2 && buf.b[2] == 'M') {
+                        skip_buf(&buf, buf.len);
+                        continue;
+                    }
                     // unknown CSI sequence. wait till it completes
                     for (int i = 2; i < buf.len; i++) {
                         if (buf.b[i] >= 0x40 && buf.b[i] <= 0x7E)  {

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -588,6 +588,12 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
     *px_height = ws.ws_ypixel;
 }
 
+void terminal_set_mouse_input(bool enable)
+{
+    printf(enable ? TERM_ESC_ENABLE_MOUSE : TERM_ESC_DISABLE_MOUSE);
+    fflush(stdout);
+}
+
 void terminal_init(void)
 {
     assert(!getch2_enabled);

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -111,15 +111,35 @@ static bool is_native_out_vt(HANDLE hOut)
 void terminal_get_size(int *w, int *h)
 {
     CONSOLE_SCREEN_BUFFER_INFO cinfo;
-    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    HANDLE hOut = hSTDOUT;
     if (GetConsoleScreenBufferInfo(hOut, &cinfo)) {
         *w = cinfo.dwMaximumWindowSize.X - (is_native_out_vt(hOut) ? 0 : 1);
         *h = cinfo.dwMaximumWindowSize.Y;
     }
 }
 
+static bool get_font_size(int *w, int *h)
+{
+  CONSOLE_FONT_INFO finfo;
+  HANDLE hOut = hSTDOUT;
+  BOOL res = GetCurrentConsoleFont(hOut, FALSE, &finfo);
+  if (res) {
+      *w = finfo.dwFontSize.X;
+      *h = finfo.dwFontSize.Y;
+  }
+  return res;
+}
+
 void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
 {
+    int w = 0, h = 0, fw = 0, fh = 0;
+    terminal_get_size(&w, &h);
+    if (get_font_size(&fw, &fh)) {
+        *px_width = fw * w;
+        *px_height = fh * h;
+        *rows = w;
+        *cols = h;
+    }
 }
 
 static bool has_input_events(HANDLE h)

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -558,6 +558,13 @@ bool terminal_try_attach(void)
 
 void terminal_set_mouse_input(bool enable)
 {
+    DWORD cmode;
+    HANDLE in = hSTDIN;
+    if (GetConsoleMode(in, &cmode)) {
+        cmode = enable ? cmode | ENABLE_MOUSE_INPUT
+                       : cmode & (~ENABLE_MOUSE_INPUT);
+        SetConsoleMode(in, cmode);
+    }
 }
 
 void terminal_init(void)

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -556,6 +556,10 @@ bool terminal_try_attach(void)
     return true;
 }
 
+void terminal_set_mouse_input(bool enable)
+{
+}
+
 void terminal_init(void)
 {
     CONSOLE_SCREEN_BUFFER_INFO cinfo;

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -35,6 +35,9 @@
 #define TERM_ESC_ALT_SCREEN         "\033[?1049h"
 #define TERM_ESC_NORMAL_SCREEN      "\033[?1049l"
 
+#define TERM_ESC_ENABLE_MOUSE       "\033[?1003h"
+#define TERM_ESC_DISABLE_MOUSE      "\033[?1003l"
+
 struct input_ctx;
 
 /* Global initialization for terminal output. */

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -58,6 +58,9 @@ void terminal_get_size(int *w, int *h);
 /* Get terminal-size in columns/rows and width/height in pixels. */
 void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height);
 
+/* Enable/Disable mouse input. */
+void terminal_set_mouse_input(bool enable);
+
 // Windows only.
 int mp_console_vfprintf(void *wstream, const char *format, va_list args);
 int mp_console_write(void *wstream, bstr str);

--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -362,7 +362,7 @@ static int preinit(struct vo *vo)
 #endif
 
     write_str(TERM_ESC_HIDE_CURSOR);
-    write_str(TERM_ESC_ENABLE_MOUSE);
+    terminal_set_mouse_input(true);
     if (p->opts.alt_screen)
         write_str(TERM_ESC_ALT_SCREEN);
 
@@ -390,7 +390,7 @@ static void uninit(struct vo *vo)
 #endif
 
     write_str(TERM_ESC_RESTORE_CURSOR);
-    write_str(TERM_ESC_DISABLE_MOUSE);
+    terminal_set_mouse_input(false);
 
     if (p->opts.alt_screen) {
         write_str(TERM_ESC_NORMAL_SCREEN);

--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -362,6 +362,7 @@ static int preinit(struct vo *vo)
 #endif
 
     write_str(TERM_ESC_HIDE_CURSOR);
+    write_str(TERM_ESC_ENABLE_MOUSE);
     if (p->opts.alt_screen)
         write_str(TERM_ESC_ALT_SCREEN);
 
@@ -389,6 +390,7 @@ static void uninit(struct vo *vo)
 #endif
 
     write_str(TERM_ESC_RESTORE_CURSOR);
+    write_str(TERM_ESC_DISABLE_MOUSE);
 
     if (p->opts.alt_screen) {
         write_str(TERM_ESC_NORMAL_SCREEN);

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -520,7 +520,7 @@ static int preinit(struct vo *vo)
         sixel_strwrite(TERM_ESC_ALT_SCREEN);
 
     sixel_strwrite(TERM_ESC_HIDE_CURSOR);
-    sixel_strwrite(TERM_ESC_ENABLE_MOUSE);
+    terminal_set_mouse_input(true);
 
     /* don't use private color registers for each frame. */
     sixel_strwrite(TERM_ESC_USE_GLOBAL_COLOR_REG);
@@ -560,7 +560,7 @@ static void uninit(struct vo *vo)
     struct priv *priv = vo->priv;
 
     sixel_strwrite(TERM_ESC_RESTORE_CURSOR);
-    sixel_strwrite(TERM_ESC_DISABLE_MOUSE);
+    terminal_set_mouse_input(false);
 
     if (priv->opts.alt_screen)
         sixel_strwrite(TERM_ESC_NORMAL_SCREEN);

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -520,6 +520,7 @@ static int preinit(struct vo *vo)
         sixel_strwrite(TERM_ESC_ALT_SCREEN);
 
     sixel_strwrite(TERM_ESC_HIDE_CURSOR);
+    sixel_strwrite(TERM_ESC_ENABLE_MOUSE);
 
     /* don't use private color registers for each frame. */
     sixel_strwrite(TERM_ESC_USE_GLOBAL_COLOR_REG);
@@ -559,6 +560,7 @@ static void uninit(struct vo *vo)
     struct priv *priv = vo->priv;
 
     sixel_strwrite(TERM_ESC_RESTORE_CURSOR);
+    sixel_strwrite(TERM_ESC_DISABLE_MOUSE);
 
     if (priv->opts.alt_screen)
         sixel_strwrite(TERM_ESC_NORMAL_SCREEN);

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -299,6 +299,7 @@ static void flip_page(struct vo *vo)
 static void uninit(struct vo *vo)
 {
     WRITE_STR(TERM_ESC_RESTORE_CURSOR);
+    WRITE_STR(TERM_ESC_DISABLE_MOUSE);
     WRITE_STR(TERM_ESC_NORMAL_SCREEN);
     struct priv *p = vo->priv;
     talloc_free(p->frame);
@@ -328,6 +329,7 @@ static int preinit(struct vo *vo)
     }
 
     WRITE_STR(TERM_ESC_HIDE_CURSOR);
+    WRITE_STR(TERM_ESC_ENABLE_MOUSE);
     WRITE_STR(TERM_ESC_ALT_SCREEN);
 
     return 0;

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -299,7 +299,7 @@ static void flip_page(struct vo *vo)
 static void uninit(struct vo *vo)
 {
     WRITE_STR(TERM_ESC_RESTORE_CURSOR);
-    WRITE_STR(TERM_ESC_DISABLE_MOUSE);
+    terminal_set_mouse_input(false);
     WRITE_STR(TERM_ESC_NORMAL_SCREEN);
     struct priv *p = vo->priv;
     talloc_free(p->frame);
@@ -329,7 +329,7 @@ static int preinit(struct vo *vo)
     }
 
     WRITE_STR(TERM_ESC_HIDE_CURSOR);
-    WRITE_STR(TERM_ESC_ENABLE_MOUSE);
+    terminal_set_mouse_input(true);
     WRITE_STR(TERM_ESC_ALT_SCREEN);
 
     return 0;


### PR DESCRIPTION
This adds mouse input parsing and enables mouse support for terminal VOs (`vo_tct`, `vo_sixel`, `vo_kitty`), making it possible to use mouse key bindings and OSC with these VOs. 