### PR TITLE
test: use ffmpeg7 test reference data

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -125,7 +125,7 @@ endif
 
 # Supported libavutil versions that work with these tests.
 # Will need to be manually updated when ffmpeg adds/removes more formats in the future.
-if libavutil.version().version_compare('>= 59.0.100')
+if libavutil.version().version_compare('>= 58.29.100')
     refdir = join_paths(source_root, 'test', 'ref', 'ffmpeg7')
 elif libavutil.version().version_compare('>= 58.27.100')
     refdir = join_paths(source_root, 'test', 'ref', 'ffmpeg6')


### PR DESCRIPTION
Fix the tests on my Arch Linux machine with ffmpeg 7.0.1.

Cc @Dudemanguy 