### PR TITLE
af_scaletempo2: fix false reporting of frame availability

### DIFF
--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -765,7 +765,8 @@ double mp_scaletempo2_get_latency(struct mp_scaletempo2 *p, double playback_rate
 
 bool mp_scaletempo2_frames_available(struct mp_scaletempo2 *p, double playback_rate)
 {
-    return p->input_buffer_final_frames > p->target_block_index
+    return (p->input_buffer_final_frames > p->target_block_index &&
+            p->input_buffer_final_frames > 0)
         || can_perform_wsola(p, playback_rate)
         || p->num_complete_frames > 0;
 }


### PR DESCRIPTION
The infinite loop mentioned can be triggered with the following when playing any file with audio matching the sample rate of AO (so no resampling filter is inserted):

`mpv --speed=0.3 any_file_with_audio.mp4`
