### PR TITLE
options: reset some options between files by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -816,12 +816,12 @@ Program Behavior
     defined profiles.
 
 ``--reset-on-next-file=<all|option1,option2,...>``
-    Normally, mpv will try to keep all settings when playing the next file on
+    Normally, mpv will try to keep most settings when playing the next file on
     the playlist, even if they were changed by the user during playback. (This
     behavior is the opposite of MPlayer's, which tries to reset all settings
     when starting next file.)
 
-    Default: Do not reset anything.
+    Default: ``ab-loop-a``, ``ab-loop-b``, ``ab-loop-count``.
 
     This can be changed with this option. It accepts a list of options, and
     mpv will reset the value of these options on playback start to the initial

--- a/options/options.c
+++ b/options/options.c
@@ -949,6 +949,14 @@ static const m_option_t mp_opts[] = {
 static const struct MPOpts mp_default_opts = {
     .use_terminal = true,
     .msg_color = true,
+
+    .reset_options = (char *[]){
+        "ab-loop-a",
+        "ab-loop-b",
+        "ab-loop-count",
+        NULL
+    },
+
     .softvol_max = 130,
     .softvol_volume = 100,
     .softvol_gain_max = 12,


### PR DESCRIPTION
Add some options to --reset-on-next-file's default value that you commonly don't want to keep between files. The catch is that if you specify options in the command line or mpv.conf --reset-on-next-file resets to those values, but the vast majority of uses for these options should be at runtime.

Fixes #17953.