### PR TITLE
ytdl_hook.lua: prefer HLS by default to avoid youtube's throttling

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -973,7 +973,7 @@ Program Behavior
     available formats can be found with the command
     ``youtube-dl --list-formats URL``. See youtube-dl's documentation for
     available aliases.
-    (Default: ``bestvideo+bestaudio/best``)
+    (Default: ``bestvideo[protocol^=m3u8]+bestaudio[protocol^=m3u8]/bestvideo+bestaudio/best``)
 
     The ``ytdl`` value does not pass a ``--format`` option to youtube-dl at all,
     and thus does not override its default. Note that sometimes youtube-dl

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -905,7 +905,7 @@ local function run_ytdl_hook(url)
     end
 
     if format == "" then
-        format = "bestvideo+bestaudio/best"
+        format = "bestvideo[protocol^=m3u8]+bestaudio[protocol^=m3u8]/bestvideo+bestaudio/best"
     end
 
     if format ~= "ytdl" then


### PR DESCRIPTION
Youtube throttles downloads of DASH streams unless you download them in chunks of up to 10MB, but not HLS. Default to HLS to speed up youtube downloads since it's by far the most popular yt-dlp site and there is no known issue in preferring HLS over DASH in other sites, if DASH is even available.