### PR TITLE
vulkan: don't tolerate suboptimal swapchain configurations

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -265,9 +265,6 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .surface = vk->surface,
         .present_mode = preferred_mode,
         .swapchain_depth = ctx->vo->opts->swapchain_depth,
-        // mpv already handles resize events, so gracefully allow suboptimal
-        // swapchains to exist in order to make resizing even smoother
-        .allow_suboptimal = true,
     };
 
     if (p->opts->swap_mode >= 0) // user override


### PR DESCRIPTION
This prevents us from recreating the swapchain when needed for direct scan out on Wayland, and the comment is old and doesn't seem to be true.

With this, direct scanout with vulkan on wayland should just work. Note that you might also need https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31122 if you're on an explicit sync compositor.