### PR TITLE
ytdl_hook: make path and json available to other scripts

### DIFF
--- a/DOCS/interface-changes/ytdl-path-and-json-properties.txt
+++ b/DOCS/interface-changes/ytdl-path-and-json-properties.txt
@@ -1,0 +1,1 @@
+add `user-data/mpv/ytdl/path` and `user-data/mpv/ytdl/json-subprocess-result` properties

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3573,6 +3573,19 @@ Property list
     and not using raw mode, the underlying content will be given (e.g. strings will be
     printed directly, rather than quoted and JSON-escaped).
 
+    ``user-data/mpv/ytdl``
+        Data shared by the builtin ytdl hook script.
+
+        ``user-data/mpv/ytdl/path``
+            Path to the ytdl executable, if found, or an empty string otherwise.
+            The property is not set until the script attempts to find the ytdl
+            executable, i.e. until an URL is being loaded by the script.
+
+        ``user-data/mpv/ytdl/json-subprocess-result``
+            Result of executing ytdl to retrieve the JSON data of the URL being
+            loaded. The format is the same as ``subprocess``'s result, capturing
+            stdout and stderr.
+
 ``menu-data`` (RW)
     This property stores the raw menu definition. See `Context Menu`_ section for details.
 

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -993,11 +993,15 @@ local function run_ytdl_hook(url)
         end
 
         ytdl.searched = true
+
+        mp.set_property("user-data/mpv/ytdl/path", ytdl.path or "")
     end
 
     if result.killed_by_us then
         return
     end
+
+    mp.set_property_native("user-data/mpv/ytdl/json-subprocess-result", result)
 
     local json = result.stdout
     local parse_err = nil
@@ -1201,4 +1205,8 @@ mp.add_hook("on_preloaded", 10, function ()
         mp.set_property_native("chapter-list", chapter_list)
         chapter_list = {}
     end
+end)
+
+mp.add_hook("on_after_end_file", 50, function ()
+    mp.del_property("user-data/mpv/ytdl/json-subprocess-result")
 end)


### PR DESCRIPTION
It's useful for user scripts to be able to use the same ytdl binary that
ytdl_hook uses without having to replicate ytdl_hook's process of
searching for the ytdl binary.

Some user scripts might also find it useful to be able to access ytdl's
json output that the ytdl_hook already receives, sparing user scripts
from having to make a duplicate ytdl binary invocation to get the json
output.

Providing just the json output is not enough though, as ytdl doesn't communicate
errors though it -- if an error occurs, ytdl provides no json output and instead
prints to stderr. So without stderr, there is no way for user scripts to figure
out why ytdl has failed: no such username / video id, the channel is not live
yet, etc. Because of that, the entire result of the subprocess call is provided
to the user scripts, containing stdout (json), stderr, ytdl's exit code, etc.

Fixes #14097, #12852 and #10410.

Tested to work with:

```lua
local utils = require 'mp.utils'

local function print_property(name, value)
    print(name .. ": " .. utils.to_string(value))
end

mp.observe_property("user-data/ytdl/json-subprocess-result", "native", print_property)
mp.observe_property("user-data/ytdl/path"                  , "string", print_property)
```