### PR TITLE
ci/mingw: pass --enable-gpl to ffmpeg's configure

### DIFF
--- a/ci/build-mingw64.sh
+++ b/ci/build-mingw64.sh
@@ -146,7 +146,7 @@ _ffmpeg () {
     [ -d ffmpeg ] || $gitclone https://github.com/FFmpeg/FFmpeg.git ffmpeg
     builddir ffmpeg
     local args=(
-        --pkg-config=pkg-config --target-os=mingw32
+        --pkg-config=pkg-config --target-os=mingw32 --enable-gpl
         --enable-cross-compile --cross-prefix=$TARGET- --arch=${TARGET%%-*}
         --cc="$CC" --cxx="$CXX" $commonflags
         --disable-{doc,programs}
@@ -320,7 +320,7 @@ if [ "$2" = pack ]; then
     pushd artifact/tmp
     dlls=(
         libgcc_*.dll lib{ssp,stdc++,winpthread}-[0-9]*.dll # compiler runtime
-        av*.dll sw*.dll lib{ass,freetype,fribidi,harfbuzz,iconv,placebo}-[0-9]*.dll
+        av*.dll sw*.dll postproc-[0-9]*.dll lib{ass,freetype,fribidi,harfbuzz,iconv,placebo}-[0-9]*.dll
         lib{shaderc_shared,spirv-cross-c-shared,dav1d}.dll zlib1.dll
     )
     if [[ -f vulkan-1.dll ]]; then


### PR DESCRIPTION
A bunch of lavfi filters were presumably not available in mingw builds because of this.

``` ps
% grep -E '=(".+ |")gpl("| .+")$' configure
blackframe_filter_deps="gpl"
boxblur_filter_deps="gpl"
boxblur_opencl_filter_deps="opencl gpl"
colormatrix_filter_deps="gpl"
cover_rect_filter_deps="avcodec avformat gpl"
cropdetect_filter_deps="gpl"
delogo_filter_deps="gpl"
eq_filter_deps="gpl"
find_rect_filter_deps="avcodec avformat gpl"
fspp_filter_deps="gpl"
histeq_filter_deps="gpl"
hqdn3d_filter_deps="gpl"
interlace_filter_deps="gpl"
kerndeint_filter_deps="gpl"
mcdeint_filter_deps="avcodec gpl"
mpdecimate_filter_deps="gpl"
mptestsrc_filter_deps="gpl"
nnedi_filter_deps="gpl"
owdenoise_filter_deps="gpl"
perspective_filter_deps="gpl"
phase_filter_deps="gpl"
pp7_filter_deps="gpl"
pp_filter_deps="gpl postproc"
pullup_filter_deps="gpl"
repeatfields_filter_deps="gpl"
sab_filter_deps="gpl swscale"
signature_filter_deps="gpl avcodec avformat"
smartblur_filter_deps="gpl swscale"
spp_filter_deps="gpl avcodec"
stereo3d_filter_deps="gpl"
super2xsai_filter_deps="gpl"
tinterlace_filter_deps="gpl"
uspp_filter_deps="gpl avcodec"
vaguedenoiser_filter_deps="gpl"
postproc_deps="avutil gpl"
```