### PR TITLE
win32: make context menu items accessible from the window menu

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1988,6 +1988,7 @@ static MP_THREAD_VOID gui_thread(void *ptr)
         goto done;
     }
 
+    w32->menu_ctx = mp_win32_menu_init();
     update_dark_mode(w32);
     update_corners_pref(w32);
     if (w32->opts->window_affinity)
@@ -2061,6 +2062,8 @@ done:
     MP_VERBOSE(w32, "uninit\n");
 
     remove_parent_hook(w32);
+    if (w32->menu_ctx)
+        mp_win32_menu_uninit(w32->menu_ctx);
     if (w32->window && !w32->destroyed)
         DestroyWindow(w32->window);
     if (w32->taskbar_list)
@@ -2086,7 +2089,6 @@ bool vo_w32_init(struct vo *vo)
         .dispatch = mp_dispatch_create(w32),
     };
     w32->opts = w32->opts_cache->opts;
-    w32->menu_ctx = mp_win32_menu_init();
     vo->w32 = w32;
 
     if (mp_thread_create(&w32->thread, gui_thread, w32))
@@ -2369,7 +2371,6 @@ void vo_w32_uninit(struct vo *vo)
 
     AvRevertMmThreadCharacteristics(w32->avrt_handle);
 
-    mp_win32_menu_uninit(w32->menu_ctx);
     talloc_free(w32);
     vo->w32 = NULL;
 }

--- a/video/out/win32/menu.c
+++ b/video/out/win32/menu.c
@@ -25,6 +25,8 @@
 #include "menu.h"
 
 struct menu_ctx {
+    HWND  hwnd;
+    bool  updated;
     HMENU menu;
     void *ta_data; // talloc context for MENUITEMINFOW.dwItemData
 };
@@ -178,9 +180,11 @@ static void build_menu(void *talloc_ctx, HMENU hmenu, struct mpv_node *node)
     }
 }
 
-struct menu_ctx *mp_win32_menu_init(void)
+struct menu_ctx *mp_win32_menu_init(HWND hwnd)
 {
     struct menu_ctx *ctx = talloc_ptrtype(NULL, ctx);
+    ctx->hwnd = hwnd;
+    ctx->updated = false;
     ctx->menu = CreatePopupMenu();
     ctx->ta_data = talloc_new(ctx);
     return ctx;
@@ -218,6 +222,17 @@ void mp_win32_menu_update(struct menu_ctx *ctx, struct mpv_node *data)
     talloc_free_children(ctx->ta_data);
 
     build_menu(ctx->ta_data, ctx->menu, data);
+    if (!ctx->updated) {
+        append_menu(GetSystemMenu(ctx->hwnd, FALSE), MIIM_FTYPE, MFT_SEPARATOR, 0, NULL, NULL, NULL);
+        append_menu(GetSystemMenu(ctx->hwnd, FALSE), MIIM_STRING | MIIM_SUBMENU, 0, 0,
+                    build_title(ctx->ta_data, "mpv", NULL), ctx->menu, NULL);
+        ctx->updated = true;
+    } else if (data->format != MPV_FORMAT_NODE_ARRAY) {
+        // recreate ctx->menu because it is destroyed here
+        GetSystemMenu(ctx->hwnd, TRUE);
+        ctx->menu = CreatePopupMenu();
+        ctx->updated = false;
+    }
 }
 
 const char* mp_win32_menu_get_cmd(struct menu_ctx *ctx, UINT id)

--- a/video/out/win32/menu.h
+++ b/video/out/win32/menu.h
@@ -23,7 +23,7 @@
 struct mpv_node;
 struct menu_ctx;
 
-struct menu_ctx *mp_win32_menu_init(void);
+struct menu_ctx *mp_win32_menu_init(HWND hwnd);
 void mp_win32_menu_uninit(struct menu_ctx *ctx);
 void mp_win32_menu_show(struct menu_ctx *ctx, HWND hwnd);
 void mp_win32_menu_update(struct menu_ctx *ctx, struct mpv_node *data);


### PR DESCRIPTION
This makes the context menu items accessible from the window menu, which can be opened by either right-clicking on the title bar or left-clicking on the mpv icon on the title bar.