### PR TITLE
player/misc: fix audio-only fallback when video init fails

### DIFF
--- a/player/misc.c
+++ b/player/misc.c
@@ -252,7 +252,8 @@ void error_on_track(struct MPContext *mpctx, struct track *track)
     if (track->type == STREAM_VIDEO)
         MP_INFO(mpctx, "Video: no video\n");
     if (mpctx->opts->stop_playback_on_init_failure ||
-        !(mpctx->vo_chain || mpctx->ao_chain))
+        (!mpctx->current_track[0][STREAM_AUDIO] &&
+         !mpctx->current_track[0][STREAM_VIDEO]))
     {
         if (!mpctx->stop_play)
             mpctx->stop_play = PT_ERROR;


### PR DESCRIPTION
`--stop-playback-on-init-failure=no` is documented to continue playback in audio-only mode if video init fails. However, this does not function properly after a0804329927904fdeb70d9712ff23baaab161bb4: because video is initialized first, if video init fails, `ao_chain` is still null. As a result, `!(mpctx->vo_chain || mpctx->ao_chain)` is true, a playback error is raised, so the playback ends and audio does not play.

Fix this by reverting that change, so it checks the tracks instead.

Fixes: a0804329927904fdeb70d9712ff23baaab161bb4
