### PR TITLE
player/lua: fix trailing whitespace for mp.log output

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -512,7 +512,7 @@ static int script_log(lua_State *L)
         const char *s = lua_tostring(L, -1);
         if (s == NULL)
             return luaL_error(L, "Invalid argument");
-        mp_msg(ctx->log, msgl, "%s%s", s, i > 0 ? " " : "");
+        mp_msg(ctx->log, msgl, (i == 2 ? "%s" : " %s"), s);
         lua_pop(L, 1);  // args... tostring
     }
     mp_msg(ctx->log, msgl, "\n");


### PR DESCRIPTION
Previously it always inserts a whitespace after an arg because `i > 0` is always true.
