### PR TITLE
file2string: Avoid emitting absolute filepaths into generated sources

### DIFF
--- a/TOOLS/file2string.py
+++ b/TOOLS/file2string.py
@@ -22,10 +22,10 @@
 # License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import sys
+import os, sys
 
 def file2string(infilename, infile, outfile):
-    outfile.write("// Generated from %s\n\n" % infilename)
+    outfile.write("// Generated from %s\n\n" % os.path.basename(infilename))
 
     conv = ["\\%03o" % c for c in range(256)]
     safe_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" \


### PR DESCRIPTION
These sources are bundled into src packages to be distributed and leaking buildpaths results in violating reproducibility norms.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.