### PR TITLE
wayland: support multiple devices and tranches when querying formats

### DIFF
--- a/video/out/hwdec/dmabuf_interop_wl.c
+++ b/video/out/hwdec/dmabuf_interop_wl.c
@@ -44,8 +44,8 @@ static bool map(struct ra_hwdec_mapper *mapper,
     if (mapper_p->desc.nb_layers != 1) {
         MP_VERBOSE(mapper, "Mapped surface has separate layers - expected composed layers.\n");
         return false;
-    } else if (!ra_compatible_format(mapper->ra, mapper->src->params.hw_subfmt,
-               drm_format, mapper_p->desc.objects[0].format_modifier)) {
+    } else if (!ra_compatible_format(mapper->ra, drm_format,
+               mapper_p->desc.objects[0].format_modifier)) {
         MP_VERBOSE(mapper, "Mapped surface with format %s; drm format '%s(%016" PRIx64 ")' "
                    "is not supported by compositor and GPU combination.\n",
                    mp_imgfmt_to_name(mapper->src->params.hw_subfmt),

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -198,7 +198,7 @@ static void vaapi_dmabuf_importer(struct buffer *buf, struct mp_image *src,
         goto done;
     }
     buf->drm_format = desc.layers[layer_no].drm_format;
-    if (!ra_compatible_format(p->ctx->ra, src->params.hw_subfmt, buf->drm_format, desc.objects[0].drm_format_modifier)) {
+    if (!ra_compatible_format(p->ctx->ra, buf->drm_format, desc.objects[0].drm_format_modifier)) {
         MP_VERBOSE(vo, "%s(%016" PRIx64 ") is not supported.\n",
                    mp_tag_str(buf->drm_format), desc.objects[0].drm_format_modifier);
         buf->drm_format = 0;
@@ -680,7 +680,7 @@ static int reconfig(struct vo *vo, struct mp_image *img)
         return VO_ERROR;
     }
 
-    if (!ra_compatible_format(p->ctx->ra, img->params.hw_subfmt, p->drm_format, p->drm_modifier)) {
+    if (!ra_compatible_format(p->ctx->ra, p->drm_format, p->drm_modifier)) {
         MP_ERR(vo, "Format '%s' with modifier '(%016" PRIx64 ")' is not supported by"
                " the compositor.\n", mp_tag_str(p->drm_format), p->drm_modifier);
         return VO_ERROR;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -22,13 +22,9 @@
 #include "input/event.h"
 #include "vo.h"
 
+struct compositor_format;
 struct vo_wayland_seat;
-
-typedef struct {
-    uint32_t format;
-    uint32_t padding;
-    uint64_t modifier;
-} compositor_format;
+struct vo_wayland_tranche;
 
 struct drm_format {
     uint32_t format;
@@ -107,16 +103,12 @@ struct vo_wayland_state {
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
 
     /* linux-dmabuf */
-    dev_t target_device_id;
+    struct wl_list tranche_list;
+    struct vo_wayland_tranche *current_tranche;
     struct zwp_linux_dmabuf_v1 *dmabuf;
     struct zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback;
-    bool add_tranche;
-    compositor_format *compositor_format_map;
+    struct compositor_format *compositor_format_map;
     uint32_t compositor_format_size;
-    struct drm_format *compositor_formats;
-    int num_compositor_formats;
-    uint32_t *planar_formats;
-    int num_planar_formats;
 
     /* presentation-time */
     struct wp_presentation  *presentation;
@@ -168,6 +160,7 @@ struct vo_wayland_state {
 };
 
 bool vo_wayland_check_visible(struct vo *vo);
+bool vo_wayland_valid_format(struct vo_wayland_state *wl, uint32_t drm_format, uint64_t modifier);
 bool vo_wayland_init(struct vo *vo);
 bool vo_wayland_reconfig(struct vo *vo);
 

--- a/video/out/wldmabuf/ra_wldmabuf.h
+++ b/video/out/wldmabuf/ra_wldmabuf.h
@@ -19,5 +19,5 @@
 #include "video/out/wayland_common.h"
 
 struct ra *ra_create_wayland(struct mp_log *log, struct vo *vo);
-bool ra_compatible_format(struct ra *ra, int imgfmt, uint32_t drm_format, uint64_t modifier);
+bool ra_compatible_format(struct ra *ra, uint32_t drm_format, uint64_t modifier);
 bool ra_is_wldmabuf(struct ra *ra);


### PR DESCRIPTION
The multi device part is mostly theoretical, but it turns out that plasma does send multiple tranches to the same device so we have to take that into account. And that means taking into account multiple devices as well. In theory if a compositor gives us a scanout tranche, that should be preferred for vo_dmabuf_wayland if there's a format match in there. Otherwise, we look at the main device.

We would still need some way to force mpv to do a reconfig + clear the autoconverter if devices actually changed during runtime. That can be for another day.