### PR TITLE
[RFC] hwdec: add v4l2request hwcontext

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1400,6 +1400,14 @@ if features['ios-gl']
     sources += files('video/out/hwdec/hwdec_ios_gl.m')
 endif
 
+v4l2request = get_option('v4l2request').require(
+    cc.has_header_symbol('libavutil/hwcontext.h', 'AV_HWDEVICE_TYPE_V4L2REQUEST')
+)
+features += {'v4l2request': v4l2request.allowed()}
+if features['v4l2request']
+    sources += files('video/v4l2request.c')
+endif
+
 libva = dependency('libva', version: '>= 1.1.0', required: get_option('vaapi'))
 
 vaapi_drm = dependency('libva-drm', version: '>= 1.1.0', required:
@@ -1851,6 +1859,7 @@ summary({'d3d11': features['d3d11'],
          'libmpv': get_option('libmpv'),
          'lua': features['lua'],
          'opengl': features['gl'],
+         'v4l2request': features['v4l2request'],
          'vulkan': features['vulkan'],
          'wayland': features['wayland'],
          'x11': features['x11']},

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -101,6 +101,7 @@ option('d3d-hwaccel', type: 'feature', value: 'auto', description: 'D3D11VA hwac
 option('d3d9-hwaccel', type: 'feature', value: 'auto', description: 'DXVA2 hwaccel')
 option('gl-dxinterop-d3d9', type: 'feature', value: 'auto', description: 'OpenGL/DirectX DXVA2 hwaccel')
 option('ios-gl', type: 'feature', value: 'auto', description: 'iOS OpenGL ES interop support')
+option('v4l2request', type: 'feature', value: 'disabled', description: 'V4L2 Request API hwaccel')
 option('videotoolbox-gl', type: 'feature', value: 'auto', description: 'Videotoolbox with OpenGL')
 option('videotoolbox-pl', type: 'feature', value: 'auto', description: 'Videotoolbox with libplacebo')
 option('vulkan-interop', type: 'feature', value: 'auto', description: 'Vulkan graphics interop')

--- a/video/hwdec.c
+++ b/video/hwdec.c
@@ -121,6 +121,9 @@ static const struct hwcontext_fns *const hwcontext_fns[] = {
 #if HAVE_DRM
     &hwcontext_fns_drmprime,
 #endif
+#if HAVE_V4L2REQUEST
+    &hwcontext_fns_v4l2request,
+#endif
 #if HAVE_VAAPI
     &hwcontext_fns_vaapi,
 #endif

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -102,6 +102,7 @@ extern const struct hwcontext_fns hwcontext_fns_cuda;
 extern const struct hwcontext_fns hwcontext_fns_d3d11;
 extern const struct hwcontext_fns hwcontext_fns_drmprime;
 extern const struct hwcontext_fns hwcontext_fns_dxva2;
+extern const struct hwcontext_fns hwcontext_fns_v4l2request;
 extern const struct hwcontext_fns hwcontext_fns_vaapi;
 extern const struct hwcontext_fns hwcontext_fns_vdpau;
 

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -92,6 +92,17 @@ static int init(struct ra_hwdec *hw)
         return -1;
     }
 
+#if HAVE_V4L2REQUEST
+    /*
+     * AVCodecHWConfig contains a combo of a pixel format and hwdevice type,
+     * correct type must be created here or hwaccel will fail.
+     *
+     * FIXME: Create hwdevice based on type in AVCodecHWConfig
+     */
+    int ret = av_hwdevice_ctx_create(&p->hwctx.av_device_ref,
+                                     AV_HWDEVICE_TYPE_V4L2REQUEST,
+                                     NULL, NULL, 0);
+#else
     /*
      * The drm_params resource is not provided when using X11 or Wayland, but
      * there are extensions that supposedly provide this information from the
@@ -118,6 +129,7 @@ static int init(struct ra_hwdec *hw)
                                      AV_HWDEVICE_TYPE_DRM,
                                      device_path, NULL, 0);
     talloc_free(tmp);
+#endif
     if (ret != 0) {
         MP_VERBOSE(hw, "Failed to create hwdevice_ctx: %s\n", av_err2str(ret));
         return -1;

--- a/video/out/hwdec/hwdec_drmprime_overlay.c
+++ b/video/out/hwdec/hwdec_drmprime_overlay.c
@@ -303,12 +303,24 @@ static int init(struct ra_hwdec *hw)
         .hw_imgfmt = IMGFMT_DRMPRIME,
     };
 
+#if HAVE_V4L2REQUEST
+    /*
+     * AVCodecHWConfig contains a combo of a pixel format and hwdevice type,
+     * correct type must be created here or hwaccel will fail.
+     *
+     * FIXME: Create hwdevice based on type in AVCodecHWConfig
+     */
+    int ret = av_hwdevice_ctx_create(&p->hwctx.av_device_ref,
+                                     AV_HWDEVICE_TYPE_V4L2REQUEST,
+                                     NULL, NULL, 0);
+#else
     char *device = drmGetDeviceNameFromFd2(p->ctx->fd);
     int ret = av_hwdevice_ctx_create(&p->hwctx.av_device_ref,
                                      AV_HWDEVICE_TYPE_DRM, device, NULL, 0);
 
     if (device)
         free(device);
+#endif
 
     if (ret != 0) {
         MP_VERBOSE(hw, "Failed to create hwdevice_ctx: %s\n", av_err2str(ret));

--- a/video/v4l2request.c
+++ b/video/v4l2request.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libavutil/hwcontext.h>
+
+#include "hwdec.h"
+
+static struct AVBufferRef *v4l2request_create_standalone(struct mpv_global *global,
+        struct mp_log *log, struct hwcontext_create_dev_params *params)
+{
+    AVBufferRef* ref = NULL;
+    av_hwdevice_ctx_create(&ref, AV_HWDEVICE_TYPE_V4L2REQUEST, NULL, NULL, 0);
+
+    return ref;
+}
+
+const struct hwcontext_fns hwcontext_fns_v4l2request = {
+    .av_hwdevice_type = AV_HWDEVICE_TYPE_V4L2REQUEST,
+    .create_dev = v4l2request_create_standalone,
+};


### PR DESCRIPTION
Current out-of-tree FFmpeg V4L2 Request API hwaccel patches abuse the drm hwdevice type.

Patches being prepared for upstream FFmpeg changes this to use a new dedicated v4l2request hwdevice type.

This PR add basic support for using the new v4l2request hwdevice type, however, it cripples old use of `AV_HWDEVICE_TYPE_DRM`, and possible break use with e.g. `rkmpp` decoders.

Please assist on how the the hwdevice created based on the picked `AVCodecHWConfig` can be re-used instead of recreating a new hwdevice.

Ideally `mpv` should behave similar to e.g. `ffmpeg -init_hw_device v4l2request`, or implicitly create the hwdevice based on the `AVCodecHWConfig.device_type`.

With the updated patches one would instead of `drm` use `v4l2request` as the `-hwaccel`, e.g.:

```
ffmpeg -hwaccel v4l2request -hwaccel_output_format drm_prime -i <input-path> -map 0:v -f null -
```

Created as a draft PR because [work-in-progress FFmpeg patches](https://github.com/FFmpeg/FFmpeg/compare/master...Kwiboo:FFmpeg:v4l2request-2024-v2) are still being worked on.