### PR TITLE
DOCS/man/input: reserve user-data/osc and user-data/mpv sub-paths

### DIFF
--- a/DOCS/interface-changes/user-data-subpath.txt
+++ b/DOCS/interface-changes/user-data-subpath.txt
@@ -1,0 +1,1 @@
+reserve `user-data/osc` and `user-data/mpv` sub-paths for internal use

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3551,6 +3551,14 @@ Property list
     upon, and writing to these properties may prevent builtin scripts from working
     properly.
 
+    Currently, the following properties have defined special semantics:
+
+    ``user-data/osc/margins``
+        This property is written by an OSC implementation to indicate the margins that it
+        occupies. Its sub-properties ``l``, ``r``, ``t``, and ``b`` should all be set to
+        the left, right, top, and bottom margins respectively.
+        Values are between 0.0 and 1.0, normalized to window width/height.
+
     Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
     read, written, or observed.
 

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3545,6 +3545,12 @@ Property list
     The player itself does not use any data in it (although some builtin scripts may).
     The property is not preserved across player restarts.
 
+    The following sub-paths are reserved for internal uses or have special semantics:
+    ``user-data/osc``, ``user-data/mpv``. Unless noted otherwise, the semantics of
+    any properties under these sub-paths can change at any time and may not be relied
+    upon, and writing to these properties may prevent builtin scripts from working
+    properly.
+
     Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
     read, written, or observed.
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1754,7 +1754,7 @@ mp.observe_property('display-hidpi-scale', 'native', update)
 mp.observe_property('focused', 'native', update)
 
 mp.observe_property("user-data/osc/margins", "native", function(_, val)
-    if val then
+    if type(val) == "table" and type(val.t) == "number" and type(val.b) == "number" then
         global_margins = val
     else
         global_margins = { t = 0, b = 0 }


### PR DESCRIPTION
Currently user-data/osc is used for interpolation between the osc and other internal scripts. Reserve this sub-path and also user-data/mpv to make sure external scripts can only use these values as directed. New internal uses of user-data should use user-data/mpv instead.
