### PR TITLE
stream_cdda: stop suppressing -Wscript-prototypes

### DIFF
--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -23,16 +23,12 @@
 
 #include <cdio/cdio.h>
 
-// For cdio_cddap_version
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 #ifndef TESTING_IS_FINISHED
 // Suppress Wundef warning
 #define TESTING_IS_FINISHED 0
 #endif
 #include <cdio/paranoia/cdda.h>
 #include <cdio/paranoia/paranoia.h>
-#pragma GCC diagnostic pop
 
 #include "common/msg.h"
 #include "config.h"


### PR DESCRIPTION
This was fixed upstream* and in a new release, so it is no longer needed for our CI.

*: https://github.com/rocky/libcdio-paranoia/commit/3ced3d72debae3cf304c81be820356c336fd31a2