### PR TITLE
various: sync track information output

### DIFF
--- a/DOCS/interface-changes/packet-bitrate.txt
+++ b/DOCS/interface-changes/packet-bitrate.txt
@@ -1,0 +1,1 @@
+remove deprecated `packet-video-bitrate` `packet-audio-bitrate` and `packet-sub-bitrate` properties

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3479,14 +3479,6 @@ Property list
     In earlier versions of mpv, these properties returned a static (but bad)
     guess using a completely different method.
 
-``packet-video-bitrate``, ``packet-audio-bitrate``, ``packet-sub-bitrate``
-    Old and deprecated properties for ``video-bitrate``, ``audio-bitrate``,
-    ``sub-bitrate``. They behave exactly the same, but return a value in
-    kilobits. Also, they don't have any OSD formatting, though the same can be
-    achieved with e.g. ``${=video-bitrate}``.
-
-    These properties shouldn't be used anymore.
-
 ``audio-device-list``
     The list of discovered audio devices. This is mostly for use with the
     client API, and reflects what ``--audio-device=help`` with the command line

--- a/player/command.c
+++ b/player/command.c
@@ -2075,9 +2075,12 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
     return m_property_read_sub(props, action, arg);
 }
 
-static const char *track_type_name(enum stream_type t)
+static const char *track_type_name(struct track *t)
 {
-    switch (t) {
+    if (t->image)
+        return "Image";
+
+    switch (t->type) {
     case STREAM_VIDEO: return "Video";
     case STREAM_AUDIO: return "Audio";
     case STREAM_SUB: return "Sub";
@@ -2099,7 +2102,7 @@ static int property_list_tracks(void *ctx, struct m_property *prop,
                     continue;
 
                 res = talloc_asprintf_append(res, "%s: ",
-                                             track_type_name(track->type));
+                                             track_type_name(track));
                 res = talloc_strdup_append(res,
                                 track->selected ? list_current : list_normal);
                 res = talloc_asprintf_append(res, "(%d) ", track->user_tid);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -299,8 +299,10 @@ static void print_stream(struct MPContext *mpctx, struct track *t, bool indent)
         if (s && s->codec->samplerate)
             APPEND(b, " %d Hz", s->codec->samplerate);
     }
-    if (s && s->hls_bitrate > 0)
-        APPEND(b, " %d kbps", (s->hls_bitrate + 500) / 1000);
+    if (s && s->codec->bitrate)
+        APPEND(b, " %d kbps", (s->codec->bitrate + 500) / 1000);
+    if (s && s->hls_bitrate)
+        APPEND(b, " %d HLS kbps", (s->hls_bitrate + 500) / 1000);
     APPEND(b, ")");
 
     bool first = true;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -308,12 +308,12 @@ static void print_stream(struct MPContext *mpctx, struct track *t, bool indent)
         ADD_FLAG(b, "default", first);
     if (t->forced_track)
         ADD_FLAG(b, "forced", first);
-    if (t->attached_picture)
-        ADD_FLAG(b, "picture", first);
+    if (t->dependent_track)
+        ADD_FLAG(b, "dependent", first);
     if (t->visual_impaired_track)
-        ADD_FLAG(b, "visual_impaired", first);
+        ADD_FLAG(b, "visual-impaired", first);
     if (t->hearing_impaired_track)
-        ADD_FLAG(b, "hearing_impaired", first);
+        ADD_FLAG(b, "hearing-impaired", first);
     if (t->is_external)
         ADD_FLAG(b, "external", first);
     if (!first)

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -252,7 +252,7 @@ static void print_stream(struct MPContext *mpctx, struct track *t, bool indent)
     const char *langopt = "?";
     switch (t->type) {
     case STREAM_VIDEO:
-        tname = "Video"; selopt = "vid"; langopt = "vlang";
+        tname = t->image ? "Image" : "Video"; selopt = "vid"; langopt = "vlang";
         break;
     case STREAM_AUDIO:
         tname = "Audio"; selopt = "aid"; langopt = "alang";

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -62,6 +62,25 @@ mp.add_forced_key_binding(nil, "select-playlist", function ()
     })
 end)
 
+local function format_flags(track)
+    local flags = ""
+
+    for _, flag in ipairs({
+        "default", "forced", "dependent", "visual-impaired", "hearing-impaired",
+        "image", "external"
+    }) do
+        if track[flag] then
+            flags = flags .. flag .. " "
+        end
+    end
+
+    if flags == "" then
+        return ""
+    end
+
+    return " [" .. flags:sub(1, -2) .. "]"
+end
+
 local function format_track(track)
     return (track.selected and "●" or "○") ..
         (track.title and " " .. track.title or "") ..
@@ -78,9 +97,8 @@ local function format_track(track)
             (track["codec-profile"] and track.type == "audio"
              and track["codec-profile"] .. " " or "") ..
             (track["demux-samplerate"] and track["demux-samplerate"] / 1000 ..
-             " kHz " or "") ..
-            (track.external and "external " or "")
-        ):sub(1, -2) .. ")"
+             " kHz " or "")
+        ):sub(1, -2) .. ")" .. format_flags(track)
 end
 
 mp.add_forced_key_binding(nil, "select-track", function ()

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -97,7 +97,11 @@ local function format_track(track)
             (track["codec-profile"] and track.type == "audio"
              and track["codec-profile"] .. " " or "") ..
             (track["demux-samplerate"] and track["demux-samplerate"] / 1000 ..
-             " kHz " or "")
+             " kHz " or "") ..
+            (track["demux-bitrate"] and string.format("%.0f", track["demux-bitrate"] / 1000)
+             .. " kbps " or "") ..
+            (track["hls-bitrate"] and string.format("%.0f", track["hls-bitrate"] / 1000)
+             .. " HLS kbps " or "")
         ):sub(1, -2) .. ")" .. format_flags(track)
 end
 

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -87,7 +87,8 @@ mp.add_forced_key_binding(nil, "select-track", function ()
     local tracks = {}
 
     for i, track in ipairs(mp.get_property_native("track-list")) do
-        tracks[i] = track.type:sub(1, 1):upper() .. track.type:sub(2) .. ": " ..
+        tracks[i] = (track.image and "Image" or
+                     track.type:sub(1, 1):upper() .. track.type:sub(2)) .. ": " ..
                     format_track(track)
     end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -993,7 +993,7 @@ local function add_video(s)
     end
     append_img_params(s, r, ro)
     append_hdr(s, ro)
-    append_property(s, "packet-video-bitrate", {prefix="Bitrate:", suffix=" kbps"})
+    append_property(s, "video-bitrate", {prefix="Bitrate:"})
     append_filters(s, "vf", "Filters:")
 end
 
@@ -1038,7 +1038,7 @@ local function add_audio(s)
     append(s, merge(r, ro, "format"), {prefix="Format:", nl=cc and "" or o.nl,
                             indent=cc and o.prefix_sep .. o.prefix_sep})
     append(s, merge(r, ro, "samplerate"), {prefix="Sample Rate:", suffix=" Hz"})
-    append_property(s, "packet-audio-bitrate", {prefix="Bitrate:", suffix=" kbps"})
+    append_property(s, "audio-bitrate", {prefix="Bitrate:"})
     append_filters(s, "af", "Filters:")
 end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1227,8 +1227,8 @@ local function add_track(c, t, i)
     append(c, t["ff-index"], {prefix="FFmpeg Index:", nl="", indent=o.prefix_sep .. o.prefix_sep})
     append(c, t["external-filename"], {prefix="File:"})
     append(c, "", {prefix="Flags:"})
-    local flags = {"default", "forced", "external", "dependent",
-                   "hearing-impaired", "visual-impaired", "image", "albumart"}
+    local flags = {"default", "forced", "dependent", "visual-impaired",
+                   "hearing-impaired", "image", "albumart", "external"}
     local any = false
     for _, flag in ipairs(flags) do
         if t[flag] then

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -952,9 +952,10 @@ local function add_video(s)
         return
     end
 
-    append(s, "", {prefix="Video:", nl=o.nl .. o.nl, indent=""})
     local track = mp.get_property_native("current-tracks/video")
-    if track and append(s, track["codec-desc"], {prefix_sep="", nl="", indent=""}) then
+    if track then
+        append(s, "", {prefix=track.image and "Image:" or "Video:", nl=o.nl .. o.nl, indent=""})
+        append(s, track["codec-desc"], {prefix_sep="", nl="", indent=""})
         append(s, track["codec-profile"], {prefix="[", nl="", indent=" ", prefix_sep="",
                no_prefix_markup=true, suffix="]"})
         if track["codec"] ~= track["decoder"] then
@@ -1217,7 +1218,7 @@ local function add_track(c, t, i)
         return
     end
 
-    local type = t["type"]:sub(1,1):upper() .. t["type"]:sub(2)
+    local type = t.image and "Image" or t["type"]:sub(1, 1):upper() .. t["type"]:sub(2)
     append(c, "", {prefix=type .. ":", nl=o.nl .. o.nl, indent=""})
     append(c, t["title"], {prefix_sep="", nl="", indent=""})
     append(c, t["id"], {prefix="ID:"})


### PR DESCRIPTION
Print "Image" instead of "Video" for video tracks. This fixes #8561.

Print the hls-bitrate in select.lua.

Show the same flags in loadfile.c, select.lua and stats.lua. The only differences are that only stats.lua prints albumart because it's supposed to show detailed track information, and select.lua prints the image flag because pressing g-v doesn't show Video or Image like in loadfile.c and stats.lua.