### PR TITLE
workflows/comment: don't error out on closed pull requests

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   pr_comment:
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - env:
@@ -17,8 +18,8 @@ jobs:
           pr=$(gh pr list --state open --json headRefOid,number \
             --jq '.[] | select(.headRefOid == "${{ github.event.workflow_run.head_sha }}") | .number')
           if [ -z "$pr" ]; then
-            echo "No matching pull request found"
-            exit 1
+            echo "No matching open pull request found"
+            exit 0
           fi
 
           artifacts=$(gh api repos/{owner}/{repo}/actions/runs/${{ github.event.workflow_run.id }}/artifacts --jq '.artifacts')


### PR DESCRIPTION
If the pull request is not found or is not open, it should not be treated as a critical error. This situation can occur after a merge. There is no reliable way to query a pull request from a workflow_run event, so this has been made a non-error log.