### PR TITLE
fuzzers/load: clear old temp files if they exist

### DIFF
--- a/fuzzers/fuzzer_load.c
+++ b/fuzzers/fuzzer_load.c
@@ -26,6 +26,13 @@
 
 #include "common.h"
 
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    // Is /tmp really persistent?
+    system("rm -f /tmp/libfuzzer.*");
+    return 0;
+}
+
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     // fmemopen doesn't have associated file descriptor, so we do copy.


### PR DESCRIPTION
They were previously left over, and now that it looks like runners are stuck, the big question is: is /tmp persistent?

This commit will be reverted after the next rebuild.