### PR TITLE
ytdl_hook.lua: add include script-opt of URLs to try with ytdl first

### DIFF
--- a/DOCS/interface-changes/ytdl_hook-include.txt
+++ b/DOCS/interface-changes/ytdl_hook-include.txt
@@ -1,0 +1,1 @@
+add `ytdl_hook-include` script-opt

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -919,6 +919,13 @@ Program Behavior
 
         See more lua patterns here: https://www.lua.org/manual/5.1/manual.html#5.4.1
 
+    ``include=<URL1|URL2|...``
+        A ``|``-separated list of URL patterns which mpv should try to parse with
+        youtube-dl first when ``try_ytdl_first`` is ``no``. The patterns are
+        matched in the same way as ``exclude``.
+
+        Default: ``^%w+%.youtube%.com/|^youtube%.com/|^youtu%.be/|^%w+%.twitch%.tv/|^twitch%.tv/``
+
     ``all_formats=<yes|no>``
         If 'yes' will attempt to add all formats found reported by youtube-dl
         (default: no). Each format is added as a separate track. In addition,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -907,6 +907,8 @@ Program Behavior
         should use ``%`` before any of the characters ``^$()%|,.[]*+-?`` to
         match that character.
 
+        URLs are converted to lower case before matching.
+
         .. admonition:: Examples
 
             - ``--script-opts=ytdl_hook-exclude='^youtube%.com'``

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -4,6 +4,7 @@ local options = require 'mp.options'
 
 local o = {
     exclude = "",
+    include = "^%w+%.youtube%.com/|^youtube%.com/|^youtu%.be/|^%w+%.twitch%.tv/|^twitch%.tv/",
     try_ytdl_first = false,
     use_manifests = false,
     all_formats = false,
@@ -281,6 +282,26 @@ local function extract_chapters(data, video_length)
     end
     table.sort(ret, function(a, b) return a.time < b.time end)
     return ret
+end
+
+local function is_whitelisted(url)
+    url = url:match("https?://(.+)")
+
+    if url == nil then
+        return false
+    end
+
+    url = url:lower()
+
+    for match in o.include:gmatch('%|?([^|]+)') do
+        if url:find(match) then
+            msg.verbose("URL matches included substring " .. match ..
+                        ". Trying ytdl first.")
+            return true
+        end
+    end
+
+    return false
 end
 
 local function is_blacklisted(url)
@@ -1177,7 +1198,7 @@ end
 local function on_load_hook(load_fail)
     local url = mp.get_property("stream-open-filename", "")
     local force = url:find("^ytdl://")
-    local early = force or o.try_ytdl_first
+    local early = force or o.try_ytdl_first or is_whitelisted(url)
     if early == load_fail then
         return
     end

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -291,7 +291,7 @@ local function is_blacklisted(url)
         end
     end
     if #ytdl.blacklisted > 0 then
-        url = url:match('https?://(.+)')
+        url = url:match('https?://(.+)'):lower()
         for _, exclude in ipairs(ytdl.blacklisted) do
             if url:match(exclude) then
                 msg.verbose('URL matches excluded substring. Skipping.')


### PR DESCRIPTION
By the default mpv tries opening URLs with ffmpeg first, and users who don't configure try_ytdl_first get a slower startup for youtube URLs, on top of yt-dlp already being slow.

Fix this by adding a script-opt of URL pattern to try with ytdl first. Youtube and twitch are included by default.

Compared to the alternative of trying ytdl first by default and excluding URLs with a media extension, this only works for the sites explicitly included in the new option, but doesn't have false positives on media URLs without an extension.

Alternative to #14963