### PR TITLE
demux_lavf: fix null derefence in io_open callback

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -945,7 +945,7 @@ static int nested_io_open(struct AVFormatContext *s, AVIOContext **pb,
     struct demuxer *demuxer = s->opaque;
     lavf_priv_t *priv = demuxer->priv;
 
-    if (priv->opts->propagate_opts) {
+    if (options && priv->opts->propagate_opts) {
         // Copy av_opts to options, but only entries that are not present in
         // options. (Hope this will break less by not overwriting important
         // settings.)


### PR DESCRIPTION
The options parameter here can be NULL. It's NULL checked a few lines down, but not for the propagate_opts loop. This results in null derefence with `--demuxer-lavf-format=image2`.

Fixes: b6413f82b22b5c3bd7b0a4fec28fdd2625feaf94