### PR TITLE
hwdec_cuda_vk: add missing io.h include

### DIFF
--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -25,6 +25,8 @@
 #include <libavutil/hwcontext_cuda.h>
 #include <libplacebo/vulkan.h>
 
+#include "osdep/io.h"
+
 #if HAVE_WIN32_DESKTOP
 #include <versionhelpers.h>
 #define HANDLE_TYPE PL_HANDLE_WIN32


### PR DESCRIPTION
Fixes compilation on Windows with cuda enabled.