### PR TITLE
playloop: don't redraw without subs on quit

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -644,7 +644,7 @@ void update_ab_loop_clip(struct MPContext *mpctx)
 
 static void handle_osd_redraw(struct MPContext *mpctx)
 {
-    if (!mpctx->video_out || !mpctx->video_out->config_ok)
+    if (!mpctx->video_out || !mpctx->video_out->config_ok || (mpctx->playing && mpctx->stop_play))
         return;
     // If we're playing normally, let OSD be redrawn naturally as part of
     // video display.


### PR DESCRIPTION
handle_osd_redraw is called while we're in the middle of the cleanup portion of play_current_file (via kill_demuxers_reentrant and mp_idle). This happens after we've torn down the subtitle track, so we end up requesting a redraw from the vo, which results in a 1-frame flash of the video without subs before we either quit or switch to the next file (or the force-window state). This detects that condition and skips the redraw, without interfering with drawing the osd during idle (eg for pseudo-gui mode).