### PR TITLE
ao: EOF handling for pull-based AO

### DIFF
--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -564,7 +564,7 @@ static MP_THREAD_VOID ao_thread(void *arg)
             int64_t ts = mp_time_ns();
             ts += MP_TIME_S_TO_NS(read_samples / (double)(ao->samplerate));
             ts += MP_TIME_S_TO_NS(AudioTrack_getLatency(ao));
-            int samples = ao_read_data_nonblocking(ao, &p->chunk, read_samples, ts);
+            int samples = ao_read_data(ao, &p->chunk, read_samples, ts, NULL, false, false);
             int ret = AudioTrack_write(ao, samples * ao->sstride);
             if (ret >= 0) {
                 p->written_frames += ret / ao->sstride;

--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -97,7 +97,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
     int64_t end = mp_time_ns();
     end += MP_TIME_S_TO_NS(p->device_latency);
     end += ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
-    ao_read_data(ao, planes, frames, end);
+    ao_read_data(ao, planes, frames, end, NULL, true, true);
     return noErr;
 }
 

--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -77,7 +77,7 @@ static void feed(struct ao *ao)
     int64_t end_time_av = MPMAX(p->end_time_av, cur_time_av);
     int64_t time_delta = CMTimeGetNanoseconds(CMTimeMake(request_sample_count, samplerate));
     bool eof;
-    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, &eof, false, false);
+    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, &eof, false, true);
     if (eof) {
         [p->renderer stopRequestingMediaData];
         ao_stop_streaming(ao);

--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -76,7 +76,7 @@ static void feed(struct ao *ao)
     int64_t cur_time_mp = mp_time_ns();
     int64_t end_time_av = MPMAX(p->end_time_av, cur_time_av);
     int64_t time_delta = CMTimeGetNanoseconds(CMTimeMake(request_sample_count, samplerate));
-    int real_sample_count = ao_read_data_nonblocking(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta);
+    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, NULL, false, false);
     if (real_sample_count == 0) {
         // avoid spinning by blocking the thread
         mp_sleep_ns(10000000);

--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -76,11 +76,14 @@ static void feed(struct ao *ao)
     int64_t cur_time_mp = mp_time_ns();
     int64_t end_time_av = MPMAX(p->end_time_av, cur_time_av);
     int64_t time_delta = CMTimeGetNanoseconds(CMTimeMake(request_sample_count, samplerate));
-    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, NULL, false, false);
+    bool eof;
+    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, &eof, false, false);
+    if (eof) {
+        [p->renderer stopRequestingMediaData];
+        ao_stop_streaming(ao);
+    }
     if (real_sample_count == 0) {
-        // avoid spinning by blocking the thread
-        mp_sleep_ns(10000000);
-        goto finish;
+        return;
     }
 
     if ((err = CMBlockBufferCreateWithMemoryBlock(

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -90,7 +90,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
     int64_t end = mp_time_ns();
     end += p->hw_latency_ns + ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
     // don't use the returned sample count since CoreAudio always expects full frames
-    ao_read_data(ao, planes, frames, end);
+    ao_read_data(ao, planes, frames, end, NULL, true, true);
     return noErr;
 }
 

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -181,7 +181,7 @@ static OSStatus render_cb_compressed(
     end += p->hw_latency_ns + ca_get_latency(ts)
         + ca_frames_to_ns(ao, pseudo_frames);
 
-    ao_read_data(ao, &buf.mData, pseudo_frames, end);
+    ao_read_data(ao, &buf.mData, pseudo_frames, end, NULL, true, true);
 
     if (p->spdif_hack)
         bad_hack_mygodwhy(buf.mData, pseudo_frames * ao->channels.num);

--- a/audio/out/ao_jack.c
+++ b/audio/out/ao_jack.c
@@ -125,7 +125,7 @@ static int process(jack_nframes_t nframes, void *arg)
     int64_t end_time = mp_time_ns();
     end_time += MP_TIME_S_TO_NS((jack_latency + nframes) / (double)ao->samplerate);
 
-    ao_read_data(ao, buffers, nframes, end_time);
+    ao_read_data(ao, buffers, nframes, end_time, NULL, true, true);
 
     return 0;
 }

--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -81,7 +81,7 @@ static void buffer_callback(SLBufferQueueItf buffer_queue, void *context)
     delay = p->frames_per_enqueue / (double)ao->samplerate;
     delay += p->audio_latency;
     ao_read_data(ao, &p->buf, p->frames_per_enqueue,
-        mp_time_ns() + MP_TIME_S_TO_NS(delay));
+        mp_time_ns() + MP_TIME_S_TO_NS(delay), NULL, true, true);
 
     res = (*buffer_queue)->Enqueue(buffer_queue, p->buf, p->bytes_per_enqueue);
     if (res != SL_RESULT_SUCCESS)

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -206,7 +206,8 @@ static void on_process(void *userdata)
 #endif
     end_time -= pw_stream_get_nsec(p->stream) - time.now;
 
-    int samples = ao_read_data(ao, data, nframes, end_time, NULL, false, false);
+    bool eof;
+    int samples = ao_read_data(ao, data, nframes, end_time, &eof, false, false);
     b->size = samples;
 
     for (int i = 0; i < buf->n_datas; i++) {
@@ -216,6 +217,11 @@ static void on_process(void *userdata)
     }
 
     pw_stream_queue_buffer(p->stream, b);
+
+    if (eof) {
+        pw_stream_flush(p->stream, true);
+        ao_stop_streaming(ao);
+    }
 
     MP_TRACE(ao, "queued %d of %d samples\n", samples, nframes);
 }

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -206,7 +206,7 @@ static void on_process(void *userdata)
 #endif
     end_time -= pw_stream_get_nsec(p->stream) - time.now;
 
