### PR TITLE
mp_image: do not skip MEL-only Dolby Vision metadata w/EL

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1174,8 +1174,12 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
     if (sd) {
 #ifdef PL_HAVE_LAV_DOLBY_VISION
         const AVDOVIMetadata *metadata = (const AVDOVIMetadata *)sd->buf->data;
+#if PL_API_VER >= 364
+        if (pl_avdovi_metadata_supported(metadata)) {
+#else
         const AVDOVIRpuDataHeader *header = av_dovi_get_header(metadata);
         if (header->disable_residual_flag) {
+#endif
             dst->dovi = dovi = av_buffer_alloc(sizeof(struct pl_dovi_metadata));
             MP_HANDLE_OOM(dovi);
             pl_map_avdovi_metadata(&dst->params.color, &dst->params.repr,


### PR DESCRIPTION
Refine the Dolby Vision metadata check to accept RPUs that indicate EL usage (profiles 4 and 7) if the original bitstream and metadata are MEL-only, instead of hardcoding a check for disable_residual_flag.

This depends on haasn/libplacebo#286 (aka libplacebo API version 248).
