### PR TITLE
vo_tct: write frame fully instead of every pixel

### DIFF
--- a/DOCS/interface-changes/vo-tct-buffering.txt
+++ b/DOCS/interface-changes/vo-tct-buffering.txt
@@ -1,0 +1,1 @@
+add `--vo-tct-buffering` option

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -361,6 +361,25 @@ Available video output drivers are:
             Uses spaces. Causes vertical resolution to drop twofolds, but in
             theory works in more places.
 
+    ``--vo-tct-buffering=<pixel|line|frame>``
+        Specifies the size of data batches buffered before being sent to the
+        terminal.
+
+        TCT image output is not synchronized with other terminal output from mpv,
+        which can lead to broken images. Sending data to the terminal in small
+        batches may improve parallelism between terminal processing and mpv
+        processing but incurs a static overhead of generating tens of thousands
+        of small writes. Also, depending on the terminal used, sending frames in
+        one chunk might help with tearing of the output, especially if not used
+        with ``--really-quiet`` and other logs interrupt the data stream.
+
+        pixel
+            Send data to terminal for each pixel.
+        line
+            Send data to terminal for each line. (Default)
+        frame
+            Send data to terminal for each frame.
+
     ``--vo-tct-width=<width>``  ``--vo-tct-height=<height>``
         Assume the terminal has the specified character width and/or height.
         These default to 80x25 if the terminal size cannot be determined.

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -56,9 +56,11 @@ static inline struct bstr bstrdup(void *talloc_ctx, struct bstr str)
     return r;
 }
 
+#define bstr0_s(s) (struct bstr){(unsigned char *)(s), (s) ? strlen(s) : 0}
+
 static inline struct bstr bstr0(const char *s)
 {
-    return (struct bstr){(unsigned char *)s, s ? strlen(s) : 0};
+    return bstr0_s(s);
 }
 
 int bstrcmp(struct bstr str1, struct bstr str2);

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -106,8 +106,8 @@ char *mp_to_utf8(void *talloc_ctx, const wchar_t *s);
 #include <sys/stat.h>
 #include <fcntl.h>
 
-int mp_puts(const char *str);
-int mp_fputs(const char *str, FILE *stream);
+size_t mp_fwrite(const void *restrict buffer, size_t size, size_t count,
+                 FILE *restrict stream);
 int mp_printf(const char *format, ...) PRINTF_ATTRIBUTE(1, 2);
 int mp_fprintf(FILE *stream, const char *format, ...) PRINTF_ATTRIBUTE(2, 3);
 int mp_open(const char *filename, int oflag, ...);
@@ -176,8 +176,7 @@ int mp_glob(const char *restrict pattern, int flags,
             int (*errfunc)(const char*, int), mp_glob_t *restrict pglob);
 void mp_globfree(mp_glob_t *pglob);
 
-#define puts(...) mp_puts(__VA_ARGS__)
-#define fputs(...) mp_fputs(__VA_ARGS__)
+#define fwrite(...) mp_fwrite(__VA_ARGS__)
 #define printf(...) mp_printf(__VA_ARGS__)
 #define fprintf(...) mp_fprintf(__VA_ARGS__)
 #define open(...) mp_open(__VA_ARGS__)

--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -32,7 +32,7 @@ int mp_console_vfprintf(void *wstream, const char *format, va_list args)
     return 0;
 }
 
-int mp_console_fputs(void *wstream, bstr str)
+int mp_console_write(void *wstream, bstr str)
 {
     return 0;
 }

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -239,7 +239,7 @@ int mp_console_vfprintf(HANDLE wstream, const char *format, va_list args)
     buffers->write_console_buf.len = 0;
     bstr_xappend_vasprintf(buffers, &buffers->write_console_buf, format, args);
 
-    int ret = mp_console_fputs(wstream, buffers->write_console_buf);
+    int ret = mp_console_write(wstream, buffers->write_console_buf);
 
     if (free_buf)
         talloc_free(buffers);
@@ -247,7 +247,7 @@ int mp_console_vfprintf(HANDLE wstream, const char *format, va_list args)
     return ret;
 }
 
