### PR TITLE
fuzzers: set network-timeout to 1 second

### DIFF
--- a/fuzzers/fuzzer_load.c
+++ b/fuzzers/fuzzer_load.c
@@ -53,6 +53,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     check_error(mpv_set_option_string(ctx, "untimed", "yes"));
     check_error(mpv_set_option_string(ctx, "video-osd", "no"));
     check_error(mpv_set_option_string(ctx, "msg-level", "all=trace"));
+    check_error(mpv_set_option_string(ctx, "network-timeout", "1"));
 
     check_error(mpv_initialize(ctx));
 

--- a/fuzzers/fuzzer_loadfile.c
+++ b/fuzzers/fuzzer_loadfile.c
@@ -53,6 +53,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     check_error(mpv_set_option_string(ctx, "untimed", "yes"));
     check_error(mpv_set_option_string(ctx, "video-osd", "no"));
     check_error(mpv_set_option_string(ctx, "msg-level", "all=trace"));
+    check_error(mpv_set_option_string(ctx, "network-timeout", "1"));
 
     check_error(mpv_initialize(ctx));
 

--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -68,6 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     check_error(mpv_set_option_string(ctx, "untimed", "yes"));
     check_error(mpv_set_option_string(ctx, "video-osd", "no"));
     check_error(mpv_set_option_string(ctx, "msg-level", "all=trace"));
+    check_error(mpv_set_option_string(ctx, "network-timeout", "1"));
 
     check_error(mpv_initialize(ctx));
 

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -57,13 +57,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (!ctx)
         exit(1);
 
+    check_error(mpv_set_option_string(ctx, "msg-level", "all=trace"));
+    check_error(mpv_set_option_string(ctx, "network-timeout", "1"));
+
 #if MPV_RUN
     check_error(mpv_set_option_string(ctx, "vo", "null"));
     check_error(mpv_set_option_string(ctx, "ao", "null"));
     check_error(mpv_set_option_string(ctx, "ao-null-untimed", "yes"));
     check_error(mpv_set_option_string(ctx, "untimed", "yes"));
     check_error(mpv_set_option_string(ctx, "video-osd", "no"));
-    check_error(mpv_set_option_string(ctx, "msg-level", "all=trace"));
 
     check_error(mpv_initialize(ctx));
 #endif


### PR DESCRIPTION
We don't expect any data to actually access, so timeout as soon as possible.