### PR TITLE
bash-completion: remove hashbang

### DIFF
--- a/etc/mpv.bash-completion
+++ b/etc/mpv.bash-completion
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # This file is part of mpv.
 #


### PR DESCRIPTION
Hashbangs are meant for scripts that are executed, but a bash completion script is meant to be sourced and therefor shouldn't have a hashbang.

Remarked by Debian's ``lintian`` tool with the ``bash-completion-with-hashbang`` tag.
