### PR TITLE
console.lua: don't enable the console-input input section

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1577,7 +1577,6 @@ set_active = function (active)
     if active then
         repl_active = true
         insert_mode = false
-        mp.enable_key_bindings('console-input', 'allow-hide-cursor+allow-vo-dragging')
         define_key_bindings()
 
         if not input_caller then


### PR DESCRIPTION
https://github.com/rossy/mpv-repl enabled and disabled its keybindings with input sections (define-section, mp.enable_key_bindings and mp.disable_key_bindings), but when wm4 merged it in mpv, he changed it to use mp.add_forced_key_binding and mp.remove_key_binding because he deprecated input sections, but he forgot to remove the mp.enable_key_bindings line. Remove it now.