### PR TITLE
ao_wasapi: limit the scope of execution context

### DIFF
--- a/audio/out/ao_wasapi_changenotify.c
+++ b/audio/out/ao_wasapi_changenotify.c
@@ -202,7 +202,7 @@ HRESULT wasapi_change_init(struct ao *ao, bool is_hotplug)
 {
     struct wasapi_state *state = ao->priv;
     struct change_notify *change = &state->change;
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER,
                                   &IID_IMMDeviceEnumerator,
                                   (void **)&change->pEnumerator);
     EXIT_ON_ERROR(hr);

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -653,7 +653,7 @@ static void init_volume_control(struct wasapi_state *state)
         MP_DBG(state, "Activating pEndpointVolume interface\n");
         hr = IMMDeviceActivator_Activate(state->pDevice,
                                          &IID_IAudioEndpointVolume,
-                                         CLSCTX_ALL, NULL,
+                                         CLSCTX_INPROC_SERVER, NULL,
                                          (void **)&state->pEndpointVolume);
         EXIT_ON_ERROR(hr);
 
@@ -845,7 +845,7 @@ static struct enumerator *create_enumerator(struct mp_log *log)
     struct enumerator *e = talloc_zero(NULL, struct enumerator);
     e->log = log;
     HRESULT hr = CoCreateInstance(
-        &CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, &IID_IMMDeviceEnumerator,
+        &CLSID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER, &IID_IMMDeviceEnumerator,
         (void **)&e->pEnumerator);
     EXIT_ON_ERROR(hr);
 
@@ -913,7 +913,7 @@ static bool load_device(struct mp_log *l,
                            IMMDevice **ppDevice, LPWSTR deviceID)
 {
     IMMDeviceEnumerator *pEnumerator = NULL;
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_INPROC_SERVER,
                                   &IID_IMMDeviceEnumerator,
                                   (void **)&pEnumerator);
     EXIT_ON_ERROR(hr);
@@ -1027,7 +1027,7 @@ retry:
 
         MP_DBG(ao, "Activating pAudioClient interface\n");
         hr = IMMDeviceActivator_Activate(state->pDevice, &IID_IAudioClient,
-                                         CLSCTX_ALL, NULL,
+                                         CLSCTX_INPROC_SERVER, NULL,
                                          (void **)&state->pAudioClient);
         if (FAILED(hr)) {
             MP_FATAL(ao, "Error activating device: %s\n",


### PR DESCRIPTION
May fix broken systems like #12145 or #14314. Probably won't change anything, but it is the correct context to use anyway.