### PR TITLE
mp_image: copy params before dovi mapping for mp_image_copy_attributes

### DIFF
--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -84,6 +84,11 @@ static void set_params(struct vf_format_opts *p, struct mp_image_params *out,
             out->light = MP_CSP_LIGHT_AUTO;
         }
     }
+    if (p->colormatrix != PL_COLOR_SYSTEM_DOLBYVISION && !p->dovi) {
+        out->primaries_orig = out->color.primaries;
+        out->transfer_orig = out->color.transfer;
+        out->sys_orig = out->repr.sys;
+    }
     if (p->sig_peak)
         out->color.hdr = (struct pl_hdr_metadata){ .max_luma = p->sig_peak * MP_REF_WHITE };
     if (p->light)

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1203,13 +1203,16 @@ struct AVFrame *mp_image_to_av_frame(struct mp_image *src)
     if (src->fields & MP_IMGFIELD_REPEAT_FIRST)
         dst->repeat_pict = 1;
 
-    pl_avframe_set_repr(dst, src->params.repr);
+    // Image params without dovi mapped; should be passed as side data instead
+    struct mp_image_params params = src->params;
+    mp_image_params_restore_dovi_mapping(&params);
+    pl_avframe_set_repr(dst, params.repr);
 
-    dst->chroma_location = pl_chroma_to_av(src->params.chroma_location);
+    dst->chroma_location = pl_chroma_to_av(params.chroma_location);
 
     dst->opaque_ref = av_buffer_alloc(sizeof(struct mp_image_params));
     MP_HANDLE_OOM(dst->opaque_ref);
-    *(struct mp_image_params *)dst->opaque_ref->data = src->params;
+    *(struct mp_image_params *)dst->opaque_ref->data = params;
 
     if (src->icc_profile) {
         AVFrameSideData *sd =
@@ -1219,14 +1222,14 @@ struct AVFrame *mp_image_to_av_frame(struct mp_image *src)
         new_ref->icc_profile = NULL;
     }
 
-    pl_avframe_set_color(dst, src->params.color);
+    pl_avframe_set_color(dst, params.color);
 
     {
         AVFrameSideData *sd = av_frame_new_side_data(dst,
                                                      AV_FRAME_DATA_DISPLAYMATRIX,
                                                      sizeof(int32_t) * 9);
         MP_HANDLE_OOM(sd);
-        av_display_rotation_set((int32_t *)sd->data, src->params.rotate);
+        av_display_rotation_set((int32_t *)sd->data, params.rotate);
     }
 
     // Add back side data, but only for types which are not specially handled

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -855,6 +855,8 @@ bool mp_image_params_static_equal(const struct mp_image_params *p1,
 // before dovi mapping.
 void mp_image_params_restore_dovi_mapping(struct mp_image_params *params)
 {
+    if (params->repr.sys != PL_COLOR_SYSTEM_DOLBYVISION)
+        return;
     params->color.primaries = params->primaries_orig;
     params->color.transfer = params->transfer_orig;
     params->repr.sys = params->sys_orig;

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -519,6 +519,9 @@ void mp_image_copy_attributes(struct mp_image *dst, struct mp_image *src)
     dst->params.chroma_location = src->params.chroma_location;
     dst->params.crop = src->params.crop;
     dst->nominal_fps = src->nominal_fps;
+    dst->params.primaries_orig = dst->params.color.primaries;
+    dst->params.transfer_orig = dst->params.color.transfer;
+    dst->params.sys_orig = dst->params.repr.sys;
 
     // ensure colorspace consistency
     enum pl_color_system dst_forced_csp = mp_image_params_get_forced_csp(&dst->params);


### PR DESCRIPTION
It currently doesn't copy original params before mapping, resulting in wrong colors when some video filters are used.

The original format also needs to be set when converting formats to make sure the correct format is restored. 