### PR TITLE
Revert "ao: in ao_play_data, wakeup core for untimed AO as well"

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -629,7 +629,7 @@ static bool ao_play_data(struct ao *ao)
     struct mp_pcm_state state;
     get_dev_state(ao, &state);
 
-    if (p->streaming && !state.playing)
+    if (p->streaming && !state.playing && !ao->untimed)
         goto eof;
 
     void **planes = NULL;


### PR DESCRIPTION
This problem does not exist with `--demuxer=lavf`. `--demuxer=mkv` just never signals EOF for the problematic sample, so it needs to be fixed there, not in AO.

This reverts commit 0cfd52074b50df623f9fa9fd9ad0ba4657311398.
