### PR TITLE
stats.lua: clip lines with ${term-clip-cc}

### DIFF
--- a/DOCS/interface-changes/stats-term-clip.txt
+++ b/DOCS/interface-changes/stats-term-clip.txt
@@ -1,2 +1,3 @@
 remove `stats-term_width_limit` script-opt
 add `stats-term_clip` script-opt
+remove `stats-term_height_limit` script-opt

--- a/DOCS/interface-changes/stats-term-clip.txt
+++ b/DOCS/interface-changes/stats-term-clip.txt
@@ -1,0 +1,2 @@
+remove `stats-term_width_limit` script-opt
+add `stats-term_clip` script-opt

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -115,11 +115,10 @@ Configurable Options
 
     Only show the first specified amount of file tags.
 
-``term_width_limit``
-    Default: -1
+``term_clip``
+    Default: yes
 
-    Sets the terminal width.
-    A value of 0 means the width is infinite, -1 means it's automatic.
+    Whether to clip lines to the terminal width.
 
 ``term_height_limit``
     Default: -1
@@ -259,10 +258,10 @@ string, and one should not expect documentation-level grouping accuracy,
 however, it should still be reasonably useful.
 
 Using ``--idle --script-opts-append=stats-bindlist=yes`` will print the list to
-the terminal and quit immediately. By default long lines are shortened to 79
-chars, and terminal escape sequences are enabled. A different length limit can
-be set by changing ``yes`` to a number (at least 40), and escape sequences can
-be disabled by adding ``-`` before the value, e.g. ``...=-yes`` or ``...=-120``.
+the terminal and quit immediately. Long lines are clipped to the terminal width
+unless this is disabled with ``--script-opts-append=stats-term_clip=no``. Escape
+sequences can be disabled by adding ``-`` before ``yes``, i.e.
+``--script-opts-append=stats-bindlist=-yes``.
 
 Like with ``--input-test``, the list includes bindings from ``input.conf`` and
 from user scripts. Use ``--no-config`` to list only built-in bindings.

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -120,12 +120,6 @@ Configurable Options
 
     Whether to clip lines to the terminal width.
 
-``term_height_limit``
-    Default: -1
-
-    Sets the terminal height.
-    A value of 0 means the height is infinite, -1 means it's automatic.
-
 ``plot_perfdata``
     Default: yes
 

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -258,11 +258,11 @@ The keys are grouped automatically using a simple analysis of the command
 string, and one should not expect documentation-level grouping accuracy,
 however, it should still be reasonably useful.
 
-Using ``--idle --script-opts=stats-bindlist=yes`` will print the list to the
-terminal and quit immediately. By default long lines are shortened to 79 chars,
-and terminal escape sequences are enabled. A different length limit can be
-set by changing ``yes`` to a number (at least 40), and escape sequences can be
-disabled by adding ``-`` before the value, e.g. ``...=-yes`` or ``...=-120``.
+Using ``--idle --script-opts-append=stats-bindlist=yes`` will print the list to
+the terminal and quit immediately. By default long lines are shortened to 79
+chars, and terminal escape sequences are enabled. A different length limit can
+be set by changing ``yes`` to a number (at least 40), and escape sequences can
+be disabled by adding ``-`` before the value, e.g. ``...=-yes`` or ``...=-120``.
 
 Like with ``--input-test``, the list includes bindings from ``input.conf`` and
 from user scripts. Use ``--no-config`` to list only built-in bindings.

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1161,7 +1161,8 @@ local function keybinding_info(after_scroll, bindlist)
     local page = pages[o.key_page_4]
     eval_ass_formatting()
     add_header(header)
-    append(header, "", {prefix=format("%s:%s", page.desc, scroll_hint(true)), nl="", indent=""})
+    local prefix = bindlist and page.desc or page.desc .. ":" .. scroll_hint(true)
+    append(header, "", {prefix=prefix, nl="", indent=""})
     header = {table.concat(header)}
 
     if not kbinfo_lines or not after_scroll then

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -81,7 +81,7 @@ local o = {
     ass_it0 = "{\\i0}",
     -- Without ASS
     no_ass_nl = "\n",
-    no_ass_indent = "\t",
+    no_ass_indent = "    ",
     no_ass_prefix_sep = " ",
     no_ass_b1 = "\027[1m",
     no_ass_b0 = "\027[0m",

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -36,7 +36,6 @@ local o = {
     file_tag_max_count = 16,         -- only show the first x file tags
     show_frame_info = false,         -- whether to show the current frame info
     term_clip = true,
-    term_height_limit = -1,          -- overwrites the terminal height
     debug = false,
 
     -- Graph options and style
@@ -91,11 +90,6 @@ local o = {
     bindlist = "no",  -- print page 4 to the terminal on startup and quit mpv
 }
 options.read_options(o)
-
-o.term_height_limit = tonumber(o.term_height_limit) or -1
-if o.term_height_limit < 0 then
-    o.term_height_limit = nil
-end
 
 local format = string.format
 local max = math.max
@@ -1110,10 +1104,9 @@ end
 -- content     : table of the content where each entry is one line
 -- apply_scroll: scroll the content
 local function finalize_page(header, content, apply_scroll)
-    local term_size = mp.get_property_native("term-size", {})
-    local term_height = o.term_height_limit or term_size.h or 24
+    local term_height = mp.get_property_native("term-size/h", 24)
     local from, to = 1, #content
-    if apply_scroll and term_height > 0 then
+    if apply_scroll then
         -- Up to 40 lines for libass because it can put a big performance toll on
         -- libass to process many lines which end up outside (below) the screen.
         -- In the terminal reduce height by 2 for the status line (can be more then one line)


### PR DESCRIPTION
Use the new property introduced in bf025cd289 to clip the lines of stats.lua with accurate unicode width detection and considering --msg-module and --msg-time.

no_ass_indent is changed from \t to 4 spaces because the width of \t is not calculated correctly.

mpv --idle --script-opts=stats-bindlist=yes uses io.write, so don't use ${term-clip-cc} in that case because it doesn't work.