### PR TITLE
command: make playlist writable

### DIFF
--- a/DOCS/interface-changes/writable-playlist.txt
+++ b/DOCS/interface-changes/writable-playlist.txt
@@ -1,0 +1,1 @@
+- make `playlist` property writable

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3029,7 +3029,7 @@ Property list
     the entries. Unavailable if the file was not originally associated with a
     playlist in some way.
 
-``playlist``
+``playlist`` (RW)
     Playlist, current entry marked. Currently, the raw property value is
     useless.
 
@@ -3080,6 +3080,39 @@ Property list
                 "playing"   MPV_FORMAT_FLAG (same)
                 "title"     MPV_FORMAT_STRING (optional)
                 "id"        MPV_FORMAT_INT64
+
+    Writing this property is also possible using the following format:
+
+    ::
+
+        MPV_FORMAT_NODE_ARRAY (the new playlist)
+            MPV_FORMAT_STRING (entry from filename)
+
+            MPV_FORMAT_INT64 (take existing entry at index, counts from 0)
+
+            MPV_FORMAT_NODE_MAP (take existing entry from id)
+                "id"        MPV_FORMAT_INT64
+                "current"   MPV_FORMAT_FLAG (optional)
+                "title"     MPV_FORMAT_STRING|MPV_FORMAT_NONE (optional)
+
+            MPV_FORMAT_NODE_MAP (entry from filename)
+                "filename"  MPV_FORMAT_STRING
+                "current"   MPV_FORMAT_FLAG (optional)
+                "title"     MPV_FORMAT_STRING|MPV_FORMAT_NONE (optional)
+
+    .. admonition:: Lua examples
+
+        ``mp.set_property_native("playlist", {1, 0})``
+
+        Swap the first two entries and remove the rest.
+
+        ``mp.set_property_native("playlist", {{filename="foo", current=true}})``
+
+        Replace playlist with a single entry and start playing.
+
+        ``mp.set_property_native("playlist", {1, {id=2}, "bar"})``
+
+        Various ways to specify an entry.
 
 ``track-list``
     List of audio/video/sub tracks, current entry marked. Currently, the raw

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -19,7 +19,10 @@
 #define MPLAYER_PLAYLIST_H
 
 #include <stdbool.h>
+
 #include "misc/bstr.h"
