### PR TITLE
misc/random: seed using libavutil/random_seed

### DIFF
--- a/misc/random.h
+++ b/misc/random.h
@@ -24,7 +24,7 @@
 
 /*
  * Initialize the pseudo-random number generator's state with
- * the given 64-bit seed.
+ * the given 64-bit seed. If the seed is 0, it is randomized.
  */
 void mp_rand_seed(uint64_t seed);
 

--- a/osdep/timer.c
+++ b/osdep/timer.c
@@ -22,7 +22,6 @@
 
 #include "common/common.h"
 #include "common/msg.h"
-#include "misc/random.h"
 #include "threads.h"
 #include "timer.h"
 
@@ -32,7 +31,6 @@ static mp_once timer_init_once = MP_STATIC_ONCE_INITIALIZER;
 static void do_timer_init(void)
 {
     mp_raw_time_init();
-    mp_rand_seed(mp_raw_time_ns());
     raw_time_offset = mp_raw_time_ns();
     assert(raw_time_offset > 0);
 }

--- a/player/main.c
+++ b/player/main.c
@@ -30,6 +30,7 @@
 #include "mpv_talloc.h"
 
 #include "misc/dispatch.h"
+#include "misc/random.h"
 #include "misc/thread_pool.h"
 #include "osdep/io.h"
 #include "osdep/terminal.h"
@@ -263,6 +264,7 @@ struct MPContext *mp_create(void)
         talloc_enable_leak_report();
 
     mp_time_init();
+    mp_rand_seed(0);
 
     struct MPContext *mpctx = talloc(NULL, MPContext);
     *mpctx = (struct MPContext){


### PR DESCRIPTION
I recently encountered issues when running multiple instances of `mpv --shuffle` in parallel like this:

    for i in $(seq 4)
    do
        mpv --shuffle dir/ &
    done

([full script here](https://gist.github.com/frostschutz/0e88a14a4b3e2a17ca0b88407c18e5ad#file-noise-sh-L42))

The same tracks were played in the same random order. On my system this happened like 1 out of 10 times.

Turns out two instances of mpv ended up using the same random seed despite using nanosecond time. Since the seed is based on time, I can work around it by sleeping some random time before starting mpv:

    sleep 0.$RANDOM && mpv --shuffle dir/ &

But then I thought, why not improve the seed...?

Since each process has a unique pid, and mpv already has `mp_getpid()`, I thought of adding it to the seed. That alone, pretty much fixed the issue already - but only if you bitshift the pid, since otherwise it just results in an off-by-one in the nanosecond range and duplicate seeds still happen.

Then I added getentropy() just for the heck of it.

And since these are no longer time related, I moved the random seed initialization from osdep/timer to misc/random, using a similar init function that osdep/timer is using.

Sample run showing duplicate time, unique seeds after changes:

```
$ (for i in $(seq 4) do ./mpv & done) | 
grep 'mp_rand' | sort | uniq -c
      1 mp_rand entropy = 1040740086676672535
      1 mp_rand entropy = 13002351960262339936
      1 mp_rand entropy = 14025217818308350244
      1 mp_rand entropy = 288080024619363937
      1 mp_rand pid = 1556506
      1 mp_rand pid = 1556507
      1 mp_rand pid = 1556508
      1 mp_rand pid = 1556509
      1 mp_rand seed = 11359191221714005714
      1 mp_rand seed = 16965586738867753646
      1 mp_rand seed = 5868483814503682390
      1 mp_rand seed = 6701094793722892719
      2 mp_rand time = 19205151801294
      1 mp_rand time = 19205151801334
      1 mp_rand time = 19205151801665
```