### PR TITLE
demux_mkv: corrected direction of ProjectionPoseRoll rotation

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1576,7 +1576,7 @@ static int demux_mkv_open_video(demuxer_t *demuxer, mkv_track_t *track)
     sh_v->color = track->color;
 
     if (track->v_projection_pose_roll_set) {
-        int rotate = lrintf(fmodf(fmodf(track->v_projection_pose_roll, 360) + 360, 360));
+        int rotate = lrintf(fmodf(fmodf(-1 * track->v_projection_pose_roll, 360) + 360, 360));
         sh_v->rotate = rotate;
     }
 


### PR DESCRIPTION
Draft PR to address https://github.com/mpv-player/mpv/issues/13830. The direction is being discussed in the issue.

Edit: see ietf-wg-cellar/matroska-specification#822.