### PR TITLE
Add support for multiple hwdecs with the same image format and different device types

### DIFF
--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -556,7 +556,9 @@ static void init_graph(struct lavfi *c)
             if (c->hwdec_interop) {
                 int imgfmt =
                     ra_hwdec_driver_get_imgfmt_for_name(c->hwdec_interop);
-                hwdec_ctx = mp_filter_load_hwdec_device(c->f, imgfmt);
+                enum AVHWDeviceType device_type =
+                    ra_hwdec_driver_get_device_type_for_name(c->hwdec_interop);
+                hwdec_ctx = mp_filter_load_hwdec_device(c->f, imgfmt, device_type);
             } else {
                 hwdec_ctx = hwdec_devices_get_first(info->hwdec_devs);
             }

--- a/filters/filter.c
+++ b/filters/filter.c
@@ -688,7 +688,8 @@ struct mp_stream_info *mp_filter_find_stream_info(struct mp_filter *f)
     return NULL;
 }
 
-struct mp_hwdec_ctx *mp_filter_load_hwdec_device(struct mp_filter *f, int imgfmt)
+struct mp_hwdec_ctx *mp_filter_load_hwdec_device(struct mp_filter *f, int imgfmt,
+                                                 enum AVHWDeviceType device_type)
 {
     struct mp_stream_info *info = mp_filter_find_stream_info(f);
     if (!info || !info->hwdec_devs)
@@ -700,7 +701,7 @@ struct mp_hwdec_ctx *mp_filter_load_hwdec_device(struct mp_filter *f, int imgfmt
     };
     hwdec_devices_request_for_img_fmt(info->hwdec_devs, &params);
 
-    return hwdec_devices_get_by_imgfmt(info->hwdec_devs, imgfmt);
+    return hwdec_devices_get_by_imgfmt_and_type(info->hwdec_devs, imgfmt, device_type);
 }
 
 static void filter_wakeup(struct mp_filter *f, bool mark_only)

--- a/filters/filter.h
+++ b/filters/filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <libavutil/hwcontext.h>
 
 #include "frame.h"
 
