### PR TITLE
stats.lua: filter input bindings by typing them

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -35,6 +35,9 @@ UP      Scroll one line up
 DOWN    Scroll one line down
 ====   ==================
 
+Page 4 also binds ``/`` to search for input bindings by typing part of a binding
+or command.
+
 Configuration
 -------------
 
@@ -62,6 +65,8 @@ Configurable Options
     Default: UP
 ``key_scroll_down``
     Default: DOWN
+``key_scroll_search``
+    Default: /
 ``scroll_lines``
     Default: 1
 


### PR DESCRIPTION
This lets you press / in page 4 of the stats and type a keybinding or part of its command to filter it by using mp.input.

This works badly without a VO because both stats.lua and console.lua use show-text and only one can be displayed at a time, but it's still better than not having the search available at all.