### PR TITLE
vo_{gpu,direct3d,xv}: support `video-target-params`

### DIFF
--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -232,5 +232,6 @@ void gl_video_configure_queue(struct gl_video *p, struct vo *vo);
 struct mp_image *gl_video_get_image(struct gl_video *p, int imgfmt, int w, int h,
                                     int stride_align, int flags);
 
+struct mp_image_params *gl_video_get_target_params_ptr(struct gl_video *p);
 
 #endif

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -85,6 +85,11 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         MP_ERR(vo, "Failed presenting frame!\n");
         return;
     }
+
+    struct mp_image_params *params = gl_video_get_target_params_ptr(p->renderer);
+    mp_mutex_lock(&vo->params_mutex);
+    vo->target_params = params;
+    mp_mutex_unlock(&vo->params_mutex);
 }
 
 static void flip_page(struct vo *vo)

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -92,6 +92,7 @@ struct xvctx {
     int Shmem_Flag;
     XShmSegmentInfo Shminfo[MAX_BUFFERS];
     int Shm_Warned_Slow;
+    struct mp_image_params dst_params;
 };
 
 #define MP_FOURCC(a,b,c,d) ((a) | ((b)<<8) | ((c)<<16) | ((unsigned)(d)<<24))
@@ -522,6 +523,13 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     int is_709 = params->repr.sys == PL_COLOR_SYSTEM_BT_709;
     xv_set_eq(vo, ctx->xv_port, "bt_709", is_709 * 200 - 100);
     read_xv_csp(vo);
+
+    ctx->dst_params = *params;
+    if (ctx->cached_csp)
+        ctx->dst_params.repr.sys = ctx->cached_csp;
+    mp_mutex_lock(&vo->params_mutex);
+    vo->target_params = &ctx->dst_params;
+    mp_mutex_unlock(&vo->params_mutex);
 
     resize(vo);
 


### PR DESCRIPTION
This adds `video-target-params` support for the remaining VOs which have video output parameters available.