### PR TITLE
egl: allow customizing egl config 

### DIFF
--- a/DOCS/interface-changes/egl-output-format.txt
+++ b/DOCS/interface-changes/egl-output-format.txt
@@ -1,0 +1,1 @@
+add `--egl-config-id` option

--- a/DOCS/interface-changes/egl-output-format.txt
+++ b/DOCS/interface-changes/egl-output-format.txt
@@ -1,1 +1,2 @@
 add `--egl-config-id` option
+add `--egl-output-format` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5716,6 +5716,12 @@ them.
     results, as can missing or incorrect display FPS information (see
     ``--display-fps-override``).
 
+``--egl-config-id=<ID>``
+    (EGL only)
+    Select EGLConfig with specific EGL_CONFIG_ID.
+    Rendering surfaces and contexts will be created using this EGLConfig.
+    You can use ``--msg-level=vo=trace`` to obtain a list of available configs.
+
 ``--vulkan-device=<device name|UUID>``
     The name or UUID of the Vulkan device to use for rendering and presentation. Use
     ``--vulkan-device=help`` to see the list of available devices and their

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5722,6 +5722,27 @@ them.
     Rendering surfaces and contexts will be created using this EGLConfig.
     You can use ``--msg-level=vo=trace`` to obtain a list of available configs.
 
+``--egl-output-format=<auto|rgb8|rgba8|rgb10|rgb10_a2|rgb16|rgba16|rgb16f|rgba16f|rgb32f|rgba32f>``
+    (EGL only)
+    Select a specific EGL output format to utilize for OpenGL rendering.
+    This option is mutually exclusive with ``--egl-config-id``.
+    "auto" is the default, which will pick the first usable config
+    based on the order given by the driver.
+
+    All formats are not available.
+    A fatal error is caused if an unavailable format is selected.
+
+    .. note::
+
+        There is no reliable API to query desktop bit depth in EGL.
+        You can manually set this option
+        according to the bit depth of your display.
+        This option also affects the auto-detection of ``--dither-depth``.
+
+    .. note::
+
+        Unlike  ``--d3d11-output-format``, this option also takes effect with ``--vo=gpu-next``.
+
 ``--vulkan-device=<device name|UUID>``
     The name or UUID of the Vulkan device to use for rendering and presentation. Use
     ``--vulkan-device=help`` to see the list of available devices and their

--- a/options/options.c
+++ b/options/options.c
@@ -905,7 +905,7 @@ static const m_option_t mp_opts[] = {
 #endif
 
 #if HAVE_EGL || HAVE_EGL_ANDROID || HAVE_EGL_ANGLE_WIN32
-    {"", OPT_SUBSTRUCT(egl_opts, egl_conf)},
+    {"egl", OPT_SUBSTRUCT(egl_opts, egl_conf)},
 #endif
 
 #if HAVE_VULKAN

--- a/options/options.c
+++ b/options/options.c
@@ -100,6 +100,7 @@ extern const struct m_sub_options macos_conf;
 extern const struct m_sub_options wayland_conf;
 extern const struct m_sub_options wingl_conf;
 extern const struct m_sub_options vaapi_conf;
+extern const struct m_sub_options egl_conf;
 
 static const struct m_sub_options screenshot_conf = {
     .opts = image_writer_opts,
@@ -901,6 +902,10 @@ static const m_option_t mp_opts[] = {
 
 #if HAVE_GL
     {"", OPT_SUBSTRUCT(opengl_opts, opengl_conf)},
+#endif
+
+#if HAVE_EGL || HAVE_EGL_ANDROID || HAVE_EGL_ANGLE_WIN32
+    {"", OPT_SUBSTRUCT(egl_opts, egl_conf)},
 #endif
 
 #if HAVE_VULKAN

--- a/options/options.h
+++ b/options/options.h
@@ -389,6 +389,7 @@ typedef struct MPOpts {
     struct vaapi_opts *vaapi_opts;
     struct sws_opts *sws_opts;
     struct zimg_opts *zimg_opts;
+    struct egl_opts *egl_opts;
 
     int cuda_device;
 } MPOpts;


### PR DESCRIPTION
This PR adds two options:

- `--egl-config-id`: select specific EGL config based on ID.
- `--egl-output-format`: select EGL config based on format names.

This allow users to customize swapchain format when using EGL.
