### PR TITLE
stats.lua: display file tags

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7169,10 +7169,10 @@ Miscellaneous
 -------------
 
 ``--display-tags=tag1,tags2,...``
-    Set the list of tags that should be displayed on the terminal. Tags that
-    are in the list, but are not present in the played file, will not be shown.
-    If a value ends with ``*``, all tags are matched by prefix (though there
-    is no general globbing). Just passing ``*`` essentially filtering.
+    Set the list of tags that should be displayed on the terminal and stats.
+    Tags that are in the list, but are not present in the played file, will not
+    be shown. If a value ends with ``*``, all tags are matched by prefix (though
+    there is no general globbing). Just passing ``*`` essentially filtering.
 
     The default includes a common list of tags, call mpv with ``--list-options``
     to see it.

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -93,6 +93,16 @@ Configurable Options
     respective duration. This can result in overlapping text when multiple
     scripts decide to print text at the same time.
 
+``file_tag_max_length``
+    Default: 128
+
+    Only show file tags shorter than this length, in bytes.
+
+``file_tag_max_count``
+    Default: 16
+
+    Only show the first specified amount of file tags.
+
 ``term_width_limit``
     Default: -1
 


### PR DESCRIPTION
This adds file tags to display along with the title, including album/artist etc. for music, and series etc. for some videos. The list of tags to display is identical to the tags printed to the terminal and is controlled by the `--display-tags` option.
