### PR TITLE
various: simplify printing floats as integers

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -388,7 +388,7 @@ static char *cut_osd_list(struct MPContext *mpctx, char *text, int pos)
 
 static char *format_delay(double time)
 {
-    return talloc_asprintf(NULL, "%d ms", (int)lrint(time * 1000));
+    return talloc_asprintf(NULL, "%.f ms", time * 1000);
 }
 
 // Property-option bridge. (Maps the property to the option with the same name.)
@@ -791,10 +791,10 @@ static int mp_property_percent_pos(void *ctx, struct m_property *prop,
         };
         return M_PROPERTY_OK;
     case M_PROPERTY_PRINT: {
-        int pos = get_percent_pos(mpctx);
+        double pos = get_current_pos_ratio(mpctx, false);
         if (pos < 0)
             return M_PROPERTY_UNAVAILABLE;
-        *(char **)arg = talloc_asprintf(NULL, "%d", pos);
+        *(char **)arg = talloc_asprintf(NULL, "%.f", pos * 100);
         return M_PROPERTY_OK;
     }
     }
@@ -1670,7 +1670,7 @@ static int mp_property_volume(void *ctx, struct m_property *prop,
         };
         return M_PROPERTY_OK;
     case M_PROPERTY_PRINT:
-        *(char **)arg = talloc_asprintf(NULL, "%i", (int)opts->softvol_volume);
+        *(char **)arg = talloc_asprintf(NULL, "%.f", opts->softvol_volume);
         return M_PROPERTY_OK;
     }
 
@@ -3372,7 +3372,7 @@ static int mp_property_packet_bitrate(void *ctx, struct m_property *prop,
     if (action == M_PROPERTY_PRINT) {
         rate /= 1000;
         if (rate < 1000) {
-            *(char **)arg = talloc_asprintf(NULL, "%d kbps", (int)rate);
+            *(char **)arg = talloc_asprintf(NULL, "%.f kbps", rate);
         } else {
             *(char **)arg = talloc_asprintf(NULL, "%.3f Mbps", rate / 1000.0);
         }

--- a/player/osd.c
+++ b/player/osd.c
@@ -54,9 +54,9 @@ static void sadd_hhmmssff(char **buf, double time, bool fractions)
     talloc_free(s);
 }
 
-static void sadd_percentage(char **buf, int percent) {
-    if (percent >= 0)
-        *buf = talloc_asprintf_append(*buf, " (%d%%)", percent);
+static void sadd_percentage(char **buf, double ratio) {
+    if (ratio >= 0)
+        *buf = talloc_asprintf_append(*buf, " (%.f%%)", ratio * 100);
 }
 
 static char *join_lines(void *ta_ctx, char **parts, int num_parts)
@@ -194,7 +194,7 @@ static char *get_term_status_msg(struct MPContext *mpctx)
     saddf(&line, " / ");
     sadd_hhmmssff(&line, get_time_length(mpctx), opts->osd_fractions);
 
-    sadd_percentage(&line, get_percent_pos(mpctx));
+    sadd_percentage(&line, get_current_pos_ratio(mpctx, false));
 
     // other
     if (opts->playback_speed != 1)
@@ -447,7 +447,7 @@ static void sadd_osd_status(char **buffer, struct MPContext *mpctx, int level)
             if (level == 3) {
                 saddf(buffer, " / ");
                 sadd_hhmmssff(buffer, get_time_length(mpctx), fractions);
-                sadd_percentage(buffer, get_percent_pos(mpctx));
+                sadd_percentage(buffer, get_current_pos_ratio(mpctx, false));
             }
         }
     }


### PR DESCRIPTION
For this purpose, the printf precision specifier can be used.
No need to call lrint.