### PR TITLE
ao: proper end_time calulation & ao_read_frame()

### DIFF
--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -157,6 +157,11 @@ Available audio output drivers are:
         if mpv is not started out of the bundle,
         though playback with spatial audio off always works.
 
+    Currently, due to the implementation of A/V compensation,
+    setting ``--video-sync`` to ``display-resample`` or ``display-vdrop``
+    can alleviate A/V drift on changing playback speed
+    when using this audio output driver.
+
 ``openal``
     OpenAL audio output driver.
 

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -162,6 +162,13 @@ Available audio output drivers are:
     can alleviate A/V drift on changing playback speed
     when using this audio output driver.
 
+    ``--avfoundation-buffer=<1-2000>``
+        Set the audio buffer size in milliseconds. A higher value buffers
+        more data, and has a lower probability of buffer underruns. A smaller
+        value makes the audio stream react faster, e.g. to playback speed
+        changes, soft volume change, and muting/unmuting.
+        The default is 2000ms, which is conservative.
+
 ``openal``
     OpenAL audio output driver.
 
@@ -190,7 +197,8 @@ Available audio output drivers are:
         Set the audio buffer size in milliseconds. A higher value buffers
         more data, and has a lower probability of buffer underruns. A smaller
         value makes the audio stream react faster, e.g. to playback speed
-        changes. "native" lets the sound server determine buffers.
+        changes, soft volume change, and muting/unmuting.
+        "native" lets the sound server determine buffers.
 
     ``--pulse-latency-hacks=<yes|no>``
         Enable hacks to workaround PulseAudio timing bugs (default: yes). If

--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -96,6 +96,7 @@ bool ao_untimed(struct ao *ao);
 int ao_control(struct ao *ao, enum aocontrol cmd, void *arg);
 void ao_set_gain(struct ao *ao, float gain);
 double ao_get_delay(struct ao *ao);
+double ao_get_playing_pts(struct ao *ao);
 void ao_reset(struct ao *ao);
 void ao_start(struct ao *ao);
 void ao_set_paused(struct ao *ao, bool paused, bool eof);

--- a/audio/out/ao_audiotrack.c
+++ b/audio/out/ao_audiotrack.c
@@ -562,7 +562,6 @@ static MP_THREAD_VOID ao_thread(void *arg)
         if (state == AudioTrack.PLAYSTATE_PLAYING) {
             int read_samples = p->chunksize / ao->sstride;
             int64_t ts = mp_time_ns();
-            ts += MP_TIME_S_TO_NS(read_samples / (double)(ao->samplerate));
             ts += MP_TIME_S_TO_NS(AudioTrack_getLatency(ao));
             int samples = ao_read_data(ao, &p->chunk, read_samples, ts, NULL, false, false);
             int ret = AudioTrack_write(ao, samples * ao->sstride);

--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -96,7 +96,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
 
     int64_t end = mp_time_ns();
     end += MP_TIME_S_TO_NS(p->device_latency);
-    end += ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
+    end += ca_get_latency(ts);
     ao_read_data(ao, planes, frames, end, NULL, true, true);
     return noErr;
 }

--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -75,9 +75,8 @@ static void feed(struct ao *ao)
     int64_t cur_time_av = CMTimeGetNanoseconds([p->synchronizer currentTime]);
     int64_t cur_time_mp = mp_time_ns();
     int64_t end_time_av = MPMAX(p->end_time_av, cur_time_av);
-    int64_t time_delta = CMTimeGetNanoseconds(CMTimeMake(request_sample_count, samplerate));
     bool eof;
