### PR TITLE
fuzzers/meson: set link language to cpp

### DIFF
--- a/fuzzers/meson.build
+++ b/fuzzers/meson.build
@@ -1,7 +1,9 @@
 incdir = include_directories('../')
 
+add_languages('cpp', native: false)
+
 executable('fuzzer_loadfile_direct', 'fuzzer_loadfile_direct.c',
-           include_directories: incdir, link_with: libmpv)
+           link_language: 'cpp', include_directories: incdir, link_with: libmpv)
 
 protocols = ['edl', 'file', 'hex', 'lavf', 'memory', 'mf', 'slice', 'smb']
 demuxers = ['disc', 'edl', 'cue', 'rawaudio', 'rawvideo', 'mkv', 'lavf', 'mf']
@@ -28,6 +30,7 @@ endif
 foreach p : protocols
   executable('fuzzer_protocol_' + p,
              'fuzzer_loadfile_direct.c',
+             link_language: 'cpp',
              c_args: ['-DMPV_PROTO=' + p, '-DMPV_PROTO_' + p.to_upper()],
              include_directories: incdir,
              link_with: libmpv)
@@ -39,6 +42,7 @@ foreach demuxer : demuxers
     demuxer_ = demuxer.underscorify()
     executable('fuzzer_load' + cmd_ + '_' + demuxer_,
                 'fuzzer_load.c',
+                link_language: 'cpp',
                 c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd_.to_upper(),
                          '-DMPV_DEMUXER="' + demuxer + '"', '-DMPV_DEMUXER' + demuxer_.to_upper()],
                 include_directories: incdir,
@@ -49,6 +53,7 @@ foreach f : ['MPV_FORMAT_STRING', 'MPV_FORMAT_FLAG', 'MPV_FORMAT_INT64', 'MPV_FO
   foreach i : ['0', '1']
     executable('fuzzer_set_property_' + f + '_' + i,
                 'fuzzer_set_property.c',
+                link_language: 'cpp',
                 c_args: ['-DMPV_FORMAT=' + f, '-DMPV_RUN=' + i],
                 include_directories: incdir,
                 link_with: libmpv)
@@ -58,6 +63,7 @@ endforeach
 foreach cmd : ['file', '-config-file', '-input-conf']
     executable('fuzzer_load' + cmd.underscorify(),
                 'fuzzer_load.c',
+                link_language: 'cpp',
                 c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd.underscorify().to_upper()],
                 include_directories: incdir,
                 link_with: libmpv)

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ project('mpv',
             'buildtype=debugoptimized',
             'b_lundef=false',
             'c_std=c11',
+            'cpp_std=c++20',
+            'cpp_eh=default',
             'warning_level=2',
         ]
 )


### PR DESCRIPTION
This is kinda required by fuzzers and makes easier to handle stdlib instead of manually injecting it into link flags.