### PR TITLE
demux/ebml: bump ebml size limit to 512 MiB

### DIFF
--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -604,8 +604,8 @@ int ebml_read_element(struct stream *s, struct ebml_parse_ctx *ctx,
         MP_MSG(ctx, msglevel, "EBML element with unknown length - unsupported\n");
         return -1;
     }
-    if (length > (128 << 20)) {
-        MP_MSG(ctx, msglevel, "Refusing to read element over 128 MiB in size\n");
+    if (length > (512 << 20)) {
+        MP_MSG(ctx, msglevel, "Element too big (%" PRIu64 " MiB) - skipping\n", length >> 20);
         return -1;
     }
     ctx->talloc_ctx = talloc_size(NULL, length);


### PR DESCRIPTION
While the code before 571f9b0f23f31741f3c5947b839411acfefae3cf had a typo and it was intended to be 100 MB, there are files that exceed this limit, like 147 MiB. Increase the limit to 512 MiB which should be more than enough for valid files.

From quick look ffmpeg limits to 1<<8 bytes, so we should be good with our new limit.

In theory this limit could be removed, but it is better to play the file, possibly with skipped some corrupted block of data, instead OOM.

Fixes: 571f9b0f23f31741f3c5947b839411acfefae3cf