### PR TITLE
wayland: don't handle keys on keyboard_enter events

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -184,9 +184,6 @@ struct vo_wayland_seat {
     bool axis_value120_scroll;
     bool has_keyboard_input;
     struct wl_list link;
-    bool keyboard_entering;
-    uint32_t *keyboard_entering_keys;
-    int num_keyboard_entering_keys;
 };
 
 static bool single_output_spanned(struct vo_wayland_state *wl);
@@ -531,12 +528,7 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
     s->has_keyboard_input = true;
-    s->keyboard_entering = true;
     guess_focus(wl);
-
-    uint32_t *key;
-    wl_array_for_each(key, keys)
-        MP_TARRAY_APPEND(s, s->keyboard_entering_keys, s->num_keyboard_entering_keys, *key);
 }
 
 static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
@@ -573,13 +565,7 @@ static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboar
                               mods_locked, 0, 0, group);
         s->mpmod = get_mods(s);
     }
-    // Handle keys pressed during the enter event.
-    if (s->keyboard_entering) {
-        s->keyboard_entering = false;
-        for (int n = 0; n < s->num_keyboard_entering_keys; n++)
-            handle_key_input(s, s->keyboard_entering_keys[n], WL_KEYBOARD_KEY_STATE_PRESSED);
-        s->num_keyboard_entering_keys = 0;
-    } else if (s->xkb_state && s->mpkey) {
+    if (s->xkb_state && s->mpkey) {
         mp_input_put_key(wl->vo->input_ctx, s->mpkey | MP_KEY_STATE_DOWN | s->mpmod);
     }
 }


### PR DESCRIPTION
0fcfbab9afbbc46de02514abf9829d2799b200e4 added this behavior based on incorrect reading at best and bad faith reading of the protocol at worst. b2a4c0ce9172c30449b31f86fa9a1b94b97f8012 expanded on this behavior, so it's part of the effect revert too. It's not possible to handle keys on keyboard_enter without synthesizing inputs that didn't exist from the user.

The protocol text does not guarantee that the keys we receive in the enter event are in the order they were pressed. They're provided just so key release events received later make sense to the clients that might need this information.

The original merge request operates on incorrect assumptions about the wayland protocol, e.g. "conceptually in the Wayland keyboard logical state, all keys are pressed at the same time in the prespective of the client, so random order is fine."

The above statement is not true, all keys are not pressed at the same time or randomly, otherwise there would be no need for the wl_keyboard::key event to exist if it wasn't deemed necessary to provide key presses in the order they happen.

The only potentially actionable comment in the original merge request is: "there needs to be a policy on how to handle keys pressed in enter and key events differently for this change to be meaningful."

It may be a good idea to state the intent behind the keys argument in the enter event more clearly, however the intent is not lost to anyone who's not interested in deliberately finding areas where the protocol does not explicitly forbid bad behavior in order to make the worst possible implementation of the wayland protocol possible.
