### PR TITLE
github/workflows: drop clang32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -501,7 +501,6 @@ jobs:
       fail-fast: false
       matrix:
         sys:
-          - clang32
           - clang64
           - mingw32
           - mingw64
@@ -541,7 +540,7 @@ jobs:
             vulkan-devel:p
 
       - name: Install dependencies
-        if: ${{ matrix.sys != 'clang32' && matrix.sys != 'mingw32' }}
+        if: ${{ matrix.sys != 'mingw32' }}
         run: |
           pacboy --noconfirm -S angleproject cppwinrt libcdio-paranoia rst2pdf \
                                 rubberband uchardet vapoursynth


### PR DESCRIPTION
It's being dropped upstream* and recently lua51 was removed along with luajit*. mingw32 already covers 32-bit support, and it's not like we're in dire need of this so just remove it.

*: https://github.com/msys2/msys2.github.io/commit/89521b9f8d43b6ebf4a4f4a51c912066ab5f5b50
*: https://github.com/msys2/MINGW-packages/commit/947a8592ca9b7d4af6d6520d3083f6118a390036