### PR TITLE
wayland: enforce a state change after a reconfigure

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2620,22 +2620,23 @@ bool vo_wayland_reconfig(struct vo *vo)
     if (wl->opts->configure_bounds)
         set_window_bounds(wl);
 
-    if (!wl->geometry_configured || !wl->locked_size) {
-        wl->geometry = wl->window_size;
-        wl->geometry_configured = true;
-    }
-
     if (wl->vo_opts->cursor_passthrough)
         set_input_region(wl, true);
 
-    if (wl->vo_opts->fullscreen)
-        toggle_fullscreen(wl);
+    if (!wl->geometry_configured || !wl->locked_size)
+        wl->geometry = wl->window_size;
 
-    if (wl->vo_opts->window_maximized)
-        toggle_maximized(wl);
+    if (!wl->geometry_configured) {
+        if (wl->vo_opts->fullscreen)
+            toggle_fullscreen(wl);
 
-    if (wl->vo_opts->window_minimized)
-        do_minimize(wl);
+        if (wl->vo_opts->window_maximized)
+            toggle_maximized(wl);
+
+        if (wl->vo_opts->window_minimized)
+            do_minimize(wl);
+        wl->geometry_configured = true;
+    }
 
     prepare_resize(wl);
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -75,6 +75,7 @@ struct vo_wayland_state {
     bool hidden;
     bool initial_size_hint;
     bool locked_size;
+    bool reconfigured;
     bool scale_configured;
     bool state_change;
     bool tiled;


### PR DESCRIPTION
If mpv is coming out of some locked size state (fullscreen, maximized, tiled), the window size given by the reconfigure event should be used assuming the --auto-window-size option is set.

Fixes 8a9749b8a563f258342450160c98e9c02ebedc96

@na-na-hi: I'm not sure what specific example you had in mind with that commit but does this affect that? I made this change about as conservative as possible.