### PR TITLE
meson.build: dont create desktop file dynamically if cross-compiling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1814,7 +1814,7 @@ if get_option('cplayer')
     endif
 
     if not win32 and not darwin
-        if meson.can_run_host_binaries()
+        if meson.can_run_host_binaries() and not meson.is_cross_build()
             mpv_desktop_path = join_paths(source_root, 'etc', 'mpv.desktop')
             custom_target('mpv.desktop',
                 depends: mpv,


### PR DESCRIPTION
[https://github.com/mpv-player/mpv/pull/14145/commits/0f4fa329357f27d0c57f8f13b426d7450a29cfa4]

Starting from this commit the mpv.desktop file gets dynamically created if meson can run host binaries. At least for the yocto/openembedded project this check is insufficient.

Although openembedded is generally able to run host binaries despite cross-compilation, gen-mpv-desktop.py fails with missing mpv binary unless we would provide a native mpv binary in the same configuration as it is built for the target machine. This seems like a bit of overkill to me. This change would ensure that the gen-mpv-desktop.py script is not executed when cross-compiling, so that we are able to copy mpv.desktop as described in the commit message.