### PR TITLE
x11_common: handle runtime keepaspect/keepaspect-window change

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2132,6 +2132,8 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
                 vo_x11_set_input_region(vo, opts->cursor_passthrough);
             if (opt == &opts->x11_present)
                 xpresent_set(x11);
+            if (opt == &opts->keepaspect || opt == &opts->keepaspect_window)
+                vo_x11_sizehint(vo, x11->fs ? x11->nofsrc : x11->winrc, false);
             if (opt == &opts->geometry || opt == &opts->autofit ||
                 opt == &opts->autofit_smaller || opt == &opts->autofit_larger)
             {


### PR DESCRIPTION
On X11, aspect ratio constraint is applied on the window manager side, so whenever keepaspect and keepaspect-window change, mpv should update the size hint immediately, otherwise the new constraint isn't applied.
