### PR TITLE
[RFC] options: convert some guarded options to new warning mechanism

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -218,9 +218,7 @@ const struct m_sub_options input_config = {
         {"input-preprocess-wheel", OPT_BOOL(preprocess_wheel)},
         {"input-touch-emulate-mouse", OPT_BOOL(touch_emulate_mouse)},
         {"input-dragging-deadzone", OPT_INT(dragging_deadzone)},
-#if HAVE_SDL2_GAMEPAD
-        {"input-gamepad", OPT_BOOL(use_gamepad)},
-#endif
+        {"input-gamepad", OPT_BOOL(use_gamepad), .unavailable = !HAVE_SDL2_GAMEPAD},
         {"window-dragging", OPT_BOOL(allow_win_drag)},
         {0}
     },

--- a/options/m_config_core.c
+++ b/options/m_config_core.c
@@ -207,6 +207,16 @@ static void get_opt_from_id(struct m_config_shadow *shadow, int32_t id,
     *out_opt_index = opt_index;
 }
 
+bool m_config_shadow_opt_unavailable(struct m_config_shadow *shadow,
+                                     int32_t id)
+{
+    int group_index, opt_index;
+    get_opt_from_id(shadow, id, &group_index, &opt_index);
+
+    return shadow->groups[group_index].group->unavailable ||
+           shadow->groups[group_index].group->opts[opt_index].unavailable;
+}
+
 const struct m_option *m_config_shadow_get_opt(struct m_config_shadow *shadow,
                                                int32_t id)
 {

--- a/options/m_config_core.h
+++ b/options/m_config_core.h
@@ -161,6 +161,11 @@ bool m_config_shadow_get_next_opt(struct m_config_shadow *shadow, int32_t *p_id)
 // covered by the m_config_cache.
 bool m_config_cache_get_next_opt(struct m_config_cache *cache, int32_t *p_id);
 
+
+// Check if the option is flagged as unavailable.
+bool m_config_shadow_opt_unavailable(struct m_config_shadow *shadow,
+                                     int32_t id);
+
 // Return the m_option that was used to declare this option.
 // id must be a valid option ID as returned by m_config_shadow_get_next_opt() or
 // m_config_cache_get_next_opt().

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -298,6 +298,13 @@ static struct m_config_option *m_config_get_co_any(const struct m_config *config
         return NULL;
 
     const char *prefix = config->is_toplevel ? "--" : "";
+    if (co->unavailable) {
+        if (!co->warning_was_printed) {
+            MP_WARN(config, "Warning: support for option %s%s is not compiled in the mpv binary.\n",
+                    prefix, co->name);
+            co->warning_was_printed = true;
+        }
+    }
     if (co->opt->type == &m_option_type_alias) {
         char buf[M_CONFIG_MAX_OPT_NAME_LEN];
         const char *alias = m_config_shadow_get_alias_from_opt(config->shadow, co->opt_id,
@@ -556,6 +563,7 @@ struct m_config *m_config_new(void *talloc_ctx, struct mp_log *log,
 
         struct m_config_option co = {
             .name = talloc_strdup(config, opt_name),
+            .unavailable = m_config_shadow_opt_unavailable(config->shadow, optid),
             .opt = m_config_shadow_get_opt(config->shadow, optid),
             .opt_id = optid,
         };
@@ -843,6 +851,8 @@ void m_config_print_option_list(const struct m_config *config, const char *name)
         struct m_config_option *co = &sorted[i];
         const struct m_option *opt = co->opt;
         if (strcmp(name, "*") != 0 && !strstr(co->name, name))
+            continue;
+        if (co->unavailable)
             continue;
         MP_INFO(config, " %s%-30s", prefix, co->name);
         if (opt->type == &m_option_type_choice) {

--- a/options/m_config_frontend.h
+++ b/options/m_config_frontend.h
@@ -50,6 +50,7 @@ struct m_config_option {
     bool is_set_from_config : 1;    // Set by a config file
     bool is_set_locally : 1;        // Has a backup entry
     bool warning_was_printed : 1;
+    bool unavailable;               // Option is missing compile-time support
     int32_t opt_id;                 // For some m_config APIs
     const char *name;               // Full name (ie option-subopt)
     const struct m_option *opt;     // Option description

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -216,6 +216,8 @@ struct m_sub_options {
     // Change flags passed to mp_option_change_callback() if any option that is
     // directly or indirectly part of this group is changed.
     int change_flags;
+    // If all sub_options require something during compile time to work.
+    bool unavailable;
     // Return further sub-options, for example for optional components. If set,
     // this is called with increasing index (starting from 0), as long as true
     // is returned. If true is returned and *sub is set in any of these calls,
@@ -392,6 +394,10 @@ struct m_option {
 
     // If the option is an alias, use the prefix of sub option.
     bool alias_use_prefix;
+
+    // If the option requires something during compile time to work potentially
+    // flag it is as not unavailable.
+    bool unavailable;
 
     int offset;
 


### PR DESCRIPTION
Here's my attempt at implementing what I suggested in https://github.com/mpv-player/mpv/pull/14618#issuecomment-2263201927. The mechanism works fine. I implemented both per option and for sub options.

1. I had to add a bunch of defines because of windows junk. It's not really a big deal but it's kind of ugly imo.
2. Not really sure how we want to handle suboptions that are conditional and private somewhere. They could just be moved to options.h for example, but then that makes them not-private obviously. Not a blocker for the feature but something to think about.