### PR TITLE
vo_gpu_next: force a reset when --image-lut is updated

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1518,12 +1518,18 @@ static int control(struct vo *vo, uint32_t request, void *data)
         return VO_TRUE;
 
     case VOCTRL_UPDATE_RENDER_OPTS: {
-        m_config_cache_update(p->opts_cache);
         update_ra_ctx_options(vo, &p->ra_ctx->opts);
         if (p->ra_ctx->fns->update_render_opts)
             p->ra_ctx->fns->update_render_opts(p->ra_ctx);
-        update_render_options(vo);
         vo->want_redraw = true;
+
+        // Special case for --image-lut which requires a full reset.
+        int old_type = p->next_opts->image_lut.type;
+        update_options(vo);
+        struct user_lut image_lut = p->next_opts->image_lut;
+        p->want_reset |= image_lut.opt && ((!image_lut.path && image_lut.opt) ||
+                         (image_lut.path && strcmp(image_lut.path, image_lut.opt)) ||
+                         (old_type != image_lut.type));
 
         // Also re-query the auto profile, in case `update_render_options`
         // unloaded a manually specified icc profile in favor of


### PR DESCRIPTION
Bit of an edge case since image-lut requires the frames to be remapped again so the normal redraw when paused doesn't work. Also we use update_options in the VOCTRL here.