### PR TITLE
win32: cache GetConsoleMode state for stdout/stderr

### DIFF
--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -467,3 +467,23 @@ bool bstr_decode_hex(void *talloc_ctx, struct bstr hex, struct bstr *out)
     *out = (struct bstr){ .start = arr, .len = len };
     return true;
 }
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+int bstr_to_wchar(void *talloc_ctx, struct bstr s, wchar_t **ret)
+{
+    int count = MultiByteToWideChar(CP_UTF8, 0, s.start, s.len, NULL, 0);
+    if (count <= 0)
+        abort();
+    wchar_t *wbuf = *ret;
+    if (!wbuf || ta_get_size(wbuf) < (count + 1) * sizeof(wchar_t))
+        wbuf = talloc_realloc(talloc_ctx, wbuf, wchar_t, count + 1);
+    MultiByteToWideChar(CP_UTF8, 0, s.start, s.len, wbuf, count);
+    wbuf[count] = L'\0';
+    *ret = wbuf;
+    return count;
+}
+
+#endif

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -223,6 +223,12 @@ static inline bool bstr_eatend0(struct bstr *s, const char *prefix)
     return bstr_eatend(s, bstr0(prefix));
 }
 
+#ifdef _WIN32
+
+int bstr_to_wchar(void *talloc_ctx, struct bstr s, wchar_t **ret);
+
+#endif
+
 // create a pair (not single value!) for "%.*s" printf syntax
 #define BSTR_P(bstr) (int)((bstr).len), ((bstr).start ? (char*)(bstr).start : "")
 

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -307,8 +307,6 @@ static int mp_vfprintf(FILE *stream, const char *format, va_list args)
 
 static int mp_vfprintf(FILE *stream, const char *format, va_list args)
 {
-    int done = 0;
-
     HANDLE wstream = INVALID_HANDLE_VALUE;
 
     if (stream == stdout || stream == stderr) {
@@ -316,20 +314,10 @@ static int mp_vfprintf(FILE *stream, const char *format, va_list args)
                                STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
     }
 
-    if (mp_check_console(wstream)) {
-        size_t len = vsnprintf(NULL, 0, format, args) + 1;
-        char *buf = talloc_array(NULL, char, len);
+    if (mp_check_console(wstream))
+        return mp_write_console_ansi(wstream, format, args);
 
-        if (buf) {
-            done = vsnprintf(buf, len, format, args);
-            mp_write_console_ansi(wstream, buf);
-        }
-        talloc_free(buf);
-    } else {
-        done = vfprintf(stream, format, args);
-    }
-
-    return done;
+    return vfprintf(stream, format, args);
 }
 #endif
 

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -304,30 +304,6 @@ static int mp_vfprintf(FILE *stream, const char *format, va_list args)
     return vfprintf(stream, format, args);
 }
 #else
