### PR TITLE
osc.lua: cycle tracks on right click

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -537,7 +537,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``audio_track_mbtn_mid_command=show-text ${track-list/audio} 3000``
 
-``audio_track_mbtn_right_command=show-text ${track-list/audio} 3000``
+``audio_track_mbtn_right_command=cycle audio``
 
 ``audio_track_wheel_down_command=cycle audio``
 
@@ -547,7 +547,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``sub_track_mbtn_mid_command=show-text ${track-list/sub} 3000``
 
-``sub_track_mbtn_right_command=show-text ${track-list/sub} 3000``
+``sub_track_mbtn_right_command=cycle sub``
 
 ``sub_track_wheel_down_command=cycle sub``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -96,13 +96,13 @@ local user_opts = {
 
     audio_track_mbtn_left_command = "script-binding select/select-aid; script-message-to osc osc-hide",
     audio_track_mbtn_mid_command = "show-text ${track-list/audio} 3000",
-    audio_track_mbtn_right_command = "show-text ${track-list/audio} 3000",
+    audio_track_mbtn_right_command = "cycle audio",
     audio_track_wheel_down_command = "cycle audio",
     audio_track_wheel_up_command = "cycle audio down",
 
     sub_track_mbtn_left_command = "script-binding select/select-sid; script-message-to osc osc-hide",
     sub_track_mbtn_mid_command = "show-text ${track-list/sub} 3000",
-    sub_track_mbtn_right_command = "show-text ${track-list/sub} 3000",
+    sub_track_mbtn_right_command = "cycle sub",
     sub_track_wheel_down_command = "cycle sub",
     sub_track_wheel_up_command = "cycle sub down",
 


### PR DESCRIPTION
This might be more useful than having the same binding as middle click. Suggested by llyyr.