### PR TITLE
[RFC] ci: add fuzzing of pull requests for 20 minutes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,44 @@
+name: Pull Request Fuzzing
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+        - 'DOCS/**'
+        - 'TOOLS/lua/**'
+        - '.editorconfig'
+        - '.gitignore'
+        - 'Copyright'
+        - 'README.md'
+        - 'RELEASE_NOTES'
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'mpv'
+        language: c
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'mpv'
+        language: c
+        fuzz-seconds: 1200
+        output-sarif: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v4
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: cifuzz-sarif/results.sarif
+        checkout_path: cifuzz-sarif


### PR DESCRIPTION
To increase our testing coverage before merging. This uses already build corpus and coverage info to test the modified code, if possible.

See: https://google.github.io/oss-fuzz/getting-started/continuous-integration