### PR TITLE
wayland: add a --wayland-present option

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5921,6 +5921,11 @@ them.
     Defines the size of an edge border (default: 32) to initiate client side
     resizes events in the wayland contexts with touch events.
 
+``--wayland-present=<yes|no>``
+    Enable the use of wayland's presentation time protocol for more accurate
+    frame presentation if it is supported by the compositor (default: ``yes``).
+    This only has an effect if ``--video-sync=display-...`` is being used.
+
 ``--spirv-compiler=<compiler>``
     Controls which compiler is used to translate GLSL to SPIR-V. This is
     only relevant for ``--gpu-api=d3d11`` with ``--vo=gpu``.

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -154,6 +154,7 @@ const struct m_sub_options wayland_conf = {
             M_RANGE(0, INT_MAX)},
         {"wayland-edge-pixels-touch", OPT_INT(edge_pixels_touch),
             M_RANGE(0, INT_MAX)},
+        {"wayland-present", OPT_BOOL(present)},
         {0},
     },
     .size = sizeof(struct wayland_opts),
@@ -161,6 +162,7 @@ const struct m_sub_options wayland_conf = {
         .configure_bounds = -1,
         .edge_pixels_pointer = 16,
         .edge_pixels_touch = 32,
+        .present = true,
     },
 };
 
@@ -1283,7 +1285,7 @@ static void pres_set_clockid(void *data, struct wp_presentation *pres,
     struct vo_wayland_state *wl = data;
 
     if (clockid == CLOCK_MONOTONIC || clockid == CLOCK_MONOTONIC_RAW)
-        wl->use_present = true;
+        wl->present_clock = true;
 }
 
 static const struct wp_presentation_listener pres_listener = {
@@ -1349,6 +1351,7 @@ static void frame_callback(void *data, struct wl_callback *callback, uint32_t ti
     wl->frame_callback = wl_surface_frame(wl->callback_surface);
     wl_callback_add_listener(wl->frame_callback, &frame_listener, wl);
 
+    wl->use_present = wl->present_clock && wl->opts->present;
     if (wl->use_present) {
         struct wp_presentation_feedback *fback = wp_presentation_feedback(wl->presentation, wl->callback_surface);
         add_feedback(wl->fback_pool, fback);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -36,6 +36,7 @@ struct wayland_opts {
     bool disable_vsync;
     int edge_pixels_pointer;
     int edge_pixels_touch;
+    bool present;
 };
 
 struct vo_wayland_state {
@@ -120,6 +121,7 @@ struct vo_wayland_state {
     struct vo_wayland_feedback_pool *fback_pool;
     struct mp_present *present;
     int64_t refresh_interval;
+    bool present_clock;
     bool use_present;
 
     /* single-pixel-buffer */


### PR DESCRIPTION
Mainly for debugging. It might be handy to disable presentation feedback on wayland to make sure something isn't going wrong with the calculations somewhere.