### PR TITLE
demux_edl: don't try to extract dirname from self-expanding protocols

### DIFF
--- a/demux/demux_edl.c
+++ b/demux/demux_edl.c
@@ -567,8 +567,13 @@ error:
 
 static void fix_filenames(struct tl_parts *parts, char *source_path)
 {
-    if (!bstrcasecmp0(mp_split_proto(bstr0(source_path), NULL), "edl"))
+    bstr proto = mp_split_proto(bstr0(source_path), NULL);
+    // Don't adjust self-expanding protocols
+    if (!bstrcasecmp0(proto, "memory") || !bstrcasecmp0(proto, "lavf") ||
+        !bstrcasecmp0(proto, "hex") || !bstrcasecmp0(proto, "edl"))
+    {
         return;
+    }
     struct bstr dirname = mp_dirname(source_path);
     for (int n = 0; n < parts->num_parts; n++) {
         struct tl_part *part = &parts->parts[n];

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -3065,7 +3065,7 @@ static int read_block_group(demuxer_t *demuxer, int64_t end,
             if (ebml_read_element(s, &parse_ctx, &additions,
                                   &ebml_block_additions_desc) < 0)
                 return -1;
-            if (additions.n_block_more > 0) {
+            if (additions.n_block_more > 0 && !block->additions) {
                 block->additions = talloc_dup(NULL, &additions);
                 talloc_steal(block->additions, parse_ctx.talloc_ctx);
                 parse_ctx.talloc_ctx = NULL;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1212,6 +1212,18 @@ static void start_open(struct MPContext *mpctx, char *url, int url_flags,
     mpctx->open_url_flags = url_flags;
     mpctx->open_for_prefetch = for_prefetch && mpctx->opts->demuxer_thread;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // Don't allow to open local paths or stdin during fuzzing
+    bstr open_url = bstr0(mpctx->open_url);
+    if (bstr_startswith0(open_url, "/") ||
+        bstr_startswith0(open_url, "./") ||
+        bstr_equals0(open_url, "-"))
+    {
+        cancel_open(mpctx);
+        return;
+    }
+#endif
+
     if (mp_thread_create(&mpctx->open_thread, open_demux_thread, mpctx)) {
         cancel_open(mpctx);
         return;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1247,6 +1247,10 @@ static void open_demux_reentrant(struct MPContext *mpctx)
     if (!mpctx->open_active)
         start_open(mpctx, url, mpctx->playing->stream_flags, false);
 
+    // If thread failed to start, cancel the playback
+    if (!mpctx->open_active)
+        goto cancel;
+
     // User abort should cancel the opener now.
     mp_cancel_set_parent(mpctx->open_cancel, mpctx->playback_abort);
 
@@ -1265,6 +1269,7 @@ static void open_demux_reentrant(struct MPContext *mpctx)
         mpctx->error_playing = mpctx->open_res_error;
     }
 
+cancel:
     cancel_open(mpctx); // cleanup
 }
 


### PR DESCRIPTION
Fixes infinite recursion. Trying to extract dirname from string of memory://<data> is not really a good idea.

Found by OSS-Fuzz.