### PR TITLE
player/javascript: use af for stream_read_file talloc context

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -534,8 +534,7 @@ static int parse_dir(struct pl_parser *p)
             }
             break;
         }
-        int flags = STREAM_ORIGIN_DIRECT | STREAM_READ | STREAM_LOCAL_FS_ONLY |
-                    STREAM_LESS_NOISE;
+        int flags = STREAM_READ_FILE_FLAGS_DEFAULT;
         bstr dir = mp_dirname(p->real_stream->url);
         if (!dir.len)
             autocreate = AUTO_NONE;

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -351,14 +351,12 @@ static void af_push_file(js_State *J, const char *fname, int limit, void *af)
         return;
     }
 
-    bstr data = stream_read_file(filename, NULL, jctx(J)->mpctx->global, limit);
+    bstr data = stream_read_file(filename, af, jctx(J)->mpctx->global, limit);
     if (data.start) {
         js_pushlstring(J, data.start, data.len);
     } else {
         js_error(J, "cannot open file: '%s'", filename);
     }
-
-    talloc_free(data.start);
 }
 
 // Safely run af_push_file.

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -354,7 +354,10 @@ static void af_push_file(js_State *J, const char *fname, int limit, void *af)
     // mp.utils.read_file allows partial read up to limit which results in
     // error for stream_read_file if the file is larger than limit, so use
     // STREAM_ALLOW_PARTIAL_READ to allow reading returning partial results.
-    int flags = STREAM_READ_FILE_FLAGS_DEFAULT | STREAM_ALLOW_PARTIAL_READ;
+    // Additionally, disable error logging by stream since the exception
+    // can be caught and handled by a JS script.
+    int flags = STREAM_READ_FILE_FLAGS_DEFAULT | STREAM_ALLOW_PARTIAL_READ |
+                STREAM_SILENT;
     bstr data = stream_read_file2(filename, af, flags,
                                   jctx(J)->mpctx->global, limit);
     if (data.start) {

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -351,7 +351,12 @@ static void af_push_file(js_State *J, const char *fname, int limit, void *af)
         return;
     }
 
