### PR TITLE
commands: make sure add_float() argument is treated as a float

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1162,7 +1162,10 @@ static char *pretty_print_float(const m_option_t *opt, const void *val)
 static void add_float(const m_option_t *opt, void *val, double add, bool wrap)
 {
     double tmp = VAL(val);
-    add_double(opt, &tmp, add, wrap);
+    // Change the double to be added
+    // to a representable float.
+    float float_add = add;
+    add_double(opt, &tmp, float_add, wrap);
     VAL(val) = tmp;
 }
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1162,10 +1162,8 @@ static char *pretty_print_float(const m_option_t *opt, const void *val)
 static void add_float(const m_option_t *opt, void *val, double add, bool wrap)
 {
     double tmp = VAL(val);
-    // Change the double to be added
-    // to a representable float.
-    float float_add = add;
-    add_double(opt, &tmp, float_add, wrap);
+    // Cast to float for consistent precision
+    add_double(opt, &tmp, (float) add, wrap);
     VAL(val) = tmp;
 }
 


### PR DESCRIPTION
The input value to be added in add_float is a double, and added as a double. Since not all double values have a corresponding float32 value, make sure to use it's nearest float if it is not exactly representable in a float before performing the addition.

This guarantees that the result of adding a float and it's inverse is 0.

Previously:
float x = 1.0       // (stored as 0.100001998)
add_float(&x, -1.0) // (0.100001998 + -0.10000000000000001)
x != 0

Now:
float x = 1.0       //(stored as 0.100001998)
add_float(&x, -1.0) //(0.100001998 + -0.100001998)
x == 0

This was discovered because "Sub delay" was displaying "-0.0" when adding and then subtracting 100ms, so the end result was -0.00000145... Should also fix it for audio delay and all the options that store it's value as a float.