### PR TITLE
stats.lua: add graph border width and vidscale options

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -183,6 +183,11 @@ Configurable Options
 
     Border color used for drawing graphs.
 
+``plot_bg_border_width``
+    Default: 0.5
+
+    Border width used for drawing graphs.
+
 ``plot_bg_color``
     Default: 262626
 

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -198,6 +198,12 @@ Configurable Options
 
     Color used for drawing graphs.
 
+``vidscale``
+    Default: yes
+
+    Scale the text and graphs with the video.
+    ``no`` tries to keep the sizes constant.
+
 Note: colors are given as hexadecimal values and use ASS tag order: BBGGRR
 (blue green red).
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -47,6 +47,7 @@ local o = {
     plot_bg_border_color = "0000FF",
     plot_bg_color = "262626",
     plot_color = "FFFFFF",
+    plot_bg_border_width = 0.5,
 
     -- Text style
     font = "",
@@ -235,8 +236,8 @@ local function generate_graph(values, i, len, v_max, v_avg, scale, x_tics)
 
     s[#s+1] = format("%f %f %f %f", x, y_max, 0, y_max)
 
-    local bg_box = format("{\\bord0.5}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
-                          o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
+    local bg_box = format("{\\bord%f}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
+                          o.plot_bg_border_width, o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
     return format("%s{\\rDefault}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
                   o.prefix_sep, y_offset, bg_box, o.plot_color, table.concat(s), text_style())
 end

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -237,7 +237,7 @@ local function generate_graph(values, i, len, v_max, v_avg, scale, x_tics)
 
     local bg_box = format("{\\bord0.5}{\\3c&H%s&}{\\1c&H%s&}m 0 %f l %f %f %f 0 0 0",
                           o.plot_bg_border_color, o.plot_bg_color, y_max, x_max, y_max, x_max)
-    return format("%s{\\r}{\\rDefault}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
+    return format("%s{\\rDefault}{\\pbo%f}{\\shad0}{\\alpha&H00}{\\p1}%s{\\p0}{\\bord0}{\\1c&H%s}{\\p1}%s{\\p0}%s",
                   o.prefix_sep, y_offset, bg_box, o.plot_color, table.concat(s), text_style())
 end
 


### PR DESCRIPTION
This adds two new options to `stats.lua`:

- `plot_bg_border_width` to control the border width of graphs
- `vidscale` to allow contents staying at constant size instead of being scaled with video, similar to the `vidscale` option for the OSC. 
