### PR TITLE
vf_d3d11vpp: always insert filter for non-standard scaling modes

### DIFF
--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -504,7 +504,8 @@ static void vf_d3d11vpp_process(struct mp_filter *vf)
         p->require_filtering = p->params.hw_subfmt != p->out_params.hw_subfmt ||
                                p->params.w != p->out_params.w ||
                                p->params.h != p->out_params.h ||
-                               p->opts->nvidia_true_hdr;
+                               p->opts->nvidia_true_hdr ||
+                               p->opts->scaling_mode != SCALING_BASIC;
     }
 
     if (!mp_refqueue_can_output(p->queue))


### PR DESCRIPTION
Apparently, some processing is still desired by users even at a 1.0 scaling factor.

Fixes: https://github.com/mpv-player/mpv/pull/14698#issuecomment-2408525834