### PR TITLE
stats.lua: prevent freeze in certain cases with vidscale=no

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1356,10 +1356,7 @@ end
 local function update_scale(_, value)
     -- Calculate scaled metrics.
     local scale = 1
-    if not o.vidscale then
-        if value <= 1 then
-            value = 1
-        end
+    if not o.vidscale and value > 0 then
         scale = 720 / value
     end
     font_size = o.font_size * scale


### PR DESCRIPTION
If using --script-opts=stats-vidscale=no, until osd-height changes from 0 to the correct value, stats.lua's text sizes are multiplied by a scale of 720, which with the default font size results in a font size of 5760. Depending on the order of operations, if the stats are drawn at this size before osd-height is updated, mpv freezes. I get this with --input-commands=script-message-to stats display-stats-toggle in conditional profiles, e.g.:

mpv --script-opts=stats-vidscale=no --include=<(echo $'[test]\nprofile-cond=true\ninput-commands=script-message-to stats display-stats-toggle') av://lavfi:testsrc

Fix this by setting a scale to 1 until osd-height is updated to the correct value.