### PR TITLE
player/loadfile: Fix the problem of automatic loop playback assertion…

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1916,7 +1916,8 @@ terminate_playback:
     } else {
         mpctx->files_played++;
     }
-
+    // Fix the problem of automatic loop playback assertion failure in Linux
+    mpctx->stop_play = AT_END_OF_FILE;
     assert(mpctx->stop_play);
 
     process_hooks(mpctx, "on_after_end_file");


### PR DESCRIPTION
… failure in Linux

https://github.com/mpv-player/mpv/issues/13778
When playing many video streams, automatic switching to the next episode will occur. If you manually switch to the next episode, this problem will not occur.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.