### PR TITLE
stats.lua: calculate sizes like --osd-*-size options

### DIFF
--- a/DOCS/interface-changes/stats-sizes.rst
+++ b/DOCS/interface-changes/stats-sizes.rst
@@ -1,0 +1,1 @@
+`stats-font_size`, `stats-border_size`, `stats-shadow_x_offset`, `stats-shadow_y_offset` and `stats-plot_bg_border_width` script-opt values result in 2.5 times smaller sizes in order to have the same sizes as the values of equivalent OSD options like `--osd-font-size`. If you customized these sizes, multiply them by 2.5 to get the previous sizes.

--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -155,7 +155,7 @@ Configurable Options
     text. Currently, monospaced digits are sufficient.
 
 ``font_size``
-    Default: 8
+    Default: 20
 
     Font size used to render text.
 
@@ -165,7 +165,7 @@ Configurable Options
     Color of the text.
 
 ``border_size``
-    Default: 0.8
+    Default: 2
 
     Size of border drawn around the font.
 
@@ -202,7 +202,7 @@ Configurable Options
     Border color used for drawing graphs.
 
 ``plot_bg_border_width``
-    Default: 0.5
+    Default: 1.25
 
     Border width used for drawing graphs.
 

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -49,14 +49,14 @@ local o = {
     plot_bg_border_color = "0000FF",
     plot_bg_color = "262626",
     plot_color = "FFFFFF",
-    plot_bg_border_width = 0.5,
+    plot_bg_border_width = 1.25,
 
     -- Text style
     font = "",
     font_mono = "monospace",   -- monospaced digits are sufficient
-    font_size = 8,
+    font_size = 20,
     font_color = "",
-    border_size = 0.8,
+    border_size = 2,
     border_color = "",
     shadow_x_offset = 0.0,
     shadow_y_offset = 0.0,
@@ -1485,9 +1485,10 @@ local function update_scale(osd_height)
     end
 
     -- Calculate scaled metrics.
-    local scale = 1
+    -- Make font_size=n the same size as --osd-font-size=n.
+    local scale = 288 / 720
     if not scale_with_video and osd_height > 0 then
-        scale = 720 / osd_height
+        scale = 288 / osd_height
     end
     font_size = o.font_size * scale
     border_size = o.border_size * scale


### PR DESCRIPTION
Currently --script-opt=stats-font_size=n is much bigger than --osd-font-size=n, which can confuse users, so calculate sizes the same way.

The \fs value to replicate --osd-font-size is
${osd-font-size} * 288 / 720 with --osd-scale-by-window, and \fs${osd-font-size} * 288 / ${osd-height}
with --osd-scale-by-window=no. This is because
sub/osd_libass.c:update_playres() sets
track->PlayResY = ass->res_y ? ass->res_y : MP_ASS_FONT_PLAYRESY, where MP_ASS_FONT_PLAYRESY is 288.

This also works with persistent_overlay=yes.

{\fscx100}{\fscy100} would also replicate --osd-font-size with show-text and with osd-verlay + --osd-scale-by-window, but not with osd-overlay + --osd-scale-by-window=no.

The default font and border sizes are multiplied by 720/288 = 2.5 to keep them the same as before.