### PR TITLE
add multi-touch support

### DIFF
--- a/DOCS/interface-changes/input-touch-emulate-mouse.txt
+++ b/DOCS/interface-changes/input-touch-emulate-mouse.txt
@@ -1,0 +1,1 @@
+add --input-touch-emulate-mouse option

--- a/DOCS/interface-changes/native-touch.txt
+++ b/DOCS/interface-changes/native-touch.txt
@@ -1,0 +1,1 @@
+add --native-touch option

--- a/DOCS/interface-changes/touch-pos.txt
+++ b/DOCS/interface-changes/touch-pos.txt
@@ -1,0 +1,1 @@
+add `touch-pos` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2800,7 +2800,7 @@ Property list
     not being opened yet or not being supported by the VO.
 
 ``mouse-pos``
-    Read-only - last known mouse position, normalizd to OSD dimensions.
+    Read-only - last known mouse position, normalized to OSD dimensions.
 
     Has the following sub-properties (which can be read as ``MPV_FORMAT_NODE``
     or Lua table with ``mp.get_property_native``):
@@ -2812,6 +2812,35 @@ Property list
         Boolean - whether the mouse pointer hovers the video window. The
         coordinates should be ignored when this value is false, because the
         video backends update them only when the pointer hovers the window.
+
+``touch-pos``
+    Read-only - last known touch point positions, normalized to OSD dimensions.
+
+    This has a number of sub-properties. Replace ``N`` with the 0-based touch
+    point index. Whenever a new finger touches the screen, a new touch point is
+    added to the list of touch points with the smallest unused ``N`` available.
+
+    ``touch-pos/count``
+        Number of active touch points.
+
+    ``touch-pos/N/x``, ``touch-pos/N/y``
+        Position of the Nth touch point.
+
+    ``touch-pos/N/id``
+        Unique identifier of the touch point. This can be used to identify
+        individual touch points when their indexes change.
+
+    When querying the property with the client API using ``MPV_FORMAT_NODE``,
+    or with Lua ``mp.get_property_native``, this will return a mpv_node with
+    the following contents:
+
+    ::
+
+        MPV_FORMAT_NODE_ARRAY
+            MPV_FORMAT_NODE_MAP (for each touch point)
+                "x"        MPV_FORMAT_INT64
+                "y"        MPV_FORMAT_INT64
+                "id"       MPV_FORMAT_INT64
 
 ``sub-ass-extradata``
     The current ASS subtitle track's extradata. There is no formatting done.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4281,6 +4281,13 @@ Input
     disabled by default in libmpv as well - it should be enabled if you want
     the mpv default key bindings.
 
+``--input-touch-emulate-mouse=<yes|no>``
+    When multi-touch support is enabled (either required by the platform,
+    or enabled by ``--native-touch``), emulate mouse move and button presses
+    for the touch events (default: yes). This is useful for compatibility
+    for mouse key bindings and scripts which read mouse positions for platforms
+    which do not support ``--native-touch=no`` (e.g. Wayland).
+
 OSD
 ---
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4101,6 +4101,17 @@ Input
     Whether this applies depends on the VO backend and how it handles
     keyboard input. Does not apply to terminal input.
 
+``--native-touch=<yes|no>``
+    (Windows only)
+    For platforms which send emulated mouse inputs for touch-unaware clients,
+    such as Windows, use system native touch events, instead of receiving them
+    as emulated mouse events (default: no). This is required for multi-touch
+    support for these platforms.
+
+    Note that this option has no effect on other platforms: either native touch
+    is not supported by mpv, or the platform does not give an option to receive
+    emulated mouse inputs (so native touch is always enabled, e.g. Wayland).
+
 ``--input-ar-delay``
     Delay in milliseconds before we start to autorepeat a key (default: 200).
     Set it to 0 to disable.

--- a/input/input.c
+++ b/input/input.c
@@ -93,6 +93,11 @@ struct wheel_state {
     double unit_accum;
 };
 
