### PR TITLE
various: fix null deref for string list options

### DIFF
--- a/player/external_files.c
+++ b/player/external_files.c
@@ -47,7 +47,7 @@ static int test_ext(MPOpts *opts, bstr ext)
 
 static int test_cover_filename(bstr fname, char **cover_files)
 {
-    for (int n = 0; cover_files[n]; n++) {
+    for (int n = 0; cover_files && cover_files[n]; n++) {
         if (bstrcasecmp(bstr0(cover_files[n]), fname) == 0) {
             size_t size = n;
             while (cover_files[++size]);

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -481,7 +481,7 @@ static void select_and_set_hwdec(struct mp_filter *vd)
     add_all_hwdec_methods(&hwdecs, &num_hwdecs);
 
     char **hwdec_api = ctx->opts->hwdec_api;
-    for (int i = 0; hwdec_api[i]; i++) {
+    for (int i = 0; hwdec_api && hwdec_api[i]; i++) {
         bstr opt = bstr0(hwdec_api[i]);
 
         bool hwdec_requested = !bstr_equals0(opt, "no");


### PR DESCRIPTION
Fixes segfault when using `--cover-art-whitelist-clr` and `--hwdec-clr` because they are not checked for list emptiness.