### PR TITLE
console.lua: allow persisting the command history

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -195,6 +195,16 @@ Configurable Options
 
     Remove duplicate entries in history as to only keep the latest one.
 
+``persist_history``
+    Default: no
+
+    Whether to save the command history to a file and load it.
+
+``history_path``
+    Default: ``~~state/command_history.txt``
+
+    The file path for ``persist_history`` (see `PATHS`_).
+
 ``font_hw_ratio``
     Default: auto
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -37,6 +37,8 @@ local opts = {
     scale_with_window = "auto",
     case_sensitive = platform ~= 'windows' and true or false,
     history_dedup = true,
+    persist_history = false,
+    history_path = '~~state/command_history.txt',
     font_hw_ratio = 'auto',
 }
 
@@ -85,6 +87,7 @@ local histories = {[id] = {}}
 local history = histories[id]
 local history_pos = 1
 local searching_history = false
+local history_to_save = ''
 local log_buffers = {[id] = {}}
 local key_bindings = {}
 local dont_bind_up_down = false
@@ -710,6 +713,10 @@ local function history_add(text)
     end
 
     history[#history + 1] = text
+
+    if id == default_id then
+        history_to_save =  history_to_save .. text .. '\n'
+    end
 end
 
 local function handle_cursor_move()
@@ -1748,6 +1755,44 @@ local function undefine_key_bindings()
     key_bindings = {}
 end
 
+local function read_history()
+    if opts.persist_history == false or history[1] then
+        return
+    end
+
+    local history_file = io.open(mp.command_native({'expand-path', opts.history_path}))
+
+    if history_file == nil then
+        return
+    end
+
+    if opts.history_dedup then
+        local unfiltered_history = {}
+        for command in history_file:lines() do
+            unfiltered_history[#unfiltered_history + 1] = command
+        end
+
+        local history_map = {}
+        for i = #unfiltered_history, 1, -1 do
+            local command = unfiltered_history[i]
+            if not history_map[command] then
+                history[#history + 1] = command
+                history_map[command] = true
+            end
+        end
+
+        for i = 1, #history / 2, 1 do
+            history[i], history[#history - i + 1] = history[#history - i + 1], history[i]
+        end
+    else
+        for command in history_file:lines() do
+            history[#history + 1] = command
+        end
+    end
+
+    history_file:close()
+end
+
 -- Set the REPL visibility ("enable", Esc)
 set_active = function (active)
     if active == repl_active then return end
@@ -1761,6 +1806,7 @@ set_active = function (active)
             prompt = default_prompt
             id = default_id
             history = histories[id]
+            read_history()
             history_pos = #history + 1
             mp.enable_messages('terminal-default')
         end
@@ -1973,6 +2019,21 @@ end)
 
 mp.register_event('shutdown', function ()
     mp.del_property('user-data/mpv/console')
+
+    if opts.persist_history == false or history_to_save == '' then
+        return
+    end
+
+    local history_path = mp.command_native({'expand-path', opts.history_path})
+    local history_file, error_message = io.open(history_path, 'ab')
+
+    if history_file == nil then
+        mp.msg.error('Failed to write the command history: ' .. error_message)
+        return
+    end
+
+    history_file:write(history_to_save)
+    history_file:close()
 end)
 
 require 'mp.options'.read_options(opts, nil, render)


### PR DESCRIPTION
Disabled by default.

Fixes #15897.