### PR TITLE
Revert "ao_coreaudio: signal buffer underruns"

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -89,6 +89,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
 
     int64_t end = mp_time_ns();
     end += p->hw_latency_ns + ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
+    // don't use the returned sample count since CoreAudio always expects full frames
     ao_read_data(ao, planes, frames, end);
     return noErr;
 }

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -89,14 +89,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
 
     int64_t end = mp_time_ns();
     end += p->hw_latency_ns + ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
-    int samples = ao_read_data(ao, planes, frames, end);
-
-    if (samples == 0)
-        *aflags |= kAudioUnitRenderAction_OutputIsSilence;
-
-    for (int n = 0; n < buffer_list->mNumberBuffers; n++)
-        buffer_list->mBuffers[n].mDataByteSize = samples * ao->sstride;
-
+    ao_read_data(ao, planes, frames, end);
     return noErr;
 }
 


### PR DESCRIPTION
This reverts commit 0341a6f1d39801160322d3fe16245f8387735f4b.
Fixes #13348.

We've discussed it in #13902.