### PR TITLE
context_drm_gl: add support for hdr metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,6 +462,7 @@ jobs:
                 libcaca \
                 libcdio-paranoia \
                 libdvdnav \
+                libdisplay-info \
                 libplacebo \
                 libXinerama \
                 libxkbcommon \

--- a/DOCS/interface-changes/target-hint.txt
+++ b/DOCS/interface-changes/target-hint.txt
@@ -1,0 +1,1 @@
+change `target-colorspace-hint` default to `yes`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6812,6 +6812,7 @@ them.
     Automatically configure the output colorspace of the display to pass
     through the input values of the stream (e.g. for HDR passthrough), if
     possible. Requires a supporting driver and ``--vo=gpu-next``.
+    (Default: ``yes``)
 
 ``--target-prim=<value>``
     Specifies the primaries of the display. Video colors will be adapted to

--- a/meson.build
+++ b/meson.build
@@ -935,9 +935,11 @@ if features['direct3d']
 endif
 
 drm = dependency('libdrm', version: '>= 2.4.105', required: get_option('drm'))
-features += {'drm': drm.found() and (features['vt.h'] or features['consio.h'] or features['wsdisplay-usl-io.h'])}
+libdisplay_info = dependency('libdisplay-info', version: '>= 0.1.1', required: get_option('drm'))
+features += {'drm': drm.found() and libdisplay_info.found() and
+             (features['vt.h'] or features['consio.h'] or features['wsdisplay-usl-io.h'])}
 if features['drm']
-    dependencies += drm
+    dependencies += [drm, libdisplay_info]
     sources += files('video/drmprime.c',
                      'video/out/drm_atomic.c',
                      'video/out/drm_common.c',

--- a/video/out/drm_atomic.c
+++ b/video/out/drm_atomic.c
@@ -299,6 +299,7 @@ void drm_atomic_destroy_context(struct drm_atomic_context *ctx)
     drm_object_free(ctx->connector);
     drm_object_free(ctx->draw_plane);
     drm_object_free(ctx->drmprime_video_plane);
+    drmModeAtomicFree(ctx->request);
     talloc_free(ctx);
 }
 

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -1365,7 +1365,8 @@ bool vo_drm_set_hdr_metadata(struct vo *vo, bool force_sdr)
 
     destroy_hdr_blob(drm);
     drm->target_params = target_params;
