### PR TITLE
don't decrement --loop-file=N and --ab-loop-count=N

### DIFF
--- a/DOCS/interface-changes/loop.txt
+++ b/DOCS/interface-changes/loop.txt
@@ -1,0 +1,2 @@
+numerical values of `--loop-file` no longer decrease on each iteration
+add `remaining-file-loops` property as a replacement to get the remaining loop count

--- a/DOCS/interface-changes/loop.txt
+++ b/DOCS/interface-changes/loop.txt
@@ -1,2 +1,4 @@
 numerical values of `--loop-file` no longer decrease on each iteration
 add `remaining-file-loops` property as a replacement to get the remaining loop count
+numerical values of `--ab-loop-count` no longer decrease on each iteration
+add `remaining-ab-loops` property as a replacement to get the remaining loop count

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2148,6 +2148,12 @@ Property list
     times it causes the player to seek to the beginning of the file, so it is 0
     the last the time is played. -1 corresponds to infinity.
 
+``remaining-ab-loops``
+    How many more times the current A-B loop is going to be looped, if one is
+    active. This is initialized from the value of ``--ab-loop-count``. This
+    counts the number of times it causes the player to seek to ``--ab-loop-a``,
+    so it is 0 the last the time the loop is played. -1 corresponds to infinity.
+
 ``chapter`` (RW)
     Current chapter number. The number of the first chapter is 0.
 

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2142,6 +2142,12 @@ Property list
     ``playback-time/full``
         ``playback-time`` with milliseconds.
 
+``remaining-file-loops``
+    How many more times the current file is going to be looped. This is
+    initialized from the value of ``--loop-file``. This counts the number of
+    times it causes the player to seek to the beginning of the file, so it is 0
+    the last the time is played. -1 corresponds to infinity.
+
 ``chapter`` (RW)
     Current chapter number. The number of the first chapter is 0.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -441,11 +441,10 @@ Playback Control
 
 ``--ab-loop-count=<N|inf>``
     Run A-B loops only N times, then ignore the A-B loop points (default: inf).
-    Every finished loop iteration will decrement this option by 1 (unless it is
-    set to ``inf`` or 0). ``inf`` means that looping goes on forever. If this
-    option is set to 0, A-B looping is ignored, and even the ``ab-loop`` command
-    will not enable looping again (the command will show ``(disabled)`` on the
-    OSD message if both loop points are set, but ``ab-loop-count`` is 0).
+    ``inf`` means that looping goes on forever. If this option is set to 0, A-B
+    looping is ignored, and even the ``ab-loop`` command will not enable looping
+    again (the command will show ``(disabled)`` on the OSD message if both loop
+    points are set, but ``ab-loop-count`` is 0).
 
 ``--ordered-chapters=<yes|no>``
     Enable support for Matroska ordered chapters. mpv will load and

--- a/player/command.c
+++ b/player/command.c
@@ -870,6 +870,13 @@ static int mp_property_playtime_remaining(void *ctx, struct m_property *prop,
     return property_time(action, arg, remaining / speed);
 }
 
+static int mp_property_remaining_file_loops(void *ctx, struct m_property *prop,
+        int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    return m_property_int_ro(action, arg, mpctx->remaining_file_loops);
+}
+
 /// Current chapter (RW)
 static int mp_property_chapter(void *ctx, struct m_property *prop,
                                int action, void *arg)
