### PR TITLE
input: remove max active section limit 

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -56,7 +56,7 @@
 #define input_lock(ictx)    mp_mutex_lock(&ictx->mutex)
 #define input_unlock(ictx)  mp_mutex_unlock(&ictx->mutex)
 
-#define MP_MAX_KEY_DOWN 4
+#define MP_MAX_KEY_DOWN 16
 
 struct cmd_bind {
     int keys[MP_MAX_KEY_DOWN];


### PR DESCRIPTION
https://github.com/mpv-player/mpv/commit/585d8c6856e8eaf77c518ad4679e8c66660fc440 increased max active section limit from 5 to 50 but this obviously doesn't properly fix the problem. Input still breaks if more than 25 scripts are loaded, or if some scripts define lots of input sections.

Remove the limit completely by using a dynamic array for active sections.

Fixes https://github.com/mpv-player/mpv/issues/13707.