### PR TITLE
console.lua: minor tweaks

### DIFF
--- a/DOCS/interface-changes/console-scale.txt
+++ b/DOCS/interface-changes/console-scale.txt
@@ -1,0 +1,1 @@
+remove `console-scale` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -131,15 +131,6 @@ documentation.
 Configurable Options
 ~~~~~~~~~~~~~~~~~~~~
 
-``scale``
-    Default: 1
-
-    All drawing is scaled by this value, including the text borders and the
-    cursor.
-
-    If the VO backend in use has HiDPI scale reporting implemented, the option
-    value is scaled with the reported HiDPI scale.
-
 ``font``
     Default: unset (picks a hardcoded font depending on detected platform)
 
@@ -151,7 +142,7 @@ Configurable Options
     Default: 16
 
     Set the font size used for the REPL and the console. This will be
-    multiplied by "scale".
+    multiplied by ``display-hidpi-scale``.
 
 ``border_size``
     Default: 1

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -638,8 +638,14 @@ local function handle_edit()
         matches = {}
         selected_match = 1
 
-        for i, match in ipairs(fuzzy_find(line, selectable_items)) do
-            matches[i] = { index = match, text = selectable_items[match] }
+        if line == '' then
+            for i, item in ipairs(selectable_items) do
+                matches[i] = { index = i, text = item }
+            end
+        else
+            for i, match in ipairs(fuzzy_find(line, selectable_items)) do
+                matches[i] = { index = match, text = selectable_items[match] }
+            end
         end
     end
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -18,16 +18,10 @@ local assdraw = require 'mp.assdraw'
 -- Default options
 local opts = {
     font = "",
-    -- Set the font size used for the REPL and the console. This will be
-    -- multiplied by "scale".
     font_size = 16,
     border_size = 1,
     case_sensitive = true,
-    -- Remove duplicate entries in history as to only keep the latest one.
     history_dedup = true,
-    -- The ratio of font height to font width.
-    -- Adjusts table width of completion suggestions.
-    -- Values in the range 1.8..2.5 make sense for common monospace fonts.
     font_hw_ratio = 'auto',
 }
 
@@ -154,7 +148,7 @@ local function truncate_utf8(str, max_length)
         len = len + 1
         if pos > last_pos + 1 then
             if len == max_length - 1 then
-                pos = prev_utf8(str, pos)
+                pos = last_pos
             else
                 len = len + 1
             end
@@ -503,19 +497,18 @@ local function update()
         return
     end
 
-    local dpi_scale = mp.get_property_native("display-hidpi-scale", 1.0)
+    -- Clear the OSD if the REPL is not active
+    if not repl_active then
+        mp.set_osd_ass(0, 0, '')
+        return
+    end
 
     local screenx, screeny = mp.get_osd_size()
+    local dpi_scale = mp.get_property_native('display-hidpi-scale', 1)
     screenx = screenx / dpi_scale
     screeny = screeny / dpi_scale
 
     local bottom_left_margin = 6
-
-    -- Clear the OSD if the REPL is not active
-    if not repl_active then
-        mp.set_osd_ass(screenx, screeny, '')
-        return
-    end
 
     local coordinate_top = math.floor(global_margins.t * screeny + 0.5)
     local clipping_coordinates = '0,' .. coordinate_top .. ',' ..

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -17,11 +17,6 @@ local assdraw = require 'mp.assdraw'
 
 -- Default options
 local opts = {
-    -- All drawing is scaled by this value, including the text borders and the
-    -- cursor. Change it if you have a high-DPI display.
-    scale = 1,
-    -- Set the font used for the REPL and the console.
-    -- This has to be a monospaced font.
     font = "",
     -- Set the font size used for the REPL and the console. This will be
     -- multiplied by "scale".
@@ -266,7 +261,6 @@ local function calculate_max_log_lines()
 
     return math.floor(mp.get_property_native('osd-height')
                       / mp.get_property_native('display-hidpi-scale', 1)
-                      / opts.scale
                       * (1 - global_margins.t - global_margins.b)
                       / opts.font_size
                       -- Subtract 1 for the input line and 1 for the newline
@@ -510,8 +504,6 @@ local function update()
     end
 
     local dpi_scale = mp.get_property_native("display-hidpi-scale", 1.0)
-
-    dpi_scale = dpi_scale * opts.scale
 
     local screenx, screeny = mp.get_osd_size()
     screenx = screenx / dpi_scale


### PR DESCRIPTION
commit 1: console.lua: remove the scale script-opt

This is redundant because you can set font_size and border_size to have the same effect.

commit 2: console.lua: minor tweaks

- Remove the opts comments because they are already in console.rst and will become outdated if not updated in both places
- Reuse last_pos in truncate_utf8() instead of recalculating the previous character's position
- Clear the OSD earlier when the console is not active