### PR TITLE
vo_gpu_next: allow setting antiring value for cscale

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1951,6 +1951,8 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
     }
 
     par->config.clamp = cfg->clamp;
+    if (cfg->antiring > 0.0)
+        par->config.antiring = cfg->antiring;
     if (cfg->kernel.blur > 0.0)
         par->config.blur = cfg->kernel.blur;
     if (cfg->kernel.taper > 0.0)
@@ -2129,7 +2131,6 @@ static void update_render_options(struct vo *vo)
     struct priv *p = vo->priv;
     pl_options pars = p->pars;
     const struct gl_video_opts *opts = p->opts_cache->opts;
-    pars->params.antiringing_strength = opts->scaler[0].antiring;
     pars->params.background_color[0] = opts->background_color.r / 255.0;
     pars->params.background_color[1] = opts->background_color.g / 255.0;
     pars->params.background_color[2] = opts->background_color.b / 255.0;


### PR DESCRIPTION
This has been possible since https://github.com/haasn/libplacebo/commit/11771cdd82cec0d2f775553611c276092fb283cf but nobody bothered to map it to mpv until now?

Fixes #11925
