### PR TITLE
add defines at configure time for wayland protocol interface versions

### DIFF
--- a/TOOLS/wayland-interface-parse.py
+++ b/TOOLS/wayland-interface-parse.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Simple script to parse out interface names and version in wayland protocols
+for meson.
+"""
+
+#
+# This file is part of mpv.
+#
+# mpv is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# mpv is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import re
+import sys
+
+def parse_interface(line):
+    line = re.sub('[<">\n]', '', line.strip())
+    line = line.replace("interface name", "interface_name")
+    split = line.split()
+    interface = ""
+    for entry in split:
+        key, value = entry.split("=")
+        if key == "interface_name":
+            interface += value.upper() + "_VERSION "
+        if key == "version":
+            interface += value
+    return interface
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file>")
+        sys.exit(1)
+
+    interfaces = []
+    with open(sys.argv[1], 'r') as f:
+        for line in f:
+            if "interface name=" in line:
+                interfaces.append(parse_interface(line))
+    sys.stdout.write(','.join(interfaces))

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ project('mpv',
 
 build_root = meson.project_build_root()
 source_root = meson.project_source_root()
+conf_data = configuration_data()
 python = find_program('python3')
 
 # ffmpeg
@@ -1660,7 +1661,6 @@ endif
 
 
 # Set config.h
-conf_data = configuration_data()
 conf_data.set_quoted('CONFIGURATION', configuration)
 conf_data.set_quoted('DEFAULT_DVD_DEVICE', dvd_device)
 conf_data.set_quoted('DEFAULT_CDROM_DEVICE', cd_device)

--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -27,6 +27,14 @@ endif
 
 foreach p: protocols
     xml = join_paths(p)
+
+    wayland_interface_parse = find_program(join_paths(tools_directory, 'wayland-interface-parse.py'))
+    interfaces = run_command(wayland_interface_parse, xml, check: true).stdout().split(',')
+    foreach interface: interfaces
+        split = interface.split()
+        conf_data.set(split[0], split[1].to_int())
+    endforeach
+
     wl_protocols_source += custom_target(xml.underscorify() + '_c',
         input: xml,
         output: '@BASENAME@.c',

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1530,7 +1530,7 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
     }
 
     if (!strcmp(interface, xdg_wm_base_interface.name) && found++) {
-        ver = MPMIN(ver, 6); /* Cap at 6 in case new events are added later. */
+        ver = MPMIN(ver, XDG_WM_BASE_VERSION);
         wl->wm_base = wl_registry_bind(reg, id, &xdg_wm_base_interface, ver);
         xdg_wm_base_add_listener(wl->wm_base, &xdg_wm_base_listener, wl);
     }


### PR DESCRIPTION
Maybe this is overengineering it but it's kind of dumb to not have this information at configure time in the first place.