### PR TITLE
x11: correct position coordinates if mpv was launched with --fs

### DIFF
--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -93,6 +93,8 @@ struct vo_x11_state {
     bool pseudo_mapped; // not necessarily mapped, but known window size
     int fs;     // whether we assume the window is in fullscreen mode
 
+    bool init_fs; // whether mpv was launched with --fs
+
     bool mouse_cursor_visible; // whether we want the cursor to be visible (only
                                // takes effect when the window is focused)
     bool mouse_cursor_set; // whether the cursor is *currently* *hidden*


### PR DESCRIPTION
When initially mapping the mpv window, if it was started in fullscreen, mpv unconditionally marked x11->pos_changed_during_fs as true. This is not needed and causes a bunch of problems. While in fullscreen, the window can be moved in a number of ways by the window manager or so on. The net result is that this just causes the mpv window to exit fullscreen on screen 0 instead of the screen it was actually moved to. The size change adjustment is still needed for this case, but forcing pos_changed_during_fs doesn't do anything but cause weird behavior. Fixes #14226.

TODO: Test a bit more to see if something weird happens on another wm.