### PR TITLE
Avoid gpu wakeup in hwdec_cuda by deferring cuInit

### DIFF
--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -50,10 +50,13 @@ struct cuda_mapper_priv {
     void *ext[4];
 };
 
-typedef bool (*cuda_interop_init)(const struct ra_hwdec *hw);
+struct cuda_interop_fn {
+    bool (*check)(const struct ra_hwdec *hw);
+    bool (*init)(const struct ra_hwdec *hw);
+};
 
-bool cuda_gl_init(const struct ra_hwdec *hw);
+extern struct cuda_interop_fn cuda_gl_fn;
 
-bool cuda_vk_init(const struct ra_hwdec *hw);
+extern struct cuda_interop_fn cuda_vk_fn;
 
 int check_cu(const struct ra_hwdec *hw, CUresult err, const char *func);

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -107,14 +107,12 @@ static void cuda_ext_gl_uninit(const struct ra_hwdec_mapper *mapper, int n)
 #define CHECK_CU(x) check_cu(hw, (x), #x)
 
 static bool cuda_gl_check(const struct ra_hwdec *hw) {
-    if (ra_is_gl(hw->ra_ctx->ra)) {
-        GL *gl = ra_gl_get(hw->ra_ctx->ra);
-        if (gl->version < 210 && gl->es < 300) {
-            MP_VERBOSE(hw, "need OpenGL >= 2.1 or OpenGL-ES >= 3.0\n");
-            return false;
-        }
-    } else {
-        // This is not an OpenGL RA.
+    if (!ra_is_gl(hw->ra_ctx->ra))
+        return false; // This is not an OpenGL RA.
+
+    GL *gl = ra_gl_get(hw->ra_ctx->ra);
+    if (gl->version < 210 && gl->es < 300) {
+        MP_VERBOSE(hw, "need OpenGL >= 2.1 or OpenGL-ES >= 3.0\n");
         return false;
     }
 

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -106,11 +106,7 @@ static void cuda_ext_gl_uninit(const struct ra_hwdec_mapper *mapper, int n)
 #undef CHECK_CU
 #define CHECK_CU(x) check_cu(hw, (x), #x)
 
-bool cuda_gl_init(const struct ra_hwdec *hw) {
-    int ret = 0;
-    struct cuda_hw_priv *p = hw->priv;
-    CudaFunctions *cu = p->cu;
-
+static bool cuda_gl_check(const struct ra_hwdec *hw) {
     if (ra_is_gl(hw->ra_ctx->ra)) {
         GL *gl = ra_gl_get(hw->ra_ctx->ra);
         if (gl->version < 210 && gl->es < 300) {
@@ -121,6 +117,14 @@ bool cuda_gl_init(const struct ra_hwdec *hw) {
         // This is not an OpenGL RA.
         return false;
     }
+
+    return true;
+}
+
+static bool cuda_gl_init(const struct ra_hwdec *hw) {
+    int ret = 0;
+    struct cuda_hw_priv *p = hw->priv;
+    CudaFunctions *cu = p->cu;
 
     CUdevice display_dev;
     unsigned int device_count;
@@ -172,3 +176,8 @@ bool cuda_gl_init(const struct ra_hwdec *hw) {
 
     return true;
 }
+
+struct cuda_interop_fn cuda_gl_fn = {
+    .check = cuda_gl_check,
+    .init = cuda_gl_init
+};

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -274,18 +274,16 @@ static bool cuda_ext_vk_signal(const struct ra_hwdec_mapper *mapper, int n)
 
 static bool cuda_vk_check(const struct ra_hwdec *hw) {
     pl_gpu gpu = ra_pl_get(hw->ra_ctx->ra);
-    if (gpu != NULL) {
-        if (!(gpu->export_caps.tex & HANDLE_TYPE)) {
-            MP_VERBOSE(hw, "CUDA hwdec with Vulkan requires exportable texture memory of type 0x%X.\n",
-                       HANDLE_TYPE);
-            return false;
-        } else if (!(gpu->export_caps.sync & HANDLE_TYPE)) {
-            MP_VERBOSE(hw, "CUDA hwdec with Vulkan requires exportable semaphores of type 0x%X.\n",
-                       HANDLE_TYPE);
-            return false;
-        }
-    } else {
-        // This is not a Vulkan RA.
+    if (gpu == NULL)
+        return false; // This is not a Vulkan RA.
+
+    if (!(gpu->export_caps.tex & HANDLE_TYPE)) {
+        MP_VERBOSE(hw, "CUDA hwdec with Vulkan requires exportable texture memory of type 0x%X.\n",
+                   HANDLE_TYPE);
+        return false;
+    } else if (!(gpu->export_caps.sync & HANDLE_TYPE)) {
+        MP_VERBOSE(hw, "CUDA hwdec with Vulkan requires exportable semaphores of type 0x%X.\n",
+                   HANDLE_TYPE);
         return false;
     }
 

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -272,12 +272,7 @@ static bool cuda_ext_vk_signal(const struct ra_hwdec_mapper *mapper, int n)
 #undef CHECK_CU
 #define CHECK_CU(x) check_cu(hw, (x), #x)
 
-bool cuda_vk_init(const struct ra_hwdec *hw) {
-    int ret = 0;
-    int level = hw->probing ? MSGL_V : MSGL_ERR;
-    struct cuda_hw_priv *p = hw->priv;
-    CudaFunctions *cu = p->cu;
-
+static bool cuda_vk_check(const struct ra_hwdec *hw) {
     pl_gpu gpu = ra_pl_get(hw->ra_ctx->ra);
     if (gpu != NULL) {
         if (!(gpu->export_caps.tex & HANDLE_TYPE)) {
@@ -293,6 +288,16 @@ bool cuda_vk_init(const struct ra_hwdec *hw) {
         // This is not a Vulkan RA.
         return false;
     }
+
+    return true;
+}
+
+static bool cuda_vk_init(const struct ra_hwdec *hw) {
+    int ret = 0;
+    int level = hw->probing ? MSGL_V : MSGL_ERR;
+    struct cuda_hw_priv *p = hw->priv;
+    CudaFunctions *cu = p->cu;
+    pl_gpu gpu = ra_pl_get(hw->ra_ctx->ra);
 
     if (!cu->cuImportExternalMemory) {
         MP_MSG(hw, level, "CUDA hwdec with Vulkan requires driver version 410.48 or newer.\n");
@@ -342,3 +347,7 @@ bool cuda_vk_init(const struct ra_hwdec *hw) {
     return true;
 }
 
+struct cuda_interop_fn cuda_vk_fn = {
+    .check = cuda_vk_check,
+    .init = cuda_vk_init
+};


### PR DESCRIPTION
`cuInit` wakes up the nvidia dgpu on nvidia laptops. This is bad news because the wake up process
is blocking and takes a few seconds. It also needlessly increases power consumption.

Sometimes, a VO loads several hwdecs (like `dmabuf_wayland`). When `cuda` is loaded, it calls
`cuInit` before running all interop inits. However, the first checks in the interops do not
require cuda initialization, so we only need to call `cuInit` after those checks.

`cuInit` is handled by the new `cuda_priv_init` function. It ensures `cuInit` is only called once.

With these changes, there's no cuda initialization if no OpenGL/Vulkan backend is available. This prevents
`dmabuf_wayland` and other VOs which automatically load cuda from waking up the nvidia dgpu unnecessarily,
making them start faster and decreasing power consumption on laptops.

Fixes: https://github.com/mpv-player/mpv/issues/13668