### PR TITLE
player/sub: ensure subtitles are updated for images with no audio

### DIFF
--- a/player/sub.c
+++ b/player/sub.c
@@ -96,7 +96,7 @@ static bool update_subtitle(struct MPContext *mpctx, double video_pts,
 {
     struct dec_sub *dec_sub = track ? track->d_sub : NULL;
 
-    if (!dec_sub || video_pts == MP_NOPTS_VALUE)
+    if (!dec_sub)
         return true;
 
     if (mpctx->vo_chain) {


### PR DESCRIPTION
The video_pts condition here would bail out on still images with no audio since their pts is always MP_NOPTS_VALUE. This is not exactly great because the subtitles may need to be updated so just let these files also go through the subtitle redraw logic below.