### PR TITLE
TOOLS/gen-interface-changes.py: sort interface changes by change types

### DIFF
--- a/DOCS/contribute.md
+++ b/DOCS/contribute.md
@@ -141,7 +141,10 @@ Interface change policy
   must be documented by making a new text file with a txt extension containing a
   small note in the DOCS/interface-changes directory.
 - The name of the file should be brief and related to the commit that makes the
-  change.
+  change. The content of the file should begin with the type of the change
+  (add, remove, deprecate, change, rename, etc.). If the file contains multiple
+  changes, the change which causes the most serious compatibility issues should
+  be placed first.
 - Grouping multiple related changes in the same file is also OK. Just be sure to
   put each separate change on a different line.
 - Documenting additions in DOCS/interface-changes is optional but encouraged.

--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -44,7 +44,7 @@ Interface changes
     - add `current-gpu-context` property
     - add `--secondary-sub-ass-override` option
     - add `--input-preprocess-wheel` option
-    - remove shared-script-properties (user-data is a replacement)
+    - remove `shared-script-properties` (`user-data` is a replacement)
     - add `--secondary-sub-delay`, decouple secondary subtitles from
       `--sub-delay`
     - add the `--osd-bar-border-size` option

--- a/DOCS/interface-changes/input-select.txt
+++ b/DOCS/interface-changes/input-select.txt
@@ -1,1 +1,1 @@
-`add mp.input.select()`
+add `mp.input.select()`

--- a/DOCS/interface-changes/input-touch-emulate-mouse.txt
+++ b/DOCS/interface-changes/input-touch-emulate-mouse.txt
@@ -1,1 +1,0 @@
-add --input-touch-emulate-mouse option

--- a/DOCS/interface-changes/native-touch.txt
+++ b/DOCS/interface-changes/native-touch.txt
@@ -1,1 +1,3 @@
-add --native-touch option
+add `--native-touch` option
+add `--input-touch-emulate-mouse` option
+add `touch-pos` property

--- a/DOCS/interface-changes/touch-pos.txt
+++ b/DOCS/interface-changes/touch-pos.txt
@@ -1,1 +1,0 @@
-add `touch-pos` property

--- a/TOOLS/gen-interface-changes.py
+++ b/TOOLS/gen-interface-changes.py
@@ -34,18 +34,19 @@ def add_new_entries(docs_dir, out, git):
             timestamp = check_output([git, "log", "--format=%ct", "-n", "1", "--",
                                       f], encoding="UTF-8")
             if timestamp:
-                files.append((f, timestamp))
+                content = f.read_text()
+                files.append(content)
             else:
                 print(f"Skipping file not tracked by git: {f.name}")
 
-    files.sort(key=lambda x: x[1])
-    for file in files:
-        with open(file[0].resolve(), "r") as f:
-            for line in f:
-                line = textwrap.fill(line.rstrip(), width=80,
-                                     initial_indent="    - ",
-                                     subsequent_indent="      ")
-                out.write(line + "\n")
+    # Sort the changes by "severity", which roughly corresponds to
+    # alphabetical order by accident (e.g. remove > deprecate > change > add)
+    for file in reversed(sorted(files)):
+        for line in file.splitlines():
+            line = textwrap.fill(line.rstrip(), width=80,
+                                  initial_indent="    - ",
+                                  subsequent_indent="      ")
+            out.write(line + "\n")
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:


### PR DESCRIPTION
Sort interface changes by the types of changes to make it easier for users to find breaking changes. I think it's more useful than sorting it by date. Closely related changes can still be grouped by files. 