-    bstr data = stream_read_file(filename, af, jctx(J)->mpctx->global, limit);
+    // mp.utils.read_file allows partial read up to limit which results in
+    // error for stream_read_file if the file is larger than limit, so use
+    // STREAM_ALLOW_PARTIAL_READ to allow reading returning partial results.
+    int flags = STREAM_READ_FILE_FLAGS_DEFAULT | STREAM_ALLOW_PARTIAL_READ;
+    bstr data = stream_read_file2(filename, af, flags,
+                                  jctx(J)->mpctx->global, limit);
     if (data.start) {
         js_pushlstring(J, data.start, data.len);
     } else {

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -856,9 +856,8 @@ struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
 struct bstr stream_read_file(const char *filename, void *talloc_ctx,
                              struct mpv_global *global, int max_size)
 {
-    int flags = STREAM_ORIGIN_DIRECT | STREAM_READ | STREAM_LOCAL_FS_ONLY |
-                STREAM_LESS_NOISE;
-    return stream_read_file2(filename, talloc_ctx, flags, global, max_size);
+    return stream_read_file2(filename, talloc_ctx, STREAM_READ_FILE_FLAGS_DEFAULT,
+                             global, max_size);
 }
 
 struct bstr stream_read_file2(const char *filename, void *talloc_ctx,

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -802,7 +802,7 @@ int stream_skip_bom(struct stream *s)
 
 // Read the rest of the stream into memory (current pos to EOF), and return it.
 //  talloc_ctx: used as talloc parent for the returned allocation
-//  max_size: must be set to >0. If the file is larger than that, it is treated
+//  max_size: must be set to >=0. If the file is larger than that, it is treated
 //            as error. This is a minor robustness measure. If the stream is
 //            created with STREAM_ALLOW_PARTIAL_READ flag, partial result up to
 //            max_size is returned instead.
@@ -814,7 +814,7 @@ int stream_skip_bom(struct stream *s)
 struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
                                  int max_size)
 {
-    if (max_size <= 0 || max_size > STREAM_MAX_READ_SIZE)
+    if (max_size < 0 || max_size > STREAM_MAX_READ_SIZE)
         abort();
     if (s->is_directory)
         return (struct bstr){NULL, 0};

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -354,6 +354,7 @@ static int stream_create_instance(const stream_info_t *sinfo,
     s->path = talloc_strdup(s, path);
     s->mode = flags & (STREAM_READ | STREAM_WRITE);
     s->requested_buffer_size = opts->buffer_size;
+    s->allow_partial_read = flags & STREAM_ALLOW_PARTIAL_READ;
 
     if (flags & STREAM_LESS_NOISE)
         mp_msg_set_max_level(s->log, MSGL_WARN);
@@ -802,7 +803,9 @@ int stream_skip_bom(struct stream *s)
 // Read the rest of the stream into memory (current pos to EOF), and return it.
 //  talloc_ctx: used as talloc parent for the returned allocation
 //  max_size: must be set to >0. If the file is larger than that, it is treated
-//            as error. This is a minor robustness measure.
+//            as error. This is a minor robustness measure. If the stream is
+//            created with STREAM_ALLOW_PARTIAL_READ flag, partial result up to
+//            max_size is returned instead.
 //  returns: stream contents, or .start/.len set to NULL on error
 // If the file was empty, but no error happened, .start will be non-NULL and
 // .len will be 0.
@@ -821,16 +824,22 @@ struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
     int padding = 1;
     char *buf = NULL;
     int64_t size = stream_get_size(s) - stream_tell(s);
-    if (size > max_size)
+    if (size > max_size && !s->allow_partial_read)
         return (struct bstr){NULL, 0};
     if (size > 0)
         bufsize = size + padding;
     else
         bufsize = 1000;
+    if (s->allow_partial_read)
+        bufsize = MPMIN(bufsize, max_size + padding);
     while (1) {
         buf = talloc_realloc_size(talloc_ctx, buf, bufsize);
         int readsize = stream_read(s, buf + total_read, bufsize - total_read);
         total_read += readsize;
+        if (total_read >= max_size && s->allow_partial_read) {
+            total_read = max_size;
+            break;
+        }
         if (total_read < bufsize)
             break;
         if (bufsize > max_size) {

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -55,6 +55,10 @@
 #define STREAM_LESS_NOISE         (1 << 6) // try to log errors only
 #define STREAM_ALLOW_PARTIAL_READ (1 << 7) // allows partial read with stream_read_file()
 
+// Default flags used by stream_read_file().
+#define STREAM_READ_FILE_FLAGS_DEFAULT \
+    (STREAM_ORIGIN_DIRECT | STREAM_READ | STREAM_LOCAL_FS_ONLY | STREAM_LESS_NOISE)
+
 // end flags for stream_open_ext (the naming convention sucks)
 
 #define STREAM_UNSAFE -3

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -38,21 +38,22 @@
 // flags for stream_open_ext (this includes STREAM_READ and STREAM_WRITE)
 
 // stream->mode
-#define STREAM_READ             0
-#define STREAM_WRITE            (1 << 0)
+#define STREAM_READ               0
+#define STREAM_WRITE              (1 << 0)
 
-#define STREAM_SILENT           (1 << 1)
+#define STREAM_SILENT             (1 << 1)
 
 // Origin value for "security". This is an integer within the flags bit-field.
-#define STREAM_ORIGIN_DIRECT    (1 << 2) // passed from cmdline or loadfile
-#define STREAM_ORIGIN_FS        (2 << 2) // referenced from playlist on unix FS
-#define STREAM_ORIGIN_NET       (3 << 2) // referenced from playlist on network
-#define STREAM_ORIGIN_UNSAFE    (4 << 2) // from a grotesque source
+#define STREAM_ORIGIN_DIRECT      (1 << 2) // passed from cmdline or loadfile
+#define STREAM_ORIGIN_FS          (2 << 2) // referenced from playlist on unix FS
+#define STREAM_ORIGIN_NET         (3 << 2) // referenced from playlist on network
+#define STREAM_ORIGIN_UNSAFE      (4 << 2) // from a grotesque source
 
-#define STREAM_ORIGIN_MASK      (7 << 2) // for extracting origin value from flags
+#define STREAM_ORIGIN_MASK        (7 << 2) // for extracting origin value from flags
 
-#define STREAM_LOCAL_FS_ONLY    (1 << 5) // stream_file only, no URLs
-#define STREAM_LESS_NOISE       (1 << 6) // try to log errors only
+#define STREAM_LOCAL_FS_ONLY      (1 << 5) // stream_file only, no URLs
+#define STREAM_LESS_NOISE         (1 << 6) // try to log errors only
+#define STREAM_ALLOW_PARTIAL_READ (1 << 7) // allows partial read with stream_read_file()
 
 // end flags for stream_open_ext (the naming convention sucks)
 
@@ -155,6 +156,7 @@ typedef struct stream {
     bool is_local_fs : 1; // from the filesystem
     bool is_directory : 1; // directory on the filesystem
     bool access_references : 1; // open other streams
+    bool allow_partial_read : 1; // allows partial read with stream_read_file()
     struct mp_log *log;
     struct mpv_global *global;
 


### PR DESCRIPTION
Needed because js_pushlstring can throw and skip the free below.

@avih Does this look good to you?