### PR TITLE
mac/app: fix building with swift disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1540,6 +1540,10 @@ swift = get_option('swift-build').require(
 )
 features += {'swift': swift.allowed()}
 
+if features['cocoa'] and not features['swift'] and get_option('cplayer')
+    error('cplayer enabled but no suitable swift version could be found or was disabled!')
+endif
+
 swift_sources = []
 if features['cocoa'] and features['swift']
     swift_sources += files('osdep/mac/application.swift',

--- a/osdep/mac/app_bridge.m
+++ b/osdep/mac/app_bridge.m
@@ -110,6 +110,7 @@ const struct m_sub_options *app_bridge_vo_conf(void)
     return &vo_sub_opts;
 }
 
+#if HAVE_SWIFT
 void cocoa_init_media_keys(void)
 {
     [[AppHub shared] startRemote];
@@ -139,4 +140,4 @@ int cocoa_main(int argc, char *argv[])
 {
     return [(Application *)[Application sharedApplication] main:argc :argv];
 }
-
+#endif


### PR DESCRIPTION
building without swift makes mpv as a standalone app completely useless, because the main function exits immediately. besides other functionalities that are also missing.

this is really only useful as a libmpv only usage.

Fixes #14931