### PR TITLE
ao: set_pause for pull-based ao

### DIFF
--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -159,6 +159,19 @@ static void stop(struct ao *ao)
     });
 }
 
+static bool set_pause(struct ao *ao, bool paused)
+{
+    struct priv *p = ao->priv;
+
+    if (paused) {
+        [p->synchronizer setRate:0];
+    } else {
+        [p->synchronizer setRate:1];
+    }
+
+    return true;
+}
+
 static int control(struct ao *ao, enum aocontrol cmd, void *arg)
 {
     struct priv *p = ao->priv;
@@ -353,6 +366,7 @@ const struct ao_driver audio_out_avfoundation = {
     .control        = control,
     .reset          = stop,
     .start          = start,
+    .set_pause      = set_pause,
     .list_devs      = ca_get_device_list,
     .priv_size      = sizeof(struct priv),
 };

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -694,6 +694,15 @@ static void start(struct ao *ao)
     pw_thread_loop_unlock(p->loop);
 }
 
+static bool set_pause(struct ao *ao, bool paused)
+{
+    struct priv *p = ao->priv;
+    pw_thread_loop_lock(p->loop);
+    pw_stream_set_active(p->stream, !paused);
+    pw_thread_loop_unlock(p->loop);
+    return true;
+}
+
 #define CONTROL_RET(r) (!r ? CONTROL_OK : CONTROL_ERROR)
 
 static int control(struct ao *ao, enum aocontrol cmd, void *arg)
@@ -885,7 +894,7 @@ const struct ao_driver audio_out_pipewire = {
     .uninit      = uninit,
     .reset       = reset,
     .start       = start,
-
+    .set_pause   = set_pause,
     .control     = control,
 
     .hotplug_init   = hotplug_init,

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -150,14 +150,32 @@ exit_label:
     return false;
 }
 
+static void thread_pause(struct ao *ao)
+{
+    struct wasapi_state *state = ao->priv;
+    MP_DBG(state, "Thread Pause\n");
+    HRESULT hr = IAudioClient_Stop(state->pAudioClient);
+    if (FAILED(hr))
+        MP_ERR(state, "IAudioClient_Stop returned: %s\n", mp_HRESULT_to_str(hr));
+}
+
+static void thread_unpause(struct ao *ao)
+{
+    struct wasapi_state *state = ao->priv;
+    MP_DBG(state, "Thread Unpause\n");
+    HRESULT hr = IAudioClient_Start(state->pAudioClient);
+    if (FAILED(hr)) {
+        MP_ERR(state, "IAudioClient_Start returned %s\n",
+               mp_HRESULT_to_str(hr));
+    }
+}
+
 static void thread_reset(struct ao *ao)
 {
     struct wasapi_state *state = ao->priv;
     HRESULT hr;
     MP_DBG(state, "Thread Reset\n");
-    hr = IAudioClient_Stop(state->pAudioClient);
-    if (FAILED(hr))
-        MP_ERR(state, "IAudioClient_Stop returned: %s\n", mp_HRESULT_to_str(hr));
+    thread_pause(ao);
 
     hr = IAudioClient_Reset(state->pAudioClient);
     if (FAILED(hr))
@@ -172,12 +190,7 @@ static void thread_resume(struct ao *ao)
     MP_DBG(state, "Thread Resume\n");
     thread_reset(ao);
     thread_feed(ao);
-
-    HRESULT hr = IAudioClient_Start(state->pAudioClient);
-    if (FAILED(hr)) {
-        MP_ERR(state, "IAudioClient_Start returned %s\n",
-               mp_HRESULT_to_str(hr));
-    }
+    thread_unpause(ao);
 }
 
 static void set_state_and_wakeup_thread(struct ao *ao,
@@ -229,6 +242,12 @@ static DWORD __stdcall AudioThread(void *lpParameter)
         case WASAPI_THREAD_SHUTDOWN:
             thread_reset(ao);
             goto exit_label;
+        case WASAPI_THREAD_PAUSE:
+            thread_pause(ao);
+            break;
+        case WASAPI_THREAD_UNPAUSE:
+            thread_unpause(ao);
+            break;
         default:
             MP_ERR(ao, "Unhandled thread state: %d\n", thread_state);
         }
@@ -463,6 +482,12 @@ static void audio_resume(struct ao *ao)
     set_state_and_wakeup_thread(ao, WASAPI_THREAD_RESUME);
 }
 
+static bool audio_set_pause(struct ao *ao, bool paused)
+{
+    set_state_and_wakeup_thread(ao, paused ? WASAPI_THREAD_PAUSE : WASAPI_THREAD_UNPAUSE);
+    return true;
+}
+
 static void hotplug_uninit(struct ao *ao)
 {
     MP_DBG(ao, "Hotplug uninit\n");
@@ -496,6 +521,7 @@ const struct ao_driver audio_out_wasapi = {
     .control        = control,
     .reset          = audio_reset,
     .start          = audio_resume,
+    .set_pause      = audio_set_pause,
     .list_devs      = wasapi_list_devs,
     .hotplug_init   = hotplug_init,
     .hotplug_uninit = hotplug_uninit,

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -51,7 +51,9 @@ enum wasapi_thread_state {
     WASAPI_THREAD_DISPATCH,
     WASAPI_THREAD_RESUME,
     WASAPI_THREAD_RESET,
-    WASAPI_THREAD_SHUTDOWN
+    WASAPI_THREAD_SHUTDOWN,
+    WASAPI_THREAD_PAUSE,
+    WASAPI_THREAD_UNPAUSE,
 };
 
 typedef struct wasapi_state {

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -108,6 +108,7 @@ struct mp_pcm_state {
  *          start
  *     Optional for both types:
  *          control
+ *          set_pause
  *  a) ->write is called to queue audio. push.c creates a thread to regularly
  *     refill audio device buffers with ->write, but all driver functions are
  *     always called under an exclusive lock.
@@ -115,8 +116,6 @@ struct mp_pcm_state {
  *          reset
  *          write
  *          get_state
- *     Optional:
- *          set_pause
  *  b) ->write must be NULL. ->start must be provided, and should make the
  *     audio API start calling the audio callback. Your audio callback should
  *     in turn call ao_read_data() to get audio data. Most functions are
@@ -149,6 +148,9 @@ struct ao_driver {
     // Stop all audio playback, clear buffers, back to state after init().
     // Optional for pull AOs.
     void (*reset)(struct ao *ao);
+    // pull based: set pause state. Only called after start() and before reset().
+    //             The return value is ignored.
+    //             The pausing state is also cleared by reset().
     // push based: set pause state. Only called after start() and before reset().
     //             returns success (this is intended for paused=true; if it
     //             returns false, playback continues, and the core emulates via


### PR DESCRIPTION
Currently `set_pause` is only used for push-based ao. This PR enables the use of it in pull-based ao.

The motivation is to avoid device buffer flushing when pull-based ao is paused. The original code path to pause and resume pull-based ao is to go through a `reset` and `start` cycle. In `reset`, the ao will flush its internal buffer. e.g., `pw_stream_flush` in pipewire, `IAudioClient_Reset` in wasapi, and `[renderer flush]` in avfoundation. If a large number of samples have been queued to device, flushing the device can cause desync when the ao is resumed.

This PR introduces the use of `set_pause` for pull-based ao. If it is not null, it will be called during pausing/resuming instead of a `reset` and `start` cycle. The ao can preserve its queued samples in this case.