### PR TITLE
player: do not always set mpctx->stop_play when seeking at EOF

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7441,16 +7441,11 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 
     if (opt_ptr == &opts->play_dir) {
         if (mpctx->play_dir != opts->play_dir) {
-            // Some weird things for play_dir if we're at EOF.
-            // 1. The option must be set before we seek.
-            // 2. queue_seek can change the stop_play value; always keep the old one.
-            int old_stop_play = mpctx->stop_play;
-            if (old_stop_play == AT_END_OF_FILE)
+            // The option must be set before we seek if we're at EOF.
+            if (mpctx->stop_play == AT_END_OF_FILE)
                 mpctx->play_dir = opts->play_dir;
             queue_seek(mpctx, MPSEEK_ABSOLUTE, get_current_time(mpctx),
                        MPSEEK_EXACT, 0);
-            if (old_stop_play == AT_END_OF_FILE)
-                mpctx->stop_play = old_stop_play;
         }
     }
 

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -430,9 +430,6 @@ void queue_seek(struct MPContext *mpctx, enum seek_type type, double amount,
 
     mp_wakeup_core(mpctx);
 
-    if (mpctx->stop_play == AT_END_OF_FILE)
-        mpctx->stop_play = KEEP_PLAYING;
-
     switch (type) {
     case MPSEEK_RELATIVE:
         seek->flags |= flags;


### PR DESCRIPTION
Normally if you seek during EOF, mpv will reset the value of mpctx->stop_play so it doesn't exit. There's at least a couple of exceptions where this *shouldn't* happen however. If the play direction changes right at the end of the file, we shouldn't touch the value to avoid an erronous assertion error. Additionally, it is apparently possible for the queue_seek call in VO reinit code to trigger the assertion issue. This is a seek of exactly zero and logically shouldn't be reset mpctx->stop_play anyways (i.e. AT_END_OF_FILE should stay the same). By moving this to queue_seek itself, most of the special handling in player/command.c can be dropped. The option still needs to be set though. Fixes #13778.

@user1121114685: Can you verify if this works for you?