-static int mp_check_console(HANDLE wstream)
-{
-    if (wstream != INVALID_HANDLE_VALUE) {
-        unsigned int filetype = GetFileType(wstream);
-
-        if (!((filetype == FILE_TYPE_UNKNOWN) &&
-            (GetLastError() != ERROR_SUCCESS)))
-        {
-            filetype &= ~(FILE_TYPE_REMOTE);
-
-            if (filetype == FILE_TYPE_CHAR) {
-                DWORD ConsoleMode;
-                int ret = GetConsoleMode(wstream, &ConsoleMode);
-
-                if (!(!ret && (GetLastError() == ERROR_INVALID_HANDLE))) {
-                    // This seems to be a console
-                    return 1;
-                }
-            }
-        }
-    }
-
-    return 0;
-}
 
 static int mp_vfprintf(FILE *stream, const char *format, va_list args)
 {

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -106,6 +106,8 @@ char *mp_to_utf8(void *talloc_ctx, const wchar_t *s);
 #include <sys/stat.h>
 #include <fcntl.h>
 
+int mp_puts(const char *str);
+int mp_fputs(const char *str, FILE *stream);
 int mp_printf(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 int mp_fprintf(FILE *stream, const char *format, ...) PRINTF_ATTRIBUTE(2, 3);
 int mp_open(const char *filename, int oflag, ...);
@@ -174,6 +176,8 @@ int mp_glob(const char *restrict pattern, int flags,
             int (*errfunc)(const char*, int), mp_glob_t *restrict pglob);
 void mp_globfree(mp_glob_t *pglob);
 
+#define puts(...) mp_puts(__VA_ARGS__)
+#define fputs(...) mp_fputs(__VA_ARGS__)
 #define printf(...) mp_printf(__VA_ARGS__)
 #define fprintf(...) mp_fprintf(__VA_ARGS__)
 #define open(...) mp_open(__VA_ARGS__)

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -1,5 +1,7 @@
 #include "terminal.h"
 
+#include "misc/bstr.h"
+
 void terminal_init(void)
 {
 }
@@ -25,8 +27,9 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
 {
 }
 
-void mp_write_console_ansi(void *wstream, char *buf)
+int mp_write_console_ansi(void *wstream, const char *format, va_list args)
 {
+    return 0;
 }
 
 bool terminal_try_attach(void)

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -27,7 +27,12 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height)
 {
 }
 
-int mp_write_console_ansi(void *wstream, const char *format, va_list args)
+int mp_console_vfprintf(void *wstream, const char *format, va_list args)
+{
+    return 0;
+}
+
+int mp_console_fputs(void *wstream, bstr str)
 {
     return 0;
 }

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -63,6 +63,7 @@ static void attempt_native_out_vt(HANDLE hOut, DWORD basemode)
 
 static bool is_console[STDERR_FILENO + 1];
 static bool is_vt[STDERR_FILENO + 1];
+static bool utf8_output;
 static short stdoutAttrs = 0;  // copied from the screen buffer on init
 static const unsigned char ansi2win32[8] = {
     0,
@@ -255,14 +256,24 @@ int mp_console_fputs(HANDLE wstream, bstr str)
         free_buf = !FlsSetValue(tmp_buffers_key, buffers);
     }
 
-    int wlen = bstr_to_wchar(buffers, str, &buffers->write_console_wbuf);
-    wchar_t *pos = buffers->write_console_wbuf;
+    bool vt = is_native_out_vt(wstream);
+    int wlen = 0;
+    wchar_t *pos = NULL;
+    if (!utf8_output || !vt) {
+        wlen = bstr_to_wchar(buffers, str, &buffers->write_console_wbuf);
+        pos = buffers->write_console_wbuf;
+    }
+
+    if (vt) {
+        if (utf8_output) {
+            WriteConsoleA(wstream, str.start, str.len, NULL, NULL);
+        } else {
+            WriteConsoleW(wstream, pos, wlen, NULL, NULL);
+        }
+        goto done;
+    }
 
     while (*pos) {
-        if (is_native_out_vt(wstream)) {
-            WriteConsoleW(wstream, pos, wlen, NULL, NULL);
-            break;
-        }
         wchar_t *next = wcschr(pos, '\033');
         if (!next) {
             WriteConsoleW(wstream, pos, wcslen(pos), NULL, NULL);
@@ -399,6 +410,7 @@ int mp_console_fputs(HANDLE wstream, bstr str)
         pos = next;
     }
 
+done:;
     int ret = buffers->write_console_buf.len;
 
     if (free_buf)
@@ -497,4 +509,5 @@ void terminal_init(void)
     stdoutAttrs = cinfo.wAttributes;
 
     tmp_buffers_key = FlsAlloc((PFLS_CALLBACK_FUNCTION)talloc_free);
+    utf8_output = SetConsoleOutputCP(CP_UTF8);
 }

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -204,6 +204,12 @@ void terminal_setup_getch(struct input_ctx *ictx)
     }
 }
 
+DWORD tmp_buffers_key = FLS_OUT_OF_INDEXES;
+struct tmp_buffers {
+    bstr write_console_buf;
+    wchar_t *write_console_wbuf;
+};
+
 void terminal_uninit(void)
 {
     if (running) {
@@ -212,6 +218,7 @@ void terminal_uninit(void)
         input_ctx = NULL;
         running = false;
     }
+    FlsFree(tmp_buffers_key);
 }
 
 bool terminal_in_background(void)
@@ -219,14 +226,20 @@ bool terminal_in_background(void)
     return false;
 }
 
-void mp_write_console_ansi(HANDLE wstream, char *buf)
+int mp_write_console_ansi(HANDLE wstream, const char *format, va_list args)
 {
-    wchar_t *wbuf = mp_from_utf8(NULL, buf);
-    wchar_t *pos = wbuf;
+    struct tmp_buffers *buffers = FlsGetValue(tmp_buffers_key);
+    if (!buffers)
+        buffers = talloc_zero(NULL, struct tmp_buffers);
+
+    buffers->write_console_buf.len = 0;
+    bstr_xappend_vasprintf(buffers, &buffers->write_console_buf, format, args);
+    int wlen = bstr_to_wchar(buffers, buffers->write_console_buf, &buffers->write_console_wbuf);
+    wchar_t *pos = buffers->write_console_wbuf;
 
     while (*pos) {
         if (is_native_out_vt(wstream)) {
-            WriteConsoleW(wstream, pos, wcslen(pos), NULL, NULL);
+            WriteConsoleW(wstream, pos, wlen, NULL, NULL);
             break;
         }
         wchar_t *next = wcschr(pos, '\033');
@@ -365,7 +378,12 @@ void mp_write_console_ansi(HANDLE wstream, char *buf)
         pos = next;
     }
 
-    talloc_free(wbuf);
+    int ret = buffers->write_console_buf.len;
+
+    if (!FlsSetValue(tmp_buffers_key, buffers))
+        talloc_free(buffers);
+
+    return ret;
 }
 
 static bool is_a_console(HANDLE h)
@@ -456,4 +474,6 @@ void terminal_init(void)
 
     GetConsoleScreenBufferInfo(hSTDOUT, &cinfo);
     stdoutAttrs = cinfo.wAttributes;