@@ -410,7 +411,8 @@ struct mp_stream_info {
 // Search for a parent filter (including f) that has this set, and return it.
 struct mp_stream_info *mp_filter_find_stream_info(struct mp_filter *f);
 
-struct mp_hwdec_ctx *mp_filter_load_hwdec_device(struct mp_filter *f, int imgfmt);
+struct mp_hwdec_ctx *mp_filter_load_hwdec_device(struct mp_filter *f, int imgfmt,
+                                                 enum AVHWDeviceType device_type);
 
 // Perform filtering. This runs until the filter graph is blocked (due to
 // missing external input or unread output). It returns whether any outside

--- a/osdep/mac/meson.build
+++ b/osdep/mac/meson.build
@@ -51,7 +51,8 @@ swift_compile = [swift_prog, swift_flags, '-module-name', 'swift',
                  '-emit-objc-header-path', '@OUTPUT1@', '-o', '@OUTPUT2@',
                  '@INPUT@', '-I.', '-I' + source_root,
                  '-I' + libplacebo.get_variable('includedir',
-                            default_value: source_root / 'subprojects' / 'libplacebo' / 'src' / 'include')]
+                            default_value: source_root / 'subprojects' / 'libplacebo' / 'src' / 'include'),
+                 '-I' + libavutil.get_variable('includedir')]
 
 swift_targets = custom_target('swift_targets',
     input: swift_sources,

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -456,7 +456,8 @@ static AVBufferRef *hwdec_create_dev(struct mp_filter *vd,
         hwdec_devices_request_for_img_fmt(ctx->hwdec_devs, &params);
 
         const struct mp_hwdec_ctx *hw_ctx =
-            hwdec_devices_get_by_imgfmt(ctx->hwdec_devs, imgfmt);
+            hwdec_devices_get_by_imgfmt_and_type(ctx->hwdec_devs, imgfmt,
+                                                 hwdec->lavc_device);
 
         if (hw_ctx && hw_ctx->av_device_ref)
             return av_buffer_ref(hw_ctx->av_device_ref);

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -435,7 +435,8 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
     hwdec_devices_request_for_img_fmt(info->hwdec_devs, &params);
 
     struct mp_hwdec_ctx *hwctx =
-        hwdec_devices_get_by_imgfmt(info->hwdec_devs, IMGFMT_D3D11);
+        hwdec_devices_get_by_imgfmt_and_type(info->hwdec_devs, IMGFMT_D3D11,
+                                             AV_HWDEVICE_TYPE_D3D11VA);
     if (!hwctx || !hwctx->av_device_ref)
         goto fail;
     AVHWDeviceContext *avhwctx = (void *)hwctx->av_device_ref->data;

--- a/video/filter/vf_vavpp.c
+++ b/video/filter/vf_vavpp.c
@@ -451,7 +451,7 @@ static struct mp_filter *vf_vavpp_create(struct mp_filter *parent, void *options
     p->queue = mp_refqueue_alloc(f);
 
     struct mp_hwdec_ctx *hwdec_ctx =
-        mp_filter_load_hwdec_device(f, IMGFMT_VAAPI);
+        mp_filter_load_hwdec_device(f, IMGFMT_VAAPI, AV_HWDEVICE_TYPE_VAAPI);
     if (!hwdec_ctx || !hwdec_ctx->av_device_ref)
         goto error;
     p->av_device_ref = av_buffer_ref(hwdec_ctx->av_device_ref);

--- a/video/filter/vf_vdpaupp.c
+++ b/video/filter/vf_vdpaupp.c
@@ -137,7 +137,7 @@ static struct mp_filter *vf_vdpaupp_create(struct mp_filter *parent, void *optio
     p->queue = mp_refqueue_alloc(f);
 
     struct mp_hwdec_ctx *hwdec_ctx =
-        mp_filter_load_hwdec_device(f, IMGFMT_VDPAU);
+        mp_filter_load_hwdec_device(f, IMGFMT_VDPAU, AV_HWDEVICE_TYPE_VDPAU);
     if (!hwdec_ctx || !hwdec_ctx->av_device_ref)
         goto error;
     p->ctx = mp_vdpau_get_ctx_from_av(hwdec_ctx->av_device_ref);

--- a/video/hwdec.c
+++ b/video/hwdec.c
@@ -34,14 +34,18 @@ void hwdec_devices_destroy(struct mp_hwdec_devices *devs)
     talloc_free(devs);
 }
 
-struct mp_hwdec_ctx *hwdec_devices_get_by_imgfmt(struct mp_hwdec_devices *devs,
-                                                 int hw_imgfmt)
+struct mp_hwdec_ctx *hwdec_devices_get_by_imgfmt_and_type(struct mp_hwdec_devices *devs,
+                                                          int hw_imgfmt,
+                                                          enum AVHWDeviceType device_type)
 {
     struct mp_hwdec_ctx *res = NULL;
     mp_mutex_lock(&devs->lock);
     for (int n = 0; n < devs->num_hwctxs; n++) {
         struct mp_hwdec_ctx *dev = devs->hwctxs[n];
-        if (dev->hw_imgfmt == hw_imgfmt) {
+        AVHWDeviceContext *hw_device_ctx =
+            dev->av_device_ref ? (AVHWDeviceContext *)dev->av_device_ref->data : NULL;
+        if (dev->hw_imgfmt == hw_imgfmt &&
+            (!hw_device_ctx || hw_device_ctx->type == device_type)) {
             res = dev;
             break;
         }

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -2,6 +2,7 @@
 #define MP_HWDEC_H_
 
 #include <libavutil/buffer.h>
+#include <libavutil/hwcontext.h>
 
 #include "options/m_option.h"
 
@@ -35,8 +36,9 @@ struct mp_hwdec_devices;
 struct mp_hwdec_devices *hwdec_devices_create(void);
 void hwdec_devices_destroy(struct mp_hwdec_devices *devs);
 
-struct mp_hwdec_ctx *hwdec_devices_get_by_imgfmt(struct mp_hwdec_devices *devs,
-                                                 int hw_imgfmt);
+struct mp_hwdec_ctx *hwdec_devices_get_by_imgfmt_and_type(struct mp_hwdec_devices *devs,
+                                                          int hw_imgfmt,
+                                                          enum AVHWDeviceType device_type);
 
 // For code which still strictly assumes there is 1 (or none) device.
 struct mp_hwdec_ctx *hwdec_devices_get_first(struct mp_hwdec_devices *devs);

--- a/video/out/d3d11/hwdec_d3d11va.c
+++ b/video/out/d3d11/hwdec_d3d11va.c
@@ -246,6 +246,7 @@ const struct ra_hwdec_driver ra_hwdec_d3d11va = {
     .name = "d3d11va",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_D3D11, 0},
+    .device_type = AV_HWDEVICE_TYPE_D3D11VA,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/d3d11/hwdec_dxva2dxgi.c
+++ b/video/out/d3d11/hwdec_dxva2dxgi.c
@@ -466,6 +466,7 @@ const struct ra_hwdec_driver ra_hwdec_dxva2dxgi = {
     .name = "dxva2-dxgi",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_DXVA2, 0},
+    .device_type = AV_HWDEVICE_TYPE_DXVA2,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -352,3 +352,13 @@ int ra_hwdec_driver_get_imgfmt_for_name(const char *name)
     }
     return IMGFMT_NONE;
 }
+
+enum AVHWDeviceType ra_hwdec_driver_get_device_type_for_name(const char *name)
+{
+    for (int i = 0; ra_hwdec_drivers[i]; i++) {
+        if (!strcmp(ra_hwdec_drivers[i]->name, name)) {
+            return ra_hwdec_drivers[i]->device_type;
+        }
+    }
+    return AV_HWDEVICE_TYPE_NONE;
+}

--- a/video/out/gpu/hwdec.h
+++ b/video/out/gpu/hwdec.h
@@ -1,6 +1,8 @@
 #ifndef MPGL_HWDEC_H_
 #define MPGL_HWDEC_H_
 
+#include <libavutil/hwcontext.h>
+
 #include "video/mp_image.h"
 #include "context.h"
 #include "ra.h"
@@ -106,6 +108,9 @@ struct ra_hwdec_driver {
     // Terminated with a 0 entry. (Extend the array size as needed.)
     const int imgfmts[3];
 
+    // The underlying ffmpeg hw device type this hwdec corresponds to.
+    enum AVHWDeviceType device_type;
+
     // Create the hwdec device. It must add it to hw->devs, if applicable.
     int (*init)(struct ra_hwdec *hw);
     void (*uninit)(struct ra_hwdec *hw);
@@ -148,5 +153,9 @@ int ra_hwdec_mapper_map(struct ra_hwdec_mapper *mapper, struct mp_image *img);
 // Get the primary image format for the given driver name.
 // Returns IMGFMT_NONE if the name doesn't get matched.
 int ra_hwdec_driver_get_imgfmt_for_name(const char *name);
+
+// Get the primary hw device type for the given driver name.
+// Returns AV_HWDEVICE_TYPE_NONE if the name doesn't get matched.
+enum AVHWDeviceType ra_hwdec_driver_get_device_type_for_name(const char *name);
 
 #endif

--- a/video/out/hwdec/hwdec_aimagereader.c
+++ b/video/out/hwdec/hwdec_aimagereader.c
@@ -392,6 +392,7 @@ const struct ra_hwdec_driver ra_hwdec_aimagereader = {
     .name = "aimagereader",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_MEDIACODEC, 0},
+    .device_type = AV_HWDEVICE_TYPE_MEDIACODEC,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -284,6 +284,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
 const struct ra_hwdec_driver ra_hwdec_cuda = {
     .name = "cuda",
     .imgfmts = {IMGFMT_CUDA, 0},
+    .device_type = AV_HWDEVICE_TYPE_CUDA,
     .priv_size = sizeof(struct cuda_hw_priv),
     .init = cuda_init,
     .uninit = cuda_uninit,

--- a/video/out/hwdec/hwdec_drmprime.c
+++ b/video/out/hwdec/hwdec_drmprime.c
@@ -307,6 +307,7 @@ const struct ra_hwdec_driver ra_hwdec_drmprime = {
     .name = "drmprime",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_DRMPRIME, 0},
+    .device_type = AV_HWDEVICE_TYPE_DRM,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/hwdec/hwdec_drmprime_overlay.c
+++ b/video/out/hwdec/hwdec_drmprime_overlay.c
@@ -328,6 +328,7 @@ const struct ra_hwdec_driver ra_hwdec_drmprime_overlay = {
     .name = "drmprime-overlay",
     .priv_size = sizeof(struct priv),
     .imgfmts = {IMGFMT_DRMPRIME, 0},
+    .device_type = AV_HWDEVICE_TYPE_DRM,
     .init = init,
     .overlay_frame = overlay_frame,
     .uninit = uninit,

--- a/video/out/hwdec/hwdec_vaapi.c
+++ b/video/out/hwdec/hwdec_vaapi.c
@@ -546,6 +546,7 @@ const struct ra_hwdec_driver ra_hwdec_vaapi = {
     .name = "vaapi",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_VAAPI, 0},
+    .device_type = AV_HWDEVICE_TYPE_VAAPI,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/hwdec/hwdec_vt.c
+++ b/video/out/hwdec/hwdec_vt.c
@@ -129,6 +129,7 @@ const struct ra_hwdec_driver ra_hwdec_videotoolbox = {
     .name = "videotoolbox",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_VIDEOTOOLBOX, 0},
+    .device_type = AV_HWDEVICE_TYPE_VIDEOTOOLBOX,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -320,6 +320,7 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
 const struct ra_hwdec_driver ra_hwdec_vulkan = {
     .name = "vulkan",
     .imgfmts = {IMGFMT_VULKAN, 0},
+    .device_type = AV_HWDEVICE_TYPE_VULKAN,
     .priv_size = sizeof(struct vulkan_hw_priv),
     .init = vulkan_init,
     .uninit = vulkan_uninit,

--- a/video/out/opengl/hwdec_d3d11egl.c
+++ b/video/out/opengl/hwdec_d3d11egl.c
@@ -351,6 +351,7 @@ const struct ra_hwdec_driver ra_hwdec_d3d11egl = {
     .name = "d3d11-egl",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_D3D11, 0},
+    .device_type = AV_HWDEVICE_TYPE_D3D11VA,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/opengl/hwdec_dxva2egl.c
+++ b/video/out/opengl/hwdec_dxva2egl.c
@@ -373,6 +373,7 @@ const struct ra_hwdec_driver ra_hwdec_dxva2egl = {
     .name = "dxva2-egl",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_DXVA2, 0},
+    .device_type = AV_HWDEVICE_TYPE_DXVA2,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/opengl/hwdec_dxva2gldx.c
+++ b/video/out/opengl/hwdec_dxva2gldx.c
@@ -236,6 +236,7 @@ const struct ra_hwdec_driver ra_hwdec_dxva2gldx = {
     .name = "dxva2-dxinterop",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_DXVA2, 0},
+    .device_type = AV_HWDEVICE_TYPE_DXVA2,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){

--- a/video/out/opengl/hwdec_vdpau.c
+++ b/video/out/opengl/hwdec_vdpau.c
@@ -239,6 +239,7 @@ const struct ra_hwdec_driver ra_hwdec_vdpau = {
     .name = "vdpau-gl",
     .priv_size = sizeof(struct priv_owner),
     .imgfmts = {IMGFMT_VDPAU, 0},
+    .device_type = AV_HWDEVICE_TYPE_VDPAU,
     .init = init,
     .uninit = uninit,
     .mapper = &(const struct ra_hwdec_mapper_driver){


### PR DESCRIPTION
This series sets up the infrastructure we will need to support the `v4l2request` hw device type in ffmpeg, assuming that code gets merged upstream.

This new device type creates a scenario we haven't seen before - two device types that produce the same hw image format (`IMGFMT_DRMPRIME`). Our existing logic will result in the first declared hwdec being used, regardless of the device type associated with the frame being decoded - and that means either the traditional `DRM` device type doesn't work or the new `V4L2REQUEST` one doesn't work. Not great.

To avoid that, we introduce the ability to look up an hwdec with both an image format and a device type, and then propagate that everywhere it needs to be known.

This change doesn't actually include anything `v4l2request` specific. That is a small set of change to the drmprime/overlay hwdecs to register extra v4l2request variants, and I'll send that separately - as it will be blocked on the patches being merged upstream.

cc @Kwiboo 