### PR TITLE
Revert "demux_lavf: pass jpg filenames to ffmpeg for probing"

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -465,18 +465,12 @@ static int lavf_check_file(demuxer_t *demuxer, enum demux_check check)
         }
     }
 
-    // HLS streams do not seem to be well tagged, so matching by MIME type is
-    // not enough - we need to strip the query string and match by their
-    // extensions. We also pass jpg filenames to fix issues like #13192 (jpgs
-    // being treated as videos due to a bogus second frame) and #13431 (jpgs
-    // misdetected as mpegts). We don't pass filenames otherwise to not
-    // misdetect files with a wrong extension, as described in 74e62ed2d1.
-    bstr ext = bstr_get_ext(mp_is_url(bstr0(priv->filename))
-                                ? bstr_split(bstr0(priv->filename), "?#", NULL)
-                                : bstr0(priv->filename));
+    // HLS streams seems to be not well tagged, so matching mime type is not
+    // enough. Strip URL parameters and match extension.
+    bstr ext = bstr_get_ext(bstr_split(bstr0(priv->filename), "?#", NULL));
     AVProbeData avpd = {
+        // Disable file-extension matching with normal checks, except for HLS
         .filename = !bstrcasecmp0(ext, "m3u8") || !bstrcasecmp0(ext, "m3u") ||
-                    !bstrcasecmp0(ext, "jpg") || !bstrcasecmp0(ext, "jpeg") ||
                     check <= DEMUX_CHECK_REQUEST ? priv->filename : "",
         .buf_size = 0,
         .buf = av_mallocz(PROBE_BUF_SIZE + AV_INPUT_BUFFER_PADDING_SIZE),

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1255,6 +1255,12 @@ static bool demux_lavf_read_packet(struct demuxer *demux,
     struct sh_stream *stream = info->sh;
     AVStream *st = priv->avfc->streams[pkt->stream_index];
 
+    // Never send additional frames for streams that are a single frame jpeg.
+    if (stream->image && !strcmp(priv->avif->name, "jpeg_pipe") && pkt->pos != 0) {
+        av_packet_unref(pkt);
+        return true;
+    }
+
     if (!demux_stream_is_selected(stream)) {
         av_packet_unref(pkt);
         return true; // don't signal EOF if skipping a packet


### PR DESCRIPTION
d0aeca59189c44b3999cc7add9d23642a73fe188 started passing the file name to libavformat when probing for jpeg files so some weird edgecases would work. The problem with that commit is that it causes image2 to be picked which is blacklisted in demux_lavf (for good reason) and then it falls back to demux_mf. This works, but it breaks fetching several properties (demux-w, demux-h, etc.) since demux_mf is not capable of providing this information. That leads to subpar behavior in scripts (e.g. my own but there could easily be other people) that rely on this information that was previously available for the vast majority of well-behaved files. So revert it since it's basically a sledgehammer.

To address the two fringe cases that tried to fix, a couple of different approaches are used. One is just forcing `jpeg_pipe` on files with a `jpg` or `jpeg` extension that get detected as mpegts. I don't know if we even want this commit, but it would address that specific issue (#13431) without affecting anything else.

The other one is prohibits demux_lavf from sending more than one frame if the stream is detected as an image. I think this is pretty safe since mpv already changes its behavior a lot if it thinks the file is an image and a misdetection in that case would already be disastrous. However `demux_lavf` is perfectly capable of reading more packets regardless so all I did was prohibit reading more than one frame from the stream if it is detected as an image. This prevents mpv from displaying metadata and other stuff as frames like in #13192.