### PR TITLE
meson: add fuzzers alias for all fuzzer targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,7 +349,7 @@ jobs:
             --werror        \
             -Dc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
             -Dfuzzers=true -Dlibmpv=true -Dcplayer=false
-          meson compile -C build
+          meson compile -C build fuzzers
 
       - name: Print meson log
         if: ${{ failure() && steps.build.outcome == 'failure' }}

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -75,7 +75,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 
     if (ret != MPV_ERROR_SUCCESS)
-        return 0;
+        goto done;
 
 #if MPV_RUN
     check_error(mpv_set_option_string(ctx, "ao-null-untimed", "yes"));
@@ -93,6 +93,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
 #endif
 
+done:
     mpv_terminate_destroy(ctx);
 
     return 0;

--- a/fuzzers/meson.build
+++ b/fuzzers/meson.build
@@ -2,8 +2,10 @@ incdir = include_directories('../')
 
 add_languages('cpp', native: false)
 
-executable('fuzzer_loadfile_direct', 'fuzzer_loadfile_direct.c',
-           link_language: 'cpp', include_directories: incdir, link_with: libmpv)
+fuzzers = []
+
+fuzzers += executable('fuzzer_loadfile_direct', 'fuzzer_loadfile_direct.c',
+                      link_language: 'cpp', include_directories: incdir, link_with: libmpv)
 
 protocols = ['edl', 'file', 'lavf', 'memory']
 demuxers = ['mkv']
@@ -28,43 +30,45 @@ if features['libarchive']
 endif
 
 foreach p : protocols
-  executable('fuzzer_protocol_' + p,
-             'fuzzer_loadfile_direct.c',
-             link_language: 'cpp',
-             c_args: ['-DMPV_PROTO=' + p, '-DMPV_PROTO_' + p.to_upper()],
-             include_directories: incdir,
-             link_with: libmpv)
+  fuzzers += executable('fuzzer_protocol_' + p,
+                        'fuzzer_loadfile_direct.c',
+                        link_language: 'cpp',
+                        c_args: ['-DMPV_PROTO=' + p, '-DMPV_PROTO_' + p.to_upper()],
+                        include_directories: incdir,
+                        link_with: libmpv)
 endforeach
 
 foreach demuxer : demuxers
     cmd = 'file'
     cmd_ = cmd.underscorify()
     demuxer_ = demuxer.underscorify()
-    executable('fuzzer_load' + cmd_ + '_' + demuxer_,
-                'fuzzer_load.c',
-                link_language: 'cpp',
-                c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd_.to_upper(),
-                         '-DMPV_DEMUXER="' + demuxer + '"', '-DMPV_DEMUXER' + demuxer_.to_upper()],
-                include_directories: incdir,
-                link_with: libmpv)
+    fuzzers += executable('fuzzer_load' + cmd_ + '_' + demuxer_,
+                          'fuzzer_load.c',
+                          link_language: 'cpp',
+                          c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd_.to_upper(),
+                                   '-DMPV_DEMUXER="' + demuxer + '"', '-DMPV_DEMUXER' + demuxer_.to_upper()],
+                          include_directories: incdir,
+                          link_with: libmpv)
 endforeach
 
 foreach f : ['MPV_FORMAT_STRING', 'MPV_FORMAT_FLAG', 'MPV_FORMAT_INT64', 'MPV_FORMAT_DOUBLE']
   foreach i : ['0', '1']
-    executable('fuzzer_set_property_' + f + '_' + i,
-                'fuzzer_set_property.c',
-                link_language: 'cpp',
-                c_args: ['-DMPV_FORMAT=' + f, '-DMPV_RUN=' + i],
-                include_directories: incdir,
-                link_with: libmpv)
+    fuzzers += executable('fuzzer_set_property_' + f + '_' + i,
+                          'fuzzer_set_property.c',
+                          link_language: 'cpp',
+                          c_args: ['-DMPV_FORMAT=' + f, '-DMPV_RUN=' + i],
+                          include_directories: incdir,
+                          link_with: libmpv)
   endforeach
 endforeach
 
 foreach cmd : ['file', '-config-file', '-input-conf']
-    executable('fuzzer_load' + cmd.underscorify(),
-                'fuzzer_load.c',
-                link_language: 'cpp',
-                c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd.underscorify().to_upper()],
-                include_directories: incdir,
-                link_with: libmpv)
+    fuzzers += executable('fuzzer_load' + cmd.underscorify(),
+                          'fuzzer_load.c',
+                          link_language: 'cpp',
+                          c_args: ['-DMPV_LOAD="' + cmd + '"', '-DMPV_LOAD' + cmd.underscorify().to_upper()],
+                          include_directories: incdir,
+                          link_with: libmpv)
 endforeach
+
+alias_target('fuzzers', fuzzers)


### PR DESCRIPTION
Makes it easier to build only fuzzer binaries and avoid building unnecessary targets from subprojects.