### PR TITLE
meson: limit concurrent link jobs to 16

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project('mpv',
         version: files('./VERSION'),
         meson_version: '>=0.62.0',
         default_options: [
+            'backend_max_links=16',
             'buildtype=debugoptimized',
             'b_lundef=false',
             'c_std=c11',


### PR DESCRIPTION
Statically linking, especially with LTO can use a lot of memory. Limit to 16 jobs by default, which is more than enough. Only fuzzers are affected as we don't produce that much binaries otherwise.