### PR TITLE
DOCS: add more details and requirements about incompatible changes

### DIFF
--- a/DOCS/compatibility.rst
+++ b/DOCS/compatibility.rst
@@ -51,6 +51,15 @@ functionality still works, and a replacement is available (if technically
 reasonable). For example, a feature deprecated in mpv 0.30.0 may be removed in
 mpv 0.32.0. Minor releases do not count towards this.
 
+Under extraordinary circumstances, such as missed incompatible changes that are
+already included in a release, critical security fixes, or a severe shortage of
+developer time to address the known incompatible changes, important/often used
+parts may be broken immediately, but the change must be extensively documented:
+all of the related documentations (including manpage, interface-changes.rst,
+etc., retrospectively modified if applicable) must clearly state the following:
+the fact that the change is a breaking change; the version when the breaking
+change happened; and the reason, impact, and suggested remedy actions.
+
 Less useful parts can be broken immediately, but must come with some sort of
 removal warning.
 

--- a/DOCS/compatibility.rst
+++ b/DOCS/compatibility.rst
@@ -50,7 +50,7 @@ reasonable). For example, a feature deprecated in mpv 0.30.0 may be removed in
 mpv 0.32.0. Minor releases do not count towards this.
 
 Less useful parts can be broken immediately, but must come with some sort of
-removal warning-
+removal warning.
 
 Parts for debugging and testing may be removed any time, potentially even
 without any sort of documentation.

--- a/DOCS/compatibility.rst
+++ b/DOCS/compatibility.rst
@@ -29,6 +29,13 @@ All of these are important for interfacing both with end users and API users
 (which include Lua scripts, libmpv, and the JSON IPC). As such, they constitute
 a large part of the user interface and APIs.
 
+Certain options and commands may have documented default values. These default
+values are considered a part of the API since scripts may already rely on these
+documented behaviors. Changing these defaults are considered incompatible
+changes and must be documented. Undocumented default values do not subject to
+this requirement, and it is recommended to discourage such usage in the related
+documentations if there is a need to frequently change such defaults.
+
 All incompatible changes to this must be declared in interface-changes.rst,
 which include the types of changes, the impact of these changes, and suggested
 actions to address such impact so that the incompatibility is alleviated.

--- a/DOCS/compatibility.rst
+++ b/DOCS/compatibility.rst
@@ -29,7 +29,9 @@ All of these are important for interfacing both with end users and API users
 (which include Lua scripts, libmpv, and the JSON IPC). As such, they constitute
 a large part of the user interface and APIs.
 
-All incompatible changes to this must be declared in interface-changes.rst.
+All incompatible changes to this must be declared in interface-changes.rst,
+which include the types of changes, the impact of these changes, and suggested
+actions to address such impact so that the incompatibility is alleviated.
 (This may also list compatible additions, but it's not a requirement.)
 
 Degrees of importance and compatibility preservation

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -64,7 +64,11 @@ Interface changes
     - change `--hidpi-window-scale` default to `no`
     - add `insert-next`, `insert-next-play`, `insert-at`, and `insert-at-play`
       actions to `loadfile` and `loadlist` commands
-    - add `index` argument to `loadfile` and `loadlist` commands
+    - add `index` argument to `loadlist` command
+    - add `index` argument to `loadfile` command. This breaks all existing
+      uses of this command which make use of the argument to include the list of
+      options to be set while the file is playing. To address this problem, the
+      third argument now needs to be set to -1 if the fourth argument needs to be used.
     - move the `options` argument of the `loadfile` command from the third
       parameter to the fourth (after `index`)
     - add `--drag-and-drop=insert-next` option

--- a/DOCS/man/ao.rst
+++ b/DOCS/man/ao.rst
@@ -15,6 +15,10 @@ in the list.
     See ``--ao=help`` for a list of compiled-in audio output drivers sorted by
     autoprobe order.
 
+    Note that the default audio output driver is subject to change, and must
+    not be relied upon. If a certain AO needs to be used, it must be
+    explicitly specified.
+
 Available audio output drivers are:
 
 ``alsa``

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -487,7 +487,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     ``insert-at-play`` actions. When used with those actions, the new item will
     be inserted at the index position in the playlist, or appended to the end if
     index is less than 0 or greater than the size of the playlist. This argument
-    will be ignored for all other actions.
+    will be ignored for all other actions. This argument is added in mpv 0.38.0.
 
     The fourth argument is a list of options and values which should be set
     while the file is playing. It is of the form ``opt1=value1,opt2=value2,..``.
@@ -495,6 +495,14 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     table), however the values themselves must be strings currently. These
     options are set during playback, and restored to the previous value at end
     of playback (see `Per-File Options`_).
+
+    .. warning::
+
+        Since mpv 0.38.0, an insertion index argument is added as the third argument.
+        This breaks all existing uses of this command which make use of the argument
+        to include the list of options to be set while the file is playing. To address
+        this problem, the third argument now needs to be set to -1 if the fourth
+        argument needs to be used.
 
 ``loadlist <url> [<flags> [<index>]]``
     Load the given playlist file or URL (like ``--playlist``).

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6447,6 +6447,9 @@ them.
     order. You can also pass ``help`` to get a complete list of compiled in backends
     (sorted by the default autoprobe order).
 
+    Note that the default GPU context is subject to change, and must not be relied upon.
+    If a certain GPU context needs to be used, it must be explicitly specified.
+
     auto
         auto-select (default). Note that this context must be used alone and
         does not participate in the priority list.
@@ -6489,7 +6492,9 @@ them.
     Controls which type of graphics APIs will be accepted:
 
     auto
-        Use any available API (default)
+        Use any available API (default). Note that the default GPU API used for this
+        value is subject to change, and must not be relied upon. If a certain GPU API
+        needs to be used, it must be explicitly specified.
     opengl
         Allow only OpenGL (requires OpenGL 2.1+ or GLES 2.0+)
     vulkan

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -19,6 +19,10 @@ in the list.
     does not work, it will fallback to other drivers (in the same order as
     listed by ``--vo=help``).
 
+    Note that the default video output driver is subject to change, and must
+    not be relied upon. If a certain VO needs to be used (e.g. for ``libmpv``
+    rendering API), it must be explicitly specified.
+
 Available video output drivers are:
 
 ``gpu``


### PR DESCRIPTION
There is clearly not enough being conveyed about the incompatible changes happened, and users are left guessing what should be done after that. This PR adds these details and requirements so that these concerns are clearly conveyed to the users so that breaking changes can be handled swiftly.

See also https://github.com/mpv-player/mpv/discussions/13974.