### PR TITLE
[PoC] don't keep frame references alive when switching between files

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1860,6 +1860,8 @@ terminate_playback:
     reinit_complex_filters(mpctx, true);
     uninit_audio_chain(mpctx);
     uninit_video_chain(mpctx);
+    if (mpctx->vo_chain)
+        vo_eof_reset(mpctx->vo_chain->vo);
     uninit_sub_all(mpctx);
     if (!opts->gapless_audio && !mpctx->encode_lavc_ctx)
         uninit_audio_out(mpctx);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -4012,6 +4012,11 @@ void gl_video_reset(struct gl_video *p)
     gl_video_reset_surfaces(p);
 }
 
+void gl_video_reset_frame(struct gl_video *p)
+{
+    unref_current_image(p);
+}
+
 bool gl_video_showing_interpolated_frame(struct gl_video *p)
 {
     return p->is_interpolated;

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -216,6 +216,7 @@ bool gl_video_icc_auto_enabled(struct gl_video *p);
 bool gl_video_gamma_auto_enabled(struct gl_video *p);
 
 void gl_video_reset(struct gl_video *p);
+void gl_video_reset_frame(struct gl_video *p);
 bool gl_video_showing_interpolated_frame(struct gl_video *p);
 
 struct mp_hwdec_devices;

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -59,6 +59,8 @@ enum {
 enum mp_voctrl {
     /* signal a device reset seek */
     VOCTRL_RESET = 1,
+    /* forget all frames (signalled together with VOCTRL_RESET) */
+    VOCTRL_FRAME_RESET,
     /* Handle input and redraw events, called by vo_check_events() */
     VOCTRL_CHECK_EVENTS,
     /* signal a device pause */
@@ -524,6 +526,7 @@ bool vo_has_frame(struct vo *vo);
 void vo_redraw(struct vo *vo);
 bool vo_want_redraw(struct vo *vo);
 void vo_seek_reset(struct vo *vo);
+void vo_eof_reset(struct vo *vo);
 void vo_destroy(struct vo *vo);
 void vo_set_paused(struct vo *vo, bool paused);
 int64_t vo_get_drop_count(struct vo *vo);

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -216,6 +216,9 @@ static int control(struct vo *vo, uint32_t request, void *data)
     case VOCTRL_RESET:
         gl_video_reset(p->renderer);
         return true;
+    case VOCTRL_FRAME_RESET:
+        gl_video_reset_frame(p->renderer);
+        return true;
     case VOCTRL_PAUSE:
         if (gl_video_showing_interpolated_frame(p->renderer))
             vo->want_redraw = true;

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -603,8 +603,9 @@ static int control(struct vo *vo, uint32_t request, void *data)
 
     switch (request) {
     case VOCTRL_RESET:
+    case VOCTRL_FRAME_RESET:
         mp_mutex_lock(&ctx->lock);
-        forget_frames(ctx, false);
+        forget_frames(ctx, request == VOCTRL_FRAME_RESET);
         ctx->need_reset = true;
         mp_mutex_unlock(&ctx->lock);
         vo->want_redraw = true;


### PR DESCRIPTION
as discussed on IRC

gpu and gpu-next tested on android to do what was intended