### PR TITLE
demux_mkv: support V_FFV1 tag

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1447,6 +1447,7 @@ static const char *const mkv_video_tags[][2] = {
     {"V_PNG",               "png"},
     {"V_AVS2",              "avs2"},
     {"V_AVS3",              "avs3"},
+    {"V_FFV1",              "ffv1"},
     {0}
 };
 


### PR DESCRIPTION
Most FFV1 videos seem to be encoded using FFmpeg, which uses the V_MS/VFW/FOURCC tag, but GStreamer's matroskamux uses [the V_FFV1 tag](https://www.matroska.org/technical/codec_specs.html#v_ffv1). This means that mpv could [previously not load GStreamer-muxed FFV1 videos in a .mkv](https://github.com/valadaptive/ntsc-rs/issues/49).

Fixing this seems to be as simple as adding V_FFV1 to `mkv_video_tags`--I've tested it and it plays back these videos properly now. I added it at the bottom since I can't ascertain any existing order.

[Here's a test video](https://github.com/mpv-player/mpv/files/14733876/v_ffv1.mkv.zip) (it's 1 FPS because lossless video is huge). In the current master branch it will fail to load, but with this PR it should work.