### PR TITLE
ao_wasapi: add `--wasapi-exclusive-buffer` option

### DIFF
--- a/DOCS/interface-changes/wasapi-exclusive-buffer.txt
+++ b/DOCS/interface-changes/wasapi-exclusive-buffer.txt
@@ -1,0 +1,1 @@
+add `--wasapi-exclusive-buffer` option

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -297,3 +297,18 @@ Available audio output drivers are:
 
 ``wasapi``
     Audio output to the Windows Audio Session API.
+
+    The following global options are supported by this audio output:
+
+    ``--wasapi-exclusive-buffer=<default|min|1-2000000>``
+        Set buffer duration in exclusive mode (i.e., with
+        ``--audio-exclusive=yes``). ``default`` and ``min`` use the default and
+        minimum device period reported by WASAPI, respectively. You can also
+        directly specify the buffer duration in microseconds, in which case a
+        duration shorter than the minimum device period will be rounded up to
+        the minimum period.
+
+        The default buffer duration should provide robust playback in most
+        cases, but reportedly on some devices there are glitches following
+        stream resets under the default setting. In such cases, specifying a
+        shorter duration might help.

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -500,4 +500,10 @@ const struct ao_driver audio_out_wasapi = {
     .hotplug_init   = hotplug_init,
     .hotplug_uninit = hotplug_uninit,
     .priv_size      = sizeof(wasapi_state),
+    .options_prefix = "wasapi",
+    .options        = (const struct m_option[]) {
+        {"exclusive-buffer", OPT_CHOICE(opt_exclusive_buffer,
+            {"default", 0}, {"min", -1}), M_RANGE(1, 2000000)},
+        {0}
+    },
 };

--- a/audio/out/ao_wasapi.h
+++ b/audio/out/ao_wasapi.h
@@ -89,6 +89,7 @@ typedef struct wasapi_state {
 
     // ao options
     int opt_exclusive;
+    int opt_exclusive_buffer; // exclusive mode buffer duration in us
 
     // format info
     WAVEFORMATEXTENSIBLE format;


### PR DESCRIPTION
This allows users to set buffer duration in exclusive mode. We have been using the default device period as the buffer size and it is robust enough in most cases. However, on some devices there are horrible glitches after a stream reset. Unfortunately, the issue is not consistently reproducible, but using a smaller buffer size (e.g., the minimum device period) seems to resolve the problem.

For shared mode, MS is actually requiring us to set both buffer duration and device period to 0 on initialization, whereas we are passing a non-zero duration. It works somehow, and has been working well thus far, so I decided to leave it for the time being.