### PR TITLE
win32: set consoleAllocationPolicy to detached in the manifest

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1797,9 +1797,9 @@ if get_option('cplayer')
     install_data('etc/mpv-symbolic.svg', install_dir: join_paths(hicolor_dir, 'symbolic', 'apps'))
 
     mpv = executable('mpv', main_fn_source, objects: libmpv.extract_all_objects(recursive: true), dependencies: dependencies,
-                     win_subsystem: 'windows', install: true)
+                     win_subsystem: get_option('win32-subsystem'), install: true)
 
-    if win32
+    if win32 and get_option('win32-subsystem') != 'console'
         wrapper_sources= 'osdep/win32-console-wrapper.c'
         executable('mpv', wrapper_sources, c_args: '-municode', link_args: '-municode',
                    name_suffix: 'com', install: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -117,6 +117,7 @@ option('swift-flags', type: 'string', description: 'Optional Swift compiler flag
 
 # Windows features
 option('win32-smtc', type: 'feature', value: 'auto', description: 'Enable Media Control support')
+option('win32-subsystem', type : 'string', value: 'windows', description : 'Windows subsystem to use for mpv.exe')
 
 # manpages
 option('html-build', type: 'feature', value: 'disabled', description: 'HTML manual generation')

--- a/osdep/mpv.exe.manifest
+++ b/osdep/mpv.exe.manifest
@@ -9,6 +9,7 @@
     <description>mpv - The Movie Player</description>
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings>
+            <consoleAllocationPolicy xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">detached</consoleAllocationPolicy>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
             <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>


### PR DESCRIPTION
This essentially obsoletes the console wrapper (mpv.com), which is no longer needed. The console is attached depending on the context in which mpv.exe is run.

Add an option to control which subsystem is targeted. Keep the GUI application as the default to preserve compatibility with Windows versions prior to 24H2.

For more information about the new console handling, see: https://github.com/microsoft/terminal/blob/4386bf07fd65f763693132ee5e4c43a2a571dc76/doc/specs/%237335%20-%20Console%20Allocation%20Policy.md