### PR TITLE
win32: fix native key repeat support

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4071,17 +4071,18 @@ Demuxer
 Input
 -----
 
-``--native-keyrepeat``
+``--native-keyrepeat=<yes|no>``
     Use system settings for keyrepeat delay and rate, instead of
-    ``--input-ar-delay`` and ``--input-ar-rate``. (Whether this applies
-    depends on the VO backend and how it handles keyboard input. Does not
-    apply to terminal input.)
+    ``--input-ar-delay`` and ``--input-ar-rate`` (default: no).
+    Whether this applies depends on the VO backend and how it handles
+    keyboard input. Does not apply to terminal input.
 
 ``--input-ar-delay``
-    Delay in milliseconds before we start to autorepeat a key (0 to disable).
+    Delay in milliseconds before we start to autorepeat a key (default: 200).
+    Set it to 0 to disable.
 
 ``--input-ar-rate``
-    Number of key presses to generate per second on autorepeat.
+    Number of key presses to generate per second on autorepeat (default: 40).
 
 ``--input-conf=<filename>``
     Specify input configuration file other than the default location in the mpv

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -502,10 +502,6 @@ static bool handle_appcommand(struct vo_w32_state *w32, UINT cmd)
 
 static void handle_key_down(struct vo_w32_state *w32, UINT vkey, UINT scancode)
 {
-    // Ignore key repeat
-    if (scancode & KF_REPEAT)
-        return;
-
     int mpkey = mp_w32_vkey_to_mpkey(vkey, scancode & KF_EXTENDED);
     if (!mpkey) {
         mpkey = decode_key(w32, vkey, scancode & (0xff | KF_EXTENDED));
@@ -513,7 +509,8 @@ static void handle_key_down(struct vo_w32_state *w32, UINT vkey, UINT scancode)
             return;
     }
 
-    mp_input_put_key(w32->input_ctx, mpkey | mod_state(w32) | MP_KEY_STATE_DOWN);
+    int state = w32->opts->native_keyrepeat ? 0 : MP_KEY_STATE_DOWN;
+    mp_input_put_key(w32->input_ctx, mpkey | mod_state(w32) | state);
 }
 
 static void handle_key_up(struct vo_w32_state *w32, UINT vkey, UINT scancode)


### PR DESCRIPTION
win32 does not respect `--native-keyrepeat` option, and native key repeat has been broken since https://github.com/mpv-player/mpv/commit/0ab3482f73a199b2e839ad4ec0a4b21adc1e75d5.

This lets mpv respect the `--native-keyrepeat` option on win32.