### PR TITLE
terminal_thread: only act on last command in stop_cont_pipe

### DIFF
--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -466,7 +466,8 @@ static MP_THREAD_VOID terminal_thread(void *ptr)
         }
         if (fds[1].revents & POLLIN) {
             int8_t c = -1;
-            (void)read(stop_cont_pipe[0], &c, 1);
+            while (read(stop_cont_pipe[0], &c, 1) == 1)
+                continue;
             if (c == PIPE_STOP) {
                 do_deactivate_getch2();
                 if (isatty(STDERR_FILENO)) {


### PR DESCRIPTION
It is possible for stop_cont_sighandler() to be called more than once before terminal_thread can act on the command.  For example, if mpv receives multiple SIGTSTP, it will suspend and when resumed will suspend again immediately.  Draining the pipe (which is non-blocking) works around this.

On OpenBSD, SIGTSTP appears to be sent to each thread, which makes it impossible to resume mpv since there will always be another PIPE_STOP byte waiting in the pipe.