### PR TITLE
video/out/gpu/context: convert `--gpu-context` to use `obj_settings_list`

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -557,7 +557,7 @@ Suffix        Meaning
 -pre          Prepend 1 or more items (same syntax as -set)
 -clr          Clear the option (remove all items)
 -remove       Delete item if present (does not interpret escapes)
--toggle       Append an item, or remove if if it already exists (no escapes)
+-toggle       Append an item, or remove it if it already exists (no escapes)
 ============= ===============================================
 
 ``-append`` is meant as a simple way to append a single item without having
@@ -591,23 +591,24 @@ appropriate structured data type.
 
 Prior to mpv 0.33, ``:`` was also recognized as separator by ``-set``.
 
-Filter options
-~~~~~~~~~~~~~~
+Object settings list options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a very complex option type for the ``--af`` and ``--vf`` options only.
-They often require complicated escaping. See `VIDEO FILTERS`_ for details. They
-support the following operations:
+This is a very complex option type for some options, such as ``--af`` and ``--vf``.
+They often require complicated escaping. See `VIDEO FILTERS`_ for details.
+
+They support the following operations:
 
 ============= ===============================================
 Suffix        Meaning
 ============= ===============================================
--set          Set a list of filters (using ``,`` as separator)
--append       Append single filter
--add          Append 1 or more filters (same syntax as -set)
--pre          Prepend 1 or more filters (same syntax as -set)
--clr          Clear the option (remove all filters)
--remove       Delete filter if present
--toggle       Append a filter, or remove if if it already exists
+-set          Set a list of items (using ``,`` as separator)
+-append       Append single item
+-add          Append 1 or more items (same syntax as -set)
+-pre          Prepend 1 or more items (same syntax as -set)
+-clr          Clear the option (remove all items)
+-remove       Delete item if present
+-toggle       Append an item, or remove it if it already exists
 -help         Pseudo operation that prints a help text to the terminal
 ============= ===============================================
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6385,13 +6385,15 @@ them.
 ``--gpu-sw``
     Continue even if a software renderer is detected.
 
-``--gpu-context=<sys>``
-    The value ``auto`` (the default) selects the GPU context. You can also pass
-    ``help`` to get a complete list of compiled in backends (sorted by
-    autoprobe order).
+``--gpu-context=<context1,context2,...[,]>``
+    Specify a priority list of the GPU contexts to be used.
+    The value ``auto`` (the default) selects the GPU context with the default autoprobe
+    order. You can also pass ``help`` to get a complete list of compiled in backends
+    (sorted by the default autoprobe order).
 
     auto
