### PR TITLE
m_property: stop expanding strings after 10 properties during fuzzing

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1319,6 +1319,8 @@ static int str_list_add(char **add, int n, void *dst, int pre)
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (ln >= 100) {
+        while (n--)
+            talloc_free(add[n]);
         talloc_free(add);
         return 0;
     }

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -293,6 +293,9 @@ char *m_properties_expand_string(const struct m_property *prop_list,
     bool skip = false;
     int level = 0, skip_level = 0;
     bstr str = bstr0(str0);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    int n = 0;
+#endif
 
     while (str.len) {
         if (level > 0 && bstr_eatstart0(&str, "}")) {
@@ -311,6 +314,10 @@ char *m_properties_expand_string(const struct m_property *prop_list,
             bool have_fallback = bstr_eatstart0(&str, ":");
 
             if (!skip) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+                if (n++ > 10)
+                    break;
+#endif
                 skip = expand_property(prop_list, &ret, &ret_len, name,
                                        have_fallback, ctx);
                 if (skip)


### PR DESCRIPTION
Some properties, like `${decoder-list}`, are resource-intensive to expand. Prevent fuzzing from generating strings with excessive expansions to encourage shorter test cases.

Expanding properties on each playback frame for `osd-msg1` can be demanding. However, in regular use cases, this typically isn’t an issue, so implementing a caching solution wouldn’t be practical in real scenarios.

Fixes timeouts on OSS-Fuzz.