### PR TITLE
x11: don't unconditionally move the window on geometry changes

### DIFF
--- a/DOCS/interface-changes/geometry-behavior.txt
+++ b/DOCS/interface-changes/geometry-behavior.txt
@@ -1,0 +1,1 @@
+change `--geometry` so that it no longer unconditionally moves the window on platforms where that is possible. Use `--force-window-position` or add `+50%+50%` to your geometry command to get the old behavior back.

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2219,10 +2219,6 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
         } else if (!(gm->w > 0) && gm->h > 0) {
             *widw = *widh * asp;
         }
-        // Center window after resize. If valid x:y values are passed to
-        // geometry, then those values will be overridden.
-        *xpos += prew / 2 - *widw / 2;
-        *ypos += preh / 2 - *widh / 2;
     }
 
     if (gm->xy_valid) {

--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -92,7 +92,7 @@ class CocoaCB: Common, EventSubscriber {
             return
         }
 
-        let wr = getWindowGeometry(forScreen: targetScreen, videoOut: vo)
+        let (wr, _) = getWindowGeometry(forScreen: targetScreen, videoOut: vo)
         if !(window?.isVisible ?? false) && !(window?.isMiniaturized ?? false) && !NSApp.isHidden {
             window?.makeKeyAndOrderFront(nil)
         }

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -426,7 +426,7 @@ class Common: NSObject {
                                         y1: Int32(originY + rv.size.height))
 
         var geo: vo_win_geometry = vo_win_geometry()
-        vo_calc_window_geometry(vo, &screenRC, &screenRC, Double(screen.backingScaleFactor), &geo)
+        vo_calc_window_geometry(vo, &screenRC, &screenRC, Double(screen.backingScaleFactor), false, &geo)
         vo_apply_window_geometry(vo, &geo)
 
         let height = CGFloat(geo.win.y1 - geo.win.y0)

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -426,7 +426,7 @@ class Common: NSObject {
                                         y1: Int32(originY + rv.size.height))
 
         var geo: vo_win_geometry = vo_win_geometry()
-        vo_calc_window_geometry2(vo, &screenRC, Double(screen.backingScaleFactor), &geo)
+        vo_calc_window_geometry(vo, &screenRC, &screenRC, Double(screen.backingScaleFactor), &geo)
         vo_apply_window_geometry(vo, &geo)
 
         let height = CGFloat(geo.win.y1 - geo.win.y0)

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -47,7 +47,7 @@ class MacCommon: Common {
             let previousActiveApp = getActiveApp()
             initApp()
 
-            let (_, wr) = getInitProperties(vo)
+            let (_, wr, _) = getInitProperties(vo)
 
             guard let layer = self.layer else {
                 log.error("Something went wrong, no MetalLayer was initialized")

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -453,7 +453,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     struct mp_rect screenrc;
 
     update_screeninfo(vo, &screenrc);
-    vo_calc_window_geometry(vo, &screenrc, &screenrc, 1.0, &geo);
+    vo_calc_window_geometry(vo, &screenrc, &screenrc, 1.0, false, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     int win_w = vo->dwidth;

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -453,7 +453,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     struct mp_rect screenrc;
 
     update_screeninfo(vo, &screenrc);
-    vo_calc_window_geometry(vo, &screenrc, &geo);
+    vo_calc_window_geometry(vo, &screenrc, &screenrc, 1.0, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     int win_w = vo->dwidth;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1920,7 +1920,7 @@ static void window_reconfig(struct vo_w32_state *w32, bool force)
     if (w32->dpi_scale == 0)
         force_update_display_info(w32);
 
-    vo_calc_window_geometry(vo, &screen, &mon, w32->dpi_scale, &geo);
+    vo_calc_window_geometry(vo, &screen, &mon, w32->dpi_scale, false, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     bool reset_size = ((w32->o_dwidth != vo->dwidth ||

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1920,7 +1920,7 @@ static void window_reconfig(struct vo_w32_state *w32, bool force)
     if (w32->dpi_scale == 0)
         force_update_display_info(w32);
 
-    vo_calc_window_geometry3(vo, &screen, &mon, w32->dpi_scale, &geo);
+    vo_calc_window_geometry(vo, &screen, &mon, w32->dpi_scale, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     bool reset_size = ((w32->o_dwidth != vo->dwidth ||

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2272,7 +2272,7 @@ static void set_geometry(struct vo_wayland_state *wl, bool resize)
 
     struct vo_win_geometry geo;
     struct mp_rect screenrc = wl->current_output->geometry;
-    vo_calc_window_geometry(vo, &screenrc, &screenrc, wl->scaling_factor, &geo);
+    vo_calc_window_geometry(vo, &screenrc, &screenrc, wl->scaling_factor, false, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     int gcd = greatest_common_divisor(vo->dwidth, vo->dheight);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2272,7 +2272,7 @@ static void set_geometry(struct vo_wayland_state *wl, bool resize)
 
     struct vo_win_geometry geo;
     struct mp_rect screenrc = wl->current_output->geometry;
-    vo_calc_window_geometry2(vo, &screenrc, wl->scaling_factor, &geo);
+    vo_calc_window_geometry(vo, &screenrc, &screenrc, wl->scaling_factor, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     int gcd = greatest_common_divisor(vo->dwidth, vo->dheight);

--- a/video/out/win_state.c
+++ b/video/out/win_state.c
@@ -69,6 +69,8 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 // Does not change *vo.
 //  screen: position of the area on virtual desktop on which the video-content
 //          should be placed (maybe after excluding decorations, taskbars, etc)
+//          can be the same as monitor for platforms that don't try to take into
+//          account decorations, taskbars, etc.
 //  monitor: position of the monitor on virtual desktop (used for pixelaspect).
 //  dpi_scale: the DPI multiplier to get from virtual to real coordinates
 //             (>1 for "hidpi")
@@ -77,9 +79,9 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 //       geometry additional to this code. This is to deal with initial window
 //       placement, fullscreen handling, avoiding resize on reconfig() with no
 //       size change, multi-monitor stuff, and possibly more.
-void vo_calc_window_geometry3(struct vo *vo, const struct mp_rect *screen,
-                              const struct mp_rect *monitor,
-                              double dpi_scale, struct vo_win_geometry *out_geo)
+void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
+                             const struct mp_rect *monitor,
+                             double dpi_scale, struct vo_win_geometry *out_geo)
 {
     struct mp_vo_opts *opts = vo->opts;
 
@@ -129,19 +131,6 @@ void vo_calc_window_geometry3(struct vo *vo, const struct mp_rect *screen,
 
     if (opts->geometry.xy_valid || opts->force_window_position)
         out_geo->flags |= VO_WIN_FORCE_POS;
-}
-
-// same as vo_calc_window_geometry3 with monitor assumed same as screen
-void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
-                              double dpi_scale, struct vo_win_geometry *out_geo)
-{
-    vo_calc_window_geometry3(vo, screen, screen, dpi_scale, out_geo);
-}
-
-void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
-                             struct vo_win_geometry *out_geo)
-{
-    vo_calc_window_geometry2(vo, screen, 1.0, out_geo);
 }
 
 // Copy the parameters in *geo to the vo fields.

--- a/video/out/win_state.h
+++ b/video/out/win_state.h
@@ -24,12 +24,8 @@ struct vo_win_geometry {
 };
 
 void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
-                             struct vo_win_geometry *out_geo);
-void vo_calc_window_geometry2(struct vo *vo, const struct mp_rect *screen,
-                              double dpi_scale, struct vo_win_geometry *out_geo);
-void vo_calc_window_geometry3(struct vo *vo, const struct mp_rect *screen,
-                              const struct mp_rect *monitor,
-                              double dpi_scale, struct vo_win_geometry *out_geo);
+                             const struct mp_rect *monitor,
+                             double dpi_scale, struct vo_win_geometry *out_geo);
 void vo_apply_window_geometry(struct vo *vo, const struct vo_win_geometry *geo);
 
 #endif

--- a/video/out/win_state.h
+++ b/video/out/win_state.h
@@ -24,8 +24,8 @@ struct vo_win_geometry {
 };
 
 void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
-                             const struct mp_rect *monitor,
-                             double dpi_scale, struct vo_win_geometry *out_geo);
+                             const struct mp_rect *monitor, double dpi_scale,
+                             bool force_center, struct vo_win_geometry *out_geo);
 void vo_apply_window_geometry(struct vo *vo, const struct vo_win_geometry *geo);
 
 #endif

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1809,7 +1809,8 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_x11_update_screeninfo(vo);
 
     struct vo_win_geometry geo;
-    vo_calc_window_geometry(vo, &x11->screenrc, &x11->screenrc, x11->dpi_scale, false, &geo);
+    vo_calc_window_geometry(vo, &x11->screenrc, &x11->screenrc, x11->dpi_scale,
+                            !x11->pseudo_mapped, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     struct mp_rect rc = geo.win;
@@ -1833,7 +1834,7 @@ void vo_x11_config_vo_window(struct vo *vo)
         x11->nofsrc = rc;
         vo_x11_map_window(vo, rc);
     } else if (reset_size) {
-        vo_x11_highlevel_resize(vo, rc, x11->geometry_change);
+        vo_x11_highlevel_resize(vo, rc, geo.flags & VO_WIN_FORCE_POS);
     }
 
     x11->geometry_change = false;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1809,7 +1809,7 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_x11_update_screeninfo(vo);
 
     struct vo_win_geometry geo;
-    vo_calc_window_geometry2(vo, &x11->screenrc, x11->dpi_scale, &geo);
+    vo_calc_window_geometry(vo, &x11->screenrc, &x11->screenrc, x11->dpi_scale, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     struct mp_rect rc = geo.win;

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1809,7 +1809,7 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_x11_update_screeninfo(vo);
 
     struct vo_win_geometry geo;
-    vo_calc_window_geometry(vo, &x11->screenrc, &x11->screenrc, x11->dpi_scale, &geo);
+    vo_calc_window_geometry(vo, &x11->screenrc, &x11->screenrc, x11->dpi_scale, false, &geo);
     vo_apply_window_geometry(vo, &geo);
 
     struct mp_rect rc = geo.win;


### PR DESCRIPTION
9e81fc9ba992949172c405e09dea8897587e3ce2 started doing this and then later when force update notifications were added it became even more apparent with issues like #14911. In retrospect, this behavior change is not really intuitive (nobody would reasonably expect --geometry=50% to also center the window) and actually completely avoidable. vo_calc_window_geometry3 already flags for us if the window should be moved either via the opts->force_window_position or if there is a valid xy specified in the geometry option. All we need to do is check the flags for VO_WIN_FORCE_POS and use that for determining whether or not an actual window move should be done.