### PR TITLE
vulkan/context: make use of VK_EXT_shader_object only if available

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -185,7 +185,9 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
     const char *opt_extensions[] = {
         VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
         VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME,
+#ifdef VK_EXT_SHADER_OBJECT_EXTENSION_NAME
         VK_EXT_SHADER_OBJECT_EXTENSION_NAME,
+#endif
         VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME,
         VK_KHR_VIDEO_DECODE_H264_EXTENSION_NAME,
         VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME,
@@ -193,15 +195,18 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
         "VK_KHR_video_decode_av1", /* VK_KHR_VIDEO_DECODE_AV1_EXTENSION_NAME */
     };
 
+#ifdef VK_EXT_SHADER_OBJECT_EXTENSION_NAME
     VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_feature = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT,
-        .pNext = NULL,
         .shaderObject = true,
     };
+#endif
 
     VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_feature = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT,
+#ifdef VK_EXT_SHADER_OBJECT_EXTENSION_NAME
         .pNext = &shader_object_feature,
+#endif
         .descriptorBuffer = true,
         .descriptorBufferPushDescriptors = true,
     };


### PR DESCRIPTION
Fixes build on Debian stable (Bookworm).

Fixes: #15041
Fixes: 2ac1d6db329a129f9f35dba0e679e9044fc05ee6