### PR TITLE
meson: add link flags also to cpp

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -392,7 +392,7 @@ endif
 
 add_project_arguments(flags, language: 'c')
 add_project_arguments(['-Wno-unused-parameter'], language: 'objc')
-add_project_link_arguments(link_flags, language: ['c', 'objc'])
+add_project_link_arguments(link_flags, language: ['c', 'cpp', 'objc'])
 
 
 # osdep


### PR DESCRIPTION
If subprojects are used, linking language of mpv might be upgraded to C++ add our flags there too.