### PR TITLE
video/out/w32_common: always move window when setting state

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1944,8 +1944,13 @@ static void window_reconfig(struct vo_w32_state *w32, bool force)
     w32->o_dheight = vo->dheight;
 
     if (!w32->parent && (!w32->window_bounds_initialized || force)) {
-        SetRect(&w32->windowrc, geo.win.x0, geo.win.y0,
-                geo.win.x0 + vo->dwidth, geo.win.y0 + vo->dheight);
+        int x0 = geo.win.x0;
+        int y0 = geo.win.y0;
+        if (!w32->opts->geometry.xy_valid && w32->window_bounds_initialized) {
+            x0 = w32->windowrc.left;
+            y0 = w32->windowrc.top;
+        }
+        SetRect(&w32->windowrc, x0, y0, x0 + vo->dwidth, y0 + vo->dheight);
         w32->prev_windowrc = w32->windowrc;
         w32->window_bounds_initialized = true;
         w32->win_force_pos = geo.flags & VO_WIN_FORCE_POS;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1174,8 +1174,7 @@ static void update_window_state(struct vo_w32_state *w32)
 
     SetWindowPos(w32->window, w32->opts->ontop ? HWND_TOPMOST : HWND_NOTOPMOST,
                  wr.left, wr.top, rect_w(wr), rect_h(wr),
-                 SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOOWNERZORDER |
-                 (!w32->win_force_pos ? SWP_NOMOVE : 0));
+                 SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOOWNERZORDER);
 
     // Unmaximize the window if a size change is requested because SetWindowPos
     // doesn't change the window maximized state.


### PR DESCRIPTION
Make sure the window is at the correct position when fullscreen while geometry is set.

Fixes: e5159de8118120163689c27f5cbc1ec68c2d27c8
Fixes: https://github.com/mpv-player/mpv/issues/15238
