### PR TITLE
vf_vapoursynth: add user-data parameter to allow user to pass arbitrary data to script

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -433,7 +433,7 @@ Available mpv-only filters are:
             subtitle colors and video under the influence of the video equalizer
             settings.
 
-``vapoursynth=file:buffered-frames:concurrent-frames``
+``vapoursynth=file:buffered-frames:concurrent-frames:user-data``
     Loads a VapourSynth filter script. This is intended for streamed
     processing: mpv actually provides a source filter, instead of using a
     native VapourSynth video source. The mpv source will answer frame
@@ -559,6 +559,10 @@ Available mpv-only filters are:
         By default, this uses the special value ``auto``, which sets the option
         to the number of detected logical CPU cores.
 
+    ``user-data``
+        Optional arbitrary string that is passed to the script. Default to empty
+        string if not set.
+
     The following ``.vpy`` script variables are defined by mpv:
 
     ``video_in``
@@ -588,6 +592,10 @@ Available mpv-only filters are:
         first entry corresponding to the width and the second entry corresponding
         to the height. These values can be 0. Note that this will not respond to
         monitor changes and may not work on all platforms.
+
+    ``user_data``
+        User data passed from the filter. This variable always exists, and defaults
+        to empty string.
 
 ``vavpp``
     VA-API video post processing. Requires the system to support VA-API,

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -46,6 +46,7 @@ struct vapoursynth_opts {
     char *file;
     int maxbuffer;
     int maxrequests;
+    char *user_data;
 
     const struct script_driver *drv;
 };
@@ -699,6 +700,7 @@ static int reinit_vs(struct priv *p, struct mp_image *input)
     p->vsapi->propSetFloat(vars, "container_fps", container_fps, 0);
     p->vsapi->propSetFloat(vars, "display_fps", display_fps, 0);
     p->vsapi->propSetIntArray(vars, "display_res", display_res, 2);
+    p->vsapi->propSetData(vars, "user_data", p->opts->user_data, -1, 0);
 
     if (p->drv->load(p, vars) < 0)
         goto error;
@@ -830,6 +832,7 @@ static const m_option_t vf_opts_fields[] = {
         OPTDEF_INT(4)},
     {"concurrent-frames", OPT_CHOICE(maxrequests, {"auto", -1}),
         M_RANGE(1, 99), OPTDEF_INT(-1)},
+    {"user-data", OPT_STRING(user_data), OPTDEF_STR("")},
     {0}
 };
 


### PR DESCRIPTION
Currently the vapoursynth video filter does not accept any argument for passing arbitrary user data. This limits what the VS script can do.

Ideally, the vapoursynth filter has an user-data parameter that contains string value. mpv passes that value to the VS script just like container_fps and others. Once the VS script gets the data, it can do all sorts of data extraction and transformation.

Another benefit is that instead of mpv always have to catch up to user needs for this filter, with this users can just pass whatever needed themselves, thus becomes more future-proof.

Fixes #14214

Discussion: I did not put any restriction on how big the user data can be. Could there be any security vulnerability without such restriction?