### PR TITLE
vo_gpu_next: update next_opts and set want_reset if changed

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1518,11 +1518,10 @@ static int control(struct vo *vo, uint32_t request, void *data)
         return VO_TRUE;
 
     case VOCTRL_UPDATE_RENDER_OPTS: {
-        m_config_cache_update(p->opts_cache);
+        update_options(vo);
         update_ra_ctx_options(vo, &p->ra_ctx->opts);
         if (p->ra_ctx->fns->update_render_opts)
             p->ra_ctx->fns->update_render_opts(p->ra_ctx);
-        update_render_options(vo);
         vo->want_redraw = true;
 
         // Also re-query the auto profile, in case `update_render_options`

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -763,8 +763,13 @@ static void update_options(struct vo *vo)
 {
     struct priv *p = vo->priv;
     pl_options pars = p->pars;
-    bool changed = m_config_cache_update(p->opts_cache);
-    changed = m_config_cache_update(p->next_opts_cache) || changed;
+
+    bool opts_changed = m_config_cache_update(p->opts_cache);
+    bool next_opts_changed = m_config_cache_update(p->next_opts_cache);
+    bool changed = opts_changed | next_opts_changed;
+
+    if (next_opts_changed)
+        p->want_reset = true;
     if (changed)
         update_render_options(vo);
 


### PR DESCRIPTION
When `VOCTRL_UPDATE_RENDER_OPTS` is triggered, update/refresh `next_opts`, and set `want_reset` if changed.

 On paused videos or images, changing image-lut for example didn't take immediate effect.

 This change fixes that.