### PR TITLE
options: force --ab-loop-count and --loop-file notification

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -603,7 +603,7 @@ static const m_option_t mp_opts[] = {
     {"ab-loop-a", OPT_TIME(ab_loop[0]), .flags = M_OPT_ALLOW_NO},
     {"ab-loop-b", OPT_TIME(ab_loop[1]), .flags = M_OPT_ALLOW_NO},
     {"ab-loop-count", OPT_CHOICE(ab_loop_count, {"inf", -1}),
-        M_RANGE(0, INT_MAX)},
+        M_RANGE(0, INT_MAX), .force_update = true},
 
     {"playlist-start", OPT_CHOICE(playlist_pos, {"auto", -1}, {"no", -1}),
         M_RANGE(0, INT_MAX)},
@@ -821,7 +821,7 @@ static const m_option_t mp_opts[] = {
         {"no", 0},
         {"inf", -1},
         {"yes", -1}),
-        M_RANGE(0, 10000)},
+        M_RANGE(0, 10000), .force_update = true},
     {"loop", OPT_ALIAS("loop-file")},
 
     {"resume-playback", OPT_BOOL(position_resume)},


### PR DESCRIPTION
Since f411f3145ba2f6eebc658917d0879d5e573bbdf0, these properties no longer change with each loop. This however caused a regression on the behavior of resetting loop count by resetting these properties.

Previously, after the loop count is decreased, it is possible to reset these properties back their original values and thus reset the remaining loop count. Currently, because setting properties has no effect if the new value is the same as the existing value (which no longer changes), resetting these properties does nothing, and remaining-*-loops (which are read-only) remain unchanged. There is no way to reset them other than temporarily setting them to a different value, which is awkward.

Fortunately, this can be fixed by marking these properties as force_update, which always notifies changes when being set.
