### PR TITLE
vo_gpu{,_next}: convert scale options to type choice

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1122,6 +1122,11 @@ local function handle_choice_completion(option, before_cur, path_pos)
         return handle_file_completion(before_cur, path_pos)
     end
 
+    -- Fix completing the empty value for --dscale and --cscale.
+    if info.choices and info.choices[1] == '' and completion_append == '' then
+        info.choices[1] = '""'
+    end
+
     return info.choices, before_cur
 end
 

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -32,23 +32,19 @@
 
 // NOTE: all filters are designed for discrete convolution
 
-const struct filter_window *mp_find_filter_window(const char *name)
+const struct filter_window *mp_find_filter_window(enum scaler_filter function)
 {
-    if (!name)
-        return NULL;
-    for (const struct filter_window *w = mp_filter_windows; w->name; w++) {
-        if (strcmp(w->name, name) == 0)
+    for (const struct filter_window *w = mp_filter_windows; w->function; w++) {
+        if (w->function == function)
             return w;
     }
     return NULL;
 }
 
-const struct filter_kernel *mp_find_filter_kernel(const char *name)
+const struct filter_kernel *mp_find_filter_kernel(enum scaler_filter function)
 {
-    if (!name)
-        return NULL;
-    for (const struct filter_kernel *k = mp_filter_kernels; k->f.name; k++) {
-        if (strcmp(k->f.name, name) == 0)
+    for (const struct filter_kernel *k = mp_filter_kernels; k->f.function; k++) {
+        if (k->f.function == function)
             return k;
     }
     return NULL;
@@ -335,21 +331,21 @@ static double sphinx(params *p, double x)
 }
 
 const struct filter_window mp_filter_windows[] = {
-    {"box",            1,   box},
-    {"triangle",       1,   triangle},
-    {"bartlett",       1,   triangle},
-    {"cosine",         M_PI_2, cosine},
-    {"hanning",        1,   hanning},
-    {"tukey",          1,   hanning, .taper = 0.5},
-    {"hamming",        1,   hamming},
-    {"quadric",        1.5, quadric},
-    {"welch",          1,   welch},
-    {"kaiser",         1,   kaiser,   .params = {6.33, NAN} },
-    {"blackman",       1,   blackman, .params = {0.16, NAN} },
-    {"gaussian",       2,   gaussian, .params = {1.00, NAN} },
-    {"sinc",           1,   sinc},
-    {"jinc",           1.2196698912665045, jinc},
-    {"sphinx",         1.4302966531242027, sphinx},
+    {WINDOW_BOX,      1,   box},
+    {WINDOW_TRIANGLE, 1,   triangle},
+    {WINDOW_BARTLETT, 1,   triangle},
+    {WINDOW_COSINE,   M_PI_2, cosine},
+    {WINDOW_HANNING,  1,   hanning},
+    {WINDOW_TUKEY,    1,   hanning, .taper = 0.5},
+    {WINDOW_HAMMING,  1,   hamming},
+    {WINDOW_QUADRIC,  1.5, quadric},
+    {WINDOW_WELCH,    1,   welch},
+    {WINDOW_KAISER,   1,   kaiser,   .params = {6.33, NAN} },
+    {WINDOW_BLACKMAN, 1,   blackman, .params = {0.16, NAN} },
+    {WINDOW_GAUSSIAN, 2,   gaussian, .params = {1.00, NAN} },
+    {WINDOW_SINC,     1,   sinc},
+    {WINDOW_JINC,     1.2196698912665045, jinc},
+    {WINDOW_SPHINX,   1.4302966531242027, sphinx},
     {0}
 };
 
@@ -358,54 +354,54 @@ const struct filter_window mp_filter_windows[] = {
 
 const struct filter_kernel mp_filter_kernels[] = {
     // Spline filters
-    {{"spline16",       2,   spline16}},
-    {{"spline36",       3,   spline36}},
-    {{"spline64",       4,   spline64}},
+    {{SCALER_SPLINE16, 2, spline16}},
+    {{SCALER_SPLINE36, 3, spline36}},
+    {{SCALER_SPLINE64, 4, spline64}},
     // Sinc filters
-    {{"sinc",           2,  sinc, .resizable = true}},
-    {{"lanczos",        3,  sinc, .resizable = true}, .window = "sinc"},
-    {{"ginseng",        3,  sinc, .resizable = true}, .window = "jinc"},
+    {{SCALER_SINC,    2,  sinc, .resizable = true}},
+    {{SCALER_LANCZOS, 3,  sinc, .resizable = true}, .window = WINDOW_SINC},
+    {{SCALER_GINSENG, 3,  sinc, .resizable = true}, .window = WINDOW_JINC},
     // Jinc filters
-    {{"jinc",           JINC_R3, jinc, .resizable = true}, .polar = true},
-    {{"ewa_lanczos",    JINC_R3, jinc, .resizable = true}, .polar = true, .window = "jinc"},
-    {{"ewa_hanning",    JINC_R3, jinc, .resizable = true}, .polar = true, .window = "hanning" },
-    {{"ewa_ginseng",    JINC_R3, jinc, .resizable = true}, .polar = true, .window = "sinc"},
+    {{SCALER_JINC,        JINC_R3, jinc, .resizable = true}, .polar = true},
+    {{SCALER_EWA_LANCZOS, JINC_R3, jinc, .resizable = true}, .polar = true, .window = WINDOW_JINC},
+    {{SCALER_EWA_HANNING, JINC_R3, jinc, .resizable = true}, .polar = true, .window = WINDOW_HANNING},
+    {{SCALER_EWA_GINSENG, JINC_R3, jinc, .resizable = true}, .polar = true, .window = WINDOW_SINC},
     // Slightly sharpened to minimize the 1D step response error (to better
     // preserve horizontal/vertical lines)
-    {{"ewa_lanczossharp", JINC_R3, jinc, .blur = 0.9812505837223707, .resizable = true},
-        .polar = true, .window = "jinc"},
+    {{SCALER_EWA_LANCZOSSHARP, JINC_R3, jinc, .blur = 0.9812505837223707, .resizable = true},
+        .polar = true, .window = WINDOW_JINC},
     // Similar to the above, but sharpened substantially to the point of
     // minimizing the total impulse response error on an integer grid. Tends
     // to preserve hash patterns well. Very sharp but rings a lot.
-    {{"ewa_lanczos4sharpest", JINC_R4, jinc, .blur = 0.8845120932605005, .resizable = true},
-        .polar = true, .window = "jinc"},
+    {{SCALER_EWA_LANCZOS4SHARPEST, JINC_R4, jinc, .blur = 0.8845120932605005, .resizable = true},
+        .polar = true, .window = WINDOW_JINC},
     // Similar to the above, but softened instead, to make even/odd integer
     // contributions exactly symmetrical. Designed to smooth out hash patterns.
-    {{"ewa_lanczossoft", JINC_R3, jinc, .blur = 1.0164667662867047, .resizable = true},
-        .polar = true, .window = "jinc"},
+    {{SCALER_EWA_LANCZOSSOFT, JINC_R3, jinc, .blur = 1.0164667662867047, .resizable = true},
+        .polar = true, .window = WINDOW_JINC},
     // Very soft (blurred) hanning-windowed jinc; removes almost all aliasing.
     // Blur parameter picked to match orthogonal and diagonal contributions
-    {{"haasnsoft", JINC_R3, jinc, .blur = 1.11, .resizable = true},
-        .polar = true, .window = "hanning"},
+    {{SCALER_HAASNSOFT, JINC_R3, jinc, .blur = 1.11, .resizable = true},
+        .polar = true, .window = WINDOW_HANNING},
     // Cubic filters
-    {{"bicubic",        2,   cubic_bc, .params = {1.0, 0.0} }},
-    {{"hermite",        1,   cubic_bc, .params = {0.0, 0.0} }},
-    {{"catmull_rom",    2,   cubic_bc, .params = {0.0, 0.5} }},
-    {{"mitchell",       2,   cubic_bc, .params = {1.0/3.0, 1.0/3.0} }},
-    {{"robidoux",       2,   cubic_bc, .params = {12 / (19 + 9 * M_SQRT2),
-                                                  113 / (58 + 216 * M_SQRT2)} }},
-    {{"robidouxsharp",  2,   cubic_bc, .params = {6 / (13 + 7 * M_SQRT2),
-                                                  7 / (2 + 12 * M_SQRT2)} }},
-    {{"ewa_robidoux",   2,   cubic_bc, .params = {12 / (19 + 9 * M_SQRT2),
-                                                  113 / (58 + 216 * M_SQRT2)}},
-            .polar = true},
-    {{"ewa_robidouxsharp", 2,cubic_bc, .params = {6 / (13 + 7 * M_SQRT2),
-                                                  7 / (2 + 12 * M_SQRT2)}},
-            .polar = true},
+    {{SCALER_BICUBIC,       2, cubic_bc, .params = {1.0, 0.0} }},
+    {{SCALER_HERMITE,       1, cubic_bc, .params = {0.0, 0.0} }},
+    {{SCALER_CATMULL_ROM,   2, cubic_bc, .params = {0.0, 0.5} }},
+    {{SCALER_MITCHELL,      2, cubic_bc, .params = {1.0/3.0, 1.0/3.0} }},
+    {{SCALER_ROBIDOUX,      2, cubic_bc,
+      .params = {12 / (19 + 9 * M_SQRT2), 113 / (58 + 216 * M_SQRT2)} }},
+    {{SCALER_ROBIDOUXSHARP, 2, cubic_bc,
+      .params = {6 / (13 + 7 * M_SQRT2), 7 / (2 + 12 * M_SQRT2)} }},
+    {{SCALER_EWA_ROBIDOUX,  2, cubic_bc,
+      .params = {12 / (19 + 9 * M_SQRT2), 113 / (58 + 216 * M_SQRT2)}},
+        .polar = true},
+    {{SCALER_EWA_ROBIDOUXSHARP, 2,cubic_bc,
+      .params = {6 / (13 + 7 * M_SQRT2), 7 / (2 + 12 * M_SQRT2)}},
+        .polar = true},
     // Miscellaneous filters
-    {{"box",            1,   box, .resizable = true}},
-    {{"nearest",        0.5, box}},
-    {{"triangle",       1,   triangle, .resizable = true}},
-    {{"gaussian",       2,   gaussian, .params = {1.0, NAN}, .resizable = true}},
+    {{SCALER_BOX,      1,   box, .resizable = true}},
+    {{SCALER_NEAREST,  0.5, box}},
+    {{SCALER_TRIANGLE, 1,   triangle, .resizable = true}},
+    {{SCALER_GAUSSIAN, 2,   gaussian, .params = {1.0, NAN}, .resizable = true}},
     {{0}}
 };

--- a/video/out/filter_kernels.h
+++ b/video/out/filter_kernels.h
@@ -14,8 +14,58 @@
 
 #include <stdbool.h>
 
+enum scaler_filter {
+    SCALER_INHERIT,
+    SCALER_BILINEAR,
+    SCALER_BICUBIC_FAST,
+    SCALER_OVERSAMPLE,
+    SCALER_LINEAR,
+    SCALER_SPLINE16,
+    SCALER_SPLINE36,
+    SCALER_SPLINE64,
+    SCALER_SINC,
+    SCALER_LANCZOS,
+    SCALER_GINSENG,
+    SCALER_JINC,
+    SCALER_EWA_LANCZOS,
+    SCALER_EWA_HANNING,
+    SCALER_EWA_GINSENG,
+    SCALER_EWA_LANCZOSSHARP,
+    SCALER_EWA_LANCZOS4SHARPEST,
+    SCALER_EWA_LANCZOSSOFT,
+    SCALER_HAASNSOFT,
+    SCALER_BICUBIC,
+    SCALER_HERMITE,
+    SCALER_CATMULL_ROM,
+    SCALER_MITCHELL,
+    SCALER_ROBIDOUX,
+    SCALER_ROBIDOUXSHARP,
+    SCALER_EWA_ROBIDOUX,
+    SCALER_EWA_ROBIDOUXSHARP,
+    SCALER_BOX,
+    SCALER_NEAREST,
+    SCALER_TRIANGLE,
+    SCALER_GAUSSIAN,
+    WINDOW_PREFERRED,
+    WINDOW_BOX,
+    WINDOW_TRIANGLE,
+    WINDOW_BARTLETT,
+    WINDOW_COSINE,
+    WINDOW_HANNING,
+    WINDOW_TUKEY,
+    WINDOW_HAMMING,
+    WINDOW_QUADRIC,
+    WINDOW_WELCH,
+    WINDOW_KAISER,
+    WINDOW_BLACKMAN,
+    WINDOW_GAUSSIAN,
+    WINDOW_SINC,
+    WINDOW_JINC,
+    WINDOW_SPHINX,
+};
+
 struct filter_window {
-    const char *name;
+    enum scaler_filter function;
     double radius; // Preferred radius, should only be changed if resizable
     double (*weight)(struct filter_window *k, double x);
     bool resizable; // Filter supports any given radius
@@ -30,7 +80,7 @@ struct filter_kernel {
     struct filter_window w; // window storage
     double clamp; // clamping factor, affects negative weights
     // Constant values
-    const char *window; // default window
+    enum scaler_filter window; // default window
     bool polar;         // whether or not the filter uses polar coordinates
     // The following values are set by mp_init_filter() at runtime.
     int size;           // number of coefficients (may depend on radius)
@@ -45,8 +95,8 @@ struct filter_kernel {
 extern const struct filter_window mp_filter_windows[];
 extern const struct filter_kernel mp_filter_kernels[];
 
-const struct filter_window *mp_find_filter_window(const char *name);
-const struct filter_kernel *mp_find_filter_kernel(const char *name);
+const struct filter_window *mp_find_filter_window(enum scaler_filter function);
+const struct filter_kernel *mp_find_filter_kernel(enum scaler_filter function);
 
 bool mp_init_filter(struct filter_kernel *filter, const int *sizes,
                     double scale);

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -29,10 +29,11 @@
 #include "video/out/filter_kernels.h"
 
 struct scaler_fun {
-    char *name;
+    int function;
     float params[2];
     float blur;
     float taper;
+    const struct m_opt_choice_alternatives *functions;
 };
 
 struct scaler_config {

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1906,13 +1906,13 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
 
     const struct gl_video_opts *opts = p->opts_cache->opts;
     const struct scaler_config *cfg = &opts->scaler[unit];
-    if (unit == SCALER_DSCALE && (!cfg->kernel.name || !cfg->kernel.name[0]))
+    if (cfg->kernel.function == SCALER_INHERIT)
         cfg = &opts->scaler[SCALER_SCALE];
-    if (unit == SCALER_CSCALE && (!cfg->kernel.name || !cfg->kernel.name[0]))
-        cfg = &opts->scaler[SCALER_SCALE];
+    const char *kernel_name = m_opt_choice_str(cfg->kernel.functions,
+                                               cfg->kernel.function);
 
     for (int i = 0; fixed_presets[i].name; i++) {
-        if (strcmp(cfg->kernel.name, fixed_presets[i].name) == 0)
+        if (strcmp(kernel_name, fixed_presets[i].name) == 0)
             return fixed_presets[i].filter;
     }
 
@@ -1920,9 +1920,9 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
     struct scaler_params *par = &p->scalers[unit];
     const struct pl_filter_preset *preset;
     const struct pl_filter_function_preset *fpreset;
-    if ((preset = pl_find_filter_preset(cfg->kernel.name))) {
+    if ((preset = pl_find_filter_preset(kernel_name))) {
         par->config = *preset->filter;
-    } else if ((fpreset = pl_find_filter_function_preset(cfg->kernel.name))) {
+    } else if ((fpreset = pl_find_filter_function_preset(kernel_name))) {
         par->config = (struct pl_filter_config) {
             .kernel = fpreset->function,
             .params[0] = fpreset->function->params[0],
@@ -1930,12 +1930,13 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
         };
     } else {
         MP_ERR(p, "Failed mapping filter function '%s', no libplacebo analog?\n",
-               cfg->kernel.name);
+               kernel_name);
         return &pl_filter_bilinear;
     }
 
     const struct pl_filter_function_preset *wpreset;
-    if ((wpreset = pl_find_filter_function_preset(cfg->window.name))) {
+    if ((wpreset = pl_find_filter_function_preset(
+             m_opt_choice_str(cfg->window.functions, cfg->window.function)))) {
         par->config.window = wpreset->function;
         par->config.wparams[0] = wpreset->function->params[0];
         par->config.wparams[1] = wpreset->function->params[1];
@@ -1958,7 +1959,7 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
             par->config.radius = cfg->radius;
         } else {
             MP_WARN(p, "Filter radius specified but filter '%s' is not "
-                    "resizable, ignoring\n", cfg->kernel.name);
+                    "resizable, ignoring\n", kernel_name);
         }
     }
 


### PR DESCRIPTION
This allows Tab completing them in the console and zsh, and using cycle scale.

jinc is also added to --tscale=help's output, while before it was missing because validate_scaler_opt() skipped filter windows with the same name as a filter kernel, but the jinc kernel was skipped with --tscale because it is polar.