### PR TITLE
input/cmd: add nonscalable prefix

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1832,6 +1832,13 @@ prefixes can be specified. They are separated by whitespace.
 ``nonrepeatable``
     For some commands, keeping a key pressed runs the command repeatedly.
     This prefix forces disabling key repeat in any case.
+``nonscalable``
+    When some commands (e.g. ``add``) are bound to scalable keys associated to a
+    high-precision input device like a touchpad (e.g. ``WHEEL_UP``), the value
+    specified in the command is scaled to smaller steps based on the high
+    resolution input data if available.
+    This prefix forces disabling this behavior, so the value is always changed
+    in the discrete unit specified in the key binding.
 ``async``
     Allow asynchronous execution (if possible). Note that only a few commands
     will support this (usually this is explicitly documented). Some commands

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -53,6 +53,7 @@ static const struct flag cmd_flags[] = {
     {"raw",                 MP_EXPAND_PROPERTIES, 0},
     {"repeatable",          MP_DISALLOW_REPEAT, MP_ALLOW_REPEAT},
     {"nonrepeatable",       MP_ALLOW_REPEAT,    MP_DISALLOW_REPEAT},
+    {"nonscalable",         0,               MP_DISALLOW_SCALE},
     {"async",               MP_SYNC_CMD,     MP_ASYNC_CMD},
     {"sync",                MP_ASYNC_CMD,    MP_SYNC_CMD},
     {0}
@@ -618,7 +619,7 @@ bool mp_input_is_repeatable_cmd(struct mp_cmd *cmd)
 
 bool mp_input_is_scalable_cmd(struct mp_cmd *cmd)
 {
-    return cmd->def->scalable;
+    return cmd->def->scalable && !(cmd->flags & MP_DISALLOW_SCALE);
 }
 
 void mp_print_cmd_list(struct mp_log *out)

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -76,6 +76,7 @@ enum mp_cmd_flags {
     MP_SYNC_CMD = 64,           // block on command completion
 
     MP_DISALLOW_REPEAT = 128,   // if used as keybinding, disallow key repeat
+    MP_DISALLOW_SCALE = 256,    // if used as keybinding, make it non-scalable
 
     MP_ON_OSD_FLAGS = MP_ON_OSD_NO | MP_ON_OSD_AUTO |
                       MP_ON_OSD_BAR | MP_ON_OSD_MSG,

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1421,7 +1421,8 @@ local function complete(backwards)
         ['osd-auto'] = true, ['no-osd'] = true, ['osd-bar'] = true,
         ['osd-msg'] = true, ['osd-msg-bar'] = true, ['raw'] = true,
         ['expand-properties'] = true, ['repeatable'] = true,
-        ['nonrepeatable'] = true, ['async'] = true, ['sync'] = true
+        ['nonrepeatable'] = true, ['nonscalable'] = true,
+        ['async'] = true, ['sync'] = true
     }
 
     while tokens[first_useful_token_index] and

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -412,8 +412,9 @@ end
 -- command prefix tokens to strip - includes generic property commands
 local cmd_prefixes = {
     osd_auto=1, no_osd=1, osd_bar=1, osd_msg=1, osd_msg_bar=1, raw=1, sync=1,
-    async=1, expand_properties=1, repeatable=1, nonrepeatable=1, set=1, add=1,
-    multiply=1, toggle=1, cycle=1, cycle_values=1, ["!reverse"]=1, change_list=1,
+    async=1, expand_properties=1, repeatable=1, nonrepeatable=1, nonscalable=1,
+    set=1, add=1, multiply=1, toggle=1, cycle=1, cycle_values=1, ["!reverse"]=1,
+    change_list=1,
 }
 -- commands/writable-properties prefix sub-words (followed by -) to strip
 local name_prefixes = {


### PR DESCRIPTION
Some keys like WHEEL_UP are "scaled" if the input source is high resolution, like touchpad. However, sometimes it's desirable to disable this scaling and only active the key binding in discrete steps, such as relative keyframe seeking which interacts poorly if the command is scaled.

This adds the nonscalable prefix to disable this scaling.

Fixes: https://github.com/mpv-player/mpv/issues/15080