### PR TITLE
demux_mkv: add missing color repr init

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1680,6 +1680,7 @@ static int demux_mkv_open_video(demuxer_t *demuxer, mkv_track_t *track)
     sh_v->par_h = p.p_h;
 
     sh_v->stereo_mode = track->stereo_mode;
+    sh_v->repr = track->repr;
     sh_v->color = track->color;
 
     if (track->v_projection_pose_roll) {


### PR DESCRIPTION
Fixes: 66e451f4e6e0d0b259eddfd3673f1aa5ff127726