### PR TITLE
fuzzers: always return 0

### DIFF
--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -27,15 +27,15 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     if (size <= 1 || data[size - 1] != '\0')
-        return -1;
+        return 0;
 
     // Exlude data with null bytes inside
     if (strlen(data) != size - 1)
-        return -1;
+        return 0;
 
 #ifdef MPV_PROTO
     if (!str_startswith(data, size - 1, MPV_STRINGIFY(MPV_PROTO) "://", sizeof(MPV_STRINGIFY(MPV_PROTO) "://") - 1))
-        return -1;
+        return 0;
 #endif
 
 #if !defined(MPV_PROTO) || defined(MPV_PROTO_FILE)
@@ -49,13 +49,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     // Exclude some common paths that are not useful for testing.
     // Exclude -
     if (size_check == 2 && !strncmp(data_check, "-", 1))
-        return -1;
+        return 0;
     // Exclude relative paths
     if (str_startswith(data_check, size_check - 1, ".", 1))
-        return -1;
+        return 0;
     // Exclude absolute paths
     if (str_startswith(data_check, size_check - 1, "/", 1))
-        return -1;
+        return 0;
 #endif
 
     mpv_handle *ctx = mpv_create();

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -27,7 +27,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     case MPV_FORMAT_STRING:
         value_len = strnlen(data, size);
         if (!value_len || value_len == size)
-            return -1;
+            return 0;
         value_len += 1;
         break;
     case MPV_FORMAT_FLAG:
@@ -46,12 +46,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     // at least two bytes for the name
     if (size < value_len + 2)
-        return -1;
+        return 0;
 
     const char *name = (const char *)data + value_len;
     size_t name_len = strnlen(name, size - value_len);
     if (!name_len || name_len != size - value_len - 1)
-        return -1;
+        return 0;
 
     mpv_handle *ctx = mpv_create();
     if (!ctx)


### PR DESCRIPTION
While LibFuzzer supports rejecting unwanted inputs, it looks like Honggfuzz treats anything other than 0 as fatal error.

https://llvm.org/docs/LibFuzzer.html#rejecting-unwanted-inputs https://github.com/google/honggfuzz/blob/348a47213919f14b9453e89a663b1515369bd9a2/libhfuzz/persistent.c#L67 This LOG_F calls exit(EXIT_FAILURE)