### PR TITLE
DOCS/man/mpv.rst: clarify configuration files should be UTF-8

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1599,6 +1599,8 @@ FILES
 Note that this section assumes Linux/BSD. On other platforms the paths may be different.
 For Windows-specifics, see `FILES ON WINDOWS`_ section.
 
+All configuration files should be encoded in UTF-8.
+
 ``/usr/local/etc/mpv/mpv.conf``
     mpv system-wide settings (depends on ``--prefix`` passed to configure - mpv
     in default configuration will use ``/usr/local/etc/mpv/`` as config

--- a/input/input.c
+++ b/input/input.c
@@ -1478,10 +1478,10 @@ static bool parse_config_file(struct input_ctx *ictx, char *file)
         MP_ERR(ictx, "Can't open input config file %s.\n", file);
         goto done;
     }
-    stream_skip_bom(s);
     bstr data = stream_read_complete(s, tmp, 1000000);
     if (data.start) {
         MP_VERBOSE(ictx, "Parsing input config file %s\n", file);
+        bstr_eatstart0(&data, "\xEF\xBB\xBF"); // skip BOM
         int num = parse_config(ictx, false, data, file, (bstr){0});
         MP_VERBOSE(ictx, "Input config file %s parsed: %d binds\n", file, num);
         r = true;


### PR DESCRIPTION
Also fixes an incorrect BOM handling. 