+
+    tmp_buffers_key = FlsAlloc((PFLS_CALLBACK_FUNCTION)talloc_free);
 }

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -53,6 +53,7 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height);
 
 // Windows only.
 void mp_write_console_ansi(void *wstream, char *buf);
+bool mp_check_console(void *handle);
 
 /* Windows-only function to attach to the parent process's console */
 bool terminal_try_attach(void);

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -20,8 +20,10 @@
 #ifndef MPLAYER_GETCH2_H
 #define MPLAYER_GETCH2_H
 
+#include <stdarg.h>
 #include <stdbool.h>
-#include <stdio.h>
+
+#include "misc/bstr.h"
 
 #define TERM_ESC_GOTO_YX            "\033[%d;%df"
 #define TERM_ESC_HIDE_CURSOR        "\033[?25l"
@@ -52,7 +54,7 @@ void terminal_get_size(int *w, int *h);
 void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height);
 
 // Windows only.
-void mp_write_console_ansi(void *wstream, char *buf);
+int mp_write_console_ansi(void *wstream, const char *format, va_list args);
 bool mp_check_console(void *handle);
 
 /* Windows-only function to attach to the parent process's console */

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -54,7 +54,8 @@ void terminal_get_size(int *w, int *h);
 void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height);
 
 // Windows only.
-int mp_write_console_ansi(void *wstream, const char *format, va_list args);
+int mp_console_vfprintf(void *wstream, const char *format, va_list args);
+int mp_console_fputs(void *wstream, bstr str);
 bool mp_check_console(void *handle);
 
 /* Windows-only function to attach to the parent process's console */

--- a/player/main.c
+++ b/player/main.c
@@ -184,16 +184,17 @@ void mp_destroy(struct MPContext *mpctx)
     cocoa_set_input_context(NULL);
 #endif
 
-    if (cas_terminal_owner(mpctx, mpctx)) {
-        terminal_uninit();
-        cas_terminal_owner(mpctx, NULL);
-    }
-
     mp_input_uninit(mpctx->input);
 
     uninit_libav(mpctx->global);
 
     mp_msg_uninit(mpctx->global);
+
+    if (cas_terminal_owner(mpctx, mpctx)) {
+        terminal_uninit();
+        cas_terminal_owner(mpctx, NULL);
+    }
+
     assert(!mpctx->num_abort_list);
     talloc_free(mpctx->abort_list);
     mp_mutex_destroy(&mpctx->abort_lock);

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -107,7 +107,8 @@ void mp_msg(struct mp_log *log, int lev, const char *format, ...) {};
 int mp_msg_find_level(const char *s) {return 0;};
 int mp_msg_level(struct mp_log *log) {return 0;};
 void mp_msg_set_max_level(struct mp_log *log, int lev) {};
-int mp_write_console_ansi(void *wstream, const char *format, va_list args) {return 0;};
+int mp_console_vfprintf(void *wstream, const char *format, va_list args) {return 0;};
+int mp_console_fputs(void *wstream, bstr str) {return 0;};
 bool mp_check_console(void *handle) { return false; };
 void mp_set_avdict(AVDictionary **dict, char **kv) {};
 struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -4,6 +4,7 @@
 #include "options/m_option.h"
 #include "options/path.h"
 #include "osdep/subprocess.h"
+#include "osdep/terminal.h"
 #include "test_utils.h"
 
 #ifdef NDEBUG
@@ -106,7 +107,8 @@ void mp_msg(struct mp_log *log, int lev, const char *format, ...) {};
 int mp_msg_find_level(const char *s) {return 0;};
 int mp_msg_level(struct mp_log *log) {return 0;};
 void mp_msg_set_max_level(struct mp_log *log, int lev) {};
-void mp_write_console_ansi(void) {};
+void mp_write_console_ansi(void *wstream, char *buf) {};
+bool mp_check_console(void *handle) { return false; };
 void mp_set_avdict(AVDictionary **dict, char **kv) {};
 struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,
                           const char *name) { return NULL; };

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -107,7 +107,7 @@ void mp_msg(struct mp_log *log, int lev, const char *format, ...) {};
 int mp_msg_find_level(const char *s) {return 0;};
 int mp_msg_level(struct mp_log *log) {return 0;};
 void mp_msg_set_max_level(struct mp_log *log, int lev) {};
-void mp_write_console_ansi(void *wstream, char *buf) {};
+int mp_write_console_ansi(void *wstream, const char *format, va_list args) {return 0;};
 bool mp_check_console(void *handle) { return false; };
 void mp_set_avdict(AVDictionary **dict, char **kv) {};
 struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -52,6 +52,5 @@ void mp_msg(struct mp_log *log, int lev, const char *format, ...)
 int mp_msg_find_level(const char *s);
 int mp_msg_level(struct mp_log *log);
 void mp_msg_set_max_level(struct mp_log *log, int lev);
-void mp_write_console_ansi(void);
 typedef struct AVDictionary AVDictionary;
 void mp_set_avdict(AVDictionary **dict, char **kv);


### PR DESCRIPTION
GetConsoleMode() can be quite slow and in mpv the mode never changes, so we can just check it once.

Fixes performance when writing lots of logs to terminal.

