### PR TITLE
DOCS/options: remove misdirection in `sub-color`

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2906,7 +2906,7 @@ Subtitles
     Alternatively, the color can be specified as a RGB hex triplet in the form
     ``#RRGGBB``, where each 2-digit group expresses a color value in the
     range 0 (``00``) to 255 (``FF``). For example, ``#FF0000`` is red.
-    This is similar to web colors. Alpha is given with ``#AARRGGBB``.
+    Alpha is given with ``#AARRGGBB``.
 
     .. admonition:: Examples
 


### PR DESCRIPTION
ARGB is in fact _not_ like web color. It's easy to skim over the actual hexadecimal provided in the next sentence and just assume mpv understands RGBA after reading the words "web colors"

As an aside, if we decide to change OPT_COLOR to actually be like web colors, the only options that use OPT_COLOR are `sub-color`, `sub-outline-color`, `sub-back-color`, `macos-title-bar-color`, and `background-color`.