### PR TITLE
select.lua: preselect the correct sub line with duration >= 100 minutes

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -195,6 +195,11 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
         return
     end
 
+    if sub.external and sub["external-filename"]:find("^edl://") then
+        sub["external-filename"] = sub["external-filename"]:match('https?://.*')
+                                   or sub["external-filename"]
+    end
+
     local r = mp.command_native({
         name = "subprocess",
         capture_stdout = true,

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -239,7 +239,11 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
         items = sub_lines,
         default_item = default_item,
         submit = function (index)
-            mp.commandv("seek", sub_times[index], "absolute")
+            -- Add an offset to seek to the correct line while paused without a
+            -- video track.
+            local offset = mp.get_property_native("current-tracks/video/image") == false
+                           and 0 or .09
+            mp.commandv("seek", sub_times[index] + offset, "absolute")
         end,
     })
 end)


### PR DESCRIPTION
commit 1: select.lua: preselect the correct sub line with duration >= 100 minutes

ffmpeg outputs timestamps like '100:00.00' in LRCs instead of adding hours, and timestamps like '100:00' are < '10:00', so since these strings are being compared, if there is no current subtitle line, there are subtitle lines at >= 100 minutes, and time-pos is between 10 minutes and 100 minutes, one of the last subtitle lines gets preselected.

Fix this by converting the timestamps to numbers before comparing them.

Also simplify the logic by merging the 2 loops to determine the default line, and reformat the timestamps by adding hours to not print minutes > 60 in the selector, and by removing the hundredths of seconds. This requires storing the accurate timestamps in a table to seek to them on submit.

commit 2: select.lua: seek to the currect subtitle line when paused without video

Add an offset to sub seek correctly like in b35e34ae2f. The extra 0.01 offset apparently isn't necessary in this case.

commit 3: select.lua: hide the hour when it's 0

Omit the hour in the chapter and subtitle line selectors when the file is shorter than an hour.