### PR TITLE
[RFC] cleanup some deprecated options

### DIFF
--- a/DOCS/interface-changes/option-removal.txt
+++ b/DOCS/interface-changes/option-removal.txt
@@ -1,0 +1,7 @@
+remove deprecated `--cache-dir` option alias
+remove deprecated `--cache-unlink-files` option alias
+remove deprecated `--demuxer-cue-codepage` option alias
+remove deprecated `--fps` option alias
+remove deprecated `--cdrom-device` option alias
+remove deprecated `--sub-forced-only` option alias
+remove deprecated `--vo-sixel-exit-clear` option alias

--- a/DOCS/interface-changes/option-removal.txt
+++ b/DOCS/interface-changes/option-removal.txt
@@ -5,3 +5,5 @@ remove deprecated `--fps` option alias
 remove deprecated `--cdrom-device` option alias
 remove deprecated `--sub-forced-only` option alias
 remove deprecated `--vo-sixel-exit-clear` option alias
+remove deprecated `--cdda-toc-bias` option
+remove deprecated `--drm-atomic` option

--- a/demux/cache.c
+++ b/demux/cache.c
@@ -44,8 +44,6 @@ const struct m_sub_options demux_cache_conf = {
         {"demuxer-cache-unlink-files", OPT_CHOICE(unlink_files,
             {"immediate", 2}, {"whendone", 1}, {"no", 0}),
         },
-        {"cache-dir", OPT_REPLACED("demuxer-cache-dir")},
-        {"cache-unlink-files", OPT_REPLACED("demuxer-cache-unlink-files")},
         {0}
     },
     .size = sizeof(struct demux_cache_opts),

--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -41,13 +41,6 @@
 
 #define PROBE_SIZE 512
 
-const struct m_sub_options demux_cue_conf = {
-        .opts = (const m_option_t[]) {
-            {"codepage", OPT_REPLACED("metadata-codepage")},
-            {0}
-        },
-};
-
 struct priv {
     struct cue_file *f;
 };

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -132,7 +132,6 @@ const struct m_sub_options dec_wrapper_conf = {
             M_RANGE(0, M_MAX_MEM_BYTES)},
         {"audio-reversal-buffer", OPT_BYTE_SIZE(audio_reverse_size),
             M_RANGE(0, M_MAX_MEM_BYTES)},
-        {"fps", OPT_REPLACED("container-fps-override")},
         {0}
     },
     .size = sizeof(struct dec_wrapper_opts),

--- a/options/options.c
+++ b/options/options.c
@@ -70,7 +70,6 @@ extern const struct m_sub_options demux_rawvideo_conf;
 extern const struct m_sub_options demux_playlist_conf;
 extern const struct m_sub_options demux_lavf_conf;
 extern const struct m_sub_options demux_mkv_conf;
-extern const struct m_sub_options demux_cue_conf;
 extern const struct m_sub_options vd_lavc_conf;
 extern const struct m_sub_options ad_lavc_conf;
 extern const struct m_sub_options input_config;