+
+typedef struct kh_playlist_id_map_s playlist_id_map_t;
 
 struct playlist_param {
     bstr name, value;
@@ -126,5 +129,11 @@ struct playlist *playlist_parse_file(const char *file, struct mp_cancel *cancel,
 void playlist_entry_unref(struct playlist_entry *e);
 
 void playlist_set_current(struct playlist *pl);
+
+playlist_id_map_t *playlist_build_id_map(const struct playlist *pl);
+void playlist_destroy_id_map(playlist_id_map_t *h);
+struct playlist_entry *playlist_entry_from_id(struct playlist *pl, const playlist_id_map_t *h, uint64_t id);
+
+void playlist_entry_remove(struct playlist_entry *entry);
 
 #endif

--- a/misc/khash.h
+++ b/misc/khash.h
@@ -1,0 +1,627 @@
+/* The MIT License
+
+   Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "khash.h"
+KHASH_MAP_INIT_INT(32, char)
+int main() {
+	int ret, is_missing;
+	khiter_t k;
+	khash_t(32) *h = kh_init(32);
+	k = kh_put(32, h, 5, &ret);
+	kh_value(h, k) = 10;
+	k = kh_get(32, h, 10);
+	is_missing = (k == kh_end(h));
+	k = kh_get(32, h, 5);
+	kh_del(32, h, k);
+	for (k = kh_begin(h); k != kh_end(h); ++k)
+		if (kh_exist(h, k)) kh_value(h, k) = 1;
+	kh_destroy(32, h);
+	return 0;
+}
+*/
+
+/*
+  2013-05-02 (0.2.8):
+
+	* Use quadratic probing. When the capacity is power of 2, stepping function
+	  i*(i+1)/2 guarantees to traverse each bucket. It is better than double
+	  hashing on cache performance and is more robust than linear probing.
+
+	  In theory, double hashing should be more robust than quadratic probing.
+	  However, my implementation is probably not for large hash tables, because
+	  the second hash function is closely tied to the first hash function,
+	  which reduce the effectiveness of double hashing.
+
+	Reference: http://research.cs.vt.edu/AVresearch/hashing/quadratic.php
+
+  2011-12-29 (0.2.7):
+
+    * Minor code clean up; no actual effect.
+
+  2011-09-16 (0.2.6):
+
+	* The capacity is a power of 2. This seems to dramatically improve the
+	  speed for simple keys. Thank Zilong Tan for the suggestion. Reference:
+
+	   - http://code.google.com/p/ulib/
+	   - http://nothings.org/computer/judy/
+
+	* Allow to optionally use linear probing which usually has better
+	  performance for random input. Double hashing is still the default as it
+	  is more robust to certain non-random input.
+
+	* Added Wang's integer hash function (not used by default). This hash
+	  function is more robust to certain non-random input.
+
+  2011-02-14 (0.2.5):
+
+    * Allow to declare global functions.
+
+  2009-09-26 (0.2.4):
+
+    * Improve portability
+
+  2008-09-19 (0.2.3):
+
+	* Corrected the example
+	* Improved interfaces
+
+  2008-09-11 (0.2.2):
+
+	* Improved speed a little in kh_put()
+
+  2008-09-10 (0.2.1):
+
+	* Added kh_clear()
+	* Fixed a compiling error
+
+  2008-09-02 (0.2.0):
+
+	* Changed to token concatenation which increases flexibility.
+
+  2008-08-31 (0.1.2):
+
+	* Fixed a bug in kh_get(), which has not been tested previously.
+
+  2008-08-31 (0.1.1):
+
+	* Added destructor
+*/
+
+
+#ifndef __AC_KHASH_H
+#define __AC_KHASH_H
+
+/*!
+  @header
+
+  Generic hash table library.
+ */
+
+#define AC_VERSION_KHASH_H "0.2.8"
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+/* compiler specific configuration */
+
+#if UINT_MAX == 0xffffffffu
+typedef unsigned int khint32_t;
+#elif ULONG_MAX == 0xffffffffu
+typedef unsigned long khint32_t;
+#endif
+
+#if ULONG_MAX == ULLONG_MAX
+typedef unsigned long khint64_t;
+#else
+typedef unsigned long long khint64_t;
+#endif
+
+#ifndef kh_inline
+#ifdef _MSC_VER
+#define kh_inline __inline
+#else
+#define kh_inline inline
+#endif
+#endif /* kh_inline */
+
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
+typedef khint32_t khint_t;
+typedef khint_t khiter_t;
+
+#define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
+#define __ac_isdel(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&1)
+#define __ac_iseither(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&3)
+#define __ac_set_isdel_false(flag, i) (flag[i>>4]&=~(1ul<<((i&0xfU)<<1)))
+#define __ac_set_isempty_false(flag, i) (flag[i>>4]&=~(2ul<<((i&0xfU)<<1)))
+#define __ac_set_isboth_false(flag, i) (flag[i>>4]&=~(3ul<<((i&0xfU)<<1)))
+#define __ac_set_isdel_true(flag, i) (flag[i>>4]|=1ul<<((i&0xfU)<<1))
+
+#define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#ifndef kcalloc
+#define kcalloc(N,Z) calloc(N,Z)
+#endif
+#ifndef kmalloc
+#define kmalloc(Z) malloc(Z)
+#endif
+#ifndef krealloc
+#define krealloc(P,Z) realloc(P,Z)
+#endif
+#ifndef kfree
+#define kfree(P) free(P)
+#endif
+
+static const double __ac_HASH_UPPER = 0.77;
+
+#define __KHASH_TYPE(name, khkey_t, khval_t) \
+	typedef struct kh_##name##_s { \
+		khint_t n_buckets, size, n_occupied, upper_bound; \
+		khint32_t *flags; \
+		khkey_t *keys; \
+		khval_t *vals; \
+	} kh_##name##_t;
+
+#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)	 					\
+	extern kh_##name##_t *kh_init_##name(void);							\
+	extern void kh_destroy_##name(kh_##name##_t *h);					\
+	extern void kh_clear_##name(kh_##name##_t *h);						\
+	extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key); 	\
+	extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets); \
+	extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
+	extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+
+#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	SCOPE kh_##name##_t *kh_init_##name(void) {							\
+		return (kh_##name##_t*)kcalloc(1, sizeof(kh_##name##_t));		\
+	}																	\
+	SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h) {														\
+			kfree((void *)h->keys); kfree(h->flags);					\
+			kfree((void *)h->vals);										\
+			kfree(h);													\
+		}																\
+	}																	\
+	SCOPE void kh_clear_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h && h->flags) {											\
+			memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t)); \
+			h->size = h->n_occupied = 0;								\
+		}																\
+	}																	\
+	SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) 	\
+	{																	\
+		if (h->n_buckets) {												\
+			khint_t k, i, last, mask, step = 0; \
+			mask = h->n_buckets - 1;									\
+			k = __hash_func(key); i = k & mask;							\
+			last = i; \
+			while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+				i = (i + (++step)) & mask; \
+				if (i == last) return h->n_buckets;						\
+			}															\
+			return __ac_iseither(h->flags, i)? h->n_buckets : i;		\
+		} else return 0;												\
+	}																	\
+	SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
+	{ /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+		khint32_t *new_flags = 0;										\
+		khint_t j = 1;													\
+		{																\
+			kroundup32(new_n_buckets); 									\
+			if (new_n_buckets < 4) new_n_buckets = 4;					\
+			if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
+			else { /* hash table size to be changed (shrink or expand); rehash */ \
+				new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));	\
+				if (!new_flags) return -1;								\
+				memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
+				if (h->n_buckets < new_n_buckets) {	/* expand */		\
+					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+					if (!new_keys) { kfree(new_flags); return -1; }		\
+					h->keys = new_keys;									\
+					if (kh_is_map) {									\
+						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+						if (!new_vals) { kfree(new_flags); return -1; }	\
+						h->vals = new_vals;								\
+					}													\
+				} /* otherwise shrink */								\
+			}															\
+		}																\
+		if (j) { /* rehashing is needed */								\
+			for (j = 0; j != h->n_buckets; ++j) {						\
+				if (__ac_iseither(h->flags, j) == 0) {					\
+					khkey_t key = h->keys[j];							\
+					khval_t val;										\
+					khint_t new_mask;									\
+					new_mask = new_n_buckets - 1; 						\
+					if (kh_is_map) val = h->vals[j];					\
+					__ac_set_isdel_true(h->flags, j);					\
+					while (1) { /* kick-out process; sort of like in Cuckoo hashing */ \
+						khint_t k, i, step = 0; \
+						k = __hash_func(key);							\
+						i = k & new_mask;								\
+						while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask; \
+						__ac_set_isempty_false(new_flags, i);			\
+						if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
+							{ khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; } \
+							if (kh_is_map) { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; } \
+							__ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
+						} else { /* write the element and jump out of the loop */ \
+							h->keys[i] = key;							\
+							if (kh_is_map) h->vals[i] = val;			\
+							break;										\
+						}												\
+					}													\
+				}														\
+			}															\
+			if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
+				h->keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+				if (kh_is_map) h->vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+			}															\
+			kfree(h->flags); /* free the working space */				\
+			h->flags = new_flags;										\
+			h->n_buckets = new_n_buckets;								\
+			h->n_occupied = h->size;									\
+			h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5); \
+		}																\
+		return 0;														\
+	}																	\
+	SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
+	{																	\
+		khint_t x;														\
+		if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
+			if (h->n_buckets > (h->size<<1)) {							\
+				if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
+					*ret = -1; return h->n_buckets;						\
+				}														\
+			} else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
+				*ret = -1; return h->n_buckets;							\
+			}															\
+		} /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
+		{																\
+			khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
+			x = site = h->n_buckets; k = __hash_func(key); i = k & mask; \
+			if (__ac_isempty(h->flags, i)) x = i; /* for speed up */	\
+			else {														\
+				last = i; \
+				while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+					if (__ac_isdel(h->flags, i)) site = i;				\
+					i = (i + (++step)) & mask; \
+					if (i == last) { x = site; break; }					\
+				}														\
+				if (x == h->n_buckets) {								\
+					if (__ac_isempty(h->flags, i) && site != h->n_buckets) x = site; \
+					else x = i;											\
+				}														\
+			}															\
+		}																\
+		if (__ac_isempty(h->flags, x)) { /* not present at all */		\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size; ++h->n_occupied;									\
+			*ret = 1;													\
+		} else if (__ac_isdel(h->flags, x)) { /* deleted */				\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size;													\
+			*ret = 2;													\
+		} else *ret = 0; /* Don't touch h->keys[x] if present and not deleted */ \
+		return x;														\
+	}																	\
+	SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)				\
+	{																	\
+		if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {			\
+			__ac_set_isdel_true(h->flags, x);							\
+			--h->size;													\
+		}																\
+	}
+
+#define KHASH_DECLARE(name, khkey_t, khval_t)		 					\
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_PROTOTYPES(name, khkey_t, khval_t)
+
+#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+/* --- BEGIN OF HASH FUNCTIONS --- */
+
+/*! @function
+  @abstract     Integer hash function
+  @param  key   The integer [khint32_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int_hash_func(key) (khint32_t)(key)
+/*! @function
+  @abstract     Integer comparison function
+ */
+#define kh_int_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     64-bit integer hash function
+  @param  key   The integer [khint64_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int64_hash_func(key) (khint32_t)((key)>>33^(key)^(key)<<11)
+/*! @function
+  @abstract     64-bit integer comparison function
+ */
+#define kh_int64_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     const char* hash function
+  @param  s     Pointer to a null terminated string
+  @return       The hash value
+ */
+static kh_inline khint_t __ac_X31_hash_string(const char *s)
+{
+	khint_t h = (khint_t)*s;
+	if (h) for (++s ; *s; ++s) h = (h << 5) - h + (khint_t)*s;
+	return h;
+}
+/*! @function
+  @abstract     Another interface to const char* hash function
+  @param  key   Pointer to a null terminated string [const char*]
+  @return       The hash value [khint_t]
+ */
+#define kh_str_hash_func(key) __ac_X31_hash_string(key)
+/*! @function
+  @abstract     Const char* comparison function
+ */
+#define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
+
+static kh_inline khint_t __ac_Wang_hash(khint_t key)
+{
+    key += ~(key << 15);
+    key ^=  (key >> 10);
+    key +=  (key << 3);
+    key ^=  (key >> 6);
+    key += ~(key << 11);
+    key ^=  (key >> 16);
+    return key;
+}
+#define kh_int_hash_func2(key) __ac_Wang_hash((khint_t)key)
+
+/* --- END OF HASH FUNCTIONS --- */
+
+/* Other convenient macros... */
+
+/*!
+  @abstract Type of the hash table.
+  @param  name  Name of the hash table [symbol]
+ */
+#define khash_t(name) kh_##name##_t
+
+/*! @function
+  @abstract     Initiate a hash table.
+  @param  name  Name of the hash table [symbol]
+  @return       Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_init(name) kh_init_##name()
+
+/*! @function
+  @abstract     Destroy a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_destroy(name, h) kh_destroy_##name(h)
+
+/*! @function
+  @abstract     Reset a hash table without deallocating memory.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_clear(name, h) kh_clear_##name(h)
+
+/*! @function
+  @abstract     Resize a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  s     New size [khint_t]
+ */
+#define kh_resize(name, h, s) kh_resize_##name(h, s)
+
+/*! @function
+  @abstract     Insert a key to the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @param  r     Extra return code: -1 if the operation failed;
+                0 if the key is present in the hash table;
+                1 if the bucket is empty (never used); 2 if the element in
+				the bucket has been deleted [int*]
+  @return       Iterator to the inserted element [khint_t]
+ */
+#define kh_put(name, h, k, r) kh_put_##name(h, k, r)
+
+/*! @function
+  @abstract     Retrieve a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @return       Iterator to the found element, or kh_end(h) if the element is absent [khint_t]
+ */
+#define kh_get(name, h, k) kh_get_##name(h, k)
+
+/*! @function
+  @abstract     Remove a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Iterator to the element to be deleted [khint_t]
+ */
+#define kh_del(name, h, k) kh_del_##name(h, k)
+
+/*! @function
+  @abstract     Test whether a bucket contains data.
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       1 if containing data; 0 otherwise [int]
+ */
+#define kh_exist(h, x) (!__ac_iseither((h)->flags, (x)))
+
+/*! @function
+  @abstract     Get key given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Key [type of keys]
+ */
+#define kh_key(h, x) ((h)->keys[x])
+
+/*! @function
+  @abstract     Get value given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Value [type of values]
+  @discussion   For hash sets, calling this results in segfault.
+ */
+#define kh_val(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Alias of kh_val()
+ */
+#define kh_value(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Get the start iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The start iterator [khint_t]
+ */
+#define kh_begin(h) (khint_t)(0)
+
+/*! @function
+  @abstract     Get the end iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The end iterator [khint_t]
+ */
+#define kh_end(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Get the number of elements in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of elements in the hash table [khint_t]
+ */
+#define kh_size(h) ((h)->size)
+
+/*! @function
+  @abstract     Get the number of buckets in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of buckets in the hash table [khint_t]
+ */
+#define kh_n_buckets(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Iterate over the entries in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(kvar) = kh_key(h,__i);								\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/*! @function
+  @abstract     Iterate over the values in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_value(h, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/* More convenient interfaces */
+
+/*! @function
+  @abstract     Instantiate a hash set containing integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT(name)										\
+	KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT(name, khval_t)								\
+	KHASH_INIT(name, khint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash set containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT64(name)										\
+	KHASH_INIT(name, khint64_t, char, 0, kh_int64_hash_func, kh_int64_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT64(name, khval_t)								\
+	KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
+
+typedef const char *kh_cstr_t;
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_STR(name)										\
+	KHASH_INIT(name, kh_cstr_t, char, 0, kh_str_hash_func, kh_str_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_STR(name, khval_t)								\
+	KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
+
+#endif /* __AC_KHASH_H */

--- a/test/meson.build
+++ b/test/meson.build
@@ -168,3 +168,5 @@ if refdir != ''
         test('scale-zimg', scale_zimg, args: [refdir, outdir], suite: 'ffmpeg')
     endif
 endif
+
+test('playlist', find_program('test.py'))

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+
+from contextlib import contextmanager
+import datetime
+import json
+import socket
+import subprocess
+
+mpv_path = "./mpv"
+anull = "av://lavfi:anullsrc"
+
+
+class IpcError(Exception):
+    pass
+
+
+@contextmanager
+def assert_error(s):
+    try:
+        yield
+        assert False
+    except IpcError as e:
+        assert str(e) == s
+
+
+class Mpv:
+    @classmethod
+    @contextmanager
+    def create(cls, *args):
+        self = cls()
+        self.request_id = 0
+        self.observe_property_id = 0
+        self.args = [
+            "--no-config",
+            "--input-ipc-client=fd://0",
+            "--idle",
+            "--vo=null",
+            "--ao=null",
+            "--no-ytdl",
+            "--load-stats-overlay=no",
+            "--load-osd-console=no",
+            "--load-auto-profiles=no",
+            *args,
+        ]
+
+        our_end, mpv_end = socket.socketpair()
+
+        self.stream = our_end.makefile("rwb")
+
+        self.process = subprocess.Popen(
+            args=[mpv_path, *self.args],
+            stdin=mpv_end,
+        )
+
+        our_end.close()
+        mpv_end.close()
+
+        yield self
+
+        self.stream.close()
+
+        print("* Waiting for exit")
+        status = self.process.wait()
+
+        print("* Exit %d" % status)
+        assert status == 0
+
+    def command(self, *args):
+        self.request_id += 1
+        request_id = self.request_id
+
+        data = {
+            "request_id": request_id,
+            "command": list(args),
+        }
+        s = json.dumps(data, separators=(",", ":"))
+        print(">", s[:1000])
+        line = bytes(s.encode("utf-8")) + b"\n"
+
+        self.stream.write(line)
+        self.stream.flush()
+
+        msg = self.wait_message(lambda msg: msg.get("request_id") == request_id)
+
+        if msg["error"] != "success":
+            raise IpcError(msg["error"])
+
+        return msg.get("data")
+
+    def set_property(self, name, value):
+        return self.command("set_property", name, value)
+
+    def get_property(self, name):
+        return self.command("get_property", name)
+
+    def wait_message(self, pred):
+        while True:
+            msg = self.read_message()
+            if pred(msg):
+                return msg
+
+    def read_message(self):
+        s = self.stream.readline()
+        print("<", s.decode("utf-8").strip()[:1000])
+        return json.loads(s)
+
+    def wait_event(self, name):
+        print("* Waiting for %r event" % name)
+        return self.wait_message(lambda msg: msg.get("event") == name)
+
+    def wait_idle(self):
+        return self.wait_event("idle")
+
+    def wait_file_loaded(self):
+        return self.wait_event("file-loaded")
+
+    def wait_start_file(self):
+        return self.wait_event("start-file")
+
+    @contextmanager
+    def wait_property_change(self, name):
+        self.observe_property_id += 1
+        id = self.observe_property_id
+
+        def pred(msg):
+            return msg.get("event") == "property-change" and msg["id"] == id
+
+        try:
+            self.command("observe_property", id, name)
+            # Skip the first event.
+            self.wait_message(pred)
+
+            msg = {}
+            yield msg
+
+            print("* Waiting for %r property to change" % name)
+            msg.update(self.wait_message(pred))
+        finally:
+            self.command("unobserve_property", id)
+
+    def __repr__(self):
+        return f"Mpv(args={self.args!r})"
+
+
+mpv = Mpv.create
+
+
+def test_new_entry():
+    with mpv() as m:
+        m.set_property("playlist", [anull, {"filename": anull}])
+        assert m.get_property("playlist") == [
+            {"id": 1, "filename": anull},
+            {"id": 2, "filename": anull},
+        ]
+
+
+def test_nonexisting_and_duplicated_entries():
+    with mpv() as m:
+        m.set_property("playlist", [-1, 0, 1, {}, {"id": 0}, {"id": -1}])
+        assert m.get_property("playlist") == []
+
+        m.set_property("playlist", [anull])
+
+        m.set_property("playlist", [{"id": 1}, {"id": 1}])
+        assert m.get_property("playlist") == [{"id": 1, "filename": anull}]
+
+        m.set_property("playlist", [0, 0])
+        assert m.get_property("playlist") == [{"id": 1, "filename": anull}]
+
+
+def test_move_entries():
+    with mpv() as m:
+        m.wait_idle()
+        m.set_property("playlist", ["a", "b", "c"])
+        m.set_property("playlist", ["d", {"id": 2}, {"id": 1}])
+        assert m.get_property("playlist") == [
+            {"id": 4, "filename": "d"},
+            {"id": 2, "filename": "b"},
+            {"id": 1, "filename": "a"},
+        ]
+
+    with mpv() as m:
+        m.wait_idle()
+        m.set_property("playlist", ["a", "b", "c"])
+        m.set_property("playlist", ["d", 1, 0])
+        assert m.get_property("playlist") == [
+            {"id": 4, "filename": "d"},
+            {"id": 2, "filename": "b"},
+            {"id": 1, "filename": "a"},
+        ]
+
+
+def test_move_playing_entry():
+    with mpv(anull) as m:
+        m.wait_file_loaded()
+        with m.wait_property_change("time-pos") as a:
+            pass
+
+        m.set_property("playlist", ["x", 0, "x"])
+        m.set_property("playlist", [0, 1])
+        with m.wait_property_change("time-pos") as b:
+            pass
+
+        m.set_property("playlist", [1])
+        with m.wait_property_change("time-pos") as c:
+            pass
+
+        # Playback went uninterrupted.
+        assert a["data"] < b["data"] < c["data"]
+
+
+def test_remove_playing_entry():
+    with mpv(*((anull,) * 5), "--keep-open", "--playlist-start=1") as m:
+        assert m.wait_start_file()["playlist_entry_id"] == 2
+        assert m.get_property("playlist-playing-pos") == 1
+
+        # Remove one.
+        m.set_property("playlist", [0, 2, 3, 4])
+        assert m.wait_start_file()["playlist_entry_id"] == 3
+        assert m.get_property("playlist-playing-pos") == 1
+
+        # Remove two.
+        m.set_property("playlist", [0, 3])
+        assert m.wait_start_file()["playlist_entry_id"] == 5
+        assert m.get_property("playlist-playing-pos") == 1
+
+        # Nothing left on its right.
+        m.set_property("playlist", [0])
+        m.wait_idle()
+        assert len(m.get_property("playlist")) == 1
+        assert m.get_property("playlist-playing-pos") == -1
+
+        # Can restarting playback with "loadfile".
+        m.command("loadfile", anull)
+        m.wait_start_file()
+
+
+def test_entry_filename():
+    with mpv() as m:
+        m.set_property("playlist", ["original"])
+        m.set_property("playlist", [{"id": 1, "filename": "ignored"}])
+        # Cannot be changed.
+        assert m.get_property("playlist") == [{"id": 1, "filename": "original"}]
+
+
+def test_entry_title():
+    with mpv() as m:
+
+        def title(**entry):
+            m.set_property("playlist", [entry])
+            return m.get_property("playlist")[0].get("title")
+
+        assert title(filename=anull, title="original") == "original"
+        assert title(id=1) == "original"
+        assert title(id=1, title="new") == "new"
+        assert title(id=1, title=None) == None
+        assert title(id=1, title="newer") == "newer"
+        assert title(id=1, title="") == None
+
+
+def test_entry_current():
+    # On new entry.
+    with mpv() as m:
+        m.wait_idle()
+        m.set_property("playlist", [{"filename": anull, "current": True}])
+        m.wait_file_loaded()
+
+    # Set on existing entry.
+    with mpv() as m:
+        m.set_property("playlist", [{"filename": anull}, {"filename": anull}])
+        m.wait_idle()
+        m.set_property("playlist", [0, {"id": 2, "current": True}])
+        assert m.wait_start_file()["playlist_entry_id"] == 2
+
+
+def test_playlist_change_event():
+    with mpv() as m:
+        m.set_property("playlist", [anull, anull])
+        # Wait for `current=True` to be set.
+        with m.wait_property_change("playlist"):
+            pass
+        assert m.get_property("playlist")[0]["current"]
+
+        with m.wait_property_change("playlist"):
+            m.set_property("playlist", [0])
+
+
+def test_stress():
+    N = 10000
+    with mpv() as m:
+        m.wait_idle()
+
+        m.set_property("playlist", list(map(str, range(0, N))))
+        pl = m.get_property("playlist")
+        assert len(pl) == N
+
+        m.set_property("playlist", list(reversed(range(0, N))))
+        assert m.get_property("playlist") == list(reversed(pl))
+
+        m.set_property("playlist", list({"id": i + 1} for i in range(0, N)))
+        assert m.get_property("playlist") == pl
+
+
+def test_invalid_format():
+    with mpv(anull) as m:
+        original = m.get_property("playlist")
+
+        with assert_error("unsupported format for accessing property"):
+            m.set_property("playlist", 0)
+        assert m.get_property("playlist") == original
+
+        m.set_property("playlist", [{"filename": 0, "no such key": "x"}, False, 0])
+        assert m.get_property("playlist") == original
+
+
+def main():
+    import inspect
+    import sys
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pattern", nargs="?", default="")
+
+    args = parser.parse_args()
+
+    test_fns = [
+        obj
+        for name, obj in inspect.getmembers(sys.modules[__name__])
+        if inspect.isfunction(obj) and name.startswith("test_") and args.pattern in name
+    ]
+
+    suite_start = datetime.datetime.now()
+
+    for f in test_fns:
+        n = max(80, len(f.__name__))
+        print("=" * n)
+        print(f.__name__)
+        print("=" * n)
+
+        start = datetime.datetime.now()
+        f()
+        elapsed = datetime.datetime.now() - start
+        print("* OK. %.2fs" % elapsed.total_seconds())
+
+    suite_elapsed = datetime.datetime.now() - suite_start
+    print("ALL OK. %.2fs" % suite_elapsed.total_seconds())
+
+
+main()


### PR DESCRIPTION
An attempt to improve #14939. It enhances the playlist property by making it writable: it allows reordering, removing and loading new playlist entries in one go. Thanks na-na-hi for the idea.

Compared to my previous approach it adds much more code but I hope the added functionality justifies it (though most of it is just copy-pasted hash map implementation).

I couldn't find too much prior work on tests so I came up with a custom script. Not sure whether this was the correct way to do it.