### PR TITLE
mac/window: fix window pinch gesture and modify current-window-scale

### DIFF
--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -505,7 +505,7 @@ class Window: NSWindow, NSWindowDelegate {
 
     func addWindowScale(_ scale: Double) {
         if !isInFullscreen {
-            input?.command("add window-scale \(scale)")
+            input?.command("add current-window-scale \(scale)")
         }
     }
 


### PR DESCRIPTION
this will prevent jumping of the window size in the case the window size was 'externally' modified and not via the window-scale property, when using the pinch gesture.

Fixes #11594
Fixes #13799