### PR TITLE
stats.lua: show osd-dimensions property

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -862,18 +862,23 @@ local function add_video_out(s)
         scale = mp.get_property_native("current-window-scale")
     end
 
-    local r = mp.get_property_native("video-target-params")
-    if not r then
-        local osd_dims = mp.get_property_native("osd-dimensions")
-        local scaled_width = osd_dims["w"] - osd_dims["ml"] - osd_dims["mr"]
-        local scaled_height = osd_dims["h"] - osd_dims["mt"] - osd_dims["mb"]
-        append_resolution(s, {w=scaled_width, h=scaled_height, s=scale},
-                          "Resolution:")
-        return
-    end
+    local od = mp.get_property_native("osd-dimensions")
+    local rt = mp.get_property_native("video-target-params")
+    r = rt or {}
 
     -- Add window scale
     r["s"] = scale
+    r["crop-x"] = od["ml"]
+    r["crop-y"] = od["mt"]
+    r["crop-w"] = od["w"] - od["ml"] - od["mr"]
+    r["crop-h"] = od["h"] - od["mt"] - od["mb"]
+
+    if not rt then
+        r["w"] = r["crop-w"]
+        r["h"] = r["crop-h"]
+        append_resolution(s, r, "Resolution:", "w", "h", true)
+        return
+    end
 
     append_img_params(s, r)
     append_hdr(s, r, true)


### PR DESCRIPTION
This change displays the scaled position and size of the image before cropping to the target rectangle. In simple terms, it shows how much margin has been added to the image or how much of the image has been cropped.

Note that target resolution is displayed after crop as in fact all other pixels are discarded anyway.