### PR TITLE
ao: don't add buffer length to timeout twice 

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -311,7 +311,7 @@ double ao_get_delay(struct ao *ao)
         driver_delay = MPMAX(0, MP_TIME_NS_TO_S(end - now));
     }
 
-    int pending = mp_async_queue_get_samples(p->queue);
+    int64_t pending = mp_async_queue_get_samples(p->queue);
     if (p->pending)
         pending += mp_aframe_get_size(p->pending);
 

--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -484,10 +484,7 @@ void ao_drain(struct ao *ao)
         double delay = ao_get_delay(ao);
         mp_mutex_lock(&p->lock);
 
-        // Limit to buffer + arbitrary ~250ms max. waiting for robustness.
-        delay += mp_async_queue_get_samples(p->queue) / (double)ao->samplerate;
-
-        // Wait for EOF signal from AO.
+        // Wait for buffer + arbitrary ~250ms for EOF signal from AO.
         if (mp_cond_timedwait(&p->wakeup, &p->lock,
                               MP_TIME_S_TO_NS(MPMAX(delay, 0) + 0.25)))
         {


### PR DESCRIPTION
Introduced by b74c09efbf7c6969fc053265f72cc0501b840ce1