### PR TITLE
DOCS/input: document sub-seek 0

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -775,7 +775,11 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
         Steps through the secondary subtitles.
 
 ``sub-seek <skip> <flags>``
-    Seek to the next (skip set to 1) or the previous (skip set to -1) subtitle.
+    Change video and audio position such that the subtitle event after
+    ``<skip>`` subtitle events is displayed. For example, ``sub-seek 1`` skips
+    to the next subtitle, ``sub-seek -1`` skips to the previous subtitles, and
+    ``sub-seek 0`` seeks to the beginning of the current subtitle.
+
     This is similar to ``sub-step``, except that it seeks video and audio
     instead of adjusting the subtitle delay.
 


### PR DESCRIPTION
Documents the functionality added by 155f7fa. Also make it clear than can you can seek with arbitrary <skip>s instead of just 1 and -1.