### PR TITLE
Revert "vo_dmabuf_wayland: assume counter-clockwise rotations"

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -695,10 +695,7 @@ done:
     if (!vo_wayland_reconfig(vo))
         return VO_ERROR;
 
-    // mpv rotates clockwise but the wayland spec has counter-clockwise rotations
-    // swap 1 and 3 to match mpv's direction
-    int transform = (360 - img->params.rotate) % 360 / 90;
-    wl_surface_set_buffer_transform(vo->wl->video_surface, transform);
+    wl_surface_set_buffer_transform(vo->wl->video_surface, img->params.rotate / 90);
 
     // Immediately destroy all buffers if params change.
     destroy_buffers(vo);


### PR DESCRIPTION
This commit was originally sparked by a change in sway. When looking at the wording of the spec, it was believed that the rotation should be counter-clockwise. But that was interpreted incorrectly. The rotation direction in the spec is meant for compositors not clients. Clients should be rotating clockwise and compositors rotate it the opposite direction. Also see the discussion in upstream wayland*.

*: https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/369

This reverts commit 27ef1725e7724f4b6899e3992ac3a884db9fbe13.

CC @mahkoh