### PR TITLE
command: run input commands after idle state is ready

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7234,8 +7234,10 @@ static void command_event(struct MPContext *mpctx, int event, void *arg)
         ctx->marked_permanent = false;
     }
 
-    if (event == MPV_EVENT_PLAYBACK_RESTART)
+    if (event == MPV_EVENT_PLAYBACK_RESTART) {
         ctx->last_seek_time = mp_time_sec();
+        run_command_opts(mpctx);
+    }
 
     if (event == MPV_EVENT_IDLE)
         run_command_opts(mpctx);

--- a/player/command.c
+++ b/player/command.c
@@ -7237,6 +7237,9 @@ static void command_event(struct MPContext *mpctx, int event, void *arg)
     if (event == MPV_EVENT_PLAYBACK_RESTART)
         ctx->last_seek_time = mp_time_sec();
 
+    if (event == MPV_EVENT_IDLE)
+        run_command_opts(mpctx);
+
     if (event == MPV_EVENT_END_FILE)
         mp_msg_flush_status_line(mpctx->log, false);
 
@@ -7270,10 +7273,6 @@ void handle_command_updates(struct MPContext *mpctx)
 
     // Depends on polling demuxer wakeup callback notifications.
     cache_dump_poll(mpctx);
-
-    // Potentially run the commands now (idle) instead of waiting for a file to load.
-    if (mpctx->stop_play == PT_STOP)
-        run_command_opts(mpctx);
 }
 
 void run_command_opts(struct MPContext *mpctx)

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1149,7 +1149,6 @@ static void handle_playback_restart(struct MPContext *mpctx)
         mpctx->hrseek_active = false;
         mpctx->restart_complete = true;
         mpctx->current_seek = (struct seek_params){0};
-        run_command_opts(mpctx);
         handle_playback_time(mpctx);
         mp_notify(mpctx, MPV_EVENT_PLAYBACK_RESTART, NULL);
         update_core_idle_state(mpctx);


### PR DESCRIPTION
This makes sure that commands like show-text update the osd properly with --idle=yes.