### PR TITLE
external_files: detect locales with a region like en-US

### DIFF
--- a/misc/language.h
+++ b/misc/language.h
@@ -20,8 +20,11 @@
 #ifndef MP_LANGUAGE_H
 #define MP_LANGUAGE_H
 
+#include "misc/bstr.h"
+
 // Result numerically higher => better match. 0 == no match.
 int mp_match_lang(char **langs, const char *lang);
 char **mp_get_user_langs(void);
+bstr mp_guess_lang_from_filename(bstr name, int *lang_start);
 
 #endif /* MP_LANGUAGE_H */

--- a/player/command.c
+++ b/player/command.c
@@ -67,6 +67,7 @@
 #include "options/path.h"
 #include "screenshot.h"
 #include "misc/dispatch.h"
+#include "misc/language.h"
 #include "misc/node.h"
 #include "misc/thread_pool.h"
 #include "misc/thread_tools.h"
@@ -6005,7 +6006,7 @@ static void cmd_track_reload(void *p)
     struct track *nt = mpctx->tracks[nt_num];
 
     if (!nt->lang)
-        nt->lang = mp_guess_lang_from_filename(nt, nt->external_filename);
+        nt->lang = bstrto0(nt, mp_guess_lang_from_filename(bstr0(nt->external_filename), NULL));
 
     mp_switch_track(mpctx, nt->type, nt, 0);
     print_track_list(mpctx, "Reloaded:");

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -108,36 +108,36 @@ static int compare_sub_priority(const void *a, const void *b)
     return strcoll(s1->fname, s2->fname);
 }
 
-static struct bstr guess_lang_from_filename(struct bstr name, int *fn_start)
+static struct bstr guess_lang_from_filename(struct bstr name, int *lang_start)
 {
     if (name.len < 2)
         return (struct bstr){NULL, 0};
 
-    int n = 0;
+    int lang_length = 0;
     int i = name.len - 1;
 
-    char thing = '.';
+    char delimiter = '.';
     if (name.start[i] == ')') {
-        thing = '(';
+        delimiter = '(';
         i--;
     }
     if (name.start[i] == ']') {
-        thing = '[';
+        delimiter = '[';
         i--;
     }
 
     while (i >= 0 && mp_isalpha(name.start[i])) {
-        n++;
-        if (n > 3)
+        lang_length++;
+        if (lang_length > 3)
             return (struct bstr){NULL, 0};
         i--;
     }
 
-    if (n < 2 || i == 0 || name.start[i] != thing)
+    if (lang_length < 2 || i == 0 || name.start[i] != delimiter)
         return (struct bstr){NULL, 0};
 
-    *fn_start = i;
-    return (struct bstr){name.start + i + 1, n};
+    *lang_start = i;
+    return (struct bstr){name.start + i + 1, lang_length};
 }
 
 char *mp_guess_lang_from_filename(void* ctx, const char *filename)

--- a/player/external_files.h
+++ b/player/external_files.h
@@ -34,6 +34,5 @@ struct subfn *find_external_files(struct mpv_global *global, const char *fname,
 
 bool mp_might_be_subtitle_file(const char *filename);
 void mp_update_subtitle_exts(struct MPOpts *opts);
-char *mp_guess_lang_from_filename(void *talloc_ctx, const char *filename);
 
 #endif /* MPLAYER_FINDFILES_H */

--- a/test/language.c
+++ b/test/language.c
@@ -54,4 +54,27 @@ int main(void)
     assert_int_equal(mp_match_lang(LANGS("ax")            , NULL)            , 0);
     assert_int_equal(mp_match_lang(LANGS("")              , "ax")            , 0);
     assert_int_equal(mp_match_lang((char*[]){NULL}        , "ax")            , 0);
+
+    void *ta_ctx = talloc_new(NULL);
+    int start; // this is actually the position of the delimiter.
+
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en.srt"), &start)), "en");
+    assert_int_equal(start, 3);
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.eng.srt"), NULL)), "eng");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.e.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.engg.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.00.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0(NULL), NULL)), "");
+
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-US.srt"), NULL)), "en-US");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-simple.srt"), NULL)), "en-simple");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.sgn-FSL.srt"), NULL)), "sgn-FSL");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.gsw-u-sd-chzh.srt"), NULL)), "gsw-u-sd-chzh");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-US-.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-aaaaaaaaa.srt"), NULL)), "");
+    assert_string_equal(bstrto0(ta_ctx, mp_guess_lang_from_filename(bstr0("foo.en-0.srt"), NULL)), "");
+
+    talloc_free(ta_ctx);
 }


### PR DESCRIPTION
commit 1: external_files: rename variables in guess_lang_from_filename()

commit 2: external_files: detect locales with a region like en-US

This loads subtitle files like foo.en-US.srt with --sub-auto=exact.

To preserve the case of these locales and not convert them to e.g. en-us, stop lower casing filenames, and instead use case insensitive functions to check if the media filename is contained in the external filenames. Extensions, whitelisted cover art filenames and idx files were already being compared case insensitively.

Fixes #12372, fixes #13251.
