### PR TITLE
osdep/compiler: add mp_unused define

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -586,7 +586,7 @@ void ao_hotplug_destroy(struct ao_hotplug *hp)
     talloc_free(hp);
 }
 
-static void dummy_wakeup(void *ctx)
+static void dummy_wakeup(mp_unused void *ctx)
 {
 }
 

--- a/audio/out/ao_lavc.c
+++ b/audio/out/ao_lavc.c
@@ -243,7 +243,7 @@ static bool write_frame(struct ao *ao, struct mp_frame frame)
     return true;
 }
 
-static bool audio_write(struct ao *ao, void **data, int samples)
+static bool audio_write(struct ao *ao, void **data, mp_unused int samples)
 {
     struct priv *ac = ao->priv;
     struct encode_lavc_context *ectx = ao->encode_lavc_ctx;
@@ -292,24 +292,24 @@ static bool audio_write(struct ao *ao, void **data, int samples)
     return write_frame(ao, MAKE_FRAME(MP_FRAME_AUDIO, af));
 }
 
-static void get_state(struct ao *ao, struct mp_pcm_state *state)
+static void get_state(mp_unused struct ao *ao, struct mp_pcm_state *state)
 {
     state->free_samples = 1;
     state->queued_samples = 0;
     state->delay = 0;
 }
 
-static bool set_pause(struct ao *ao, bool paused)
+static bool set_pause(mp_unused struct ao *ao, mp_unused bool paused)
 {
     return true; // signal support so common code doesn't write silence
 }
 
-static void start(struct ao *ao)
+static void start(mp_unused struct ao *ao)
 {
     // we use data immediately
 }
 
-static void reset(struct ao *ao)
+static void reset(mp_unused struct ao *ao)
 {
 }
 

--- a/audio/out/ao_null.c
+++ b/audio/out/ao_null.c
@@ -112,7 +112,7 @@ static int init(struct ao *ao)
 }
 
 // close audio device
-static void uninit(struct ao *ao)
+static void uninit(mp_unused struct ao *ao)
 {
 }
 
@@ -156,7 +156,7 @@ static bool set_pause(struct ao *ao, bool paused)
     return true;
 }
 
-static bool audio_write(struct ao *ao, void **data, int samples)
+static bool audio_write(struct ao *ao, mp_unused void **data, int samples)
 {
     struct priv *priv = ao->priv;
 

--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -59,7 +59,7 @@ struct priv {
     bool direct_channels;
 };
 
-static int control(struct ao *ao, enum aocontrol cmd, void *arg)
+static int control(mp_unused struct ao *ao, enum aocontrol cmd, void *arg)
 {
     switch (cmd) {
     case AOCONTROL_GET_VOLUME:

--- a/audio/out/ao_pcm.c
+++ b/audio/out/ao_pcm.c
@@ -210,17 +210,17 @@ static void get_state(struct ao *ao, struct mp_pcm_state *state)
     state->delay = 0;
 }
 
-static bool set_pause(struct ao *ao, bool paused)
+static bool set_pause(mp_unused struct ao *ao, mp_unused bool paused)
 {
     return true; // signal support so common code doesn't write silence
 }
 
-static void start(struct ao *ao)
+static void start(mp_unused struct ao *ao)
 {
     // we use data immediately
 }
 
-static void reset(struct ao *ao)
+static void reset(mp_unused struct ao *ao)
 {
 }
 

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -364,8 +364,9 @@ static bool is_sink_node(const char *type, const struct spa_dict *props)
 }
 
 static void for_each_sink_registry_event_global(void *data, uint32_t id,
-                                                uint32_t permissions, const
-                                                char *type, uint32_t version,
+                                                mp_unused uint32_t permissions,
+                                                const char *type,
+                                                mp_unused uint32_t version,
                                                 const struct spa_dict *props)
 {
     struct registry_event_global_ctx *ctx = data;
@@ -387,7 +388,7 @@ static const struct pw_registry_events for_each_sink_registry_events = {
     .global = for_each_sink_registry_event_global,
 };
 
-static void for_each_sink_done(void *data, uint32_t it, int seq)
+static void for_each_sink_done(void *data, mp_unused uint32_t it, mp_unused int seq)
 {
     struct for_each_done_ctx *ctx = data;
     ctx->done = true;
@@ -452,7 +453,8 @@ unlock_loop:
     return ret;
 }
 
-static void have_sink(struct ao *ao, uint32_t id, const struct spa_dict *props, void *ctx)
+static void have_sink(mp_unused struct ao *ao, mp_unused uint32_t id,
+                      mp_unused const struct spa_dict *props, void *ctx)
 {
     bool *b = ctx;
     *b = true;
@@ -468,7 +470,8 @@ static bool session_has_sinks(struct ao *ao)
     return b;
 }
 
-static void on_error(void *data, uint32_t id, int seq, int res, const char *message)
+static void on_error(void *data, mp_unused uint32_t id, mp_unused int seq,
+                     int res, const char *message)
 {
     struct ao *ao = data;
 
@@ -772,7 +775,8 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
     }
 }
 
-static void add_device_to_list(struct ao *ao, uint32_t id, const struct spa_dict *props, void *ctx)
+static void add_device_to_list(struct ao *ao, mp_unused uint32_t id,
+                               const struct spa_dict *props, void *ctx)
 {
     struct ao_device_list *list = ctx;
     const char *name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
@@ -786,8 +790,8 @@ static void add_device_to_list(struct ao *ao, uint32_t id, const struct spa_dict
 }
 
 static void hotplug_registry_global_cb(void *data, uint32_t id,
-                                       uint32_t permissions, const char *type,
-                                       uint32_t version, const struct spa_dict *props)
+                                       mp_unused uint32_t permissions, const char *type,
+                                       mp_unused uint32_t version, const struct spa_dict *props)
 {
     struct ao *ao = data;
     struct priv *priv = ao->priv;

--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -76,8 +76,8 @@ static void context_state_cb(pa_context *c, void *userdata)
     }
 }
 
-static void subscribe_cb(pa_context *c, pa_subscription_event_type_t t,
-                         uint32_t idx, void *userdata)
+static void subscribe_cb(mp_unused pa_context *c, pa_subscription_event_type_t t,
+                         mp_unused uint32_t idx, void *userdata)
 {
     struct ao *ao = userdata;
     int type = t & PA_SUBSCRIPTION_MASK_SINK;
@@ -89,7 +89,7 @@ static void subscribe_cb(pa_context *c, pa_subscription_event_type_t t,
     }
 }
 
-static void context_success_cb(pa_context *c, int success, void *userdata)
+static void context_success_cb(mp_unused pa_context *c, int success, void *userdata)
 {
     struct ao *ao = userdata;
     struct priv *priv = ao->priv;
@@ -114,7 +114,7 @@ static void stream_state_cb(pa_stream *s, void *userdata)
     }
 }
 
-static void stream_request_cb(pa_stream *s, size_t length, void *userdata)
+static void stream_request_cb(mp_unused pa_stream *s, mp_unused size_t length, void *userdata)
 {
     struct ao *ao = userdata;
     struct priv *priv = ao->priv;
@@ -122,14 +122,14 @@ static void stream_request_cb(pa_stream *s, size_t length, void *userdata)
     pa_threaded_mainloop_signal(priv->mainloop, 0);
 }
 
-static void stream_latency_update_cb(pa_stream *s, void *userdata)
+static void stream_latency_update_cb(mp_unused pa_stream *s, void *userdata)
 {
     struct ao *ao = userdata;
     struct priv *priv = ao->priv;
     pa_threaded_mainloop_signal(priv->mainloop, 0);
 }
 
-static void underflow_cb(pa_stream *s, void *userdata)
+static void underflow_cb(mp_unused pa_stream *s, void *userdata)
 {
     struct ao *ao = userdata;
     struct priv *priv = ao->priv;
@@ -139,7 +139,7 @@ static void underflow_cb(pa_stream *s, void *userdata)
     pa_threaded_mainloop_signal(priv->mainloop, 0);
 }
 
