### PR TITLE
ytdl_hook: strip quotes from cookie values

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -180,7 +180,7 @@ end
 local function serialize_cookies_for_avformat(cookies)
     local result = ''
     for _, cookie in pairs(cookies) do
-        local cookie_str = ('%s=%s; '):format(cookie.name, cookie.value)
+        local cookie_str = ('%s=%s; '):format(cookie.name, cookie.value:gsub('^"(.+)"$', '%1'))
         for k, v in pairs(cookie) do
             if k ~= "name" and k ~= "value" then
                 cookie_str = cookie_str .. ('%s=%s; '):format(k, v)


### PR DESCRIPTION
Sometimes the `cookies` field output from yt-dlp will have a cookie with a quoted value, e.g. when it contains a special character such as `=`:

```
yt-dlp --print "%(.{formats.-1.cookies})#j" "https://www.tiktok.com/@conner_omalley_/video/7365919655254347050"
```
```json
{
  "cookies": "tt_chain_token=\"bCJCjdkykbJshO3+LUEj4w==\"; Domain=.tiktok.com; Path=/; Secure; Expires=1735098525"
}
```

These quotes are added by the Python stdlib function `http.cookies.SimpleCookie.value_encode()`, and do not pose an issue for yt-dlp or other Python scripts.

They do pose an issue for mpv, though. The following command throws HTTP 403 Forbidden due to ffmpeg making a request with a cookie value that has literal quotes:
```
mpv -v -v -v "ytdl://https://www.tiktok.com/@conner_omalley_/video/7365919655254347050"
```

Some highlights from the log:
```
[cplayer] Set property: file-local-options/stream-lavf-o={"cookies":"ttwid=1%7C8hqCcGdyqr1oit-S82qVK3H2ItuN91_0HJaFyS_p6hw%7C1719545583%7Cf92c088930b281dc8d7c46bcf62e5bcda4fae4f82370da0c6f20697b8f8447ef; domain=.tiktok.com; path=/; expires=1750649583; \r\ntt_csrf_token=5rXklG9W--6carDYDZjEs5SKKCyE2YIovLP0; domain=.tiktok.com; path=/; \r\ntt_chain_token=\"mSivynZIM1NGNTnwCnlCpA==\"; domain=.tiktok.com; path=/; expires=1735097583; \r\n"} -> 1
...
[ffmpeg] https: request: GET /video/tos/useast5/tos-useast5-ve-0068c002-tx/ooUDAQDgFEcrOA5BnRtmAB5EIoYIESQfgmQewE/?a=1988&bti=ODszNWYuMDE6&ch=0&cr=3&dr=0&lr=unwatermarked&cd=0%7C0%7C0%7C&cv=1&br=1860&bt=930&cs=0&ds=6&ft=4KJMyMzm8Zmo07GUm-4jVVKRdpWrKsd.&mime_type=video_mp4&qs=0&rc=aDM5NjM6OTg3OGdnOTNlPEBpM3Y2Om45cmRqcjMzZzczNEAtMTZjYC1eNmExLjYvXjReYSNnZmcvMmRzLXBgLS1kMS9zcw%3D%3D&btag=e00088000&expire=1719567223&l=20240628033303C3BF235F72B033004833&ply_type=2&policy=2&signature=94d16205735798100ed49a9ac098767e&tk=tt_chain_token HTTP/1.1
[ffmpeg] User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36
[ffmpeg] Accept: */*
[ffmpeg] Range: bytes=0-
[ffmpeg] Connection: close
[ffmpeg] Host: v19-webapp-prime.us.tiktok.com
[ffmpeg] Cookie: ttwid=1%7C8hqCcGdyqr1oit-S82qVK3H2ItuN91_0HJaFyS_p6hw%7C1719545583%7Cf92c088930b281dc8d7c46bcf62e5bcda4fae4f82370da0c6f20697b8f8447ef; tt_csrf_token=5rXklG9W--6carDYDZjEs5SKKCyE2YIovLP0; tt_chain_token="mSivynZIM1NGNTnwCnlCpA=="
[ffmpeg] Icy-MetaData: 1
[ffmpeg] Referer: https://www.tiktok.com/@conner_omalley_/video/7365919655254347050
[ffmpeg] 
[ffmpeg] 
[ffmpeg] https: header='HTTP/1.1 403 Forbidden'
[ffmpeg] https: http_code=403
[ffmpeg] https: HTTP error 403 Forbidden
```

Here's the part that matters:

```
tt_chain_token="mSivynZIM1NGNTnwCnlCpA=="
```

---

This ytdl_hook patch strips the quotes from the cookie value, so we get video playback without issue:

```
[cplayer] Set property: file-local-options/stream-lavf-o={"cookies":"ttwid=1%7C5LSjvl94M7F7SR-saaKlfxWTRvT3IpLQ4U8DOU7FdIc%7C1719545839%7C74250e89e54f427daefdb5bbf62e5bcda4fae4f82370da0c6f20697b8f8447ef; expires=1750649839; path=/; domain=.tiktok.com; \r\ntt_csrf_token=TgcpcnFB-xo4uv6dJqbAxiYfBn6nZcax0UOM; domain=.tiktok.com; path=/; \r\ntt_chain_token=Pvwd3YYFSx4VImZKimeVTg==; expires=1735097839; path=/; domain=.tiktok.com; \r\n"} -> 1
...
[ffmpeg] https: request: GET /video/tos/useast5/tos-useast5-ve-0068c002-tx/ooUDAQDgFEcrOA5BnRtmAB5EIoYIESQfgmQewE/?a=1988&bti=ODszNWYuMDE6&ch=0&cr=3&dr=0&lr=unwatermarked&cd=0%7C0%7C0%7C&cv=1&br=1860&bt=930&cs=0&ds=6&ft=4KJMyMzm8Zmo075Um-4jVdvjdpWrKsd.&mime_type=video_mp4&qs=0&rc=aDM5NjM6OTg3OGdnOTNlPEBpM3Y2Om45cmRqcjMzZzczNEAtMTZjYC1eNmExLjYvXjReYSNnZmcvMmRzLXBgLS1kMS9zcw%3D%3D&btag=e00088000&expire=1719567479&l=2024062803371983FCE49E4B0F8D00075B&ply_type=2&policy=2&signature=4a338201f5bb716a89f215a56a1a6c44&tk=tt_chain_token HTTP/1.1
[ffmpeg] User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36
[ffmpeg] Accept: */*
[ffmpeg] Range: bytes=0-
[ffmpeg] Connection: close
[ffmpeg] Host: v19-webapp-prime.us.tiktok.com
[ffmpeg] Cookie: ttwid=1%7C5LSjvl94M7F7SR-saaKlfxWTRvT3IpLQ4U8DOU7FdIc%7C1719545839%7C74250e89e54f427daefdb5bbf62e5bcda4fae4f82370da0c6f20697b8f8447ef; tt_csrf_token=TgcpcnFB-xo4uv6dJqbAxiYfBn6nZcax0UOM; tt_chain_token=Pvwd3YYFSx4VImZKimeVTg==
[ffmpeg] Icy-MetaData: 1
[ffmpeg] Referer: https://www.tiktok.com/@conner_omalley_/video/7365919655254347050
[ffmpeg] 
[ffmpeg] 
[ffmpeg] https: header='HTTP/1.1 206 Partial Content'
[ffmpeg] https: http_code=206
```

```
tt_chain_token=Pvwd3YYFSx4VImZKimeVTg==
```

---

References:
- https://github.com/mpv-player/mpv/pull/12505
- https://github.com/yt-dlp/yt-dlp/issues/9997