### PR TITLE
mac: compatibility for older dev tools

### DIFF
--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -254,9 +254,11 @@ static int init(struct ao *ao)
     }
 
     [p->synchronizer addRenderer:p->renderer];
+#if HAVE_MACOS_11_3_FEATURES
     if (@available(tvOS 14.5, iOS 14.5, macOS 11.3, *)) {
         [p->synchronizer setDelaysRateChangeUntilHasSufficientMediaData:NO];
     }
+#endif
 
     if (af_fmt_is_spdif(ao->format)) {
         MP_FATAL(ao, "avfoundation does not support SPDIF\n");
@@ -315,7 +317,11 @@ static int init(struct ao *ao)
 
     p->observer = [[AVObserver alloc] initWithAO:ao];
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center addObserver:p->observer selector:@selector(handleRestartNotification:) name:AVSampleBufferAudioRendererOutputConfigurationDidChangeNotification object:p->renderer];
+#if HAVE_MACOS_12_FEATURES
+    if (@available(tvOS 15.0, iOS 15.0, macOS 12.0, *)) {
+        [center addObserver:p->observer selector:@selector(handleRestartNotification:) name:AVSampleBufferAudioRendererOutputConfigurationDidChangeNotification object:p->renderer];
+    }
+#endif
     [center addObserver:p->observer selector:@selector(handleRestartNotification:) name:AVSampleBufferAudioRendererWasFlushedAutomaticallyNotification object:p->renderer];
 
     return CONTROL_OK;

--- a/meson.build
+++ b/meson.build
@@ -1585,6 +1585,12 @@ macos_11_features = get_option('macos-11-features').require(
 )
 features += {'macos-11-features': macos_11_features.allowed()}
 
+macos_11_3_features = get_option('macos-11-3-features').require(
+    macos_sdk_version.version_compare('>= 11.3'),
+    error_message: 'A macos sdk version >= 11.3 could not be found!',
+)
+features += {'macos-11-3-features': macos_11_3_features.allowed()}
+
 macos_12_features = get_option('macos-12-features').require(
     macos_sdk_version.version_compare('>= 12'),
     error_message: 'A macos sdk version >= 12 could not be found!',

--- a/meson.build
+++ b/meson.build
@@ -1573,6 +1573,12 @@ if features['cocoa'] and features['swift']
                            'video/out/mac/window.swift')
 endif
 
