### PR TITLE
demux_mkv: fix image detection

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2044,14 +2044,14 @@ static void probe_if_image(demuxer_t *demuxer)
 
         int64_t timecode = -1;
         // Arbitrary restriction on packet reading.
-        for (int i = 0; i < 1000; i++) {
-            int ret = read_next_block_into_queue(demuxer);
-            if (ret == 1 && mkv_d->blocks[i].track == track) {
-                if (timecode != mkv_d->blocks[i].timecode)
-                    ++video_blocks;
-                timecode = mkv_d->blocks[i].timecode;
-            }
-            // No need to read more
+        for (size_t block = 0; block < 100000; block++) {
+            if (block >= mkv_d->num_blocks && read_next_block_into_queue(demuxer) != 1)
+                break;
+            if (mkv_d->blocks[block].track != track)
+                continue;
+            if (timecode != mkv_d->blocks[block].timecode)
+                ++video_blocks;
+            timecode = mkv_d->blocks[block].timecode;
             if (video_blocks > 1)
                 break;
         }


### PR DESCRIPTION
If blocks were already demuxed we would skip them and ask for new ones. For files with few blocks it would return EOF without actually checking the content.

Also make demux limit higher. In practice it doesn't matter, because if it is image, video track will have only 1 block. And if it is not image it will break on 2nd video block.

Fixes: #13975