### PR TITLE
osc.lua: add script message to show up the OSC

### DIFF
--- a/DOCS/interface-changes/osc-show.txt
+++ b/DOCS/interface-changes/osc-show.txt
@@ -1,0 +1,1 @@
+add `osc-show` script message

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -499,7 +499,10 @@ in ``input.conf``, or sent by other scripts.
 
 ``osc-visibility``
     Controls visibility mode ``never`` / ``auto`` (on mouse move) / ``always``
-    and also ``cycle`` to cycle between the modes
+    and also ``cycle`` to cycle between the modes.
+
+``osc-show``
+    Triggers the OSC to show up, just as if user moved mouse.
 
 Example
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2925,6 +2925,7 @@ local function idlescreen_visibility(mode, no_osd)
 end
 
 mp.register_script_message("osc-visibility", visibility_mode)
+mp.register_script_message("osc-show", show_osc)
 mp.add_key_binding(nil, "visibility", function() visibility_mode("cycle") end)
 
 mp.register_script_message("osc-idlescreen", idlescreen_visibility)


### PR DESCRIPTION
Add a way to briefly show the OSC, which is useful to check file name, playback progress and time left, etc.

Fix issue #3826