### PR TITLE
Revert "ci/mingw: don't run test on 32-bit binary"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           python -m pip install build wheel
           python -m build --wheel --no-isolation meson
           python -m pip install (Get-Item ./meson/dist/meson-*-py3-none-any.whl).FullName
-          choco install ccache
+          choco install ccache nasm
 
       - name: Update Meson WrapDB
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,14 @@ jobs:
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: 500M
-      WINE: ${{ matrix.wine }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: i686-w64-mingw32
+            wine: wine32
           - target: x86_64-w64-mingw32
-            wine: wine
+            wine: wine64
     steps:
       - uses: actions/checkout@v4
 
@@ -58,18 +58,11 @@ jobs:
           key: ${{ matrix.target }}-${{ steps.get_time.outputs.timestamp }}
           restore-keys: ${{ matrix.target }}-
 
-      # For LuaJIT build
-      - name: Enable multilib
-        if: ${{ matrix.target == 'i686-w64-mingw32' }}
+      - name: Install dependencies
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y gcc-multilib
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ccache g++-mingw-w64 meson nasm ninja-build pkg-config ${{ matrix.wine }}
+          sudo apt-get install -y ccache g++-mingw-w64 gcc-multilib meson nasm ninja-build pkg-config ${{ matrix.wine }}
 
       - name: Install Meson Wraps
         run: |
@@ -95,14 +88,12 @@ jobs:
           cat ./mingw_build/meson-logs/meson-log.txt
 
       - name: Functional test
-        if: ${{ matrix.wine }}
         run: |
           cd artifact && wine ./mpv.com -v --no-config
         env:
           WINEDEBUG: '+loaddll'
 
       - name: Run meson tests
-        if: ${{ matrix.wine }}
         id: tests
         run: |
           meson test -C mingw_build

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -46,6 +46,7 @@ pkgconfig = 'pkg-config'
 pkg-config = 'pkg-config'
 windres = '${TARGET}-windres'
 dlltool = '${TARGET}-dlltool'
+nasm = 'nasm'
 exe_wrapper = '${WINE}'
 [host_machine]
 system = 'windows'

--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -47,7 +47,7 @@ pkg-config = 'pkg-config'
 windres = '${TARGET}-windres'
 dlltool = '${TARGET}-dlltool'
 nasm = 'nasm'
-exe_wrapper = '${WINE}'
+exe_wrapper = 'wine'
 [host_machine]
 system = 'windows'
 cpu_family = '${fam}'


### PR DESCRIPTION
Support for 32-bit binaries were restored.

See:
https://github.com/actions/runner-images/issues/9977
https://bugs.launchpad.net/ubuntu/+source/linux-signed-azure/+bug/2071445
https://launchpad.net/ubuntu/+source/linux-azure/6.8.0-1012.14

This reverts commit f47cbcd43967fca0d2ae8b5a0a409a6e3ed96528.