### PR TITLE
win32: always fit to the screen on initial positioning

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1950,7 +1950,7 @@ static void window_reconfig(struct vo_w32_state *w32, bool force)
         w32->prev_windowrc = w32->windowrc;
         w32->window_bounds_initialized = true;
         w32->win_force_pos = geo.flags & VO_WIN_FORCE_POS;
-        w32->fit_on_screen = !w32->win_force_pos;
+        w32->fit_on_screen = true;
         goto finish;
     }
 


### PR DESCRIPTION
Now VO_WIN_FORCE_POS is set even if position is not provided by user, so we have no choice to always fit. We should do that anyway and if some issues in multi monitor configuration happens, this has to be fixed differently.

Fixes: #15049
Fixes: e5159de8118120163689c27f5cbc1ec68c2d27c8