### PR TITLE
meson: use relative file paths for file2string

### DIFF
--- a/TOOLS/file2string.py
+++ b/TOOLS/file2string.py
@@ -22,6 +22,7 @@
 # License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
 import sys
 
 def file2string(infilename, infile, outfile):
@@ -39,6 +40,6 @@ def file2string(infilename, infile, outfile):
         outfile.write('"' + ''.join(conv[c] for c in line) + '"\n')
 
 if __name__ == "__main__":
-    outfile = open(sys.argv[2], "w")
-    with open(sys.argv[1], 'rb') as infile:
-        file2string(sys.argv[1], infile, outfile)
+
+    with open(sys.argv[1], 'rb') as infile, open(sys.argv[2], "w") as outfile:
+        file2string(os.path.relpath(sys.argv[1], sys.argv[3]), infile, outfile)

--- a/TOOLS/osxbundle/meson.build
+++ b/TOOLS/osxbundle/meson.build
@@ -1,8 +1,6 @@
-input = join_paths(source_root, 'TOOLS', 'osxbundle',
-                   'mpv.app', 'Contents', 'Resources', 'icon.icns')
 osxbundle = custom_target('osxbundle',
-    input: input,
+    input: join_paths('mpv.app', 'Contents', 'Resources', 'icon.icns'),
     output: 'icon.icns.inc',
-    command: [file2string, '@INPUT@', '@OUTPUT@'],
+    command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
 )
 sources += osxbundle

--- a/etc/meson.build
+++ b/etc/meson.build
@@ -2,9 +2,9 @@ icons = ['16', '32', '64', '128']
 foreach size: icons
     name = 'mpv-icon-8bit-'+size+'x'+size+'.png'
     icon = custom_target(name,
-        input: join_paths(source_root, 'etc', name),
+        input: name,
         output: name + '.inc',
-        command: [file2string, '@INPUT@', '@OUTPUT@'],
+        command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
     )
     sources += icon
 endforeach
@@ -12,9 +12,9 @@ endforeach
 etc_files = ['input.conf', 'builtin.conf']
 foreach file: etc_files
     etc_file = custom_target(file,
-        input: join_paths(source_root, 'etc', file),
+        input: file,
         output: file + '.inc',
-        command: [file2string, '@INPUT@', '@OUTPUT@'],
+        command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
     )
     sources += etc_file
 endforeach

--- a/input/meson.build
+++ b/input/meson.build
@@ -2,9 +2,9 @@ icons = ['16', '32', '64', '128']
 foreach size: icons
     name = 'mpv-icon-8bit-'+size+'x'+size+'.png'
     icon = custom_target(name,
-        input: join_paths(source_root, 'etc', name),
+        input: name,
         output: name + '.inc',
-        command: [file2string, '@INPUT@', '@OUTPUT@'],
+        command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
     )
     sources += icon
 endforeach
@@ -12,9 +12,9 @@ endforeach
 etc_files = ['input.conf', 'builtin.conf']
 foreach file: etc_files
     etc_file = custom_target(file,
-        input: join_paths(source_root, 'etc', file),
+        input: file,
         output: file + '.inc',
-        command: [file2string, '@INPUT@', '@OUTPUT@'],
+        command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
     )
     sources += etc_file
 endforeach

--- a/player/javascript/meson.build
+++ b/player/javascript/meson.build
@@ -1,6 +1,6 @@
 defaults_js = custom_target('defaults.js',
-    input: join_paths(source_root, 'player', 'javascript', 'defaults.js'),
+    input: 'defaults.js',
     output: 'defaults.js.inc',
-    command: [file2string, '@INPUT@', '@OUTPUT@'],
+    command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
 )
 sources += defaults_js

--- a/player/lua/meson.build
+++ b/player/lua/meson.build
@@ -3,9 +3,9 @@ lua_files = ['defaults.lua', 'assdraw.lua', 'options.lua', 'osc.lua',
              'input.lua', 'fzy.lua', 'select.lua']
 foreach file: lua_files
     lua_file = custom_target(file,
-        input: join_paths(source_root, 'player', 'lua', file),
+        input: file,
         output: file + '.inc',
-        command: [file2string, '@INPUT@', '@OUTPUT@'],
+        command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
     )
     sources += lua_file
 endforeach

--- a/sub/meson.build
+++ b/sub/meson.build
@@ -1,6 +1,6 @@
 osd_font = custom_target('osd_font.otf',
-    input: join_paths(source_root, 'sub', 'osd_font.otf'),
+    input: 'osd_font.otf',
     output: 'osd_font.otf.inc',
-    command: [file2string, '@INPUT@', '@OUTPUT@'],
+    command: [file2string, '@INPUT@', '@OUTPUT@', '@SOURCE_ROOT@'],
 )
 sources += osd_font


### PR DESCRIPTION
This fixes "Generated from" comments to not include local source path in generated files.