### PR TITLE
wayland: only perform a rescale if window is on one output

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -996,7 +996,7 @@ static void surface_handle_preferred_buffer_scale(void *data,
 {
     struct vo_wayland_state *wl = data;
 
-    if (wl->fractional_scale_manager)
+    if (wl->fractional_scale_manager || wl->scaling == scale)
         return;
 
     wl->pending_scaling = scale;
@@ -1221,7 +1221,11 @@ static void preferred_scale(void *data,
                             uint32_t scale)
 {
     struct vo_wayland_state *wl = data;
-    wl->pending_scaling = (double)scale / 120;
+    double new_scale = (double)scale / 120;
+    if (wl->scaling == new_scale)
+        return;
+
+    wl->pending_scaling = new_scale;
     wl->scale_configured = true;
     MP_VERBOSE(wl, "Obtained preferred scale, %f, from the compositor.\n",
                wl->pending_scaling);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -75,6 +75,7 @@ struct vo_wayland_state {
     bool hidden;
     bool initial_size_hint;
     bool locked_size;
+    bool need_rescale;
     bool reconfigured;
     bool scale_configured;
     bool state_change;
@@ -84,6 +85,7 @@ struct vo_wayland_state {
     int mouse_x;
     int mouse_y;
     int pending_vo_events;
+    double pending_scaling;
     double scaling;
     int timeout_count;
     int wakeup_pipe[2];


### PR DESCRIPTION
See commit message for full details.

This unfortunately has a really bizarre bug on specifically sway 1.9 (sway master works well), so this will have to be a draft for that reason alone. Try to move a window to another monitor with a different scale value using the hotkey shortcuts and only the border appears to move and not the actual mpv buffer. No idea how the code changes here could cause that.