### PR TITLE
console.lua: scale with the window height

### DIFF
--- a/DOCS/interface-changes/console-scale-with-window.rst
+++ b/DOCS/interface-changes/console-scale-with-window.rst
@@ -1,0 +1,1 @@
+add `console-scale_with_window` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -142,13 +142,13 @@ Configurable Options
     aligned correctly.
 
 ``font_size``
-    Default: 16
+    Default: 24
 
     Set the font size used for the REPL and the console. This will be
     multiplied by ``display-hidpi-scale``.
 
 ``border_size``
-    Default: 1
+    Default: 1.5
 
     Set the font border size used for the REPL and the console.
 

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -152,6 +152,12 @@ Configurable Options
 
     Set the font border size used for the REPL and the console.
 
+``scale_with_window``
+    Default: ``auto``
+
+    Whether to scale the console with the window height. Can be ``yes``, ``no``,
+    or ``auto``, which follows the value of ``--osd-scale-by-window``.
+
 ``case_sensitive``
     Default: no on Windows, yes on other platforms.
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -18,8 +18,8 @@ local assdraw = require 'mp.assdraw'
 -- Default options
 local opts = {
     font = "",
-    font_size = 16,
-    border_size = 1,
+    font_size = 24,
+    border_size = 1.5,
     scale_with_window = "auto",
     case_sensitive = true,
     history_dedup = true,


### PR DESCRIPTION
This makes console.lua consistent with the OSD, osc.lua and stats.lua. This reads --osd-scale-by-window so users don't have to configure vidscale in yet another script.