### PR TITLE
player/main: uninit input after terminal uninit

### DIFF
--- a/player/main.c
+++ b/player/main.c
@@ -187,8 +187,6 @@ void mp_destroy(struct MPContext *mpctx)
     cocoa_set_input_context(NULL);
 #endif
 
-    mp_input_uninit(mpctx->input);
-
     uninit_libav(mpctx->global);
 
     mp_msg_uninit(mpctx->global);
@@ -197,6 +195,8 @@ void mp_destroy(struct MPContext *mpctx)
         terminal_uninit();
         cas_terminal_owner(mpctx, NULL);
     }
+
+    mp_input_uninit(mpctx->input);
 
     assert(!mpctx->num_abort_list);
     talloc_free(mpctx->abort_list);


### PR DESCRIPTION
The terminal input thread holds the input_ctx reference.

Fixes: c1282d4d43be8fb8bbc8529b22804d288d59038a
Fixes: https://github.com/mpv-player/mpv/issues/14817