### PR TITLE
terminal-win: use proper __stdcall callback for FLS

### DIFF
--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -632,6 +632,11 @@ void terminal_set_mouse_input(bool enable)
     }
 }
 
+static VOID NTAPI fls_free_cb(PVOID ptr)
+{
+    talloc_free(ptr);
+}
+
 void terminal_init(void)
 {
     CONSOLE_SCREEN_BUFFER_INFO cinfo;
@@ -653,6 +658,6 @@ void terminal_init(void)
     GetConsoleScreenBufferInfo(hSTDOUT, &cinfo);
     stdoutAttrs = cinfo.wAttributes;
 
-    tmp_buffers_key = FlsAlloc((PFLS_CALLBACK_FUNCTION)talloc_free);
+    tmp_buffers_key = FlsAlloc(fls_free_cb);
     utf8_output = SetConsoleOutputCP(CP_UTF8);
 }


### PR DESCRIPTION
Fixes crash when FLS data is attempted to be cleared.

This affects only 32-bit build where the calling convention were not matching the expected one.