### PR TITLE
demux: avoid seeking video streams for refresh seek

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1724,8 +1724,10 @@ static void play_current_file(struct MPContext *mpctx)
         }
     }
 
-    for (int n = 0; n < mpctx->num_tracks; n++)
-        reselect_demux_stream(mpctx, mpctx->tracks[n], false);
+    for (int t = 0; t < STREAM_TYPE_COUNT; t++)
+        for (int n = 0; n < mpctx->num_tracks; n++)
+            if (mpctx->tracks[n]->type == t)
+                reselect_demux_stream(mpctx, mpctx->tracks[n], false);
 
     update_demuxer_properties(mpctx);
 


### PR DESCRIPTION
Slightly tighten the refresh seek requirement for https://github.com/mpv-player/mpv/pull/14399 to make sure not to unnecessarily seek video streams. 
