### PR TITLE
input.conf: swap the positions of values for `ctrl+h` binding

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -167,7 +167,7 @@
 #L cycle-values loop-file "inf" "no"    # toggle infinite looping
 #ctrl+c quit 4
 #DEL script-binding osc/visibility      # cycle OSC visibility between never, auto (mouse-move) and always
-#ctrl+h cycle-values hwdec "auto-safe" "no"  # toggle hardware decoding
+#ctrl+h cycle-values hwdec "no" "auto-safe" # toggle hardware decoding
 #F8 show-text ${playlist}               # show the playlist
 #F9 show-text ${track-list}             # show the list of video, audio and sub tracks
 #g ignore


### PR DESCRIPTION
Allows users to toggle software decoding with a single action if they are using a value for `hwdec` that is different from `auto-safe`.

The previous behavior was annoying if you selected specific decoding APIs like `--hwdec=vulkan,d3d11va,...`, since you had to cycle to `auto-safe` first before being able to cycle to `no`. Doesn't regress the previous behavior of the keybind when you're using `--hwdec=no`, so it should be a straight improvement unless I'm missing something.