### PR TITLE
options: add --osd-playlist-entry

### DIFF
--- a/DOCS/interface-changes/show-playlist-titles.txt
+++ b/DOCS/interface-changes/show-playlist-titles.txt
@@ -1,0 +1,2 @@
+add `--osd-playlist-entry` option
+remove `osc-playlist_media_title` script-opt

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4392,6 +4392,12 @@ OSD
     Set the duration of ``osd-playing-msg`` in ms. If this is unset,
     ``osd-playing-msg`` stays on screen for the duration of ``osd-duration``.
 
+``--osd-playlist-entry=<title|filename|both>``
+    Whether to display the media title, filename, or both. If the
+    ``media-title`` is not available, it will display only the ``filename``.
+
+    Default: ``title``.
+
 ``--osd-bar-align-x=<-1-1>``
     Position of the OSD bar. -1 is far left, 0 is centered, 1 is far right.
     Fractional values (like 0.5) are allowed.

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -408,13 +408,6 @@ Configurable Options
     Whether to display the chapters/playlist at the OSD when left-clicking the
     next/previous OSC buttons, respectively.
 
-``playlist_media_title``
-    Default: yes
-
-    Whether to display playlist entries in media titles. If set to ``no``, file
-    names are used instead. Note that media title of a file is only available
-    once it has been loaded.
-
 ``chapter_fmt``
     Default: ``Chapter: %s``
 

--- a/options/options.c
+++ b/options/options.c
@@ -862,6 +862,9 @@ static const m_option_t mp_opts[] = {
     {"osd-msg2", OPT_STRING(osd_msg[1]), .flags = UPDATE_OSD},
     {"osd-msg3", OPT_STRING(osd_msg[2]), .flags = UPDATE_OSD},
 
+    {"osd-playlist-entry", OPT_CHOICE(playlist_entry_name,
+        {"title", 0}, {"filename", 1}, {"both", 2})},
+
     {"video-osd", OPT_BOOL(video_osd), .flags = UPDATE_OSD},
 
     {"idle", OPT_CHOICE(player_idle_mode,

--- a/options/options.h
+++ b/options/options.h
@@ -259,6 +259,7 @@ typedef struct MPOpts {
     char *status_msg;
     char *osd_status_msg;
     char *osd_msg[3];
+    int playlist_entry_name;
     int player_idle_mode;
     char **input_commands;
     bool consolecontrols;

--- a/player/command.c
+++ b/player/command.c
@@ -3262,8 +3262,10 @@ static int mp_property_playlist(void *ctx, struct m_property *prop,
 
         for (int n = 0; n < pl->num_entries; n++) {
             struct playlist_entry *e = pl->entries[n];
+            res =  talloc_strdup_append(res, pl->current == e ? list_current
+                                                              : list_normal);
             char *p = e->title;
-            if (!p) {
+            if (!p || mpctx->opts->playlist_entry_name > 0) {
                 p = e->filename;
                 if (!mp_is_url(bstr0(p))) {
                     char *s = mp_basename(e->filename);
@@ -3271,8 +3273,11 @@ static int mp_property_playlist(void *ctx, struct m_property *prop,
                         p = s;
                 }
             }
-            const char *m = pl->current == e ? list_current : list_normal;
-            res = talloc_asprintf_append(res, "%s%s\n", m, p);
+            if (!e->title || p == e->title || mpctx->opts->playlist_entry_name == 1) {
+                res = talloc_asprintf_append(res, "%s\n", p);
+            } else {
+                res = talloc_asprintf_append(res, "%s (%s)\n", e->title, p);
+            }
         }
 
         *(char **)arg =

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -56,7 +56,6 @@ local user_opts = {
     livemarkers = true,         -- update seekbar chapter markers on duration change
     chapters_osd = true,        -- whether to show chapters OSD on next/prev
     playlist_osd = true,        -- whether to show playlist OSD on next/prev
-    playlist_media_title = true, -- whether to use media titles as playlist entry names
     chapter_fmt = "Chapter: %s", -- chapter print format for seekbar-hover. "no" to disable
     unicodeminus = false,       -- whether to use the Unicode minus sign character
 
@@ -525,14 +524,20 @@ local function get_playlist()
     end
 
     local message = string.format('Playlist [%d/%d]:\n', pos, count)
+    local show = mp.get_property_native('osd-playlist-entry')
     for _, v in ipairs(limlist) do
-        local title = v.title
-        local _, filename = utils.split_path(v.filename)
-        if not user_opts.playlist_media_title or title == nil then
-            title = filename
+        local entry = v.title
+        if not entry or show ~= 'title' then
+            entry = v.filename
+            if not entry:find("://") then
+                entry = select(2, utils.split_path(entry))
+            end
+        end
+        if v.title and show == 'both' then
+            entry = string.format('%s (%s)', v.title, entry)
         end
         message = string.format('%s %s %s\n', message,
-            (v.current and '●' or '○'), title)
+            (v.current and '●' or '○'), entry)
     end
     return message
 end

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -28,9 +28,19 @@ end
 mp.add_forced_key_binding(nil, "select-playlist", function ()
     local playlist = {}
     local default_item
+    local show = mp.get_property_native("osd-playlist-entry")
 
     for i, entry in ipairs(mp.get_property_native("playlist")) do
-        playlist[i] = select(2, utils.split_path(entry.filename))
+        playlist[i] = entry.title
+        if not playlist[i] or show ~= "title" then
+            playlist[i] = entry.filename
+            if not playlist[i]:find("://") then
+                playlist[i] = select(2, utils.split_path(playlist[i]))
+            end
+        end
+        if entry.title and show == "both" then
+            playlist[i] = string.format("%s (%s)", entry.title, playlist[i])
+        end
 
         if entry.playing then
             default_item = i


### PR DESCRIPTION
Allow configuring whether to print the media-title or the filename in show-text ${playlist}, the OSC playlist and in the playlist selector.

Showing titles can be annoying when files are badly tagged, or when it hides the track numbers of album songs.

The OSC's playlist_media_title script-opt is removed because this option is better since it works everywhere after configuring it once.

Closes #11653.