### PR TITLE
playlist: fix some playlist-prev/playlist-next edge cases

### DIFF
--- a/common/playlist.c
+++ b/common/playlist.c
@@ -116,6 +116,7 @@ void playlist_clear(struct playlist *pl)
     assert(!pl->current);
     pl->current_was_replaced = false;
     pl->playlist_completed = false;
+    pl->playlist_started = false;
 }
 
 void playlist_clear_except_current(struct playlist *pl)
@@ -125,6 +126,7 @@ void playlist_clear_except_current(struct playlist *pl)
             playlist_remove(pl, pl->entries[n]);
     }
     pl->playlist_completed = false;
+    pl->playlist_started = false;
 }
 
 // Moves the entry so that it takes "at"'s place (or move to end, if at==NULL).
@@ -209,6 +211,8 @@ struct playlist_entry *playlist_get_next(struct playlist *pl, int direction)
     assert(direction == -1 || direction == +1);
     if (!pl->current && pl->playlist_completed && direction < 0) {
         return playlist_entry_from_index(pl, pl->num_entries - 1);
+    } else if (!pl->current && !pl->playlist_started && direction > 0) {
+        return playlist_entry_from_index(pl, 0);
     } else if (!pl->current) {
         return NULL;
     }
@@ -339,6 +343,7 @@ int64_t playlist_transfer_entries_to(struct playlist *pl, int dst_index,
     source_pl->num_entries = 0;
 
     pl->playlist_completed = source_pl->playlist_completed;
+    pl->playlist_started = source_pl->playlist_started;
 
     return first ? first->id : 0;
 }

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -71,6 +71,7 @@ struct playlist {
     struct playlist_entry *current;
     bool current_was_replaced;
     bool playlist_completed;
+    bool playlist_started;
 
     uint64_t id_alloc;
 };

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -70,6 +70,7 @@ struct playlist {
     // current_was_replaced is set to true.
     struct playlist_entry *current;
     bool current_was_replaced;
+    bool playlist_completed;
 
     uint64_t id_alloc;
 };

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1025,6 +1025,7 @@ void prepare_playlist(struct MPContext *mpctx, struct playlist *pl)
 
     pl->current = NULL;
     pl->playlist_completed = false;
+    pl->playlist_started = false;
 
     if (opts->playlist_pos >= 0)
         pl->current = playlist_entry_from_index(pl, opts->playlist_pos);
@@ -1754,6 +1755,7 @@ static void play_current_file(struct MPContext *mpctx)
     mpctx->playback_initialized = true;
     mpctx->playing->playlist_prev_attempt = false;
     mpctx->playlist->playlist_completed = false;
+    mpctx->playlist->playlist_started = true;
     mp_notify(mpctx, MPV_EVENT_FILE_LOADED, NULL);
     update_screensaver_state(mpctx);
     clear_playlist_paths(mpctx);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1024,6 +1024,7 @@ void prepare_playlist(struct MPContext *mpctx, struct playlist *pl)
     struct MPOpts *opts = mpctx->opts;
 
     pl->current = NULL;
+    pl->playlist_completed = false;
 
     if (opts->playlist_pos >= 0)
         pl->current = playlist_entry_from_index(pl, opts->playlist_pos);
@@ -1752,6 +1753,7 @@ static void play_current_file(struct MPContext *mpctx)
 
     mpctx->playback_initialized = true;
     mpctx->playing->playlist_prev_attempt = false;
+    mpctx->playlist->playlist_completed = false;
     mp_notify(mpctx, MPV_EVENT_FILE_LOADED, NULL);
     update_screensaver_state(mpctx);
     clear_playlist_paths(mpctx);
@@ -1991,6 +1993,9 @@ void mp_play_files(struct MPContext *mpctx)
         } else if (mpctx->stop_play == PT_CURRENT_ENTRY) {
             new_entry = mpctx->playlist->current;
         }
+
+        if (!new_entry)
+            mpctx->playlist->playlist_completed = true;
 
         mpctx->playlist->current = new_entry;
         mpctx->playlist->current_was_replaced = false;


### PR DESCRIPTION
Previously, playlist-prev didn't work if you played a playlist to completion using --idle and tried to go back. Naturally, one would expect this to bring up the last item in the playlist, but nothing happens. This is just because playlist_get_next is stupid and doesn't take this into account since pl->current is NULL and thus returns NULL. Fix this by also considering the direction and grabbing the last playlist entry in the index.