### PR TITLE
ytdl_hook.lua: support playlist_title

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -27,6 +27,7 @@ end)
 
 local chapter_list = {}
 local playlist_cookies = {}
+local playlist_metadata = {}
 
 local function Set (t)
     local set = {}
@@ -1079,6 +1080,11 @@ local function run_ytdl_hook(url)
             return
         end
 
+        playlist_metadata[url] = {
+            playlist_title = json["title"],
+            playlist_id = json["id"]
+        }
+
         local self_redirecting_url =
             json.entries[1]["_type"] ~= "url_transparent" and
             json.entries[1]["webpage_url"] and
@@ -1193,6 +1199,12 @@ local function run_ytdl_hook(url)
         end
 
     else -- probably a video
+        -- add playlist metadata if any belongs to the current video
+        local metadata = playlist_metadata[mp.get_property("playlist-path")] or {}
+        for key, value in pairs(metadata) do
+            json[key] = value
+        end
+
         add_single_video(json)
     end
     msg.debug('script running time: '..os.clock()-start_time..' seconds')


### PR DESCRIPTION
This PR mostly serves as a discussion about how this issue might be resolved.

`ytdl_hook` is aware of many useful playlist metadata tags which are essentially lost during the creation of a playlist as `yt-dlp` is called twice: once for the playlist url and then again for each entry. Here the json representing the playlist and its metadata is no longer available in the json produced for each entry.

It is not clear whether `yt-dlp` should provide the metadata or if `ytdl_hook` should go out of its way to try and capture this information and provide it during another instance of `run_ytdl_hook()` and what consequences that might have.

See also https://github.com/yt-dlp/yt-dlp/issues/11234
