### PR TITLE
vo: add --display-fps-limiter option

### DIFF
--- a/DOCS/interface-changes/display-fps-limiter.txt
+++ b/DOCS/interface-changes/display-fps-limiter.txt
@@ -1,0 +1,1 @@
+add `--display-fps-limiter` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1212,7 +1212,17 @@ Video
     monitor.
 
     Set this option only if you have reason to believe the automatically
-    determined value is wrong.
+    determined value is wrong or intend to use the ``--display-fps-limiter``
+    option.
+
+``--display-fps-limiter=<yes|no>``
+    When using a ``--video-sync=display-*``, limit mpv's framerate to the
+    detected display FPS. This can be combined with the
+    ``--display-fps-override`` option to essentially set a specific framerate
+    limiter. This is mainly useful for VRR monitors with very high refresh rates
+    that can also support a lower rate. Using this is probably less accurate
+    than setting a custom modeline to your target frame rate, so use with
+    caution.
 
 ``--hwdec=<api1,api2,...|no|auto|auto-safe|auto-copy>``
     Specify the hardware video decoding API that should be used if possible.

--- a/options/options.c
+++ b/options/options.c
@@ -172,6 +172,7 @@ static const m_option_t mp_vo_opt_list[] = {
     {"native-fs", OPT_BOOL(native_fs)},
     {"native-touch", OPT_BOOL(native_touch)},
     {"show-in-taskbar", OPT_BOOL(show_in_taskbar)},
+    {"display-fps-limiter", OPT_BOOL(display_fps_limiter)},
     {"display-fps-override", OPT_DOUBLE(display_fps_override),
         M_RANGE(0, DBL_MAX)},
     {"video-timing-offset", OPT_DOUBLE(timing_offset), M_RANGE(0.0, 1.0)},

--- a/options/options.h
+++ b/options/options.h
@@ -77,6 +77,7 @@ typedef struct mp_vo_opts {
     char *mmcss_profile;
     int window_corners;
 
+    bool display_fps_limiter;
     double display_fps_override;
     double timing_offset;
     int video_sync;


### PR DESCRIPTION
On my end, it seems to be about the same as using `--opengl-swapinterval=2` + `--display-fps-override=30`. But people with better monitors should test to make sure it actually works. Also, I'm pretty sure using this breaks interpolation so that's a gap item as well.