### PR TITLE
mpv.desktop: fix typo

### DIFF
--- a/etc/mpv.desktop
+++ b/etc/mpv.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=mpv Media Player
-name[ar]=مشغل وسائط mpv
+Name[ar]=مشغل وسائط mpv
 Name[ca]=Reproductor multimèdia mpv
 Name[cs]=mpv přehrávač
 Name[da]=mpv-medieafspiller


### PR DESCRIPTION
That error prevents an mpv appimage that I maintain from building, as appimagetool checks integrity of the .desktop file. 