### PR TITLE
mac/vulkan: error out on context creation without an NSApplication

### DIFF
--- a/test/libmpv_lifetime.c
+++ b/test/libmpv_lifetime.c
@@ -63,11 +63,6 @@ static inline void check_error_(int status, __typeof__(&mpv_error_string) error_
 
 int main(void)
 {
-#ifdef __APPLE__
-    // FIXME: Hangs after libplacebo initialization
-    return 77;
-#endif
-
     // Skip this test when run through a wrapper like Wine. It is well-tested on
     // different configurations. Meson does not set PATH and WINEPATH when
     // libmpv is not directly linked, and doing it manually would be annoying.

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -56,6 +56,11 @@ static bool mac_vk_init(struct ra_ctx *ctx)
     struct mpvk_ctx *vk = &p->vk;
     int msgl = ctx->opts.probing ? MSGL_V : MSGL_ERR;
 
+    if (!NSApp) {
+        MP_ERR(ctx, "Failed to initialize macvk context, no NSApplication initialized.\n");
+        goto error;
+    }
+
     if (!mpvk_init(vk, ctx, VK_EXT_METAL_SURFACE_EXTENSION_NAME))
         goto error;
 


### PR DESCRIPTION
@kasper93 just wonder if this is what you had in mind. was the test supposed to test a vo on every platform or is it more like a test that libmpv init works properly and if no vo can be initialised it should error out gracefully?

this does the latter now on macOS and errors out properly if the context can't be initialised because no NSApplication environment is found.

if we want the former, we would need to init an NSApplication in the test.