### PR TITLE
demux_playlist: ensure the file is added to autocreated playlist

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -416,6 +416,9 @@ static bool test_path(struct pl_parser *p, char *path, int autocreate)
     if (autocreate & AUTO_ANY)
         return true;
 
+    if (!strcmp(path, p->real_stream->path))
+        return true;
+
     bstr ext = bstr_get_ext(bstr0(path));
     if (autocreate & AUTO_VIDEO && str_in_list(ext, p->mp_opts->video_exts))
         return true;


### PR DESCRIPTION
Even if it doesn't match extensions in filter mode.