### PR TITLE
osc.lua: cycle tracks when there's only one

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -497,6 +497,9 @@ Configurable Options
 The following options configure what commands are run when the buttons are
 clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
+When there's only one track of a type, left clicks on track buttons always cycle
+it instead of using the configured command.
+
 ``title_mbtn_left_command=script-binding select/select-playlist; script-message-to osc osc-hide``
 
 ``title_mbtn_mid_command=show-text ${filename}``

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1866,7 +1866,9 @@ local function osc_init()
         return ("\238\132\134" .. osc_styles.smallButtonsLlabel .. " " ..
                (mp.get_property_native("aid") or "-") .. "/" .. audio_track_count)
     end
-    ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.audio_track_mbtn_left_command)
+    ne.eventresponder["mbtn_left_up"] = command_callback(audio_track_count == 1
+        and "cycle audio"
+        or user_opts.audio_track_mbtn_left_command)
     ne.eventresponder["shift+mbtn_left_up"] = command_callback(
         user_opts.audio_track_mbtn_mid_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.audio_track_mbtn_right_command)
@@ -1886,7 +1888,9 @@ local function osc_init()
         return ("\238\132\135" .. osc_styles.smallButtonsLlabel .. " " ..
                (mp.get_property_native("sid") or "-") .. "/" .. sub_track_count)
     end
-    ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.sub_track_mbtn_left_command)
+    ne.eventresponder["mbtn_left_up"] = command_callback(sub_track_count == 1
+        and "cycle sub"
+        or user_opts.sub_track_mbtn_left_command)
     ne.eventresponder["shift+mbtn_left_up"] = command_callback(user_opts.sub_track_mbtn_mid_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.sub_track_mbtn_right_command)
 


### PR DESCRIPTION
When there is 1 audio or sub track, if the command wasn't configured, make left click select or unselect it directly without opening the selector. Unfortunately this is awkward to implement with the command script-opts.

Requested by sfan5.