### PR TITLE
osc.lua: add option to make rendering smoother

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -479,6 +479,12 @@ Configurable Options
 
     Sets the colors of the elements that are being pressed or held down.
 
+``tick_delay``
+    Default: 1/60
+
+    Sets the minimum interval between OSC redraws in seconds. This can be
+    decreased on fast systems to make OSC rendering smoother.
+
 
 Script Commands
 ~~~~~~~~~~~~~~~

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -485,6 +485,14 @@ Configurable Options
     Sets the minimum interval between OSC redraws in seconds. This can be
     decreased on fast systems to make OSC rendering smoother.
 
+    Ignored if ``tick_delay_follow_display_fps`` is set to yes and the VO
+    supports the ``display-fps`` property.
+
+``tick_delay_follow_display_fps``
+    Default: no
+
+    Use display fps to calculate the interval between OSC redraws.
+
 
 Script Commands
 ~~~~~~~~~~~~~~~

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2752,37 +2752,28 @@ mp.register_script_message("osc-tracklist", function(dur)
     show_message(table.concat(message, '\n\n'), dur)
 end)
 
-mp.observe_property("fullscreen", "bool",
-    function(_, val)
-        state.fullscreen = val
-        state.marginsREQ = true
-        request_init_resize()
-    end
-)
-mp.observe_property("border", "bool",
-    function(_, val)
-        state.border = val
-        request_init_resize()
-    end
-)
-mp.observe_property("title-bar", "bool",
-    function(_, val)
-        state.title_bar = val
-        request_init_resize()
-    end
-)
-mp.observe_property("window-maximized", "bool",
-    function(_, val)
-        state.maximized = val
-        request_init_resize()
-    end
-)
-mp.observe_property("idle-active", "bool",
-    function(_, val)
-        state.idle = val
-        request_tick()
-    end
-)
+mp.observe_property("fullscreen", "bool", function(_, val)
+    state.fullscreen = val
+    state.marginsREQ = true
+    request_init_resize()
+end)
+mp.observe_property("border", "bool", function(_, val)
+    state.border = val
+    request_init_resize()
+end)
+mp.observe_property("title-bar", "bool", function(_, val)
+    state.title_bar = val
+    request_init_resize()
+end)
+mp.observe_property("window-maximized", "bool", function(_, val)
+    state.maximized = val
+    request_init_resize()
+end)
+mp.observe_property("idle-active", "bool", function(_, val)
+    state.idle = val
+    request_tick()
+end)
+
 mp.observe_property("pause", "bool", pause_state)
 mp.observe_property("demuxer-cache-state", "native", cache_state)
 mp.observe_property("vo-configured", "bool", request_tick)

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -70,7 +70,9 @@ local user_opts = {
     top_buttons_color = "#FFFFFF",	-- color of top buttons
     held_element_color = "#999999",	-- color of an element while held down
 
-    time_pos_outline_color = "#000000"	-- color of the border timecodes in slimbox and TimePosBar
+    time_pos_outline_color = "#000000",	-- color of the border timecodes in slimbox and TimePosBar
+
+    tick_delay = 1 / 60,                  -- minimum interval between OSC redraws in seconds
 }
 
 local osc_param = { -- calculated by osc_init()
@@ -91,7 +93,7 @@ local margins_opts = {
     {"b", "video-margin-ratio-bottom"},
 }
 
-local tick_delay = 0.03
+local tick_delay = 1 / 60
 local tracks_osc = {}
 local tracks_mpv = {}
 local window_control_box_width = 80
@@ -2975,6 +2977,7 @@ end
 opt.read_options(user_opts, "osc", function()
     validate_user_opts()
     set_osc_styles()
+    tick_delay = user_opts.tick_delay
     request_tick()
     visibility_mode(user_opts.visibility, true)
     update_duration_watch()

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -73,6 +73,7 @@ local user_opts = {
     time_pos_outline_color = "#000000",	-- color of the border timecodes in slimbox and TimePosBar
 
     tick_delay = 1 / 60,                  -- minimum interval between OSC redraws in seconds
+    tick_delay_follow_display_fps = false -- use display fps as the minimum interval
 }
 
 local osc_param = { -- calculated by osc_init()
@@ -2725,6 +2726,15 @@ local function update_duration_watch()
     end
 end
 
+local function set_tick_delay(_, display_fps)
+    -- may be nil if unavailable or 0 fps is reported
+    if not display_fps or not user_opts.tick_delay_follow_display_fps then
+        tick_delay = user_opts.tick_delay
+        return
+    end
+    tick_delay = 1 / display_fps
+end
+
 mp.register_event("shutdown", shutdown)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", "native", request_init)
@@ -2774,6 +2784,7 @@ mp.observe_property("idle-active", "bool", function(_, val)
     request_tick()
 end)
 
+mp.observe_property("display-fps", "number", set_tick_delay)
 mp.observe_property("pause", "bool", pause_state)
 mp.observe_property("demuxer-cache-state", "native", cache_state)
 mp.observe_property("vo-configured", "bool", request_tick)
@@ -2965,10 +2976,12 @@ local function validate_user_opts()
 end
 
 -- read options from config and command-line
-opt.read_options(user_opts, "osc", function()
+opt.read_options(user_opts, "osc", function(changed)
     validate_user_opts()
     set_osc_styles()
-    tick_delay = user_opts.tick_delay
+    if changed.tick_delay or changed.tick_delay_follow_display_fps then
+        set_tick_delay("display_fps", mp.get_property_number("display_fps", nil))
+    end
     request_tick()
     visibility_mode(user_opts.visibility, true)
     update_duration_watch()
@@ -2977,6 +2990,7 @@ end)
 
 validate_user_opts()
 set_osc_styles()
+set_tick_delay("display_fps", mp.get_property_number("display_fps", nil))
 visibility_mode(user_opts.visibility, true)
 update_duration_watch()
 


### PR DESCRIPTION
OSC rendering used to be smooth (up to OSD rendering fps) before 48f906249ef359c66fc6c5bf4cc5885c8293bf8e, but after that commit the frame duration is hardcoded to 30 ms. This is too high and results in choppy OSC rendering, which is very noticable with the progress bar while moving mouse over it or playing a short 60 fps video.

This makes the duration an option so that it can be decreased to make OSC rendering smoother.