### PR TITLE
mac: fix or silence several deprecations

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -27,6 +27,7 @@
 #include "ao_coreaudio_chmap.h"
 #include "ao_coreaudio_properties.h"
 #include "ao_coreaudio_utils.h"
+#include "osdep/mac/compat.h"
 
 // The timeout for stopping the audio unit after being reset. This allows the
 // device to sleep after playback paused. The duration is chosen to match the
@@ -490,7 +491,7 @@ static bool register_hotplug_cb(struct ao *ao)
         AudioObjectPropertyAddress addr = {
             hotplug_properties[i],
             kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
+            kAudioObjectPropertyElementMain
         };
         err = AudioObjectAddPropertyListener(
             kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);
@@ -520,7 +521,7 @@ static void unregister_hotplug_cb(struct ao *ao)
         AudioObjectPropertyAddress addr = {
             hotplug_properties[i],
             kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
+            kAudioObjectPropertyElementMain
         };
         err = AudioObjectRemovePropertyListener(
             kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);

--- a/audio/out/ao_coreaudio_exclusive.c
+++ b/audio/out/ao_coreaudio_exclusive.c
@@ -50,6 +50,7 @@
 #include "audio/out/ao_coreaudio_chmap.h"
 #include "audio/out/ao_coreaudio_properties.h"
 #include "audio/out/ao_coreaudio_utils.h"
