### PR TITLE
player/main: revert msg uninit order changes

### DIFF
--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -285,6 +285,7 @@ void terminal_uninit(void)
         running = false;
     }
     FlsFree(tmp_buffers_key);
+    tmp_buffers_key = FLS_OUT_OF_INDEXES;
 }
 
 bool terminal_in_background(void)

--- a/player/main.c
+++ b/player/main.c
@@ -187,10 +187,6 @@ void mp_destroy(struct MPContext *mpctx)
     cocoa_set_input_context(NULL);
 #endif
 
-    uninit_libav(mpctx->global);
-
-    mp_msg_uninit(mpctx->global);
-
     if (cas_terminal_owner(mpctx, mpctx)) {
         terminal_uninit();
         cas_terminal_owner(mpctx, NULL);
@@ -198,6 +194,9 @@ void mp_destroy(struct MPContext *mpctx)
 
     mp_input_uninit(mpctx->input);
 
+    uninit_libav(mpctx->global);
+
+    mp_msg_uninit(mpctx->global);
     assert(!mpctx->num_abort_list);
     talloc_free(mpctx->abort_list);
     mp_mutex_destroy(&mpctx->abort_lock);


### PR DESCRIPTION
msg must be the last module to uninit since pretty much everything else uses logging.

This reverts commit f92d5da89cf0b025f1bee1801e66911fe1efb6ff.
This reverts commit c1282d4d43be8fb8bbc8529b22804d288d59038a.
Fixes https://github.com/mpv-player/mpv/issues/14851