### PR TITLE
DOCS/input: move escape-ass documentation

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -827,6 +827,18 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
         This line of Lua would show the location of the user's mpv
         configuration directory on the OSD.
 
+``escape-ass <text>``
+    Modify ``text`` so that commands and functions that interpret ASS tags,
+    such as ``osd-overlay`` and ``mp.create_osd_overlay``, will display it
+    verbatim, and return it. This can only be used through the client API or
+    from a script using ``mp.command_native``.
+
+    .. admonition:: Example
+
+        ``mp.osd_message(mp.command_native({"escape-ass", "foo {bar}"}))``
+
+        This line of Lua prints "foo \\{bar}" on the OSD.
+
 ``show-progress``
     Show the progress bar, the elapsed time and the total duration of the file
     on the OSD. ``no-osd`` has no effect on this command.
@@ -1265,18 +1277,6 @@ Input Commands that are Possibly Subject to Change
         Always use named arguments (``mpv_command_node()``). Lua scripts should
         use the ``mp.create_osd_overlay()`` helper instead of invoking this
         command directly.
-
-``escape-ass <text>``
-    Modify ``text`` so that commands and functions that interpret ASS tags,
-    such as ``osd-overlay`` and ``mp.create_osd_overlay``, will display it
-    verbatim, and return it. This can only be used through the client API or
-    from a script using ``mp.command_native``.
-
-    .. admonition:: Example
-
-        ``mp.osd_message(mp.command_native({"escape-ass", "foo {bar}"}))``
-
-        This line of Lua prints "foo \\{bar}" on the OSD.
 
 ``script-message [<arg1> [<arg2> [...]]]``
     Send a message to all clients, and pass it the following list of arguments.


### PR DESCRIPTION
It should be next to expand-text and expand-path, not under Input Commands that are Possibly Subject to Change.