### PR TITLE
lua: make fixes for lua 5.4

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -458,11 +458,6 @@ static int load_lua(struct mp_script_args *args)
 
     stats_register_thread_cputime(ctx->stats, "cpu");
 
-    if (LUA_VERSION_NUM != 501 && LUA_VERSION_NUM != 502) {
-        MP_FATAL(ctx, "Only Lua 5.1 and 5.2 are supported.\n");
-        goto error_out;
-    }
-
     lua_State *L = ctx->state = luaL_newstate();
     if (!L) {
         MP_FATAL(ctx, "Could not initialize Lua.\n");
@@ -879,7 +874,7 @@ static void pushnode(lua_State *L, mpv_node *node)
         lua_pushstring(L, node->u.string);
         break;
     case MPV_FORMAT_INT64:
-        lua_pushnumber(L, node->u.int64);
+        lua_pushinteger(L, node->u.int64);
         break;
     case MPV_FORMAT_DOUBLE:
         lua_pushnumber(L, node->u.double_);

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -131,7 +131,11 @@ function mp.disable_key_bindings(section)
 end
 
 function mp.set_mouse_area(x0, y0, x1, y1, section)
-    mp.input_set_section_mouse_area(section or default_section, x0, y0, x1, y1)
+    mp.input_set_section_mouse_area(section or default_section,
+                                    math.floor(x0),
+                                    math.floor(y0),
+                                    math.floor(x1),
+                                    math.floor(y1))
 end
 
 -- "Newer" and more convenient API

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -254,7 +254,9 @@ end
 
 local function set_virt_mouse_area(x0, y0, x1, y1, name)
     local sx, sy = get_virt_scale_factor()
-    mp.set_mouse_area(x0 / sx, y0 / sy, x1 / sx, y1 / sy, name)
+    if sx > 0 and sy > 0 then
+        mp.set_mouse_area(x0 / sx, y0 / sy, x1 / sx, y1 / sy, name)
+    end
 end
 
 local function scale_value(x0, x1, y0, y1, val)
@@ -360,7 +362,7 @@ end
 
 -- multiplies two alpha values, formular can probably be improved
 local function mult_alpha(alphaA, alphaB)
-    return 255 - (((1-(alphaA/255)) * (1-(alphaB/255))) * 255)
+    return math.floor(255 - (((1-(alphaA/255)) * (1-(alphaB/255))) * 255))
 end
 
 local function add_area(name, x1, y1, x2, y2)

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -189,7 +189,7 @@ local function format_time(t, duration)
     local h = math.floor(t / (60 * 60))
     t = t - (h * 60 * 60)
     local m = math.floor(t / 60)
-    local s = t - (m * 60)
+    local s = math.floor(t - m * 60)
 
     if duration >= 60 * 60 or h > 0 then
         return string.format("%.2d:%.2d:%.2d", h, m, s)

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -337,7 +337,7 @@ local function append_perfdata(header, s, dedicated_page)
     -- Pretty print measured time
     local function pp(i)
         -- rescale to microseconds for a saner display
-        return format("%5d", i / 1000)
+        return format("%5.0f", i / 1000)
     end
 
     -- Format n/m with a font weight based on the ratio
@@ -349,10 +349,10 @@ local function append_perfdata(header, s, dedicated_page)
         -- Calculate font weight. 100 is minimum, 400 is normal, 700 bold, 900 is max
         local w = (700 * math.sqrt(i)) + 200
         if not o.use_ass then
-            local str = format("%3d%%", i * 100)
+            local str = format("%3.0f%%", i * 100)
             return w >= 700 and bold(str) or str
         end
-        return format("{\\b%d}%3d%%{\\b0}", w, i * 100)
+        return format("{\\b%f}%3.0f%%{\\b0}", w, i * 100)
     end
 
     local font_small = o.use_ass and format("{\\fs%s}", font_size * 0.66) or ""
@@ -525,9 +525,9 @@ local function get_kbinfo_lines()
     local kpre = term and "" or format("{\\q2\\fn%s}%s", o.font_mono, LTR)
     local kpost = term and " " or format(" {\\fn%s}", o.font)
     local spre = term and kspaces .. "   "
-                       or format("{\\q2\\fn%s}%s   {\\fn%s}{\\fs%d\\u1}",
+                       or format("{\\q2\\fn%s}%s   {\\fn%s}{\\fs%f\\u1}",
                                  o.font_mono, kspaces, o.font, 1.3*font_size)
-    local spost = term and "" or format("{\\u0\\fs%d}%s", font_size, text_style())
+    local spost = term and "" or format("{\\u0\\fs%f}%s", font_size, text_style())
 
     -- create the display lines
     local info_lines = {}


### PR DESCRIPTION
This commit doesn't allow compilation with Lua 5.4 yet, but by making a few changes scripts work with Lua 5.4.

What causes breakage is that string.format('%d', 1.1) (or %X in the case of OSC), string.format('%d', 0/0) (i.e. nan), and luaL_checkinteger() with floats and nan error in newer Lua.

lua_pushinteger is used to expose integers without converting them to float, this also works in Lua 5.2.

The version check in lua.c is removed because it is already checked by meson.