+struct touch_point {
+    int id;
+    int x, y;
+};
+
 struct input_ctx {
     mp_mutex mutex;
     struct mp_log *log;
@@ -142,6 +147,10 @@ struct input_ctx {
     // List currently active command sections
     struct active_section *active_sections;
     int num_active_sections;
+
+    // List currently active touch points
+    struct touch_point *touch_points;
+    int num_touch_points;
 
     unsigned int mouse_event_counter;
 
@@ -894,6 +903,88 @@ void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y)
     input_unlock(ictx);
 }
 
+static int find_touch_point_index(struct input_ctx *ictx, int id)
+{
+    for (int i = 0; i < ictx->num_touch_points; i++) {
+        if (ictx->touch_points[i].id == id)
+            return i;
+    }
+    return -1;
+}
+
+static void notify_touch_update(struct input_ctx *ictx)
+{
+    // queue dummy cmd so that touch-pos can notify observers
+    mp_cmd_t *cmd = mp_input_parse_cmd(ictx, bstr0("ignore"), "<internal>");
+    queue_cmd(ictx, cmd);
+}
+
+static void update_touch_point(struct input_ctx *ictx, int idx, int id, int x, int y)
+{
+    MP_TRACE(ictx, "Touch point %d update (id %d) %d/%d\n",
+             idx, id, x, y);
+    if (ictx->touch_points[idx].x == x && ictx->touch_points[idx].y == y)
+        return;
+    ictx->touch_points[idx].x = x;
+    ictx->touch_points[idx].y = y;
+    notify_touch_update(ictx);
+}
+
+void mp_input_add_touch_point(struct input_ctx *ictx, int id, int x, int y)
+{
+    input_lock(ictx);
+    int idx = find_touch_point_index(ictx, id);
+    if (idx != -1) {
+        MP_WARN(ictx, "Touch point %d (id %d) already exists! Treat as update.\n",
+                idx, id);
+        update_touch_point(ictx, idx, id, x, y);
+    } else {
+        MP_TRACE(ictx, "Touch point %d add (id %d) %d/%d\n",
+                 ictx->num_touch_points, id, x, y);
+        MP_TARRAY_APPEND(ictx, ictx->touch_points, ictx->num_touch_points,
+                         (struct touch_point){id, x, y});
+        notify_touch_update(ictx);
+    }
+    input_unlock(ictx);
+}
+
+void mp_input_update_touch_point(struct input_ctx *ictx, int id, int x, int y)
+{
+    input_lock(ictx);
+    int idx = find_touch_point_index(ictx, id);
+    if (idx != -1) {
+        update_touch_point(ictx, idx, id, x, y);
+    } else {
+        MP_WARN(ictx, "Touch point id %d does not exist!\n", id);
+    }
+    input_unlock(ictx);
+}
+
+void mp_input_remove_touch_point(struct input_ctx *ictx, int id)
+{
+    input_lock(ictx);
+    int idx = find_touch_point_index(ictx, id);
+    if (idx != -1) {
+        MP_TRACE(ictx, "Touch point %d remove (id %d)\n", idx, id);
+        MP_TARRAY_REMOVE_AT(ictx->touch_points, ictx->num_touch_points, idx);
+        notify_touch_update(ictx);
+    }
+    input_unlock(ictx);
+}
+
+int mp_input_get_touch_pos(struct input_ctx *ictx, int count, int *x, int *y, int *id)
+{
+    input_lock(ictx);
+    int num_touch_points = ictx->num_touch_points;
+    for (int i = 0; i < MPMIN(num_touch_points, count); i++) {
+        x[i] = ictx->touch_points[i].x;
+        y[i] = ictx->touch_points[i].y;
+        id[i] = ictx->touch_points[i].id;
+    }
+    input_unlock(ictx);
+    return num_touch_points;
+}
+
 static bool test_mouse(struct input_ctx *ictx, int x, int y, int rej_flags)
 {
     bool res = false;
@@ -1348,6 +1439,7 @@ struct input_ctx *mp_input_init(struct mpv_global *global,
         .wakeup_cb = wakeup_cb,
         .wakeup_ctx = wakeup_ctx,
         .active_sections = talloc_array(ictx, struct active_section, 0),
+        .touch_points = talloc_array(ictx, struct touch_point, 0),
     };
 
     ictx->opts = ictx->opts_cache->opts;

--- a/input/input.c
+++ b/input/input.c
@@ -735,6 +735,11 @@ static void feed_key(struct input_ctx *ictx, int code, double scale,
         release_down_cmd(ictx, false);
         return;
     }
+    if (code == MP_TOUCH_RELEASE_ALL) {
+        MP_TRACE(ictx, "release all touch\n");
+        ictx->num_touch_points = 0;
+        return;
+    }
     if (!opts->enable_mouse_movements && MP_KEY_IS_MOUSE(unmod) && !force_mouse)
         return;
     if (unmod == MP_KEY_MOUSE_LEAVE || unmod == MP_KEY_MOUSE_ENTER) {

--- a/input/input.h
+++ b/input/input.h
@@ -102,6 +102,16 @@ void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y);
 
 void mp_input_get_mouse_pos(struct input_ctx *ictx, int *x, int *y, int *hover);
 
+// Add/Update/Remove a touch point (in window coordinates).
+void mp_input_add_touch_point(struct input_ctx *ictx, int id, int x, int y);
+void mp_input_update_touch_point(struct input_ctx *ictx, int id, int x, int y);
+void mp_input_remove_touch_point(struct input_ctx *ictx, int id);
+
+// Get the positions of the touch points. xs and ys are arrays of at least
+// count elements. ids is an array of at least count elements to uniquely
+// identify touch points. Return the current number of touch points.
+int mp_input_get_touch_pos(struct input_ctx *ictx, int count, int *xs, int *ys, int *ids);
+
 // Return whether we want/accept mouse input.
 bool mp_input_mouse_enabled(struct input_ctx *ictx);
 

--- a/input/keycodes.h
+++ b/input/keycodes.h
@@ -216,6 +216,8 @@
 #define MP_KEY_ANY_UNICODE      (MP_KEY_INTERN+5)
 // For mp_input_put_key(): release all keys that are down.
 #define MP_INPUT_RELEASE_ALL    (MP_KEY_INTERN+6)
+// For mp_input_put_key(): release all touch points.
+#define MP_TOUCH_RELEASE_ALL    (MP_KEY_INTERN+7)
 
 // Emit a command even on key-up (normally key-up is ignored). This means by
 // default they binding will be triggered on key-up instead of key-down.

--- a/options/options.c
+++ b/options/options.c
@@ -169,6 +169,7 @@ static const m_option_t mp_vo_opt_list[] = {
     {"keepaspect-window", OPT_BOOL(keepaspect_window)},
     {"hidpi-window-scale", OPT_BOOL(hidpi_window_scale)},
     {"native-fs", OPT_BOOL(native_fs)},
+    {"native-touch", OPT_BOOL(native_touch)},
     {"show-in-taskbar", OPT_BOOL(show_in_taskbar)},
     {"display-fps-override", OPT_DOUBLE(display_fps_override),
         M_RANGE(0, DBL_MAX)},

--- a/options/options.h
+++ b/options/options.h
@@ -56,6 +56,7 @@ typedef struct mp_vo_opts {
     bool keepaspect_window;
     bool hidpi_window_scale;
     bool native_fs;
+    bool native_touch;
     bool show_in_taskbar;
 
     int64_t WinID;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -568,19 +568,29 @@ static void begin_dragging(struct vo_w32_state *w32)
     mp_input_put_key(w32->input_ctx, MP_INPUT_RELEASE_ALL);
 }
 
-static bool handle_mouse_down(struct vo_w32_state *w32, int btn, int x, int y)
+// If native touch is enabled and the mouse event is emulated, ignore it.
+// See: <https://learn.microsoft.com/en-us/windows/win32/tablet/
+//       system-events-and-mouse-messages#distinguishing-pen-input-from-mouse-and-touch>
+static bool should_ignore_mouse_event(const struct vo_w32_state *w32)
 {
+    return w32->opts->native_touch && ((GetMessageExtraInfo() & 0xFFFFFF00) == 0xFF515700);
+}
+
+static void handle_mouse_down(struct vo_w32_state *w32, int btn, int x, int y)
+{
+    if (should_ignore_mouse_event(w32))
+        return;
     btn |= mod_state(w32);
     mp_input_put_key(w32->input_ctx, btn | MP_KEY_STATE_DOWN);
     SetCapture(w32->window);
-    return false;
 }
 
 static void handle_mouse_up(struct vo_w32_state *w32, int btn)
 {
+    if (should_ignore_mouse_event(w32))
+        return;
     btn |= mod_state(w32);
     mp_input_put_key(w32->input_ctx, btn | MP_KEY_STATE_UP);
-
     ReleaseCapture();
 }
 
@@ -1315,6 +1325,19 @@ static void update_cursor_passthrough(const struct vo_w32_state *w32)
     }
 }
 
