### PR TITLE
command: add playlist-order

### DIFF
--- a/DOCS/interface-changes/playlist-reorder.txt
+++ b/DOCS/interface-changes/playlist-reorder.txt
@@ -1,0 +1,1 @@
+add `playlist-reorder`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -554,6 +554,12 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
     because index2 refers to the target entry, not the index the entry
     will have after moving.)
 
+``playlist-reorder [<index1> [<index2> [...]]]``
+    Reorder playlist to start with playlist entry at index1, followed by the
+    entry at index2 and so on. Entries not mentioned in the list are removed.
+    Removing the current entry stops playback and starts playing the next kept
+    entry. Index values start counting with 0.
+
 ``playlist-shuffle``
     Shuffle the playlist. This is similar to what is done on start if the
     ``--shuffle`` option is used.

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -98,6 +98,7 @@ void playlist_append_file(struct playlist *pl, const char *filename);
 void playlist_populate_playlist_path(struct playlist *pl, const char *path);
 void playlist_shuffle(struct playlist *pl);
 void playlist_unshuffle(struct playlist *pl);
+void playlist_reorder(struct playlist *pl, const int *indexes, int num_indexes);
 struct playlist_entry *playlist_get_first(struct playlist *pl);
 struct playlist_entry *playlist_get_last(struct playlist *pl);
 struct playlist_entry *playlist_get_next(struct playlist *pl, int direction);


### PR DESCRIPTION
I couldn't find an straightforward and performant way to manipulate the playlist (from Lua scripts).

On one hand, `playlist-move` based solutions work but can be very slow, on the other hand `loadfile`/`loadlist` solutions are faster but they create new playlist entries that lose original id, title, options and playlist-path.

`playlist-order` covers functionality of `playlist-move` and `playlist-remove`. It modifies playlist in one operation, so observers don't get flooded with thousands of intermediate property changes.