### PR TITLE
ao: in ao_play_data, wakeup core for untimed AO as well

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -629,7 +629,7 @@ static bool ao_play_data(struct ao *ao)
     struct mp_pcm_state state;
     get_dev_state(ao, &state);
 
-    if (p->streaming && !state.playing && !ao->untimed)
+    if (p->streaming && !state.playing)
         goto eof;
 
     void **planes = NULL;


### PR DESCRIPTION
Fixes #13641

`ao_play_data` (which is only used in push-based AO) wakes up the core for more data on EOF or underruns. However, it did not wake up the core if `ao->untimed` was set to `true`. This caused the issue of indefinite spinning. This PR addresses this problem by modifying `ao_play_data` to also wake up the core for untimed AO.

I have no idea why untimed AO was explicitly checked in the original code. It was written by wm4. Perhaps someone more familiar with the AO codebase can provide further insight. Nevertheless, this patch just works.

CC @kasper93 