### PR TITLE
ao_alsa: fix snd_config memory leak

### DIFF
--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -623,7 +623,8 @@ static void uninit(struct ao *ao)
         CHECK_ALSA_ERROR("pcm close error");
     }
 
-alsa_error: ;
+alsa_error:
+    snd_config_update_free_global();
 }
 
 #define INIT_DEVICE_ERR_GENERIC -1


### PR DESCRIPTION
During AO init, snd_pcm_open() is called, which calls snd_config_update() to allocate a global config node and stores it in the snd_config global variable. This is never freed on uninit.

Fix this by freeing the global config node on uninit.
