### PR TITLE
select.lua: consider --sub-delay for the subtitle line selector

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -232,8 +232,7 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
     local sub_lines = {}
     local sub_times = {}
     local default_item
-    local sub_start = mp.get_property_native("sub-start",
-                                             mp.get_property_native("time-pos"))
+    local time_pos = mp.get_property_native("time-pos")
     local duration = mp.get_property_native("duration", math.huge)
 
     -- Strip HTML and ASS tags.
@@ -243,17 +242,9 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
         sub_lines[#sub_lines + 1] = format_time(sub_times[#sub_times], duration) ..
                                     " " .. line:gsub(".*]", "", 1)
 
-        if sub_times[#sub_times] <= sub_start then
+        if sub_times[#sub_times] <= time_pos then
             default_item = #sub_times
         end
-    end
-
-    -- Handle sub-start of embedded subs being slightly earlier than
-    -- ffmpeg's timestamps.
-    sub_start = mp.get_property_native("sub-start")
-    if sub_start and default_item and sub_times[default_item] < sub_start and
-       sub_lines[default_item + 1] then
-        default_item = default_item + 1
     end
 
     input.select({

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -232,7 +232,8 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
     local sub_lines = {}
     local sub_times = {}
     local default_item
-    local time_pos = mp.get_property_native("time-pos")
+    local delay = mp.get_property_native("sub-delay")
+    local time_pos = mp.get_property_native("time-pos") - delay
     local duration = mp.get_property_native("duration", math.huge)
 
     -- Strip HTML and ASS tags.
@@ -254,9 +255,11 @@ mp.add_forced_key_binding(nil, "select-subtitle-line", function ()
         submit = function (index)
             -- Add an offset to seek to the correct line while paused without a
             -- video track.
-            local offset = mp.get_property_native("current-tracks/video/image") == false
-                           and 0 or .09
-            mp.commandv("seek", sub_times[index] + offset, "absolute")
+            if mp.get_property_native("current-tracks/video/image") ~= false then
+                delay = delay + 0.1
+            end
+
+            mp.commandv("seek", sub_times[index] + delay, "absolute")
         end,
     })
 end)


### PR DESCRIPTION
commit 1: select.lua: don't use sub-start to preselect subtitle lines

There is no need to compare sub-start now that we don't check for exact matches with ffmpeg's timestamps. time-pos can always be used.

Comparing time-pos removes the need for the workaround of sub-start of embedded subtitles being earlier than ffmpeg's timestamps, as time-pos is always slightly after sub-start.

Removing this workaround also fixes a bug present since 4059d1832b, which started comparing numerical values of timestamps instead of strings to determine the preselected subtitle line, where the line after the current one is preselected when sub-start is greater than ffmpeg's timestamps because they have been rounded, e.g. sub-start 10.001 is > than ffmpeg's 10.00.

This will also allow considering --sub-delay in the comparisons, as comparing sub-start - sub-delay would preselect the wrong lines.

commit 2: select.lua: consider --sub-delay for the subtitle line selector

Preselect and seek to the correct subtitle line when there is a sub-delay.

Also slightly increase the offset without a video track else it occasionally doesn't seek to the selected line with non-0 sub-delay and no video. This now uses the same offset as sub/sd.h.