### PR TITLE
various: use avcodec_get_supported_config() to resolve deprecation warn

### DIFF
--- a/misc/lavc_compat.h
+++ b/misc/lavc_compat.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <libavcodec/avcodec.h>
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
+enum AVCodecConfig {
+    AV_CODEC_CONFIG_PIX_FORMAT,     ///< AVPixelFormat, terminated by AV_PIX_FMT_NONE
+    AV_CODEC_CONFIG_FRAME_RATE,     ///< AVRational, terminated by {0, 0}
+    AV_CODEC_CONFIG_SAMPLE_RATE,    ///< int, terminated by 0
+    AV_CODEC_CONFIG_SAMPLE_FORMAT,  ///< AVSampleFormat, terminated by AV_SAMPLE_FMT_NONE
+    AV_CODEC_CONFIG_CHANNEL_LAYOUT, ///< AVChannelLayout, terminated by {0}
+    AV_CODEC_CONFIG_COLOR_RANGE,    ///< AVColorRange, terminated by AVCOL_RANGE_UNSPECIFIED
+    AV_CODEC_CONFIG_COLOR_SPACE,    ///< AVColorSpace, terminated by AVCOL_SPC_UNSPECIFIED
+};
+#endif
+
+static inline int mp_avcodec_get_supported_config(const AVCodecContext *avctx,
+                                                  const AVCodec *codec,
+                                                  enum AVCodecConfig config,
+                                                  const void **out_configs)
+{
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+    return avcodec_get_supported_config(avctx, codec, config, 0, out_configs, NULL);
+#else
+    const AVCodec *avcodec = codec ? codec : avctx->codec;
+
+    switch (config) {
+    case AV_CODEC_CONFIG_PIX_FORMAT:
+        *out_configs = avcodec->pix_fmts;
+        break;
+    case AV_CODEC_CONFIG_FRAME_RATE:
+        *out_configs = avcodec->supported_framerates;
+        break;
+    case AV_CODEC_CONFIG_SAMPLE_RATE:
+        *out_configs = avcodec->supported_samplerates;
+        break;
+    case AV_CODEC_CONFIG_SAMPLE_FORMAT:
+        *out_configs = avcodec->sample_fmts;
+        break;
+    case AV_CODEC_CONFIG_CHANNEL_LAYOUT:
+        *out_configs = avcodec->ch_layouts;
+        break;
+    default:
+        abort();  // Not implemented
+    }
+
+    return *out_configs ? 0 : -1;
+#endif
+}

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -42,6 +42,7 @@
 #include "common/msg.h"
 #include "image_writer.h"
 #include "mpv_talloc.h"
+#include "misc/lavc_compat.h"
 #include "video/fmt-conversion.h"
 #include "video/img_format.h"
 #include "video/mp_image.h"
@@ -490,9 +491,12 @@ free_data:
 
 static int get_encoder_format(const AVCodec *codec, int srcfmt, bool highdepth)
 {
-    const enum AVPixelFormat *pix_fmts = codec->pix_fmts;
+    const enum AVPixelFormat *pix_fmts;
+    int ret = mp_avcodec_get_supported_config(NULL, codec,
+                                              AV_CODEC_CONFIG_PIX_FORMAT,
+                                              (const void **)&pix_fmts);
     int current = 0;
-    for (int n = 0; pix_fmts && pix_fmts[n] != AV_PIX_FMT_NONE; n++) {
+    for (int n = 0; ret >= 0 && pix_fmts && pix_fmts[n] != AV_PIX_FMT_NONE; n++) {
         int fmt = pixfmt2imgfmt(pix_fmts[n]);
         if (!fmt)
             continue;


### PR DESCRIPTION
See: https://github.com/FFmpeg/FFmpeg/commit/3305767560a6303f474fffa3afb10c500059b455

Someone had to do janitorial work... sigh.