### PR TITLE
input.conf: bind ? to show keybindings

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -47,7 +47,8 @@ See `COMMAND INTERFACE`_ and `Key names`_ sections for more details on
 configuring keybindings.
 
 See also ``--input-test`` for interactive binding details by key, and the
-`stats`_ built-in script for key bindings list (including print to terminal).
+`stats`_ built-in script for key bindings list (including print to terminal). By
+default, the ? key toggles the display of this list.
 
 Keyboard Control
 ----------------
@@ -239,6 +240,10 @@ i and I
     Show/toggle an overlay displaying statistics about the currently playing
     file such as codec, framerate, number of dropped frames and so on. See
     `STATS`_ for more information.
+
+?
+    Toggle an overlay displaying the active key bindings. See `STATS`_ for more
+    information.
 
 DEL
     Cycle OSC visibility between never / auto (mouse-move) / always

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -14,6 +14,7 @@ already bound to them:
 ====   ==============================================
 i      Show stats for a fixed duration
 I      Toggle stats (shown until toggled again)
+?      Toggle displaying the key bindings
 ====   ==============================================
 
 While the stats are visible on screen the following key bindings are active,

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -96,6 +96,7 @@
 #P show-progress                        # show playback progress
 #i script-binding stats/display-stats   # display information and statistics
 #I script-binding stats/display-stats-toggle # toggle displaying information and statistics
+#? script-binding stats/display-page-4-toggle # toggle displaying key bindings
 #` script-binding console/enable        # open the console
 #z add sub-delay -0.1                   # shift subtitles 100 ms earlier
 #Z add sub-delay +0.1                   # delay subtitles by 100 ms


### PR DESCRIPTION
This should help new users to view mpv's key bindings as it's easier to discover than shift+i and 4, because many other websites and terminal applications show key bindings upon pressing ?.