### PR TITLE
Revert "manpage: deprecate input section commands"

### DIFF
--- a/DOCS/interface-changes/undeprecate-input-sections.txt
+++ b/DOCS/interface-changes/undeprecate-input-sections.txt
@@ -1,0 +1,1 @@
+undeprecate input section commands

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1019,8 +1019,6 @@ Input Commands that are Possibly Subject to Change
     list yourself when adding a second key binding for cycling backwards.
 
 ``enable-section <name> [<flags>]``
-    This command is deprecated, except for mpv-internal uses.
-
     Enable all key bindings in the named input section.
 
     The enabled input sections form a stack. Bindings in sections on the top of
@@ -1043,13 +1041,9 @@ Input Commands that are Possibly Subject to Change
         Same.
 
 ``disable-section <name>``
-    This command is deprecated, except for mpv-internal uses.
-
     Disable the named input section. Undoes ``enable-section``.
 
 ``define-section <name> <contents> [<flags>]``
-    This command is deprecated, except for mpv-internal uses.
-
     Create a named input section, or replace the contents of an already existing
     input section. The ``contents`` parameter uses the same syntax as the
     ``input.conf`` file (except that using the section syntax in it is not


### PR DESCRIPTION
This reverts commit 13815bf25179da6dd450141fa6c1ab67a4b00b6b.

Input sections have been deprecated for 4 years, but no one but wm4 has shown interest in removing them, and he left the project.

With 28a4fb8e4e implementing touch support, if we are to properly support it we need to keep input sections to let multiple scripts listen to touches at the same time: (quoted from christoph-heinrich) "One thing that sections provide that's impossible to do without is that multiple scripts can listen to clicks at the same time. e.g. you can have a progress bar from one script at the bottom and a menu from some other script in the middle and they can both react to mbtn_left at the same time. With mouse input it doesn't really matter, because the scripts can conditionally bind based on the mouse position, but for touch input that's not possible"

They are also convenient for enabling different bindings to view images.

Though they have issues like
https://github.com/mpv-player/mpv/issues/11154 which need to be fixed.