### PR TITLE
input/cmd: add nonrepeatable prefix

### DIFF
--- a/DOCS/interface-changes/cmd-nonrepeatable.txt
+++ b/DOCS/interface-changes/cmd-nonrepeatable.txt
@@ -1,0 +1,1 @@
+add `nonrepeatable` input command prefix

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1818,6 +1818,9 @@ prefixes can be specified. They are separated by whitespace.
     This prefix forces enabling key repeat in any case. For a list of commands:
     the first command determines the repeatability of the whole list (up to and
     including version 0.33 - a list was always repeatable).
+``nonrepeatable``
+    For some commands, keeping a key pressed runs the command repeatedly.
+    This prefix forces disabling key repeat in any case.
 ``async``
     Allow asynchronous execution (if possible). Note that only a few commands
     will support this (usually this is explicitly documented). Some commands

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -51,9 +51,10 @@ static const struct flag cmd_flags[] = {
     {"osd-auto",            MP_ON_OSD_FLAGS, MP_ON_OSD_AUTO},
     {"expand-properties",   0,               MP_EXPAND_PROPERTIES},
     {"raw",                 MP_EXPAND_PROPERTIES, 0},
-    {"repeatable",          0,               MP_ALLOW_REPEAT},
+    {"repeatable",          MP_DISALLOW_REPEAT, MP_ALLOW_REPEAT},
+    {"nonrepeatable",       MP_ALLOW_REPEAT,    MP_DISALLOW_REPEAT},
     {"async",               MP_SYNC_CMD,     MP_ASYNC_CMD},
-    {"sync",                MP_ASYNC_CMD,     MP_SYNC_CMD},
+    {"sync",                MP_ASYNC_CMD,    MP_SYNC_CMD},
     {0}
 };
 
@@ -611,7 +612,8 @@ bool mp_input_is_repeatable_cmd(struct mp_cmd *cmd)
     if (cmd->def == &mp_cmd_list && cmd->args[0].v.p)
         cmd = cmd->args[0].v.p;  // list - only 1st cmd is considered
 
-    return (cmd->def->allow_auto_repeat) || (cmd->flags & MP_ALLOW_REPEAT);
+    return (cmd->def->allow_auto_repeat && !(cmd->flags & MP_DISALLOW_REPEAT)) ||
+           (cmd->flags & MP_ALLOW_REPEAT);
 }
 
 bool mp_input_is_scalable_cmd(struct mp_cmd *cmd)

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -75,6 +75,8 @@ enum mp_cmd_flags {
     MP_ASYNC_CMD = 32,          // do not wait for command to complete
     MP_SYNC_CMD = 64,           // block on command completion
 
+    MP_DISALLOW_REPEAT = 128,   // if used as keybinding, disallow key repeat
+
     MP_ON_OSD_FLAGS = MP_ON_OSD_NO | MP_ON_OSD_AUTO |
                       MP_ON_OSD_BAR | MP_ON_OSD_MSG,
 };

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1243,8 +1243,8 @@ function complete(backwards)
     local command_prefixes = {
         ['osd-auto'] = true, ['no-osd'] = true, ['osd-bar'] = true,
         ['osd-msg'] = true, ['osd-msg-bar'] = true, ['raw'] = true,
-        ['expand-properties'] = true, ['repeatable'] = true, ['async'] = true,
-        ['sync'] = true
+        ['expand-properties'] = true, ['repeatable'] = true,
+        ['nonrepeatable'] = true, ['async'] = true, ['sync'] = true
     }
 
     while tokens[first_useful_token_index] and


### PR DESCRIPTION
This allows forcing certain commands to be non-repeatable, e.g. volume.

Closes https://github.com/mpv-player/mpv/issues/14165.