### PR TITLE
Some EGL fixes

### DIFF
--- a/filters/user_filters.c
+++ b/filters/user_filters.c
@@ -94,7 +94,7 @@ const struct mp_user_filter_entry *vf_list[] = {
 #if HAVE_D3D_HWACCEL
     &vf_d3d11vpp,
 #endif
-#if HAVE_EGL_HELPERS && HAVE_GL && HAVE_EGL
+#if HAVE_GL && HAVE_EGL
     &vf_gpu,
 #endif
 };

--- a/meson.build
+++ b/meson.build
@@ -1226,12 +1226,11 @@ if plain_gl.allowed()
     features += {'gl': true}
 endif
 
-features += {'egl-helpers': features['egl'] or egl_android.found() or egl_angle_win32.allowed()}
-if features['egl-helpers']
+if features['egl'] or features['egl-android'] or features['egl-angle-win32']
     sources += files('video/out/opengl/egl_helpers.c')
 endif
 
-if features['egl'] and features['egl-helpers']
+if features['gl'] and features['egl']
     sources += files('video/filter/vf_gpu.c')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1172,7 +1172,7 @@ if features['d3d11'] or features['egl-angle-win32']
     sources += files('video/out/gpu/d3d11_helpers.c')
 endif
 
-egl = dependency('egl', version: '> 1.4.0', required: get_option('egl'))
+egl = dependency('egl', version: '>= 1.4.0', required: get_option('egl'))
 features += {'egl': egl.found() and gl_allowed}
 if features['egl']
     dependencies += egl

--- a/meson.build
+++ b/meson.build
@@ -1147,9 +1147,10 @@ if features['egl-angle']
     sources += files('video/out/opengl/angle_dynamic.c')
 endif
 
-egl_dep = cc.find_library('EGL', required: get_option('egl-angle-lib'))
+egl_dep = cc.find_library('EGL', required:
+    get_option('egl-angle-lib').require(features['egl-angle']))
 egl_angle_lib = get_option('egl-angle-lib').require(
-    features['egl-angle'] and cc.has_function('eglCreateWindowSurface',
+    egl_dep.found() and cc.has_function('eglCreateWindowSurface',
                                                dependencies: egl_dep,
                                                prefix: '#include <EGL/egl.h>'),
     error_message: 'egl-angle-lib could not be found!',

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -192,14 +192,15 @@ static bool create_context(struct ra_ctx *ctx, EGLDisplay display,
     }
     if (!egl_ctx) {
         // Fallback for EGL 1.4 without EGL_KHR_create_context or GLES
-        // Add the context flags only for GLES - GL has been attempted above
         EGLint attrs[] = {
-            EGL_CONTEXT_CLIENT_VERSION, 2,
-            es ? EGL_CONTEXT_FLAGS_KHR : EGL_NONE, ctx_flags,
+            EGL_CONTEXT_FLAGS_KHR, ctx_flags,
+            es ? EGL_CONTEXT_CLIENT_VERSION : EGL_NONE, 2,
             EGL_NONE
         };
 
         egl_ctx = eglCreateContext(display, config, EGL_NO_CONTEXT, attrs);
+        if (!egl_ctx)
+            egl_ctx = eglCreateContext(display, config, EGL_NO_CONTEXT, &attrs[2]);
     }
 
     if (!egl_ctx) {

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -203,7 +203,8 @@ static bool create_context(struct ra_ctx *ctx, EGLDisplay display,
     }
 
     if (!egl_ctx) {
-        MP_MSG(ctx, msgl, "Could not create EGL context for %s!\n", name);
+        MP_MSG(ctx, msgl, "Could not create EGL context for %s (error=%d)!\n",
+               name, eglGetError());
         return false;
     }
 


### PR DESCRIPTION
the knowledge that `EGL_CONTEXT_CLIENT_VERSION` is not allowed with GL comes from here: https://n9.dy.fi/meego/html/egl/eglCreateContext.html?tab=0 (and is also written in the EGL 1.4 spec)