### PR TITLE
ao_pipewire: proper delay calculation

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -47,6 +47,15 @@ static inline int pw_stream_get_time_n(struct pw_stream *stream, struct pw_time 
 #define spa_hook_remove(hook) if ((hook)->link.prev) spa_hook_remove(hook)
 #endif
 
+#if !PW_CHECK_VERSION(1, 0, 4)
+static uint64_t pw_stream_get_nsec(struct pw_stream *stream)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return SPA_TIMESPEC_TO_NSEC(&ts);
+}
+#endif
+
 enum init_state {
     INIT_STATE_NONE,
     INIT_STATE_SUCCESS,
@@ -190,9 +199,13 @@ static void on_process(void *userdata)
         time.rate.num = 1;
 
     int64_t end_time = mp_time_ns();
-    /* time.queued is always going to be 0, so we don't need to care */
-    end_time += (nframes * 1e9 / ao->samplerate) +
-                ((double) time.delay * SPA_NSEC_PER_SEC * time.rate.num / time.rate.denom);
+    end_time += MP_TIME_S_TO_NS(nframes) / ao->samplerate;
+    end_time += MP_TIME_S_TO_NS(time.delay) * time.rate.num / time.rate.denom;
+    end_time += MP_TIME_S_TO_NS(time.queued) / ao->samplerate;
+#if PW_CHECK_VERSION(0, 3, 50)
+    end_time += MP_TIME_S_TO_NS(time.buffered) / ao->samplerate;
+#endif
+    end_time -= pw_stream_get_nsec(p->stream) - time.now;
 
     int samples = ao_read_data_nonblocking(ao, data, nframes, end_time);
     b->size = samples;


### PR DESCRIPTION
Pipewire 0.3.50 has introduced `time.buffered` for the number of samples buffered in its resampler. It can be non-zero if the sink has a different samplerate. This commit takes it into consideration when calculating total delay.

This commit also includes `time.now` in calculation for more precise delay.

By the way, the buffer size is made proper for planar format. `SPA_PARAM_BUFFERS_size` should be the size of a single plane, not all planes.