### PR TITLE
mac/log: fix use after free when freeing mpv handle

### DIFF
--- a/osdep/mac/app_hub.swift
+++ b/osdep/mac/app_hub.swift
@@ -58,6 +58,7 @@ class AppHub: NSObject {
             log.log = mp_log_new(UnsafeMutablePointer(mpv), mp_client_get_log(mpv), "app")
             option = OptionHelper(UnsafeMutablePointer(mpv), mp_client_get_global(mpv))
             input.option = option
+            event?.subscribe(log, event: .init(name: "MPV_EVENT_SHUTDOWN"))
         }
 
 #if HAVE_MACOS_MEDIA_PLAYER


### PR DESCRIPTION
alternatively but unclean, we could not set the mpv_handle as ta_parent and not free it at all. it's still possible for uses after free but it won't happen the way the log is used.

Fixes #13823