### PR TITLE
Revert "ci/msys2: disable some features for 32-bit build"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,6 +527,7 @@ jobs:
             lcms2:p
             libarchive:p
             libass:p
+            libcdio-paranoia:p
             libdvdnav:p
             libjpeg-turbo:p
             libplacebo:p
@@ -537,13 +538,14 @@ jobs:
             python:p
             shaderc:p
             spirv-cross:p
+            uchardet:p
+            vapoursynth:p
             vulkan-devel:p
 
       - name: Install dependencies
         if: ${{ matrix.sys != 'mingw32' }}
         run: |
-          pacboy --noconfirm -S angleproject cppwinrt libcdio-paranoia rst2pdf \
-                                rubberband uchardet vapoursynth
+          pacboy --noconfirm -S {angleproject,cppwinrt,rst2pdf,rubberband}:p
 
       - name: Build with meson
         id: build

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -3,14 +3,13 @@
 args=(
   --werror
   -Dc_args='-Wno-error=deprecated -Wno-error=deprecated-declarations'
-  -D{d3d-hwaccel,d3d11,dvdnav,jpeg,lcms2,libarchive}=enabled
-  -D{libbluray,lua,shaderc,spirv-cross}=enabled
+  -D{cdda,d3d-hwaccel,d3d11,dvdnav,jpeg,lcms2,libarchive}=enabled
+  -D{libbluray,lua,shaderc,spirv-cross,uchardet,vapoursynth}=enabled
   -D{libmpv,tests}=true
 )
 
 [[ "$SYS" != "clang32" && "$SYS" != "mingw32" ]] && args+=(
-  -D{cdda,egl-angle-lib,egl-angle-win32,pdf-build}=enabled
-  -D{rubberband,uchardet,vapoursynth,win32-smtc}=enabled
+  -D{egl-angle-lib,egl-angle-win32,pdf-build,rubberband,win32-smtc}=enabled
 )
 
 meson setup build "${args[@]}"

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -8,7 +8,7 @@ args=(
   -D{libmpv,tests}=true
 )
 
-[[ "$SYS" != "clang32" && "$SYS" != "mingw32" ]] && args+=(
+[[ "$SYS" != "mingw32" ]] && args+=(
   -D{egl-angle-lib,egl-angle-win32,pdf-build,rubberband,win32-smtc}=enabled
 )
 


### PR DESCRIPTION
No longer needed after 232919336d567b70330c43a41920238a56e100da.

This reverts commit 883a45fa3eb7347431c246d831cf8ece12da8676.