### PR TITLE
wayland: use wp-presentation v2 if available

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1591,7 +1591,7 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
 #endif
 
     if (!strcmp(interface, wp_presentation_interface.name) && found++) {
-        ver = 1;
+        ver = MPMIN(ver, 2);
         wl->presentation = wl_registry_bind(reg, id, &wp_presentation_interface, ver);
         wp_presentation_add_listener(wl->presentation, &pres_listener, wl);
     }


### PR DESCRIPTION
Version 2 allows the compositor to send an appropriate refresh rate if the output uses VRR. There are no changes to the API. Since mpv would otherwise use a heuristic based on the last-seen output, it does not matter to mpv if the output uses VRR.

https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/320/diffs