### PR TITLE
docs: mention Cache section in sub-seek

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -788,7 +788,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 
     For embedded subtitles (like with Matroska), this works only with subtitle
     events that have already been displayed, or are within a short prefetch
-    range.
+    range. See `Cache`_ for details on how to control the available prefetch range.
 
 ``print-text <text>``
     Print text to stdout. The string can contain properties (see


### PR DESCRIPTION
sub-seek depends on cached range to know future subtitles, make it clear in documentation how to control this range.