### PR TITLE
x11: remove nvidia blacklist logic from --x11-present=auto

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3658,9 +3658,9 @@ Window
     is being used.
 
     The auto option enumerates XRandr providers for autodetection. If amd, radeon,
-    intel, or nouveau (the standard x86 Mesa drivers) is found and nvidia is NOT
-    found, presentation feedback is enabled. Other drivers are not assumed to
-    work, so they are not enabled automatically.
+    intel, or nouveau (the standard x86 Mesa drivers) is found presentation
+    feedback is enabled. Other drivers are not assumed to work, so they are not
+    enabled automatically.
 
     ``yes`` or ``no`` can still be passed regardless to enable/disable this
     mechanism in case there is good/bad behavior with whatever your combination

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -396,7 +396,7 @@ static void xpresent_set(struct vo_x11_state *x11)
 {
     int present = x11->opts->x11_present;
     x11->use_present = x11->present_code &&
-                       ((x11->has_mesa && !x11->has_nvidia && present) ||
+                       ((x11->has_mesa && present) ||
                         present == 2);
     if (x11->use_present) {
         MP_VERBOSE(x11, "XPresent enabled.\n");
@@ -430,11 +430,8 @@ static void xrandr_read(struct vo_x11_state *x11)
     }
 
     /* Look at the available providers on the current screen and try to determine
-     * the driver. If amd/intel/radeon, assume this is mesa. If nvidia is found,
-     * assume nvidia. Because the same screen can have multiple providers (e.g.
-     * a laptop with switchable graphics), we need to know both of these things.
-     * In practice, this is used for determining whether or not to use XPresent
-     * (i.e. needs to be Mesa and not Nvidia). Requires Randr 1.4. */
+     * the driver. If amd/intel/radeon, assume this is mesa. For any of the mesa
+     * drivers, enable XPresent. */
     XRRProviderResources *pr = XRRGetProviderResources(x11->display, x11->rootwin);
     for (int i = 0; i < pr->nproviders; i++) {
         XRRProviderInfo *info = XRRGetProviderInfo(x11->display, r, pr->providers[i]);
@@ -444,11 +441,9 @@ static void xrandr_read(struct vo_x11_state *x11)
         int intel = bstr_find0(provider_name, "intel");
         int modesetting = bstr_find0(provider_name, "modesetting");
         int nouveau = bstr_find0(provider_name, "nouveau");
-        int nvidia = bstr_find0(provider_name, "nvidia");
         int radeon = bstr_find0(provider_name, "radeon");
         x11->has_mesa = x11->has_mesa || amd >= 0 || intel >= 0 ||
                         modesetting >= 0 || nouveau >= 0 || radeon >= 0;
-        x11->has_nvidia = x11->has_nvidia || nvidia >= 0;
         XRRFreeProviderInfo(info);
     }
     if (x11->present_code)

--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -71,7 +71,6 @@ struct vo_x11_state {
 
     int xrandr_event;
     bool has_mesa;
-    bool has_nvidia;
 
     bool screensaver_enabled;
     bool dpms_touched;


### PR DESCRIPTION
When the present extension was originally implemented, nvidia was specifically blacklisted. The reason was because at the time it would give bogus values that appeared to be real but actively made playback worse. So out of an abundance of caution, any nvidia detection at all (e.g. on a multi-gpu system) would disable the use of the extension. Well times have changed and actually presentation-time on wayland for nvidia works now amazingly enough. For xorg, the extension still doesn't work, but from user testing it does not seem to be harmful anymore. It just does nothing. So we can remove the blacklist part and just only use a whitelist. Like before, we only enable the extension for mesa drivers by default so no practical change for anyone except multi-gpu systems whom may have this enabled now but should not see any negative behavior change.