### PR TITLE
etc/mpv.conf: update stale comment about mpv config location

### DIFF
--- a/etc/mpv.conf
+++ b/etc/mpv.conf
@@ -8,8 +8,8 @@
 # no builtin or example mpv.conf with all the defaults.
 #
 #
-# Configuration files are read system-wide from /usr/local/etc/mpv.conf
-# and per-user from ~/.config/mpv/mpv.conf, where per-user settings override
+# Configuration files are read system-wide from /etc/mpv or /usr/local/etc/mpv,
+# and per-user from ~/.config/mpv, where per-user settings override
 # system-wide settings, all of which are overridden by the command line.
 #
 # Configuration file settings and the command line options use the same


### PR DESCRIPTION
We don't support reading mpv.conf without a mpv parent directory anymore (did we ever?).