### PR TITLE
vo_tct: clear backbuffer on reconfig

### DIFF
--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -243,6 +243,8 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     if (!p->frame)
         return -1;
 
+    mp_image_clear(p->frame, 0, 0, p->frame->w, p->frame->h);
+
     if (mp_sws_reinit(p->sws) < 0)
         return -1;
 


### PR DESCRIPTION
We were drawing garbage data after reconfig, if there is no yet video frame ready or in --force-window without video track.

Found by OSS-Fuzz.