### PR TITLE
wayland: add support for frog-color-management-v1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1025,6 +1025,8 @@ endforeach
 features += {'wayland': wayland_deps and wayland['header'] and wayland['scanner'].found()}
 
 if features['wayland']
+    frog_protocols = dependency('frog-protocols', required: false)
+    features += {'frog-protocols': frog_protocols.found()}
     subdir(join_paths('video', 'out'))
 endif
 

--- a/options/options.c
+++ b/options/options.c
@@ -194,6 +194,7 @@ static const m_option_t mp_vo_opt_list[] = {
     {"x11-wid-title", OPT_BOOL(x11_wid_title)},
 #endif
 #if HAVE_WAYLAND
+    {"wayland-colorspace-hint", OPT_BOOL(wl_colorspace_hint)},
     {"wayland-configure-bounds", OPT_CHOICE(wl_configure_bounds,
         {"auto", -1}, {"no", 0}, {"yes", 1})},
     {"wayland-content-type", OPT_CHOICE(wl_content_type, {"auto", -1}, {"none", 0},

--- a/options/options.h
+++ b/options/options.h
@@ -35,6 +35,7 @@ typedef struct mp_vo_opts {
     bool cursor_passthrough;
     bool native_keyrepeat;
 
+    bool wl_colorspace_hint;
     int wl_configure_bounds;
     int wl_content_type;
     bool wl_disable_vsync;

--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -11,6 +11,11 @@ protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml']
 wl_protocols_source = []
 wl_protocols_headers = []
 
+if features['frog-protocols']
+    frog_protocol_dir = frog_protocols.get_variable(pkgconfig: 'pkgdatadir', internal: 'pkgdatadir')
+    protocols += [[frog_protocol_dir, 'frog-color-management-v1.xml']]
+endif
+
 foreach v: ['1.32']
     features += {'wayland-protocols-' + v.replace('.', '-'):
         wayland['deps'][2].version().version_compare('>=' + v)}

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -67,6 +67,8 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    vo_wayland_handle_hdr_metadata(wl);
+
     eglSwapBuffers(p->egl_display, p->egl_surface);
 
     if (!wl->opts->wl_disable_vsync)

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -100,6 +100,8 @@ struct priv {
     bool destroy_buffers;
     bool force_window;
     enum hwdec_type hwdec_type;
+
+    struct mp_image_params target_params;
     uint32_t drm_format;
     uint64_t drm_modifier;
 };
@@ -538,6 +540,12 @@ static void resize(struct vo *vo)
                                                   lround(vo->dheight / wl->scaling_factor));
     wl_subsurface_set_position(wl->osd_subsurface, lround((0 - dst.x0) / wl->scaling_factor), lround((0 - dst.y0) / wl->scaling_factor));
     set_viewport_source(vo, src);
+
+    mp_mutex_lock(&vo->params_mutex);
+    vo->target_params->w = mp_rect_w(dst);
+    vo->target_params->h = mp_rect_h(dst);
+    vo->target_params->rotate = (vo->params->rotate % 90) * 90;
+    mp_mutex_unlock(&vo->params_mutex);
 }
 
 static bool draw_osd(struct vo *vo, struct mp_image *cur, double pts)
@@ -609,6 +617,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
 
     pts = frame->current ? frame->current->pts : 0;
     if (frame->current) {
+        vo_wayland_handle_hdr_metadata(wl);
         buf = buffer_get(vo, frame);
 
         if (buf && buf->frame) {
@@ -690,6 +699,17 @@ static int reconfig(struct vo *vo, struct mp_image *img)
 done:
     if (!vo_wayland_reconfig(vo))
         return VO_ERROR;
+
+    mp_mutex_lock(&vo->params_mutex);
+    p->target_params = img->params;
+    // Restore fallback layer parameters if available.
+    mp_image_params_restore_dovi_mapping(&p->target_params);
+    // Strip metadata that are not understood anyway.
+    struct pl_hdr_metadata *hdr = &p->target_params.color.hdr;
+    hdr->scene_max[0] = hdr->scene_max[1] = hdr->scene_max[2] = 0;
+    hdr->scene_avg = hdr->max_pq_y = hdr->avg_pq_y = 0;
+    vo->target_params = &p->target_params;
+    mp_mutex_unlock(&vo->params_mutex);
 
     wl_surface_set_buffer_transform(vo->wl->video_surface, img->params.rotate / 90);
 

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -250,6 +250,8 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
     if (!render)
         return;
 
+    vo_wayland_handle_hdr_metadata(wl);
+
     buf = p->free_buffers;
     if (buf) {
         p->free_buffers = buf->next;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -36,6 +36,8 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
 {
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    vo_wayland_handle_hdr_metadata(wl);
+
     if (!wl->opts->wl_disable_vsync)
         vo_wayland_wait_frame(wl);
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -85,6 +85,11 @@ struct vo_wayland_state {
     int timeout_count;
     int wakeup_pipe[2];
 
+    /* color-management */
+    void *color_management;
+    void *color_surface;
+    bool reset_colorspace;
+
     /* content-type */
     struct wp_content_type_manager_v1 *content_type_manager;
     struct wp_content_type_v1 *content_type;
@@ -167,6 +172,7 @@ bool vo_wayland_reconfig(struct vo *vo);
 int vo_wayland_allocate_memfd(struct vo *vo, size_t size);
 int vo_wayland_control(struct vo *vo, int *events, int request, void *arg);
 
+void vo_wayland_handle_hdr_metadata(struct vo_wayland_state *wl);
 void vo_wayland_handle_scale(struct vo_wayland_state *wl);
 void vo_wayland_set_opaque_region(struct vo_wayland_state *wl, bool alpha);
 void vo_wayland_sync_swap(struct vo_wayland_state *wl);


### PR DESCRIPTION
Completely untested. I don't even own any HDR displays. In theory, this should do something on Kwin which supports this protocol (didn't check if that is in a release or not yet). Basically this uses `frog-color-management` to implement a `--wayland-colorspace-hint` option which is a graphics API-independent way to pass HDR metadata to the compositor.

Some obvious questions (not an exhaustive list) that need to be answered.
- Does this even work?
- What happens if you set `--target-colorspace-hint` and `--wayland-colorpace-hint` at the same time
- Is it sufficient to assume we only care about setting primaries/etc. only when it's HDR?
- `frog_color_managed_surface_set_hdr_metadata` doesn't seem to have an obvious way to "unset" itself; is simply setting the primaries and transfer function back to unknown sufficient?
- Should we be always setting primaries and transfer?
- Currently this uses `wl->surface` for the frog color surface, but does that even work for dmabuf-wayland (which uses multiple subsurface)?

Any feedback and testing much appreciated. Probably should split the primaries/transfer part from the hdr metadata part now that I look at it again.