### PR TITLE
zsh-completion: complete --gpu-context

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -101,7 +101,7 @@ function _mpv_generate_arguments {
 
         entry+='->files'
 
-      elif [[ $name == (ao|vo|af|vf|profile|audio-device|vulkan-device) ]]; then
+      elif [[ $desc = 'Object settings list'* || $name == (profile|audio-device|vulkan-device) ]]; then
 
         entry+="->parse-help-$name"
 


### PR DESCRIPTION
This is made by possible by 96e1f1dfa5 standardizing --gpu-context's help output. This changes the check to complete any Object settings list so it will automatically work with future options of this kind.
