### PR TITLE
wayland: set wl->scaling if there is no wl->current_output yet

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1010,6 +1010,9 @@ static void surface_handle_preferred_buffer_scale(void *data,
     // Update scaling now.
     if (single_output_spanned(wl))
         update_output_scaling(wl);
+
+    if (!wl->current_output)
+        wl->scaling = wl->pending_scaling;
 }
 
 static void surface_handle_preferred_buffer_transform(void *data,
@@ -1235,6 +1238,9 @@ static void preferred_scale(void *data,
     // Update scaling now.
     if (single_output_spanned(wl))
         update_output_scaling(wl);
+
+    if (!wl->current_output)
+        wl->scaling = wl->pending_scaling;
 }
 
 static const struct wp_fractional_scale_v1_listener fractional_scale_listener = {


### PR DESCRIPTION
If we get either preferred_scale or preferred_buffer_scale this early during initialization the wl->scaling value should be immediately updated instead of being deferred until later for correct geometry. Fixes #14019.