### PR TITLE
misc/natural_sort: avoid implementation-defined behavior in comparison

### DIFF
--- a/misc/natural_sort.c
+++ b/misc/natural_sort.c
@@ -51,9 +51,9 @@ int mp_natural_sort_cmp(const char *name1, const char *name2)
                 name2++;
             }
         } else {
-            if (mp_tolower(name1[0]) < mp_tolower(name2[0]))
+            if ((unsigned char)mp_tolower(name1[0]) < (unsigned char)mp_tolower(name2[0]))
                 return -1;
-            if (mp_tolower(name1[0]) > mp_tolower(name2[0]))
+            if ((unsigned char)mp_tolower(name1[0]) > (unsigned char)mp_tolower(name2[0]))
                 return 1;
             name1++;
             name2++;


### PR DESCRIPTION
Before a7158ceec00f14e680a885722cfe23761b4662d3, string comparision was done with strcmp, which does unsigned comparison. The natural sort implementation instead compares on char values.
This causes implementation-defined behavior in comparison, depending on the signedness of char type.

Fix this by using unsigned comparison instead.

Fixes: #13435