### PR TITLE
vo_{dmabuf_wayland,wlshm}: use proper values with MP_ALIGN_{UP,DOWN}

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -451,7 +451,7 @@ static void create_shm_pool(struct vo *vo)
     struct vo_wayland_state *wl = vo->wl;
     struct priv *p = vo->priv;
 
-    int stride = MP_ALIGN_UP(vo->dwidth * 4, 16);
+    int stride = MP_ALIGN_UP(vo->dwidth * 4, MP_IMAGE_BYTE_ALIGN);
     size_t size = vo->dheight * stride;
     int fd = vo_wayland_allocate_memfd(vo, size);
     if (fd < 0)
@@ -783,7 +783,7 @@ static int preinit(struct vo *vo)
     } else {
         int width = 1;
         int height = 1;
-        int stride = MP_ALIGN_UP(width * 4, 16);
+        int stride = MP_ALIGN_UP(width * 4, MP_IMAGE_BYTE_ALIGN);
         int fd = vo_wayland_allocate_memfd(vo, stride);
         if (fd < 0)
             goto err;

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -85,7 +85,7 @@ static struct buffer *buffer_create(struct vo *vo, int width, int height)
     uint8_t *data;
     struct buffer *buf;
 
-    stride = MP_ALIGN_UP(width * 4, 16);
+    stride = MP_ALIGN_UP(width * 4, MP_IMAGE_BYTE_ALIGN);
     size = height * stride;
     fd = vo_wayland_allocate_memfd(vo, size);
     if (fd < 0)
@@ -264,12 +264,12 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         struct mp_image dst = buf->mpi;
         struct mp_rect src_rc;
         struct mp_rect dst_rc;
-        src_rc.x0 = MP_ALIGN_DOWN(p->src.x0, MPMAX(src->fmt.align_x, 4));
-        src_rc.y0 = MP_ALIGN_DOWN(p->src.y0, MPMAX(src->fmt.align_y, 4));
+        src_rc.x0 = MP_ALIGN_DOWN(p->src.x0, src->fmt.align_x);
+        src_rc.y0 = MP_ALIGN_DOWN(p->src.y0, src->fmt.align_y);
         src_rc.x1 = p->src.x1 - (p->src.x0 - src_rc.x0);
         src_rc.y1 = p->src.y1 - (p->src.y0 - src_rc.y0);
-        dst_rc.x0 = MP_ALIGN_DOWN(p->dst.x0, MPMAX(dst.fmt.align_x, 4));
-        dst_rc.y0 = MP_ALIGN_DOWN(p->dst.y0, MPMAX(dst.fmt.align_y, 4));
+        dst_rc.x0 = MP_ALIGN_DOWN(p->dst.x0, dst.fmt.align_x);
+        dst_rc.y0 = MP_ALIGN_DOWN(p->dst.y0, dst.fmt.align_y);
         dst_rc.x1 = p->dst.x1 - (p->dst.x0 - dst_rc.x0);
         dst_rc.y1 = p->dst.y1 - (p->dst.y0 - dst_rc.y0);
         mp_image_crop_rc(src, src_rc);


### PR DESCRIPTION
Both of these VOs draw buffers in software via wl_shm to an mp_image, so they are affected by the internals of whatever mpv does for alignment. When wlshm was originally written, mp_sws was aligning to 16 bytes and thus it chose this value but it was hardcoded. vo_dmabuf_wayland later blindly copied this value. e1157cb6e8191f98b60813dc91342e3baf577d92 actually changed the internal value to 64 bytes. In theory, this doesn't probably doesn't really matter since 16 should also work in most cases, but we might as well stop using a magic number and be consistent.

Additionally, wl_shm did some funny alignments that no other software output did. The reasoning was apparently due to warning messages from ffmpeg while cropping*. This was left in at the time, but I'm not able to reproduce any such warning messages on my end when I make this match other software VOs. Go ahead and remove the MP_MAX business and align to the fmt x/y like the other VOs do.

*: https://github.com/mpv-player/mpv/pull/6240#discussion_r227930233