### PR TITLE
mac/app: add homebrew ARM install paths to the bundle PATH environment

### DIFF
--- a/osdep/mac/application.swift
+++ b/osdep/mac/application.swift
@@ -87,7 +87,9 @@ class Application: NSApplication, NSApplicationDelegate {
         }
 
         let path = (ProcessInfo.processInfo.environment["PATH"] ?? "") +
-            ":/usr/local/bin:/usr/local/sbin:/opt/local/bin:/opt/local/sbin"
+            ":/usr/local/bin:/usr/local/sbin" + // homebrew Intel
+            ":/opt/local/bin:/opt/local/sbin" + // MacPorts
+            ":/opt/homebrew/bin:/opt/homebrew/sbin" // homebrew ARM
         appHub.log.verbose("Setting Bundle $PATH to: \(path)")
         _ = path.withCString { setenv("PATH", $0, 1) }
     }


### PR DESCRIPTION
since the bundle operates in a different shell environment than the one from the terminal, it only has a few default paths set.

add the homebrew ARM default install paths to the PATH environment variable, so the bundle can also find the needed binaries like yt-dl.