### PR TITLE
console.lua: fix crash if no completions exist

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1184,7 +1184,7 @@ local function complete_match(part, list)
     local prefix = find_common_prefix(completions)
 
     if opts.case_sensitive then
-        return completions, prefix
+        return completions, prefix or part
     end
 
     completions = {}


### PR DESCRIPTION
If complete is case-sensitive and no completions exist the script crashes with the following:

`Lua error: @console.lua:1417: attempt to concatenate local 'prefix' (a nil value)`
