### PR TITLE
editorconfig: punish tab usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+tab_width = 7
 max_line_length = 80
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
This makes tab width to 7 on GitHub web UI and supported editors, making it impossible to use tabs to match the existing 4 space indentation.
