### PR TITLE
input: fix use of bstr like null terminated one

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -1720,7 +1720,7 @@ struct mpv_node mp_input_get_bindings(struct input_ctx *ictx)
             if (b_priority >= 0 && !b->is_builtin)
                 b_priority += ictx->num_active_sections;
 
-            node_map_add_string(entry, "section", s->section.start);
+            node_map_add_bstr(entry, "section", s->section);
             if (s->owner)
                 node_map_add_string(entry, "owner", s->owner);
             node_map_add_string(entry, "cmd", b->cmd);

--- a/misc/node.c
+++ b/misc/node.c
@@ -73,6 +73,15 @@ void node_map_add_string(struct mpv_node *dst, const char *key, const char *val)
     entry->u.string = talloc_strdup(dst->u.list, val);
 }
 
+void node_map_add_bstr(struct mpv_node *dst, const char *key, bstr val)
+{
+    assert(val.start);
+
+    struct mpv_node *entry = node_map_add(dst, key, MPV_FORMAT_NONE);
+    entry->format = MPV_FORMAT_STRING;
+    entry->u.string = bstrto0(dst->u.list, val);
+}
+
 void node_map_add_int64(struct mpv_node *dst, const char *key, int64_t v)
 {
     node_map_add(dst, key, MPV_FORMAT_INT64)->u.int64 = v;

--- a/misc/node.h
+++ b/misc/node.h
@@ -9,6 +9,7 @@ struct mpv_node *node_array_add(struct mpv_node *dst, int format);
 struct mpv_node *node_map_add(struct mpv_node *dst, const char *key, int format);
 struct mpv_node *node_map_badd(struct mpv_node *dst, struct bstr key, int format);
 void node_map_add_string(struct mpv_node *dst, const char *key, const char *val);
+void node_map_add_bstr(struct mpv_node *dst, const char *key, bstr val);
 void node_map_add_int64(struct mpv_node *dst, const char *key, int64_t v);
 void node_map_add_double(struct mpv_node *dst, const char *key, double v);
 void node_map_add_flag(struct mpv_node *dst, const char *key, bool v);


### PR DESCRIPTION
It has been changed in one of the iterations of the patch during review, but bstr doesn't have to be null terminated. Fix it by adding dedicated node_map helper.

Fixes: 1a27f3c