### PR TITLE
stats.lua bindings fixes

### DIFF
--- a/DOCS/interface-changes/display-page-toggle.txt
+++ b/DOCS/interface-changes/display-page-toggle.txt
@@ -1,0 +1,1 @@
+add `display-page-n-toggle` script bindings to stats.lua, where n is a page number

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -233,7 +233,7 @@ Additional keys can be configured in ``input.conf`` to display the stats::
 And to display a certain page directly::
 
     i script-binding stats/display-page-1
-    e script-binding stats/display-page-2
+    h script-binding stats/display-page-4-toggle
 
 Active key bindings page
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -670,24 +670,9 @@ function register_event_handler(t) {
 mp.input = {
     get: function(t) {
         mp.commandv("script-message-to", "console", "get-input", mp.script_name,
-                    JSON.stringify({
-                        prompt: t.prompt,
-                        default_text: t.default_text,
-                        cursor_position: t.cursor_position,
-                        id: t.id,
-                    }));
+                    JSON.stringify(t));
 
         register_event_handler(t)
-    },
-    select: function (t) {
-        mp.commandv("script-message-to", "console", "get-input", mp.script_name,
-                    JSON.stringify({
-                        prompt: t.prompt,
-                        items: t.items,
-                        default_item: t.default_item,
-                    }));
-
-        register_event_handler(t);
     },
     terminate: function () {
         mp.commandv("script-message-to", "console", "disable");
@@ -708,6 +693,7 @@ mp.input = {
                     JSON.stringify(log));
     }
 }
+mp.input.select = mp.input.get
 
 /**********************************************************************
  *  various

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -93,6 +93,7 @@ local history_pos = 1
 local searching_history = false
 local log_buffers = {[id] = {}}
 local key_bindings = {}
+local dont_bind_up_down = false
 local global_margins = { t = 0, b = 0 }
 local input_caller
 
@@ -1624,10 +1625,12 @@ local function define_key_bindings()
         return
     end
     for _, bind in ipairs(get_bindings()) do
-        -- Generate arbitrary name for removing the bindings later.
-        local name = "_console_" .. (#key_bindings + 1)
-        key_bindings[#key_bindings + 1] = name
-        mp.add_forced_key_binding(bind[1], name, bind[2], {repeatable = true})
+        if not (dont_bind_up_down and (bind[1] == 'up' or bind[1] == 'down')) then
+            -- Generate arbitrary name for removing the bindings later.
+            local name = "_console_" .. (#key_bindings + 1)
+            key_bindings[#key_bindings + 1] = name
+            mp.add_forced_key_binding(bind[1], name, bind[2], {repeatable = true})
+        end
     end
     mp.add_forced_key_binding("any_unicode", "_console_text", text_input,
         {repeatable = true, complex = true})
@@ -1675,6 +1678,7 @@ set_active = function (active)
             line = ''
             cursor = 1
             selectable_items = nil
+            dont_bind_up_down = false
         end
         collectgarbage()
     end
@@ -1734,6 +1738,7 @@ mp.register_script_message('get-input', function (script_name, args)
     line = args.default_text or ''
     cursor = args.cursor_position or line:len() + 1
     id = args.id or script_name .. prompt
+    dont_bind_up_down = args.dont_bind_up_down
     if histories[id] == nil then
         histories[id] = {}
         log_buffers[id] = {}

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -18,6 +18,18 @@ License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 local utils = require "mp.utils"
 local input = {}
 
+local function get_non_callbacks(t)
+    local non_callbacks = {}
+
+    for key, value in pairs(t) do
+        if type(value) ~= "function" then
+            non_callbacks[key] = value
+        end
+    end
+
+    return non_callbacks
+end
+
 local function register_event_handler(t)
     mp.register_script_message("input-event", function (type, args)
         if t[type] then
@@ -38,26 +50,12 @@ end
 
 function input.get(t)
     mp.commandv("script-message-to", "console", "get-input",
-                mp.get_script_name(), utils.format_json({
-                    prompt = t.prompt,
-                    default_text = t.default_text,
-                    cursor_position = t.cursor_position,
-                    id = t.id,
-                }))
+                mp.get_script_name(), utils.format_json(get_non_callbacks(t)))
 
     register_event_handler(t)
 end
 
-function input.select(t)
-    mp.commandv("script-message-to", "console", "get-input",
-                mp.get_script_name(), utils.format_json({
-                    prompt = t.prompt,
-                    items = t.items,
-                    default_item = t.default_item,
-                }))
-
-    register_event_handler(t)
-end
+input.select = input.get
 
 function input.terminate()
     mp.commandv("script-message-to", "console", "disable")

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -474,7 +474,7 @@ local function get_kbinfo_lines()
            and bind.section ~= "input_forced_console"
            and (
                searched_text == nil or
-               (bind.key .. bind.cmd):lower():find(searched_text, 1, true)
+               (bind.key .. bind.cmd .. (bind.comment or "")):lower():find(searched_text, 1, true)
            )
         then
             active[bind.key] = bind

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1619,6 +1619,7 @@ local function filter_bindings()
                 end
             end
         end,
+        dont_bind_up_down = true,
     })
 end
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1750,14 +1750,20 @@ mp.add_key_binding(nil, "display-stats", function() process_key_binding(true) en
 mp.add_key_binding(nil, "display-stats-toggle", function() process_key_binding(false) end,
     {repeatable=false})
 
--- Single invocation bindings without key, can be used in input.conf to create
--- bindings for a specific page: "e script-binding stats/display-page-2"
 for k, _ in pairs(pages) do
-    mp.add_key_binding(nil, "display-page-" .. k,
-        function()
-            curr_page = k
-            process_key_binding(true)
-        end, {repeatable=true})
+    -- Single invocation key bindings for specific pages, e.g.:
+    -- "e script-binding stats/display-page-2"
+    mp.add_key_binding(nil, "display-page-" .. k, function()
+        curr_page = k
+        process_key_binding(true)
+    end, {repeatable=true})
+
+    -- Key bindings to toggle a specific page, e.g.:
+    -- "h script-binding stats/display-page-4-toggle".
+    mp.add_key_binding(nil, "display-page-" .. k .. "-toggle", function()
+        curr_page = k
+        process_key_binding(false)
+    end, {repeatable=true})
 end
 
 -- Reprint stats immediately when VO was reconfigured, only when toggled


### PR DESCRIPTION
commit 1: stats.lua: filter keybindings by comment

Requested in #14966.

commit 2: stats.lua: scroll keybindings while filtering them

console.lua binds up and down to navigate its history. After it is opened by pressing /, bind up and down to scroll the keybindings again.

Fixes #14966.