### PR TITLE
loadfile: improve the format of terminal track information

### DIFF
--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -38,6 +38,8 @@
 #define TERM_ESC_ENABLE_MOUSE       "\033[?1003h"
 #define TERM_ESC_DISABLE_MOUSE      "\033[?1003l"
 
+#define TERM_ESC_GREY               "\033[38;5;8m"
+
 struct input_ctx;
 
 /* Global initialization for terminal output. */


### PR DESCRIPTION
Make terminal output consistent with the symbols introduced in 14462dafe4.

There is no need to print ◌ for unselected tracks for alignment since terminal text is always monospace.