### PR TITLE
vo_libmpv: use fallback colorspace for Dolby Vision

### DIFF
--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -124,7 +124,9 @@ static void reconfig(struct render_backend *ctx, struct mp_image_params *params)
 {
     struct priv *p = ctx->priv;
 
-    gl_video_config(p->renderer, params);
+    struct mp_image_params fallback_params = *params;
+    mp_image_params_restore_dovi_mapping(&fallback_params);
+    gl_video_config(p->renderer, &fallback_params);
 }
 
 static void reset(struct render_backend *ctx)


### PR DESCRIPTION
Same as 2a72e6cb20c2af302041a0b30dbf0d1b93990a4a for libmpv.