### PR TITLE
af_scaletempo2: prioritize louder channels for similarity measure

### DIFF
--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -93,15 +93,15 @@ static void multi_channel_moving_block_energies(
 }
 
 static float multi_channel_similarity_measure(
-    const float* dot_prod_a_b,
-    const float* energy_a, const float* energy_b,
+    const float* dot_prod,
+    const float* energy_target, const float* energy_candidate,
     int channels)
 {
     const float epsilon = 1e-12f;
     float similarity_measure = 0.0f;
     for (int n = 0; n < channels; ++n) {
-        similarity_measure += dot_prod_a_b[n]
-            / sqrtf(energy_a[n] * energy_b[n] + epsilon);
+        similarity_measure += dot_prod[n] * energy_target[n]
+            / sqrtf(energy_target[n] * energy_candidate[n] + epsilon);
     }
     return similarity_measure;
 }


### PR DESCRIPTION
This is an attempt to fix #8705 and is the result to my ideas [commented](https://github.com/mpv-player/mpv/pull/13737#issuecommnt-2013445939) on #13737.

The idea here is to increase the weight of louder channels. Some details are in the commit message. Should have very little effect on stereo audio and none on mono.

I tested it with the [sample](https://github.com/mpv-player/mpv/issues/8705#issuecomment-2000666720) from the issue, with the [test file](https://github.com/mpv-player/mpv/pull/13737#issuecomment-2014064370) in the discussion, and in random other videos I've watched and my impression is pretty good so far.