### PR TITLE
etc/restore-osc-bindings.conf: add file to restore old osc bindings

### DIFF
--- a/DOCS/compatibility.rst
+++ b/DOCS/compatibility.rst
@@ -126,7 +126,7 @@ CLI
 Things such as default key bindings do not necessarily require compatibility.
 However, the release notes should be extremely clear on changes to "important"
 key bindings. Bindings which restore the old behavior should be added to
-restore-old-bindings.conf.
+restore-old-bindings.conf and restore-osc-bindings.conf.
 
 Some option parsing is CLI-only and not available from libmpv or scripting. No
 compatibility guarantees come with them. However, the rules which mpv uses to

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -31,7 +31,7 @@ The Interface
 pl prev
     =============   ================================================
     left-click      play previous file in playlist
-    right-click     open the playlist selector
+    right-click     show the playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
     =============   ================================================
@@ -39,7 +39,7 @@ pl prev
 pl next
     =============   ================================================
     left-click      play next file in playlist
-    right-click     open the playlist selector
+    right-click     show the playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
     =============   ================================================
@@ -66,14 +66,14 @@ play
 skip back
     =============   ================================================
     left-click      go to beginning of chapter / previous chapter
-    right-click     show chapters
+    right-click     open the chapter selector
     shift+L-click   show chapters
     =============   ================================================
 
 skip frwd
     =============   ================================================
     left-click      go to next chapter
-    right-click     show chapters
+    right-click     open the chapter selector
     shift+L-click   show chapters
     =============   ================================================
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -123,6 +123,11 @@ fs
     left-click      toggle fullscreen
     =============   ================================================
 
+Since mpv 0.40.0, it is possible to configure the commands to run with mouse
+actions on some interface elements, and the default behaviors of several
+elements were changed. If you miss some older behaviors, look at
+``etc/restore-osc-bindings.conf`` in the mpv git repository.
+
 Key Bindings
 ~~~~~~~~~~~~
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ on every release.
 Changes to the default key bindings are indicated in
 [restore-old-bindings.conf][restore-old-bindings].
 
+Changes to the default OSC bindings are indicated in
+[restore-osc-bindings.conf][restore-osc-bindings].
+
 ## Compilation
 
 
@@ -214,4 +217,5 @@ Most activity happens on the IRC channel and the GitHub issue tracker.
 [interface-changes]: https://github.com/mpv-player/mpv/blob/master/DOCS/interface-changes.rst
 [api-changes]: https://github.com/mpv-player/mpv/blob/master/DOCS/client-api-changes.rst
 [restore-old-bindings]: https://github.com/mpv-player/mpv/blob/master/etc/restore-old-bindings.conf
+[restore-osc-bindings]: https://github.com/mpv-player/mpv/blob/master/etc/restore-osc-bindings.conf
 [contribute.md]: https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

--- a/etc/restore-old-bindings.conf
+++ b/etc/restore-old-bindings.conf
@@ -1,5 +1,5 @@
-
-# This file contains all bindings that were removed after a certain release.
+# This file contains all bindings that were removed or changed
+# after a certain release.
 # If you want MPlayer bindings, use mplayer-input.conf
 
 # Pick the bindings you want back and add them to your own input.conf. Append

--- a/etc/restore-osc-bindings.conf
+++ b/etc/restore-osc-bindings.conf
@@ -1,0 +1,31 @@
+# This file contains all bindings that were removed or changed
+# after a certain release.
+
+# Pick the bindings you want back and add them to your own osc.conf. Append
+# this file to your osc.conf if you want them all back:
+#
+#    cat restore-osc-bindings.conf >> ~/.config/mpv/script-opts/osc.conf
+
+# changed in mpv 0.40.0
+
+# restore playlist_osd=yes behavior
+playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000
+playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000
+
+# restore chapter_osd=yes behavior
+chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000
+chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000
+
+# restore behavior before select.lua usage
+title=${media-title}
+title_mbtn_left_command=show-text "${!playlist-count==1:[${playlist-pos-1}/${playlist-count}] }${media-title}"
+title_mbtn_right_command=show-text ${filename}
+
+chapter_prev_mbtn_right_command=show-text ${chapter-list} 3000
+chapter_next_mbtn_right_command=show-text ${chapter-list} 3000
+
+audio_track_mbtn_left_command=cycle audio
+audio_track_mbtn_right_command=cycle audio down
+
+sub_track_mbtn_left_command=cycle sub
+sub_track_mbtn_right_command=cycle sub down

--- a/meson.build
+++ b/meson.build
@@ -1779,7 +1779,8 @@ if get_option('cplayer')
     confdir = get_option('sysconfdir')
 
     conf_files = ['etc/mpv.conf', 'etc/input.conf',
-                  'etc/mplayer-input.conf', 'etc/restore-old-bindings.conf']
+                  'etc/mplayer-input.conf', 'etc/restore-old-bindings.conf',
+                  'etc/restore-osc-bindings.conf']
     install_data(conf_files, install_dir: join_paths(datadir, 'doc', 'mpv'))
 
     bash_install_dir = join_paths(datadir, 'bash-completion', 'completions')


### PR DESCRIPTION
The OSC changed to use select.lua for various tasks, resulting in a significant change in user interaction. This adds a config file which records OSC behavior changes so that the old behavior can be restored.

Fixes: https://github.com/mpv-player/mpv/issues/15176