### PR TITLE
player/main: fix --force-window=yes acting like immediate

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7395,7 +7395,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
         mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
     }
 
-    if (flags & UPDATE_VO) {
+    if (flags & UPDATE_VO && mpctx->video_out) {
         struct track *track = mpctx->current_track[0][STREAM_VIDEO];
         uninit_video_out(mpctx);
         handle_force_window(mpctx, true);


### PR DESCRIPTION
It turns out that mpv runs all option callbacks with a flag on init, so since a5937ac7e3 if --force-window is passed, the VO is immediately reinited and initialized and mpv acts as if --force-window=immediate was passed. Fix this by excluding UPDATE_VO from UPDATE_OPTS_MASK on init.