-        auto-select (default)
+        auto-select (default). Note that this context must be used alone and
+        does not participate in the priority list.
     win
         Win32/WGL
     winvk

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -3166,7 +3166,7 @@ print_help: ;
     } else if (list->print_unknown_entry_help) {
         list->print_unknown_entry_help(log, mp_tprintf(80, "%.*s", BSTR_P(name)));
     } else {
-        mp_warn(log, "Option %.*s: item %.*s doesn't exist.\n",
+        mp_warn(log, "Option %.*s: item '%.*s' isn't supported.\n",
                BSTR_P(opt_name), BSTR_P(name));
     }
     r = M_OPT_EXIT;
@@ -3221,7 +3221,7 @@ static int parse_obj_settings(struct mp_log *log, struct bstr opt, int op,
     int idx = bstrspn(*pstr, NAMECH);
     str = bstr_splice(*pstr, 0, idx);
     if (!str.len) {
-        mp_err(log, "Option %.*s: filter name expected.\n", BSTR_P(opt));
+        mp_err(log, "Option %.*s: item name expected.\n", BSTR_P(opt));
         return M_OPT_INVALID;
     }
     *pstr = bstr_cut(*pstr, idx);
@@ -3238,7 +3238,7 @@ static int parse_obj_settings(struct mp_log *log, struct bstr opt, int op,
         char name[80];
         snprintf(name, sizeof(name), "%.*s", BSTR_P(str));
         if (list->check_unknown_entry && !list->check_unknown_entry(name)) {
-            mp_err(log, "Option %.*s: %.*s doesn't exist.\n",
+            mp_err(log, "Option %.*s: '%.*s' isn't supported.\n",
                    BSTR_P(opt), BSTR_P(str));
             return M_OPT_INVALID;
         }
@@ -3332,15 +3332,15 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
                 "  %s-set\n"
                 " Overwrite the old list with the given list\n\n"
                 "  %s-append\n"
-                " Append the given filter to the current list\n\n"
+                " Append the given item to the current list\n\n"
                 "  %s-add\n"
                 " Append the given list to the current list\n\n"
                 "  %s-pre\n"
                 " Prepend the given list to the current list\n\n"
                 "  %s-remove\n"
-                " Remove the given filter from the current list\n\n"
+                " Remove the given item from the current list\n\n"
                 "  %s-toggle\n"
-                " Add the filter to the list, or remove it if it's already added.\n\n"
+                " Add the item to the list, or remove it if it's already added.\n\n"
                 "  %s-clr\n"
                 " Clear the current list.\n\n",
                 opt->name, opt->name, opt->name, opt->name, opt->name,
@@ -3420,7 +3420,7 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
 
     if (op != OP_NONE && res && res[0].name && res[1].name) {
         if (op == OP_APPEND) {
-            mp_err(log, "Option %.*s: -append takes only 1 filter (no ',').\n",
+            mp_err(log, "Option %.*s: -append takes only 1 item (no ',').\n",
                    BSTR_P(name));
             free_obj_settings_list(&res);
             return M_OPT_INVALID;

--- a/player/command.c
+++ b/player/command.c
@@ -7306,7 +7306,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     }
 
     if (opt_ptr == &opts->vo->video_driver_list ||
-        opt_ptr == &opts->ra_ctx_opts->context_name ||
+        opt_ptr == &opts->ra_ctx_opts->context_list ||
         opt_ptr == &opts->ra_ctx_opts->context_type) {
         struct track *track = mpctx->current_track[0][STREAM_VIDEO];
         uninit_video_out(mpctx);

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -547,6 +547,7 @@ bool ra_d3d11_ctx_prefer_8bit_output_format(struct ra_ctx *ra)
 const struct ra_ctx_fns ra_ctx_d3d11 = {
     .type               = "d3d11",
     .name               = "d3d11",
+    .description        = "Direct3D 11",
     .reconfig           = d3d11_reconfig,
     .control            = d3d11_control,
     .update_render_opts = d3d11_update_render_opts,

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -147,6 +147,7 @@ static bool get_desc(struct m_obj_desc *dst, int index)
     const struct ra_ctx_fns *ctx = contexts[index];
     *dst = (struct m_obj_desc) {
         .name = ctx->name,
+        .description = ctx->description,
     };
     return true;
 }

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -34,6 +34,7 @@ struct ra_ctx {
 struct ra_ctx_fns {
     const char *type; // API type (for --gpu-api)
     const char *name; // name (for --gpu-context)
+    const char *description; // description (for --gpu-context=help)
 
     // Resize the window, or create a new window if there isn't one yet.
     // Currently, there is an unfortunate interaction with ctx->vo, and

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -10,7 +10,7 @@ struct ra_ctx_opts {
     bool want_alpha;      // create an alpha framebuffer if possible
     bool debug;           // enable debugging layers/callbacks etc.
     bool probing;        // the backend was auto-probed
-    char *context_name;  // filter by `ra_ctx_fns.name`
+    struct m_obj_settings *context_list; // list of `ra_ctx_fns.name` to probe
     char *context_type;  // filter by `ra_ctx_fns.type`
 };
 

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -35,8 +35,6 @@ struct ra_ctx_fns {
     const char *type; // API type (for --gpu-api)
     const char *name; // name (for --gpu-context)
 
-    bool hidden; // hide the ra_ctx from users
-
     // Resize the window, or create a new window if there isn't one yet.
     // Currently, there is an unfortunate interaction with ctx->vo, and
     // display size etc. are determined by it.

--- a/video/out/opengl/context_android.c
+++ b/video/out/opengl/context_android.c
@@ -123,6 +123,7 @@ static int android_control(struct ra_ctx *ctx, int *events, int request, void *a
 const struct ra_ctx_fns ra_ctx_android = {
     .type           = "opengl",
     .name           = "android",
+    .description    = "Android/EGL",
     .reconfig       = android_reconfig,
     .control        = android_control,
     .init           = android_init,

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -646,6 +646,7 @@ static int angle_control(struct ra_ctx *ctx, int *events, int request, void *arg
 const struct ra_ctx_fns ra_ctx_angle = {
     .type           = "opengl",
     .name           = "angle",
+    .description    = "Win32/ANGLE (via Direct3D)",
     .init           = angle_init,
     .reconfig       = angle_reconfig,
     .control        = angle_control,

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -739,6 +739,7 @@ static void drm_egl_wakeup(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_drm_egl = {
     .type           = "opengl",
     .name           = "drm",
+    .description    = "DRM/EGL",
     .reconfig       = drm_egl_reconfig,
     .control        = drm_egl_control,
     .init           = drm_egl_init,

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -598,6 +598,7 @@ static int dxgl_control(struct ra_ctx *ctx, int *events, int request,
 const struct ra_ctx_fns ra_ctx_dxgl = {
     .type         = "opengl",
     .name         = "dxinterop",
+    .description  = "WGL rendering/Direct3D 9Ex presentation",
     .init         = dxgl_init,
     .reconfig     = dxgl_reconfig,
     .control      = dxgl_control,

--- a/video/out/opengl/context_glx.c
+++ b/video/out/opengl/context_glx.c
@@ -342,6 +342,7 @@ static void glx_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
 const struct ra_ctx_fns ra_ctx_glx = {
     .type           = "opengl",
     .name           = "x11",
+    .description    = "X11/GLX",
     .reconfig       = glx_reconfig,
     .control        = glx_control,
     .wakeup         = glx_wakeup,

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -220,6 +220,7 @@ static bool wayland_egl_init(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_wayland_egl = {
     .type               = "opengl",
     .name               = "wayland",
+    .description        = "Wayland/EGL",
     .reconfig           = wayland_egl_reconfig,
     .control            = wayland_egl_control,
     .wakeup             = wayland_egl_wakeup,

--- a/video/out/opengl/context_win.c
+++ b/video/out/opengl/context_win.c
@@ -380,6 +380,7 @@ static void wgl_update_render_opts(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_wgl = {
     .type               = "opengl",
     .name               = "win",
+    .description        = "Win32/WGL",
     .init               = wgl_init,
     .reconfig           = wgl_reconfig,
     .control            = wgl_control,

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -216,6 +216,7 @@ static void mpegl_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
 const struct ra_ctx_fns ra_ctx_x11_egl = {
     .type           = "opengl",
     .name           = "x11egl",
+    .description    = "X11/EGL",
     .reconfig       = mpegl_reconfig,
     .control        = mpegl_control,
     .wakeup         = mpegl_wakeup,

--- a/video/out/vulkan/context_android.c
+++ b/video/out/vulkan/context_android.c
@@ -89,6 +89,7 @@ static int android_control(struct ra_ctx *ctx, int *events, int request, void *a
 const struct ra_ctx_fns ra_ctx_vulkan_android = {
     .type           = "vulkan",
     .name           = "androidvk",
+    .description    = "Android/Vulkan",
     .reconfig       = android_reconfig,
     .control        = android_control,
     .init           = android_init,

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -486,6 +486,7 @@ static void display_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
 const struct ra_ctx_fns ra_ctx_vulkan_display = {
     .type           = "vulkan",
     .name           = "displayvk",
+    .description    = "VK_KHR_display",
     .reconfig       = display_reconfig,
     .control        = display_control,
     .wakeup         = display_wakeup,

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -128,6 +128,7 @@ static int mac_vk_control(struct ra_ctx *ctx, int *events, int request, void *ar
 const struct ra_ctx_fns ra_ctx_vulkan_mac = {
     .type           = "vulkan",
     .name           = "macvk",
+    .description    = "mac/Vulkan (via Metal)",
     .reconfig       = mac_vk_reconfig,
     .control        = mac_vk_control,
     .init           = mac_vk_init,

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -157,6 +157,7 @@ static void wayland_vk_update_render_opts(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_vulkan_wayland = {
     .type               = "vulkan",
     .name               = "waylandvk",
+    .description        = "Wayland/Vulkan",
     .reconfig           = wayland_vk_reconfig,
     .control            = wayland_vk_control,
     .wakeup             = wayland_vk_wakeup,

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -107,6 +107,7 @@ static void win_update_render_opts(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_vulkan_win = {
     .type               = "vulkan",
     .name               = "winvk",
+    .description        = "Win32/Vulkan",
     .reconfig           = win_reconfig,
     .control            = win_control,
     .update_render_opts = win_update_render_opts,

--- a/video/out/vulkan/context_xlib.c
+++ b/video/out/vulkan/context_xlib.c
@@ -134,6 +134,7 @@ static void xlib_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
 const struct ra_ctx_fns ra_ctx_vulkan_xlib = {
     .type           = "vulkan",
     .name           = "x11vk",
+    .description    = "X11/Vulkan",
     .reconfig       = xlib_reconfig,
     .control        = xlib_control,
     .wakeup         = xlib_wakeup,

--- a/video/out/wldmabuf/context_wldmabuf.c
+++ b/video/out/wldmabuf/context_wldmabuf.c
@@ -37,7 +37,6 @@ static bool init(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_wldmabuf = {
     .type               = "none",
     .name               = "wldmabuf",
-    .hidden             = true,
     .init               = init,
     .uninit             = uninit,
 };

--- a/video/out/wldmabuf/context_wldmabuf.c
+++ b/video/out/wldmabuf/context_wldmabuf.c
@@ -37,6 +37,7 @@ static bool init(struct ra_ctx *ctx)
 const struct ra_ctx_fns ra_ctx_wldmabuf = {
     .type               = "none",
     .name               = "wldmabuf",
+    .description        = "Wayland/DMA-BUF",
     .init               = init,
     .uninit             = uninit,
 };


### PR DESCRIPTION
Since the list of available GPU contexts is a compile time constant, use `obj_settings_list` instead of `opt_string_validate` for GPU contexts. This has several advantages:

- Aligns with the existing usage of vo, ao, and filter lists.
- Allows custom probing order.
- Allows list option suffixes. (`--gpu-context-append`, etc.)
- Allows autocomplete in `console.lua`.
- Uses the standard `obj_settings_list` help printing, so detailed descriptions of the contexts are printed and the custom help printing function is no longer needed.