### PR TITLE
osc.lua: show track-list for one more second

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -535,9 +535,9 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``audio_track_mbtn_left_command=script-binding select/select-aid; script-message-to osc osc-hide``
 
-``audio_track_mbtn_mid_command=show-text ${track-list/audio} 2000``
+``audio_track_mbtn_mid_command=show-text ${track-list/audio} 3000``
 
-``audio_track_mbtn_right_command=show-text ${track-list/audio} 2000``
+``audio_track_mbtn_right_command=show-text ${track-list/audio} 3000``
 
 ``audio_track_wheel_down_command=cycle audio``
 
@@ -545,9 +545,9 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``sub_track_mbtn_left_command=script-binding select/select-sid; script-message-to osc osc-hide``
 
-``sub_track_mbtn_mid_command=show-text ${track-list/sub} 2000``
+``sub_track_mbtn_mid_command=show-text ${track-list/sub} 3000``
 
-``sub_track_mbtn_right_command=show-text ${track-list/sub} 2000``
+``sub_track_mbtn_right_command=show-text ${track-list/sub} 3000``
 
 ``sub_track_wheel_down_command=cycle sub``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -95,14 +95,14 @@ local user_opts = {
     chapter_next_mbtn_right_command = "script-binding select/select-chapter; script-message-to osc osc-hide",
 
     audio_track_mbtn_left_command = "script-binding select/select-aid; script-message-to osc osc-hide",
-    audio_track_mbtn_mid_command = "show-text ${track-list/audio} 2000",
-    audio_track_mbtn_right_command = "show-text ${track-list/audio} 2000",
+    audio_track_mbtn_mid_command = "show-text ${track-list/audio} 3000",
+    audio_track_mbtn_right_command = "show-text ${track-list/audio} 3000",
     audio_track_wheel_down_command = "cycle audio",
     audio_track_wheel_up_command = "cycle audio down",
 
     sub_track_mbtn_left_command = "script-binding select/select-sid; script-message-to osc osc-hide",
-    sub_track_mbtn_mid_command = "show-text ${track-list/sub} 2000",
-    sub_track_mbtn_right_command = "show-text ${track-list/sub} 2000",
+    sub_track_mbtn_mid_command = "show-text ${track-list/sub} 3000",
+    sub_track_mbtn_right_command = "show-text ${track-list/sub} 3000",
     sub_track_wheel_down_command = "cycle sub",
     sub_track_wheel_up_command = "cycle sub down",
 


### PR DESCRIPTION
Useful now that track metadata is printed. This now uses the same duration as playlist and chapter-list.