### PR TITLE
[RFC] player: handle audio pts more consistently

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2110,9 +2110,10 @@ Property list
 
 ``audio-pts``
     Current audio playback position in current file in seconds. Unlike time-pos,
-    this updates more often than once per frame. For audio-only files, it is
-    mostly equivalent to time-pos, while for video-only files this property is
-    not available.
+    this updates more often than once per frame. This is mostly equivalent to
+    time-pos for audio-only files however it also takes into account the audio
+    driver delay. This can lead to negative values in certain cases, so in
+    general you probably want to simply use time-pos.
 
     This has a sub-property:
 

--- a/player/command.c
+++ b/player/command.c
@@ -820,7 +820,7 @@ static int mp_property_time_pos(void *ctx, struct m_property *prop,
         queue_seek(mpctx, MPSEEK_ABSOLUTE, *(double *)arg, MPSEEK_DEFAULT, 0);
         return M_PROPERTY_OK;
     }
-    return property_time(action, arg, get_current_time(mpctx));
+    return property_time(action, arg, get_playback_time(mpctx));
 }
 
 /// Current audio pts in seconds (R)

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -335,7 +335,7 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     write_filename(mpctx, file, path);
 
     bool write_start = true;
-    double pos = get_current_time(mpctx);
+    double pos = get_playback_time(mpctx);
 
     if ((demux && (!demux->seekable || demux->partially_seekable)) ||
         pos == MP_NOPTS_VALUE)

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -529,6 +529,9 @@ double get_playback_time(struct MPContext *mpctx)
         if (length >= 0)
             cur = MPCLAMP(cur, 0, length);
     }
+    // Force to 0 if this is not MP_NOPTS_VALUE.
+    if (cur != MP_NOPTS_VALUE && cur < 0)
+        cur = 0.0;
     return cur;
 }
 

--- a/player/video.c
+++ b/player/video.c
@@ -646,9 +646,8 @@ static void update_av_diff(struct MPContext *mpctx, double offset)
     if (mpctx->vo_chain && mpctx->vo_chain->is_sparse)
         return;
 
-    double a_pos = written_audio_pts(mpctx);
+    double a_pos = playing_audio_pts(mpctx);
     if (a_pos != MP_NOPTS_VALUE && mpctx->video_pts != MP_NOPTS_VALUE) {
-        a_pos -= mpctx->audio_speed * ao_get_delay(mpctx->ao);
         mpctx->last_av_difference = a_pos - mpctx->video_pts
                                   + opts->audio_delay + offset;
     }


### PR DESCRIPTION
See commit message for full details. Supersedes #14205. Hopefully if I understood it right, this should fix all the weird behavior that happens because the audio pts becomes negative.

This fully fixes https://github.com/mpv-player/mpv/issues/10346, and https://github.com/mpv-player/mpv/issues/12247 is still fixed (used a different file that I confirmed exhibited the described issue before some related commits closed it).