### PR TITLE
vf_vapoursynth: upgrade to VapourSynth API v4

### DIFF
--- a/DOCS/interface-changes/vapoursynth-api-v4.txt.txt
+++ b/DOCS/interface-changes/vapoursynth-api-v4.txt.txt
@@ -1,0 +1,1 @@
+Bump dependency of VapourSynth to utilize its API version 4. New minimum VapourSynth version for runtime is R56. Some functions and plugins are changed or removed. For details, refer to VapourSynth documentation http://www.vapoursynth.com/2021/09/r55-audio-support-and-improved-performance/ and https://github.com/vapoursynth/vapoursynth/blob/R68/APIV4%20changes.txt

--- a/meson.build
+++ b/meson.build
@@ -764,8 +764,8 @@ if not features['lavu-uuid']
     sources += files('misc/uuid.c')
 endif
 
-vapoursynth = dependency('vapoursynth', version: '>= 26', required: get_option('vapoursynth'))
-vapoursynth_script = dependency('vapoursynth-script', version: '>= 26',
+vapoursynth = dependency('vapoursynth', version: '>= 56', required: get_option('vapoursynth'))
+vapoursynth_script = dependency('vapoursynth-script', version: '>= 56',
                                 required: get_option('vapoursynth'))
 features += {'vapoursynth': vapoursynth.found() and vapoursynth_script.found()}
 if features['vapoursynth']


### PR DESCRIPTION
VapourSynth introduced their version 4 API in R55, 3 years ago. mpv is still using the deprecated version 3. I think it is good to migrate before VapourSynth completely removes it.

The gist of the change is documented in https://github.com/vapoursynth/vapoursynth/blob/master/APIV4%20changes.txt. The most impacted area is the video format. Previously we have a fixed table of supported formats, each represented by an integer. In v4, the integer is replaced by pointer to the full struct of the format. More details below.

Second, the way to create video filter is changed. Previously caller needs to supply a "initialization" callback to `createFilter()`, which sets up video info etc. In v4, video info is prepared first, passed to the `createVideoFilter2()` and we get back the node.

Also, previously mpv was using the `fmSerial` filter mode, which means VapourSynth 1) can only request one frame from mpv at a time, and 2) the order of frames requested must be sequential. I propose to change it to the parallel mode, which requests multiple frames at a time in semi random order. The reasons are, for 1), the get frame function, `infiltGetFrame()`, unlocks the mutex during output image generation, thus can benefit from parallel get. For 2) thanks to the frame buffer, unordered frame requests are acceptable. Just make sure the buffer is large enough.

Third, the way VapourSynth scripting environment works change. In v4, the scripting API is operated through struct pointer, much like the exist `vsapi` pointer. The "finalize" function is also no longer needed.

### More on video formats

I took liberty to change how we handle input and output formats. Previously,

* We use `mp_autoconvert` to convert input format into one of the supported VapourSynth formats, defined in the `mpvs_fmt_table` table.
* The format of VapourSynth script output frame must also be from that table. We convert the frame into a `mp_image` for downstream.

What I did are:

* No longer use the `mpvs_fmt_table` table to determine if a format is valid. Instead rely on whether a format can be handled both by mpv and VapourSynth.
* Still restricts to only YUV formats. YUV formats are tend to be the most structured and consistent color family. Also the most popular.
* Thanks to this, mpv now support a few new formats that were previously "disabled".
* Due the API change, and the lack of access to VapourSynth when autoconvert is set up, the formats we sent is a superset of what's actually needed. I don't believe they do any harm, and all of them are extremely rare.

### List of currently supported formats for VapourSynth
```
=== The following are also supported by VapourSynth resize filter ===

YUV410P8
YUV411P8
YUV440P8
YUV420P8
YUV422P8
YUV444P8

YUV420P9
YUV422P9
YUV444P9

YUV420P10
YUV422P10
YUV444P10

YUV420P16
YUV422P16
YUV444P16

=== Newly supported ===

YUV420P12
YUV422P12
YUV444P12

YUV420P14
YUV422P14
YUV444P14

YUV444PS / YUV444PF

=== The following are not supported by VapourSynth resize filter. Requires zimg when building mpv ===

YUV410PF
YUV411PF
YUV420PF
YUV422PF
YUV440PF

YUV440P10
YUV440P12
```

### False positive input formats (all deprecated in AVPixelFormat), indistinguishable from their non-jpeg counterpart due to difference only in color range
```
YUVJ411P
YUVJ422P
YUVJ440P
```