### PR TITLE
console.lua: fix the hovered line calculation

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -157,7 +157,8 @@ Configurable Options
     Default: 24
 
     Set the font size used for the REPL and the console. This will be
-    multiplied by ``display-hidpi-scale``.
+    multiplied by ``display-hidpi-scale`` when the console is not scaled with
+    the window.
 
 ``border_size``
     Default: 1.5

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -814,8 +814,7 @@ local function determine_hovered_item()
     y = y - global_margins.t * height
     -- Calculate how many lines could be printed without decreasing them for
     -- the input line and OSC.
-    local max_lines = height / mp.get_property_native('display-hidpi-scale', 1)
-                      / opts.font_size
+    local max_lines = height / opts.font_size
     local clicked_line = math.floor(y / height * max_lines + .5)
 
     local offset = first_match_to_print - 1


### PR DESCRIPTION
console.lua: fix the hovered line calculation

Update the logic for the hidpi scaling changes introduced by a670f75679.