### PR TITLE
DOCS: fix sub-ass-use-video-data documentation

### DIFF
--- a/DOCS/interface-changes/sub-ass-use-video-data.txt
+++ b/DOCS/interface-changes/sub-ass-use-video-data.txt
@@ -1,6 +1,5 @@
-Remove sub-ass-vsfilter-aspect-compat.
-Remove sub-ass-vsfilter-blur-compat.
-Add sub-ass-use-video-data.
-Add sub-ass-video-aspect-override.
-Change default V keybind to cycle sub-ass-use-video-data
-instead of toggling the now removed sub-ass-vsfilter-aspect-compat.
+remove `sub-ass-vsfilter-aspect-compat`: use `sub-ass-use-video-data=none` for disabling aspect compat
+remove `sub-ass-vsfilter-blur-compat`: use `sub-ass-use-video-data=aspect-ratio` for disabling blur compat
+add `sub-ass-use-video-data`
+add `sub-ass-video-aspect-override`
+change default V keybind to cycle `sub-ass-use-video-data` instead of the now removed `sub-ass-vsfilter-aspect-compat`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2570,7 +2570,17 @@ Subtitles
 
 ``--sub-ass-use-video-data=<none|aspect-ratio|all>``
     Controls which information about the video stream is passed to libass.
-    Any option but ``all`` is incompatible with standard ASS and VSFilters.
+    Any option but ``all`` is incompatible with VSFilter, whose behavior
+    most subtitle scripts and renderers target, including libass.
+    Aspect ratio and storage resolution information are needed for VSFilter
+    compatibility, and withholding them will likely result in broken subtitle
+    rendering for most files. It's thus recommended to only use ``none`` or
+    ``aspect-ratio`` on a per-file basis.
+
+    :nono:  Don't use aspect ratio or storage resolution.
+    :aspect-ratio: Use aspect ratio only. Resolutions specified in the script
+                   are used in place of storage resolution.
+    :all:   Use both aspect ratio and storage resolution.
 
     For certain kinds of broken ASS files which got repurposed across
     several video resolutions without either setting ``LayoutRes`` headers
@@ -2589,7 +2599,7 @@ Subtitles
     Allows passing any arbitrary aspect ratio to libass instead of the video’s
     actual aspect ratio. Zero or negative aspect ratios are identical to ``no``.
 
-    This has no effect if ``sub-ass-use-video-data`` is set to none.
+    This has no effect if ``sub-ass-use-video-data`` is set to ``none``.
 
 ``--sub-vsfilter-bidi-compat=<yes|no>``
     Set implicit bidi detection to ``ltr`` instead of ``auto`` to match ASS'


### PR DESCRIPTION
I didn't get a chance to review that before it was LGTM'd.