### PR TITLE
various: introduce UNUSED macro, and fix a few warnings in video/out

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -192,4 +192,6 @@ typedef long long ssize_t;
 typedef unsigned short mode_t;
 #endif
 
+#define UNUSED(x) (void)(x)
+
 #endif /* MPLAYER_MPCOMMON_H */

--- a/video/out/aspect.c
+++ b/video/out/aspect.c
@@ -27,7 +27,7 @@
 #include "sub/osd.h"
 
 static void aspect_calc_panscan(struct mp_vo_opts *opts,
-                                int w, int h, int d_w, int d_h, int unscaled,
+                                int h, int d_w, int d_h, int unscaled,
                                 int window_w, int window_h, double monitor_par,
                                 int *out_w, int *out_h)
 {
@@ -168,7 +168,7 @@ void mp_get_src_dst_rects(struct mp_log *log, struct mp_vo_opts *opts,
 
     if (opts->keepaspect) {
         int scaled_width, scaled_height;
-        aspect_calc_panscan(opts, src_w, src_h, src_dw, src_dh, opts->unscaled,
+        aspect_calc_panscan(opts, src_h, src_dw, src_dh, opts->unscaled,
                             vid_window_w, vid_window_h, monitor_par,
                             &scaled_width, &scaled_height);
         src_dst_split_scaling(src_w, vid_window_w, scaled_width,

--- a/video/out/dr_helper.c
+++ b/video/out/dr_helper.c
@@ -89,6 +89,7 @@ static void dr_thread_free(void *ptr)
 
 static void free_dr_buffer_on_dr_thread(void *opaque, uint8_t *data)
 {
+    UNUSED(data);
     struct free_dr_context *ctx = opaque;
     struct dr_helper *dr = ctx->dr;
 

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -180,6 +180,8 @@ typedef struct filter_window params;
 
 static double box(params *p, double x)
 {
+    UNUSED(p);
+    UNUSED(x);
     // This is mathematically 1.0 everywhere, the clipping is done implicitly
     // based on the radius.
     return 1.0;
@@ -192,21 +194,25 @@ static double triangle(params *p, double x)
 
 static double cosine(params *p, double x)
 {
+    UNUSED(p);
     return cos(x);
 }
 
 static double hanning(params *p, double x)
 {
+    UNUSED(p);
     return 0.5 + 0.5 * cos(M_PI * x);
 }
 
 static double hamming(params *p, double x)
 {
+    UNUSED(p);
     return 0.54 + 0.46 * cos(M_PI * x);
 }
 
 static double quadric(params *p, double x)
 {
+    UNUSED(p);
     if (x <  0.5) {
         return 0.75 - x * x;
     } else if (x <  1.5) {
@@ -248,6 +254,7 @@ static double blackman(params *p, double x)
 
 static double welch(params *p, double x)
 {
+    UNUSED(p);
     return 1.0 - x*x;
 }
 
@@ -274,6 +281,7 @@ static double cubic_bc(params *p, double x)
 
 static double spline16(params *p, double x)
 {
+    UNUSED(p);
     if (x < 1.0) {
         return ((x - 9.0/5.0 ) * x - 1.0/5.0 ) * x + 1.0;
     } else {
@@ -283,6 +291,7 @@ static double spline16(params *p, double x)
 
 static double spline36(params *p, double x)
 {
+    UNUSED(p);
     if (x < 1.0) {
         return ((13.0/11.0 * x - 453.0/209.0) * x - 3.0/209.0) * x + 1.0;
     } else if (x < 2.0) {
@@ -312,6 +321,7 @@ static double gaussian(params *p, double x)
 
 static double sinc(params *p, double x)
 {
+    UNUSED(p);
     if (fabs(x) < 1e-8)
         return 1.0;
     x *= M_PI;
@@ -320,6 +330,7 @@ static double sinc(params *p, double x)
 
 static double jinc(params *p, double x)
 {
+    UNUSED(p);
     if (fabs(x) < 1e-8)
         return 1.0;
     x *= M_PI;
@@ -328,6 +339,7 @@ static double jinc(params *p, double x)
 
 static double sphinx(params *p, double x)
 {
+    UNUSED(p);
     if (fabs(x) < 1e-8)
         return 1.0;
     x *= M_PI;

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -60,11 +60,13 @@ extern const struct ra_ctx_fns ra_ctx_wldmabuf;
 /* Autoprobe dummy. Always fails to create. */
 static bool dummy_init(struct ra_ctx *ctx)
 {
+    UNUSED(ctx);
     return false;
 }
 
 static void dummy_uninit(struct ra_ctx *ctx)
 {
+    UNUSED(ctx);
 }
 
 static const struct ra_ctx_fns ra_ctx_dummy = {
@@ -154,6 +156,7 @@ static bool get_desc(struct m_obj_desc *dst, int index)
 
 static bool check_unknown_entry(const char *name)
 {
+    UNUSED(name);
     return false;
 }
 

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -180,6 +180,8 @@ static int ra_hwdec_validate_opt_full(struct mp_log *log, bool include_modes,
                                       const m_option_t *opt,
                                       struct bstr name, const char **value)
 {
+    UNUSED(opt);
+    UNUSED(name);
     struct bstr param = bstr0(*value);
     bool help = bstr_equals0(param, "help");
     if (help)

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -57,6 +57,7 @@ struct gl_lcms {
 static void lcms2_error_handler(cmsContext ctx, cmsUInt32Number code,
                                 const char *msg)
 {
+    UNUSED(code);
     struct gl_lcms *p = cmsGetContextUserData(ctx);
     MP_ERR(p, "lcms2: %s\n", msg);
 }

--- a/video/out/libmpv_sw.c
+++ b/video/out/libmpv_sw.c
@@ -47,6 +47,8 @@ static bool check_format(struct render_backend *ctx, int imgfmt)
 
 static int set_parameter(struct render_backend *ctx, mpv_render_param param)
 {
+    UNUSED(ctx);
+    UNUSED(param);
     return MPV_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -60,6 +62,7 @@ static void reconfig(struct render_backend *ctx, struct mp_image_params *params)
 
 static void reset(struct render_backend *ctx)
 {
+    UNUSED(ctx);
     // stateless
 }
 
@@ -84,6 +87,7 @@ static void resize(struct render_backend *ctx, struct mp_rect *src,
 static int get_target_size(struct render_backend *ctx, mpv_render_param *params,
                            int *out_w, int *out_h)
 {
+    UNUSED(ctx);
     int *sz = get_mpv_render_param(params, MPV_RENDER_PARAM_SW_SIZE, NULL);
     if (!sz)
         return MPV_ERROR_INVALID_PARAMETER;
@@ -191,6 +195,7 @@ static int render(struct render_backend *ctx, mpv_render_param *params,
 
 static void destroy(struct render_backend *ctx)
 {
+    UNUSED(ctx);
     // nop
 }
 

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -218,6 +218,9 @@ done:
 static int print_display_info(struct mp_log *log, const struct m_option *opt,
                               struct bstr name)
 {
+    UNUSED(opt);
+    UNUSED(name);
+
     void *ta_ctx = talloc_new(NULL);
     pl_log pllog = mppl_log_create(ta_ctx, log);
     if (!pllog)
@@ -471,16 +474,23 @@ static bool display_reconfig(struct ra_ctx *ctx)
 
 static int display_control(struct ra_ctx *ctx, int *events, int request, void *arg)
 {
+    UNUSED(ctx);
+    UNUSED(events);
+    UNUSED(request);
+    UNUSED(arg);
     return VO_NOTIMPL;
 }
 
 static void display_wakeup(struct ra_ctx *ctx)
 {
+    UNUSED(ctx);
     // TODO
 }
 
 static void display_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
 {
+    UNUSED(ctx);
+    UNUSED(until_time_ns);
     // TODO
 }
 


### PR DESCRIPTION
This change introduces a UNUSED macro, and uses it to silence around 35 unused-parameter warnings in the video/out folder.

Work towards the goal of removing the -Wno-unused-parameter flag from the build process.