### PR TITLE
lcms: check for null arg in gl_parse_3dlut_size

### DIFF
--- a/video/out/gpu/lcms.h
+++ b/video/out/gpu/lcms.h
@@ -44,6 +44,8 @@ bool gl_lcms_has_changed(struct gl_lcms *p, enum pl_color_primaries prim,
 
 static inline bool gl_parse_3dlut_size(const char *arg, int *p1, int *p2, int *p3)
 {
+    if (!arg)
+        return false;
     if (!strcmp(arg, "auto")) {
         *p1 = *p2 = *p3 = 0;
         return true;


### PR DESCRIPTION
This fixes `icc-3dlut-size` validation in config which would crash if set without argument.

Found by OSS-Fuzz.