### PR TITLE
wayland: fix segfault in surface_handle_enter due to memory read

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -957,7 +957,8 @@ static void surface_handle_enter(void *data, struct wl_surface *wl_surface,
         update_output_geometry(wl, old_geometry, old_output_geometry);
 
     MP_VERBOSE(wl, "Surface entered output %s %s (0x%x), scale = %f, refresh rate = %f Hz\n",
-               o->make, o->model, o->id, wl->scaling, o->refresh_rate);
+               wl->current_output->make, wl->current_output->model,
+               wl->current_output->id, wl->scaling, wl->current_output->refresh_rate);
 
     wl->pending_vo_events |= VO_EVENT_WIN_STATE;
 }


### PR DESCRIPTION
Fixes: 895f40e150d4 ("wayland: only perform a rescale if window is on one output")

Fixes #13887