### PR TITLE
mp_image: save fallback colorspace when dovi metadata is present

### DIFF
--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -168,8 +168,7 @@ static void vf_format_process(struct mp_filter *f)
         }
 
         if (!priv->opts->dovi) {
-            if (img->params.repr.sys == PL_COLOR_SYSTEM_DOLBYVISION)
-                img->params.repr.sys = PL_COLOR_SYSTEM_BT_2020_NC;
+            mp_image_params_restore_dovi_mapping(&img->params);
             // Map again to strip any DV metadata set to common fields.
             img->params.color.hdr = (struct pl_hdr_metadata){0};
             pl_map_hdr_metadata(&img->params.color.hdr, &(struct pl_av_hdr_metadata) {

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -50,6 +50,11 @@ struct mp_image_params {
     bool force_window;          // fake image created by handle_force_window
     struct pl_color_space color;
     struct pl_color_repr repr;
+    // Original values before Dolby Vision metadata mapping
+    enum pl_color_primaries primaries_orig;
+    enum pl_color_transfer transfer_orig;
+    enum pl_color_system sys_orig;
+
     enum mp_csp_light light;
     enum pl_chroma_location chroma_location;
     // The image should be rotated clockwise (0-359 degrees).
@@ -177,6 +182,7 @@ bool mp_image_params_equal(const struct mp_image_params *p1,
                            const struct mp_image_params *p2);
 bool mp_image_params_static_equal(const struct mp_image_params *p1,
                                   const struct mp_image_params *p2);
+void mp_image_params_restore_dovi_mapping(struct mp_image_params *params);
 
 void mp_image_params_get_dsize(const struct mp_image_params *p,
                                int *d_w, int *d_h);

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -123,7 +123,9 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
         return -1;
 
     resize(vo);
-    gl_video_config(p->renderer, params);
+    struct mp_image_params fallback_params = *params;
+    mp_image_params_restore_dovi_mapping(&fallback_params);
+    gl_video_config(p->renderer, &fallback_params);
 
     return 0;
 }


### PR DESCRIPTION
Since d9c1e9bc5c8ca5e4a75b197789b77890375cb8e2 dovi metadata is unconditionally mapped to colorspace in mp_image.

However, Dolby Vision videos can have backwards compatibility present for players without the ability to interpret dovi metadata, like all current VOs other than gpu-next. In this case, the original video colorspace should be used instead of the fabricated dolbyvision/pq colorspace.

So make mp_image contain both colorspaces (original and mapped), and only use the mapped colorspace when the VO understands dovi metadata.

Fixes: d9c1e9bc5c8ca5e4a75b197789b77890375cb8e2
Fixes: https://github.com/mpv-player/mpv/issues/14770