### PR TITLE
wayland: use wl->callback_surface for idle inhibitor creation

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2120,7 +2120,7 @@ static int set_screensaver_inhibitor(struct vo_wayland_state *wl, int state)
     if (state) {
         MP_VERBOSE(wl, "Enabling idle inhibitor\n");
         struct zwp_idle_inhibit_manager_v1 *mgr = wl->idle_inhibit_manager;
-        wl->idle_inhibitor = zwp_idle_inhibit_manager_v1_create_inhibitor(mgr, wl->surface);
+        wl->idle_inhibitor = zwp_idle_inhibit_manager_v1_create_inhibitor(mgr, wl->callback_surface);
     } else {
         MP_VERBOSE(wl, "Disabling the idle inhibitor\n");
         zwp_idle_inhibitor_v1_destroy(wl->idle_inhibitor);


### PR DESCRIPTION
The idle inhibit protocol specifies that the compositor may ignore the idle inhibitor if the surface is occluded. In the case of vo_dmabuf_wayland, wl->surface corresponds to typical black bars when the video aspect ratio is different than the display's. So in many cases, wl->surface is actually occluded by wl->video_surface which sits above it. Change this so that the idle inhibitor is created on wl->callback_surface instead which is either wl->surface for the gpu VOs or wl->video_surface for vo_dmabuf_wayland. Fixes #14206.