### PR TITLE
loadfile,select.lua: print only one bitrate

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -299,10 +299,11 @@ static void print_stream(struct MPContext *mpctx, struct track *t, bool indent)
         if (s && s->codec->samplerate)
             APPEND(b, " %d Hz", s->codec->samplerate);
     }
-    if (s && s->codec->bitrate)
+    if (s && s->codec->bitrate) {
         APPEND(b, " %d kbps", (s->codec->bitrate + 500) / 1000);
-    if (s && s->hls_bitrate)
-        APPEND(b, " %d HLS kbps", (s->hls_bitrate + 500) / 1000);
+    } else if (s && s->hls_bitrate) {
+        APPEND(b, " %d kbps", (s->hls_bitrate + 500) / 1000);
+    }
     APPEND(b, ")");
 
     bool first = true;

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -82,6 +82,8 @@ local function format_flags(track)
 end
 
 local function format_track(track)
+    local bitrate = track["demux-bitrate"] or track["hls-bitrate"]
+
     return (track.selected and "●" or "○") ..
         (track.title and " " .. track.title or "") ..
         " (" .. (
@@ -98,10 +100,8 @@ local function format_track(track)
              and track["codec-profile"] .. " " or "") ..
             (track["demux-samplerate"] and track["demux-samplerate"] / 1000 ..
              " kHz " or "") ..
-            (track["demux-bitrate"] and string.format("%.0f", track["demux-bitrate"] / 1000)
-             .. " kbps " or "") ..
-            (track["hls-bitrate"] and string.format("%.0f", track["hls-bitrate"] / 1000)
-             .. " HLS kbps " or "")
+            (bitrate and string.format("%.0f", bitrate / 1000) ..
+             " kbps " or "")
         ):sub(1, -2) .. ")" .. format_flags(track)
 end
 


### PR DESCRIPTION
Print demux-bitrate if available, else hls-bitrate, not both (as demux-bitrate is generally more reliable). This avoids printing "HLS kbps" which looks weird.

Fixes
https://github.com/mpv-player/mpv/pull/14453#discussion_r1700550385