### PR TITLE
various: use stream_read_file for loading files

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -1469,16 +1469,11 @@ static bool parse_config_file(struct input_ctx *ictx, char *file)
 {
     bool r = false;
     void *tmp = talloc_new(NULL);
-    stream_t *s = NULL;
 
     file = mp_get_user_path(tmp, ictx->global, file);
 
-    s = stream_create(file, STREAM_ORIGIN_DIRECT | STREAM_READ, NULL, ictx->global);
-    if (!s || s->is_directory) {
-        MP_ERR(ictx, "Can't open input config file %s.\n", file);
-        goto done;
-    }
-    bstr data = stream_read_complete(s, tmp, 1000000);
+    bstr data = stream_read_file2(file, tmp, STREAM_ORIGIN_DIRECT | STREAM_READ,
+                                  ictx->global, 1000000);
     if (data.start) {
         MP_VERBOSE(ictx, "Parsing input config file %s\n", file);
         bstr_eatstart0(&data, "\xEF\xBB\xBF"); // skip BOM
@@ -1489,8 +1484,6 @@ static bool parse_config_file(struct input_ctx *ictx, char *file)
         MP_ERR(ictx, "Error reading input config file %s\n", file);
     }
 
-done:
-    free_stream(s);
     talloc_free(tmp);
     return r;
 }

--- a/options/parse_configfile.c
+++ b/options/parse_configfile.c
@@ -165,16 +165,11 @@ int m_config_parse_config_file(m_config_t *config, struct mpv_global *global,
 
     int r = 0;
 
-    struct stream *s = stream_create(conffile, STREAM_READ | STREAM_ORIGIN_DIRECT,
-                                     NULL, global);
-    if (!s)
-        goto done;
-    bstr data = stream_read_complete(s, s, 1000000000);
-    if (!data.start)
-        goto done;
-    r = m_config_parse(config, conffile, data, initial_section, flags);
+    bstr data = stream_read_file2(conffile, NULL, STREAM_ORIGIN_DIRECT | STREAM_READ,
+                                  global, 1000000000);
+    if (data.start)
+        r = m_config_parse(config, conffile, data, initial_section, flags);
 
-done:
-    free_stream(s);
+    talloc_free(data.start);
     return r;
 }

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -416,7 +416,6 @@ static int stream_create_instance(const stream_info_t *sinfo,
 }
 
 int stream_create_with_args(struct stream_open_args *args, struct stream **ret)
-
 {
     assert(args->url);
 

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -848,9 +848,15 @@ struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
 struct bstr stream_read_file(const char *filename, void *talloc_ctx,
                              struct mpv_global *global, int max_size)
 {
-    struct bstr res = {0};
     int flags = STREAM_ORIGIN_DIRECT | STREAM_READ | STREAM_LOCAL_FS_ONLY |
                 STREAM_LESS_NOISE;
+    return stream_read_file2(filename, talloc_ctx, flags, global, max_size);
+}
+
+struct bstr stream_read_file2(const char *filename, void *talloc_ctx,
+                              int flags, struct mpv_global *global, int max_size)
+{
+    struct bstr res = {0};
     stream_t *s = stream_create(filename, flags, NULL, global);
     if (s) {
         if (s->is_directory)

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -228,6 +228,9 @@ struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
                                  int max_size);
 struct bstr stream_read_file(const char *filename, void *talloc_ctx,
                              struct mpv_global *global, int max_size);
+// Like stream_read_file(), but allows specifying flags like with stream_create().
+struct bstr stream_read_file2(const char *filename, void *talloc_ctx,
+                              int flags, struct mpv_global *global, int max_size);
 
 int stream_control(stream_t *s, int cmd, void *arg);
 void free_stream(stream_t *s);


### PR DESCRIPTION
This allows cleaning up some code duplication which can be served by `stream_read_file`.