@@ -4000,7 +4007,7 @@ static const struct m_property mp_properties_base[] = {
     {"audio-pts", mp_property_audio_pts},
     {"playtime-remaining", mp_property_playtime_remaining},
     M_PROPERTY_ALIAS("playback-time", "time-pos"),
-    {"chapter", mp_property_chapter},
+    {"remaining-file-loops", mp_property_remaining_file_loops},
     {"edition", mp_property_edition},
     {"current-edition", mp_property_current_edition},
     {"chapters", mp_property_chapters},
@@ -7494,6 +7501,11 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (flags & UPDATE_DVB_PROG) {
         if (!mpctx->stop_play)
             mpctx->stop_play = PT_CURRENT_ENTRY;
+    }
+
+    if (opt_ptr == &opts->loop_file) {
+        mpctx->remaining_file_loops = opts->loop_file;
+        mp_notify_property(mpctx, "remaining-file-loops");
     }
 
     if (opt_ptr == &opts->ab_loop[0] || opt_ptr == &opts->ab_loop[1]) {

--- a/player/command.c
+++ b/player/command.c
@@ -877,6 +877,13 @@ static int mp_property_remaining_file_loops(void *ctx, struct m_property *prop,
     return m_property_int_ro(action, arg, mpctx->remaining_file_loops);
 }
 
+static int mp_property_remaining_ab_loops(void *ctx, struct m_property *prop,
+        int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    return m_property_int_ro(action, arg, mpctx->remaining_ab_loops);
+}
+
 /// Current chapter (RW)
 static int mp_property_chapter(void *ctx, struct m_property *prop,
                                int action, void *arg)
@@ -4008,6 +4015,8 @@ static const struct m_property mp_properties_base[] = {
     {"playtime-remaining", mp_property_playtime_remaining},
     M_PROPERTY_ALIAS("playback-time", "time-pos"),
     {"remaining-file-loops", mp_property_remaining_file_loops},
+    {"remaining-ab-loops", mp_property_remaining_ab_loops},
+    {"chapter", mp_property_chapter},
     {"edition", mp_property_edition},
     {"current-edition", mp_property_current_edition},
     {"chapters", mp_property_chapters},
@@ -7506,6 +7515,12 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (opt_ptr == &opts->loop_file) {
         mpctx->remaining_file_loops = opts->loop_file;
         mp_notify_property(mpctx, "remaining-file-loops");
+    }
+
+    if (opt_ptr == &opts->ab_loop[0] || opt_ptr == &opts->ab_loop[1] ||
+        opt_ptr == &opts->ab_loop_count) {
+        mpctx->remaining_ab_loops = opts->ab_loop_count;
+        mp_notify_property(mpctx, "remaining-ab-loops");
     }
 
     if (opt_ptr == &opts->ab_loop[0] || opt_ptr == &opts->ab_loop[1]) {

--- a/player/core.h
+++ b/player/core.h
@@ -420,6 +420,8 @@ typedef struct MPContext {
     int max_frames;
     bool playing_msg_shown;
 
+    int remaining_file_loops;
+
     bool paused_for_cache;
     bool demux_underrun;
     double cache_stop_time;

--- a/player/core.h
+++ b/player/core.h
@@ -421,6 +421,7 @@ typedef struct MPContext {
     bool playing_msg_shown;
 
     int remaining_file_loops;
+    int remaining_ab_loops;
 
     bool paused_for_cache;
     bool demux_underrun;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1616,6 +1616,8 @@ static void play_current_file(struct MPContext *mpctx)
 
     mpctx->remaining_file_loops = mpctx->opts->loop_file;
     mp_notify_property(mpctx, "remaining-file-loops");
+    mpctx->remaining_ab_loops = mpctx->opts->ab_loop_count;
+    mp_notify_property(mpctx, "remaining-ab-loops");
 
     mpctx->max_frames = opts->play_frames;
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1614,6 +1614,9 @@ static void play_current_file(struct MPContext *mpctx)
     load_per_file_options(mpctx->mconfig, mpctx->playing->params,
                           mpctx->playing->num_params);
 
+    mpctx->remaining_file_loops = mpctx->opts->loop_file;
+    mp_notify_property(mpctx, "remaining-file-loops");
+
     mpctx->max_frames = opts->play_frames;
 
     handle_force_window(mpctx, false);

--- a/player/misc.c
+++ b/player/misc.c
@@ -129,7 +129,7 @@ bool get_ab_loop_times(struct MPContext *mpctx, double t[2])
     t[0] = opts->ab_loop[0];
     t[1] = opts->ab_loop[1];
 
-    if (!opts->ab_loop_count)
+    if (!mpctx->remaining_ab_loops)
         return false;
 
     if (t[0] == MP_NOPTS_VALUE || t[1] == MP_NOPTS_VALUE || t[0] == t[1])

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -901,10 +901,10 @@ static void handle_loop_file(struct MPContext *mpctx)
         }
         target = ab[0];
         prec = MPSEEK_EXACT;
-    } else if (opts->loop_file) {
-        if (opts->loop_file > 0) {
-            opts->loop_file--;
-            m_config_notify_change_opt_ptr(mpctx->mconfig, &opts->loop_file);
+    } else if (mpctx->remaining_file_loops) {
+        if (mpctx->remaining_file_loops > 0) {
+            mpctx->remaining_file_loops--;
+            mp_notify_property(mpctx, "remaining-file-loops");
         }
         target = get_start_time(mpctx, mpctx->play_dir);
     }

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -885,8 +885,6 @@ static void handle_sstep(struct MPContext *mpctx)
 
 static void handle_loop_file(struct MPContext *mpctx)
 {
-    struct MPOpts *opts = mpctx->opts;
-
     if (mpctx->stop_play != AT_END_OF_FILE)
         return;
 
@@ -895,9 +893,9 @@ static void handle_loop_file(struct MPContext *mpctx)
 
     double ab[2];
     if (get_ab_loop_times(mpctx, ab) && mpctx->ab_loop_clip) {
-        if (opts->ab_loop_count > 0) {
-            opts->ab_loop_count--;
-            m_config_notify_change_opt_ptr(mpctx->mconfig, &opts->ab_loop_count);
+        if (mpctx->remaining_ab_loops > 0) {
+            mpctx->remaining_ab_loops--;
+            mp_notify_property(mpctx, "remaining-ab-loops");
         }
         target = ab[0];
         prec = MPSEEK_EXACT;


### PR DESCRIPTION
commit 1: player: don't decrement --loop-file=N and add remaining-file-loops

This stops decreasing numerical values of --loop-file on each iteration so that loop-file=N loops every playlist entry without having to add --loop-file to --reset-on-next-file.

The current behavior confuses users as seen in:

https://github.com/mpv-player/mpv/issues/2481
https://github.com/mpv-player/mpv/issues/5943
https://github.com/mpv-player/mpv/issues/11291
https://github.com/mpv-player/mpv/issues/13860
https://www.reddit.com/r/mpv/comments/rcwnrw/looping_each_file_n_times_in_a_playlist/

Also options are supposed to reflect the value configured by the user and not change on their own.

A remaining-file-loops property is exposed as a replacement to check how many loops are left.


commit 2: player: don't decrement --ab-loop-count=N and add remaining-ab-loops

Follow up to the previous commit. Stop decreasing --ab-loop-count=N on each iteration so it is preserved across different loops. In particular it is preserved between different files without adding it to --reset-on-next-file. Add a property to expose the remaning A-B loop count instead.

The current behavior of --ab-loop-count=N is even worse than --loop-file since it also doesn't reset when defining a new A-B loop in the same file. Defining it has no effect after --ab-loop-count has decreased to 0, and this can't be fixed by adding it to --reset-on-next-file. This commit also resets remaining-ab-loops every time --ab-loop-a and --ab-loop-b are set to fix this.


I didn't add `remaining-playlist-loops` because `--playlist-loop` already applies to all files. We also avoid dealing with the inconsistency of `--loop-playlist=1` corresponding to 1 playthrough and `--loop-file=1` corresponding to 2.