-    int samples = ao_read_data_nonblocking(ao, data, nframes, end_time);
+    int samples = ao_read_data(ao, data, nframes, end_time, NULL, false, false);
     b->size = samples;
 
     for (int i = 0; i < buf->n_datas; i++) {

--- a/audio/out/ao_sdl.c
+++ b/audio/out/ao_sdl.c
@@ -61,7 +61,7 @@ static void audio_callback(void *userdata, Uint8 *stream, int len)
     // fixed latency.
     double delay = 2 * len / (double)ao->bps;
 
-    ao_read_data(ao, data, len / ao->sstride, mp_time_ns() + MP_TIME_S_TO_NS(delay));
+    ao_read_data(ao, data, len / ao->sstride, mp_time_ns() + MP_TIME_S_TO_NS(delay), NULL, true, true);
 }
 
 static void uninit(struct ao *ao)

--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -268,6 +268,16 @@ int ao_read_data_converted(struct ao *ao, struct ao_convert_fmt *fmt,
     return res;
 }
 
+// Called by pull-based AO to indicate the AO has stopped requesting more data,
+// usually when EOF is got from ao_read_data().
+// After this function is called, the core will call ao->driver->start() again
+// when more audio data after EOF arrives.
+void ao_stop_streaming(struct ao *ao)
+{
+    struct buffer_state *p = ao->buffer_state;
+    p->streaming = false;
+}
+
 int ao_control(struct ao *ao, enum aocontrol cmd, void *arg)
 {
     struct buffer_state *p = ao->buffer_state;

--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -179,12 +179,12 @@ static int read_buffer(struct ao *ao, void **data, int samples, bool *eof,
 }
 
 static int ao_read_data_locked(struct ao *ao, void **data, int samples,
-                               int64_t out_time_ns, bool pad_silence)
+                               int64_t out_time_ns, bool *eof, bool pad_silence)
 {
     struct buffer_state *p = ao->buffer_state;
     assert(!ao->driver->write);
 
-    int pos = read_buffer(ao, data, samples, &(bool){0}, pad_silence);
+    int pos = read_buffer(ao, data, samples, eof, pad_silence);
 
     if (pos > 0)
         p->end_time_ns = out_time_ns;
@@ -207,29 +207,23 @@ static int ao_read_data_locked(struct ao *ao, void **data, int samples,
 // If this is called in paused mode, it will always return 0.
 // The caller should set out_time_ns to the expected delay until the last sample
 // reaches the speakers, in nanoseconds, using mp_time_ns() as reference.
-int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns)
+int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns, bool *eof, bool pad_silence, bool blocking)
 {
     struct buffer_state *p = ao->buffer_state;
 
-    mp_mutex_lock(&p->lock);
+    if (blocking) {
+        mp_mutex_lock(&p->lock);
+    } else if (mp_mutex_trylock(&p->lock)) {
+        return 0;
+    }
 
-    int pos = ao_read_data_locked(ao, data, samples, out_time_ns, true);
+    bool eof_buf;
+    if (eof == NULL) {
+        // This is a public API. We want to reduce the cognitive burden of the caller.
+        eof = &eof_buf;
+    }
 
-    mp_mutex_unlock(&p->lock);
-
-    return pos;
-}
-
-// Like ao_read_data() but does not block and also may return partial data.
-// Callers have to check the return value.
-int ao_read_data_nonblocking(struct ao *ao, void **data, int samples, int64_t out_time_ns)
-{
-    struct buffer_state *p = ao->buffer_state;
-
-    if (mp_mutex_trylock(&p->lock))
-            return 0;
-
-    int pos = ao_read_data_locked(ao, data, samples, out_time_ns, false);
+    int pos = ao_read_data_locked(ao, data, samples, out_time_ns, eof, pad_silence);
 
     mp_mutex_unlock(&p->lock);
 
@@ -245,7 +239,7 @@ int ao_read_data_converted(struct ao *ao, struct ao_convert_fmt *fmt,
     void *ndata[MP_NUM_CHANNELS] = {0};
 
     if (!ao_need_conversion(fmt))
-        return ao_read_data(ao, data, samples, out_time_ns);
+        return ao_read_data(ao, data, samples, out_time_ns, NULL, true, true);
 
     assert(ao->format == fmt->src_fmt);
     assert(ao->channels.num == fmt->channels);
@@ -265,7 +259,7 @@ int ao_read_data_converted(struct ao *ao, struct ao_convert_fmt *fmt,
     for (int n = 0; n < planes; n++)
         ndata[n] = p->convert_buffer + n * src_plane_size;
 
-    int res = ao_read_data(ao, ndata, samples, out_time_ns);
+    int res = ao_read_data(ao, ndata, samples, out_time_ns, NULL, true, true);
 
     ao_convert_inplace(fmt, ndata, samples);
     for (int n = 0; n < planes; n++)

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -234,4 +234,6 @@ void ao_wakeup(struct ao *ao);
 int ao_read_data_converted(struct ao *ao, struct ao_convert_fmt *fmt,
                            void **data, int samples, int64_t out_time_ns);
 
+void ao_stop_streaming(struct ao *ao);
+
 #endif

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -201,9 +201,7 @@ struct ao_driver {
 
 // These functions can be called by AOs.
 
-int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns);
-MP_WARN_UNUSED_RESULT
-int ao_read_data_nonblocking(struct ao *ao, void **data, int samples, int64_t out_time_ns);
+int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns, bool *eof, bool pad_silence, bool blocking);
 
 bool ao_chmap_sel_adjust(struct ao *ao, const struct mp_chmap_sel *s,
                          struct mp_chmap *map);


### PR DESCRIPTION
As we've previously discussed in #13902, a mechanism for pull-based AO to know EOF is needed. This PR addresses this by adding an `eof` out param to `ao_read_data`. The AO can know whether EOF has been reached by checking its value and do proper EOF handling like stop requesting more data.

Meanwhile, to reduce code duplication, this PR merges `ao_read_data` and `ao_read_data_nonblocking` into a unified interface. `ao_read_data` now accepts three more arguments: `bool *eof, bool pad_silence, bool blocking`. I have not touched `ao_read_data_converted` yet; maybe it can also be unified.

This is a draft: I have only implemented EOF handling in `ao_avfoundation`. Work need to be done for other AOs. Also, proper handling of audio frames after EOF is WIP.