### PR TITLE
demux_mkv: support VVC matroska demux

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -184,6 +184,7 @@ static const struct format_hack format_hacks[] = {
     // In theory, such streams might contain timestamps, but virtually none do.
     {"h264", .if_flags = AVFMT_NOTIMESTAMPS },
     {"hevc", .if_flags = AVFMT_NOTIMESTAMPS },
+    {"vvc", .if_flags = AVFMT_NOTIMESTAMPS },
 
     // Some Ogg shoutcast streams are essentially concatenated OGG files. They
     // reset timestamps, which causes all sorts of problems.

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1461,6 +1461,7 @@ static const char *const mkv_video_tags[][2] = {
     {"V_DIRAC",             "dirac"},
     {"V_PRORES",            "prores"},
     {"V_MPEGH/ISO/HEVC",    "hevc"},
+    {"V_MPEGI/ISO/VVC",     "vvc"},
     {"V_SNOW",              "snow"},
     {"V_AV1",               "av1"},
     {"V_PNG",               "png"},


### PR DESCRIPTION
This allows to demux Versatile Video Codec with Matroska container to play, but MKV tag is V_QUICKTIME.

Feel free to reply or ask question to me. Thank you! :)

Sincerely,
- Martin Eesmaa