### PR TITLE
DOCS/man/input.rst: mention demuxer-readahead-secs in sub-seek

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -788,7 +788,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
     For embedded subtitles (like with Matroska), this works only with subtitle
     events that have already been displayed, or are within a short prefetch
-    range.
+    range (``--demuxer-readahead-secs``).
 
 ``print-text <text>``
     Print text to stdout. The string can contain properties (see


### PR DESCRIPTION
sub-seek often didn't work, and the "short prefetch range" is rather vague. I had to read the source to find out that increasing demuxer-readahead-secs would be the solution.

Simple enough of a change, but maybe will save someone else some time and confusion.