### PR TITLE
ao/pulse: set similar properties as the pipewire backend

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -306,8 +306,20 @@ static int pa_init_boilerplate(struct ao *ao)
     pa_threaded_mainloop_lock(priv->mainloop);
     locked = true;
 
-    if (!(priv->context = pa_context_new(pa_threaded_mainloop_get_api(
-                                         priv->mainloop), ao->client_name)))
+    pa_proplist *props = pa_proplist_new();
+
+    pa_proplist_sets(props, PA_PROP_MEDIA_ROLE, ao->init_flags & AO_INIT_MEDIA_ROLE_MUSIC ?  "music" : "video");
+    pa_proplist_sets(props, PA_PROP_APPLICATION_NAME, ao->client_name);
+    pa_proplist_sets(props, PA_PROP_APPLICATION_ID, ao->client_name);
+    pa_proplist_sets(props, PA_PROP_APPLICATION_ICON_NAME, ao->client_name);
+
+    priv->context = pa_context_new_with_proplist(pa_threaded_mainloop_get_api(priv->mainloop),
+                                                 ao->client_name,
+                                                 props);
+
+    pa_proplist_free(props);
+
+    if (!priv->context)
     {
         MP_ERR(ao, "Failed to allocate context\n");
         goto fail;


### PR DESCRIPTION
Not setting `media.role` especially negatively affects wireplumber's restore-stream feature as it will save different stream settings for ao=pulse and ao=pipewire, so they will be restored differently.

For example:

 1. mpv --ao=pipewire ...
 2. mute the stream in pavucontrol
 3. mpv --ao=pulse ...
 4. note that the stream is not muted

To alleviate that issue, set `media.role` the same way it is set in the pipewire audio backend. (As well as some others.)

See https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3848