### PR TITLE
playloop: don't loop when seeking to the end of cover art while paused

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1206,7 +1206,8 @@ static void handle_eof(struct MPContext *mpctx)
      * other hand, if we don't have a video frame, then the user probably seeked
      * outside of the video, and we do want to quit. */
     bool prevent_eof =
-        mpctx->paused && mpctx->video_out && vo_has_frame(mpctx->video_out);
+        mpctx->paused && mpctx->video_out && vo_has_frame(mpctx->video_out) &&
+        !mpctx->vo_chain->is_coverart;
     /* It's possible for the user to simultaneously switch both audio
      * and video streams to "disabled" at runtime. Handle this by waiting
      * rather than immediately stopping playback due to EOF.


### PR DESCRIPTION
Fix the bug that seeking to the end of cover art while paused goes back to the beginning of the file because of this condition meant for videos.

This doesn't check mpctx->vo_chain->is_sparse because prevent_eof should be true with actual sparse videos.