### PR TITLE
zsh-completion: fix completing --screenshot-avif-opts-*

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -65,7 +65,7 @@ function _mpv_generate_arguments {
         _mpv_completion_arguments+="$name"
       else
         # Find the parent option and use that with this option's name
-        _mpv_completion_arguments+="${_mpv_completion_arguments[(R)${name%-*}=*]/*=/$name=}"
+        _mpv_completion_arguments+="${(S)_mpv_completion_arguments[(R)${name%-*}=*]/*=/$name=}"
       fi
 
     elif [[ $desc == Print* ]]; then


### PR DESCRIPTION
The list options --screenshot-avif-opts and --vo-image-opts are completed with an extra 8), e.g. --screenshot-avif-opts-add=8), because *= in
`screenshot-avif-opts=-:Key/value list (default\: usage=allintra,crf=0,cpu-used=8):`
matches up to `cpu-used=` instead of instead of up to `screenshot-avif-opts=.`

Fix this by enabling non-greedy matching.