### PR TITLE
osc.lua: open select.lua by clicking buttons

### DIFF
--- a/DOCS/interface-changes/osc-buttons.txt
+++ b/DOCS/interface-changes/osc-buttons.txt
@@ -1,0 +1,4 @@
+change several OSC mouse bindings to select.lua functions
+add script-opts to configure what OSC buttons do when clicked
+remove `osc-playlist_osd` script-opt and behave as if it was off by default; `playlist_osd=yes` can be replicated with `osc-playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000` and `osc-playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000`
+remove `osc-chapters_osd` script-opt and behave as if it was off by default; `chapter_osd=yes` can be replicated with `osc-chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000` and `osc-chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000`

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -31,15 +31,17 @@ The Interface
 pl prev
     =============   ================================================
     left-click      play previous file in playlist
-    right-click     show playlist
-    shift+L-click   show playlist
+    right-click     open the playlist selector
+    shift+L-click   show the playlist
+    middle-click    show the playlist
     =============   ================================================
 
 pl next
     =============   ================================================
     left-click      play next file in playlist
-    right-click     show playlist
-    shift+L-click   show playlist
+    right-click     open the playlist selector
+    shift+L-click   show the playlist
+    middle-click    show the playlist
     =============   ================================================
 
 title
@@ -47,9 +49,8 @@ title
       name while hovering the seekbar.
 
     =============   ================================================
-    left-click      show file and track info
-    middle-click    show filename
-    shift+L-click   show filename
+    left-click      open the playlist selector
+    middle-click    show the filename
     right-click     show file and track info
     =============   ================================================
 
@@ -101,15 +102,17 @@ audio and sub
     | Displays selected track and amount of available tracks
 
     =============   ================================================
-    left-click      cycle audio/sub tracks forward
-    right-click     cycle audio/sub tracks backwards
+    left-click      open the audio/sub track selector
     shift+L-click   show available audio/sub tracks
+    middle-click    show available audio/sub tracks
+    right-click     show available audio/sub tracks
     mouse wheel     cycle audio/sub tracks forward/backwards
     =============   ================================================
 
 vol
     =============   ================================================
     left-click      toggle mute
+    right-click     open the audio device selector
     mouse wheel     volume up/down
     =============   ================================================
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -60,6 +60,7 @@ cache
 play
     =============   ================================================
     left-click      toggle play/pause
+    right-click     toggle infinite looping
     =============   ================================================
 
 skip back
@@ -516,7 +517,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``play_pause_mbtn_mid_command=``
 
-``play_pause_mbtn_right_command=``
+``play_pause_mbtn_right_command=cycle-values loop-file inf no``
 
 ``chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -47,8 +47,10 @@ title
       name while hovering the seekbar.
 
     =============   ================================================
-    left-click      show playlist position and length and full title
-    right-click     show filename
+    left-click      show file and track info
+    middle-click    show filename
+    shift+L-click   show filename
+    right-click     show file and track info
     =============   ================================================
 
 cache

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -500,6 +500,9 @@ in ``input.conf``, or sent by other scripts.
 ``osc-show``
     Triggers the OSC to show up, just as if user moved mouse.
 
+``osc-hide``
+    Hide the OSC when ``visibility`` is ``auto``.
+
 Example
 
 You could put this into ``input.conf`` to hide the OSC with the ``a`` key and

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -491,6 +491,74 @@ Configurable Options
 
     Use display fps to calculate the interval between OSC redraws.
 