+#include "osdep/mac/compat.h"
 
 struct priv {
     // This must be put in the front
@@ -123,7 +124,7 @@ static OSStatus enable_property_listener(struct ao *ao, bool enabled)
     for (int n = 0; n < MP_ARRAY_SIZE(devs); n++) {
         AudioObjectPropertyAddress addr = {
             .mScope    = kAudioObjectPropertyScopeGlobal,
-            .mElement  = kAudioObjectPropertyElementMaster,
+            .mElement  = kAudioObjectPropertyElementMain,
             .mSelector = selectors[n],
         };
         AudioDeviceID device = devs[n];

--- a/audio/out/ao_coreaudio_properties.c
+++ b/audio/out/ao_coreaudio_properties.c
@@ -22,6 +22,7 @@
 #include "audio/out/ao_coreaudio_properties.h"
 #include "audio/out/ao_coreaudio_utils.h"
 #include "mpv_talloc.h"
+#include "osdep/mac/compat.h"
 
 OSStatus ca_get(AudioObjectID id, ca_scope scope, ca_sel selector,
                 uint32_t size, void *data)
@@ -29,7 +30,7 @@ OSStatus ca_get(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectGetPropertyData(id, &p_addr, 0, NULL, &size, data);
@@ -41,7 +42,7 @@ OSStatus ca_set(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectSetPropertyData(id, &p_addr, 0, NULL, size, data);
@@ -56,7 +57,7 @@ OSStatus ca_get_ary(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = scope,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     err = AudioObjectGetPropertyDataSize(id, &p_addr, 0, NULL, &p_size);
@@ -95,7 +96,7 @@ Boolean ca_settable(AudioObjectID id, ca_scope scope, ca_sel selector,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = selector,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     return AudioObjectIsPropertySettable(id, &p_addr, data);

--- a/audio/out/ao_coreaudio_utils.c
+++ b/audio/out/ao_coreaudio_utils.c
@@ -26,6 +26,7 @@
 #include "osdep/timer.h"
 #include "osdep/endian.h"
 #include "audio/format.h"
+#include "osdep/mac/compat.h"
 
 #if HAVE_COREAUDIO || HAVE_AVFOUNDATION
 #include "audio/out/ao_coreaudio_properties.h"
@@ -97,7 +98,7 @@ OSStatus ca_select_device(struct ao *ao, char* name, AudioDeviceID *device)
         AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
             .mSelector = kAudioHardwarePropertyDeviceForUID,
             .mScope    = kAudioObjectPropertyScopeGlobal,
-            .mElement  = kAudioObjectPropertyElementMaster,
+            .mElement  = kAudioObjectPropertyElementMain,
         };
         err = AudioObjectGetPropertyData(
             kAudioObjectSystemObject, &p_addr, 0, 0, &size, &v);
@@ -377,7 +378,7 @@ static OSStatus ca_change_mixing(struct ao *ao, AudioDeviceID device,
     AudioObjectPropertyAddress p_addr = (AudioObjectPropertyAddress) {
         .mSelector = kAudioDevicePropertySupportsMixing,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     if (AudioObjectHasProperty(device, &p_addr)) {
@@ -486,7 +487,7 @@ bool ca_change_physical_format_sync(struct ao *ao, AudioStreamID stream,
     AudioObjectPropertyAddress p_addr = {
         .mSelector = kAudioStreamPropertyPhysicalFormat,
         .mScope    = kAudioObjectPropertyScopeGlobal,
-        .mElement  = kAudioObjectPropertyElementMaster,
+        .mElement  = kAudioObjectPropertyElementMain,
     };
 
     err = AudioObjectAddPropertyListener(stream, &p_addr,

--- a/osdep/mac/compat.h
+++ b/osdep/mac/compat.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "config.h"
+
+#if !HAVE_MACOS_12_FEATURES
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif

--- a/osdep/mac/compat.h
+++ b/osdep/mac/compat.h
@@ -19,6 +19,10 @@
 
 #include "config.h"
 
+#ifndef GL_SILENCE_DEPRECATION
+#define GL_SILENCE_DEPRECATION
+#endif
+
 #if !HAVE_MACOS_12_FEATURES
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
 #endif

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -44,6 +44,10 @@ extension NSDraggingInfo {
 }
 #endif
 
+#if !HAVE_MACOS_12_FEATURES
+let kIOMainPortDefault: mach_port_t = kIOMasterPortDefault
+#endif
+
 #if !HAVE_MACOS_12_FEATURES && HAVE_MACOS_11_FEATURES
 @available(macOS 11.0, *)
 extension CGColorSpace {

--- a/osdep/mac/type_helper.swift
+++ b/osdep/mac/type_helper.swift
@@ -125,7 +125,7 @@ class TypeHelper {
               let values = list.values else { return dict }
 
         for index in 0..<Int(list.num) {
-            guard var keyPtr = list.keys?[index] else { continue }
+            guard let keyPtr = list.keys?[index] else { continue }
             let key = String(cString: keyPtr)
             dict[key] = TypeHelper.nodeToAny(values[index])
         }

--- a/video/out/hwdec/hwdec_mac_gl.c
+++ b/video/out/hwdec/hwdec_mac_gl.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+#include "osdep/mac/compat.h"
+
 #include <IOSurface/IOSurface.h>
 #include <CoreVideo/CoreVideo.h>
 #include <OpenGL/OpenGL.h>

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -281,13 +281,13 @@ class Common: NSObject {
     }
 
     func initLightSensor() {
-        let srv = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("AppleLMUController"))
+        let srv = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleLMUController"))
         if srv == IO_OBJECT_NULL {
             log.verbose("Can't find an ambient light sensor")
             return
         }
 
-        lightSensorIOPort = IONotificationPortCreate(kIOMasterPortDefault)
+        lightSensorIOPort = IONotificationPortCreate(kIOMainPortDefault)
         IONotificationPortSetDispatchQueue(lightSensorIOPort, queue)
         var n = io_object_t()
         IOServiceAddInterestNotification(lightSensorIOPort, srv, kIOGeneralInterest, lightSensorCallback,


### PR DESCRIPTION
just some cleaning up. only tested the macOS 12 deprecation fixes as much as i could, but didn't actually build it on macOS 11 with the corresponding SDK.

OpenGL deprecations are only silenced for the (objective-)c parts. they sadly can't be silenced in swift.

alternative to #9045