### PR TITLE
input: implement VO dragging deadzone

### DIFF
--- a/DOCS/interface-changes/input-builtin-dragging.txt
+++ b/DOCS/interface-changes/input-builtin-dragging.txt
@@ -1,0 +1,1 @@
+add `--input-builtin-dragging` option

--- a/DOCS/interface-changes/input-dragging-deadzone.txt
+++ b/DOCS/interface-changes/input-dragging-deadzone.txt
@@ -1,0 +1,1 @@
+add `--input-dragging-deadzone` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4303,6 +4303,11 @@ Input
     for mouse key bindings and scripts which read mouse positions for platforms
     which do not support ``--native-touch=no`` (e.g. Wayland).
 
+``--input-dragging-deadzone=<N>``
+    Begin the built-in window dragging when the mouse moves outside a deadzone of
+    ``N`` pixels while the mouse button is being held down (default: 3). This only
+    affects VOs which support the ``begin-vo-dragging`` command.
+
 OSD
 ---
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4139,6 +4139,12 @@ Input
     option is applied only during (lib)mpv initialization, and if disabled then it
     will not be not possible to enable them later. May be useful to libmpv clients.
 
+``--input-builtin-dragging=<yes|no>``
+    Enable the built-in window-dragging behavior (default: yes). Setting it to no
+    disables the built-in dragging behavior. Note that unlike the ``window-dragging``
+    option, this option only affects VOs which support the ``begin-vo-dragging``
+    command, and does not disable window dragging initialized with the command.
+
 ``--input-cmdlist``
     Prints all commands that can be bound to keys.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4236,8 +4236,7 @@ Input
 
 ``--input-cursor=<yes|no>``
     Permit mpv to receive pointer events reported by the video output
-    driver. Necessary to use the OSC, or to select the buttons in DVD menus.
-    Support depends on the VO in use.
+    driver. Necessary to use the OSC. Support depends on the VO in use.
 
 ``--input-cursor-passthrough=<yes|no>``
     Tell the backend windowing system to allow pointer events to passthrough

--- a/input/input.c
+++ b/input/input.c
@@ -922,6 +922,8 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
     if (ictx->dragging_button_down && mouse_outside_dragging_deadzone) {
         // Begin built-in VO dragging if the mouse moves while the dragging button is down.
         ictx->dragging_button_down = false;
+        // Prevent activation of MBTN_LEFT key binding if VO dragging begins.
+        release_down_cmd(ictx, true);
         mp_cmd_t *drag_cmd = mp_input_parse_cmd(ictx, bstr0("begin-vo-dragging"), "<internal>");
         queue_cmd(ictx, drag_cmd);
     }

--- a/input/input.c
+++ b/input/input.c
@@ -122,6 +122,8 @@ struct input_ctx {
 
     // VO dragging state
     bool dragging_button_down;
+    // Raw mouse position before transform
+    int mouse_raw_x, mouse_raw_y;
 
     // Mouse position on the consumer side (as command.c sees it)
     int mouse_x, mouse_y;
@@ -863,9 +865,11 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
 {
     MP_TRACE(ictx, "mouse move %d/%d\n", x, y);
 
-    if (ictx->mouse_vo_x == x && ictx->mouse_vo_y == y) {
+    if (ictx->mouse_raw_x == x && ictx->mouse_raw_y == y) {
         return;
     }
+    ictx->mouse_raw_x = x;
+    ictx->mouse_raw_y = y;
 
     if (ictx->mouse_mangle) {
         struct mp_rect *src = &ictx->mouse_src;

--- a/input/input.c
+++ b/input/input.c
@@ -187,6 +187,7 @@ struct input_opts {
     bool use_media_keys;
     bool default_bindings;
     bool builtin_bindings;
+    bool builtin_dragging;
     bool enable_mouse_movements;
     bool vo_key_input;
     bool test;
@@ -204,6 +205,7 @@ const struct m_sub_options input_config = {
         {"input-cmdlist", OPT_PRINT(mp_print_cmd_list)},
         {"input-default-bindings", OPT_BOOL(default_bindings)},
         {"input-builtin-bindings", OPT_BOOL(builtin_bindings)},
+        {"input-builtin-dragging", OPT_BOOL(builtin_dragging)},
         {"input-test", OPT_BOOL(test)},
         {"input-doubleclick-time", OPT_INT(doubleclick_time),
          M_RANGE(0, 1000)},
@@ -233,6 +235,7 @@ const struct m_sub_options input_config = {
         .use_media_keys = true,
         .default_bindings = true,
         .builtin_bindings = true,
+        .builtin_dragging = true,
         .vo_key_input = true,
         .allow_win_drag = true,
         .preprocess_wheel = true,
@@ -919,7 +922,9 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
     bool mouse_outside_dragging_deadzone =
         abs(ictx->mouse_raw_x - ictx->mouse_drag_x) >= ictx->opts->dragging_deadzone ||
         abs(ictx->mouse_raw_y - ictx->mouse_drag_y) >= ictx->opts->dragging_deadzone;
-    if (ictx->dragging_button_down && mouse_outside_dragging_deadzone) {
+    if (ictx->dragging_button_down && mouse_outside_dragging_deadzone &&
+        ictx->opts->builtin_dragging)
+    {
         // Begin built-in VO dragging if the mouse moves while the dragging button is down.
         ictx->dragging_button_down = false;
         // Prevent activation of MBTN_LEFT key binding if VO dragging begins.

--- a/input/input.c
+++ b/input/input.c
@@ -929,6 +929,8 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
         ictx->dragging_button_down = false;
         // Prevent activation of MBTN_LEFT key binding if VO dragging begins.
         release_down_cmd(ictx, true);
+        // Prevent activation of MBTN_LEFT_DBL if VO dragging begins.
+        ictx->last_doubleclick_time = 0;
         mp_cmd_t *drag_cmd = mp_input_parse_cmd(ictx, bstr0("begin-vo-dragging"), "<internal>");
         queue_cmd(ictx, drag_cmd);
     }


### PR DESCRIPTION
This PR fixes several problems with VO dragging: 

- Adds `--input-dragging-deadzone` option, which adds a deadzone for the built-in VO dragging.
- Dragging now only begins after the mouse is moved outside of the deadzone while the left button is held down, which should resolve race condition with dragging on some WMs.
- Resolves the conflict between VO dragging and `MBTN_LEFT` binding.
- Makes it possible to disable the built-in VO dragging so that custom dragging behavior can be implemented.
- Prevents activation of double click if the first click begins VO dragging.

Fixes #7563.
Fixes #13225.
Fixes #13958.
Fixes #14248.
