### PR TITLE
ci/macos: shift macOS versions to 13-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,17 +218,17 @@ jobs:
         cxx:
           - "clang++"
         os:
-          - "macos-12"
           - "macos-13"
           - "macos-14"
+          - "macos-15"
         include:
-          - os: "macos-12"
-            arch: "intel"
           - os: "macos-13"
             arch: "intel"
           - os: "macos-14"
             arch: "arm"
             xcode: "Xcode_15.2"
+          - os: "macos-15"
+            arch: "arm"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Homebrew does support 3 latest macOS versions, so while macOS 12 still works it takes 1h 40m 7s to build. It is bit too much...

While we drop macOS 12, add macOS 15 as it is available now.