### PR TITLE
mac/vulkan: add retrieval of color depth and return auto (0)

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -842,7 +842,7 @@ static void apply_target_options(struct priv *p, struct pl_frame *target)
     int dither_depth = opts->dither_depth;
     if (dither_depth == 0) {
         struct ra_swapchain *sw = p->ra_ctx->swapchain;
-        if (sw->fns->color_depth) {
+        if (sw->fns->color_depth && sw->fns->color_depth(sw) != -1) {
             dither_depth = sw->fns->color_depth(sw);
         } else if (!pl_color_transfer_is_hdr(target->color.transfer)) {
             dither_depth = 8;

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -314,6 +314,15 @@ char *ra_vk_ctx_get_device_name(struct ra_ctx *ctx)
     return device_name;
 }
 
+static int color_depth(struct ra_swapchain *sw)
+{
+    struct priv *p = sw->priv;
+    if (p->params.color_depth)
+        return p->params.color_depth(sw->ctx);
+
+    return -1;
+}
+
 static bool start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
 {
     struct priv *p = sw->priv;
@@ -363,6 +372,7 @@ static void get_vsync(struct ra_swapchain *sw,
 }
 
 static const struct ra_swapchain_fns vulkan_swapchain = {
+    .color_depth   = color_depth,
     .start_frame   = start_frame,
     .submit_frame  = submit_frame,
     .swap_buffers  = swap_buffers,

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -13,6 +13,9 @@ struct ra_vk_ctx_params {
 
     // In case something special needs to be done on the buffer swap.
     void (*swap_buffers)(struct ra_ctx *ctx);
+
+    // See ra_swapchain_fns.color_depth.
+    int (*color_depth)(struct ra_ctx *ctx);
 };
 
 // Helpers for ra_ctx based on ra_vk. These initialize ctx->ra and ctx->swchain.

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -50,6 +50,11 @@ static void mac_vk_get_vsync(struct ra_ctx *ctx, struct vo_vsync_info *info)
     [p->vo_mac fillVsyncWithInfo:info];
 }
 
+static int mac_vk_color_depth(struct ra_ctx *ctx)
+{
+    return 0;
+}
+
 static bool mac_vk_init(struct ra_ctx *ctx)
 {
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
@@ -78,6 +83,7 @@ static bool mac_vk_init(struct ra_ctx *ctx)
     struct ra_vk_ctx_params params = {
         .swap_buffers = mac_vk_swap_buffers,
         .get_vsync = mac_vk_get_vsync,
+        .color_depth = mac_vk_color_depth,
     };
 
     VkInstance inst = vk->vkinst->instance;


### PR DESCRIPTION
see #13767.

@Dudemanguy is that what you had in mind?

should i optimise the `sw->fns->color_depth(sw)` call so it isn't called twice in the worst case?