+static void update_native_touch(const struct vo_w32_state *w32)
+{
+    if (w32->parent)
+        return;
+
+    if (w32->opts->native_touch) {
+        RegisterTouchWindow(w32->window, 0);
+    } else {
+        UnregisterTouchWindow(w32->window);
+        mp_input_put_key(w32->input_ctx, MP_TOUCH_RELEASE_ALL);
+    }
+}
+
 static void set_ime_conversion_mode(const struct vo_w32_state *w32, DWORD mode)
 {
     if (w32->parent)
@@ -1615,14 +1638,14 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         if (x != w32->mouse_x || y != w32->mouse_y) {
             w32->mouse_x = x;
             w32->mouse_y = y;
-            mp_input_set_mouse_pos(w32->input_ctx, x, y);
+            if (!should_ignore_mouse_event(w32))
+                mp_input_set_mouse_pos(w32->input_ctx, x, y);
         }
         break;
     }
     case WM_LBUTTONDOWN:
-        if (handle_mouse_down(w32, MP_MBTN_LEFT, GET_X_LPARAM(lParam),
-                                                 GET_Y_LPARAM(lParam)))
-            return 0;
+        handle_mouse_down(w32, MP_MBTN_LEFT, GET_X_LPARAM(lParam),
+                                             GET_Y_LPARAM(lParam));
         break;
     case WM_LBUTTONUP:
         handle_mouse_up(w32, MP_MBTN_LEFT);
