### PR TITLE
options: move all wayland specific options to vo_opts

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -194,8 +194,16 @@ static const m_option_t mp_vo_opt_list[] = {
     {"x11-wid-title", OPT_BOOL(x11_wid_title)},
 #endif
 #if HAVE_WAYLAND
-    {"wayland-content-type", OPT_CHOICE(content_type, {"auto", -1}, {"none", 0},
+    {"wayland-configure-bounds", OPT_CHOICE(wl_configure_bounds,
+        {"auto", -1}, {"no", 0}, {"yes", 1})},
+    {"wayland-content-type", OPT_CHOICE(wl_content_type, {"auto", -1}, {"none", 0},
         {"photo", 1}, {"video", 2}, {"game", 3})},
+    {"wayland-disable-vsync", OPT_BOOL(wl_disable_vsync)},
+    {"wayland-edge-pixels-pointer", OPT_INT(wl_edge_pixels_pointer),
+        M_RANGE(0, INT_MAX)},
+    {"wayland-edge-pixels-touch", OPT_INT(wl_edge_pixels_touch),
+        M_RANGE(0, INT_MAX)},
+    {"wayland-present", OPT_BOOL(wl_present)},
 #endif
 #if HAVE_WIN32_DESKTOP
 // For old MinGW-w64 compatibility
@@ -250,11 +258,15 @@ const struct m_sub_options vo_sub_opts = {
         .border = true,
         .title_bar = true,
         .appid = "mpv",
-        .content_type = -1,
         .WinID = -1,
         .window_scale = 1.0,
         .x11_bypass_compositor = 2,
         .x11_present = 1,
+        .wl_configure_bounds = -1,
+        .wl_content_type = -1,
+        .wl_edge_pixels_pointer = 16,
+        .wl_edge_pixels_touch = 32,
+        .wl_present = true,
         .mmcss_profile = "Playback",
         .ontop_level = -1,
         .timing_offset = 0.050,
@@ -926,10 +938,6 @@ static const m_option_t mp_opts[] = {
 
 #if HAVE_DRM
     {"", OPT_SUBSTRUCT(drm_opts, drm_conf)},
-#endif
-
-#if HAVE_WAYLAND
-    {"", OPT_SUBSTRUCT(wayland_opts, wayland_conf)},
 #endif
 
 #if HAVE_GL_WIN32

--- a/options/options.h
+++ b/options/options.h
@@ -28,13 +28,19 @@ typedef struct mp_vo_opts {
     char *fsscreen_name;
     char *winname;
     char *appid;
-    int content_type;
     int x11_netwm;
     int x11_bypass_compositor;
     int x11_present;
     bool x11_wid_title;
     bool cursor_passthrough;
     bool native_keyrepeat;
+
+    int wl_configure_bounds;
+    int wl_content_type;
+    bool wl_disable_vsync;
+    int wl_edge_pixels_pointer;
+    int wl_edge_pixels_touch;
+    bool wl_present;
 
     float panscan;
     float zoom;
@@ -381,7 +387,6 @@ typedef struct MPOpts {
     struct d3d11va_opts *d3d11va_opts;
     struct macos_opts *macos_opts;
     struct drm_opts *drm_opts;
-    struct wayland_opts *wayland_opts;
     struct wingl_opts *wingl_opts;
     struct cuda_opts *cuda_opts;
     struct dvd_opts *dvd_opts;

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -69,7 +69,7 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
 
     eglSwapBuffers(p->egl_display, p->egl_surface);
 
-    if (!wl->opts->disable_vsync)
+    if (!wl->opts->wl_disable_vsync)
         vo_wayland_wait_frame(wl);
 
     if (wl->use_present)

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -505,7 +505,7 @@ static void resize(struct vo *vo)
 
     struct mp_rect src;
     struct mp_rect dst;
-    struct mp_vo_opts *vo_opts = wl->vo_opts;
+    struct mp_vo_opts *opts = wl->opts;
 
     const int width = mp_rect_w(wl->geometry);
     const int height = mp_rect_h(wl->geometry);
@@ -529,8 +529,8 @@ static void resize(struct vo *vo)
                                 lround(window_h / wl->scaling_factor));
 
     //now we restore pan for video viewport calculation
-    vo->opts->pan_x = vo_opts->pan_x;
-    vo->opts->pan_y = vo_opts->pan_y;
+    vo->opts->pan_x = opts->pan_x;
+    vo->opts->pan_y = opts->pan_y;
     vo_get_src_dst_rects(vo, &src, &dst, &p->screen_osd_res);
     wp_viewport_set_destination(wl->video_viewport, lround(mp_rect_w(dst) / wl->scaling_factor),
                                                     lround(mp_rect_h(dst) / wl->scaling_factor));
@@ -643,7 +643,7 @@ static void flip_page(struct vo *vo)
     wl_surface_commit(wl->osd_surface);
     wl_surface_commit(wl->surface);
 
-    if (!wl->opts->disable_vsync)
+    if (!wl->opts->wl_disable_vsync)
         vo_wayland_wait_frame(wl);
 
     if (wl->use_present)

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -299,7 +299,7 @@ static void flip_page(struct vo *vo)
                              vo->dheight);
     wl_surface_commit(wl->surface);
 
-    if (!wl->opts->disable_vsync)
+    if (!wl->opts->wl_disable_vsync)
         vo_wayland_wait_frame(wl);
 
     if (wl->use_present)

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -36,7 +36,7 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
 
-    if (!wl->opts->disable_vsync)
+    if (!wl->opts->wl_disable_vsync)
         vo_wayland_wait_frame(wl);
 
     if (wl->use_present)

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -30,21 +30,11 @@ typedef struct {
     uint64_t modifier;
 } wayland_format;
 
-struct wayland_opts {
-    int configure_bounds;
-    int content_type;
-    bool disable_vsync;
-    int edge_pixels_pointer;
-    int edge_pixels_touch;
-    bool present;
-};
-
 struct vo_wayland_state {
-    struct m_config_cache   *vo_opts_cache;
+    struct m_config_cache   *opts_cache;
     struct mp_log           *log;
-    struct mp_vo_opts       *vo_opts;
+    struct mp_vo_opts       *opts;
     struct vo               *vo;
-    struct wayland_opts     *opts;
     struct wl_callback      *frame_callback;
     struct wl_compositor    *compositor;
     struct wl_subcompositor *subcompositor;


### PR DESCRIPTION
Unlike every other platforming backend, wayland has its own specific sub_options struct. 027ca4fb855f3dff4cba1c907c92c509b82e6fe8 originally introduced this and some more options were added later, but in retrospect it's unneccesary complications. There are already x11, windows, and macos-specific options within vo_opts. In fact, there actually is a wayland one in there already as well (wayland-content-type) so it's split between two places. All of the platform-specific code already has to handle vo_opts as well. Additionally, we already make sure to update vo_opts on runtime and there's an existing mechanism already in place to handle callbacks if needed. The wayland-specific sub_options struct was stuck with whatever you set at init time.

So solve everything by deleting the old sub_options struct, moving it to vo_opts and make some minor option naming changes for clarity (i.e. adding a 'wl_' in front of the name). This simplifies the wayland common code and also makes it have more functionality since you get runtime updates for free.