### PR TITLE
test: only run ffmpeg tests on release versions

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -135,9 +135,9 @@ endif
 
 # Supported libavutil versions that work with these tests.
 # Will need to be manually updated when ffmpeg adds/removes more formats in the future.
-if libavutil.version().version_compare('>= 59.0.100')
+if libavutil.version().version_compare('>= 59.0.100') and libavutil.version().version_compare('<= 59.39.100')
     refdir = join_paths(source_root, 'test', 'ref', 'ffmpeg7')
-elif libavutil.version().version_compare('>= 58.27.100')
+elif libavutil.version().version_compare('>= 58.27.100') and libavutil.version().version_compare('< 59.0.100')
     refdir = join_paths(source_root, 'test', 'ref', 'ffmpeg6')
 endif
 


### PR DESCRIPTION
The CI breaking because some new format was added in the master branch is pretty annoying so only run these on release versions that are known to work to reduce some maintenance burden. Although why we even bother with this is still a valid question.