### PR TITLE
wayland: add support for wp-color-representation-v1

### DIFF
--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -13,7 +13,7 @@ protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml']
 wl_protocols_source = []
 wl_protocols_headers = []
 
-foreach v: ['1.32', '1.38', '1.39', '1.41']
+foreach v: ['1.32', '1.38', '1.39', '1.41', '1.44']
     features += {'wayland-protocols-' + v.replace('.', '-'):
         wayland['deps'][2].version().version_compare('>=' + v)}
 endforeach
@@ -34,6 +34,10 @@ endif
 
 if features['wayland-protocols-1-41']
     protocols += [[wl_protocol_dir, 'staging/color-management/color-management-v1.xml']]
+endif
+
+if features['wayland-protocols-1-44']
+    protocols += [[wl_protocol_dir, 'staging/color-representation/color-representation-v1.xml']]
 endif
 
 foreach p: protocols

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -67,6 +67,8 @@ static void wayland_egl_swap_buffers(struct ra_ctx *ctx)
     struct priv *p = ctx->priv;
     struct vo_wayland_state *wl = ctx->vo->wl;
 
+    vo_wayland_handle_color(wl);
+
     eglSwapBuffers(p->egl_display, p->egl_surface);
 
     if (wl->opts->wl_internal_vsync)

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -261,6 +261,7 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
         }
     }
     if (src) {
+        vo_wayland_handle_color(wl);
         struct mp_image dst = buf->mpi;
         struct mp_rect src_rc;
         struct mp_rect dst_rc;

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -38,6 +38,8 @@ static void wayland_vk_swap_buffers(struct ra_ctx *ctx)
     struct vo_wayland_state *wl = ctx->vo->wl;
     struct priv *p = ctx->priv;
 
+    vo_wayland_handle_color(wl);
+
     if ((!p->use_fifo && wl->opts->wl_internal_vsync == 1) || wl->opts->wl_internal_vsync == 2)
         vo_wayland_wait_frame(wl);
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -106,6 +106,13 @@ struct vo_wayland_state {
     void *icc_file;
     uint32_t icc_size;
 
+    /* color-representation */
+    struct wp_color_representation_manager_v1 *color_representation_manager;
+    struct wp_color_representation_surface_v1 *color_representation_surface;
+    int alpha_map[PL_ALPHA_MODE_COUNT];
+    int coefficients_map[PL_COLOR_SYSTEM_COUNT];
+    int range_map[PL_COLOR_SYSTEM_COUNT * 2];
+
     /* content-type */
     struct wp_content_type_manager_v1 *content_type_manager;
     struct wp_content_type_v1 *content_type;


### PR DESCRIPTION
Alternative to #14917. The downside is that this protocol is ungodly complicated. Upside is that more people seem to implement and in theory when the color management protocol lands upstream next decade it will be like this. So probably longer term this is better.

Weston atm doesn't support the minimum features we need so it's not good for testing other than making sure I didn't make a protocol error. kwin is probably the best but `xx-color-management-v4` is only supported in kwin master at the moment and not at release (release supports v2). So not really tested yet until I go compile a bunch of kde junk later. Mutter 47 seems to support `xx-color-management-v4` though.

TODO:

- [ ] Add ICC. Weston advertises ICC support at least.
- [x] Check the multipliers. I think everything is supposed to be multiplied by 10000 (should be correct now).