+macos_10_15_4_features = get_option('macos-10-15-4-features').require(
+    macos_sdk_version.version_compare('>= 10.15.4'),
+    error_message: 'A macos sdk version >= 10.15.4 could not be found!',
+)
+features += {'macos-10-15-4-features': macos_10_15_4_features.allowed()}
+
 macos_11_features = get_option('macos-11-features').require(
     macos_sdk_version.version_compare('>= 11'),
     error_message: 'A macos sdk version >= 11 could not be found!',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,6 +108,7 @@ option('vulkan-interop', type: 'feature', value: 'auto', description: 'Vulkan gr
 # macOS features
 option('macos-10-15-4-features', type: 'feature', value: 'auto', description: 'macOS 10.15.4 SDK Features')
 option('macos-11-features', type: 'feature', value: 'auto', description: 'macOS 11 SDK Features')
+option('macos-11-3-features', type: 'feature', value: 'auto', description: 'macOS 11.3 SDK Features')
 option('macos-12-features', type: 'feature', value: 'auto', description: 'macOS 12 SDK Features')
 option('macos-cocoa-cb', type: 'feature', value: 'auto', description: 'macOS libmpv backend')
 option('macos-media-player', type: 'feature', value: 'auto', description: 'macOS Media Player support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -106,6 +106,7 @@ option('videotoolbox-pl', type: 'feature', value: 'auto', description: 'Videotoo
 option('vulkan-interop', type: 'feature', value: 'auto', description: 'Vulkan graphics interop')
 
 # macOS features
+option('macos-10-15-4-features', type: 'feature', value: 'auto', description: 'macOS 10.15.4 SDK Features')
 option('macos-11-features', type: 'feature', value: 'auto', description: 'macOS 11 SDK Features')
 option('macos-12-features', type: 'feature', value: 'auto', description: 'macOS 12 SDK Features')
 option('macos-cocoa-cb', type: 'feature', value: 'auto', description: 'macOS libmpv backend')

--- a/osdep/mac/event_helper.swift
+++ b/osdep/mac/event_helper.swift
@@ -75,7 +75,7 @@ class EventHelper {
         mpv_set_wakeup_callback(mpv, wakeup, TypeHelper.bridge(obj: self))
     }
 
-    func subscribe(_ subscriber: any EventSubscriber, event: Event) {
+    func subscribe(_ subscriber: EventSubscriber, event: Event) {
         guard let mpv = mpv else { return }
 
         if !event.name.isEmpty {

--- a/osdep/mac/log_helper.swift
+++ b/osdep/mac/log_helper.swift
@@ -20,7 +20,12 @@ import os
 
 class LogHelper {
     var log: OpaquePointer?
-    let logger = Logger(subsystem: "io.mpv", category: "mpv")
+#if HAVE_MACOS_11_FEATURES
+    @available(macOS 11.0, *)
+    var logger: Logger? {
+        return Logger(subsystem: "io.mpv", category: "mpv")
+    }
+#endif
 
     let loggerMapping: [Int: OSLogType] = [
         MSGL_V: .debug,
@@ -51,7 +56,11 @@ class LogHelper {
 
     func send(message: String, type: Int) {
         guard let log = log else {
-            logger.log(level: loggerMapping[type] ?? .default, "\(message, privacy: .public)")
+#if HAVE_MACOS_11_FEATURES
+        if #available(macOS 11.0, *) {
+            logger?.log(level: loggerMapping[type] ?? .default, "\(message, privacy: .public)")
+        }
+#endif
             return
         }
 

--- a/osdep/mac/meson.build
+++ b/osdep/mac/meson.build
@@ -19,6 +19,10 @@ if get_option('optimization') != '0'
     swift_flags += '-O'
 endif
 
+if macos_10_15_4_features.allowed()
+    swift_flags += ['-D', 'HAVE_MACOS_10_15_4_FEATURES']
+endif
+
 if macos_11_features.allowed()
     swift_flags += ['-D', 'HAVE_MACOS_11_FEATURES']
 endif

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -43,3 +43,11 @@ extension NSDraggingInfo {
     }
 }
 #endif
+
+#if !HAVE_MACOS_12_FEATURES && HAVE_MACOS_11_FEATURES
+@available(macOS 11.0, *)
+extension CGColorSpace {
+    static let itur_2100_HLG: CFString = kCGColorSpaceITUR_2100_HLG
+    static let itur_2100_PQ: CFString = kCGColorSpaceITUR_2100_PQ
+}
+#endif

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -15,6 +15,16 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if !swift(>=5.7)
+extension NSCondition {
+    func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        self.lock()
+        defer { self.unlock() }
+        return try body()
+    }
+}
+#endif
+
 #if !swift(>=5.0)
 extension Data {
     mutating func withUnsafeMutableBytes<Type>(_ body: (UnsafeMutableRawBufferPointer) throws -> Type) rethrows -> Type {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -135,7 +135,6 @@ class CocoaCB: Common, EventSubscriber {
         case MAC_CSP_AUTO: return colorSpace
         case MAC_CSP_DISPLAY_P3: return CGColorSpace(name: CGColorSpace.displayP3)
         case MAC_CSP_DISPLAY_P3_HLG: return CGColorSpace(name: CGColorSpace.displayP3_HLG)
-        case MAC_CSP_DISPLAY_P3_PQ: return CGColorSpace(name: CGColorSpace.displayP3_PQ)
         case MAC_CSP_DCI_P3: return CGColorSpace(name: CGColorSpace.dcip3)
         case MAC_CSP_BT_2020: return CGColorSpace(name: CGColorSpace.itur_2020)
         case MAC_CSP_BT_709: return CGColorSpace(name: CGColorSpace.itur_709)
@@ -145,6 +144,15 @@ class CocoaCB: Common, EventSubscriber {
         case MAC_CSP_ADOBE: return CGColorSpace(name: CGColorSpace.adobeRGB1998)
         default: break
         }
+
+#if HAVE_MACOS_10_15_4_FEATURES
+        if #available(macOS 10.15.4, *) {
+            switch outputCsp {
+            case MAC_CSP_DISPLAY_P3_PQ: return CGColorSpace(name: CGColorSpace.displayP3_PQ)
+            default: break
+            }
+        }
+#endif
 
 #if HAVE_MACOS_11_FEATURES
         if #available(macOS 11.0, *) {


### PR DESCRIPTION
https://developer.apple.com/documentation/foundation/nslocking/4059821-withlock available from macOS 10.10 but xcode 14+ required. xcode 14.0 introduced swift 5.7

logger is a macOS 11 feature. ~~i hope the runtime check works like that.~~ otherwise the initialisation of the logger has to move to init or a computed property.

Fixes #14310