-    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp + time_delta, &eof, false, true);
+    int real_sample_count = ao_read_data(ao, data, request_sample_count, end_time_av - cur_time_av + cur_time_mp, &eof, false, true);
     if (eof) {
         [p->renderer stopRequestingMediaData];
         ao_stop_streaming(ao);
@@ -127,7 +126,7 @@ static void feed(struct ao *ao)
 
     [p->renderer enqueueSampleBuffer:sample_buffer];
 
-    time_delta = CMTimeGetNanoseconds(CMTimeMake(real_sample_count, samplerate));
+    int64_t time_delta = CMTimeGetNanoseconds(CMTimeMake(real_sample_count, samplerate));
     p->end_time_av = end_time_av + time_delta;
 
     goto finish;

--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -92,7 +92,7 @@ static OSStatus render_cb_lpcm(void *ctx, AudioUnitRenderActionFlags *aflags,
         planes[n] = buffer_list->mBuffers[n].mData;
 
     int64_t end = mp_time_ns();
-    end += p->hw_latency_ns + ca_get_latency(ts) + ca_frames_to_ns(ao, frames);
+    end += p->hw_latency_ns + ca_get_latency(ts);
     // don't use the returned sample count since CoreAudio always expects full frames
     ao_read_data(ao, planes, frames, end, NULL, true, true);
     return noErr;

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -181,8 +181,7 @@ static OSStatus render_cb_compressed(
     }
 
     int64_t end = mp_time_ns();
-    end += p->hw_latency_ns + ca_get_latency(ts)
-        + ca_frames_to_ns(ao, pseudo_frames);
+    end += p->hw_latency_ns + ca_get_latency(ts);
 
     ao_read_data(ao, &buf.mData, pseudo_frames, end, NULL, true, true);
 

--- a/audio/out/ao_jack.c
+++ b/audio/out/ao_jack.c
@@ -122,7 +122,7 @@ static int process(jack_nframes_t nframes, void *arg)
         atomic_load(&p->graph_latency_max) + atomic_load(&p->buffer_size);
 
     int64_t end_time = mp_time_ns();
-    end_time += MP_TIME_S_TO_NS((jack_latency + nframes) / (double)ao->samplerate);
+    end_time += MP_TIME_S_TO_NS(jack_latency) / ao->samplerate;
 
     ao_read_data(ao, buffers, nframes, end_time, NULL, true, true);
 

--- a/audio/out/ao_opensles.c
+++ b/audio/out/ao_opensles.c
@@ -74,14 +74,11 @@ static void buffer_callback(SLBufferQueueItf buffer_queue, void *context)
     struct ao *ao = context;
     struct priv *p = ao->priv;
     SLresult res;
-    double delay;
 
     mp_mutex_lock(&p->buffer_lock);
 
-    delay = p->frames_per_enqueue / (double)ao->samplerate;
-    delay += p->audio_latency;
     ao_read_data(ao, &p->buf, p->frames_per_enqueue,
-        mp_time_ns() + MP_TIME_S_TO_NS(delay), NULL, true, true);
+        mp_time_ns() + MP_TIME_S_TO_NS(p->audio_latency), NULL, true, true);
 
     res = (*buffer_queue)->Enqueue(buffer_queue, p->buf, p->bytes_per_enqueue);
     if (res != SL_RESULT_SUCCESS)

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -193,7 +193,6 @@ static void on_process(void *userdata)
         time.rate.num = 1;
 
     int64_t end_time = mp_time_ns();
-    end_time += MP_TIME_S_TO_NS(nframes) / ao->samplerate;
     end_time += MP_TIME_S_TO_NS(time.delay) * time.rate.num / time.rate.denom;
     end_time += MP_TIME_S_TO_NS(time.queued) / ao->samplerate;
     end_time += MP_TIME_S_TO_NS(time.buffered) / ao->samplerate;

--- a/audio/out/ao_sdl.c
+++ b/audio/out/ao_sdl.c
@@ -57,9 +57,8 @@ static void audio_callback(void *userdata, Uint8 *stream, int len)
     if (len % ao->sstride)
         MP_ERR(ao, "SDL audio callback not sample aligned");
 
-    // Time this buffer will take, plus assume 1 period (1 callback invocation)
-    // fixed latency.
-    double delay = 2 * len / (double)ao->bps;
+    // assume 1 period (1 callback invocation) fixed latency.
+    double delay = len / (double)ao->bps;
 
     ao_read_data(ao, data, len / ao->sstride, mp_time_ns() + MP_TIME_S_TO_NS(delay), NULL, true, true);
 }

--- a/audio/out/ao_wasapi.c
+++ b/audio/out/ao_wasapi.c
@@ -120,8 +120,6 @@ static bool thread_feed(struct ao *ao)
     double delay_ns;
     hr = get_device_delay(state, &delay_ns);
     EXIT_ON_ERROR(hr);
