### PR TITLE
Revert "mp_image: don't restore image params if they're unknown"

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -852,8 +852,6 @@ bool mp_image_params_static_equal(const struct mp_image_params *p1,
 // before dovi mapping.
 void mp_image_params_restore_dovi_mapping(struct mp_image_params *params)
 {
-    if (!params->primaries_orig || !params->transfer_orig || !params->sys_orig)
-        return;
     params->color.primaries = params->primaries_orig;
     params->color.transfer = params->transfer_orig;
     params->repr.sys = params->sys_orig;


### PR DESCRIPTION
This results in all image params not being restored even if only one is unknown. In particular params->color.hdr isn't cleared, causing overblown color for some samples.

It should be safe to restore even unknown values.
mp_image_params_guess_csp will handle that.

This reverts commit 3acd253e896206c79cd0c46ba93bf29219f61aa8.
