### PR TITLE
msg: switch to bright ANSI color palette

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -322,7 +322,7 @@ static void set_term_color(void *talloc_ctx, bstr *text, int c)
         return;
     }
 
-    bstr_xappend_asprintf(talloc_ctx, text, "\033[%d;3%dm", c >> 3, c & 7);
+    bstr_xappend_asprintf(talloc_ctx, text, "\033[%d;9%dm", c >> 3, c & 7);
 }
 
 static void set_msg_color(void *talloc_ctx, bstr *text, int lev)


### PR DESCRIPTION
mpv by default uses bold black text for debug output. Most terminals have darker or even black backgrounds by default these days, so the text is not readable by default in nearly all cases. foot, alacritty and kitty all have default themes where mpv debug text can't be read.

Fix this by switching to the bright ANSI color palette which should mean that ANSI black and background are distinct enough in most cases.

Proceed bikeshedding