@@ -632,7 +631,6 @@ static const m_option_t mp_opts[] = {
 
 #if HAVE_CDDA
     {"cdda", OPT_SUBSTRUCT(stream_cdda_opts, stream_cdda_conf)},
-    {"cdrom-device", OPT_REPLACED("cdda-device")},
 #endif
 
     // demuxer.c - select audio/sub file/demuxer
@@ -684,7 +682,6 @@ static const m_option_t mp_opts[] = {
     {"demuxer-rawvideo", OPT_SUBSTRUCT(demux_rawvideo, demux_rawvideo_conf)},
     {"", OPT_SUBSTRUCT(demux_playlist, demux_playlist_conf)},
     {"demuxer-mkv", OPT_SUBSTRUCT(demux_mkv, demux_mkv_conf)},
-    {"demuxer-cue", OPT_SUBSTRUCT(demux_cue, demux_cue_conf)},
 
 // ------------------------- subtitles options --------------------
 
@@ -955,7 +952,6 @@ static const m_option_t mp_opts[] = {
     {"", OPT_SUBSTRUCT(encode_opts, encode_config)},
 
     {"play-dir", OPT_REPLACED("play-direction")},
-    {"sub-forced-only", OPT_REPLACED("sub-forced-events-only")},
     {0}
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -351,7 +351,6 @@ typedef struct MPOpts {
     struct demux_playlist_opts *demux_playlist;
     struct demux_lavf_opts *demux_lavf;
     struct demux_mkv_opts *demux_mkv;
-    struct demux_cue_opts *demux_cue;
 
     struct demux_opts *demux_opts;
     struct demux_cache_opts *demux_cache_opts;

--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -62,7 +62,6 @@ typedef struct cdda_params {
     int paranoia_mode;
     int sector_size;
     int search_overlap;
-    int toc_bias;
     int toc_offset;
     bool skip;
     char *device;
@@ -78,8 +77,6 @@ const struct m_sub_options stream_cdda_conf = {
         {"paranoia", OPT_INT(paranoia_mode), M_RANGE(0, 2)},
         {"sector-size", OPT_INT(sector_size), M_RANGE(1, 100)},
         {"overlap", OPT_INT(search_overlap), M_RANGE(0, 75)},
-        {"toc-bias", OPT_INT(toc_bias),
-            .deprecation_message = "toc-bias is no longer used"},
         {"toc-offset", OPT_INT(toc_offset)},
         {"skip", OPT_BOOL(skip)},
         {"span-a", OPT_INT(span[0])},

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -81,8 +81,6 @@ const struct m_sub_options drm_conf = {
             .help = drm_connector_opt_help},
         {"drm-mode", OPT_STRING_VALIDATE(mode_spec, drm_validate_mode_opt),
             .help = drm_mode_opt_help},
-        {"drm-atomic", OPT_CHOICE(drm_atomic, {"no", 0}, {"auto", 1}),
-            .deprecation_message = "this option is deprecated: DRM Atomic is required"},
         {"drm-draw-plane", OPT_CHOICE(draw_plane,
             {"primary", DRM_OPTS_PRIMARY_PLANE},
             {"overlay", DRM_OPTS_OVERLAY_PLANE}),
@@ -104,7 +102,6 @@ const struct m_sub_options drm_conf = {
     },
     .defaults = &(const struct drm_opts) {
         .mode_spec = "preferred",
-        .drm_atomic = 1,
         .draw_plane = DRM_OPTS_PRIMARY_PLANE,
         .drmprime_video_plane = DRM_OPTS_OVERLAY_PLANE,
         .drm_format = DRM_OPTS_FORMAT_XRGB8888,

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -347,10 +347,8 @@ static OPT_STRING_VALIDATE_FUNC(validate_error_diffusion_opt);
     {n"-param1", OPT_FLOATDEF(scaler[i].kernel.params[0])},                \
     {n"-param2", OPT_FLOATDEF(scaler[i].kernel.params[1])},                \
     {n"-blur",   OPT_FLOAT(scaler[i].kernel.blur)},                        \
-    {n"-cutoff", OPT_REMOVED("Hard-coded as 0.001")},                      \
     {n"-taper",  OPT_FLOAT(scaler[i].kernel.taper), M_RANGE(0.0, 1.0)},    \
     {n"-wparam", OPT_FLOATDEF(scaler[i].window.params[0])},                \
-    {n"-wblur",  OPT_REMOVED("Just adjust filter radius directly")},       \
     {n"-wtaper", OPT_FLOAT(scaler[i].window.taper), M_RANGE(0.0, 1.0)},    \
     {n"-clamp",  OPT_FLOAT(scaler[i].clamp), M_RANGE(0.0, 1.0)},           \
     {n"-radius", OPT_FLOAT(scaler[i].radius), M_RANGE(0.5, 16.0)},         \
@@ -422,7 +420,6 @@ const struct m_sub_options gl_video_conf = {
         SCALER_OPTS("dscale", SCALER_DSCALE),
         SCALER_OPTS("cscale", SCALER_CSCALE),
         SCALER_OPTS("tscale", SCALER_TSCALE),
-        {"scaler-lut-size", OPT_REMOVED("hard-coded as 8")},
         {"scaler-resizes-only", OPT_BOOL(scaler_resizes_only)},
         {"correct-downscaling", OPT_BOOL(correct_downscaling)},
         {"linear-downscaling", OPT_BOOL(linear_downscaling)},
@@ -473,8 +470,6 @@ const struct m_sub_options gl_video_conf = {
         {"gamut-clipping", OPT_REMOVED("Replaced by --gamut-mapping-mode=desaturate")},
         {"tone-mapping-desaturate", OPT_REMOVED("Replaced by --tone-mapping-mode")},
         {"tone-mapping-desaturate-exponent", OPT_REMOVED("Replaced by --tone-mapping-mode")},
-        {"tone-mapping-crosstalk", OPT_REMOVED("Hard-coded as 0.04")},
-        {"tone-mapping-mode", OPT_REMOVED("no replacement")},
         {0}
     },
     .size = sizeof(struct gl_video_opts),

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -618,7 +618,6 @@ const struct vo_driver video_out_sixel = {
         {"config-clear", OPT_BOOL(opts.config_clear), },
         {"alt-screen", OPT_BOOL(opts.alt_screen), },
         {"buffered", OPT_BOOL(opts.buffered), },
-        {"exit-clear", OPT_REPLACED("vo-sixel-alt-screen")},
         {0}
     },
     .options_prefix = "vo-sixel",

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -119,7 +119,6 @@ const struct m_sub_options vulkan_conf = {
         {"vulkan-queue-count", OPT_INT(queue_count), M_RANGE(1, 8)},
         {"vulkan-async-transfer", OPT_BOOL(async_transfer)},
         {"vulkan-async-compute", OPT_BOOL(async_compute)},
-        {"vulkan-disable-events", OPT_REMOVED("Unused")},
         {0}
     },
     .size = sizeof(struct vulkan_opts),


### PR DESCRIPTION
Felt like doing some janitor work again. All of these were from mpv 0.37 or earlier, and I see no reason to continue leaving these deprecated/useless options in the codebase for years. Let me know if you think if any of these are too soon. I also didn't document the removal of the `OPT_REMOVED` ones because mpv fails opening if you use any one of those so it's not really a terribly relevant interface change imo. Just the removal message goes away.

Didn't touch the `--gamma-auto` or `--gamma-factor` stuff since we already have a PR for that (#14369).