### PR TITLE
defaults.lua: add an exit() function

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -64,6 +64,7 @@ local mp_globals = {
             set_osd_ass = {},
         }
     },
+    exit = {},
     unpack = {},
 }
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,6 +5,7 @@ local mp_globals = {
             commandv = {},
             command_native = {},
             command_native_async = {},
+            add_hook = {},
             abort_async_command = {},
             del_property = {},
             get_property = {},
@@ -53,7 +54,6 @@ local mp_globals = {
             },
             -- Not documented
             -- TODO: Document or remove them
-            add_hook = {},
             disable_key_bindings = {},
             enable_key_bindings = {},
             find_config_file = {},

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -208,6 +208,8 @@ string/boolean/number)
 
 ``mp.input.set_log(log)``
 
+``exit()`` (global)
+
 Additional utilities
 --------------------
 
@@ -255,10 +257,6 @@ text content only.
 
 ``mp.get_script_file()``
     Returns the file name of the current script.
-
-``exit()`` (global)
-    Make the script exit at the end of the current event loop iteration.
-    Note: please remove added key bindings before calling ``exit()``.
 
 ``mp.utils.compile_js(fname, content_str)``
     Compiles the JS code ``content_str`` as file name ``fname`` (without loading

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -646,6 +646,20 @@ are useful only in special situations.
 
     May return invalid/nonsense values if OSD is not initialized yet.
 
+``exit()`` (global)
+    Make the script exit at the end of the current event loop iteration. This
+    does not terminate mpv itself or other scripts.
+
+    This can be polyfilled to support mpv versions older than 0.40 with:
+
+    ::
+
+        if not _G.exit then
+            function exit()
+                mp.keep_running = false
+            end
+        end
+
 mp.msg functions
 ----------------
 

--- a/player/lua/auto_profiles.lua
+++ b/player/lua/auto_profiles.lua
@@ -194,8 +194,7 @@ mp.observe_property("profile-list", "native", function (_, profiles_property)
     load_profiles(profiles_property)
 
     if #profiles < 1 and mp.get_property("load-auto-profiles") == "auto" then
-        -- make it exit immediately
-        _G.mp_event_loop = function() end
+        exit()
         return
     end
 

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -416,6 +416,10 @@ end
 -- used by default event loop (mp_event_loop()) to decide when to quit
 mp.keep_running = true
 
+function _G.exit()
+    mp.keep_running = false
+end
+
 local event_handlers = {}
 
 function mp.register_event(name, cb)
@@ -455,7 +459,7 @@ function mp.unregister_event(cb)
 end
 
 -- default handlers
-mp.register_event("shutdown", function() mp.keep_running = false end)
+mp.register_event("shutdown", exit)
 mp.register_event("client-message", message_dispatch)
 mp.register_event("property-change", property_change)
 


### PR DESCRIPTION
commit 1: defaults.lua: add an exit() function

Scripts can terminate execution by setting mp.keep_running = false. Add an exit() function to wrap setting mp.keep_running and properly expose this feature. It can be used e.g. by a thumbnail script to spawn workers with load-script and then let them quit.

It is not added to the mp namespace as mp.exit because that would make it look like it terminates mpv.

commit 2: auto_profiles.lua: actually exit when no auto profiles are defined

Unsetting _G.mp_event_loop at the top level quits the script, but not within callbacks. Use the new exit() function instead. Fixes e2284fba18.

This actually has an edge case since e2284fba18 where you can add auto profiles only later with load-config-file and the script stays unloaded, but it's still reasonable to quit if mpv.conf has no conditional profiles. You could always explicitly set --load-auto-profiles=yes in this case.