### PR TITLE
input: prioritize builtin bindings matching longer key sequences

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -452,8 +452,12 @@ static struct cmd_bind *find_any_bind_for_key(struct input_ctx *ictx,
                                                                ictx->mouse_vo_x,
                                                                ictx->mouse_vo_y)))
             {
-                if (!best_bind || (best_bind->is_builtin && !bind->is_builtin))
+                if (!best_bind || bind->num_keys > best_bind->num_keys ||
+                    (best_bind->is_builtin && !bind->is_builtin &&
+                     bind->num_keys == best_bind->num_keys))
+                {
                     best_bind = bind;
+                }
             }
         }
         if (s->flags & MP_INPUT_EXCLUSIVE)


### PR DESCRIPTION
This fixes 2 different bugs:

- mp.add_key_binding('c', ...) taking priority over the builtin g-c binding.

This follows up 994a08f5a7 which fixed this within the same input section. This fixes it across different input sections.

- mp.add_key_binding('g-c', ...) not taking priority over a c binding defined in input.conf.

This happened because is_builtin of bindings added with mp.add_key_binding is true though they're not actually builtin.