### PR TITLE
DOCS/compile-windows.md: fix MSYS2 packages

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -212,15 +212,15 @@ For guidance on updating MSYS2, please refer to the official documentation:
 ### Installing mpv Dependencies
 
 ``` bash
-# Install pacboy
-pacman -S pactoys
+# Install pacboy and git
+pacman -S pactoys git
 
 # Install MSYS2 build dependencies and a MinGW-w64 compiler
-pacboy -S git {python,pkgconf,cc,meson}:p
+pacboy -S python pkgconf cc meson
 
 # Install key dependencies. libass and lcms2 are also included as dependencies
 # of ffmpeg.
-pacboy -S {ffmpeg,libjpeg-turbo,libplacebo,luajit}:p
+pacboy -S ffmpeg libjpeg-turbo libplacebo luajit vulkan-headers
 ```
 
 ### Building mpv


### PR DESCRIPTION
Attempting to install `git` on the `pacboy` line fails with `error: target not found: mingw-w64-clang-x86_64-git` so move that to another spot.

`video_mp_image_pool.c` fails to build due to libavutil right now because of missing vulkan headers so make sure to also install those with `pacboy`. A relevant github issue elsewhere: https://github.com/mesonbuild/meson/issues/13016
<details>
<summary>Example error:</summary>
<pre>
[164/254] Compiling C object libmpv-2.dll.p/video_mp_image_pool.c.obj
FAILED: libmpv-2.dll.p/video_mp_image_pool.c.obj
"cc" "-Ilibmpv-2.dll.p" "-I." "-I.." "-Icommon" "-Ietc" "-Iplayer/javascript" "-Iplayer/lua" "-Isub"
 "-IC:/msys64/clang64/include/fribidi" "-IC:/msys64/clang64/include/freetype2" "-IC:/msys64/clang64/
include/libpng16" "-IC:/msys64/clang64/include/harfbuzz" "-IC:/msys64/clang64/include/glib-2.0" "-IC
:/msys64/clang64/lib/glib-2.0/include" "-IC:/msys64/clang64/include/spirv_cross" "-IC:/msys64/clang6
4/include/libxml2" "-IC:/msys64/clang64/include/luajit-2.1" "-fvisibility=hidden" "-fdiagnostics-col
or=always" "-Wall" "-Winvalid-pch" "-Wextra" "-std=c11" "-O2" "-g" "-D_FILE_OFFSET_BITS=64" "-Wdisab
led-optimization" "-Wempty-body" "-Wformat" "-Wimplicit-fallthrough" "-Wmissing-prototypes" "-Wparen
theses" "-Wpointer-arith" "-Wshadow" "-Wstrict-prototypes" "-Wundef" "-Wvla" "-Werror=implicit-funct
ion-declaration" "-Wno-cast-function-type" "-Wno-format-zero-length" "-Wno-missing-field-initializer
s" "-Wno-pointer-sign" "-Wno-sign-compare" "-Wno-switch" "-Wno-unused-parameter" "-fno-math-errno" "
-fno-signed-zeros" "-fno-trapping-math" "-Werror=format-security" "-D_WIN32_WINNT=0x0602" "-DWINVER=
0x0602" "-DUNICODE" "-DCOBJMACROS" "-DINITGUID" "-U__STRICT_ANSI__" "-DNOMINMAX" "-D_USE_MATH_DEFINE
S" "-DWIN32_LEAN_AND_MEAN" "-D_CRT_DECLARE_NONSTDC_NAMES" "-D_CRT_NONSTDC_NO_WARNINGS" "-D_CRT_SECUR
E_NO_WARNINGS" -MD -MQ libmpv-2.dll.p/video_mp_image_pool.c.obj -MF "libmpv-2.dll.p/video_mp_image_p
ool.c.obj.d" -o libmpv-2.dll.p/video_mp_image_pool.c.obj "-c" ../video/mp_image_pool.c
In file included from ../video/mp_image_pool.c:27:
C:/msys64/clang64/include/libavutil/hwcontext_vulkan.h:25:10: fatal error: 'vulkan/vulkan.h' file no
t found
   25 | #include <vulkan/vulkan.h>
      |          ^~~~~~~~~~~~~~~~~
1 error generated.
[177/254] Compiling C object libmpv-2.dll.p/video_out_gpu_shader_cache.c.obj
ninja: build stopped: subcommand failed.
</pre>
</details>