### PR TITLE
vo: hwdec: drmprime: add separate hwdecs for v4l2request

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1447,6 +1447,16 @@ if features['ios-gl']
     sources += files('video/out/hwdec/hwdec_ios_gl.m')
 endif
 
+v4l2request = get_option('v4l2request').require(
+    cc.has_header_symbol('libavutil/hwcontext.h',
+                         'AV_HWDEVICE_TYPE_V4L2REQUEST',
+                         dependencies: libavutil)
+)
+features += {'v4l2request': v4l2request.allowed()}
+if features['v4l2request']
+    sources += files('video/v4l2request.c')
+endif
+
 libva = dependency('libva', version: '>= 1.1.0', required: get_option('vaapi'))
 
 vaapi_drm = dependency('libva-drm', version: '>= 1.1.0', required:
@@ -1921,6 +1931,7 @@ summary({'cocoa': features['cocoa'] and features['swift'],
          'libmpv': get_option('libmpv'),
          'lua': features['lua'],
          'opengl': features['gl'],
+         'v4l2request': features['v4l2request'],
          'vulkan': features['vulkan'],
          'wayland': features['wayland'],
          'x11': features['x11']},

--- a/meson.options
+++ b/meson.options
@@ -103,6 +103,7 @@ option('d3d-hwaccel', type: 'feature', value: 'auto', description: 'D3D11VA hwac
 option('d3d9-hwaccel', type: 'feature', value: 'auto', description: 'DXVA2 hwaccel')
 option('gl-dxinterop-d3d9', type: 'feature', value: 'auto', description: 'OpenGL/DirectX DXVA2 hwaccel')
 option('ios-gl', type: 'feature', value: 'auto', description: 'iOS OpenGL ES interop support')
+option('v4l2request', type: 'feature', value: 'auto', description: 'V4L2 Request API hwaccel')
 option('videotoolbox-gl', type: 'feature', value: 'auto', description: 'Videotoolbox with OpenGL')
 option('videotoolbox-pl', type: 'feature', value: 'auto', description: 'Videotoolbox with libplacebo')
 

--- a/video/hwdec.c
+++ b/video/hwdec.c
@@ -125,6 +125,9 @@ static const struct hwcontext_fns *const hwcontext_fns[] = {
 #if HAVE_DRM
     &hwcontext_fns_drmprime,
 #endif
+#if HAVE_V4L2REQUEST
+    &hwcontext_fns_v4l2request,
+#endif
 #if HAVE_VAAPI
     &hwcontext_fns_vaapi,
 #endif

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -119,6 +119,7 @@ extern const struct hwcontext_fns hwcontext_fns_cuda;
 extern const struct hwcontext_fns hwcontext_fns_d3d11;
 extern const struct hwcontext_fns hwcontext_fns_drmprime;
 extern const struct hwcontext_fns hwcontext_fns_dxva2;
+extern const struct hwcontext_fns hwcontext_fns_v4l2request;
 extern const struct hwcontext_fns hwcontext_fns_vaapi;
 extern const struct hwcontext_fns hwcontext_fns_vdpau;
 

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -38,6 +38,8 @@ extern const struct ra_hwdec_driver ra_hwdec_drmprime;
 extern const struct ra_hwdec_driver ra_hwdec_drmprime_overlay;
 extern const struct ra_hwdec_driver ra_hwdec_aimagereader;
 extern const struct ra_hwdec_driver ra_hwdec_vulkan;
+extern const struct ra_hwdec_driver ra_hwdec_v4l2request;
+extern const struct ra_hwdec_driver ra_hwdec_v4l2request_overlay;
 
 const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
 #if HAVE_D3D_HWACCEL
@@ -72,6 +74,10 @@ const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
 #if HAVE_DRM
     &ra_hwdec_drmprime,
     &ra_hwdec_drmprime_overlay,
+#endif
+#if HAVE_V4L2REQUEST
+    &ra_hwdec_v4l2request,
+    &ra_hwdec_v4l2request_overlay,
 #endif
 #if HAVE_ANDROID_MEDIA_NDK
     &ra_hwdec_aimagereader,

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -861,6 +861,7 @@ static int preinit(struct vo *vo)
     // Initialize all possible hwdec drivers.
     ra_hwdec_ctx_init(&p->hwdec_ctx, vo->hwdec_devs, "vaapi", false);
     ra_hwdec_ctx_init(&p->hwdec_ctx, vo->hwdec_devs, "drmprime", false);
+    ra_hwdec_ctx_init(&p->hwdec_ctx, vo->hwdec_devs, "v4l2request", false);
 
     p->src = (struct mp_rect){0, 0, 0, 0};
     return 0;

--- a/video/v4l2request.c
+++ b/video/v4l2request.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libavutil/hwcontext.h>
+
+#include "hwdec.h"
+
+static struct AVBufferRef *v4l2request_create_standalone(struct mpv_global *global,
+        struct mp_log *log, struct hwcontext_create_dev_params *params)
+{
+    AVBufferRef* ref = NULL;
+    av_hwdevice_ctx_create(&ref, AV_HWDEVICE_TYPE_V4L2REQUEST, NULL, NULL, 0);
+
+    return ref;
+}
+
+const struct hwcontext_fns hwcontext_fns_v4l2request = {
+    .av_hwdevice_type = AV_HWDEVICE_TYPE_V4L2REQUEST,
+    .create_dev = v4l2request_create_standalone,
+};


### PR DESCRIPTION
With all the machinery in place, we can now add the v4l2request hwdecs with a different hw device type, and a different initialisation path. This applies to both the drmprime and drmprime_overlay hwdecs.

At the moment, the device initialisation is done in the bare minimum way, but it can be extended to take a device path (for example) if that makes sense as we better understand what meaningful configuration will be.

This change is based on the code proposed by Jonas Karlman <jonas@kwiboo.se> in https://github.com/mpv-player/mpv/pull/14511