### PR TITLE
scripting: add mp.input.select()

### DIFF
--- a/DOCS/interface-changes/input-select.txt
+++ b/DOCS/interface-changes/input-select.txt
@@ -1,0 +1,1 @@
+`add mp.input.select()`

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -196,7 +196,9 @@ meta-paths like ``~~/foo`` (other JS file functions do expand meta paths).
 ``mp.options.read_options(obj [, identifier [, on_update]])`` (types:
 string/boolean/number)
 
-``mp.input.get(obj)`` (LE)
+``mp.input.get(obj)``
+
+``mp.input.select(obj)``
 
 ``mp.input.terminate()``
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -888,9 +888,8 @@ REPL.
         present a list of options with ``input.set_log()``.
 
     ``edited``
-        A callback invoked when the text changes. This can be used to filter a
-        list of options based on what the user typed with ``input.set_log()``,
-        like dmenu does. The first argument is the text in the console.
+        A callback invoked when the text changes. The first argument is the text
+        in the console.
 
     ``complete``
         A callback invoked when the user presses TAB. The first argument is the
@@ -950,6 +949,44 @@ REPL.
                 terminal_style = "\027[31m",
             }
         })
+
+``input.select(table)``
+    Specify a list of items that are presented to the user for selection. The
+    user can type part of the desired item and/or navigate them with
+    keybindings: ``Down`` and ``Ctrl+n`` go down, ``Up`` and ``Ctrl+p`` go up,
+    ``Page down`` and ``Ctrl+f`` scroll down one page, and ``Page up`` and
+    ``Ctrl+b`` scroll up one page.
+
+    The following entries of ``table`` are read:
+
+    ``prompt``
+        The string to be displayed before the input field.
+
+    ``items``
+        The table of the entries to choose from.
+
+    ``default_item``
+        The 1-based integer index of the preselected item.
+
+    ``submit``
+        The callback invoked when the user presses Enter. The first argument is
+        the 1-based index of the selected item. You can close the console from
+        within the callback by calling ``input.terminate()``.
+
+    Example:
+
+        ::
+
+            input.select({
+                items = {
+                    "First playlist entry",
+                    "Second playlist entry",
+                },
+                submit = function (id)
+                    mp.commandv("playlist-play-index", id - 1)
+                    input.terminate()
+                end,
+            })
 
 Events
 ------

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -646,6 +646,22 @@ mp.options = { read_options: read_options };
 /**********************************************************************
 *  input
 *********************************************************************/
+function register_event_handler(t) {
+    mp.register_script_message("input-event", function (type, text, cursor_position) {
+        if (t[type]) {
+            var result = t[type](text, cursor_position);
+
+            if (type == "complete" && result) {
+                mp.commandv("script-message-to", "console", "complete",
+                            JSON.stringify(result[0]), result[1]);
+            }
+        }
+
+        if (type == "closed")
+            mp.unregister_script_message("input-event");
+    })
+}
+
 mp.input = {
     get: function(t) {
         mp.commandv("script-message-to", "console", "get-input", mp.script_name,
@@ -656,23 +672,18 @@ mp.input = {
                         id: t.id,
                     }));
 
-        mp.register_script_message("input-event", function (type, text, cursor_position) {
-            if (t[type]) {
-                var result = t[type](text, cursor_position);
-
-                if (type == "complete" && result) {
-                    mp.commandv("script-message-to", "console", "complete",
-                                JSON.stringify(result[0]), result[1]);
-                }
-            }
-
-            if (type == "closed") {
-                mp.unregister_script_message("input-event");
-            }
-        })
-
-        return true;
+        register_event_handler(t)
     },
+    select: function () {
+        mp.commandv("script-message-to", "console", "get-input", mp.script_name,
+                    JSON.stringify({
+                        prompt: t.prompt,
+                        items: t.items,
+                        default_item: t.default_item,
+                    }));
+
+        register_event_handler(t)
+    }
     terminate: function () {
         mp.commandv("script-message-to", "console", "disable");
     },