@@ -1713,6 +1736,26 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
     case WM_SHOWMENU:
         mp_win32_menu_show(w32->menu_ctx, w32->window);
         break;
+    case WM_TOUCH: {
+        UINT count = LOWORD(wParam);
+        TOUCHINPUT *inputs = talloc_array_ptrtype(NULL, inputs, count);
+        if (GetTouchInputInfo((HTOUCHINPUT)lParam, count, inputs, sizeof(TOUCHINPUT))) {
+            for (UINT i = 0; i < count; i++) {
+                TOUCHINPUT *ti = &inputs[i];
+                POINT pt = {TOUCH_COORD_TO_PIXEL(ti->x), TOUCH_COORD_TO_PIXEL(ti->y)};
+                ScreenToClient(w32->window, &pt);
+                if (ti->dwFlags & TOUCHEVENTF_DOWN)
+                    mp_input_add_touch_point(w32->input_ctx, ti->dwID, pt.x, pt.y);
+                if (ti->dwFlags & TOUCHEVENTF_MOVE)
+                    mp_input_update_touch_point(w32->input_ctx, ti->dwID, pt.x, pt.y);
+                if (ti->dwFlags & TOUCHEVENTF_UP)
+                    mp_input_remove_touch_point(w32->input_ctx, ti->dwID);
+            }
+        }
+        CloseTouchInputHandle((HTOUCHINPUT)lParam);
+        talloc_free(inputs);
+        return 0;
+    }
     }
 
     if (message == w32->tbtn_created_msg) {
@@ -1996,6 +2039,8 @@ static MP_THREAD_VOID gui_thread(void *ptr)
         update_backdrop(w32);
     if (w32->opts->cursor_passthrough)
         update_cursor_passthrough(w32);
+    if (w32->opts->native_touch)
+        update_native_touch(w32);
 
     if (SUCCEEDED(OleInitialize(NULL))) {
         ole_ok = true;
@@ -2193,6 +2238,8 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
                 update_maximized_state(w32, false);
             } else if (changed_option == &vo_opts->window_corners) {
                 update_corners_pref(w32);
+            } else if (changed_option == &vo_opts->native_touch) {
+                update_native_touch(w32);
             } else if (changed_option == &vo_opts->geometry || changed_option == &vo_opts->autofit ||
                 changed_option == &vo_opts->autofit_smaller || changed_option == &vo_opts->autofit_larger)
             {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -440,19 +440,17 @@ static void touch_handle_down(void *data, struct wl_touch *wl_touch,
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
+    // Note: the position should still be saved here for VO dragging handling.
     wl->mouse_x = wl_fixed_to_int(x_w) * wl->scaling;
     wl->mouse_y = wl_fixed_to_int(y_w) * wl->scaling;
 
-    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
-    mp_input_put_key(wl->vo->input_ctx, MP_MBTN_LEFT | MP_KEY_STATE_DOWN);
+    mp_input_add_touch_point(wl->vo->input_ctx, id, wl->mouse_x, wl->mouse_y);
 
     enum xdg_toplevel_resize_edge edge;
     if (!mp_input_test_dragging(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y) &&
         !wl->locked_size && check_for_resize(wl, wl->opts->edge_pixels_touch, &edge))
     {
         xdg_toplevel_resize(wl->xdg_toplevel, s->seat, serial, edge);
-        // Explicitly send an UP event after the client finishes a resize
-        mp_input_put_key(wl->vo->input_ctx, MP_MBTN_LEFT | MP_KEY_STATE_UP);
     } else {
         // Save the serial and seat for voctrl-initialized dragging requests.
         s->pointer_button_serial = serial;
@@ -465,7 +463,7 @@ static void touch_handle_up(void *data, struct wl_touch *wl_touch,
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
-    mp_input_put_key(wl->vo->input_ctx, MP_MBTN_LEFT | MP_KEY_STATE_UP);
+    mp_input_remove_touch_point(wl->vo->input_ctx, id);
     wl->last_button_seat = NULL;
 }
 
@@ -478,7 +476,7 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
     wl->mouse_x = wl_fixed_to_int(x_w) * wl->scaling;
     wl->mouse_y = wl_fixed_to_int(y_w) * wl->scaling;
 
-    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+    mp_input_update_touch_point(wl->vo->input_ctx, id, wl->mouse_x, wl->mouse_y);
 }
 
 static void touch_handle_frame(void *data, struct wl_touch *wl_touch)
@@ -487,6 +485,9 @@ static void touch_handle_frame(void *data, struct wl_touch *wl_touch)
 
 static void touch_handle_cancel(void *data, struct wl_touch *wl_touch)
 {
+    struct vo_wayland_seat *s = data;
+    struct vo_wayland_state *wl = s->wl;
+    mp_input_put_key(wl->vo->input_ctx, MP_TOUCH_RELEASE_ALL);
 }
 
 static void touch_handle_shape(void *data, struct wl_touch *wl_touch,


### PR DESCRIPTION
Currently, mpv's input system has no real touch handling. Touch messages are either not requested, or very awkwardly translated to emulated mouse, which results in some bugs on Wayland and severely limits mpv's gesture recognition ability. 

This adds multi-touch support to mpv, in the form of added `touch-pos` property, and implements the support for Win32 and Wayland. The property contains the positions of all current touch points, each corresponds to a finger on the touch surface. Scripts can implement custom gesture recognition algorithms to process these values and determine the appropriate action to perform. 

For compatibility, `--input-touch-emulate-mouse` and `--native-touch` options are added to control whether touch events need to be emulated as mouse events. 

The following example script demonstrates the recognition of 2-finger vertical scroll gesture to control the video brightness:

```lua
local scroll = false
local y = 0
local brightness = 0

function ypos(points)
    return (points[1].y + points[2].y) / 2
end

function handle_scroll(name, points)
    if #points ~= 2 then
        scroll = false
    elseif scroll == false then
        scroll = true
        y = ypos(points)
        brightness = mp.get_property_native("brightness")
    else
        mp.set_property_native("brightness", brightness + (y - ypos(points)) / 5)
    end
end

mp.observe_property("touch-pos", "native", handle_scroll)
```