### PR TITLE
mac/app: add option to adjust Bundle PATH variable

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6593,6 +6593,21 @@ them.
     precedence over any other shortcuts, they are not propagated to the mpv core and they can't be
     used in config files like ``input.conf`` or script bindings.
 
+``--macos-bundle-path=path1,path2,...``
+    App Bundles operate in their own shell environment that is different from the one in the
+    terminal. The default PATH variable for all Bundles is ``/usr/bin:/bin:/usr/sbin:/sbin``.
+    Because of that mpv can not find binaries installed by package manager that might be used in
+    scripts for example. This option prepends all given paths to the default Bundle PATH.
+
+    Default value in following order:
+
+    :/usr/local/bin:     homebrew (Intel) install path
+    :/usr/local/sbin:    homebrew (Intel) install path
+    :/opt/local/bin:     MacPorts install path
+    :/opt/local/sbin:    MacPorts install path
+    :/opt/homebrew/bin:  homebrew (ARM) install path
+    :/opt/homebrew/sbin: homebrew (ARM) install path
+
 ``--android-surface-size=<WxH>``
     Set dimensions of the rendering surface used by the Android gpu context.
     Needs to be set by the embedding application if the dimensions change during

--- a/osdep/mac/app_bridge.h
+++ b/osdep/mac/app_bridge.h
@@ -63,6 +63,7 @@ struct macos_opts {
     int macos_geometry_calculation;
     int macos_render_timer;
     bool macos_menu_shortcuts;
+    char **macos_bundle_path;
     int cocoa_cb_sw_renderer;
     bool cocoa_cb_10bit_context;
     int cocoa_cb_output_csp;

--- a/osdep/mac/app_bridge.m
+++ b/osdep/mac/app_bridge.m
@@ -53,6 +53,7 @@ const struct m_sub_options macos_conf = {
             {"callback", RENDER_TIMER_CALLBACK}, {"precise", RENDER_TIMER_PRECISE},
             {"system", RENDER_TIMER_SYSTEM}, {"feedback", RENDER_TIMER_PRESENTATION_FEEDBACK})},
         {"macos-menu-shortcuts", OPT_BOOL(macos_menu_shortcuts)},
+        {"macos-bundle-path", OPT_STRINGLIST(macos_bundle_path)},
         {"cocoa-cb-sw-renderer", OPT_CHOICE(cocoa_cb_sw_renderer,
             {"auto", -1}, {"no", 0}, {"yes", 1})},
         {"cocoa-cb-10bit-context", OPT_BOOL(cocoa_cb_10bit_context)},
@@ -80,6 +81,10 @@ const struct m_sub_options macos_conf = {
         .macos_fs_animation_duration = -1,
         .macos_render_timer = RENDER_TIMER_CALLBACK,
         .macos_menu_shortcuts = true,
+        .macos_bundle_path = (char *[]){
+            "/usr/local/bin", "/usr/local/sbin", "/opt/local/bin", "/opt/local/sbin",
+            "/opt/homebrew/bin", "/opt/homebrew/sbin", NULL
+        },
         .cocoa_cb_sw_renderer = -1,
         .cocoa_cb_10bit_context = true,
         .cocoa_cb_output_csp = MAC_CSP_AUTO,

--- a/osdep/mac/app_hub.swift
+++ b/osdep/mac/app_hub.swift
@@ -38,6 +38,7 @@ class AppHub: NSObject {
 
     let MPV_PROTOCOL: String = "mpv://"
     var isApplication: Bool { return NSApp is Application }
+    var isBundle: Bool { return ProcessInfo.processInfo.environment["MPVBUNDLE"] == "true" }
     var openEvents: Int = 0
 
     private override init() {
@@ -58,6 +59,12 @@ class AppHub: NSObject {
             option = OptionHelper(UnsafeMutablePointer(mpv), mp_client_get_global(mpv))
             input.option = option
             DispatchQueue.main.sync { menu = MenuBar(self) }
+        }
+        if let bundlePath = option?.mac.macos_bundle_path, isBundle {
+            let path = TypeHelper.toStringArray(bundlePath).joined(separator: ":") + ":" +
+                (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            log.verbose("Setting Bundle PATH to: \(path)")
+            _ = path.withCString { setenv("PATH", $0, 1) }
         }
 
 #if HAVE_MACOS_MEDIA_PLAYER

--- a/osdep/mac/type_helper.swift
+++ b/osdep/mac/type_helper.swift
@@ -50,6 +50,17 @@ class TypeHelper {
         }
     }
 
+    // char ** OPT_STRINGLIST
+    class func toStringArray(_ obj: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?) -> [String] {
+        guard var cStringArray = obj else { return [] }
+        var stringArray: [String] = []
+        while let cString = cStringArray.pointee {
+            stringArray.append(String(cString: cString))
+            cStringArray += 1
+        }
+        return stringArray
+    }
+
     // *(char **) MPV_FORMAT_STRING
     class func toString(_ obj: UnsafeMutableRawPointer?) -> String? {
         guard let str = obj else { return nil }


### PR DESCRIPTION
this wasn't previously possible, but with the recent complete rewrite of Application mechanics it is now possible to access options early in the mac App creation.

App Bundles operate in their own shell environment that is different from the one in the terminal. the default PATH variable for all Bundles is /usr/bin:/bin:/usr/sbin:/sbin. because of that mpv can not find binaries installed by package manager that might be used in scripts for example.

add an option to prepend paths to the Bundle PATH. we prepend to make the order fully configurable, opposed to appending where the default Bundle binaries would always take precedence.