### PR TITLE
options: mark sub-lavc-o as UPDATE_SUB_HARD

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -345,7 +345,7 @@ const struct m_sub_options mp_subtitle_sub_opts = {
         {"teletext-page", OPT_INT(teletext_page), M_RANGE(-1, 999), .flags = UPDATE_SUB_FILT},
         {"sub-past-video-end", OPT_BOOL(sub_past_video_end)},
         {"sub-ass-force-style", OPT_REPLACED("sub-ass-style-overrides")},
-        {"sub-lavc-o", OPT_KEYVALUELIST(sub_avopts)},
+        {"sub-lavc-o", OPT_KEYVALUELIST(sub_avopts), .flags = UPDATE_SUB_HARD},
         {0}
     },
     .size = sizeof(OPT_BASE_STRUCT),


### PR DESCRIPTION
To properly update lavc options it may be required to reinit sub decoder, so mark this option as UPDATE_SUB_HARD.