### PR TITLE
vo_gpu: raise deband-threshold to 64

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -65,6 +65,7 @@ Interface changes
     - add `hdr10plus` sub-parameter to `format` video filter
     - remove `--focus-on-open` and add replacement `--focus-on`
     - remove debanding from the high-quality profile
+    - raise default `--deband-threshold` to 64
  --- mpv 0.37.0 ---
     - `--save-position-on-quit` and its associated commands now store state files
       in %LOCALAPPDATA% instead of %APPDATA% directory by default on Windows.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6087,8 +6087,10 @@ them.
     Enable the debanding algorithm. This greatly reduces the amount of visible
     banding, blocking and other quantization artifacts, at the expense of
     very slightly blurring some of the finest details. In practice, it's
-    virtually always an improvement - the only reason to disable it would be
-    for performance.
+    virtually always an improvement for files with visible banding.
+
+    This can also be used as a pure grain generator by setting
+    ``--deband-iterations=0``.
 
 ``--deband-iterations=<0..16>``
     The number of debanding steps to perform per sample. Each step reduces a

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6101,7 +6101,7 @@ them.
 ``--deband-threshold=<0..4096>``
     The debanding filter's cut-off threshold. Higher numbers increase the
     debanding strength dramatically but progressively diminish image details.
-    (Default 48)
+    (Default 64)
 
 ``--deband-range=<1..64>``
     The debanding filter's initial radius. The radius increases linearly for

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -946,7 +946,7 @@ static void prng_init(struct gl_shader_cache *sc, AVLFG *lfg)
 
 const struct deband_opts deband_opts_def = {
     .iterations = 1,
-    .threshold = 48.0,
+    .threshold = 64.0,
     .range = 16.0,
     .grain = 32.0,
 };


### PR DESCRIPTION
Since we no longer activate deband in any default profiles, doing this shouldn't destroy any files.

We can discuss whether this should go even further than 64, but 64 seems fine to me even on files with heavy banding