### PR TITLE
player/command: reinit video chain when decoder thread count changes

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -111,7 +111,7 @@ const struct m_sub_options vd_lavc_conf = {
         {"vd-lavc-skipidct", OPT_DISCARD(skip_idct)},
         {"vd-lavc-skipframe", OPT_DISCARD(skip_frame)},
         {"vd-lavc-framedrop", OPT_DISCARD(framedrop)},
-        {"vd-lavc-threads", OPT_INT(threads), M_RANGE(0, DBL_MAX)},
+        {"vd-lavc-threads", OPT_INT(threads), M_RANGE(0, DBL_MAX), .flags = UPDATE_VD},
         {"vd-lavc-bitexact", OPT_BOOL(bitexact)},
         {"vd-lavc-assume-old-x264", OPT_BOOL(old_x264)},
         {"vd-lavc-check-hw-profile", OPT_BOOL(check_hw_profile)},


### PR DESCRIPTION
My goal is to reinitialize the video decoder when the `vd-lavc-threads` option changes.
This reinitializes the whole video chain, no idea how this could be restricted to the decoder only without touching the rest of the chain or if that's even desirable.

I don't really know what I'm doing here, so there is probably a much better way to achieve this.

We could also extend this to other decoder related options once the approach has been figured out.