### PR TITLE
player/{command,scripting}: log subprocess execution

### DIFF
--- a/osdep/subprocess.c
+++ b/osdep/subprocess.c
@@ -21,10 +21,6 @@
 
 #include "subprocess.h"
 
-void mp_devnull(void *ctx, char *data, size_t size)
-{
-}
-
 const char *mp_subprocess_err_str(int num)
 {
     // Note: these are visible to the public client API
@@ -36,4 +32,18 @@ const char *mp_subprocess_err_str(int num)
     case MP_SUBPROCESS_EGENERIC:        // fall through
     default:                            return "unknown";
     }
+}
+
+void mp_subprocess(struct mp_log *log,
+                   struct mp_subprocess_opts *opts,
+                   struct mp_subprocess_result *res)
+{
+    mp_verbose(log, "Starting subprocess: [%s", opts->args[0]);
+    char **arg = &opts->args[1];
+    while (*arg)
+        mp_verbose(log, ", %s", *arg++);
+    mp_verbose(log, "]\n");
+    mp_subprocess2(opts, res);
+    if (res->error < 0)
+        mp_err(log, "Subprocess failed: %s\n", mp_subprocess_err_str(res->error));
 }

--- a/osdep/subprocess.h
+++ b/osdep/subprocess.h
@@ -35,8 +35,6 @@ typedef void (*subprocess_read_cb)(void *ctx, char *data, size_t size);
 // Not filling the buffer means EOF.
 typedef void (*subprocess_write_cb)(void *ctx);
 
-void mp_devnull(void *ctx, char *data, size_t size);
-
 #define MP_SUBPROCESS_MAX_FDS 10
 
 struct mp_subprocess_fd {
@@ -64,7 +62,7 @@ struct mp_subprocess_opts {
 };
 
 struct mp_subprocess_result {
-    int error;              // one of MP_SUBPROCESS_* (>0 on error)
+    int error;              // one of MP_SUBPROCESS_* (<0 on error)
     // NB: if WIFEXITED applies, error==0, and this is WEXITSTATUS
     //     on win32, this can use the full 32 bit
     //     if started with detach==true, this is always 0
@@ -84,5 +82,10 @@ const char *mp_subprocess_err_str(int num);
 // Caller must set *opts.
 void mp_subprocess2(struct mp_subprocess_opts *opts,
                     struct mp_subprocess_result *res);
+
+struct mp_log;
+void mp_subprocess(struct mp_log *log,
+                   struct mp_subprocess_opts *opts,
+                   struct mp_subprocess_result *res);
 
 #endif

--- a/player/command.c
+++ b/player/command.c
@@ -6052,11 +6052,7 @@ static void cmd_run(void *p)
         .detach = true,
     };
     struct mp_subprocess_result res;
-    mp_subprocess2(&opts, &res);
-    if (res.error < 0) {
-        mp_err(mpctx->log, "Starting subprocess failed: %s\n",
-               mp_subprocess_err_str(res.error));
-    }
+    mp_subprocess(mpctx->log, &opts, &res);
     talloc_free(args);
 }
 
@@ -6170,7 +6166,7 @@ static void cmd_subprocess(void *p)
     }
 
     struct mp_subprocess_result sres;
-    mp_subprocess2(&opts, &sres);
+    mp_subprocess(fdlog, &opts, &sres);
     int status = sres.exit_status;
     char *error = NULL;
     if (sres.error < 0) {

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -97,8 +97,6 @@ local function platform_is_windows()
 end
 
 local function exec(args)
-    msg.debug("Running: " .. table.concat(args, " "))
-
     return mp.command_native({
         name = "subprocess",
         args = args,

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -433,7 +433,7 @@ static int load_run(struct mp_script_args *args)
         .detach = true,
     };
     struct mp_subprocess_result res;
-    mp_subprocess2(&opts, &res);
+    mp_subprocess(args->log, &opts, &res);
 
     // Closing these will (probably) make the client exit, if it really died.
     // They _should_ be CLOEXEC, but are not, because
@@ -443,13 +443,7 @@ static int load_run(struct mp_script_args *args)
     if (fds[1] >= 0)
         close(fds[1]);
 
-    if (res.error < 0) {
-        MP_ERR(args, "Starting '%s' failed: %s\n", args->filename,
-               mp_subprocess_err_str(res.error));
-        return -1;
-    }
-
-    return 0;
+    return res.error;
 }
 
 const struct mp_scripting mp_scripting_run = {


### PR DESCRIPTION
Useful for debugging purposes and sanity checks.