### PR TITLE
fuzzer_loadfile_direct: exclude paths also for file://

### DIFF
--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -34,18 +34,27 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return -1;
 
 #ifdef MPV_PROTO
-    if (!str_startswith(data, size - 1, MPV_STRINGIFY(MPV_PROTO) "://", strlen(MPV_STRINGIFY(MPV_PROTO) "://")))
+    if (!str_startswith(data, size - 1, MPV_STRINGIFY(MPV_PROTO) "://", sizeof(MPV_STRINGIFY(MPV_PROTO) "://") - 1))
         return -1;
-#else
+#endif
+
+#if !defined(MPV_PROTO) || defined(MPV_PROTO_FILE)
+    const uint8_t *data_check = data;
+    size_t size_check = size;
+    size_t prefix_size = sizeof("file://") - 1;
+    if (str_startswith(data, size - 1, "file://", prefix_size)) {
+        data_check += prefix_size;
+        size_check -= prefix_size;
+    }
     // Exclude some common paths that are not useful for testing.
     // Exclude -
-    if (size == 2 && !strncmp(data, "-", 1))
+    if (size_check == 2 && !strncmp(data_check, "-", 1))
         return -1;
     // Exclude relative paths
-    if (str_startswith(data, size - 1, ".", 1))
+    if (str_startswith(data_check, size_check - 1, ".", 1))
         return -1;
     // Exclude absolute paths
-    if (str_startswith(data, size - 1, "/", 1))
+    if (str_startswith(data_check, size_check - 1, "/", 1))
         return -1;
 #endif
 

--- a/fuzzers/meson.build
+++ b/fuzzers/meson.build
@@ -9,7 +9,7 @@ foreach p : ['bd', 'cdda', 'dvb', 'dvd', 'edl', 'file', 'hex', 'lavf', 'memory',
              'mf', 'slice', 'smb']
   executable('fuzzer_protocol_' + p,
              'fuzzer_loadfile_direct.c',
-             c_args: ['-DMPV_PROTO=' + p],
+             c_args: ['-DMPV_PROTO=' + p, '-DMPV_PROTO_' + p.to_upper()],
              include_directories: incdir,
              link_with: libmpv)
 endforeach


### PR DESCRIPTION
Loading external files makes little sense. Might disable this completely later, but let see how it works, The idea is the same as for direct load. Exclude paths starting with `file://.` and `file:///`. But still fuzz any processing that other input might have. It shouldn't be a huge problem if we do `file://mpv` for example. Not great, but also not terrible.