### PR TITLE
osc.lua: don't print auto before tracks are selected

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1863,8 +1863,13 @@ local function osc_init()
 
     ne.enabled = audio_track_count > 0
     ne.content = function ()
+        local aid = mp.get_property("aid")
+        if aid == "no" or aid == "auto" then
+            aid = "-"
+        end
+
         return ("\238\132\134" .. osc_styles.smallButtonsLlabel .. " " ..
-               (mp.get_property_native("aid") or "-") .. "/" .. audio_track_count)
+               aid .. "/" .. audio_track_count)
     end
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.audio_track_mbtn_left_command)
     ne.eventresponder["shift+mbtn_left_up"] = command_callback(
@@ -1883,8 +1888,13 @@ local function osc_init()
 
     ne.enabled = sub_track_count > 0
     ne.content = function ()
+        local sid = mp.get_property("sid")
+        if sid == "no" or sid == "auto" then
+            sid = "-"
+        end
+
         return ("\238\132\135" .. osc_styles.smallButtonsLlabel .. " " ..
-               (mp.get_property_native("sid") or "-") .. "/" .. sub_track_count)
+               sid .. "/" .. sub_track_count)
     end
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.sub_track_mbtn_left_command)
     ne.eventresponder["shift+mbtn_left_up"] = command_callback(user_opts.sub_track_mbtn_mid_command)


### PR DESCRIPTION
While files are loading, track options have the value "auto". Print "-" in that case.

Fixes 1a558bf5c2.