### PR TITLE
osc.lua: remove NIH list formatting

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2180,8 +2180,7 @@ Property list
     Number of MKV editions.
 
 ``edition-list``
-    List of editions, current entry marked. Currently, the raw property value
-    is useless.
+    List of editions, current entry marked.
 
     This has a number of sub-properties. Replace ``N`` with the 0-based edition
     index.
@@ -3082,8 +3081,7 @@ Property list
                 "id"        MPV_FORMAT_INT64
 
 ``track-list``
-    List of audio/video/sub tracks, current entry marked. Currently, the raw
-    property value is useless.
+    List of audio/video/sub tracks, current entry marked.
 
     This has a number of sub-properties. Replace ``N`` with the 0-based track
     index.
@@ -3323,8 +3321,7 @@ Property list
     first one is returned.
 
 ``chapter-list`` (RW)
-    List of chapters, current entry marked. Currently, the raw property value
-    is useless.
+    List of chapters, current entry marked.
 
     This has a number of sub-properties. Replace ``N`` with the 0-based chapter
     index.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3091,6 +3091,18 @@ Property list
     ``track-list/count``
         Total number of tracks.
 
+    ``track-list/video``
+        The list of video tracks. This is only usable for printing and its value
+        can't be retrieved.
+
+    ``track-list/audio``
+        The list of audio tracks. This is only usable for printing and its value
+        can't be retrieved.
+
+    ``track-list/sub``
+        The list of sub tracks. This is only usable for printing and its value
+        can't be retrieved.
+
     ``track-list/N/id``
         The ID as it's used for ``--sid``/``--aid``/``--vid``. This is unique
         within tracks of the same type (sub/audio/video), but otherwise not.

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -493,10 +493,6 @@ Script Commands
 The OSC script listens to certain script commands. These commands can bound
 in ``input.conf``, or sent by other scripts.
 
-``osc-message``
-    Show a message on screen using the OSC. First argument is the message,
-    second the duration in seconds.
-
 ``osc-visibility``
     Controls visibility mode ``never`` / ``auto`` (on mouse move) / ``always``
     and also ``cycle`` to cycle between the modes.
@@ -515,8 +511,3 @@ to set auto mode (the default) with ``b``::
 ``osc-idlescreen``
     Controls the visibility of the mpv logo on idle. Valid arguments are ``yes``,
     ``no``, and ``cycle`` to toggle between yes and no.
-
-``osc-playlist``, ``osc-chapterlist``, ``osc-tracklist``
-    Shows a limited view of the respective type of list using the OSC. First
-    argument is duration in seconds.
-

--- a/player/command.c
+++ b/player/command.c
@@ -1057,17 +1057,16 @@ static int mp_property_list_chapters(void *ctx, struct m_property *prop,
         }
 
         for (n = 0; n < count; n++) {
-            char *name = chapter_display_name(mpctx, n);
+            char *name = chapter_name(mpctx, n);
             double t = chapter_start_time(mpctx, n);
             char* time = mp_format_time(t, false);
             res = talloc_asprintf_append(res, "%s", time);
             talloc_free(time);
             const char *m = n == cur ? list_current : list_normal;
-            res = talloc_asprintf_append(res, "   %s%s\n", m, name);
-            talloc_free(name);
+            res = talloc_asprintf_append(res, "  %s%s\n", m, name);
         }
 
-        *(char **)arg = res;
+        *(char **)arg = count ? cut_osd_list(mpctx, "Chapters", res, cur) : res;
         return M_PROPERTY_OK;
     }
     case M_PROPERTY_SET: {

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -256,7 +256,7 @@ static ASS_Style *prepare_osd_ass(struct osd_state *osd, struct osd_object *obj)
 
     double playresy = obj->ass.track->PlayResY;
     // Compensate for libass and mp_ass_set_style scaling the font etc.
-    if (!opts->osd_scale_by_window)
+    if (!opts->osd_scale_by_window && obj->vo_res.h)
         playresy *= 720.0 / obj->vo_res.h;
 
     ASS_Style *style = get_style(&obj->ass, "OSD");


### PR DESCRIPTION
All of the code to format playlist/track-list/chapter-list is unnecessary when mpv's core can already show-text these properties.

Also an issue with this custom formatting is that showing fewer entries than can fit on the OSD can make it seem like the playlist ends there and there are no entries afterwards.

Also remove lots of pointless code around the track-list (mpv's track id and the osc_id are exactly the same).

This simplification will make it easier to bind customizable commands, otherwise yet another script message to call set_track would have to be added, when cycle sub/audio already output information about the new track on their own.

show-text ${track-list} shows all types of tracks unlike the OSC formatting. Sub-properties to only show one type can be added to replicate that if requested.

Disclaimer: I don't use OSCs at all so I might be missing something about the purpose of this formatting.