### PR TITLE
mac/common: fix usage of vo struct after vo uninit race

### DIFF
--- a/video/out/cocoa_cb_common.swift
+++ b/video/out/cocoa_cb_common.swift
@@ -40,7 +40,7 @@ class CocoaCB: Common, EventSubscriber {
     }
 
     func preinit(_ vo: UnsafeMutablePointer<vo>) {
-        self.vo = vo
+        eventsLock.withLock { self.vo = vo }
         input = InputHelper(vo.pointee.input_ctx, option)
 
         if backendState == .uninitialized {
@@ -57,12 +57,13 @@ class CocoaCB: Common, EventSubscriber {
     }
 
     func uninit() {
+        eventsLock.withLock { self.vo = nil }
         window?.orderOut(nil)
         window?.close()
     }
 
     func reconfig(_ vo: UnsafeMutablePointer<vo>) {
-        self.vo = vo
+        eventsLock.withLock { self.vo = vo }
         if backendState == .needsInit {
             DispatchQueue.main.sync { self.initBackend(vo) }
         } else if option.vo.auto_window_resize {

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -29,7 +29,7 @@ class MacCommon: Common {
         let log = LogHelper(mp_log_new(vo, vo.pointee.log, "mac"))
         let option = OptionHelper(vo, vo.pointee.global)
         super.init(option, log)
-        self.vo = vo
+        eventsLock.withLock { self.vo = vo }
         input = InputHelper(vo.pointee.input_ctx, option)
         presentation = Presentation(common: self)
         timer = PreciseTimer(common: self)
@@ -41,7 +41,7 @@ class MacCommon: Common {
     }
 
     @objc func config(_ vo: UnsafeMutablePointer<vo>) -> Bool {
-        self.vo = vo
+        eventsLock.withLock { self.vo = vo }
 
         DispatchQueue.main.sync {
             let previousActiveApp = getActiveApp()


### PR DESCRIPTION
we keep track of the current vo struct to flag for events that are initiated async by various thread from different system notifications. the problem here is the usage of that vo struct after uninit.

make accessing of that vo struct atomic and clear it on uninit, so it can't be used afterwards by concurrent threads from system notifications or events.

Fixes #15088