### PR TITLE
command: don't use OSD_ASS_0 when converting lists to strings

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -227,12 +227,10 @@ Alt+BACKSPACE
     Reset the pan/zoom settings.
 
 F8
-    Show the playlist and the current position in it (useful only if a UI window
-    is used, broken on the terminal).
+    Show the playlist and the current position in it.
 
 F9
-    Show the list of audio and subtitle streams (useful only if a UI window  is
-    used, broken on the terminal).
+    Show the list of audio and subtitle streams.
 
 i and I
     Show/toggle an overlay displaying statistics about the currently playing

--- a/player/command.c
+++ b/player/command.c
@@ -159,12 +159,15 @@ struct load_action {
     bool play;
 };
 
-// U+279C HEAVY ROUND-TIPPED RIGHTWARDS ARROW
+// U+25CB WHITE CIRCLE
+// U+25CF BLACK CIRCLE
 // U+00A0 NO-BREAK SPACE
-#define ARROW_SP "\342\236\234\302\240"
+#define WHITECIRCLE "\xe2\x97\x8b"
+#define BLACKCIRCLE "\xe2\x97\x8f"
+#define NBSP "\xc2\xa0"
 
-const char list_current[] = OSD_ASS_0 ARROW_SP OSD_ASS_1;
-const char list_normal[] = OSD_ASS_0 "{\\alpha&HFF}" ARROW_SP "{\\r}" OSD_ASS_1;
+const char list_current[] = BLACKCIRCLE NBSP;
+const char list_normal[] = WHITECIRCLE NBSP;
 
 static int edit_filters(struct MPContext *mpctx, struct mp_log *log,
                         enum stream_type mediatype,


### PR DESCRIPTION
When converting a list to string for show-text, since 05c398fb6c3a48c6a72b6b0706ea0156c46b146d the OSD_ASS_0 escape hatch is used. This usage is problematic because the same format string is used for print-text, which results in these ASS escape sequences being printed in the terminal.

Also since d6610a5b2f34e398e2ceba2a4da2b79e556b1c9e, the print-text output to console.lua is no longer escaped if OSD_ASS_0 is present. This results in abnormally formated text in the console output.

Fix this by not using ASS escape sequences for this. Instead, use the circle symbols used by the OSC, which also results in the same width for active and inactive items.
