### PR TITLE
input/ipc-win: support fd:// for --input-ipc-client 

### DIFF
--- a/DOCS/man/ipc.rst
+++ b/DOCS/man/ipc.rst
@@ -3,8 +3,10 @@ JSON IPC
 
 mpv can be controlled by external programs using the JSON-based IPC protocol.
 It can be enabled by specifying the path to a unix socket or a named pipe using
-the option ``--input-ipc-server``. Clients can connect to this socket and send
-commands to the player or receive events from it.
+the option ``--input-ipc-server``, or the file descriptor number of a unix socket
+or a named pipe using ``--input-ipc-client``.
+Clients can connect to this socket and send commands to the player or receive
+events from it.
 
 .. warning::
 

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1034,17 +1034,17 @@ There are three choices for using mpv from other programs or scripts:
 
        Your code should work even if you pass ``--terminal=no``. Do not attempt
        to simulate user input by sending terminal control codes to mpv's stdin.
-       If you need interactive control, using ``--input-ipc-server`` is
-       recommended. This gives you access to the `JSON IPC`_  over unix domain
-       sockets (or named pipes on Windows).
+       If you need interactive control, using ``--input-ipc-server`` or
+       ``--input-ipc-client`` is recommended. This gives you access to the
+       `JSON IPC`_  over unix domain sockets (or named pipes on Windows).
 
        Depending on what you do, passing ``--no-config`` or ``--config-dir`` may
        be a good idea to avoid conflicts with the normal mpv user configuration
        intended for CLI playback.
 
-       Using ``--input-ipc-server`` is also suitable for purposes like remote
-       control (however, the IPC protocol itself is not "secure" and not
-       intended to be so).
+       Using ``--input-ipc-server`` or ``--input-ipc-client`` is also suitable for
+       purposes like remote control (however, the IPC protocol itself is not
+       "secure" and not intended to be so).
 
     2. Using libmpv. This is generally recommended when mpv is used as playback
        backend for a completely different application. The provided C API is

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4223,7 +4223,11 @@ Input
 
     .. note::
 
-        Does not and will not work on Windows.
+        To use this option on Windows, the fd must refer to a wrapped
+        (created by ``_open_osfhandle``) named pipe server handle with a client
+        already connected. The named pipe must be created duplex with overlapped
+        IO and inheritable handles. The program communicates with mpv through
+        the client handle.
 
     .. warning::
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4209,8 +4209,8 @@ Input
     ``--input-ipc-server``, except no socket is created, and instead the passed
     FD is treated like a socket connection received from ``accept()``. In
     practice, you could pass either a FD created by ``socketpair()``, or a pipe.
-    In both cases, you must sure the FD is actually inherited by mpv (do not
-    set the POSIX ``CLOEXEC`` flag).
+    In both cases, you must make sure that the FD is actually inherited by mpv
+    (do not set the POSIX ``CLOEXEC`` flag).
 
     The player quits when the connection is closed.
 

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -395,11 +395,11 @@ struct mp_ipc_ctx *mp_init_ipc(struct mp_client_api *client_api,
 
     if (opts->ipc_client && opts->ipc_client[0]) {
         int fd = -1;
-        if (strncmp(opts->ipc_client, "fd://", 5) == 0) {
-            char *end;
-            unsigned long l = strtoul(opts->ipc_client + 5, &end, 0);
-            if (!end[0] && l <= INT_MAX)
-                fd = l;
+        bstr str = bstr0(opts->ipc_client);
+        if (bstr_eatstart0(&str, "fd://") && str.len) {
+            long long ll = bstrtoll(str, &str, 0);
+            if (!str.len && ll >= 0 && ll <= INT_MAX)
+                fd = ll;
         }
         if (fd < 0) {
             MP_ERR(arg, "Invalid IPC client argument: '%s'\n", opts->ipc_client);

--- a/input/ipc-win.c
+++ b/input/ipc-win.c
@@ -466,11 +466,11 @@ struct mp_ipc_ctx *mp_init_ipc(struct mp_client_api *client_api,
 
     if (opts->ipc_client && opts->ipc_client[0]) {
         int fd = -1;
-        if (strncmp(opts->ipc_client, "fd://", 5) == 0) {
-            char *end;
-            unsigned long l = strtoul(opts->ipc_client + 5, &end, 0);
-            if (!end[0] && l <= INT_MAX)
-                fd = l;
+        bstr str = bstr0(opts->ipc_client);
+        if (bstr_eatstart0(&str, "fd://") && str.len) {
+            long long ll = bstrtoll(str, &str, 0);
+            if (!str.len && ll >= 0 && ll <= INT_MAX)
+                fd = ll;
         }
         if (fd < 0) {
             MP_ERR(arg, "Invalid IPC client argument: '%s'\n", opts->ipc_client);

--- a/options/options.c
+++ b/options/options.c
@@ -868,9 +868,7 @@ static const m_option_t mp_opts[] = {
     {"input-terminal", OPT_BOOL(consolecontrols), .flags = UPDATE_TERM},
 
     {"input-ipc-server", OPT_STRING(ipc_path), .flags = M_OPT_FILE},
-#if HAVE_POSIX
     {"input-ipc-client", OPT_STRING(ipc_client)},
-#endif
 
     {"screenshot", OPT_SUBSTRUCT(screenshot_image_opts, screenshot_conf)},
     {"screenshot-template", OPT_STRING(screenshot_template)},

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -436,9 +436,6 @@ static int load_run(struct mp_script_args *args)
     mp_subprocess2(&opts, &res);
 
     // Closing these will (probably) make the client exit, if it really died.
-    // They _should_ be CLOEXEC, but are not, because
-    // posix_spawn_file_actions_adddup2() may not clear the CLOEXEC flag
-    // properly if by coincidence fd==src_fd.
     close(fds[0]);
     if (fds[1] >= 0)
         close(fds[1]);


### PR DESCRIPTION
This makes `--input-ipc-client` work on Windows.
