### PR TITLE
ci/win32: use hybrid crt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,7 @@ jobs:
       CXX: "ccache clang++"
       CC_LD: "lld"
       CXX_LD: "lld"
+      _LINK_: "/nodefaultlib:libucrt.lib /defaultlib:ucrt.lib"
       WINDRES: "llvm-rc"
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_DIR: "${{ github.workspace }}\\.ccache"


### PR DESCRIPTION
VCRuntime is still statically linked, but now UCRT is dynamically linked, this approach is officially used by Windows App SDK.

ref: https://github.com/microsoft/WindowsAppSDK/blob/main/docs/Coding-Guidelines/HybridCRT.md

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.