### PR TITLE
ra_wldambuf: don't unconditionally filter out non-planar formats

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1880,14 +1880,14 @@ static void get_gpu_drm_formats(struct vo_wayland_state *wl)
     // Only check the formats on the first primary plane we find as a crude guess.
     int index = -1;
     for (int i = 0; i < res->count_planes; ++i) {
-	    drmModeObjectProperties *props = NULL;
-		props = drmModeObjectGetProperties(fd, res->planes[i], DRM_MODE_OBJECT_PLANE);
+        drmModeObjectProperties *props = NULL;
+        props = drmModeObjectGetProperties(fd, res->planes[i], DRM_MODE_OBJECT_PLANE);
         if (!props) {
             MP_VERBOSE(wl, "Unable to get DRM plane properties: %s\n", mp_strerror(errno));
             continue;
         }
         for (int j = 0; j < props->count_props; ++j) {
-		    drmModePropertyRes *prop = drmModeGetProperty(fd, props->props[j]);
+            drmModePropertyRes *prop = drmModeGetProperty(fd, props->props[j]);
             if (!prop) {
                 MP_VERBOSE(wl, "Unable to get DRM plane property: %s\n", mp_strerror(errno));
                 continue;
@@ -1898,7 +1898,7 @@ static void get_gpu_drm_formats(struct vo_wayland_state *wl)
                         index = i;
                 }
             }
-		    drmModeFreeProperty(prop);
+            drmModeFreeProperty(prop);
             if (index > -1)
                 break;
         }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -212,7 +212,7 @@ static int spawn_cursor(struct vo_wayland_state *wl);
 static void add_feedback(struct vo_wayland_feedback_pool *fback_pool,
                          struct wp_presentation_feedback *fback);
 static void apply_keepaspect(struct vo_wayland_state *wl, int *width, int *height);
-static void get_gpu_drm_formats(struct vo_wayland_state *wl);
+static void get_planar_drm_formats(struct vo_wayland_state *wl);
 static void get_shape_device(struct vo_wayland_state *wl, struct vo_wayland_seat *s);
 static void guess_focus(struct vo_wayland_state *wl);
 static void handle_key_input(struct vo_wayland_seat *s, uint32_t key, uint32_t state, bool no_emit);
@@ -1406,7 +1406,7 @@ static void tranche_target_device(void *data,
             memcpy(&wl->target_device_id, id, sizeof(dev_t));
             break;
         }
-        get_gpu_drm_formats(wl);
+        get_planar_drm_formats(wl);
     }
 }
 
@@ -1828,7 +1828,7 @@ static char **get_displays_spanned(struct vo_wayland_state *wl)
     return names;
 }
 
-static void get_gpu_drm_formats(struct vo_wayland_state *wl)
+static void get_planar_drm_formats(struct vo_wayland_state *wl)
 {
 #if HAVE_DRM
     drmDevice *device = NULL;
@@ -1913,15 +1913,15 @@ static void get_gpu_drm_formats(struct vo_wayland_state *wl)
     }
 
     plane = drmModeGetPlane(fd, res->planes[index]);
-    wl->num_gpu_formats = plane->count_formats;
+    wl->num_planar_formats = plane->count_formats;
 
-    if (wl->gpu_formats)
-        talloc_free(wl->gpu_formats);
+    if (wl->planar_formats)
+        talloc_free(wl->planar_formats);
 
-    wl->gpu_formats = talloc_zero_array(wl, int, wl->num_gpu_formats);
-    for (int i = 0; i < wl->num_gpu_formats; ++i) {
+    wl->planar_formats = talloc_zero_array(wl, int, wl->num_planar_formats);
+    for (int i = 0; i < wl->num_planar_formats; ++i) {
         MP_DBG(wl, "DRM primary plane supports drm format: %s\n", mp_tag_str(plane->formats[i]));
-        wl->gpu_formats[i] = plane->formats[i];
+        wl->planar_formats[i] = plane->formats[i];
     }
 
 done:

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -115,8 +115,8 @@ struct vo_wayland_state {
     uint32_t compositor_format_size;
     struct drm_format *compositor_formats;
     int num_compositor_formats;
-    uint32_t *gpu_formats;
-    int num_gpu_formats;
+    uint32_t *planar_formats;
+    int num_planar_formats;
 
     /* presentation-time */
     struct wp_presentation  *presentation;

--- a/video/out/wldmabuf/ra_wldmabuf.c
+++ b/video/out/wldmabuf/ra_wldmabuf.c
@@ -35,17 +35,17 @@ bool ra_compatible_format(struct ra *ra, int imgfmt, uint32_t drm_format, uint64
     struct drm_format *formats = wl->compositor_formats;
 
 
-    // If we were able to make the DRM query, filter out the GPU formats.
+    // If we were able to make the DRM query, filter out the planar formats.
     // If not, just assume they all work and hope for the best.
-    if (wl->gpu_formats) {
-        bool supported_gpu_format = false;
-        for (int i = 0; i < wl->num_gpu_formats; i++) {
-            if (drm_format == wl->gpu_formats[i]) {
-                supported_gpu_format = true;
+    if (wl->planar_formats) {
+        bool supported_planar_format = false;
+        for (int i = 0; i < wl->num_planar_formats; i++) {
+            if (drm_format == wl->planar_formats[i]) {
+                supported_planar_format = true;
                 break;
             }
         }
-        if (!supported_gpu_format)
+        if (!supported_planar_format)
             return false;
     }
 


### PR DESCRIPTION
I believe my mistake in #14815 is that I was too aggressive with the format filters and planar ones should only be used if there was not any valid modifiers. If a valid format + modifier pair is matched, then it should be considered valid and we accept it.

@na-na-hi: Does this fix the extra conversion you were seeing?