### PR TITLE
bug fix: There is a chance that command 'audio-add' will abort unexpectedly

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5807,6 +5807,7 @@ static void cmd_loadfile(void *p)
             mp_write_watch_later_conf(mpctx);
         mp_set_playlist_entry(mpctx, entry);
     }
+    mp_cancel_reset(mpctx->playback_abort);
     mp_notify(mpctx, MP_EVENT_CHANGE_PLAYLIST, NULL);
     mp_wakeup_core(mpctx);
 }


### PR DESCRIPTION
bug fix: There is a chance that command `audio-add` will fail if executed immediately after `mp_create` and `loadfile`. The `loadfile` command returned success, but the subsequent `audio-add` failed....

The reason is that `playback_abort` is detected in the `mp_abort_recheck_locked` method when `audio-add` is executed. The flag is set to true in a line of code in `mp_create`

	mp_cancel_trigger(mpctx->playback_abort);

Then it is cleared in the `play_current_file` method.

	mp_cancel_reset(mpctx->playback_abort);

According to the comments, this is done to make the subprocess enter the idle state immediately after create, but it causes a bug. `play_current_file` is executed asynchronously in the core thread. If `play_current_file` has not yet executed `mp_cancel_reset` when `audio-add` is called, then `audio-add` will fail due to playback_abort. And I think this is a bug bacause:

1 `audio-add` sometimes succeeds and sometimes fails, depending on the execution speed of the core thread.
2 It would be strange if `loadfile` succeeded and then `audio-add` failed

To fix this, you can let the application detect the MPV_EVENT_PLAYBACK_RESTART event and then call `audio-add`, but this is not convenient and efficient. It is better to clear the `playback_abort` flag when `loadfile`.  Please correct me if I'm wrong.
