### PR TITLE
build: fix dynamic generation of mpv.desktop file protocols

### DIFF
--- a/TOOLS/gen-mpv-desktop.py
+++ b/TOOLS/gen-mpv-desktop.py
@@ -21,7 +21,6 @@
 #
 
 import sys
-from subprocess import check_output
 
 if __name__ == "__main__":
     with open(sys.argv[1], encoding="UTF-8") as f:
@@ -31,15 +30,13 @@ if __name__ == "__main__":
     if not mpv_desktop["X-KDE-Protocols"]:
         raise ValueError("Missing X-KDE-Protocols entry in mpv.desktop file")
 
-    mpv_protocols = check_output(
-        [sys.argv[2], "--no-config", "--list-protocols"],
-        encoding="UTF-8",
-    )
-    mpv_protocols = {
-        line.strip(" :/")
-        for line in mpv_protocols.splitlines()
-        if "://" in line
-    }
+    with open(sys.argv[2], encoding="UTF-8") as mpv_protocols:
+        mpv_protocols = {
+            line.strip(" :/")
+            for line in mpv_protocols.read().splitlines()
+            if "://" in line
+        }
+
     if len(mpv_protocols) == 0:
         raise ValueError("Unable to parse any protocols from mpv '--list-protocols'")
 

--- a/meson.build
+++ b/meson.build
@@ -1815,11 +1815,16 @@ if get_option('cplayer')
 
     if not win32 and not darwin
         if meson.can_run_host_binaries()
+            mpv_protocols = custom_target('mpv_protocols',
+                output: 'mpv_protocols',
+                command: [mpv, '--no-config','--list-protocols'],
+                capture: true,
+            )
             mpv_desktop_path = join_paths(source_root, 'etc', 'mpv.desktop')
             custom_target('mpv.desktop',
-                depends: mpv,
+                input: mpv_protocols,
                 output: 'mpv.desktop',
-                command: [mpv_desktop, mpv_desktop_path, mpv.full_path(), '@OUTPUT@'],
+                command: [mpv_desktop, mpv_desktop_path, '@INPUT@', '@OUTPUT@'],
                 install: true,
                 install_dir: join_paths(datadir, 'applications'),
             )


### PR DESCRIPTION
Running cross-compiled binaries may be possible, but the runtime environment must be configured correctly. In some configurations, an exe_wrapper needs to be used, and in all cases, the library path must be set correctly for the given binary. Fortunately, Meson handles all of this if cross-compilation is configured correctly.

Fix this by having Meson run the mpv binary directly, instead of as a subprocess of a Python script. This ensures that the environment is properly set for running host binaries, if possible.

Fixes: #15075
Fixes: 056b03f9ed05607786427da8f336e3ef819b3a1e