### PR TITLE
loadfile: update the format of terminal track information

### DIFF
--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -38,8 +38,6 @@
 #define TERM_ESC_ENABLE_MOUSE       "\033[?1003h"
 #define TERM_ESC_DISABLE_MOUSE      "\033[?1003l"
 
-#define TERM_ESC_GREY               "\033[38;5;8m"
-
 struct input_ctx;
 
 /* Global initialization for terminal output. */

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1780,20 +1780,8 @@ mp.register_event('log-message', function(e)
     if e.level == 'trace' then return end
 
     -- Use color for debug/v/warn/error/fatal messages.
-    local style = styles[e.level]
-    local terminal_style = terminal_styles[e.level]
-
-    -- Strip the terminal escape sequence from unselected tracks.
-    if e.prefix == 'cplayer' and e.level == 'info' then
-        local found
-        e.text, found = e.text:gsub('^\027%[38;5;8m', '')
-        if found == 1 then
-            style = styles.disabled
-            terminal_style = terminal_styles.disabled
-        end
-    end
-
-    log_add('[' .. e.prefix .. '] ' .. e.text, style, terminal_style)
+    log_add('[' .. e.prefix .. '] ' .. e.text, styles[e.level],
+            terminal_styles[e.level])
 end)
 
 collectgarbage()

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -74,7 +74,7 @@ local function format_track(track)
              and string.format("%.4f", track["demux-fps"]):gsub("%.?0*$", "") ..
              " fps " or "") ..
             (track["demux-channel-count"] and track["demux-channel-count"] ..
-             " ch " or "") ..
+             "ch " or "") ..
             (track["codec-profile"] and track.type == "audio"
              and track["codec-profile"] .. " " or "") ..
             (track["demux-samplerate"] and track["demux-samplerate"] / 1000 ..


### PR DESCRIPTION
Stop making unselected tracks and editions grey because they can be hard to read over a dark background (\033[2m would be hard to differentiate from regular text with a light theme instead), and because there is no way to not print the escape sequences in --log-file.

Just use the same circles as the OSD and OSC. We need to print the empty circles for alignment on mlterm with East Asian fonts (we could also make them invisible with \033[8m but it would still get added to log files).

Add back the space before tracks and editions so they look like a sub-section of the "Playing..." line printed with playlists and of "Track switched", consistently with the metadata which starts with space which makes it look like a sub-section of the "File tags" line.

Also stop converting Hz to kHz for consistency with other log messages, e.g. AO: [pipewire] 48000Hz stereo 2ch floatp