### PR TITLE
f_decoder_wrapper: clear decoder info on deinit

### DIFF
--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -367,6 +367,8 @@ static void decf_destroy(struct mp_filter *f)
         MP_DBG(f, "Uninit decoder.\n");
         talloc_free(p->decoder->f);
         p->decoder = NULL;
+        p->codec->decoder = NULL;
+        p->codec->decoder_desc = NULL;
     }
 
     decf_reset(f);


### PR DESCRIPTION
It is not longer valid and may cause use-after-free if used after decoder itself is destroyed.

Fixes: #14051