### PR TITLE
ytdl_hook.lua: default to try_ytdl_first=yes and exclude by extension

### DIFF
--- a/DOCS/interface-changes/try_ytdl_first.txt
+++ b/DOCS/interface-changes/try_ytdl_first.txt
@@ -1,0 +1,2 @@
+change `ytdl_hook-try_ytdl_first`'s default to `yes`
+add `ytdl_hook-exclude_by_extension` script-opt

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -894,14 +894,17 @@ Program Behavior
     ``--script-opts`` option (using ``ytdl_hook-`` as prefix):
 
     ``try_ytdl_first=<yes|no>``
-        If 'yes' will try parsing the URL with youtube-dl first, instead of the
-        default where it's only after mpv failed to open it. This mostly depends
-        on whether most of your URLs need youtube-dl parsing.
+        If ``yes`` and the URL is not excluded by the next options, mpv will try
+        parsing the URL with youtube-dl first, instead of only after it fails to
+        open it. This mostly depends on whether most of your URLs need
+        youtube-dl parsing.
+
+        Default: ``yes``.
 
     ``exclude=<URL1|URL2|...``
-        A ``|``-separated list of URL patterns which mpv should not use with
-        youtube-dl. The patterns are matched after the ``http(s)://`` part of
-        the URL.
+        A ``|``-separated list of URL patterns which mpv should not try parsing
+        with youtube-dl first when ``try_ytdl_first`` is ``yes``. The patterns
+        are matched after the ``http(s)://`` part of the URL.
 
         ``^`` matches the beginning of the URL, ``$`` matches its end, and you
         should use ``%`` before any of the characters ``^$()%|,.[]*+-?`` to
@@ -916,6 +919,12 @@ Program Behavior
               will exclude any URL that ends with ``.mkv`` or ``.mp4``.
 
         See more lua patterns here: https://www.lua.org/manual/5.1/manual.html#5.4.1
+
+    ``exclude_by_extension=<yes|no>``
+
+        Whether to also exclude URLs containing one of the extensions in
+        ``audio-exts``, ``--image-exts`` and ``-video-exts``, and also ``m3u``
+        and ``m3u8``.
 
     ``all_formats=<yes|no>``
         If 'yes' will attempt to add all formats found reported by youtube-dl

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -3,8 +3,9 @@ local msg = require 'mp.msg'
 local options = require 'mp.options'
 
 local o = {
+    try_ytdl_first = true,
     exclude = "",
-    try_ytdl_first = false,
+    exclude_by_extension = true,
     use_manifests = false,
     all_formats = false,
     force_all_formats = true,
@@ -284,10 +285,18 @@ local function extract_chapters(data, video_length)
 end
 
 local function is_blacklisted(url)
-    if o.exclude == "" then return false end
     if #ytdl.blacklisted == 0 then
         for match in o.exclude:gmatch('%|?([^|]+)') do
             ytdl.blacklisted[#ytdl.blacklisted + 1] = match
+        end
+
+        if o.exclude_by_extension then
+            for _, property in pairs({"audio-exts", "image-exts", "video-exts"}) do
+                for _, ext in pairs(mp.get_property_native(property)) do
+                    ytdl.blacklisted[#ytdl.blacklisted + 1] = "%." .. ext
+                end
+            end
+            ytdl.blacklisted[#ytdl.blacklisted + 1] = "%.m3u"
         end
     end
     if #ytdl.blacklisted > 0 then


### PR DESCRIPTION
By the default mpv tries opening URLs with ffmpeg first, and users who don't configure try_ytdl_first get a slower startup for youtube URLs, on top of yt-dlp already being slow.

Fix this by defaulting to try_ytdl_first=yes and adding an exclude_by_extension script-opt to keep trying ffmpeg first with URLs containing known media extensions, so that they will keep loading as quickly.

Compared to adding a whitelist of URL patterns to try with ytdl first, this works with all sites supported by yt-dlp, but has false positives on media URLs without an extension.