### PR TITLE
video/out/gpu/context: convert --gpu-api to object settings list

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6495,8 +6495,8 @@ them.
     macvk
         Vulkan on macOS with a metal surface through a translation layer (experimental)
 
-``--gpu-api=<type>``
-    Controls which type of graphics APIs will be accepted:
+``--gpu-api=<type1,type2,...[,]>``
+    Specify a priority list of accepted graphics APIs.
 
     auto
         Use any available API (default). Note that the default GPU API used for this

--- a/player/command.c
+++ b/player/command.c
@@ -7391,7 +7391,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 
     if (opt_ptr == &opts->vo->video_driver_list ||
         opt_ptr == &opts->ra_ctx_opts->context_list ||
-        opt_ptr == &opts->ra_ctx_opts->context_type) {
+        opt_ptr == &opts->ra_ctx_opts->context_type_list) {
         struct track *track = mpctx->current_track[0][STREAM_VIDEO];
         uninit_video_out(mpctx);
         handle_force_window(mpctx, true);

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -154,11 +154,6 @@ static bool get_desc(struct m_obj_desc *dst, int index)
 
 static bool check_unknown_entry(const char *name)
 {
-    struct bstr param = bstr0(name);
-    for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++) {
-        if (bstr_equals0(param, contexts[i]->name))
-            return true;
-    }
     return false;
 }
 

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -11,7 +11,7 @@ struct ra_ctx_opts {
     bool debug;           // enable debugging layers/callbacks etc.
     bool probing;        // the backend was auto-probed
     struct m_obj_settings *context_list; // list of `ra_ctx_fns.name` to probe
-    char *context_type;  // filter by `ra_ctx_fns.type`
+    struct m_obj_settings *context_type_list;  // list of `ra_ctx_fns.type` to probe
 };
 
 extern const struct m_sub_options ra_ctx_conf;


### PR DESCRIPTION
This follows up 96e1f1dfa5 which converted --gpu-context, and has the same advantages as listed there.

Unlike with --gpu-context auto can be used anywhere in the list, e.g. --gpu-api=d3d11,auto works.

I wanted to use the list of GPU contexts as the description in get_type_desc(), but there is no talloc context to allocate it to, so I set a print_help_list to print them. The printed lines don't being with spaces because otherwise they are added to the completions by etc/_mpv.zsh.