### PR TITLE
vf_d3d11vpp: make scale a double value

### DIFF
--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -74,7 +74,7 @@ enum scaling_mode {
 
 struct opts {
     bool deint_enabled;
-    float scale;
+    double scale;
     int scaling_mode;
     bool interlaced_only;
     int mode;
@@ -606,7 +606,7 @@ fail:
 #define OPT_BASE_STRUCT struct opts
 static const m_option_t vf_opts_fields[] = {
     {"deint", OPT_BOOL(deint_enabled)},
-    {"scale", OPT_FLOAT(scale)},
+    {"scale", OPT_DOUBLE(scale)},
     {"scaling-mode", OPT_CHOICE(scaling_mode,
         {"standard", SCALING_BASIC},
         {"intel", SCALING_INTEL_VSR},


### PR DESCRIPTION
I found that when the value of scale has a non-zero digit in the second decimal place, the filter fails and gets disabled.

Honestly, I could not build mpv on Windows, so I'm unsure if it could fix this.