### PR TITLE
demux: use the cache for video-reconfigs of images

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -663,7 +663,7 @@ static void update_seek_ranges(struct demux_cached_range *range)
         }
     }
 
-    if (range->seek_start >= range->seek_end)
+    if (range->seek_start >= range->seek_end && !(range->is_bof && range->is_eof))
         goto broken;
 
     prune_metadata(range);


### PR DESCRIPTION
When a video-reconfig occurs with an image, the cache is not used because the code checks if the start time was initialized, but for images it stays at MP_NOPTS_VALUE. This make rotating large network images slow because they are re-downloaded on every rotation.

Fix this by allowing the use of image cache ranges whose times are uninitialized, but that span from the beginning to the end of the file (r->is_bof and r->is_eof are true) and are therefore still valid.