### PR TITLE
TOOLS/cycle-deinterlace-pullup.lua: fix removing the filter

### DIFF
--- a/TOOLS/lua/cycle-deinterlace-pullup.lua
+++ b/TOOLS/lua/cycle-deinterlace-pullup.lua
@@ -30,7 +30,7 @@ end
 local function do_cycle()
     if pullup_on() == "yes" then
         -- if pullup is on remove it
-        mp.command(string.format("vf del @%s:pullup", pullup_label))
+        mp.command(string.format("vf remove @%s:pullup", pullup_label))
         return
     elseif mp.get_property("deinterlace") == "yes" then
         -- if deinterlace is on, turn it off and insert pullup filter


### PR DESCRIPTION
This has been broken since b56e63e2a9 removed vf del. Replace it with vf remove. Fixes #14881.