### PR TITLE
command: add normalize-path command

### DIFF
--- a/DOCS/interface-changes/normalize-path.txt
+++ b/DOCS/interface-changes/normalize-path.txt
@@ -1,0 +1,1 @@
+add the `normalize-path` command

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -827,6 +827,21 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
         This line of Lua would show the location of the user's mpv
         configuration directory on the OSD.
 
+``normalize-path <filename>``
+    Return a canonical representation of the path ``filename`` by converting it
+    to an absolute path, removing consecutive slashes, removing ``.``
+    components, resolving ``..`` components, and converting slashes to
+    backslashes on Windows. Symlinks are not resolved unless the platform is
+    Unix-like and one of the path components is ``..``. If ``filename`` is a
+    URL, it is returned unchanged. This can only be used through the client API
+    or from a script using ``mp.command_native``.
+
+    .. admonition:: Example
+
+        ``mp.osd_message(mp.command_native({"normalize-path", "/foo//./bar"}))``
+
+        This line of Lua prints "/foo/bar" on the OSD.
+
 ``escape-ass <text>``
     Modify ``text`` so that commands and functions that interpret ASS tags,
     such as ``osd-overlay`` and ``mp.create_osd_overlay``, will display it

--- a/player/command.c
+++ b/player/command.c
@@ -5644,6 +5644,19 @@ static void cmd_expand_path(void *p)
     };
 }
 
+static void cmd_normalize_path(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    void *ctx = talloc_new(NULL);
+
+    cmd->result = (mpv_node){
+        .format = MPV_FORMAT_STRING,
+        .u.string = talloc_strdup(NULL, mp_normalize_path(ctx, cmd->args[0].v.s)),
+    };
+
+    talloc_free(ctx);
+}
+
 static void cmd_escape_ass(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -6764,6 +6777,7 @@ const struct mp_cmd_def mp_cmds[] = {
         .is_noisy = true },
     { "expand-path", cmd_expand_path, { {"text", OPT_STRING(v.s)} },
         .is_noisy = true },
+    { "normalize-path", cmd_normalize_path, { {"filename", OPT_STRING(v.s)} }},
     { "escape-ass", cmd_escape_ass, { {"text", OPT_STRING(v.s)} },
         .is_noisy = true },
     { "show-progress", cmd_show_progress, .allow_auto_repeat = true,


### PR DESCRIPTION
This can be used e.g. by a bookmarking script to show normalized paths.