### PR TITLE
sub/sd_ass: don't override event attributes to mpv defaults

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -534,8 +534,13 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
     ass_set_line_position(priv, set_sub_pos);
     ass_set_shaper(priv, opts->ass_shaper);
     int set_force_flags = 0;
-    if (total_override)
-        set_force_flags |= ASS_OVERRIDE_BIT_STYLE | ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
+    if (total_override) {
+        set_force_flags |= ASS_OVERRIDE_BIT_FONT_NAME
+                            | ASS_OVERRIDE_BIT_FONT_SIZE_FIELDS
+                            | ASS_OVERRIDE_BIT_COLORS
+                            | ASS_OVERRIDE_BIT_BORDER
+                            | ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
+    }
     if (shared_opts->ass_style_override[sd->order] == ASS_STYLE_OVERRIDE_SCALE)
         set_force_flags |= ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
     if (converted)


### PR DESCRIPTION
ASS_OVERRIDE_BIT_STYLE includes ASS_OVERRIDE_BIT_ATTRIBUTES, which we don't want.

This prevents --sub-ass-override=force from overriding attributes such as bold, italics, underline or strikeout to mpv defaults.