### PR TITLE
sd_ass: don't log if subtitles have unknown duration

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -420,7 +420,7 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         if (sd->opts->sub_stretch_durations ||
             packet->duration < 0 || sub_duration == UINT32_MAX) {
             if (!ctx->duration_unknown) {
-                MP_WARN(sd, "Subtitle with unknown duration.\n");
+                MP_VERBOSE(sd, "Subtitle with unknown duration.\n");
                 ctx->duration_unknown = true;
             }
             sub_duration = UNKNOWN_DURATION;


### PR DESCRIPTION
Users shouldn't have to care if subtitles' duration is unknown because the only difference is that decode() sets a duration to packets without one, if any.

The main difference was code intentionally breaking sub-seek, sub-step, sub-start and sub-end for unknown duration subtitles for some reason, but I removed it in 0f2370476b and 185fa9ffc6.

LRC subtitles always have unknown duration so if you use them having this logged on every song is annoying, so only log it in verbose mode.