### PR TITLE
console.lua: restore font size and border size

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -30,8 +30,8 @@ local platform = detect_platform()
 -- Default options
 local opts = {
     font = "",
-    font_size = 16,
-    border_size = 1,
+    font_size = 24,
+    border_size = 1.5,
     scale_with_window = "auto",
     case_sensitive = platform ~= 'windows' and true or false,
     history_dedup = true,


### PR DESCRIPTION
Fixes rebase error in aa66f0dced0f9e1c970b5adfe3f0f111ddb5a7a1.

Font size has been updated recently in d2fd394036e5c4c44b84eedc65da0132d6139c90.
