### PR TITLE
scaletempo2: fix audio corruption after input buffer resize

### DIFF
--- a/audio/filter/af_scaletempo2_internals.c
+++ b/audio/filter/af_scaletempo2_internals.c
@@ -534,7 +534,7 @@ int mp_scaletempo2_fill_input_buffer(struct mp_scaletempo2 *p,
 
     int required_size = read + p->input_buffer_frames;
     if (required_size > p->input_buffer_size)
-        resize_input_buffer(p, required_size);
+        grow_input_buffer(p, MPMAX(required_size, p->input_buffer_size * 1.5));
 
     for (int i = 0; i < p->channels; ++i) {
         memcpy(p->input_buffer[i] + p->input_buffer_frames,


### PR DESCRIPTION
I noticed audio clicks when increasing playback speed a lot. I found every time the input buffer grew, the buffered audio was corrupted. Because uninitialized memory is involved, there is some randomness to it. The initial `input_buffer` size is pretty generous, so it doesn't happen at "humane" speeds. In my tests it started around 15x.

In theory this happened whenever the speed is set very high for the first time, but the only reliable way I have found to reproduce it is with my mpv-skipsilence script with very aggressive profile ("extreme" profile [here](https://codeberg.org/ferreum/mpv-skipsilence/issues/2#issuecomment-1737227) with `speed_max=64`), setting the threshold high so it keeps skipping, and then repeatedly skipping backwards every half-second to re-initialize the filter. This could produce deafening noises. Of course the scaletempo2 filter should also be unlocked with `af-add=scaletempo2=max-speed=100` so it doesn't mute itself.

Because I debugged this I also noticed the buffer getting reallocated many times in small increments. I added a fix so it grows at least by 50%, which should reduce memmove operations without sacrificing much memory. The 50% measure is pretty common I think; the Java ArrayList comes to mind.