### PR TITLE
console.lua: increase default font and border size

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -148,13 +148,13 @@ Configurable Options
     aligned correctly.
 
 ``font_size``
-    Default: 16
+    Default: 26
 
     Set the font size used for the REPL and the console. This will be
     multiplied by "scale".
 
 ``border_size``
-    Default: 1
+    Default: 3
 
     Set the font border size used for the REPL and the console.
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -25,8 +25,8 @@ local opts = {
     font = "",
     -- Set the font size used for the REPL and the console. This will be
     -- multiplied by "scale".
-    font_size = 16,
-    border_size = 1,
+    font_size = 26,
+    border_size = 3,
     case_sensitive = true,
     -- Remove duplicate entries in history as to only keep the latest one.
     history_dedup = true,


### PR DESCRIPTION
I don't know how people can use it but console.lua with the default font and border size is unreadable to me. It looks ridiculous next to the default huge --osd-font-size. Increment them to make the console more readable, especially since it can now be used a seletcor.