### PR TITLE
audio: change bps format to int64_t

### DIFF
--- a/audio/aframe.c
+++ b/audio/aframe.c
@@ -600,7 +600,7 @@ bool mp_aframe_set_silence(struct mp_aframe *f, int offset, int samples)
 bool mp_aframe_reverse(struct mp_aframe *f)
 {
     int format = mp_aframe_get_format(f);
-    size_t bps = af_fmt_to_bytes(format);
+    int bps = af_fmt_to_bytes(format);
     if (!af_fmt_is_pcm(format) || bps > 16)
         return false;
 

--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -241,7 +241,7 @@ static struct ao *ao_init(bool probing, struct mpv_global *global,
     } else {
         ao->sstride *= ao->channels.num;
     }
-    ao->bps = ao->samplerate * ao->sstride;
+    ao->bps = (int64_t)ao->samplerate * ao->sstride;
 
     if (ao->device_buffer <= 0 && ao->driver->write) {
         MP_ERR(ao, "Device buffer size not set.\n");

--- a/audio/out/ao_pcm.c
+++ b/audio/out/ao_pcm.c
@@ -86,7 +86,7 @@ static void write_wave_header(struct ao *ao, FILE *fp, uint64_t data_length)
     fput16le(WAV_ID_FORMAT_EXTENSIBLE, fp);
     fput16le(ao->channels.num, fp);
     fput32le(ao->samplerate, fp);
-    fput32le(ao->bps, fp);
+    fput32le(MPCLAMP(ao->bps, 0, UINT32_MAX), fp);
     fput16le(ao->channels.num * (bits / 8), fp);
     fput16le(bits, fp);
 
@@ -145,7 +145,7 @@ static int init(struct ao *ao)
     if (!ao_chmap_sel_adjust(ao, &sel, &ao->channels))
         return -1;
 
-    ao->bps = ao->channels.num * ao->samplerate * af_fmt_to_bytes(ao->format);
+    ao->bps = ao->channels.num * (int64_t)ao->samplerate * af_fmt_to_bytes(ao->format);
 
     MP_INFO(ao, "File: %s (%s)\nPCM: Samplerate: %d Hz Channels: %d Format: %s\n",
             outputfilename,

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -28,7 +28,7 @@ struct ao {
     int samplerate;
     struct mp_chmap channels;
     int format;                 // one of AF_FORMAT_...
-    int bps;                    // bytes per second (per plane)
+    int64_t bps;                // bytes per second (per plane)
     int sstride;                // size of a sample on each plane
                                 // (format_size*num_channels/num_planes)
     int num_planes;


### PR DESCRIPTION
It happens that sample rate can have completely bogus value coming from lavf. Reject that, as we wouldn't do anything useful with it anyway.

Fixes: #13648