--- a/player/lua.c
+++ b/player/lua.c
@@ -61,6 +61,9 @@ static const char * const builtin_lua_scripts[][2] = {
     {"mp.assdraw",
 #   include "player/lua/assdraw.lua.inc"
     },
+    {"mp.fzy",
+#   include "player/lua/fzy.lua.inc"
+    },
     {"mp.input",
 #   include "player/lua/input.lua.inc"
     },

--- a/player/lua/fzy.lua
+++ b/player/lua/fzy.lua
@@ -1,0 +1,297 @@
+--[[ The MIT License (MIT)
+
+Copyright (c) 2020 Seth Warn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. ]]
+
+-- The lua implementation of the fzy string matching algorithm
+
+local SCORE_GAP_LEADING = -0.005
+local SCORE_GAP_TRAILING = -0.005
+local SCORE_GAP_INNER = -0.01
+local SCORE_MATCH_CONSECUTIVE = 1.0
+local SCORE_MATCH_SLASH = 0.9
+local SCORE_MATCH_WORD = 0.8
+local SCORE_MATCH_CAPITAL = 0.7
+local SCORE_MATCH_DOT = 0.6
+local SCORE_MAX = math.huge
+local SCORE_MIN = -math.huge
+local MATCH_MAX_LENGTH = 1024
+
+local fzy = {}
+
+-- Check if `needle` is a subsequence of the `haystack`.
+--
+-- Usually called before `score` or `positions`.
+--
+-- Args:
+--   needle (string)
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   bool
+function fzy.has_match(needle, haystack, case_sensitive)
+  if not case_sensitive then
+    needle = string.lower(needle)
+    haystack = string.lower(haystack)
+  end
+
+  local j = 1
+  for i = 1, string.len(needle) do
+    j = string.find(haystack, needle:sub(i, i), j, true)
+    if not j then
+      return false
+    else
+      j = j + 1
+    end
+  end
+
+  return true
+end
+
+local function is_lower(c)
+  return c:match("%l")
+end
+
+local function is_upper(c)
+  return c:match("%u")
+end
+
+local function precompute_bonus(haystack)
+  local match_bonus = {}
+
+  local last_char = "/"
+  for i = 1, string.len(haystack) do
+    local this_char = haystack:sub(i, i)
+    if last_char == "/" or last_char == "\\" then
+      match_bonus[i] = SCORE_MATCH_SLASH
+    elseif last_char == "-" or last_char == "_" or last_char == " " then
+      match_bonus[i] = SCORE_MATCH_WORD
+    elseif last_char == "." then
+      match_bonus[i] = SCORE_MATCH_DOT
+    elseif is_lower(last_char) and is_upper(this_char) then
+      match_bonus[i] = SCORE_MATCH_CAPITAL
+    else
+      match_bonus[i] = 0
+    end
+
+    last_char = this_char
+  end
+
+  return match_bonus
+end
+
+local function compute(needle, haystack, D, M, case_sensitive)
+  -- Note that the match bonuses must be computed before the arguments are
+  -- converted to lowercase, since there are bonuses for camelCase.
+  local match_bonus = precompute_bonus(haystack)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if not case_sensitive then
+    needle = string.lower(needle)
+    haystack = string.lower(haystack)
+  end
+
+  -- Because lua only grants access to chars through substring extraction,
+  -- get all the characters from the haystack once now, to reuse below.
+  local haystack_chars = {}
+  for i = 1, m do
+    haystack_chars[i] = haystack:sub(i, i)
+  end
+
+  for i = 1, n do
+    D[i] = {}
+    M[i] = {}
+
+    local prev_score = SCORE_MIN
+    local gap_score = i == n and SCORE_GAP_TRAILING or SCORE_GAP_INNER
+    local needle_char = needle:sub(i, i)
+
+    for j = 1, m do
+      if needle_char == haystack_chars[j] then
+        local score = SCORE_MIN
+        if i == 1 then
+          score = ((j - 1) * SCORE_GAP_LEADING) + match_bonus[j]
+        elseif j > 1 then
+          local a = M[i - 1][j - 1] + match_bonus[j]
+          local b = D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE
+          score = math.max(a, b)
+        end
+        D[i][j] = score
+        prev_score = math.max(score, prev_score + gap_score)
+        M[i][j] = prev_score
+      else
+        D[i][j] = SCORE_MIN
+        prev_score = prev_score + gap_score
+        M[i][j] = prev_score
+      end
+    end
+  end
+end
+
+-- Compute a matching score.
+--
+-- Args:
+--   needle (string): must be a subequence of `haystack`, or the result is
+--     undefined.
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   number: higher scores indicate better matches. See also `get_score_min`
+--     and `get_score_max`.
+function fzy.score(needle, haystack, case_sensitive)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
+    return SCORE_MIN
+  elseif n == m then
+    return SCORE_MAX
+  else
+    local D = {}
+    local M = {}
+    compute(needle, haystack, D, M, case_sensitive)
+    return M[n][m]
+  end
+end
+
+-- Compute the locations where fzy matches a string.
+--
+-- Determine where each character of the `needle` is matched to the `haystack`
+-- in the optimal match.
+--
+-- Args:
+--   needle (string): must be a subequence of `haystack`, or the result is
+--     undefined.
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   {int,...}: indices, where `indices[n]` is the location of the `n`th
+--     character of `needle` in `haystack`.
+--   number: the same matching score returned by `score`
+function fzy.positions(needle, haystack, case_sensitive)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
+    return {}, SCORE_MIN
+  elseif n == m then
+    local consecutive = {}
+    for i = 1, n do
+      consecutive[i] = i
+    end
+    return consecutive, SCORE_MAX
+  end
+
+  local D = {}
+  local M = {}
+  compute(needle, haystack, D, M, case_sensitive)
+
+  local positions = {}
+  local match_required = false
+  local j = m
+  for i = n, 1, -1 do
+    while j >= 1 do
+      if D[i][j] ~= SCORE_MIN and (match_required or D[i][j] == M[i][j]) then
+        match_required = (i ~= 1) and (j ~= 1) and (
+        M[i][j] == D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE)
+        positions[i] = j
+        j = j - 1
+        break
+      else
+        j = j - 1
+      end
+    end
+  end
+
+  return positions, M[n][m]
+end
+
+-- Apply `has_match` and `positions` to an array of haystacks.
+--
+-- Args:
+--   needle (string)
+--   haystack ({string, ...})
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   {{idx, positions, score}, ...}: an array with one entry per matching line
+--     in `haystacks`, each entry giving the index of the line in `haystacks`
+--     as well as the equivalent to the return value of `positions` for that
+--     line.
+function fzy.filter(needle, haystacks, case_sensitive)
+  local result = {}
+
+  for i, line in ipairs(haystacks) do
+    if fzy.has_match(needle, line, case_sensitive) then
+      local p, s = fzy.positions(needle, line, case_sensitive)
+      table.insert(result, {i, p, s})
+    end
+  end
+
+  return result
+end
+
+-- The lowest value returned by `score`.
+--
+-- In two special cases:
+--  - an empty `needle`, or
+--  - a `needle` or `haystack` larger than than `get_max_length`,
+-- the `score` function will return this exact value, which can be used as a
+-- sentinel. This is the lowest possible score.
+function fzy.get_score_min()
+  return SCORE_MIN
+end
+
+-- The score returned for exact matches. This is the highest possible score.
+function fzy.get_score_max()
+  return SCORE_MAX
+end
+
+-- The maximum size for which `fzy` will evaluate scores.
+function fzy.get_max_length()
+  return MATCH_MAX_LENGTH
+end
+
+-- The minimum score returned for normal matches.
+--
+-- For matches that don't return `get_score_min`, their score will be greater
+-- than than this value.
+function fzy.get_score_floor()
+  return MATCH_MAX_LENGTH * SCORE_GAP_INNER
+end
+
+-- The maximum score for non-exact matches.
+--
+-- For matches that don't return `get_score_max`, their score will be less than
+-- this value.
+function fzy.get_score_ceiling()
+  return MATCH_MAX_LENGTH * SCORE_MATCH_CONSECUTIVE
+end
+
+-- The name of the currently-running implmenetation, "lua" or "native".
+function fzy.get_implementation_name()
+  return "lua"
+end
+
+return fzy

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -18,15 +18,7 @@ License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 local utils = require "mp.utils"
 local input = {}
 
-function input.get(t)
-    mp.commandv("script-message-to", "console", "get-input",
-                mp.get_script_name(), utils.format_json({
-                    prompt = t.prompt,
-                    default_text = t.default_text,
-                    cursor_position = t.cursor_position,
-                    id = t.id,
-                }))
-
+local function register_event_handler(t)
     mp.register_script_message("input-event", function (type, text, cursor_position)
         if t[type] then
             local suggestions, completion_start_position = t[type](text, cursor_position)
@@ -41,8 +33,29 @@ function input.get(t)
             mp.unregister_script_message("input-event")
         end
     end)
+end
 
-    return true
+function input.get(t)
+    mp.commandv("script-message-to", "console", "get-input",
+                mp.get_script_name(), utils.format_json({
+                    prompt = t.prompt,
+                    default_text = t.default_text,
+                    cursor_position = t.cursor_position,
+                    id = t.id,
+                }))
+
+    register_event_handler(t)
+end
+
+function input.select(t)
+    mp.commandv("script-message-to", "console", "get-input",
+                mp.get_script_name(), utils.format_json({
+                    prompt = t.prompt,
+                    items = t.items,
+                    default_item = t.default_item,
+                }))
+
+    register_event_handler(t)
 end
 
 function input.terminate()

--- a/player/lua/meson.build
+++ b/player/lua/meson.build
@@ -1,6 +1,6 @@
 lua_files = ['defaults.lua', 'assdraw.lua', 'options.lua', 'osc.lua',
              'ytdl_hook.lua', 'stats.lua', 'console.lua', 'auto_profiles.lua',
-             'input.lua']
+             'input.lua', 'fzy.lua']
 foreach file: lua_files
     lua_file = custom_target(file,
         input: join_paths(source_root, 'player', 'lua', file),


### PR DESCRIPTION
This allows scripts to make the user choose from a list of entries by typing part of their text and/or by navigating them with keybindings, like dmenu or fzf.

Closes #13964.

This is simple by reusing console.lua's code and even works in the terminal. I'm not sure if we should go with this or implement a more graphical menu. Example usage:

```lua
local input = require 'mp.input'
local default_item = 1

mp.add_key_binding('F1', function ()
    local playlist = {}
    for i, entry in ipairs(mp.get_property_native('playlist')) do
        local _, filename = require 'mp.utils'.split_path(entry.filename)
        playlist[i] = filename

        if entry.playing then
            default_item = i
        end
    end

    input.select({
        items = playlist,
        default_item = default_item,
        submit = function (id)
            mp.commandv('playlist-play-index', id - 1)
            input.terminate()
        end,
    })
end)
```