+The following options configure what commands are run when the buttons are
+clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
+
+``title_mbtn_left_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+
+``title_mbtn_mid_command=show-text ${filename}``
+
+``title_mbtn_right_command=script-binding stats/display-page-5``
+
+``playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000``
+
+``playlist_prev_mbtn_mid_command=show-text ${playlist} 3000``
+
+``playlist_prev_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+
+``playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000``
+
+``playlist_next_mbtn_mid_command=show-text ${playlist} 3000``
+
+``playlist_next_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+
+``play_pause_mbtn_left_command=cycle pause``
+
+``play_pause_mbtn_mid_command=``
+
+``play_pause_mbtn_right_command=``
+
+``chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000``
+
+``chapter_prev_mbtn_mid_command=show-text ${chapter-list} 3000``
+
+``chapter_prev_mbtn_right_command=script-binding select/select-chapter; script-message-to osc osc-hide``
+
+``chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000``
+
+``chapter_next_mbtn_mid_command=show-text ${chapter-list} 3000``
+
+``chapter_next_mbtn_right_command=script-binding select/select-chapter; script-message-to osc osc-hide``
+
+``audio_track_mbtn_left_command=script-binding select/select-aid; script-message-to osc osc-hide``
+
+``audio_track_mbtn_mid_command=show-text ${track-list/audio} 2000``
+
+``audio_track_mbtn_right_command=show-text ${track-list/audio} 2000``
+
+``audio_track_wheel_down_command=cycle audio``
+
+``audio_track_wheel_up_command=cycle audio down``
+
+``sub_track_mbtn_left_command=script-binding select/select-sid; script-message-to osc osc-hide``
+
+``sub_track_mbtn_mid_command=show-text ${track-list/sub} 2000``
+
+``sub_track_mbtn_right_command=show-text ${track-list/sub} 2000``
+
+``sub_track_wheel_down_command=cycle sub``
+
+``sub_track_wheel_up_command=cycle sub down``
+
+``volume_mbtn_left_command=no-osd cycle mute``
+
+``volume_mbtn_mid_command=``
+
+``volume_mbtn_right_command=script-binding select/select-audio-device; script-message-to osc osc-hide``
+
+``volume_wheel_down_command=add volume -5``
+
+``volume_wheel_up_command=add volume 5``
 
 Script Commands
 ~~~~~~~~~~~~~~~

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -84,7 +84,7 @@ local user_opts = {
 
     play_pause_mbtn_left_command = "cycle pause",
     play_pause_mbtn_mid_command = "",
-    play_pause_mbtn_right_command = "",
+    play_pause_mbtn_right_command = "cycle-values loop-file inf no",
 
     chapter_prev_mbtn_left_command = "add chapter -1",
     chapter_prev_mbtn_mid_command = "show-text ${chapter-list} 3000",

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1728,9 +1728,8 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${playlist} 3000") end
-    ne.eventresponder["mbtn_right_up"] = function ()
-        mp.command("show-text ${playlist} 3000")
-    end
+    ne.eventresponder["mbtn_right_up"] =
+        function () mp.command("show-text ${playlist} 3000") end
 
     --next
     ne = new_element("pl_next", "button")
@@ -1746,9 +1745,8 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${playlist} 3000") end
-    ne.eventresponder["mbtn_right_up"] = function ()
-        mp.command("show-text ${playlist} 3000")
-    end
+    ne.eventresponder["mbtn_right_up"] =
+        function () mp.command("show-text ${playlist} 3000") end
 
 
     -- big buttons
@@ -1844,7 +1842,7 @@ local function osc_init()
     ne.eventresponder["mbtn_left_up"] = function ()
         mp.command("script-binding select/select-aid; script-message-to osc osc-hide")
     end
-    ne.eventresponder["shift+mbtn_left_down"] =
+    ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${track-list/audio} 2000") end
     ne.eventresponder["shift+mbtn_right_up"] =
         function () mp.command("show-text ${track-list/sub} 2000") end
@@ -1867,7 +1865,7 @@ local function osc_init()
     ne.eventresponder["mbtn_left_up"] = function ()
         mp.command("script-binding select/select-sid; script-message-to osc osc-hide")
     end
-    ne.eventresponder["shift+mbtn_left_down"] =
+    ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${track-list/sub} 2000") end
     ne.eventresponder["shift+mbtn_right_up"] =
         function () mp.command("show-text ${track-list/sub} 2000") end

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1703,11 +1703,14 @@ local function osc_init()
     end
 
     ne.eventresponder["mbtn_left_up"] = function ()
-        mp.command("show-text '[${playlist-pos-1}/${playlist-count}] ${media-title}'")
+        mp.command("script-binding stats/display-page-5")
     end
-
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("show-text ${filename}") end
+    ne.eventresponder["shift+mbtn_left_up"] = function ()
+        mp.command("show-text ${filename}")
+    end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("script-binding stats/display-page-5")
+    end
 
     -- playlist buttons
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2711,6 +2711,11 @@ end
 
 mp.register_script_message("osc-visibility", visibility_mode)
 mp.register_script_message("osc-show", show_osc)
+mp.register_script_message("osc-hide", function ()
+    if user_opts.visibility == "auto" then
+        hide_osc()
+    end
+end)
 mp.add_key_binding(nil, "visibility", function() visibility_mode("cycle") end)
 
 mp.register_script_message("osc-idlescreen", idlescreen_visibility)

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -50,8 +50,8 @@ local user_opts = {
     windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
     greenandgrumpy = false,     -- disable santa hat
     livemarkers = true,         -- update seekbar chapter markers on duration change
-    chapters_osd = true,        -- whether to show chapters OSD on next/prev
-    playlist_osd = true,        -- whether to show playlist OSD on next/prev
+    chapters_osd = false,        -- whether to show chapters OSD on next/prev
+    playlist_osd = false,        -- whether to show playlist OSD on next/prev
     chapter_fmt = "Chapter: %s", -- chapter print format for seekbar-hover. "no" to disable
     unicodeminus = false,       -- whether to use the Unicode minus sign character
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1703,7 +1703,7 @@ local function osc_init()
     end
 
     ne.eventresponder["mbtn_left_up"] = function ()
-        mp.command("script-binding stats/display-page-5")
+        mp.command("script-binding select/select-playlist; script-message-to osc osc-hide")
     end
     ne.eventresponder["shift+mbtn_left_up"] = function ()
         mp.command("show-text ${filename}")
@@ -1728,8 +1728,9 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${playlist} 3000") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("show-text ${playlist} 3000") end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("show-text ${playlist} 3000")
+    end
 
     --next
     ne = new_element("pl_next", "button")
@@ -1745,8 +1746,9 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${playlist} 3000") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("show-text ${playlist} 3000") end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("show-text ${playlist} 3000")
+    end
 
 
     -- big buttons
@@ -1806,8 +1808,9 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${chapter-list} 3000") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("show-text ${chapter-list} 3000") end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("script-binding select/select-chapter; script-message-to osc osc-hide")
+    end
 
     --ch_next
     ne = new_element("ch_next", "button")
@@ -1823,8 +1826,9 @@ local function osc_init()
         end
     ne.eventresponder["shift+mbtn_left_up"] =
         function () mp.command("show-text ${chapter-list} 3000") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("show-text ${chapter-list} 3000") end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("script-binding select/select-chapter; script-message-to osc osc-hide")
+    end
 
     --
     update_tracklist()
@@ -1837,12 +1841,13 @@ local function osc_init()
         return ("\238\132\134" .. osc_styles.smallButtonsLlabel .. " " ..
                (mp.get_property_native("aid") or "-") .. "/" .. audio_track_count)
     end
-    ne.eventresponder["mbtn_left_up"] =
-        function () mp.command("cycle audio") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("cycle audio down") end
+    ne.eventresponder["mbtn_left_up"] = function ()
+        mp.command("script-binding select/select-aid; script-message-to osc osc-hide")
+    end
     ne.eventresponder["shift+mbtn_left_down"] =
         function () mp.command("show-text ${track-list/audio} 2000") end
+    ne.eventresponder["shift+mbtn_right_up"] =
+        function () mp.command("show-text ${track-list/sub} 2000") end
 
     if user_opts.scrollcontrols then
         ne.eventresponder["wheel_down_press"] =
@@ -1859,11 +1864,12 @@ local function osc_init()
         return ("\238\132\135" .. osc_styles.smallButtonsLlabel .. " " ..
                (mp.get_property_native("sid") or "-") .. "/" .. sub_track_count)
     end
-    ne.eventresponder["mbtn_left_up"] =
-        function () mp.command("cycle sub") end
-    ne.eventresponder["mbtn_right_up"] =
-        function () mp.command("cycle sub down") end
+    ne.eventresponder["mbtn_left_up"] = function ()
+        mp.command("script-binding select/select-sid; script-message-to osc osc-hide")
+    end
     ne.eventresponder["shift+mbtn_left_down"] =
+        function () mp.command("show-text ${track-list/sub} 2000") end
+    ne.eventresponder["shift+mbtn_right_up"] =
         function () mp.command("show-text ${track-list/sub} 2000") end
 
     if user_opts.scrollcontrols then
@@ -2050,6 +2056,9 @@ local function osc_init()
     end
     ne.eventresponder["mbtn_left_up"] =
         function () mp.commandv("cycle", "mute") end
+    ne.eventresponder["mbtn_right_up"] = function ()
+        mp.command("script-binding select/select-audio-device; script-message-to osc osc-hide")
+    end
 
     if user_opts.scrollcontrols then
         ne.eventresponder["wheel_up_press"] =

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1221,12 +1221,12 @@ layouts["box"] = function ()
     lo.style = osc_styles.vidtitle
     lo.button.maxchars = user_opts.boxmaxchars
 
-    lo = add_layout("pl_prev")
+    lo = add_layout("playlist_prev")
     lo.geometry =
         {x = (posX - pos_offsetX), y = titlerowY, an = 7, w = 12, h = 12}
     lo.style = osc_styles.topButtons
 
-    lo = add_layout("pl_next")
+    lo = add_layout("playlist_next")
     lo.geometry =
         {x = (posX + pos_offsetX), y = titlerowY, an = 9, w = 12, h = 12}
     lo.style = osc_styles.topButtons
@@ -1238,37 +1238,37 @@ layouts["box"] = function ()
     local bigbtnrowY = posY - pos_offsetY + 35
     local bigbtndist = 60
 
-    lo = add_layout("playpause")
+    lo = add_layout("play_pause")
     lo.geometry =
         {x = posX, y = bigbtnrowY, an = 5, w = 40, h = 40}
     lo.style = osc_styles.bigButtons
 
-    lo = add_layout("skipback")
+    lo = add_layout("skip_backward")
     lo.geometry =
         {x = posX - bigbtndist, y = bigbtnrowY, an = 5, w = 40, h = 40}
     lo.style = osc_styles.bigButtons
 
-    lo = add_layout("skipfrwd")
+    lo = add_layout("skip_forward")
     lo.geometry =
         {x = posX + bigbtndist, y = bigbtnrowY, an = 5, w = 40, h = 40}
     lo.style = osc_styles.bigButtons
 
-    lo = add_layout("ch_prev")
+    lo = add_layout("chapter_prev")
     lo.geometry =
         {x = posX - (bigbtndist * 2), y = bigbtnrowY, an = 5, w = 40, h = 40}
     lo.style = osc_styles.bigButtons
 
-    lo = add_layout("ch_next")
+    lo = add_layout("chapter_next")
     lo.geometry =
         {x = posX + (bigbtndist * 2), y = bigbtnrowY, an = 5, w = 40, h = 40}
     lo.style = osc_styles.bigButtons
 
-    lo = add_layout("cy_audio")
+    lo = add_layout("audio_track")
     lo.geometry =
         {x = posX - pos_offsetX, y = bigbtnrowY, an = 1, w = 70, h = 18}
     lo.style = osc_styles.smallButtonsL
 
-    lo = add_layout("cy_sub")
+    lo = add_layout("sub_track")
     lo.geometry =
         {x = posX - pos_offsetX, y = bigbtnrowY, an = 7, w = 70, h = 18}
     lo.style = osc_styles.smallButtonsL
@@ -1511,12 +1511,12 @@ local function bar_layout(direction)
     -- Playlist prev/next
     geo = { x = osc_geo.x + padX, y = line1,
             an = 4, w = 18, h = 18 - padY }
-    lo = add_layout("pl_prev")
+    lo = add_layout("playlist_prev")
     lo.geometry = geo
     lo.style = osc_styles.topButtonsBar
 
     geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("pl_next")
+    lo = add_layout("playlist_next")
     lo.geometry = geo
     lo.style = osc_styles.topButtonsBar
 
@@ -1544,17 +1544,17 @@ local function bar_layout(direction)
     -- Playback control buttons
     geo = { x = osc_geo.x + padX + padwc_l, y = line2, an = 4,
             w = buttonW, h = 36 - padY*2}
-    lo = add_layout("playpause")
+    lo = add_layout("play_pause")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
 
     geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("ch_prev")
+    lo = add_layout("chapter_prev")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
 
     geo = { x = geo.x + geo.w + padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("ch_next")
+    lo = add_layout("chapter_next")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
 
@@ -1582,12 +1582,12 @@ local function bar_layout(direction)
 
     -- Track selection buttons
     geo = { x = geo.x - tsW - padX, y = geo.y, an = geo.an, w = tsW, h = geo.h }
-    lo = add_layout("cy_sub")
+    lo = add_layout("sub_track")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
 
     geo = { x = geo.x - geo.w - padX, y = geo.y, an = geo.an, w = geo.w, h = geo.h }
-    lo = add_layout("cy_audio")
+    lo = add_layout("audio_track")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar
 
@@ -1715,7 +1715,7 @@ local function osc_init()
     -- playlist buttons
 
     -- prev
-    ne = new_element("pl_prev", "button")
+    ne = new_element("playlist_prev", "button")
 
     ne.content = "\238\132\144"
     ne.enabled = (pl_pos > 1) or (loop ~= "no")
@@ -1732,7 +1732,7 @@ local function osc_init()
         function () mp.command("show-text ${playlist} 3000") end
 
     --next
-    ne = new_element("pl_next", "button")
+    ne = new_element("playlist_next", "button")
 
     ne.content = "\238\132\129"
     ne.enabled = (have_pl and (pl_pos < pl_count)) or (loop ~= "no")
@@ -1751,8 +1751,8 @@ local function osc_init()
 
     -- big buttons
 
-    --playpause
-    ne = new_element("playpause", "button")
+    --play_pause
+    ne = new_element("play_pause", "button")
 
     ne.content = function ()
         if mp.get_property("pause") == "yes" then
@@ -1768,8 +1768,8 @@ local function osc_init()
     ne.eventresponder["mbtn_left_up"] =
         function () mp.commandv("cycle", "pause") end
 
-    --skipback
-    ne = new_element("skipback", "button")
+    --skip_backward
+    ne = new_element("skip_backward", "button")
 
     ne.softrepeat = true
     ne.content = "\238\128\132"
@@ -1780,8 +1780,8 @@ local function osc_init()
     ne.eventresponder["mbtn_right_down"] =
         function () mp.commandv("seek", -30) end
 
-    --skipfrwd
-    ne = new_element("skipfrwd", "button")
+    --skip_forward
+    ne = new_element("skip_forward", "button")
 
     ne.softrepeat = true
     ne.content = "\238\128\133"
@@ -1792,8 +1792,8 @@ local function osc_init()
     ne.eventresponder["mbtn_right_down"] =
         function () mp.commandv("seek", 60) end
 
-    --ch_prev
-    ne = new_element("ch_prev", "button")
+    --chapter_prev
+    ne = new_element("chapter_prev", "button")
 
     ne.enabled = have_ch
     ne.content = "\238\132\132"
@@ -1810,8 +1810,8 @@ local function osc_init()
         mp.command("script-binding select/select-chapter; script-message-to osc osc-hide")
     end
 
-    --ch_next
-    ne = new_element("ch_next", "button")
+    --chapter_next
+    ne = new_element("chapter_next", "button")
 
     ne.enabled = have_ch
     ne.content = "\238\132\133"
@@ -1831,8 +1831,8 @@ local function osc_init()
     --
     update_tracklist()
 
-    --cy_audio
-    ne = new_element("cy_audio", "button")
+    --audio_track
+    ne = new_element("audio_track", "button")
 
     ne.enabled = audio_track_count > 0
     ne.content = function ()
@@ -1854,8 +1854,8 @@ local function osc_init()
             function () mp.command("cycle audio down") end
     end
 
-    --cy_sub
-    ne = new_element("cy_sub", "button")
+    --sub_track
+    ne = new_element("sub_track", "button")
 
     ne.enabled = sub_track_count > 0
     ne.content = function ()


### PR DESCRIPTION
8bf5548589 added mouse support to selectors, so open them from OSC buttons.

It's up for debate where middle or right click should be bound. By binding middle click `show_message(get_tracklist())` is no longer bound. By binding right click, it no longers cycles tracks backwards, though scrolling with the wheel still does.

Closes #5067, closes #6291, closes #10621, closes #11878.