-    // add the buffer delay
-    delay_ns += frame_count * 1e9 / state->format.Format.nSamplesPerSec;
 
     BYTE *pData;
     hr = IAudioRenderClient_GetBuffer(state->pRenderClient,

--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -554,7 +554,14 @@ void ao_set_paused(struct ao *ao, bool paused, bool eof)
                 ao->driver->set_pause(ao, true);
                 p->queued_time_ns = p->end_time_ns - mp_time_ns();
             } else {
-                p->end_time_ns = p->queued_time_ns + mp_time_ns();
+                int64_t new_end_time_ns = p->queued_time_ns + mp_time_ns();
+                double time_adjustment = MP_TIME_NS_TO_S(new_end_time_ns - p->end_time_ns);
+                p->end_time_ns = new_end_time_ns;
+
+                for (int i = 0; i < p->num_queued_aframes; i++) {
+                    p->queued_aframes[i].start_time += time_adjustment;
+                }
+
                 ao->driver->set_pause(ao, false);
             }
         } else {

--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -123,6 +123,10 @@ static int read_buffer(struct ao *ao, void **data, int samples, bool *eof,
 {
     struct buffer_state *p = ao->buffer_state;
     int pos = 0;
+
+    if (eof == NULL) {
+        eof = &(bool){0};
+    }
     *eof = false;
 
     while (p->playing && !p->paused && pos < samples) {
@@ -214,12 +218,6 @@ int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns, b
         mp_mutex_lock(&p->lock);
     } else if (mp_mutex_trylock(&p->lock)) {
         return 0;
-    }
-
-    bool eof_buf;
-    if (eof == NULL) {
-        // This is a public API. We want to reduce the cognitive burden of the caller.
-        eof = &eof_buf;
     }
 
     int pos = ao_read_data_locked(ao, data, samples, out_time_ns, eof, pad_silence);

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -201,7 +201,7 @@ struct ao_driver {
 
 // These functions can be called by AOs.
 
-int ao_read_data(struct ao *ao, void **data, int samples, int64_t out_time_ns, bool *eof, bool pad_silence, bool blocking);
+int ao_read_data(struct ao *ao, void **data, int samples, int64_t start_time_ns, bool *eof, bool pad_silence, bool blocking);
 
 bool ao_chmap_sel_adjust(struct ao *ao, const struct mp_chmap_sel *s,
                          struct mp_chmap *map);
@@ -232,7 +232,7 @@ void ao_convert_inplace(struct ao_convert_fmt *fmt, void **data, int num_samples
 void ao_wakeup(struct ao *ao);
 
 int ao_read_data_converted(struct ao *ao, struct ao_convert_fmt *fmt,
-                           void **data, int samples, int64_t out_time_ns);
+                           void **data, int samples, int64_t start_time_ns);
 
 void ao_stop_streaming(struct ao *ao);
 

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -203,6 +203,8 @@ struct ao_driver {
 
 int ao_read_data(struct ao *ao, void **data, int samples, int64_t start_time_ns, bool *eof, bool pad_silence, bool blocking);
 
+struct mp_aframe *ao_read_frame(struct ao *ao, int64_t start_time_ns, bool *eof, bool blocking);
+
 bool ao_chmap_sel_adjust(struct ao *ao, const struct mp_chmap_sel *s,
                          struct mp_chmap *map);
 bool ao_chmap_sel_adjust2(struct ao *ao, const struct mp_chmap_sel *s,

--- a/player/audio.c
+++ b/player/audio.c
@@ -626,7 +626,12 @@ double playing_audio_pts(struct MPContext *mpctx)
     double pts = written_audio_pts(mpctx);
     if (pts == MP_NOPTS_VALUE || !mpctx->ao)
         return pts;
-    return pts - mpctx->audio_speed * ao_get_delay(mpctx->ao);
+    double playing_pts = ao_get_playing_pts(mpctx->ao);
+    if (playing_pts == MP_NOPTS_VALUE) {
+        // The AO driver has not received data yet; data is still in ao->p->queue.
+        return pts - mpctx->audio_speed * ao_get_delay(mpctx->ao);
+    }
+    return playing_pts;
 }
 
 // This garbage is needed for untimed AOs. These consume audio infinitely fast,


### PR DESCRIPTION
This PR fixes the calculation of `ao->buffer_state->end_time_ns` when `pad_silence == false` and partial data is returned for pull-based AO. Previously, `end_time_ns` was calculated by driver delay plus the duration of requested sample count. It was not accurate if `pad_silence == false` giving the number of returned samples can vary. To fix this issue, this PR introduces an API change that `ao_read_data()` and `ao_read_data_converted()` now accepts `start_time_ns`, which is the the expected delay until the *first* sample reaches the speakers, instead of `out_time_ns`. `ao_read_data()` then updates `ao->buffer_state->end_time_ns` using `start_time_ns` and the actual sample count got from the buffer.

This PR also introduces a new API `ao_read_frame()` for pull-based AO. Now pull-based AO can directly get `mp_aframe`. For AO that can handle data with variable size, this new API bypass the copying of audio data from audio frames into data buffer in `read_buffer()`. A zero-copy `ao_avfoundation` that utilizes `ao_read_frame()` is included in this PR.

This PR depends on #13967. Before it is merged, I think I'd better keep this PR a draft, though my work is done already.