### PR TITLE
DOCS/man/osc: remove non-existent options

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -410,12 +410,6 @@ Configurable Options
     Update chapter markers positions on duration changes, e.g. live streams.
     The updates are unoptimized - consider disabling it on very low-end systems.
 
-``chapters_osd``, ``playlist_osd``
-    Default: yes
-
-    Whether to display the chapters/playlist at the OSD when left-clicking the
-    next/previous OSC buttons, respectively.
-
 ``chapter_fmt``
     Default: ``Chapter: %s``
 


### PR DESCRIPTION
Fixes: a80f535a6dfc889dc32c9984e25d5c60ae906d05