### PR TITLE
osc.lua: remove scaleforcedwindow

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -247,11 +247,6 @@ Configurable Options
 
     Scale factor of the OSC when fullscreen
 
-``scaleforcedwindow``
-    Default: 2.0
-
-    Scale factor of the OSC when rendered on a forced (dummy) window
-
 ``vidscale``
     Default: yes
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -14,7 +14,6 @@ local user_opts = {
     idlescreen = true,          -- show mpv logo on idle
     scalewindowed = 1,          -- scaling of the controller when windowed
     scalefullscreen = 1,        -- scaling of the controller when fullscreen
-    scaleforcedwindow = 2,      -- scaling when rendered on a forced window
     vidscale = true,            -- scale the controller with the video?
     valign = 0.8,               -- vertical alignment, -1 (top) to 1 (bottom)
     halign = 0,                 -- horizontal alignment, -1 (left) to 1 (right)
@@ -1777,9 +1776,7 @@ function osc_init()
     local display_w, display_h, display_aspect = mp.get_osd_size()
     local scale = 1
 
-    if mp.get_property("video") == "no" then -- dummy/forced window
-        scale = user_opts.scaleforcedwindow
-    elseif state.fullscreen then
+    if state.fullscreen then
         scale = user_opts.scalefullscreen
     else
         scale = user_opts.scalewindowed


### PR DESCRIPTION
This is unused since 4e013afd37 because the mpv logo and the "Drop files or URLs to play here." message are shown instead of the OSC controls. It has the adverse affect of making the OSC twice as big when playing videos with --lavfi-complex, because that makes the video property which osc.lua checks unavailable.