### PR TITLE
input: don't resolve double clicks on the active mouse section

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -448,7 +448,9 @@ static struct cmd_bind *find_any_bind_for_key(struct input_ctx *ictx,
 
     // First look whether a mouse section is capturing all mouse input
     // exclusively (regardless of the active section stack order).
-    if (use_mouse && MP_KEY_IS_MOUSE_BTN_SINGLE(ictx->last_key_down)) {
+    if (use_mouse && MP_KEY_IS_MOUSE_BTN_SINGLE(ictx->last_key_down) &&
+        !MP_KEY_IS_MOUSE_BTN_DBL(code))
+    {
         struct cmd_bind *bind =
             find_bind_for_key_section(ictx, ictx->mouse_section, code);
         if (bind)


### PR DESCRIPTION
Normally, key bindings are resolved in the input section stack order. However, mouse key bindings have a special "active mouse section" feature (which is a section with MOUSE_MOVE bound and mouse button is down in the section) which lets the section to be selected instead, with a fallback to the "default" section. The intention of the feature is for mouse dragging which should "stick" to the section where the mouse is down.

This causes a problem with scripts which bind mouse double clicks: since double clicks are triggered on mouse down, it's resolved with the "active mouse section" feature instead of the section stack order. If the section which has the double click bound doesn't also have MOUSE_MOVE bound, the "default" section will be used instead. If it's already bound there, it will be triggered.

Fix this by not resolving double clicks on the active mouse section, which is not the intention of the feature.

Fixes: #11154
Fixes: #13083