-    bool use_sdr = !target_params_supported_by_display(drm) || force_sdr;
+    drm->supported_colorspace = target_params_supported_by_display(drm);
+    bool use_sdr = !drm->supported_colorspace || force_sdr;
 
     // For any HDR, the BT2020 drm colorspace is the only one that works in practice.
     struct drm_atomic_context *atomic_ctx = drm->atomic_context;

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -138,6 +138,7 @@ struct vo_drm_state {
     const struct di_edid_chromaticity_coords *chromaticity;
     const struct di_cta_hdr_static_metadata_block *hdr_static_metadata;
     const struct di_cta_colorimetry_block *colorimetry;
+    bool supported_colorspace;
 
     bool active;
     bool paused;

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -22,6 +22,10 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
+#include <libdisplay-info/cta.h>
+#include <libdisplay-info/edid.h>
+#include <libdisplay-info/info.h>
+
 #include "video/mp_image.h"
 #include "vo.h"
 
@@ -128,6 +132,12 @@ struct vo_drm_state {
     struct mp_present *present;
     struct vo *vo;
     struct vt_switcher vt_switcher;
+
+    // libdisplay-info edid stuff
+    struct di_info *info;
+    const struct di_edid_chromaticity_coords *chromaticity;
+    const struct di_cta_hdr_static_metadata_block *hdr_static_metadata;
+    const struct di_cta_colorimetry_block *colorimetry;
 
     bool active;
     bool paused;

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -41,6 +41,10 @@ struct ra_ctx_fns {
     // display size etc. are determined by it.
     bool (*reconfig)(struct ra_ctx *ctx);
 
+    // Signal if the underlying context can use colorspace/hdr related functionality
+    // on its own.
+    bool (*pass_colorspace)(struct ra_ctx *ctx);
+
     // This behaves exactly like vo_driver.control().
     int (*control)(struct ra_ctx *ctx, int *events, int request, void *arg);
 

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -708,6 +708,11 @@ static bool drm_egl_reconfig(struct ra_ctx *ctx)
     return true;
 }
 
+static bool drm_egl_pass_colorspace(struct ra_ctx *ctx)
+{
+    return ctx->vo->drm->supported_colorspace;
+}
+
 static int drm_egl_control(struct ra_ctx *ctx, int *events, int request,
                            void *arg)
 {
@@ -726,13 +731,14 @@ static void drm_egl_wakeup(struct ra_ctx *ctx)
 }
 
 const struct ra_ctx_fns ra_ctx_drm_egl = {
-    .type           = "opengl",
-    .name           = "drm",
-    .description    = "DRM/EGL",
-    .reconfig       = drm_egl_reconfig,
-    .control        = drm_egl_control,
-    .init           = drm_egl_init,
-    .uninit         = drm_egl_uninit,
-    .wait_events    = drm_egl_wait_events,
-    .wakeup         = drm_egl_wakeup,
+    .type            = "opengl",
+    .name            = "drm",
+    .description     = "DRM/EGL",
+    .reconfig        = drm_egl_reconfig,
+    .pass_colorspace = drm_egl_pass_colorspace,
+    .control         = drm_egl_control,
+    .init            = drm_egl_init,
+    .uninit          = drm_egl_uninit,
+    .wait_events     = drm_egl_wait_events,
+    .wakeup          = drm_egl_wakeup,
 };

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -279,6 +279,10 @@ static void uninit(struct vo *vo)
     struct gpu_priv *p = vo->priv;
 
     gl_video_uninit(p->renderer);
+    mp_mutex_lock(&vo->params_mutex);
+    vo->target_params = NULL;
+    mp_mutex_unlock(&vo->params_mutex);
+
     if (vo->hwdec_devs) {
         hwdec_devices_set_loader(vo->hwdec_devs, NULL, NULL);
         hwdec_devices_destroy(vo->hwdec_devs);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -206,6 +206,7 @@ const struct m_sub_options gl_next_conf = {
     .defaults = &(struct gl_next_opts) {
         .border_background = BACKGROUND_COLOR,
         .inter_preserve = true,
+        .target_hint = true,
     },
     .size = sizeof(struct gl_next_opts),
     .change_flags = UPDATE_VIDEO,

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -990,8 +990,12 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         p->last_id = id;
     }
 
+    bool pass_colorspace = false;
+    struct pl_color_space hint;
     if (p->next_opts->target_hint && frame->current) {
-        struct pl_color_space hint = frame->current->params.color;
+        hint = frame->current->params.color;
+        if (p->ra_ctx->fns->pass_colorspace && p->ra_ctx->fns->pass_colorspace(p->ra_ctx))
+            pass_colorspace = true;
         if (opts->target_prim)
             hint.primaries = opts->target_prim;
         if (opts->target_trc)
@@ -999,7 +1003,8 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
         if (opts->target_peak)
             hint.hdr.max_luma = opts->target_peak;
         apply_target_contrast(p, &hint);
-        pl_swapchain_colorspace_hint(p->sw, &hint);
+        if (!pass_colorspace)
+            pl_swapchain_colorspace_hint(p->sw, &hint);
     } else if (!p->next_opts->target_hint) {
         pl_swapchain_colorspace_hint(p->sw, NULL);
     }
@@ -1142,7 +1147,7 @@ static void draw_frame(struct vo *vo, struct vo_frame *frame)
                         ? swframe.fbo->params.format->name : NULL,
         .w = mp_rect_w(p->dst),
         .h = mp_rect_h(p->dst),
-        .color = target.color,
+        .color = pass_colorspace ? hint : target.color,
         .repr = target.repr,
         .rotate = target.rotation,
     };

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1985,18 +1985,18 @@ static void add_feedback(struct vo_wayland_feedback_pool *fback_pool,
     }
 }
 
+#if HAVE_DRM
 static bool devices_are_equal(dev_t a, dev_t b)
 {
     bool ret = false;
-#if HAVE_DRM
     drmDevice *deviceA, *deviceB;
     if (!drmGetDeviceFromDevId(a, 0, &deviceA) && !drmGetDeviceFromDevId(b, 0, &deviceB))
         ret = drmDevicesEqual(deviceA, deviceB);
     drmFreeDevice(&deviceA);
     drmFreeDevice(&deviceB);
-#endif
     return ret;
 }
+#endif
 
 static void do_minimize(struct vo_wayland_state *wl)
 {


### PR DESCRIPTION
Somebody please actually test since I have no actual hdr capable monitors. There's also a `HDMI_EOTF_TRADITIONAL_GAMMA_HDR` enum in there but I have no idea what on earth that was supposed to be so I ignored it.

Also not sure if any existing `--drm-format` options are capable enough here.