### PR TITLE
osdep/terminal: fix dummy implementation

### DIFF
--- a/osdep/terminal-dummy.c
+++ b/osdep/terminal-dummy.c
@@ -42,3 +42,7 @@ bool terminal_try_attach(void)
 {
     return false;
 }
+
+void terminal_set_mouse_input(bool enable)
+{
+}


### PR DESCRIPTION
c2ed2e7 introduced the terminal_set_mouse_input function to various terminal backends, but overlooked the dummy backend.
This causes linking errors when trying to build on platforms with no terminal, as vo_kitty and vo_tct are unconditionally enabled and make use of that function.