### PR TITLE
f_auto_filters: rework --deinterlace=auto option

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2282,7 +2282,8 @@ Property list
     Equivalent to ``vf-metadata/<filter-label>``, but for audio filters.
 
 ``deinterlace-active``
-    Returns ``yes``/true if mpv's deinterlacing filter is active. Note that it
+    Returns ``yes``/true if mpv's deinterlacing filter is active. This is only
+    a guess with ``--deinterlace=auto`` and may not be accurate. Note that it
     will not detect any manually inserted deinterlacing filters done via
     ``--vf``.
 


### PR DESCRIPTION
Before this commit, deinterlace=auto and deinterlace=yes were the exact same option for d3d11 and vaapi, the only difference being that with `auto` we would create/destroy the deinterlacing filter on every frame that changed the deinterlace flag and with `yes`, we left that the responsibility to determine whether to deinterlace or not to d3d11vpp and vavpp and the filters were always inserted.

Inserting and removing filters on every frame the interlaced flag changes is expensive and it will be more efficient to let the deinterlacing filters handle this distinction instead.

With this change, `yes` works as it should: deinterlacing is forced enable regardless of the frame flag. `auto` will always insert the deinterlacing filter, however the filters will only deinterlace the frames marked as interlaced.

One downside of this change is that we don't know if the filter is actually deinterlacing or not, we can only guess that if the filter is inserted and the frame is interlaced then it should be deinterlacing. It's possible for it to fail for whatever reason, and it's also possible future changes to ffmpeg (since bwdif lives in ffmpeg), might make the logic more complicated than this check. However, for now this is good enough.