### PR TITLE
cocoa-cb: fix race on shutdown and toggling fullscreen

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -262,6 +262,7 @@ class CocoaCB: Common, EventSubscriber {
 
         uninit()
         uninitCommon()
+        window = nil
 
         layer?.lockCglContext()
         libmpv.uninit()


### PR DESCRIPTION
since commit 15c48f3 we were force to start drawing on the main queue again. this has several unintended side effects due to the nature of the main queue. in this case fullscreen event and shutdown event are executed out of order and fullscreening is done after shutdown, leading to accessing options that are already de-initialised.

just nil the window on shutdown and make it impossible to fullscreen after shutdown.

Fixes #14810