### PR TITLE
demux_playlist: don't add base path to self-expanding protocols

### DIFF
--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -904,6 +904,9 @@ struct mp_lavfi *mp_lavfi_create_graph(struct mp_filter *parent,
                                        char *hwdec_interop,
                                        char **graph_opts, const char *graph)
 {
+    if (!graph)
+        return NULL;
+
     struct lavfi *c = lavfi_alloc(parent);
     if (!c)
         return NULL;

--- a/fuzzers/fuzzer_load.c
+++ b/fuzzers/fuzzer_load.c
@@ -81,9 +81,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     check_error(mpv_command(ctx, cmd));
 
 #ifdef MPV_LOADFILE
+    bool loaded = false;
     while (1) {
-        mpv_event *event = mpv_wait_event(ctx, 10000);
-        if (event->event_id == MPV_EVENT_IDLE)
+        mpv_event *event = mpv_wait_event(ctx, -1);
+        if (event->event_id == MPV_EVENT_START_FILE)
+            loaded = true;
+        if (loaded && event->event_id == MPV_EVENT_IDLE)
             break;
     }
 #endif

--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -75,9 +75,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     const char *cmd[] = {"loadfile", data, NULL};
     check_error(mpv_command(ctx, cmd));
 
+    bool loaded = false;
     while (1) {
-        mpv_event *event = mpv_wait_event(ctx, 10000);
-        if (event->event_id == MPV_EVENT_IDLE)
+        mpv_event *event = mpv_wait_event(ctx, -1);
+        if (event->event_id == MPV_EVENT_START_FILE)
+            loaded = true;
+        if (loaded && event->event_id == MPV_EVENT_IDLE)
             break;
     }
 

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -104,9 +104,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     const char *cmd[] = {"loadfile", "av://lavfi:yuvtestsrc=d=0.01", NULL};
     check_error(mpv_command(ctx, cmd));
 
+    bool loaded = false;
     while (1) {
-        mpv_event *event = mpv_wait_event(ctx, 10000);
-        if (event->event_id == MPV_EVENT_IDLE)
+        mpv_event *event = mpv_wait_event(ctx, -1);
+        if (event->event_id == MPV_EVENT_START_FILE)
+            loaded = true;
+        if (loaded && event->event_id == MPV_EVENT_IDLE)
             break;
     }
 #endif


### PR DESCRIPTION
Adding base path make sense only if it is real directory or url location. In case of protocols like memory adding base path to playlist entry in facts adds whole playlist to that entry.

For example `mpv $'memory://#EXTM3U\na/b` produces infinite loop, expanding playlist.

Found by OSS-Fuzz.