### PR TITLE
DOCS/man: refer to "mp.options functions" for script config docs

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -123,7 +123,7 @@ Configuration
 
 This script can be customized through a config file ``script-opts/console.conf``
 placed in mpv's user directory and through the ``--script-opts`` command-line
-option. The configuration syntax is described in `ON SCREEN CONTROLLER`_.
+option. The configuration syntax is described in `mp.options functions`_.
 
 Key bindings can be changed in a standard way, see for example stats.lua
 documentation.

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -130,22 +130,9 @@ del             Cycles visibility between never / auto (mouse-move) / always
 Configuration
 -------------
 
-The OSC offers limited configuration through a config file
-``script-opts/osc.conf`` placed in mpv's user dir and through the
-``--script-opts`` command-line option. Options provided through the command-line
-will override those from the config file.
-
-Config Syntax
-~~~~~~~~~~~~~
-
-The config file must exactly follow the following syntax::
-
-    # this is a comment
-    optionA=value1
-    optionB=value2
-
-``#`` can only be used at the beginning of a line and there may be no
-spaces around the ``=`` or anywhere else.
+This script can be customized through a config file ``script-opts/osc.conf``
+placed in mpv's user directory and through the ``--script-opts`` command-line
+option. The configuration syntax is described in `mp.options functions`_.
 
 Command-line Syntax
 ~~~~~~~~~~~~~~~~~~~

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -43,7 +43,7 @@ Configuration
 
 This script can be customized through a config file ``script-opts/stats.conf``
 placed in mpv's user directory and through the ``--script-opts`` command-line
-option. The configuration syntax is described in `ON SCREEN CONTROLLER`_.
+option. The configuration syntax is described in `mp.options functions`_.
 
 Configurable Options
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Currently they refer to the OSC documentation. However, the "mp.options functions" already documents that, is more detailed, and does not contain false statements like "there may be no spaces around the ``=`` or anywhere else" (the primitive parser does not care about them, so starting a string option value with spaces is perfectly fine).

Change them to refer to "mp.options functions" and remove the redundant section in the OSC documentation.
