### PR TITLE
vo_dmabuf_wayland: don't use -ve margins in window size calculation

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -523,8 +523,8 @@ static void resize(struct vo *vo)
     vo->opts->pan_x = 0;
     vo->opts->pan_y = 0;
     vo_get_src_dst_rects(vo, &src, &dst, &p->screen_osd_res);
-    int window_w = p->screen_osd_res.ml + p->screen_osd_res.mr + mp_rect_w(dst);
-    int window_h = p->screen_osd_res.mt + p->screen_osd_res.mb + mp_rect_h(dst);
+    int window_w = MPMAX(0, p->screen_osd_res.ml + p->screen_osd_res.mr) + mp_rect_w(dst);
+    int window_h = MPMAX(0, p->screen_osd_res.mt + p->screen_osd_res.mb) + mp_rect_h(dst);
     wp_viewport_set_destination(wl->viewport, lround(window_w / wl->scaling),
                                 lround(window_h / wl->scaling));
 


### PR DESCRIPTION
This happens with a positive --video-zoom value. We send invalid toplevel size and get killed by the compositor.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.