### PR TITLE
video/out/gpu/context: prefer vulkan over opengl when reasonable

### DIFF
--- a/video/out/gpu/context.c
+++ b/video/out/gpu/context.c
@@ -82,6 +82,22 @@ static const struct ra_ctx_fns *contexts[] = {
     &ra_ctx_d3d11,
 #endif
 
+// Vulkan contexts:
+#if HAVE_VULKAN
+#if HAVE_WIN32_DESKTOP
+    &ra_ctx_vulkan_win,
+#endif
+#if HAVE_WAYLAND
+    &ra_ctx_vulkan_wayland,
+#endif
+#if HAVE_X11
+    &ra_ctx_vulkan_xlib,
+#endif
+#if HAVE_COCOA && HAVE_SWIFT
+    &ra_ctx_vulkan_mac,
+#endif
+#endif
+
 // OpenGL contexts:
 #if HAVE_EGL_ANDROID
     &ra_ctx_android,
@@ -108,26 +124,13 @@ static const struct ra_ctx_fns *contexts[] = {
     &ra_ctx_drm_egl,
 #endif
 
-// Vulkan contexts:
+// Vulkan contexts (fallbacks):
 #if HAVE_VULKAN
-
 #if HAVE_ANDROID
     &ra_ctx_vulkan_android,
 #endif
-#if HAVE_WIN32_DESKTOP
-    &ra_ctx_vulkan_win,
-#endif
-#if HAVE_WAYLAND
-    &ra_ctx_vulkan_wayland,
-#endif
-#if HAVE_X11
-    &ra_ctx_vulkan_xlib,
-#endif
 #if HAVE_VK_KHR_DISPLAY
     &ra_ctx_vulkan_display,
-#endif
-#if HAVE_COCOA && HAVE_SWIFT
-    &ra_ctx_vulkan_mac,
 #endif
 #endif
 };


### PR DESCRIPTION
For most actual desktop users, vulkan should be the a superior experience over opengl as this point and our autoprobe should pick that. For linux users, vulkan on wayland is rapidly seeing improvements and is far ahead of egl. There is no sign of that changing anytime soon and working fifo is on the horizon, so really wayland users should just all be using vulkan from now on. For x11, there is not a big difference between using egl vs vulkan as far as I know and both work well. macOS already prefers the vulkan backend over the libmpv one anyways, and finally windows still defaults to d3d11. Probably virtually no one uses opengl on windows, but vulkan is reasonably common among windows users and it doesn't make any sense to prefer opengl over it.

The two outliers here are Android and VK_KHR_display. On Android, vulkan drivers are probably just a total disaster and let's not put ourselves in that mess if there's no reason to. For VK_KHR_display, it actually works fine except for one really big problem: VT switching doesn't work. If you try it, enjoy losing all input and being forced to do a hard reboot. It might be fixable if you use logind or something, but the method of using signals like the drm context does won't work because VK_KHR_display uses render nodes not primary nodes. Also, the opengl drm context could support hdr in theory (some attempts were made but none succesful) so it is probably "better". Maybe. Anyways, for these two platforms, we still prefer opengl.

Something similar was done in #13620. But I don't believe this needs to wait until a consensus is formed around preferring `vo_gpu_next`.