### PR TITLE
playloop: make --loop aware of options that modify the start time

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -913,7 +913,7 @@ static void handle_loop_file(struct MPContext *mpctx)
             opts->loop_file--;
             m_config_notify_change_opt_ptr(mpctx->mconfig, &opts->loop_file);
         }
-        target = get_start_time(mpctx, mpctx->play_dir);
+        target = get_play_start_pts(mpctx);
     }
 
     if (target != MP_NOPTS_VALUE) {


### PR DESCRIPTION
Currently we just seek to the first frame marked by the demuxer, which is wrong because the user might use the --start option together with --loop.