-int mp_console_fputs(HANDLE wstream, bstr str)
+int mp_console_write(HANDLE wstream, bstr str)
 {
     struct tmp_buffers *buffers = FlsGetValue(tmp_buffers_key);
     bool free_buf = false;

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -57,7 +57,7 @@ void terminal_get_size2(int *rows, int *cols, int *px_width, int *px_height);
 
 // Windows only.
 int mp_console_vfprintf(void *wstream, const char *format, va_list args);
-int mp_console_fputs(void *wstream, bstr str);
+int mp_console_write(void *wstream, bstr str);
 bool mp_check_console(void *handle);
 
 /* Windows-only function to attach to the parent process's console */

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -28,6 +28,8 @@
 #define TERM_ESC_GOTO_YX            "\033[%d;%df"
 #define TERM_ESC_HIDE_CURSOR        "\033[?25l"
 #define TERM_ESC_RESTORE_CURSOR     "\033[?25h"
+#define TERM_ESC_SYNC_UPDATE_BEGIN  "\033[?2026h"
+#define TERM_ESC_SYNC_UPDATE_END    "\033[?2026l"
 
 #define TERM_ESC_CLEAR_SCREEN       "\033[2J"
 #define TERM_ESC_ALT_SCREEN         "\033[?1049h"

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -114,7 +114,7 @@ int mp_msg_find_level(const char *s) {return 0;};
 int mp_msg_level(struct mp_log *log) {return 0;};
 void mp_msg_set_max_level(struct mp_log *log, int lev) {};
 int mp_console_vfprintf(void *wstream, const char *format, va_list args) {return 0;};
-int mp_console_fputs(void *wstream, bstr str) {return 0;};
+int mp_console_write(void *wstream, bstr str) {return 0;};
 bool mp_check_console(void *handle) { return false; };
 void mp_set_avdict(AVDictionary **dict, char **kv) {};
 struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -39,16 +39,16 @@
 #define ALGO_PLAIN 1
 #define ALGO_HALF_BLOCKS 2
 
-#define TERM_ESC_CLEAR_COLORS           bstr0("\033[0m")
-#define TERM_ESC_COLOR256_BG            bstr0("\033[48;5")
-#define TERM_ESC_COLOR256_FG            bstr0("\033[38;5")
-#define TERM_ESC_COLOR24BIT_BG          bstr0("\033[48;2")
-#define TERM_ESC_COLOR24BIT_FG          bstr0("\033[38;2")
-
-#define UNICODE_LOWER_HALF_BLOCK        bstr0("\xe2\x96\x84")
-
 #define DEFAULT_WIDTH 80
 #define DEFAULT_HEIGHT 25
+
+static const bstr TERM_ESC_CLEAR_COLORS    = bstr0_s("\033[0m");
+static const bstr TERM_ESC_COLOR256_BG     = bstr0_s("\033[48;5");
+static const bstr TERM_ESC_COLOR256_FG     = bstr0_s("\033[38;5");
+static const bstr TERM_ESC_COLOR24BIT_BG   = bstr0_s("\033[48;2");
+static const bstr TERM_ESC_COLOR24BIT_FG   = bstr0_s("\033[38;2");
+
+static const bstr UNICODE_LOWER_HALF_BLOCK = bstr0_s("\xe2\x96\x84");
 
 struct vo_tct_opts {
     int algo;
@@ -111,14 +111,14 @@ static void print_seq3(bstr *frame, struct lut_item *lut, bstr prefix,
     bstr_xappend(NULL, frame, (bstr){ lut[r].str, lut[r].width });
     bstr_xappend(NULL, frame, (bstr){ lut[g].str, lut[g].width });
     bstr_xappend(NULL, frame, (bstr){ lut[b].str, lut[b].width });
-    bstr_xappend(NULL, frame, bstr0("m"));
+    bstr_xappend(NULL, frame, bstr0_s("m"));
 }
 
 static void print_seq1(bstr *frame, struct lut_item *lut, bstr prefix, uint8_t c)
 {
     bstr_xappend(NULL, frame, prefix);
     bstr_xappend(NULL, frame, (bstr){ lut[c].str, lut[c].width });
-    bstr_xappend(NULL, frame, bstr0("m"));
+    bstr_xappend(NULL, frame, bstr0_s("m"));
 }
 
 static void write_plain(bstr *frame,
@@ -142,7 +142,7 @@ static void write_plain(bstr *frame,
             } else {
                 print_seq3(frame, lut, TERM_ESC_COLOR24BIT_BG, r, g, b);
             }
-            bstr_xappend(NULL, frame, bstr0(" "));
+            bstr_xappend(NULL, frame, bstr0_s(" "));
         }
         bstr_xappend(NULL, frame, TERM_ESC_CLEAR_COLORS);
     }
@@ -263,7 +263,7 @@ static void flip_page(struct vo *vo)
             p->opts.term256, p->lut);
     }
 
-    bstr_xappend(NULL, &p->frame_buf, bstr0("\n"));
+    bstr_xappend(NULL, &p->frame_buf, bstr0_s("\n"));
 #ifdef _WIN32
     printf("%.*s", BSTR_P(p->frame_buf));
 #else

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -275,6 +275,8 @@ static void flip_page(struct vo *vo)
     if (vo->dwidth != width || vo->dheight != height)
         reconfig(vo, vo->params);
 
+    printf(TERM_ESC_SYNC_UPDATE_BEGIN);
+
     p->frame_buf.len = 0;
     if (p->opts.algo == ALGO_PLAIN) {
         write_plain(&p->frame_buf,
@@ -291,6 +293,8 @@ static void flip_page(struct vo *vo)
     bstr_xappend(NULL, &p->frame_buf, bstr0_s("\n"));
     if (p->opts.buffering <= VO_TCT_BUFFER_FRAME)
         print_buffer(&p->frame_buf);
+
+    printf(TERM_ESC_SYNC_UPDATE_END);
     fflush(stdout);
 }
 


### PR DESCRIPTION
This is multiple times faster than just writing every pixel sequence separately. Especially on slower terminal emulators. In general no need to stress I/O, while we can just prepare the frame to print and do it once.