### PR TITLE
player/command: don't restore auto profiles while we're shutting down 

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6521,7 +6521,7 @@ static void cmd_apply_profile(void *p)
     int mode = cmd->args[1].v.i;
     if (mode == 0) {
         cmd->success = m_config_set_profile(mpctx->mconfig, profile, 0) >= 0;
-    } else {
+    } else if (!mp_is_shutting_down(mpctx)) {
         cmd->success = m_config_restore_profile(mpctx->mconfig, profile) >= 0;
     }
 }


### PR DESCRIPTION
This can happen if you disable a builtin script with auto profiles and set profile-restore=copy on it. In that scenario, mpv will try to reload built in profiles while trying to quit and fail because the client handle is gone.