### PR TITLE
osc.lua: don't place the overlay above other ones

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2474,7 +2474,7 @@ local function render()
 
     -- submit
     set_osd(osc_param.playresy * osc_param.display_aspect,
-            osc_param.playresy, ass.text, 1000)
+            osc_param.playresy, ass.text, user_opts.layout == "box" and -1 or 1000)
 end
 
 -- called by mpv on every frame


### PR DESCRIPTION
Stop setting the z of the OSD overlay. This prevents the console from being drawn below the box layout when clicking buttons with visibility=always.

This reverts 9c22d6b438 and 86d24b069b.