### PR TITLE
{osc,select}.lua: show playlist entries with trailing /

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -544,12 +544,15 @@ local function get_playlist()
 
     local message = string.format('Playlist [%d/%d]:\n', pos, count)
     local show = mp.get_property_native('osd-playlist-entry')
+    local trailing_slash_pattern = mp.get_property("platform") == "windows"
+                                   and "[/\\]+$" or "/+$"
     for _, v in ipairs(limlist) do
         local entry = v.title
         if not entry or show ~= 'title' then
             entry = v.filename
             if not entry:find("://") then
-                entry = select(2, utils.split_path(entry))
+                entry = select(2, utils.split_path(
+                    entry:gsub(trailing_slash_pattern, "")))
             end
         end
         if v.title and show == 'both' then

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -29,13 +29,16 @@ mp.add_forced_key_binding(nil, "select-playlist", function ()
     local playlist = {}
     local default_item
     local show = mp.get_property_native("osd-playlist-entry")
+    local trailing_slash_pattern = mp.get_property("platform") == "windows"
+                                   and "[/\\]+$" or "/+$"
 
     for i, entry in ipairs(mp.get_property_native("playlist")) do
         playlist[i] = entry.title
         if not playlist[i] or show ~= "title" then
             playlist[i] = entry.filename
             if not playlist[i]:find("://") then
-                playlist[i] = select(2, utils.split_path(playlist[i]))
+                playlist[i] = select(2, utils.split_path(
+                    playlist[i]:gsub(trailing_slash_pattern, "")))
             end
         end
         if entry.title and show == "both" then


### PR DESCRIPTION
If a playlist entry ends with a slash these scripts only show the basename which is empty. Fix this by stripping trailing slashes so that the last directory component becomes the basename.

This was broken even before dc998560aa.