### PR TITLE
command: return lavfi filters in option-info/[av]f/choices

### DIFF
--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -1124,6 +1124,22 @@ static void print_help_a(struct mp_log *log)
     print_help(log, AVMEDIA_TYPE_AUDIO, "audio", "--af=lavfi=[volume=0.5]");
 }
 
+const char **mp_get_lavfi_filters(void *talloc_ctx, int media_type)
+{
+    const char **filters = NULL;
+    void *iter = NULL;
+    int num = 0;
+    for (;;) {
+        const AVFilter *filter = av_filter_iterate(&iter);
+        if (!filter)
+            break;
+        if (is_usable(filter, media_type))
+            MP_TARRAY_APPEND(talloc_ctx, filters, num, filter->name);
+    }
+    MP_TARRAY_APPEND(talloc_ctx, filters, num, NULL);
+    return filters;
+}
+
 #define OPT_BASE_STRUCT struct lavfi_user_opts
 
 const struct mp_user_filter_entry af_lavfi = {

--- a/filters/f_lavfi.h
+++ b/filters/f_lavfi.h
@@ -40,3 +40,5 @@ void print_lavfi_help(struct mp_log *log, const char *name, int media_type);
 
 // Return whether the given filter exists and has the required media_type in/outs.
 bool mp_lavfi_is_usable(const char *name, int media_type);
+
+const char **mp_get_lavfi_filters(void *talloc_ctx, int media_type);

--- a/filters/user_filters.c
+++ b/filters/user_filters.c
@@ -63,6 +63,11 @@ static bool check_af_lavfi(const char *name)
     return check_unknown_entry(name, AVMEDIA_TYPE_AUDIO);
 }
 
+static const char **get_lavfi_audio_filters(void *talloc_ctx)
+{
+    return mp_get_lavfi_filters(talloc_ctx, AVMEDIA_TYPE_AUDIO);
+}
+
 const struct m_obj_list af_obj_list = {
     .get_desc = get_af_desc,
     .description = "audio filters",
@@ -70,6 +75,7 @@ const struct m_obj_list af_obj_list = {
     .check_unknown_entry = check_af_lavfi,
     .print_help_list = print_af_help_list,
     .print_unknown_entry_help = print_af_lavfi_help,
+    .get_lavfi_filters = get_lavfi_audio_filters,
 };
 
 // --vf option
@@ -119,6 +125,11 @@ static bool check_vf_lavfi(const char *name)
     return check_unknown_entry(name, AVMEDIA_TYPE_VIDEO);
 }
 
+static const char **get_lavfi_video_filters(void *talloc_ctx)
+{
+    return mp_get_lavfi_filters(talloc_ctx, AVMEDIA_TYPE_VIDEO);
+}
+
 const struct m_obj_list vf_obj_list = {
     .get_desc = get_vf_desc,
     .description = "video filters",
@@ -126,6 +137,7 @@ const struct m_obj_list vf_obj_list = {
     .check_unknown_entry = check_vf_lavfi,
     .print_help_list = print_vf_help_list,
     .print_unknown_entry_help = print_vf_lavfi_help,
+    .get_lavfi_filters = get_lavfi_video_filters,
 };
 
 // Create a bidir, single-media filter from command line arguments.

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -161,6 +161,8 @@ struct m_obj_list {
     void (*print_help_list)(struct mp_log *log);
     // Callback to print help for _unknown_ entries with "vf=entry=help"
     void (*print_unknown_entry_help)(struct mp_log *log, const char *name);
+    // Get lavfi filters for option-info/[av]f/choices.
+    const char **(*get_lavfi_filters)(void *talloc_ctx);
 };
 
 // Find entry by name

--- a/player/command.c
+++ b/player/command.c
@@ -3613,6 +3613,12 @@ static int mp_property_option_info(void *ctx, struct m_property *prop,
                     break;
                 MP_TARRAY_APPEND(NULL, choices, num, (char *)desc.name);
             }
+            if (objs->get_lavfi_filters) {
+                const char **filters = objs->get_lavfi_filters(choices);
+                for (int n = 0; filters[n]; n++) {
+                    MP_TARRAY_APPEND(NULL, choices, num, (char *)filters[n]);
+                }
+            }
             MP_TARRAY_APPEND(NULL, choices, num, NULL);
         }
 


### PR DESCRIPTION
This adds non-mpv filters to option-info/af/choices and option-info/vf/choices, which allows completing them with set af/vf \<Tab> in console.lua.

Partial fix of #13017. Getting the filter options would required adding af-list and vf-list properties.