### PR TITLE
audio/ad_spdif: specify media type and sample rate in output codecpar

### DIFF
--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -196,7 +196,8 @@ static int init_filter(struct mp_filter *da)
     if (!stream)
         goto fail;
 
-    stream->codecpar->codec_id = spdif_ctx->codec_id;
+    stream->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
+    stream->codecpar->codec_id   = spdif_ctx->codec_id;
 
     AVDictionary *format_opts = NULL;
 
@@ -259,6 +260,8 @@ static int init_filter(struct mp_filter *da)
     default:
         abort();
     }
+
+    stream->codecpar->sample_rate = samplerate;
 
     struct mp_chmap chmap;
     mp_chmap_from_channels(&chmap, num_channels);

--- a/audio/decode/ad_spdif.c
+++ b/audio/decode/ad_spdif.c
@@ -89,7 +89,7 @@ static void destroy(struct mp_filter *da)
             av_write_trailer(lavf_ctx);
         if (lavf_ctx->pb)
             av_freep(&lavf_ctx->pb->buffer);
-        av_freep(&lavf_ctx->pb);
+        avio_context_free(&lavf_ctx->pb);
         avformat_free_context(lavf_ctx);
         spdif_ctx->lavf_ctx = NULL;
     }

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -142,7 +142,7 @@ _ffmpeg () {
         --enable-cross-compile --cross-prefix=$TARGET- --arch=${TARGET%%-*}
         --cc="$CC" --cxx="$CXX" $commonflags
         --disable-{doc,programs,muxers,encoders}
-        --enable-encoder=mjpeg,png --enable-libdav1d
+        --enable-muxer=spdif --enable-encoder=mjpeg,png --enable-libdav1d
     )
     pkg-config vulkan && args+=(--enable-vulkan --enable-libshaderc)
     ../configure "${args[@]}"


### PR DESCRIPTION
No idea how things previously worked without having these set, but apparently they did...

If this was a normal encoder to muxer case, we would utilize `avcodec_parameters_to_context`, but alas this is not.

Fixes: #13794