### PR TITLE
DOCS/lua: fix some argument names

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -810,12 +810,12 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     <level>
         The minimum OSD level to show the text at (see ``--osd-level``).
 
-``expand-text <string>``
+``expand-text <text>``
     Property-expand the argument and return the expanded string. This can be
     used only through the client API or from a script using
     ``mp.command_native``. (see `Property Expansion`_).
 
-``expand-path "<string>"``
+``expand-path "<text>"``
     Expand a path's double-tilde placeholders into a platform-specific path.
     As ``expand-text``, this can only be used through the client API or from
     a script using ``mp.command_native``.


### PR DESCRIPTION
These need to coincide with the ones in command.c because they can be specified in mp.command_native.