### PR TITLE
DOCS/man: replace legacy option syntax usage

### DIFF
--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -8,7 +8,7 @@ You can encode files from one format/codec to another using this facility.
 
 ``--of=<format>``
     Specifies the output format (overrides autodetection by the file name
-    extension of the file specified by ``-o``). See ``--of=help`` for a full
+    extension of the file specified by ``--o``). See ``--of=help`` for a full
     list of supported formats.
 
 ``--ofopts=<options>``

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3056,7 +3056,7 @@ Property list
         Total number of tracks.
 
     ``track-list/N/id``
-        The ID as it's used for ``-sid``/``--aid``/``--vid``. This is unique
+        The ID as it's used for ``--sid``/``--aid``/``--vid``. This is unique
         within tracks of the same type (sub/audio/video), but otherwise not.
 
     ``track-list/N/type``

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -146,7 +146,7 @@ Track Selection
 ``--subs-match-os-language=<yes|no>``
     When autoselecting a subtitle track, select the track that matches the language of your OS
     if the audio stream is in a different language if suitable (default track or a forced track
-    under the right conditions). Note that if ``-slang`` is set, this will be completely ignored
+    under the right conditions). Note that if ``--slang`` is set, this will be completely ignored
     (default: yes).
 
 ``--subs-fallback=<yes|default|no>``

--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -103,7 +103,7 @@ filter list.
     compared. (Passing multiple filters is currently still possible, but
     deprecated.)
 
-``-vf-toggle=filter``
+``--vf-toggle=filter``
     Add the given filter to the list if it was not present yet, or remove it
     from the list if it was present. Matching of filters works as described in
     ``--vf-remove``.
@@ -192,7 +192,7 @@ Available mpv-only filters are:
         space if the system video driver supports it, but not input and output
         levels. The ``scale`` video filter can configure color space and input
         levels, but only if the output format is RGB (if the video output driver
-        supports RGB output, you can force this with ``-vf scale,format=rgba``).
+        supports RGB output, you can force this with ``--vf=scale,format=rgba``).
 
         If this option is set to ``auto`` (which is the default), the video's
         color space flag will be used. If that flag is unset, the color space


### PR DESCRIPTION
They are replaced by `--option=value`.
