### PR TITLE
input/cmd: move m_option_type_cycle_dir to m_option.c

### DIFF
--- a/input/cmd.c
+++ b/input/cmd.c
@@ -637,37 +637,3 @@ void mp_print_cmd_list(struct mp_log *out)
         mp_info(out, "\n");
     }
 }
-
-static int parse_cycle_dir(struct mp_log *log, const struct m_option *opt,
-                           struct bstr name, struct bstr param, void *dst)
-{
-    double val;
-    if (bstrcmp0(param, "up") == 0) {
-        val = +1;
-    } else if (bstrcmp0(param, "down") == 0) {
-        val = -1;
-    } else {
-        return m_option_type_double.parse(log, opt, name, param, dst);
-    }
-    *(double *)dst = val;
-    return 1;
-}
-
-static char *print_cycle_dir(const m_option_t *opt, const void *val)
-{
-    return talloc_asprintf(NULL, "%f", *(double *)val);
-}
-
-static void copy_opt(const m_option_t *opt, void *dst, const void *src)
-{
-    if (dst && src)
-        memcpy(dst, src, opt->type->size);
-}
-
-const struct m_option_type m_option_type_cycle_dir = {
-    .name = "up|down",
-    .parse = parse_cycle_dir,
-    .print = print_cycle_dir,
-    .copy = copy_opt,
-    .size = sizeof(double),
-};

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -154,6 +154,4 @@ void mp_cmd_dump(struct mp_log *log, int msgl, char *header, struct mp_cmd *cmd)
 // This creates a copy of a command (used by the auto repeat stuff).
 struct mp_cmd *mp_cmd_clone(struct mp_cmd *cmd);
 
-extern const struct m_option_type m_option_type_cycle_dir;
-
 #endif

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -3879,6 +3879,34 @@ const m_option_type_t m_option_type_node = {
     .equal = node_equal,
 };
 
+static int parse_cycle_dir(struct mp_log *log, const struct m_option *opt,
+                           struct bstr name, struct bstr param, void *dst)
+{
+    double val;
+    if (bstrcmp0(param, "up") == 0) {
+        val = +1;
+    } else if (bstrcmp0(param, "down") == 0) {
+        val = -1;
+    } else {
+        return m_option_type_double.parse(log, opt, name, param, dst);
+    }
+    *(double *)dst = val;
+    return 1;
+}
+
+static char *print_cycle_dir(const m_option_t *opt, const void *val)
+{
+    return talloc_asprintf(NULL, "%f", *(double *)val);
+}
+
+const m_option_type_t m_option_type_cycle_dir = {
+    .name = "up|down",
+    .parse = parse_cycle_dir,
+    .print = print_cycle_dir,
+    .copy = copy_opt,
+    .size = sizeof(double),
+};
+
 // Special-cased by m_config.c.
 const m_option_type_t m_option_type_alias = {
     .name  = "alias",

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -68,6 +68,7 @@ extern const m_option_type_t m_option_type_aspect;
 extern const m_option_type_t m_option_type_obj_settings_list;
 extern const m_option_type_t m_option_type_node;
 extern const m_option_type_t m_option_type_rect;
+extern const m_option_type_t m_option_type_cycle_dir;
 
 // Used internally by m_config.c
 extern const m_option_type_t m_option_type_alias;


### PR DESCRIPTION
A relic when commands lived in input.c. Move them to where other option types live. Also remove the redundant copy_opt.