-static void success_cb(pa_stream *s, int success, void *userdata)
+static void success_cb(mp_unused pa_stream *s, int success, void *userdata)
 {
     struct ao *ao = userdata;
     struct priv *priv = ao->priv;
@@ -646,7 +646,7 @@ static void audio_get_state(struct ao *ao, struct mp_pcm_state *state)
  * pa_context_get_sink_input_info() operation completes. Saves the
  * volume field of the specified structure to the global variable volume.
  */
-static void info_func(struct pa_context *c, const struct pa_sink_input_info *i,
+static void info_func(mp_unused struct pa_context *c, const struct pa_sink_input_info *i,
                       int is_last, void *userdata)
 {
     struct ao *ao = userdata;
@@ -744,7 +744,7 @@ struct sink_cb_ctx {
     struct ao_device_list *list;
 };
 
-static void sink_info_cb(pa_context *c, const pa_sink_info *i, int eol, void *ud)
+static void sink_info_cb(mp_unused pa_context *c, const pa_sink_info *i, int eol, void *ud)
 {
     struct sink_cb_ctx *ctx = ud;
     struct priv *priv = ctx->ao->priv;

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -2826,7 +2826,7 @@ done:
     return out_pkt;
 }
 
-int demuxer_help(struct mp_log *log, const m_option_t *opt, struct bstr name)
+int demuxer_help(struct mp_log *log, mp_unused const m_option_t *opt, mp_unused struct bstr name)
 {
     int i;
 
@@ -4634,7 +4634,7 @@ static void visit_meta(struct demuxer *demuxer, void *ctx,
 }
 
 
-static void visit_detect(void *ctx, void *ta, char **s)
+static void visit_detect(void *ctx, mp_unused void *ta, char **s)
 {
     char **all = ctx;
 

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -909,8 +909,8 @@ static int interrupt_cb(void *ctx)
     return mp_cancel_test(demuxer->cancel);
 }
 
-static int block_io_open(struct AVFormatContext *s, AVIOContext **pb,
-                         const char *url, int flags, AVDictionary **options)
+static int block_io_open(struct AVFormatContext *s, mp_unused AVIOContext **pb,
+                         const char *url, mp_unused int flags, mp_unused AVDictionary **options)
 {
     struct demuxer *demuxer = s->opaque;
     MP_ERR(demuxer, "Not opening '%s' due to --access-references=no.\n", url);

--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -420,7 +420,7 @@ error:
     return -1;
 }
 
-static void demux_close_mf(demuxer_t *demuxer)
+static void demux_close_mf(mp_unused demuxer_t *demuxer)
 {
 }
 

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2286,7 +2286,7 @@ static int read_mkv_segment_header(demuxer_t *demuxer, int64_t *segment_end)
     return 0;
 }
 
-static int demux_mkv_open(demuxer_t *demuxer, enum demux_check check)
+static int demux_mkv_open(demuxer_t *demuxer, mp_unused enum demux_check check)
 {
     stream_t *s = demuxer->stream;
     mkv_demuxer_t *mkv_d;

--- a/demux/demux_timeline.c
+++ b/demux/demux_timeline.c
@@ -635,7 +635,7 @@ static bool add_tl(struct demuxer *demuxer, struct timeline_par *tl)
     return true;
 }
 
-static int d_open(struct demuxer *demuxer, enum demux_check check)
+static int d_open(struct demuxer *demuxer, mp_unused enum demux_check check)
 {
     struct priv *p = demuxer->priv = talloc_zero(demuxer, struct priv);
     p->tl = demuxer->params ? demuxer->params->timeline : NULL;

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -231,7 +231,7 @@ struct priv {
 };
 
 static int decoder_list_help(struct mp_log *log, const m_option_t *opt,
-                             struct bstr name)
+                             mp_unused struct bstr name)
 {
     if (strcmp(opt->name, "ad") == 0) {
         struct mp_decoder_list *list = audio_decoder_list();

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -146,7 +146,7 @@ static void copy_opt(const m_option_t *opt, void *dst, const void *src)
 
 #define VAL(x) (*(bool *)(x))
 
-static int parse_bool(struct mp_log *log, const m_option_t *opt,
+static int parse_bool(struct mp_log *log, mp_unused const m_option_t *opt,
                       struct bstr name, struct bstr param, void *dst)
 {
     if (bstr_equals0(param, "yes") || !param.len) {
@@ -173,12 +173,12 @@ static int parse_bool(struct mp_log *log, const m_option_t *opt,
     return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
-static char *print_bool(const m_option_t *opt, const void *val)
+static char *print_bool(mp_unused const m_option_t *opt, const void *val)
 {
     return talloc_strdup(NULL, VAL(val) ? "yes" : "no");
 }
 
-static void add_bool(const m_option_t *opt, void *val, double add, bool wrap)
+static void add_bool(mp_unused const m_option_t *opt, void *val, double add, bool wrap)
 {
     if (fabs(add) < 0.5)
         return;
@@ -187,7 +187,7 @@ static void add_bool(const m_option_t *opt, void *val, double add, bool wrap)
     VAL(val) = state ? 1 : 0;
 }
 
-static int bool_set(const m_option_t *opt, void *dst, struct mpv_node *src)
+static int bool_set(mp_unused const m_option_t *opt, void *dst, struct mpv_node *src)
 {
     if (src->format != MPV_FORMAT_FLAG)
         return M_OPT_UNKNOWN;
@@ -195,7 +195,7 @@ static int bool_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     return 1;
 }
 
-static int bool_get(const m_option_t *opt, void *ta_parent,
+static int bool_get(mp_unused const m_option_t *opt, mp_unused void *ta_parent,
                     struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_FLAG;
@@ -203,7 +203,7 @@ static int bool_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool bool_equal(const m_option_t *opt, void *a, void *b)
+static bool bool_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return VAL(a) == VAL(b);
 }
@@ -264,7 +264,7 @@ static int flag_get(const m_option_t *opt, void *ta_parent,
     return bool_get(opt, ta_parent, dst, &(bool){VAL(src)});
 }
 
-static bool flag_equal(const m_option_t *opt, void *a, void *b)
+static bool flag_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return VAL(a) == VAL(b);
 }
@@ -453,7 +453,7 @@ static int int_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     return r;
 }
 
-static int int64_get(const m_option_t *opt, void *ta_parent,
+static int int64_get(mp_unused const m_option_t *opt, mp_unused void *ta_parent,
                      struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_INT64;
@@ -461,7 +461,7 @@ static int int64_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static int int_get(const m_option_t *opt, void *ta_parent,
+static int int_get(mp_unused const m_option_t *opt, mp_unused void *ta_parent,
                    struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_INT64;
@@ -469,12 +469,12 @@ static int int_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool int_equal(const m_option_t *opt, void *a, void *b)
+static bool int_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return *(int *)a == *(int *)b;
 }
 
-static bool int64_equal(const m_option_t *opt, void *a, void *b)
+static bool int64_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return *(int64_t *)a == *(int64_t *)b;
 }
@@ -588,7 +588,7 @@ char *format_file_size(int64_t size)
     return talloc_asprintf(NULL, "%.3f TiB", s / (1024.0 * 1024.0 * 1024.0 * 1024.0));
 }
 
-static char *pretty_print_byte_size(const m_option_t *opt, const void *val)
+static char *pretty_print_byte_size(mp_unused const m_option_t *opt, const void *val)
 {
     return format_file_size(*(int64_t *)val);
 }
@@ -1084,7 +1084,7 @@ static int double_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool double_equal(const m_option_t *opt, void *a, void *b)
+static bool double_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     double fa = VAL(a), fb = VAL(b);
     if (isnan(fa) || isnan(fb))
@@ -1215,8 +1215,8 @@ const m_option_type_t m_option_type_float = {
 #undef VAL
 #define VAL(x) (*(char **)(x))
 
-static int parse_str(struct mp_log *log, const m_option_t *opt,
-                     struct bstr name, struct bstr param, void *dst)
+static int parse_str(mp_unused struct mp_log *log, mp_unused const m_option_t *opt,
+                     mp_unused struct bstr name, struct bstr param, void *dst)
 {
     if (dst) {
         talloc_free(VAL(dst));
@@ -1226,12 +1226,12 @@ static int parse_str(struct mp_log *log, const m_option_t *opt,
     return 0;
 }
 
-static char *print_str(const m_option_t *opt, const void *val)
+static char *print_str(mp_unused const m_option_t *opt, const void *val)
 {
     return talloc_strdup(NULL, VAL(val) ? VAL(val) : "");
 }
 
-static void copy_str(const m_option_t *opt, void *dst, const void *src)
+static void copy_str(mp_unused const m_option_t *opt, void *dst, const void *src)
 {
     if (dst && src) {
         talloc_free(VAL(dst));
@@ -1250,7 +1250,7 @@ static int str_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     return r;
 }
 
-static int str_get(const m_option_t *opt, void *ta_parent,
+static int str_get(mp_unused const m_option_t *opt, void *ta_parent,
                    struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_STRING;
@@ -1258,7 +1258,7 @@ static int str_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool str_equal(const m_option_t *opt, void *a, void *b)
+static bool str_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return bstr_equals(bstr0(VAL(a)), bstr0(VAL(b)));
 }
@@ -1481,7 +1481,7 @@ static int parse_str_list_impl(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static void copy_str_list(const m_option_t *opt, void *dst, const void *src)
+static void copy_str_list(mp_unused const m_option_t *opt, void *dst, const void *src)
 {
     int n;
     char **d, **s;
@@ -1525,7 +1525,7 @@ static char *print_str_list(const m_option_t *opt, const void *src)
     return ret;
 }
 
-static int str_list_set(const m_option_t *opt, void *dst, struct mpv_node *src)
+static int str_list_set(mp_unused const m_option_t *opt, void *dst, struct mpv_node *src)
 {
     if (src->format != MPV_FORMAT_NODE_ARRAY)
         return M_OPT_UNKNOWN;
@@ -1544,7 +1544,7 @@ static int str_list_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     return 1;
 }
 
-static int str_list_get(const m_option_t *opt, void *ta_parent,
+static int str_list_get(mp_unused const m_option_t *opt, void *ta_parent,
                         struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_NODE_ARRAY;
@@ -1565,7 +1565,7 @@ static int parse_str_list(struct mp_log *log, const m_option_t *opt,
     return parse_str_list_impl(log, opt, name, param, dst, OP_NONE);
 }
 
-static bool str_list_equal(const m_option_t *opt, void *a, void *b)
+static bool str_list_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     char **la = VAL(a);
     char **lb = VAL(b);
@@ -1721,7 +1721,7 @@ static int parse_keyvalue_list(struct mp_log *log, const m_option_t *opt,
     return r;
 }
 
-static char *print_keyvalue_list(const m_option_t *opt, const void *src)
+static char *print_keyvalue_list(mp_unused const m_option_t *opt, const void *src)
 {
     char **lst = VAL(src);
     char *ret = talloc_strdup(NULL, "");
@@ -1733,7 +1733,7 @@ static char *print_keyvalue_list(const m_option_t *opt, const void *src)
     return ret;
 }
 
-static int keyvalue_list_set(const m_option_t *opt, void *dst,
+static int keyvalue_list_set(mp_unused const m_option_t *opt, void *dst,
                              struct mpv_node *src)
 {
     if (src->format != MPV_FORMAT_NODE_MAP)
@@ -1756,7 +1756,7 @@ static int keyvalue_list_set(const m_option_t *opt, void *dst,
     return 1;
 }
 
-static int keyvalue_list_get(const m_option_t *opt, void *ta_parent,
+static int keyvalue_list_get(mp_unused const m_option_t *opt, void *ta_parent,
                              struct mpv_node *dst, void *src)
 {
     dst->format = MPV_FORMAT_NODE_MAP;
@@ -1862,7 +1862,8 @@ const m_option_type_t m_option_type_msglevels = {
 };
 
 static int parse_print(struct mp_log *log, const m_option_t *opt,
-                       struct bstr name, struct bstr param, void *dst)
+                       mp_unused struct bstr name, mp_unused struct bstr param,
+                       mp_unused void *dst)
 {
     ((m_opt_print_fn) opt->priv)(log);
     return M_OPT_EXIT;
@@ -1874,8 +1875,8 @@ const m_option_type_t m_option_type_print_fn = {
     .parse = parse_print,
 };
 
-static int parse_dummy_flag(struct mp_log *log, const m_option_t *opt,
-                            struct bstr name, struct bstr param, void *dst)
+static int parse_dummy_flag(struct mp_log *log, mp_unused const m_option_t *opt,
+                            struct bstr name, struct bstr param, mp_unused void *dst)
 {
     if (param.len) {
         mp_err(log, "Invalid parameter for %.*s flag: %.*s\n",
@@ -2001,7 +2002,7 @@ static int split_char(bstr str, unsigned char split, int max, bstr *out_arr)
     return count;
 }
 
-static int parse_color(struct mp_log *log, const m_option_t *opt,
+static int parse_color(struct mp_log *log, mp_unused const m_option_t *opt,
                        struct bstr name, struct bstr param, void *dst)
 {
     if (param.len == 0)
@@ -2065,13 +2066,13 @@ exit:
     return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
-static char *print_color(const m_option_t *opt, const void *val)
+static char *print_color(mp_unused const m_option_t *opt, const void *val)
 {
     const struct m_color *c = val;
     return talloc_asprintf(NULL, "#%02X%02X%02X%02X", c->a, c->r, c->g, c->b);
 }
 
-static bool color_equal(const m_option_t *opt, void *a, void *b)
+static bool color_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     struct m_color *ca = a;
     struct m_color *cb = b;
@@ -2177,7 +2178,7 @@ error:
 #define APPEND_PER(F, F_PER) \
     res = talloc_asprintf_append(res, "%d%s", gm->F, gm->F_PER ? "%" : "")
 
-static char *print_geometry(const m_option_t *opt, const void *val)
+static char *print_geometry(mp_unused const m_option_t *opt, const void *val)
 {
     const struct m_geometry *gm = val;
     char *res = talloc_strdup(NULL, "");
@@ -2245,7 +2246,7 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
     }
 }
 
-static int parse_geometry(struct mp_log *log, const m_option_t *opt,
+static int parse_geometry(struct mp_log *log, mp_unused const m_option_t *opt,
                           struct bstr name, struct bstr param, void *dst)
 {
     bool is_help = bstr_equals0(param, "help");
@@ -2271,7 +2272,7 @@ exit:
     return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 
-static bool geometry_equal(const m_option_t *opt, void *a, void *b)
+static bool geometry_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     struct m_geometry *ga = a;
     struct m_geometry *gb = b;
@@ -2292,7 +2293,7 @@ const m_option_type_t m_option_type_geometry = {
     .equal = geometry_equal,
 };
 
-static int parse_size_box(struct mp_log *log, const m_option_t *opt,
+static int parse_size_box(struct mp_log *log, mp_unused const m_option_t *opt,
                           struct bstr name, struct bstr param, void *dst)
 {
     bool is_help = bstr_equals0(param, "help");
@@ -2347,7 +2348,7 @@ void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm)
         rc->y1 += rc->y0;
 }
 
-static int parse_rect(struct mp_log *log, const m_option_t *opt,
+static int parse_rect(struct mp_log *log, mp_unused const m_option_t *opt,
                       struct bstr name, struct bstr param, void *dst)
 {
     bool is_help = bstr_equals0(param, "help");
@@ -2390,7 +2391,7 @@ const m_option_type_t m_option_type_rect = {
 
 #include "video/img_format.h"
 
-static int parse_imgfmt(struct mp_log *log, const m_option_t *opt,
+static int parse_imgfmt(struct mp_log *log, mp_unused const m_option_t *opt,
                         struct bstr name, struct bstr param, void *dst)
 {
     if (param.len == 0)
@@ -2420,7 +2421,7 @@ static int parse_imgfmt(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static char *print_imgfmt(const m_option_t *opt, const void *val)
+static char *print_imgfmt(mp_unused const m_option_t *opt, const void *val)
 {
     int fmt = *(int *)val;
     return talloc_strdup(NULL, fmt ? mp_imgfmt_to_name(fmt) : "no");
@@ -2435,7 +2436,7 @@ const m_option_type_t m_option_type_imgfmt = {
     .equal = int_equal,
 };
 
-static int parse_fourcc(struct mp_log *log, const m_option_t *opt,
+static int parse_fourcc(struct mp_log *log, mp_unused const m_option_t *opt,
                         struct bstr name, struct bstr param, void *dst)
 {
     if (param.len == 0)
@@ -2462,7 +2463,7 @@ static int parse_fourcc(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static char *print_fourcc(const m_option_t *opt, const void *val)
+static char *print_fourcc(mp_unused const m_option_t *opt, const void *val)
 {
     unsigned int fourcc = *(unsigned int *)val;
     return talloc_asprintf(NULL, "%08x", fourcc);
@@ -2479,7 +2480,7 @@ const m_option_type_t m_option_type_fourcc = {
 
 #include "audio/format.h"
 
-static int parse_afmt(struct mp_log *log, const m_option_t *opt,
+static int parse_afmt(struct mp_log *log, mp_unused const m_option_t *opt,
                       struct bstr name, struct bstr param, void *dst)
 {
     if (param.len == 0)
@@ -2510,7 +2511,7 @@ static int parse_afmt(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static char *print_afmt(const m_option_t *opt, const void *val)
+static char *print_afmt(mp_unused const m_option_t *opt, const void *val)
 {
     int fmt = *(int *)val;
     return talloc_strdup(NULL, fmt ? af_fmt_to_str(fmt) : "no");
@@ -2528,7 +2529,7 @@ const m_option_type_t m_option_type_afmt = {
 #include "audio/chmap.h"
 
 static int parse_channels(struct mp_log *log, const m_option_t *opt,
-                          struct bstr name, struct bstr param, void *dst)
+                          mp_unused struct bstr name, struct bstr param, void *dst)
 {
     bool limited = opt->flags & M_OPT_CHANNELS_LIMITED;
 
@@ -2583,7 +2584,7 @@ static int parse_channels(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static char *print_channels(const m_option_t *opt, const void *val)
+static char *print_channels(mp_unused const m_option_t *opt, const void *val)
 {
     const struct m_channels *ch = val;
     if (!ch->set)
@@ -2612,7 +2613,7 @@ static void free_channels(void *src)
     *ch = (struct m_channels){0};
 }
 
-static void copy_channels(const m_option_t *opt, void *dst, const void *src)
+static void copy_channels(mp_unused const m_option_t *opt, void *dst, const void *src)
 {
     if (!(dst && src))
         return;
@@ -2624,7 +2625,7 @@ static void copy_channels(const m_option_t *opt, void *dst, const void *src)
         talloc_memdup(NULL, ch->chmaps, sizeof(ch->chmaps[0]) * ch->num_chmaps);
 }
 
-static bool channels_equal(const m_option_t *opt, void *a, void *b)
+static bool channels_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     struct m_channels *ca = a;
     struct m_channels *cb = b;
@@ -2761,7 +2762,7 @@ const m_option_type_t m_option_type_time = {
 
 // Relative time
 
-static int parse_rel_time(struct mp_log *log, const m_option_t *opt,
+static int parse_rel_time(struct mp_log *log, mp_unused const m_option_t *opt,
                           struct bstr name, struct bstr param, void *dst)
 {
     struct m_rel_time t = {0};
@@ -2815,7 +2816,7 @@ out:
     return 1;
 }
 
-static char *print_rel_time(const m_option_t *opt, const void *val)
+static char *print_rel_time(mp_unused const m_option_t *opt, const void *val)
 {
     const struct m_rel_time *t = val;
     switch(t->type) {
@@ -2831,7 +2832,7 @@ static char *print_rel_time(const m_option_t *opt, const void *val)
     return talloc_strdup(NULL, "none");
 }
 
-static bool rel_time_equal(const m_option_t *opt, void *a, void *b)
+static bool rel_time_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     struct m_rel_time *ta = a;
     struct m_rel_time *tb = b;
@@ -2983,7 +2984,7 @@ static void free_obj_settings_list(void *dst)
     VAL(dst) = NULL;
 }
 
-static void copy_obj_settings_list(const m_option_t *opt, void *dst,
+static void copy_obj_settings_list(mp_unused const m_option_t *opt, void *dst,
                                    const void *src)
 {
     m_obj_settings_t *d, *s;
@@ -3542,7 +3543,7 @@ static void append_param(char **res, char *param)
     }
 }
 
-static char *print_obj_settings_list(const m_option_t *opt, const void *val)
+static char *print_obj_settings_list(mp_unused const m_option_t *opt, const void *val)
 {
     m_obj_settings_t *list = VAL(val);
     char *res = talloc_strdup(NULL, "");
@@ -3570,7 +3571,7 @@ static char *print_obj_settings_list(const m_option_t *opt, const void *val)
     return res;
 }
 
-static int set_obj_settings_list(const m_option_t *opt, void *dst,
+static int set_obj_settings_list(mp_unused const m_option_t *opt, void *dst,
                                  struct mpv_node *src)
 {
     if (src->format != MPV_FORMAT_NODE_ARRAY)
@@ -3648,7 +3649,7 @@ static void add_map_string(struct mpv_node *dst, const char *key, const char *va
     entry->u.string = talloc_strdup(dst->u.list, val);
 }
 
-static int get_obj_settings_list(const m_option_t *opt, void *ta_parent,
+static int get_obj_settings_list(mp_unused const m_option_t *opt, void *ta_parent,
                                  struct mpv_node *dst, void *val)
 {
     m_obj_settings_t *list = VAL(val);
@@ -3677,7 +3678,7 @@ static int get_obj_settings_list(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool obj_settings_list_equal(const m_option_t *opt, void *pa, void *pb)
+static bool obj_settings_list_equal(mp_unused const m_option_t *opt, void *pa, void *pb)
 {
     struct m_obj_settings *a = VAL(pa);
     struct m_obj_settings *b = VAL(pb);
@@ -3735,15 +3736,16 @@ const m_option_type_t m_option_type_obj_settings_list = {
 #undef VAL
 #define VAL(x) (*(struct mpv_node *)(x))
 
-static int parse_node(struct mp_log *log, const m_option_t *opt,
-                      struct bstr name, struct bstr param, void *dst)
+static int parse_node(struct mp_log *log, mp_unused const m_option_t *opt,
+                      mp_unused struct bstr name, mp_unused struct bstr param,
+                      mp_unused void *dst)
 {
     // Maybe use JSON?
     mp_err(log, "option type doesn't accept strings");
     return M_OPT_INVALID;
 }
 
-static char *print_node(const m_option_t *opt, const void *val)
+static char *print_node(mp_unused const m_option_t *opt, const void *val)
 {
     char *t = talloc_strdup(NULL, "");
     if (json_write(&t, &VAL(val)) < 0) {
@@ -3753,7 +3755,7 @@ static char *print_node(const m_option_t *opt, const void *val)
     return t;
 }
 
-static char *pretty_print_node(const m_option_t *opt, const void *val)
+static char *pretty_print_node(mp_unused const m_option_t *opt, const void *val)
 {
     char *t = talloc_strdup(NULL, "");
     if (json_write_pretty(&t, &VAL(val)) < 0) {
@@ -3853,7 +3855,7 @@ static int node_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     return 1;
 }
 
-static int node_get(const m_option_t *opt, void *ta_parent,
+static int node_get(mp_unused const m_option_t *opt, void *ta_parent,
                     struct mpv_node *dst, void *src)
 {
     *dst = VAL(src);
@@ -3861,7 +3863,7 @@ static int node_get(const m_option_t *opt, void *ta_parent,
     return 1;
 }
 
-static bool node_equal(const m_option_t *opt, void *a, void *b)
+static bool node_equal(mp_unused const m_option_t *opt, void *a, void *b)
 {
     return equal_mpv_node(&VAL(a), &VAL(b));
 }
@@ -3894,7 +3896,7 @@ static int parse_cycle_dir(struct mp_log *log, const struct m_option *opt,
     return 1;
 }
 
-static char *print_cycle_dir(const m_option_t *opt, const void *val)
+static char *print_cycle_dir(mp_unused const m_option_t *opt, const void *val)
 {
     return talloc_asprintf(NULL, "%f", *(double *)val);
 }

--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -9,12 +9,14 @@
 #define MP_NORETURN __attribute__((noreturn))
 #define MP_FALLTHROUGH __attribute__((fallthrough))
 #define MP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define mp_unused __attribute__((unused))
 #else
 #define PRINTF_ATTRIBUTE(a1, a2)
 #define SCANF_ATTRIBUTE(a1, a2)
 #define MP_NORETURN
 #define MP_FALLTHROUGH do {} while (0)
 #define MP_WARN_UNUSED_RESULT
+#define mp_unused
 #endif
 
 // Broken crap with __USE_MINGW_ANSI_STDIO

--- a/osdep/path-unix.c
+++ b/osdep/path-unix.c
@@ -81,7 +81,7 @@ static void path_init(void)
     }
 }
 
-const char *mp_get_platform_path_unix(void *talloc_ctx, const char *type)
+const char *mp_get_platform_path_unix(mp_unused void *talloc_ctx, const char *type)
 {
     mp_exec_once(&path_init_once, path_init);
     if (strcmp(type, "home") == 0)

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -430,14 +430,14 @@ static void close_tty(void)
     tty_in = tty_out = -1;
 }
 
-static void quit_request_sighandler(int signum)
+static void quit_request_sighandler(mp_unused int signum)
 {
     int saved_errno = errno;
     (void)write(death_pipe[1], &(char){1}, 1);
     errno = saved_errno;
 }
 
-static MP_THREAD_VOID terminal_thread(void *ptr)
+static MP_THREAD_VOID terminal_thread(mp_unused void *ptr)
 {
     mp_thread_set_name("terminal/input");
     bool stdin_ok = read_terminal; // if false, we still wait for SIGTERM

--- a/player/client.c
+++ b/player/client.c
@@ -2119,12 +2119,12 @@ void mpv_free(void *data)
     talloc_free(data);
 }
 
-int64_t mpv_get_time_ns(mpv_handle *ctx)
+int64_t mpv_get_time_ns(mp_unused mpv_handle *ctx)
 {
     return mp_time_ns();
 }
 
-int64_t mpv_get_time_us(mpv_handle *ctx)
+int64_t mpv_get_time_us(mp_unused mpv_handle *ctx)
 {
     return mp_time_ns() / 1000;
 }

--- a/player/command.c
+++ b/player/command.c
@@ -465,14 +465,14 @@ static int mp_property_av_speed_correction(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, val);
 }
 
-static int mp_property_display_sync_active(void *ctx, struct m_property *prop,
+static int mp_property_display_sync_active(void *ctx, mp_unused struct m_property *prop,
                                            int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_bool_ro(action, arg, mpctx->display_sync_active);
 }
 
-static int mp_property_pid(void *ctx, struct m_property *prop,
+static int mp_property_pid(mp_unused void *ctx, mp_unused struct m_property *prop,
                            int action, void *arg)
 {
     // 32 bit on linux/windows - which C99 `int' is not guaranteed to hold
@@ -480,7 +480,7 @@ static int mp_property_pid(void *ctx, struct m_property *prop,
 }
 
 /// filename with path (RO)
-static int mp_property_path(void *ctx, struct m_property *prop,
+static int mp_property_path(void *ctx, mp_unused struct m_property *prop,
                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -489,7 +489,7 @@ static int mp_property_path(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, mpctx->filename);
 }
 
-static int mp_property_filename(void *ctx, struct m_property *prop,
+static int mp_property_filename(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -538,7 +538,7 @@ static int mp_property_stream_open_filename(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_file_size(void *ctx, struct m_property *prop,
+static int mp_property_file_size(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -587,7 +587,7 @@ static int mp_property_media_title(void *ctx, struct m_property *prop,
     return mp_property_filename(ctx, prop, action, arg);
 }
 
-static int mp_property_stream_path(void *ctx, struct m_property *prop,
+static int mp_property_stream_path(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -597,7 +597,7 @@ static int mp_property_stream_path(void *ctx, struct m_property *prop,
 }
 
 /// Demuxer name (RO)
-static int mp_property_demuxer(void *ctx, struct m_property *prop,
+static int mp_property_demuxer(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -607,7 +607,7 @@ static int mp_property_demuxer(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, demuxer->desc->name);
 }
 
-static int mp_property_file_format(void *ctx, struct m_property *prop,
+static int mp_property_file_format(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -618,7 +618,7 @@ static int mp_property_file_format(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, name);
 }
 
-static int mp_property_stream_pos(void *ctx, struct m_property *prop,
+static int mp_property_stream_pos(void *ctx, mp_unused struct m_property *prop,
                                   int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -672,7 +672,7 @@ static int property_time(int action, void *arg, double time)
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_duration(void *ctx, struct m_property *prop,
+static int mp_property_duration(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -684,7 +684,7 @@ static int mp_property_duration(void *ctx, struct m_property *prop,
     return property_time(action, arg, len);
 }
 
-static int mp_property_avsync(void *ctx, struct m_property *prop,
+static int mp_property_avsync(void *ctx, mp_unused struct m_property *prop,
                               int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -698,7 +698,7 @@ static int mp_property_avsync(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, mpctx->last_av_difference);
 }
 
-static int mp_property_total_avsync_change(void *ctx, struct m_property *prop,
+static int mp_property_total_avsync_change(void *ctx, mp_unused struct m_property *prop,
                                            int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -709,7 +709,7 @@ static int mp_property_total_avsync_change(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, mpctx->total_avsync_change);
 }
 
-static int mp_property_frame_drop_dec(void *ctx, struct m_property *prop,
+static int mp_property_frame_drop_dec(void *ctx, mp_unused struct m_property *prop,
                                       int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -722,7 +722,7 @@ static int mp_property_frame_drop_dec(void *ctx, struct m_property *prop,
                              mp_decoder_wrapper_get_frames_dropped(dec));
 }
 
-static int mp_property_mistimed_frame_count(void *ctx, struct m_property *prop,
+static int mp_property_mistimed_frame_count(void *ctx, mp_unused struct m_property *prop,
                                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -732,7 +732,7 @@ static int mp_property_mistimed_frame_count(void *ctx, struct m_property *prop,
     return m_property_int_ro(action, arg, mpctx->mistimed_frames_total);
 }
 
-static int mp_property_vsync_ratio(void *ctx, struct m_property *prop,
+static int mp_property_vsync_ratio(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -754,7 +754,7 @@ static int mp_property_vsync_ratio(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, vsyncs / (double)frames);
 }
 
-static int mp_property_frame_drop_vo(void *ctx, struct m_property *prop,
+static int mp_property_frame_drop_vo(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -764,7 +764,7 @@ static int mp_property_frame_drop_vo(void *ctx, struct m_property *prop,
     return m_property_int_ro(action, arg, vo_get_drop_count(mpctx->video_out));
 }
 
-static int mp_property_vo_delayed_frame_count(void *ctx, struct m_property *prop,
+static int mp_property_vo_delayed_frame_count(void *ctx, mp_unused struct m_property *prop,
                                               int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -775,7 +775,7 @@ static int mp_property_vo_delayed_frame_count(void *ctx, struct m_property *prop
 }
 
 /// Current position in percent (RW)
-static int mp_property_percent_pos(void *ctx, struct m_property *prop,
+static int mp_property_percent_pos(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -813,7 +813,7 @@ static int mp_property_percent_pos(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_time_start(void *ctx, struct m_property *prop,
+static int mp_property_time_start(mp_unused void *ctx, mp_unused struct m_property *prop,
                                   int action, void *arg)
 {
     // minor backwards-compat.
@@ -821,7 +821,7 @@ static int mp_property_time_start(void *ctx, struct m_property *prop,
 }
 
 /// Current position in seconds (RW)
-static int mp_property_time_pos(void *ctx, struct m_property *prop,
+static int mp_property_time_pos(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -836,7 +836,7 @@ static int mp_property_time_pos(void *ctx, struct m_property *prop,
 }
 
 /// Current audio pts in seconds (R)
-static int mp_property_audio_pts(void *ctx, struct m_property *prop,
+static int mp_property_audio_pts(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -860,7 +860,7 @@ static bool time_remaining(MPContext *mpctx, double *remaining)
     return len >= 0;
 }
 
-static int mp_property_remaining(void *ctx, struct m_property *prop,
+static int mp_property_remaining(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     double remaining;
@@ -870,7 +870,7 @@ static int mp_property_remaining(void *ctx, struct m_property *prop,
     return property_time(action, arg, remaining);
 }
 
-static int mp_property_playtime_remaining(void *ctx, struct m_property *prop,
+static int mp_property_playtime_remaining(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -882,14 +882,14 @@ static int mp_property_playtime_remaining(void *ctx, struct m_property *prop,
     return property_time(action, arg, remaining / speed);
 }
 
-static int mp_property_remaining_file_loops(void *ctx, struct m_property *prop,
+static int mp_property_remaining_file_loops(void *ctx, mp_unused struct m_property *prop,
         int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_int_ro(action, arg, mpctx->remaining_file_loops);
 }
 
-static int mp_property_remaining_ab_loops(void *ctx, struct m_property *prop,
+static int mp_property_remaining_ab_loops(void *ctx, mp_unused struct m_property *prop,
         int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -897,7 +897,7 @@ static int mp_property_remaining_ab_loops(void *ctx, struct m_property *prop,
 }
 
 /// Current chapter (RW)
-static int mp_property_chapter(void *ctx, struct m_property *prop,
+static int mp_property_chapter(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1051,7 +1051,7 @@ static int parse_node_chapters(struct MPContext *mpctx,
     return M_PROPERTY_OK;
 }
 
-static int mp_property_list_chapters(void *ctx, struct m_property *prop,
+static int mp_property_list_chapters(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1088,7 +1088,7 @@ static int mp_property_list_chapters(void *ctx, struct m_property *prop,
     return m_property_read_list(action, arg, count, get_chapter_entry, mpctx);
 }
 
-static int mp_property_current_edition(void *ctx, struct m_property *prop,
+static int mp_property_current_edition(void *ctx, mp_unused struct m_property *prop,
                                       int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1158,7 +1158,7 @@ static int get_edition_entry(int item, int action, void *arg, void *ctx)
     return m_property_read_sub(props, action, arg);
 }
 
-static int property_list_editions(void *ctx, struct m_property *prop,
+static int property_list_editions(void *ctx, mp_unused struct m_property *prop,
                                   int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1196,7 +1196,7 @@ static int property_list_editions(void *ctx, struct m_property *prop,
 }
 
 /// Number of chapters in file
-static int mp_property_chapters(void *ctx, struct m_property *prop,
+static int mp_property_chapters(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1206,7 +1206,7 @@ static int mp_property_chapters(void *ctx, struct m_property *prop,
     return m_property_int_ro(action, arg, count);
 }
 
-static int mp_property_editions(void *ctx, struct m_property *prop,
+static int mp_property_editions(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1304,7 +1304,7 @@ static int tag_property(int action, void *arg, struct mp_tags *tags)
 }
 
 /// Demuxer meta data
-static int mp_property_metadata(void *ctx, struct m_property *prop,
+static int mp_property_metadata(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1315,7 +1315,7 @@ static int mp_property_metadata(void *ctx, struct m_property *prop,
     return tag_property(action, arg, demuxer->metadata);
 }
 
-static int mp_property_filtered_metadata(void *ctx, struct m_property *prop,
+static int mp_property_filtered_metadata(void *ctx, mp_unused struct m_property *prop,
                                          int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1325,7 +1325,7 @@ static int mp_property_filtered_metadata(void *ctx, struct m_property *prop,
     return tag_property(action, arg, mpctx->filtered_tags);
 }
 
-static int mp_property_chapter_metadata(void *ctx, struct m_property *prop,
+static int mp_property_chapter_metadata(void *ctx, mp_unused struct m_property *prop,
                                         int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1383,14 +1383,14 @@ static int mp_property_filter_metadata(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_core_idle(void *ctx, struct m_property *prop,
+static int mp_property_core_idle(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_bool_ro(action, arg, !mpctx->playback_active);
 }
 
-static int mp_property_deinterlace(void *ctx, struct m_property *prop,
+static int mp_property_deinterlace(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1402,14 +1402,14 @@ static int mp_property_deinterlace(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, deinterlace_active);
 }
 
-static int mp_property_idle(void *ctx, struct m_property *prop,
+static int mp_property_idle(void *ctx, mp_unused struct m_property *prop,
                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_bool_ro(action, arg, mpctx->stop_play == PT_STOP);
 }
 
-static int mp_property_window_id(void *ctx, struct m_property *prop,
+static int mp_property_window_id(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1420,7 +1420,7 @@ static int mp_property_window_id(void *ctx, struct m_property *prop,
     return m_property_int64_ro(action, arg, wid);
 }
 
-static int mp_property_eof_reached(void *ctx, struct m_property *prop,
+static int mp_property_eof_reached(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1431,7 +1431,7 @@ static int mp_property_eof_reached(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, eof);
 }
 
-static int mp_property_seeking(void *ctx, struct m_property *prop,
+static int mp_property_seeking(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1440,14 +1440,14 @@ static int mp_property_seeking(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, !mpctx->restart_complete);
 }
 
-static int mp_property_playback_abort(void *ctx, struct m_property *prop,
+static int mp_property_playback_abort(void *ctx, mp_unused struct m_property *prop,
                                       int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_bool_ro(action, arg, !mpctx->playing || mpctx->stop_play);
 }
 
-static int mp_property_cache_speed(void *ctx, struct m_property *prop,
+static int mp_property_cache_speed(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1466,7 +1466,7 @@ static int mp_property_cache_speed(void *ctx, struct m_property *prop,
     return m_property_int64_ro(action, arg, val);
 }
 
-static int mp_property_demuxer_cache_duration(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_cache_duration(void *ctx, mp_unused struct m_property *prop,
                                               int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1482,7 +1482,7 @@ static int mp_property_demuxer_cache_duration(void *ctx, struct m_property *prop
     return m_property_double_ro(action, arg, s.ts_info.duration);
 }
 
-static int mp_property_demuxer_cache_time(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_cache_time(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1498,7 +1498,7 @@ static int mp_property_demuxer_cache_time(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, s.ts_info.end);
 }
 
-static int mp_property_demuxer_cache_idle(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_cache_idle(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1511,7 +1511,7 @@ static int mp_property_demuxer_cache_idle(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, s.idle);
 }
 
-static int mp_property_demuxer_cache_state(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_cache_state(void *ctx, mp_unused struct m_property *prop,
                                            int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1590,7 +1590,7 @@ static int mp_property_demuxer_cache_state(void *ctx, struct m_property *prop,
     return M_PROPERTY_OK;
 }
 
-static int mp_property_demuxer_start_time(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_start_time(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1600,7 +1600,7 @@ static int mp_property_demuxer_start_time(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, mpctx->demuxer->start_time);
 }
 
-static int mp_property_paused_for_cache(void *ctx, struct m_property *prop,
+static int mp_property_paused_for_cache(void *ctx, mp_unused struct m_property *prop,
                                         int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1609,7 +1609,7 @@ static int mp_property_paused_for_cache(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, mpctx->paused_for_cache);
 }
 
-static int mp_property_cache_buffering(void *ctx, struct m_property *prop,
+static int mp_property_cache_buffering(void *ctx, mp_unused struct m_property *prop,
                                        int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1619,7 +1619,7 @@ static int mp_property_cache_buffering(void *ctx, struct m_property *prop,
     return m_property_int_ro(action, arg, state);
 }
 
-static int mp_property_demuxer_is_network(void *ctx, struct m_property *prop,
+static int mp_property_demuxer_is_network(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1630,7 +1630,7 @@ static int mp_property_demuxer_is_network(void *ctx, struct m_property *prop,
 }
 
 
-static int mp_property_clock(void *ctx, struct m_property *prop,
+static int mp_property_clock(mp_unused void *ctx, mp_unused struct m_property *prop,
                              int action, void *arg)
 {
     char outstr[6];
@@ -1642,7 +1642,7 @@ static int mp_property_clock(void *ctx, struct m_property *prop,
     return M_PROPERTY_UNAVAILABLE;
 }
 
-static int mp_property_seekable(void *ctx, struct m_property *prop,
+static int mp_property_seekable(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1651,7 +1651,7 @@ static int mp_property_seekable(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, mpctx->demuxer->seekable);
 }
 
-static int mp_property_partially_seekable(void *ctx, struct m_property *prop,
+static int mp_property_partially_seekable(void *ctx, mp_unused struct m_property *prop,
                                           int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1660,7 +1660,7 @@ static int mp_property_partially_seekable(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, mpctx->demuxer->partially_seekable);
 }
 
-static int mp_property_mixer_active(void *ctx, struct m_property *prop,
+static int mp_property_mixer_active(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1712,7 +1712,7 @@ static int mp_property_volume_gain(void *ctx, struct m_property *prop,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
-static int mp_property_ao_volume(void *ctx, struct m_property *prop,
+static int mp_property_ao_volume(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1751,7 +1751,7 @@ static int mp_property_ao_volume(void *ctx, struct m_property *prop,
 }
 
 
-static int mp_property_ao_mute(void *ctx, struct m_property *prop,
+static int mp_property_ao_mute(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1831,7 +1831,7 @@ static int mp_property_audio_device(void *ctx, struct m_property *prop,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
-static int mp_property_audio_devices(void *ctx, struct m_property *prop,
+static int mp_property_audio_devices(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     struct MPContext *mpctx = ctx;
@@ -1843,7 +1843,7 @@ static int mp_property_audio_devices(void *ctx, struct m_property *prop,
                                 get_device_entry, list);
 }
 
-static int mp_property_ao(void *ctx, struct m_property *p, int action, void *arg)
+static int mp_property_ao(void *ctx, mp_unused struct m_property *p, int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_strdup_ro(action, arg, mpctx->ao ? ao_get_name(mpctx->ao) : NULL);
@@ -1881,7 +1881,7 @@ static int property_audiofmt(struct mp_aframe *fmt, int action, void *arg)
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_audio_params(void *ctx, struct m_property *prop,
+static int mp_property_audio_params(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -1889,7 +1889,7 @@ static int mp_property_audio_params(void *ctx, struct m_property *prop,
         mpctx->ao_chain->filter->input_aformat : NULL, action, arg);
 }
 
-static int mp_property_audio_out_params(void *ctx, struct m_property *prop,
+static int mp_property_audio_out_params(void *ctx, mp_unused struct m_property *prop,
                                         int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2115,7 +2115,7 @@ static const char *track_type_name(struct track *t)
     return NULL;
 }
 
-static int property_list_tracks(void *ctx, struct m_property *prop,
+static int property_list_tracks(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2158,7 +2158,7 @@ static int property_list_tracks(void *ctx, struct m_property *prop,
                                 get_track_entry, mpctx);
 }
 
-static int property_current_tracks(void *ctx, struct m_property *prop,
+static int property_current_tracks(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2215,7 +2215,7 @@ static int property_current_tracks(void *ctx, struct m_property *prop,
     return mp_property_do(name, ka->action, ka->arg, ctx);
 }
 
-static int mp_property_hwdec_current(void *ctx, struct m_property *prop,
+static int mp_property_hwdec_current(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2232,7 +2232,7 @@ static int mp_property_hwdec_current(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, current);
 }
 
-static int mp_property_hwdec_interop(void *ctx, struct m_property *prop,
+static int mp_property_hwdec_interop(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2260,7 +2260,7 @@ static int get_frame_count(struct MPContext *mpctx)
     return len * fps;
 }
 
-static int mp_property_frame_number(void *ctx, struct m_property *prop,
+static int mp_property_frame_number(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2272,7 +2272,7 @@ static int mp_property_frame_number(void *ctx, struct m_property *prop,
         lrint(get_current_pos_ratio(mpctx, false) * frames));
 }
 
-static int mp_property_frame_count(void *ctx, struct m_property *prop,
+static int mp_property_frame_count(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2480,7 +2480,7 @@ static int mp_property_dec_imgparams(void *ctx, struct m_property *prop,
     return property_imgparams(&p, action, arg);
 }
 
-static int mp_property_vd_imgparams(void *ctx, struct m_property *prop,
+static int mp_property_vd_imgparams(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2536,7 +2536,7 @@ static int mp_property_video_frame_info(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_current_window_scale(void *ctx, struct m_property *prop,
+static int mp_property_current_window_scale(void *ctx, mp_unused struct m_property *prop,
                                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2586,7 +2586,7 @@ static void update_window_scale(struct MPContext *mpctx)
                                      M_PROPERTY_SET, (void*)&scale);
 }
 
-static int mp_property_display_fps(void *ctx, struct m_property *prop,
+static int mp_property_display_fps(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2603,7 +2603,7 @@ static int mp_property_display_fps(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_estimated_display_fps(void *ctx, struct m_property *prop,
+static int mp_property_estimated_display_fps(void *ctx, mp_unused struct m_property *prop,
                                              int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2616,7 +2616,7 @@ static int mp_property_estimated_display_fps(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, 1.0 / interval);
 }
 
-static int mp_property_vsync_jitter(void *ctx, struct m_property *prop,
+static int mp_property_vsync_jitter(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2646,7 +2646,7 @@ static int mp_property_display_resolution(void *ctx, struct m_property *prop,
     }
 }
 
-static int mp_property_hidpi_scale(void *ctx, struct m_property *prop,
+static int mp_property_hidpi_scale(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2685,7 +2685,7 @@ static void update_hidpi_window_scale(struct MPContext *mpctx, bool hidpi_scale)
     vo_control(vo, VOCTRL_SET_UNFS_WINDOW_SIZE, s);
 }
 
-static int mp_property_focused(void *ctx, struct m_property *prop,
+static int mp_property_focused(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2700,7 +2700,7 @@ static int mp_property_focused(void *ctx, struct m_property *prop,
     return m_property_bool_ro(action, arg, focused);
 }
 
-static int mp_property_display_names(void *ctx, struct m_property *prop,
+static int mp_property_display_names(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2724,7 +2724,7 @@ static int mp_property_display_names(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_vo_configured(void *ctx, struct m_property *prop,
+static int mp_property_vo_configured(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2761,7 +2761,7 @@ static char *asprint_perf(char *res, struct mp_frame_perf *perf)
     return res;
 }
 
-static int mp_property_vo_passes(void *ctx, struct m_property *prop,
+static int mp_property_vo_passes(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2813,7 +2813,7 @@ static int mp_property_vo_passes(void *ctx, struct m_property *prop,
     return M_PROPERTY_OK;
 }
 
-static int mp_property_perf_info(void *ctx, struct m_property *p, int action,
+static int mp_property_perf_info(void *ctx, mp_unused struct m_property *p, int action,
                                  void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2830,21 +2830,22 @@ static int mp_property_perf_info(void *ctx, struct m_property *p, int action,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_vo(void *ctx, struct m_property *p, int action, void *arg)
+static int mp_property_vo(void *ctx, mp_unused struct m_property *p, int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_strdup_ro(action, arg, mpctx->video_out ?
                                 mpctx->video_out->driver->name : NULL);
 }
 
-static int mp_property_gpu_context(void *ctx, struct m_property *p, int action, void *arg)
+static int mp_property_gpu_context(void *ctx, mp_unused struct m_property *p,
+                                   int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return m_property_strdup_ro(action, arg, mpctx->video_out ?
                                 mpctx->video_out->context_name : NULL);
 }
 
-static int mp_property_osd_dim(void *ctx, struct m_property *prop,
+static int mp_property_osd_dim(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2871,7 +2872,7 @@ static int mp_property_osd_dim(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_osd_sym(void *ctx, struct m_property *prop,
+static int mp_property_osd_sym(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2880,7 +2881,7 @@ static int mp_property_osd_sym(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, temp);
 }
 
-static int mp_property_osd_ass(void *ctx, struct m_property *prop,
+static int mp_property_osd_ass(mp_unused void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     struct m_sub_property props[] = {
@@ -2891,7 +2892,7 @@ static int mp_property_osd_ass(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_term_size(void *ctx, struct m_property *prop,
+static int mp_property_term_size(mp_unused void *ctx, mp_unused struct m_property *prop,
                                   int action, void *arg)
 {
     int w = -1, h = -1;
@@ -2908,7 +2909,7 @@ static int mp_property_term_size(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_mouse_pos(void *ctx, struct m_property *prop,
+static int mp_property_mouse_pos(void *ctx, mp_unused struct m_property *prop,
                                     int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2951,7 +2952,7 @@ static int get_touch_pos(int item, int action, void *arg, void *ctx)
 }
 
 #define MAX_TOUCH_POINTS 10
-static int mp_property_touch_pos(void *ctx, struct m_property *prop,
+static int mp_property_touch_pos(void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2963,7 +2964,7 @@ static int mp_property_touch_pos(void *ctx, struct m_property *prop,
 }
 
 /// Video fps (RO)
-static int mp_property_fps(void *ctx, struct m_property *prop,
+static int mp_property_fps(void *ctx, mp_unused struct m_property *prop,
                            int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -2973,7 +2974,7 @@ static int mp_property_fps(void *ctx, struct m_property *prop,
     return m_property_float_ro(action, arg, fps);
 }
 
-static int mp_property_vf_fps(void *ctx, struct m_property *prop,
+static int mp_property_vf_fps(void *ctx, mp_unused struct m_property *prop,
                               int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3055,7 +3056,7 @@ static int mp_property_sub_pos(void *ctx, struct m_property *prop,
     return mp_property_generic_option(mpctx, prop, action, arg);
 }
 
-static int mp_property_sub_ass_extradata(void *ctx, struct m_property *prop,
+static int mp_property_sub_ass_extradata(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3122,7 +3123,7 @@ static int mp_property_sub_text(void *ctx, struct m_property *prop,
 }
 
 static struct sd_times get_times(void *ctx, struct m_property *prop,
-                                int action, void *arg)
+                                mp_unused int action, mp_unused void *arg)
 {
     struct sd_times res = { .start = MP_NOPTS_VALUE, .end = MP_NOPTS_VALUE };
     MPContext *mpctx = ctx;
@@ -3154,7 +3155,7 @@ static int mp_property_sub_end(void *ctx, struct m_property *prop,
     return property_time(action, arg, end);
 }
 
-static int mp_property_playlist_current_pos(void *ctx, struct m_property *prop,
+static int mp_property_playlist_current_pos(void *ctx, mp_unused struct m_property *prop,
                                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3178,7 +3179,7 @@ static int mp_property_playlist_current_pos(void *ctx, struct m_property *prop,
 }
 
 
-static int mp_property_playlist_playing_pos(void *ctx, struct m_property *prop,
+static int mp_property_playlist_playing_pos(void *ctx, mp_unused struct m_property *prop,
                                             int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3187,7 +3188,7 @@ static int mp_property_playlist_playing_pos(void *ctx, struct m_property *prop,
                              playlist_entry_to_index(pl, mpctx->playing));
 }
 
-static int mp_property_playlist_pos_x(void *ctx, struct m_property *prop,
+static int mp_property_playlist_pos_x(void *ctx, mp_unused struct m_property *prop,
                                       int action, void *arg, int base)
 {
     MPContext *mpctx = ctx;
@@ -3257,7 +3258,7 @@ static int get_playlist_entry(int item, int action, void *arg, void *ctx)
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_playlist_path(void *ctx, struct m_property *prop,
+static int mp_property_playlist_path(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3268,7 +3269,7 @@ static int mp_property_playlist_path(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, e->playlist_path);
 }
 
-static int mp_property_playlist(void *ctx, struct m_property *prop,
+static int mp_property_playlist(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3326,7 +3327,7 @@ static char *print_obj_osd_list(struct m_obj_settings *list)
 }
 
 static int property_filter(struct m_property *prop, int action, void *arg,
-                           MPContext *mpctx, enum stream_type mt)
+                           MPContext *mpctx, mp_unused enum stream_type mt)
 {
     if (action == M_PROPERTY_PRINT) {
         struct m_config_option *opt = m_config_get_co(mpctx->mconfig,
@@ -3397,7 +3398,7 @@ static int mp_property_packet_bitrate(void *ctx, struct m_property *prop,
     return m_property_int64_ro(action, arg, llrint(rate));
 }
 
-static int mp_property_cwd(void *ctx, struct m_property *prop,
+static int mp_property_cwd(mp_unused void *ctx, mp_unused struct m_property *prop,
                            int action, void *arg)
 {
     switch (action) {
@@ -3415,7 +3416,7 @@ static int mp_property_cwd(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_protocols(void *ctx, struct m_property *prop,
+static int mp_property_protocols(mp_unused void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     switch (action) {
@@ -3429,7 +3430,7 @@ static int mp_property_protocols(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_keylist(void *ctx, struct m_property *prop,
+static int mp_property_keylist(mp_unused void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     switch (action) {
@@ -3458,7 +3459,7 @@ static int get_decoder_entry(int item, int action, void *arg, void *ctx)
     return m_property_read_sub(props, action, arg);
 }
 
-static int mp_property_decoders(void *ctx, struct m_property *prop,
+static int mp_property_decoders(mp_unused void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     struct mp_decoder_list *codecs = talloc_zero(NULL, struct mp_decoder_list);
@@ -3472,7 +3473,7 @@ static int mp_property_decoders(void *ctx, struct m_property *prop,
     return r;
 }
 
-static int mp_property_encoders(void *ctx, struct m_property *prop,
+static int mp_property_encoders(mp_unused void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     struct mp_decoder_list *codecs = talloc_zero(NULL, struct mp_decoder_list);
@@ -3483,7 +3484,7 @@ static int mp_property_encoders(void *ctx, struct m_property *prop,
     return r;
 }
 
-static int mp_property_lavf_demuxers(void *ctx, struct m_property *prop,
+static int mp_property_lavf_demuxers(mp_unused void *ctx, mp_unused struct m_property *prop,
                                  int action, void *arg)
 {
     switch (action) {
@@ -3497,31 +3498,31 @@ static int mp_property_lavf_demuxers(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_version(void *ctx, struct m_property *prop,
+static int mp_property_version(mp_unused void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     return m_property_strdup_ro(action, arg, mpv_version);
 }
 
-static int mp_property_configuration(void *ctx, struct m_property *prop,
+static int mp_property_configuration(mp_unused void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     return m_property_strdup_ro(action, arg, CONFIGURATION);
 }
 
-static int mp_property_ffmpeg(void *ctx, struct m_property *prop,
+static int mp_property_ffmpeg(mp_unused void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     return m_property_strdup_ro(action, arg, av_version_info());
 }
 
-static int mp_property_libass_version(void *ctx, struct m_property *prop,
+static int mp_property_libass_version(mp_unused void *ctx, mp_unused struct m_property *prop,
                                       int action, void *arg)
 {
     return m_property_int64_ro(action, arg, ass_library_version());
 }
 
-static int mp_property_platform(void *ctx, struct m_property *prop,
+static int mp_property_platform(mp_unused void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     return m_property_strdup_ro(action, arg, PLATFORM);
@@ -3598,21 +3599,21 @@ static int access_option_list(int action, void *arg, bool local, MPContext *mpct
 }
 
 
-static int mp_property_options(void *ctx, struct m_property *prop,
+static int mp_property_options(void *ctx, mp_unused struct m_property *prop,
                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return access_option_list(action, arg, false, mpctx);
 }
 
-static int mp_property_local_options(void *ctx, struct m_property *prop,
+static int mp_property_local_options(void *ctx, mp_unused struct m_property *prop,
                                      int action, void *arg)
 {
     MPContext *mpctx = ctx;
     return access_option_list(action, arg, true, mpctx);
 }
 
-static int mp_property_option_info(void *ctx, struct m_property *prop,
+static int mp_property_option_info(void *ctx, mp_unused struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3688,7 +3689,7 @@ static int mp_property_option_info(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_list(void *ctx, struct m_property *prop,
+static int mp_property_list(void *ctx, mp_unused struct m_property *prop,
                             int action, void *arg)
 {
     struct MPContext *mpctx = ctx;
@@ -3713,7 +3714,7 @@ static int mp_property_list(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_profile_list(void *ctx, struct m_property *prop,
+static int mp_profile_list(void *ctx, mp_unused struct m_property *prop,
                            int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -3729,8 +3730,8 @@ static int mp_profile_list(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_commands(void *ctx, struct m_property *prop,
-                           int action, void *arg)
+static int mp_property_commands(mp_unused void *ctx, mp_unused struct m_property *prop,
+                                int action, void *arg)
 {
     switch (action) {
     case M_PROPERTY_GET_TYPE:
@@ -3767,7 +3768,7 @@ static int mp_property_commands(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_bindings(void *ctx, struct m_property *prop,
+static int mp_property_bindings(void *ctx, mp_unused struct m_property *prop,
                                 int action, void *arg)
 {
     MPContext *mpctx = ctx;
@@ -6100,7 +6101,7 @@ static void subprocess_read(void *p, char *data, size_t size)
     }
 }
 
-static void subprocess_write(void *p)
+static void subprocess_write(mp_unused void *p)
 {
     // Unused; we write a full buffer.
 }
@@ -7244,7 +7245,7 @@ void command_init(struct MPContext *mpctx)
     talloc_free(prop_names);
 }
 
-static void command_event(struct MPContext *mpctx, int event, void *arg)
+static void command_event(struct MPContext *mpctx, int event, mp_unused void *arg)
 {
     struct command_ctx *ctx = mpctx->command_ctx;
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -124,7 +124,7 @@ void mp_abort_recheck_locked(struct MPContext *mpctx,
     }
 }
 
-void mp_abort_trigger_locked(struct MPContext *mpctx,
+void mp_abort_trigger_locked(mp_unused struct MPContext *mpctx,
                              struct mp_abort_entry *abort)
 {
     mp_cancel_trigger(abort->cancel);

--- a/stream/dvb_tune.c
+++ b/stream/dvb_tune.c
@@ -377,7 +377,7 @@ static int do_diseqc(int secfd, int sat_no, int polv, int hi_lo)
 }
 
 static int dvbv5_tune(dvb_priv_t *priv, int fd_frontend,
-                       unsigned int delsys, struct dtv_properties* cmdseq)
+                       mp_unused unsigned int delsys, struct dtv_properties* cmdseq)
 {
     MP_VERBOSE(priv, "Dumping raw tuning commands and values:\n");
     for (int i = 0; i < cmdseq->num; ++i) {

--- a/stream/stream_libarchive.c
+++ b/stream/stream_libarchive.c
@@ -101,7 +101,7 @@ static bool volume_seek(struct mp_archive_volume *vol)
     return r;
 }
 
-static ssize_t read_cb(struct archive *arch, void *priv, const void **buffer)
+static ssize_t read_cb(mp_unused struct archive *arch, void *priv, const void **buffer)
 {
     struct mp_archive_volume *vol = priv;
     if (!vol->src)
@@ -115,7 +115,7 @@ static ssize_t read_cb(struct archive *arch, void *priv, const void **buffer)
 }
 
 // lazy seek to avoid problems with end seeking over http
-static int64_t seek_cb(struct archive *arch, void *priv,
+static int64_t seek_cb(mp_unused struct archive *arch, void *priv,
                        int64_t offset, int whence)
 {
     struct mp_archive_volume *vol = priv;
@@ -142,7 +142,7 @@ static int64_t seek_cb(struct archive *arch, void *priv,
     return vol->seek_to;
 }
 
-static int64_t skip_cb(struct archive *arch, void *priv, int64_t request)
+static int64_t skip_cb(mp_unused struct archive *arch, void *priv, int64_t request)
 {
     struct mp_archive_volume *vol = priv;
     if (!vol->src)
@@ -154,7 +154,7 @@ static int64_t skip_cb(struct archive *arch, void *priv, int64_t request)
     return stream_tell(vol->src) - old;
 }
 
-static int open_cb(struct archive *arch, void *priv)
+static int open_cb(mp_unused struct archive *arch, void *priv)
 {
     struct mp_archive_volume *vol = priv;
     vol->seek_to = -1;
@@ -200,7 +200,7 @@ static void volume_close(struct mp_archive_volume *vol)
     }
 }
 
-static int close_cb(struct archive *arch, void *priv)
+static int close_cb(mp_unused struct archive *arch, void *priv)
 {
     struct mp_archive_volume *vol = priv;
     volume_close(vol);

--- a/stream/stream_memory.c
+++ b/stream/stream_memory.c
@@ -33,7 +33,7 @@ static int fill_buffer(stream_t *s, void *buffer, int len)
     return len;
 }
 
-static int seek(stream_t *s, int64_t newpos)
+static int seek(mp_unused stream_t *s, mp_unused int64_t newpos)
 {
     return 1;
 }

--- a/stream/stream_null.c
+++ b/stream/stream_null.c
@@ -22,7 +22,7 @@
 
 #include "stream.h"
 
-static int open_s(stream_t *stream)
+static int open_s(mp_unused stream_t *stream)
 {
     return 1;
 }

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -545,7 +545,7 @@ void osd_rescale_bitmaps(struct sub_bitmaps *imgs, int frame_w, int frame_h,
 //           read it. You have to free it with talloc_free() when done.
 //  in: valid struct, or NULL (in this case it also returns NULL)
 //  returns: new copy, or NULL if there was no data in the input
-struct sub_bitmaps *sub_bitmaps_copy(struct sub_bitmap_copy_cache **p_cache,
+struct sub_bitmaps *sub_bitmaps_copy(mp_unused struct sub_bitmap_copy_cache **p_cache,
                                      struct sub_bitmaps *in)
 {
     if (!in || !in->num_parts)

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -434,7 +434,7 @@ static struct sub *get_current(struct sd_lavc_priv *priv, double pts)
 }
 
 static struct sub_bitmaps *get_bitmaps(struct sd *sd, struct mp_osd_res d,
-                                       int format, double pts)
+                                       mp_unused int format, double pts)
 {
     struct sd_lavc_priv *priv = sd->priv;
     struct mp_subtitle_opts *opts = sd->opts;

--- a/video/cuda.c
+++ b/video/cuda.c
@@ -22,7 +22,7 @@
 #include <libavutil/hwcontext.h>
 
 static struct AVBufferRef *cuda_create_standalone(struct mpv_global *global,
-        struct mp_log *log, struct hwcontext_create_dev_params *params)
+        mp_unused struct mp_log *log, mp_unused struct hwcontext_create_dev_params *params)
 {
     struct cuda_opts *opts = mp_get_config_group(NULL, global, &cuda_conf);
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -605,8 +605,8 @@ static void select_and_set_hwdec(struct mp_filter *vd)
     }
 }
 
-static int hwdec_opt_help(struct mp_log *log, const m_option_t *opt,
-                          struct bstr name)
+static int hwdec_opt_help(struct mp_log *log, mp_unused const m_option_t *opt,
+                          mp_unused struct bstr name)
 {
     struct hwdec_info *hwdecs = NULL;
     int num_hwdecs = 0;

--- a/video/drmprime.c
+++ b/video/drmprime.c
@@ -23,7 +23,7 @@
 
 extern const struct m_sub_options drm_conf;
 static struct AVBufferRef *drm_create_standalone(struct mpv_global *global,
-        struct mp_log *log, struct hwcontext_create_dev_params *params)
+        mp_unused struct mp_log *log, mp_unused struct hwcontext_create_dev_params *params)
 {
     void *tmp = talloc_new(NULL);
     struct drm_opts *drm_opts = mp_get_config_group(tmp, global, &drm_conf);

--- a/video/filter/vf_gpu.c
+++ b/video/filter/vf_gpu.c
@@ -48,8 +48,8 @@ static inline OPT_STRING_VALIDATE_FUNC(offscreen_ctx_validate_api)
     return M_OPT_INVALID;
 }
 
-static int offscreen_ctx_api_help(struct mp_log *log, const struct m_option *opt,
-                                  struct bstr name)
+static int offscreen_ctx_api_help(struct mp_log *log, mp_unused const struct m_option *opt,
+                                  mp_unused struct bstr name)
 {
     mp_info(log, "GPU APIs (offscreen contexts):\n");
     for (int i = 0; i < MP_ARRAY_SIZE(contexts); i++)

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -251,7 +251,7 @@ static void drain_oldest_buffered_frame(struct priv *p)
 }
 
 static void VS_CC vs_frame_done(void *userData, const VSFrame *f, int n,
-                                VSNode *node, const char *errorMsg)
+                                mp_unused VSNode *node, const char *errorMsg)
 {
     struct priv *p = userData;
 
@@ -434,10 +434,9 @@ done:
     mp_mutex_unlock(&p->lock);
 }
 
-static const VSFrame *VS_CC infiltGetFrame(int frameno, int activationReason,
-    void *instanceData, void **frameData,
-    VSFrameContext *frameCtx, VSCore *core,
-    const VSAPI *vsapi)
+static const VSFrame *VS_CC infiltGetFrame(int frameno, mp_unused int activationReason,
+        void *instanceData, mp_unused void **frameData, VSFrameContext *frameCtx,
+        mp_unused VSCore *core, mp_unused const VSAPI *vsapi)
 {
     struct priv *p = instanceData;
     VSFrame *ret = NULL;
@@ -521,7 +520,8 @@ static const VSFrame *VS_CC infiltGetFrame(int frameno, int activationReason,
     return ret;
 }
 
-static void VS_CC infiltFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
+static void VS_CC infiltFree(void *instanceData, mp_unused VSCore *core,
+                             mp_unused const VSAPI *vsapi)
 {
     struct priv *p = instanceData;
 

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -354,7 +354,7 @@ struct free_args {
     void (*free)(void *arg);
 };
 
-static void call_free(void *opaque, uint8_t *data)
+static void call_free(void *opaque, mp_unused uint8_t *data)
 {
     struct free_args *args = opaque;
     args->free(args->arg);

--- a/video/mp_image_pool.c
+++ b/video/mp_image_pool.c
@@ -102,7 +102,7 @@ void mp_image_pool_clear(struct mp_image_pool *pool)
 
 // This is the only function that is allowed to run in a different thread.
 // (Consider passing an image to another thread, which frees it.)
-static void unref_image(void *opaque, uint8_t *data)
+static void unref_image(void *opaque, mp_unused uint8_t *data)
 {
     struct mp_image *img = opaque;
     struct image_flags *it = img->priv;

--- a/video/out/dr_helper.c
+++ b/video/out/dr_helper.c
@@ -87,7 +87,7 @@ static void dr_thread_free(void *ptr)
     talloc_free(ctx);
 }
 
-static void free_dr_buffer_on_dr_thread(void *opaque, uint8_t *data)
+static void free_dr_buffer_on_dr_thread(void *opaque, mp_unused uint8_t *data)
 {
     struct free_dr_context *ctx = opaque;
     struct dr_helper *dr = ctx->dr;

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -265,7 +265,7 @@ static bool vt_switcher_init(struct vt_switcher *s, struct mp_log *log)
     return true;
 }
 
-static void vt_switcher_interrupt_poll(struct vt_switcher *s)
+static void vt_switcher_interrupt_poll(mp_unused struct vt_switcher *s)
 {
     unsigned char event = EVT_INTERRUPT;
     (void)write(vt_switcher_pipe[1], &event, sizeof(event));
@@ -910,7 +910,7 @@ err:
     drmFreeDevices(devices, card_count);
 }
 
-static void drm_pflip_cb(int fd, unsigned int msc, unsigned int sec,
+static void drm_pflip_cb(mp_unused int fd, unsigned int msc, unsigned int sec,
                          unsigned int usec, void *data)
 {
     struct vo_drm_state *drm = data;
@@ -921,7 +921,7 @@ static void drm_pflip_cb(int fd, unsigned int msc, unsigned int sec,
     drm->waiting_for_flip = false;
 }
 
-int vo_drm_control(struct vo *vo, int *events, int request, void *arg)
+int vo_drm_control(struct vo *vo, mp_unused int *events, int request, void *arg)
 {
     struct vo_drm_state *drm = vo->drm;
     switch (request) {
@@ -1122,7 +1122,8 @@ err:
         drmModeFreeResources(res);
 }
 
-static void drm_show_connector_name_and_state_callback(struct mp_log *log, int card_no,
+static void drm_show_connector_name_and_state_callback(struct mp_log *log,
+                                                       mp_unused int card_no,
                                                        const drmModeConnector *connector)
 {
     char other_connector_name[MAX_CONNECTOR_NAME_LEN];
@@ -1208,22 +1209,22 @@ static void drm_show_available_cards_connectors_and_modes(struct mp_log *log)
     drm_show_foreach_card(log, drm_show_available_connectors_and_modes);
 }
 
-static int drm_connector_opt_help(struct mp_log *log, const struct m_option *opt,
-                                  struct bstr name)
+static int drm_connector_opt_help(struct mp_log *log, mp_unused const struct m_option *opt,
+                                  mp_unused struct bstr name)
 {
     drm_show_available_cards_and_connectors(log);
     return M_OPT_EXIT;
 }
 
-static int drm_mode_opt_help(struct mp_log *log, const struct m_option *opt,
-                             struct bstr name)
+static int drm_mode_opt_help(struct mp_log *log, mp_unused const struct m_option *opt,
+                             mp_unused struct bstr name)
 {
     drm_show_available_cards_connectors_and_modes(log);
     return M_OPT_EXIT;
 }
 
-static int drm_validate_mode_opt(struct mp_log *log, const struct m_option *opt,
-                                 struct bstr name, const char **value)
+static int drm_validate_mode_opt(struct mp_log *log, mp_unused const struct m_option *opt,
+                                 mp_unused struct bstr name, const char **value)
 {
     const char *param = *value;
     if (!parse_mode_spec(param, NULL)) {

--- a/video/out/filter_kernels.c
+++ b/video/out/filter_kernels.c
@@ -178,7 +178,7 @@ void mp_compute_lut(struct filter_kernel *filter, int count, int stride,
 
 typedef struct filter_window params;
 
-static double box(params *p, double x)
+static double box(mp_unused params *p, mp_unused double x)
 {
     // This is mathematically 1.0 everywhere, the clipping is done implicitly
     // based on the radius.
@@ -190,22 +190,22 @@ static double triangle(params *p, double x)
     return fmax(0.0, 1.0 - fabs(x / p->radius));
 }
 
-static double cosine(params *p, double x)
+static double cosine(mp_unused params *p, double x)
 {
     return cos(x);
 }
 
-static double hanning(params *p, double x)
+static double hanning(mp_unused params *p, double x)
 {
     return 0.5 + 0.5 * cos(M_PI * x);
 }
 
-static double hamming(params *p, double x)
+static double hamming(mp_unused params *p, double x)
 {
     return 0.54 + 0.46 * cos(M_PI * x);
 }
 
-static double quadric(params *p, double x)
+static double quadric(mp_unused params *p, double x)
 {
     if (x <  0.5) {
         return 0.75 - x * x;
@@ -246,7 +246,7 @@ static double blackman(params *p, double x)
     return a0 + a1*cos(pix) + a2*cos(2 * pix);
 }
 
-static double welch(params *p, double x)
+static double welch(mp_unused params *p, double x)
 {
     return 1.0 - x*x;
 }
@@ -272,7 +272,7 @@ static double cubic_bc(params *p, double x)
     return 0.0;
 }
 
-static double spline16(params *p, double x)
+static double spline16(mp_unused params *p, double x)
 {
     if (x < 1.0) {
         return ((x - 9.0/5.0 ) * x - 1.0/5.0 ) * x + 1.0;
@@ -281,7 +281,7 @@ static double spline16(params *p, double x)
     }
 }
 
-static double spline36(params *p, double x)
+static double spline36(mp_unused params *p, double x)
 {
     if (x < 1.0) {
         return ((13.0/11.0 * x - 453.0/209.0) * x - 3.0/209.0) * x + 1.0;
@@ -292,7 +292,7 @@ static double spline36(params *p, double x)
     }
 }
 
-static double spline64(params *p, double x)
+static double spline64(mp_unused params *p, double x)
 {
     if (x < 1.0) {
         return ((49.0/41.0 * x - 6387.0/2911.0) * x - 3.0/2911.0) * x + 1.0;
@@ -310,7 +310,7 @@ static double gaussian(params *p, double x)
     return exp(-2.0 * x * x / p->params[0]);
 }
 
-static double sinc(params *p, double x)
+static double sinc(mp_unused params *p, double x)
 {
     if (fabs(x) < 1e-8)
         return 1.0;
@@ -318,7 +318,7 @@ static double sinc(params *p, double x)
     return sin(x) / x;
 }
 
-static double jinc(params *p, double x)
+static double jinc(mp_unused params *p, double x)
 {
     if (fabs(x) < 1e-8)
         return 1.0;
@@ -326,7 +326,7 @@ static double jinc(params *p, double x)
     return 2.0 * j1(x) / x;
 }
 
-static double sphinx(params *p, double x)
+static double sphinx(mp_unused params *p, double x)
 {
     if (fabs(x) < 1e-8)
         return 1.0;

--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -58,12 +58,12 @@ extern const struct ra_ctx_fns ra_ctx_d3d11;
 extern const struct ra_ctx_fns ra_ctx_wldmabuf;
 
 /* Autoprobe dummy. Always fails to create. */
-static bool dummy_init(struct ra_ctx *ctx)
+static bool dummy_init(mp_unused struct ra_ctx *ctx)
 {
     return false;
 }
 
-static void dummy_uninit(struct ra_ctx *ctx)
+static void dummy_uninit(mp_unused struct ra_ctx *ctx)
 {
 }
 
@@ -152,7 +152,7 @@ static bool get_desc(struct m_obj_desc *dst, int index)
     return true;
 }
 
-static bool check_unknown_entry(const char *name)
+static bool check_unknown_entry(mp_unused const char *name)
 {
     return false;
 }

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -177,8 +177,8 @@ int ra_hwdec_mapper_map(struct ra_hwdec_mapper *mapper, struct mp_image *img)
 }
 
 static int ra_hwdec_validate_opt_full(struct mp_log *log, bool include_modes,
-                                      const m_option_t *opt,
-                                      struct bstr name, const char **value)
+                                      mp_unused const m_option_t *opt,
+                                      mp_unused struct bstr name, const char **value)
 {
     struct bstr param = bstr0(*value);
     bool help = bstr_equals0(param, "help");

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -54,7 +54,7 @@ struct gl_lcms {
     struct mp_icc_opts *opts;
 };
 
-static void lcms2_error_handler(cmsContext ctx, cmsUInt32Number code,
+static void lcms2_error_handler(cmsContext ctx, mp_unused cmsUInt32Number code,
                                 const char *msg)
 {
     struct gl_lcms *p = cmsGetContextUserData(ctx);

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -504,7 +504,7 @@ static void update_ubo(struct ra *ra, struct ra_buf *ubo, struct sc_uniform *u)
     }
 }
 
-static void update_pushc(struct ra *ra, void *pushc, struct sc_uniform *u)
+static void update_pushc(mp_unused struct ra *ra, void *pushc, struct sc_uniform *u)
 {
     uintptr_t src = (uintptr_t) &u->v;
     uintptr_t dst = (uintptr_t) pushc + (ptrdiff_t) u->offset;

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1936,15 +1936,15 @@ static bool image_equiv(struct image a, struct image b)
 }
 
 static void deband_hook(struct gl_video *p, struct image img,
-                        struct gl_transform *trans, void *priv)
+                        mp_unused struct gl_transform *trans, mp_unused void *priv)
 {
     pass_describe(p, "debanding (%s)", plane_names[img.type]);
     pass_sample_deband(p->sc, p->opts.deband_opts, &p->lfg,
                        p->image_params.color.transfer);
 }
 
-static void unsharp_hook(struct gl_video *p, struct image img,
-                         struct gl_transform *trans, void *priv)
+static void unsharp_hook(struct gl_video *p, mp_unused struct image img,
+                         mp_unused struct gl_transform *trans, mp_unused void *priv)
 {
     pass_describe(p, "unsharp masking");
     pass_sample_unsharp(p->sc, p->opts.unsharp);
@@ -4196,7 +4196,7 @@ void gl_video_configure_queue(struct gl_video *p, struct vo *vo)
     vo_set_queue_params(vo, 0, queue_size);
 }
 
-static int validate_scaler_opt(struct mp_log *log, const m_option_t *opt,
+static int validate_scaler_opt(struct mp_log *log, mp_unused const m_option_t *opt,
                                struct bstr name, const char **value)
 {
     struct bstr param = bstr0(*value);
@@ -4239,8 +4239,8 @@ next_window: ;
     return r;
 }
 
-static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
-                               struct bstr name, const char **value)
+static int validate_window_opt(struct mp_log *log, mp_unused const m_option_t *opt,
+                               mp_unused struct bstr name, const char **value)
 {
     struct bstr param = bstr0(*value);
     char s[32] = {0};
@@ -4265,8 +4265,8 @@ static int validate_window_opt(struct mp_log *log, const m_option_t *opt,
     return r;
 }
 
-static int validate_error_diffusion_opt(struct mp_log *log, const m_option_t *opt,
-                                        struct bstr name, const char **value)
+static int validate_error_diffusion_opt(struct mp_log *log, mp_unused const m_option_t *opt,
+                                        mp_unused struct bstr name, const char **value)
 {
     struct bstr param = bstr0(*value);
     char s[32] = {0};

--- a/video/out/hwdec/dmabuf_interop_pl.c
+++ b/video/out/hwdec/dmabuf_interop_pl.c
@@ -23,7 +23,7 @@
 #include "video/out/placebo/utils.h"
 
 static bool vaapi_pl_map(struct ra_hwdec_mapper *mapper,
-                         struct dmabuf_interop *dmabuf_interop,
+                         mp_unused struct dmabuf_interop *dmabuf_interop,
                          bool probing)
 {
     struct dmabuf_interop_priv *p = mapper->priv;

--- a/video/out/hwdec/dmabuf_interop_wl.c
+++ b/video/out/hwdec/dmabuf_interop_wl.c
@@ -17,19 +17,19 @@
 #include "video/out/wldmabuf/ra_wldmabuf.h"
 #include "dmabuf_interop.h"
 
-static bool mapper_init(struct ra_hwdec_mapper *mapper,
-                        const struct ra_imgfmt_desc *desc)
+static bool mapper_init(mp_unused struct ra_hwdec_mapper *mapper,
+                        mp_unused const struct ra_imgfmt_desc *desc)
 {
     return true;
 }
 
-static void mapper_uninit(const struct ra_hwdec_mapper *mapper)
+static void mapper_uninit(mp_unused const struct ra_hwdec_mapper *mapper)
 {
 }
 
 static bool map(struct ra_hwdec_mapper *mapper,
                 struct dmabuf_interop *dmabuf_interop,
-                bool probing)
+                mp_unused bool probing)
 {
     // 1. only validate format when composed layers is enabled (i.e. vaapi)
     // 2. for drmprime, just return true for now, as this use case
@@ -61,7 +61,7 @@ static bool map(struct ra_hwdec_mapper *mapper,
     return true;
 }
 
-static void unmap(struct ra_hwdec_mapper *mapper)
+static void unmap(mp_unused struct ra_hwdec_mapper *mapper)
 {
 }
 

--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -221,7 +221,7 @@ static void mapper_uninit(struct ra_hwdec_mapper *mapper)
     CHECK_CU(cu->cuCtxPopCurrent(&dummy));
 }
 
-static void mapper_unmap(struct ra_hwdec_mapper *mapper)
+static void mapper_unmap(mp_unused struct ra_hwdec_mapper *mapper)
 {
 }
 

--- a/video/out/hwdec/hwdec_drmprime_overlay.c
+++ b/video/out/hwdec/hwdec_drmprime_overlay.c
@@ -140,7 +140,7 @@ static void disable_video_plane(struct ra_hwdec *hw)
 }
 
 static int overlay_frame(struct ra_hwdec *hw, struct mp_image *hw_image,
-                         struct mp_rect *src, struct mp_rect *dst, bool newframe)
+                         struct mp_rect *src, struct mp_rect *dst, mp_unused bool newframe)
 {
     struct priv *p = hw->priv;
     AVDRMFrameDescriptor *desc = NULL;

--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -206,7 +206,7 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
     return 0;
 }
 
-static void mapper_uninit(struct ra_hwdec_mapper *mapper)
+static void mapper_uninit(mp_unused struct ra_hwdec_mapper *mapper)
 {
 
 }

--- a/video/out/libmpv_sw.c
+++ b/video/out/libmpv_sw.c
@@ -45,7 +45,8 @@ static bool check_format(struct render_backend *ctx, int imgfmt)
     return mp_sws_supports_formats(p->sws, IMGFMT_RGB0, imgfmt);
 }
 
-static int set_parameter(struct render_backend *ctx, mpv_render_param param)
+static int set_parameter(mp_unused struct render_backend *ctx,
+                         mp_unused mpv_render_param param)
 {
     return MPV_ERROR_NOT_IMPLEMENTED;
 }
@@ -58,7 +59,7 @@ static void reconfig(struct render_backend *ctx, struct mp_image_params *params)
     p->anything_changed = true;
 }
 
-static void reset(struct render_backend *ctx)
+static void reset(mp_unused struct render_backend *ctx)
 {
     // stateless
 }
@@ -81,7 +82,7 @@ static void resize(struct render_backend *ctx, struct mp_rect *src,
     p->anything_changed = true;
 }
 
-static int get_target_size(struct render_backend *ctx, mpv_render_param *params,
+static int get_target_size(mp_unused struct render_backend *ctx, mpv_render_param *params,
                            int *out_w, int *out_h)
 {
     int *sz = get_mpv_render_param(params, MPV_RENDER_PARAM_SW_SIZE, NULL);
@@ -189,7 +190,7 @@ static int render(struct render_backend *ctx, mpv_render_param *params,
     return 0;
 }
 
-static void destroy(struct render_backend *ctx)
+static void destroy(mp_unused struct render_backend *ctx)
 {
     // nop
 }

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -59,7 +59,7 @@ static bool is_fast_dr(GL *gl)
            strcasecmp(vendor, "ATI Technologies Inc.") == 0;    // AMD on Windows
 }
 
-static void GLAPIENTRY dummy_glBindFramebuffer(GLenum target, GLuint framebuffer)
+static void GLAPIENTRY dummy_glBindFramebuffer(mp_unused GLenum target, GLuint framebuffer)
 {
     assert(framebuffer == 0);
 }

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -254,7 +254,7 @@ static bool init_gbm(struct ra_ctx *ctx)
     return true;
 }
 
-static void framebuffer_destroy_callback(struct gbm_bo *bo, void *data)
+static void framebuffer_destroy_callback(mp_unused struct gbm_bo *bo, void *data)
 {
     struct framebuffer *fb = data;
     if (fb) {

--- a/video/out/opengl/egl_helpers.c
+++ b/video/out/opengl/egl_helpers.c
@@ -93,7 +93,7 @@ static void dump_egl_config(struct mp_log *log, int msgl, EGLDisplay display,
     }
 }
 
-static void *mpegl_get_proc_address(void *ctx, const char *name)
+static void *mpegl_get_proc_address(mp_unused void *ctx, const char *name)
 {
     void *p = eglGetProcAddress(name);
 #if defined(__GLIBC__) && HAVE_LIBDL

--- a/video/out/opengl/ra_gl.c
+++ b/video/out/opengl/ra_gl.c
@@ -717,7 +717,7 @@ static void gl_blit(struct ra *ra, struct ra_tex *dst, struct ra_tex *src,
     gl->BindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }
 
-static int gl_desc_namespace(struct ra *ra, enum ra_vartype type)
+static int gl_desc_namespace(mp_unused struct ra *ra, enum ra_vartype type)
 {
     return type;
 }

--- a/video/out/opengl/utils.c
+++ b/video/out/opengl/utils.c
@@ -241,8 +241,9 @@ void gl_vao_draw_data(struct gl_vao *vao, GLenum prim, void *ptr, size_t num)
     gl_vao_unbind(vao);
 }
 
-static void GLAPIENTRY gl_debug_cb(GLenum source, GLenum type, GLuint id,
-                                   GLenum severity, GLsizei length,
+static void GLAPIENTRY gl_debug_cb(mp_unused GLenum source, mp_unused GLenum type,
+                                   mp_unused GLuint id, GLenum severity,
+                                   mp_unused GLsizei length,
                                    const GLchar *message, const void *userParam)
 {
     // keep in mind that the debug callback can be asynchronous

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -285,7 +285,7 @@ static bool buf_poll_pl(struct ra *ra, struct ra_buf *buf)
 }
 
 static void clear_pl(struct ra *ra, struct ra_tex *dst, float color[4],
-                     struct mp_rect *scissor)
+                     mp_unused struct mp_rect *scissor)
 {
     // TODO: implement scissor clearing by bltting a 1x1 tex instead
     pl_tex_clear(get_gpu(ra), dst->priv, color);

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -105,7 +105,7 @@ struct priv {
     uint64_t drm_modifier;
 };
 
-static void buffer_handle_release(void *data, struct wl_buffer *wl_buffer)
+static void buffer_handle_release(void *data, mp_unused struct wl_buffer *wl_buffer)
 {
     struct buffer *buf = data;
     if (buf->frame) {
@@ -118,7 +118,7 @@ static const struct wl_buffer_listener buffer_listener = {
     buffer_handle_release,
 };
 
-static void osd_buffer_handle_release(void *data, struct wl_buffer *wl_buffer)
+static void osd_buffer_handle_release(void *data, mp_unused struct wl_buffer *wl_buffer)
 {
     struct osd_buffer *osd_buf = data;
     wl_list_remove(&osd_buf->link);
@@ -662,7 +662,7 @@ static bool is_supported_fmt(int fmt)
     return (fmt == IMGFMT_DRMPRIME || fmt == IMGFMT_VAAPI);
 }
 
-static int query_format(struct vo *vo, int format)
+static int query_format(mp_unused struct vo *vo, int format)
 {
     return is_supported_fmt(format);
 }

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -556,7 +556,7 @@ static pl_tex hwdec_get_tex(struct priv *p, int n)
     return false;
 }
 
-static bool hwdec_acquire(pl_gpu gpu, struct pl_frame *frame)
+static bool hwdec_acquire(mp_unused pl_gpu gpu, struct pl_frame *frame)
 {
     struct mp_image *mpi = frame->user_data;
     struct frame_priv *fp = mpi->priv;
@@ -577,7 +577,7 @@ static bool hwdec_acquire(pl_gpu gpu, struct pl_frame *frame)
     return true;
 }
 
-static void hwdec_release(pl_gpu gpu, struct pl_frame *frame)
+static void hwdec_release(mp_unused pl_gpu gpu, struct pl_frame *frame)
 {
     struct mp_image *mpi = frame->user_data;
     struct frame_priv *fp = mpi->priv;
@@ -721,7 +721,7 @@ static bool map_frame(pl_gpu gpu, pl_tex *tex, const struct pl_source_frame *src
     return true;
 }
 
-static void unmap_frame(pl_gpu gpu, struct pl_frame *frame,
+static void unmap_frame(mp_unused pl_gpu gpu, mp_unused struct pl_frame *frame,
                         const struct pl_source_frame *src)
 {
     struct mp_image *mpi = src->frame_data;
@@ -1224,7 +1224,7 @@ static void resize(struct vo *vo)
     p->dst = dst;
 }
 
-static int reconfig(struct vo *vo, struct mp_image_params *params)
+static int reconfig(struct vo *vo, mp_unused struct mp_image_params *params)
 {
     struct priv *p = vo->priv;
     if (!p->ra_ctx->fns->reconfig(p->ra_ctx))

--- a/video/out/vo_image.c
+++ b/video/out/vo_image.c
@@ -123,14 +123,14 @@ static void flip_page(struct vo *vo)
     talloc_free(t);
 }
 
-static int query_format(struct vo *vo, int fmt)
+static int query_format(mp_unused struct vo *vo, int fmt)
 {
     if (mp_sws_supported_format(fmt))
         return 1;
     return 0;
 }
 
-static void uninit(struct vo *vo)
+static void uninit(mp_unused struct vo *vo)
 {
 }
 
@@ -143,7 +143,7 @@ static int preinit(struct vo *vo)
     return 0;
 }
 
-static int control(struct vo *vo, uint32_t request, void *data)
+static int control(mp_unused struct vo *vo, mp_unused uint32_t request, mp_unused void *data)
 {
     return VO_NOTIMPL;
 }

--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -369,12 +369,12 @@ static int preinit(struct vo *vo)
     return 0;
 }
 
-static int query_format(struct vo *vo, int format)
+static int query_format(mp_unused struct vo *vo, int format)
 {
     return format == IMGFMT;
 }
 
-static int control(struct vo *vo, uint32_t request, void *data)
+static int control(struct vo *vo, uint32_t request, mp_unused void *data)
 {
     if (request == VOCTRL_SET_PANSCAN)
         return (vo->config_ok && !reconfig(vo, vo->params)) ? VO_TRUE : VO_FALSE;

--- a/video/out/vo_lavc.c
+++ b/video/out/vo_lavc.c
@@ -236,11 +236,11 @@ static void draw_frame(struct vo *vo, struct vo_frame *voframe)
     av_frame_free(&frame);
 }
 
-static void flip_page(struct vo *vo)
+static void flip_page(mp_unused struct vo *vo)
 {
 }
 
-static int control(struct vo *vo, uint32_t request, void *data)
+static int control(mp_unused struct vo *vo, mp_unused uint32_t request, mp_unused void *data)
 {
     return VO_NOTIMPL;
 }

--- a/video/out/vo_null.c
+++ b/video/out/vo_null.c
@@ -32,7 +32,7 @@ struct priv {
     double cfg_fps;
 };
 
-static void draw_frame(struct vo *vo, struct vo_frame *frame)
+static void draw_frame(mp_unused struct vo *vo, mp_unused struct vo_frame *frame)
 {
 }
 
@@ -52,21 +52,21 @@ static void flip_page(struct vo *vo)
     }
 }
 
-static int query_format(struct vo *vo, int format)
+static int query_format(mp_unused struct vo *vo, mp_unused int format)
 {
     return 1;
 }
 
-static int reconfig(struct vo *vo, struct mp_image_params *params)
+static int reconfig(mp_unused struct vo *vo, mp_unused struct mp_image_params *params)
 {
     return 0;
 }
 
-static void uninit(struct vo *vo)
+static void uninit(mp_unused struct vo *vo)
 {
 }
 
-static int preinit(struct vo *vo)
+static int preinit(mp_unused struct vo *vo)
 {
     return 0;
 }

--- a/video/out/vo_sixel.c
+++ b/video/out/vo_sixel.c
@@ -538,12 +538,12 @@ static int preinit(struct vo *vo)
     return 0;
 }
 
-static int query_format(struct vo *vo, int format)
+static int query_format(mp_unused struct vo *vo, int format)
 {
     return format == IMGFMT;
 }
 
-static int control(struct vo *vo, uint32_t request, void *data)
+static int control(struct vo *vo, uint32_t request, mp_unused void *data)
 {
     if (request == VOCTRL_SET_PANSCAN)
         return (vo->config_ok && !reconfig(vo, vo->params)) ? VO_TRUE : VO_FALSE;

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -336,12 +336,12 @@ static int preinit(struct vo *vo)
     return 0;
 }
 
-static int query_format(struct vo *vo, int format)
+static int query_format(mp_unused struct vo *vo, int format)
 {
     return format == IMGFMT;
 }
 
-static int control(struct vo *vo, uint32_t request, void *data)
+static int control(mp_unused struct vo *vo, mp_unused uint32_t request, mp_unused void *data)
 {
     return VO_NOTIMPL;
 }

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -49,7 +49,7 @@ struct priv {
     struct mp_osd_res osd;
 };
 
-static void buffer_handle_release(void *data, struct wl_buffer *wl_buffer)
+static void buffer_handle_release(void *data, mp_unused struct wl_buffer *wl_buffer)
 {
     struct buffer *buf = data;
     struct vo *vo = buf->vo;

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -166,7 +166,7 @@ static void freeMyXImage(struct priv *p, int foo)
 
 #define MAKE_MASK(comp) (((1ul << (comp).size) - 1) << (comp).offset)
 
-static int reconfig(struct vo *vo, struct mp_image_params *fmt)
+static int reconfig(struct vo *vo, mp_unused struct mp_image_params *fmt)
 {
     vo_x11_config_vo_window(vo);
 
@@ -276,7 +276,7 @@ static bool resize(struct vo *vo)
     return true;
 }
 
-static void Display_Image(struct priv *p, XImage *myximage)
+static void Display_Image(struct priv *p, mp_unused XImage *myximage)
 {
     struct vo *vo = p->vo;
 

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -335,7 +335,7 @@ static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
     return true;
 }
 
-static bool submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
+static bool submit_frame(struct ra_swapchain *sw, mp_unused const struct vo_frame *frame)
 {
     struct priv *p = sw->priv;
     return pl_swapchain_submit_frame(p->vk->swapchain);

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -215,8 +215,8 @@ done:
     return ret;
 }
 
-static int print_display_info(struct mp_log *log, const struct m_option *opt,
-                              struct bstr name)
+static int print_display_info(struct mp_log *log, mp_unused const struct m_option *opt,
+                              mp_unused struct bstr name)
 {
     void *ta_ctx = talloc_new(NULL);
     pl_log pllog = mppl_log_create(ta_ctx, log);
@@ -469,17 +469,18 @@ static bool display_reconfig(struct ra_ctx *ctx)
     return ra_vk_ctx_resize(ctx, p->width, p->height);
 }
 
-static int display_control(struct ra_ctx *ctx, int *events, int request, void *arg)
+static int display_control(mp_unused struct ra_ctx *ctx, mp_unused int *events,
+                           mp_unused int request, mp_unused void *arg)
 {
     return VO_NOTIMPL;
 }
 
-static void display_wakeup(struct ra_ctx *ctx)
+static void display_wakeup(mp_unused struct ra_ctx *ctx)
 {
     // TODO
 }
 
-static void display_wait_events(struct ra_ctx *ctx, int64_t until_time_ns)
+static void display_wait_events(mp_unused struct ra_ctx *ctx, mp_unused int64_t until_time_ns)
 {
     // TODO
 }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -219,8 +219,8 @@ static void update_output_geometry(struct vo_wayland_state *wl, struct mp_rect o
                                    struct mp_rect old_output_geometry);
 
 /* Wayland listener boilerplate */
-static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
-                                 uint32_t serial, struct wl_surface *surface,
+static void pointer_handle_enter(void *data, mp_unused struct wl_pointer *pointer,
+                                 uint32_t serial, mp_unused struct wl_surface *surface,
                                  wl_fixed_t sx, wl_fixed_t sy)
 {
     struct vo_wayland_seat *s = data;
@@ -238,16 +238,17 @@ static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
     wl->toplevel_configured = false;
 }
 
-static void pointer_handle_leave(void *data, struct wl_pointer *pointer,
-                                 uint32_t serial, struct wl_surface *surface)
+static void pointer_handle_leave(void *data, mp_unused struct wl_pointer *pointer,
+                                 mp_unused uint32_t serial,
+                                 mp_unused struct wl_surface *surface)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
     mp_input_put_key(wl->vo->input_ctx, MP_KEY_MOUSE_LEAVE);
 }
 
-static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
-                                  uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
+static void pointer_handle_motion(void *data, mp_unused struct wl_pointer *pointer,
+                                  mp_unused uint32_t time, wl_fixed_t sx, wl_fixed_t sy)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -260,9 +261,9 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
     wl->toplevel_configured = false;
 }
 
-static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
-                                  uint32_t serial, uint32_t time, uint32_t button,
-                                  uint32_t state)
+static void pointer_handle_button(void *data, mp_unused struct wl_pointer *wl_pointer,
+                                  uint32_t serial, mp_unused uint32_t time,
+                                  uint32_t button, uint32_t state)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -315,8 +316,8 @@ static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
     }
 }
 
-static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
-                                uint32_t time, uint32_t axis, wl_fixed_t value)
+static void pointer_handle_axis(void *data, mp_unused struct wl_pointer *wl_pointer,
+                                mp_unused uint32_t time, uint32_t axis, wl_fixed_t value)
 {
     struct vo_wayland_seat *s = data;
     switch (axis) {
@@ -329,7 +330,7 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
     }
 }
 
-static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer)
+static void pointer_handle_frame(void *data, mp_unused struct wl_pointer *wl_pointer)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -364,22 +365,26 @@ static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer)
     s->axis_value120_horizontal = 0;
 }
 
-static void pointer_handle_axis_source(void *data, struct wl_pointer *wl_pointer,
-                                       uint32_t axis_source)
+static void pointer_handle_axis_source(mp_unused void *data,
+                                       mp_unused struct wl_pointer *wl_pointer,
+                                       mp_unused uint32_t axis_source)
 {
 }
 
-static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
-                                     uint32_t time, uint32_t axis)
+static void pointer_handle_axis_stop(mp_unused void *data,
+                                     mp_unused struct wl_pointer *wl_pointer,
+                                     mp_unused uint32_t time, mp_unused uint32_t axis)
 {
 }
 
-static void pointer_handle_axis_discrete(void *data, struct wl_pointer *wl_pointer,
-                                         uint32_t axis, int32_t discrete)
+static void pointer_handle_axis_discrete(mp_unused void *data,
+                                         mp_unused struct wl_pointer *wl_pointer,
+                                         mp_unused uint32_t axis,
+                                         mp_unused int32_t discrete)
 {
 }
 
-static void pointer_handle_axis_value120(void *data, struct wl_pointer *wl_pointer,
+static void pointer_handle_axis_value120(void *data, mp_unused struct wl_pointer *wl_pointer,
                                          uint32_t axis, int32_t value120)
 {
     struct vo_wayland_seat *s = data;
@@ -407,8 +412,9 @@ static const struct wl_pointer_listener pointer_listener = {
     pointer_handle_axis_value120,
 };
 
-static void touch_handle_down(void *data, struct wl_touch *wl_touch,
-                              uint32_t serial, uint32_t time, struct wl_surface *surface,
+static void touch_handle_down(void *data, mp_unused struct wl_touch *wl_touch,
+                              uint32_t serial, mp_unused uint32_t time,
+                              mp_unused struct wl_surface *surface,
                               int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
 {
     struct vo_wayland_seat *s = data;
@@ -431,8 +437,8 @@ static void touch_handle_down(void *data, struct wl_touch *wl_touch,
     }
 }
 
-static void touch_handle_up(void *data, struct wl_touch *wl_touch,
-                            uint32_t serial, uint32_t time, int32_t id)
+static void touch_handle_up(void *data, mp_unused struct wl_touch *wl_touch,
+                            mp_unused uint32_t serial, mp_unused uint32_t time, int32_t id)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -440,8 +446,9 @@ static void touch_handle_up(void *data, struct wl_touch *wl_touch,
     wl->last_button_seat = NULL;
 }
 
-static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
-                                uint32_t time, int32_t id, wl_fixed_t x_w, wl_fixed_t y_w)
+static void touch_handle_motion(void *data, mp_unused struct wl_touch *wl_touch,
+                                mp_unused uint32_t time, int32_t id,
+                                wl_fixed_t x_w, wl_fixed_t y_w)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -452,24 +459,27 @@ static void touch_handle_motion(void *data, struct wl_touch *wl_touch,
     mp_input_update_touch_point(wl->vo->input_ctx, id, wl->mouse_x, wl->mouse_y);
 }
 
-static void touch_handle_frame(void *data, struct wl_touch *wl_touch)
+static void touch_handle_frame(mp_unused void *data, mp_unused struct wl_touch *wl_touch)
 {
 }
 
-static void touch_handle_cancel(void *data, struct wl_touch *wl_touch)
+static void touch_handle_cancel(void *data, mp_unused struct wl_touch *wl_touch)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
     mp_input_put_key(wl->vo->input_ctx, MP_TOUCH_RELEASE_ALL);
 }
 
-static void touch_handle_shape(void *data, struct wl_touch *wl_touch,
-                               int32_t id, wl_fixed_t major, wl_fixed_t minor)
+static void touch_handle_shape(mp_unused void *data, mp_unused struct wl_touch *wl_touch,
+                               mp_unused int32_t id, mp_unused wl_fixed_t major,
+                               mp_unused wl_fixed_t minor)
 {
 }
 
-static void touch_handle_orientation(void *data, struct wl_touch *wl_touch,
-                                     int32_t id, wl_fixed_t orientation)
+static void touch_handle_orientation(mp_unused void *data,
+                                     mp_unused struct wl_touch *wl_touch,
+                                     mp_unused int32_t id,
+                                     mp_unused wl_fixed_t orientation)
 {
 }
 
@@ -483,7 +493,7 @@ static const struct wl_touch_listener touch_listener = {
     touch_handle_orientation,
 };
 
-static void keyboard_handle_keymap(void *data, struct wl_keyboard *wl_keyboard,
+static void keyboard_handle_keymap(void *data, mp_unused struct wl_keyboard *wl_keyboard,
                                    uint32_t format, int32_t fd, uint32_t size)
 {
     struct vo_wayland_seat *s = data;
@@ -524,8 +534,9 @@ static void keyboard_handle_keymap(void *data, struct wl_keyboard *wl_keyboard,
     }
 }
 
-static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
-                                  uint32_t serial, struct wl_surface *surface,
+static void keyboard_handle_enter(void *data, mp_unused struct wl_keyboard *wl_keyboard,
+                                  mp_unused uint32_t serial,
+                                  mp_unused struct wl_surface *surface,
                                   struct wl_array *keys)
 {
     struct vo_wayland_seat *s = data;
@@ -539,8 +550,9 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
         MP_TARRAY_APPEND(s, s->keyboard_entering_keys, s->num_keyboard_entering_keys, *key);
 }
 
-static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
-                                  uint32_t serial, struct wl_surface *surface)
+static void keyboard_handle_leave(void *data, mp_unused struct wl_keyboard *wl_keyboard,
+                                  mp_unused uint32_t serial,
+                                  mp_unused struct wl_surface *surface)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -552,16 +564,16 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
     guess_focus(wl);
 }
 
-static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
-                                uint32_t serial, uint32_t time, uint32_t key,
-                                uint32_t state)
+static void keyboard_handle_key(void *data, mp_unused struct wl_keyboard *wl_keyboard,
+                                mp_unused uint32_t serial, mp_unused uint32_t time,
+                                uint32_t key, uint32_t state)
 {
     struct vo_wayland_seat *s = data;
     handle_key_input(s, key, state);
 }
 
-static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboard,
-                                      uint32_t serial, uint32_t mods_depressed,
+static void keyboard_handle_modifiers(void *data, mp_unused struct wl_keyboard *wl_keyboard,
+                                      mp_unused uint32_t serial, uint32_t mods_depressed,
                                       uint32_t mods_latched, uint32_t mods_locked,
                                       uint32_t group)
 {
@@ -584,7 +596,7 @@ static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboar
     }
 }
 
-static void keyboard_handle_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
+static void keyboard_handle_repeat_info(void *data, mp_unused struct wl_keyboard *wl_keyboard,
                                         int32_t rate, int32_t delay)
 {
     struct vo_wayland_seat *s = data;
@@ -634,8 +646,8 @@ static void seat_handle_caps(void *data, struct wl_seat *seat,
     }
 }
 
-static void seat_handle_name(void *data, struct wl_seat *seat,
-                             const char *name)
+static void seat_handle_name(mp_unused void *data, mp_unused struct wl_seat *seat,
+                             mp_unused const char *name)
 {
 }
 
@@ -644,7 +656,7 @@ static const struct wl_seat_listener seat_listener = {
     seat_handle_name,
 };
 
-static void data_offer_handle_offer(void *data, struct wl_data_offer *offer,
+static void data_offer_handle_offer(void *data, mp_unused struct wl_data_offer *offer,
                                     const char *mime_type)
 {
     struct vo_wayland_seat *s = data;
@@ -659,11 +671,14 @@ static void data_offer_handle_offer(void *data, struct wl_data_offer *offer,
     }
 }
 
-static void data_offer_source_actions(void *data, struct wl_data_offer *offer, uint32_t source_actions)
+static void data_offer_source_actions(mp_unused void *data,
+                                      mp_unused struct wl_data_offer *offer,
+                                      mp_unused uint32_t source_actions)
 {
 }
 
-static void data_offer_action(void *data, struct wl_data_offer *wl_data_offer, uint32_t dnd_action)
+static void data_offer_action(void *data, mp_unused struct wl_data_offer *wl_data_offer,
+                              uint32_t dnd_action)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -691,7 +706,8 @@ static const struct wl_data_offer_listener data_offer_listener = {
     data_offer_action,
 };
 
-static void data_device_handle_data_offer(void *data, struct wl_data_device *wl_ddev,
+static void data_device_handle_data_offer(void *data,
+                                          mp_unused struct wl_data_device *wl_ddev,
                                           struct wl_data_offer *id)
 {
     struct vo_wayland_seat *s = data;
@@ -703,9 +719,9 @@ static void data_device_handle_data_offer(void *data, struct wl_data_device *wl_
     wl_data_offer_add_listener(id, &data_offer_listener, s);
 }
 
-static void data_device_handle_enter(void *data, struct wl_data_device *wl_ddev,
-                                     uint32_t serial, struct wl_surface *surface,
-                                     wl_fixed_t x, wl_fixed_t y,
+static void data_device_handle_enter(void *data, mp_unused struct wl_data_device *wl_ddev,
+                                     uint32_t serial, mp_unused struct wl_surface *surface,
+                                     mp_unused wl_fixed_t x, mp_unused wl_fixed_t y,
                                      struct wl_data_offer *id)
 {
     struct vo_wayland_seat *s = data;
@@ -725,7 +741,7 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_ddev,
 
 }
 
-static void data_device_handle_leave(void *data, struct wl_data_device *wl_ddev)
+static void data_device_handle_leave(void *data, mp_unused struct wl_data_device *wl_ddev)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -745,15 +761,16 @@ static void data_device_handle_leave(void *data, struct wl_data_device *wl_ddev)
     }
 }
 
-static void data_device_handle_motion(void *data, struct wl_data_device *wl_ddev,
-                                      uint32_t time, wl_fixed_t x, wl_fixed_t y)
+static void data_device_handle_motion(void *data, mp_unused struct wl_data_device *wl_ddev,
+                                      uint32_t time,
+                                      mp_unused wl_fixed_t x, mp_unused wl_fixed_t y)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
     wl_data_offer_accept(wl->dnd_offer, time, wl->dnd_mime_type);
 }
 
-static void data_device_handle_drop(void *data, struct wl_data_device *wl_ddev)
+static void data_device_handle_drop(void *data, mp_unused struct wl_data_device *wl_ddev)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -774,8 +791,8 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_ddev)
     wl->dnd_fd = pipefd[0];
 }
 
-static void data_device_handle_selection(void *data, struct wl_data_device *wl_ddev,
-                                         struct wl_data_offer *id)
+static void data_device_handle_selection(void *data, mp_unused struct wl_data_device *wl_ddev,
+                                         mp_unused struct wl_data_offer *id)
 {
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
@@ -797,11 +814,11 @@ static const struct wl_data_device_listener data_device_listener = {
     data_device_handle_selection,
 };
 
-static void output_handle_geometry(void *data, struct wl_output *wl_output,
+static void output_handle_geometry(void *data, mp_unused struct wl_output *wl_output,
                                    int32_t x, int32_t y, int32_t phys_width,
-                                   int32_t phys_height, int32_t subpixel,
+                                   int32_t phys_height, mp_unused int32_t subpixel,
                                    const char *make, const char *model,
-                                   int32_t transform)
+                                   mp_unused int32_t transform)
 {
     struct vo_wayland_output *output = data;
     output->make = talloc_strdup(output->wl, make);
@@ -812,7 +829,7 @@ static void output_handle_geometry(void *data, struct wl_output *wl_output,
     output->phys_height = phys_height;
 }
 
-static void output_handle_mode(void *data, struct wl_output *wl_output,
+static void output_handle_mode(void *data, mp_unused struct wl_output *wl_output,
                                uint32_t flags, int32_t width,
                                int32_t height, int32_t refresh)
 {
@@ -857,7 +874,7 @@ static void output_handle_done(void *data, struct wl_output *wl_output)
     wl->pending_vo_events |= VO_EVENT_WIN_STATE;
 }
 
-static void output_handle_scale(void *data, struct wl_output *wl_output,
+static void output_handle_scale(void *data, mp_unused struct wl_output *wl_output,
                                 int32_t factor)
 {
     struct vo_wayland_output *output = data;
@@ -868,15 +885,16 @@ static void output_handle_scale(void *data, struct wl_output *wl_output,
     output->scale = factor * WAYLAND_SCALE_FACTOR;
 }
 
-static void output_handle_name(void *data, struct wl_output *wl_output,
+static void output_handle_name(void *data, mp_unused struct wl_output *wl_output,
                                const char *name)
 {
     struct vo_wayland_output *output = data;
     output->name = talloc_strdup(output->wl, name);
 }
 
-static void output_handle_description(void *data, struct wl_output *wl_output,
-                                      const char *description)
+static void output_handle_description(mp_unused void *data,
+                                      mp_unused struct wl_output *wl_output,
+                                      mp_unused const char *description)
 {
 }
 
@@ -889,7 +907,7 @@ static const struct wl_output_listener output_listener = {
     output_handle_description,
 };
 
-static void surface_handle_enter(void *data, struct wl_surface *wl_surface,
+static void surface_handle_enter(void *data, mp_unused struct wl_surface *wl_surface,
                                  struct wl_output *output)
 {
     struct vo_wayland_state *wl = data;
@@ -921,7 +939,7 @@ static void surface_handle_enter(void *data, struct wl_surface *wl_surface,
     wl->pending_vo_events |= VO_EVENT_WIN_STATE;
 }
 
-static void surface_handle_leave(void *data, struct wl_surface *wl_surface,
+static void surface_handle_leave(void *data, mp_unused struct wl_surface *wl_surface,
                                  struct wl_output *output)
 {
     struct vo_wayland_state *wl = data;
@@ -950,7 +968,7 @@ static void surface_handle_leave(void *data, struct wl_surface *wl_surface,
 
 #ifdef HAVE_WAYLAND_1_22
 static void surface_handle_preferred_buffer_scale(void *data,
-                                                  struct wl_surface *wl_surface,
+                                                  mp_unused struct wl_surface *wl_surface,
                                                   int32_t scale)
 {
     struct vo_wayland_state *wl = data;
@@ -975,9 +993,9 @@ static void surface_handle_preferred_buffer_scale(void *data,
     }
 }
 
-static void surface_handle_preferred_buffer_transform(void *data,
-                                                      struct wl_surface *wl_surface,
-                                                      uint32_t transform)
+static void surface_handle_preferred_buffer_transform(mp_unused void *data,
+                                                      mp_unused struct wl_surface *wl_surface,
+                                                      mp_unused uint32_t transform)
 {
 }
 #endif
@@ -991,7 +1009,7 @@ static const struct wl_surface_listener surface_listener = {
 #endif
 };
 
-static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base, uint32_t serial)
+static void xdg_wm_base_ping(mp_unused void *data, struct xdg_wm_base *wm_base, uint32_t serial)
 {
     xdg_wm_base_pong(wm_base, serial);
 }
@@ -1000,7 +1018,7 @@ static const struct xdg_wm_base_listener xdg_wm_base_listener = {
     xdg_wm_base_ping,
 };
 
-static void handle_surface_config(void *data, struct xdg_surface *surface,
+static void handle_surface_config(mp_unused void *data, struct xdg_surface *surface,
                                   uint32_t serial)
 {
     xdg_surface_ack_configure(surface, serial);
@@ -1010,7 +1028,7 @@ static const struct xdg_surface_listener xdg_surface_listener = {
     handle_surface_config,
 };
 
-static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
+static void handle_toplevel_config(void *data, mp_unused struct xdg_toplevel *toplevel,
                                    int32_t width, int32_t height, struct wl_array *states)
 {
     struct vo_wayland_state *wl = data;
@@ -1149,13 +1167,15 @@ resize:
     wl->toplevel_configured = true;
 }
 
-static void handle_toplevel_close(void *data, struct xdg_toplevel *xdg_toplevel)
+static void handle_toplevel_close(void *data,
+                                  mp_unused struct xdg_toplevel *xdg_toplevel)
 {
     struct vo_wayland_state *wl = data;
     mp_input_put_key(wl->vo->input_ctx, MP_KEY_CLOSE_WIN);
 }
 
-static void handle_configure_bounds(void *data, struct xdg_toplevel *xdg_toplevel,
+static void handle_configure_bounds(void *data,
+                                    mp_unused struct xdg_toplevel *xdg_toplevel,
                                     int32_t width, int32_t height)
 {
     struct vo_wayland_state *wl = data;
@@ -1163,8 +1183,9 @@ static void handle_configure_bounds(void *data, struct xdg_toplevel *xdg_topleve
     wl->bounded_height = handle_round(wl->scaling, height);
 }
 
-static void handle_wm_capabilities(void *data, struct xdg_toplevel *xdg_toplevel,
-                                   struct wl_array *capabilities)
+static void handle_wm_capabilities(mp_unused void *data,
+                                   mp_unused struct xdg_toplevel *xdg_toplevel,
+                                   mp_unused struct wl_array *capabilities)
 {
 }
 
@@ -1176,7 +1197,7 @@ static const struct xdg_toplevel_listener xdg_toplevel_listener = {
 };
 
 static void preferred_scale(void *data,
-                            struct wp_fractional_scale_v1 *fractional_scale,
+                            mp_unused struct wp_fractional_scale_v1 *fractional_scale,
                             uint32_t scale)
 {
     struct vo_wayland_state *wl = data;
@@ -1216,7 +1237,7 @@ static const char *zxdg_decoration_mode_to_str(const uint32_t mode)
 }
 
 static void configure_decorations(void *data,
-                                  struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration,
+                                  mp_unused struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration,
                                   uint32_t mode)
 {
     struct vo_wayland_state *wl = data;
@@ -1245,7 +1266,7 @@ static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {
     configure_decorations,
 };
 
-static void pres_set_clockid(void *data, struct wp_presentation *pres,
+static void pres_set_clockid(void *data, mp_unused struct wp_presentation *pres,
                              uint32_t clockid)
 {
     struct vo_wayland_state *wl = data;
@@ -1258,8 +1279,9 @@ static const struct wp_presentation_listener pres_listener = {
     pres_set_clockid,
 };
 
-static void feedback_sync_output(void *data, struct wp_presentation_feedback *fback,
-                               struct wl_output *output)
+static void feedback_sync_output(mp_unused void *data,
+                                 mp_unused struct wp_presentation_feedback *fback,
+                                 mp_unused struct wl_output *output)
 {
 }
 
@@ -1267,7 +1289,7 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
                               uint32_t tv_sec_hi, uint32_t tv_sec_lo,
                               uint32_t tv_nsec, uint32_t refresh_nsec,
                               uint32_t seq_hi, uint32_t seq_lo,
-                              uint32_t flags)
+                              mp_unused uint32_t flags)
 {
     struct vo_wayland_feedback_pool *fback_pool = data;
     struct vo_wayland_state *wl = fback_pool->wl;
@@ -1307,7 +1329,7 @@ static const struct wp_presentation_feedback_listener feedback_listener = {
 
 static const struct wl_callback_listener frame_listener;
 
-static void frame_callback(void *data, struct wl_callback *callback, uint32_t time)
+static void frame_callback(void *data, struct wl_callback *callback, mp_unused uint32_t time)
 {
     struct vo_wayland_state *wl = data;
 
@@ -1332,13 +1354,13 @@ static const struct wl_callback_listener frame_listener = {
     frame_callback,
 };
 
-static void done(void *data,
-                 struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
+static void done(mp_unused void *data,
+                 mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
 {
 }
 
 static void format_table(void *data,
-                         struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
+                         mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
                          int32_t fd,
                          uint32_t size)
 {
@@ -1353,32 +1375,32 @@ static void format_table(void *data,
     }
 }
 
-static void main_device(void *data,
-                        struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
-                        struct wl_array *device)
+static void main_device(mp_unused void *data,
+                        mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
+                        mp_unused struct wl_array *device)
 {
 }
 
-static void tranche_done(void *data,
-                         struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
+static void tranche_done(mp_unused void *data,
+                         mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1)
 {
 }
 
-static void tranche_target_device(void *data,
-                                  struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
-                                  struct wl_array *device)
+static void tranche_target_device(mp_unused void *data,
+                                  mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
+                                  mp_unused struct wl_array *device)
 {
 }
 
-static void tranche_formats(void *data,
-                            struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
-                            struct wl_array *indices)
+static void tranche_formats(mp_unused void *data,
+                            mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
+                            mp_unused struct wl_array *indices)
 {
 }
 
-static void tranche_flags(void *data,
-                          struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
-                          uint32_t flags)
+static void tranche_flags(mp_unused void *data,
+                          mp_unused struct zwp_linux_dmabuf_feedback_v1 *zwp_linux_dmabuf_feedback_v1,
+                          mp_unused uint32_t flags)
 {
 }
 
@@ -1521,7 +1543,7 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         MP_VERBOSE(wl, "Registered interface %s at version %d\n", interface, ver);
 }
 
-static void registry_handle_remove(void *data, struct wl_registry *reg, uint32_t id)
+static void registry_handle_remove(void *data, mp_unused struct wl_registry *reg, uint32_t id)
 {
     struct vo_wayland_state *wl = data;
     struct vo_wayland_output *output, *output_tmp;

--- a/video/repack.c
+++ b/video/repack.c
@@ -521,7 +521,7 @@ static void setup_fringe_rgb_packer(struct mp_repack *rp)
     }
 }
 
-static void unpack_pal(struct mp_repack *rp,
+static void unpack_pal(mp_unused struct mp_repack *rp,
                        struct mp_image *a, int a_x, int a_y,
                        struct mp_image *b, int b_x, int b_y, int w)
 {
@@ -804,7 +804,7 @@ static void setup_nv_packer(struct mp_repack *rp)
 
 #define UN_F32(name, packed_t)                                              \
     static void name(void *restrict src, float *restrict dst, int w, float m, \
-                     float o, uint32_t unused) {                            \
+                     float o, mp_unused uint32_t unused) {                            \
         for (int x = 0; x < w; x++)                                         \
             dst[x] = ((packed_t *)src)[x] * m + o;                          \
     }

--- a/video/vaapi.c
+++ b/video/vaapi.c
@@ -200,8 +200,8 @@ static void x11_destroy(void *native_ctx)
     XCloseDisplay(native_ctx);
 }
 
-static void x11_create(struct mp_log *log, VADisplay **out_display,
-                       void **out_native_ctx, const char *path)
+static void x11_create(mp_unused struct mp_log *log, VADisplay **out_display,
+                       void **out_native_ctx, mp_unused const char *path)
 {
     void *native_display = XOpenDisplay(NULL);
     if (!native_display)
@@ -261,7 +261,7 @@ static void drm_destroy(void *native_ctx)
     talloc_free(ctx);
 }
 
-static void drm_create(struct mp_log *log, VADisplay **out_display,
+static void drm_create(mp_unused struct mp_log *log, VADisplay **out_display,
                        void **out_native_ctx, const char *path)
 {
     int drm_fd = open(path, O_RDWR);

--- a/video/vdpau.c
+++ b/video/vdpau.c
@@ -42,7 +42,7 @@ static void mark_vdpau_objects_uninitialized(struct mp_vdpau_ctx *ctx)
     ctx->preemption_obj = VDP_INVALID_HANDLE;
 }
 
-static void preemption_callback(VdpDevice device, void *context)
+static void preemption_callback(mp_unused VdpDevice device, void *context)
 {
     struct mp_vdpau_ctx *ctx = context;
 
@@ -547,7 +547,7 @@ static bool is_emulated(struct AVBufferRef *hw_device_ctx)
     return mp_vdpau_guess_if_emulated(ctx);
 }
 
-static struct AVBufferRef *vdpau_create_standalone(struct mpv_global *global,
+static struct AVBufferRef *vdpau_create_standalone(mp_unused struct mpv_global *global,
         struct mp_log *log, struct hwcontext_create_dev_params *params)
 {
     XInitThreads();


### PR DESCRIPTION
Alternative to #14736

This is the supported way of doing this, and while `(void)(x)` works, there's no guarantee that it won't stop working in the future similar to how casting to void to silence unused-result warnings used to work in the past, but now they don't and likely will continue to not work.