### PR TITLE
console.lua: allow clicking selectable items

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -274,10 +274,10 @@ Command + f (macOS only)
     Toggle fullscreen (see also ``--fs``).
 
 (The following keybindings open a selector in the console that lets you choose
-from a list of items by typing part of the desired item and/or by navigating
-them with keybindings: ``Down`` and ``Ctrl+n`` go down, ``Up`` and ``Ctrl+p`` go
-up, ``Page down`` and ``Ctrl+f`` scroll down one page, and ``Page up`` and
-``Ctrl+b`` scroll up one page.)
+from a list of items by typing part of the desired item, by clicking the desired
+item, or by navigating them with keybindings: ``Down`` and ``Ctrl+n`` go down,
+``Up`` and ``Ctrl+p`` go up, ``Page down`` and ``Ctrl+f`` scroll down one page,
+and ``Page up`` and ``Ctrl+b`` scroll up one page.)
 
 g-p
     Select a playlist entry.


### PR DESCRIPTION
This adds click support for the select menu. Scrolling with the wheel already worked.

If a custom OSC binds a button to a select.lua script-binding, this lets users keep using the mouse to select an item.

While the OSC and the select menu are open at the same time, you can no longer click the OSC's buttons. By using mp.add_key_binding instead of add_forced_key_binding you could click both, but the console's binding would be shadowed by MBTN_LEFT bindings in input.conf.

Inspired by https://github.com/Samillion/ModernZ