### PR TITLE
osc.lua: don't show the osd-bar on chapter navigation

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -507,13 +507,13 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``playlist_prev_mbtn_mid_command=show-text ${playlist} 3000``
 
-``playlist_prev_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+``playlist_prev_mbtn_right_command=show-text ${playlist} 3000``
 
 ``playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000``
 
 ``playlist_next_mbtn_mid_command=show-text ${playlist} 3000``
 
-``playlist_next_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+``playlist_next_mbtn_right_command=show-text ${playlist} 3000``
 
 ``play_pause_mbtn_left_command=cycle pause``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -521,13 +521,13 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``play_pause_mbtn_right_command=cycle-values loop-file inf no``
 
-``chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000``
+``chapter_prev_mbtn_left_command=osd-msg add chapter -1``
 
 ``chapter_prev_mbtn_mid_command=show-text ${chapter-list} 3000``
 
 ``chapter_prev_mbtn_right_command=script-binding select/select-chapter; script-message-to osc osc-hide``
 
-``chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000``
+``chapter_next_mbtn_left_command=osd-msg add chapter 1``
 
 ``chapter_next_mbtn_mid_command=show-text ${chapter-list} 3000``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -86,11 +86,11 @@ local user_opts = {
     play_pause_mbtn_mid_command = "",
     play_pause_mbtn_right_command = "cycle-values loop-file inf no",
 
-    chapter_prev_mbtn_left_command = "add chapter -1",
+    chapter_prev_mbtn_left_command = "osd-msg add chapter -1",
     chapter_prev_mbtn_mid_command = "show-text ${chapter-list} 3000",
     chapter_prev_mbtn_right_command = "script-binding select/select-chapter; script-message-to osc osc-hide",
 
-    chapter_next_mbtn_left_command = "add chapter 1",
+    chapter_next_mbtn_left_command = "osd-msg add chapter 1",
     chapter_next_mbtn_mid_command = "show-text ${chapter-list} 3000",
     chapter_next_mbtn_right_command = "script-binding select/select-chapter; script-message-to osc osc-hide",
 


### PR DESCRIPTION
osc.lua: don't show the osd-bar on chapter navigation

It is redundant if you're already using the OSC, so only show the chapter text. Also fix the documented default commands of these buttons which were outdated.