### PR TITLE
demux_playlist: fix comparison for current file if it's in current dir

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -416,10 +416,21 @@ static bool test_path(struct pl_parser *p, char *path, int autocreate)
     if (autocreate & AUTO_ANY)
         return true;
 
-    if (!strcmp(path, p->real_stream->path))
+    bstr bpath = bstr0(path);
+    bstr bstream_path = bstr0(p->real_stream->path);
+
+    // When opening a file from cwd, 'path' starts with "./" while stream->path
+    // matches what the user passed as arg. So it may or not not contain ./.
+    // Strip it from both to make the comparison work.
+    if (!mp_path_is_absolute(bstream_path)) {
+        bstr_eatstart0(&bpath, "./");
+        bstr_eatstart0(&bstream_path, "./");
+    }
+
+    if (!bstrcmp(bpath, bstream_path))
         return true;
 
-    bstr ext = bstr_get_ext(bstr0(path));
+    bstr ext = bstr_get_ext(bpath);
     if (autocreate & AUTO_VIDEO && str_in_list(ext, p->mp_opts->video_exts))
         return true;
     if (autocreate & AUTO_AUDIO && str_in_list(ext, p->mp_opts->audio_exts))


### PR DESCRIPTION
when the file is in the current directory, p->real_stream->path points
directly to the path, while path includes "./". Neither include "./" in
any other situation


Fixes: c201c4874def40b30e5017728bbfbe04ad065dcc

