### PR TITLE
player/client: reduce log level for hooks not sent to clients

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -216,7 +216,9 @@ static int invoke_hook_handler(struct MPContext *mpctx, struct hook_handler *h)
     char *name = mp_tprintf(22, "@%"PRIi64, h->client_id);
     int r = mp_client_send_event(mpctx, name, reply_id, MPV_EVENT_HOOK, m);
     if (r < 0) {
-        MP_WARN(mpctx, "Sending hook command failed. Removing hook.\n");
+        MP_MSG(mpctx, mp_client_id_exists(mpctx, h->client_id) ? MSGL_WARN : MSGL_V,
+               "Failed sending hook command %s/%s. Removing hook.\n", h->client,
+               h->type);
         hook_remove(mpctx, h);
         mp_wakeup_core(mpctx); // repeat next iteration to finish
     }


### PR DESCRIPTION
If a script registers hooks before exiting mpv logs "Sending hook command failed. Removing hook.". (Also there is no function to unregister hooks.) Don't register hooks in auto_profiles.lua before it exits to not log these warnings. Fixes 5dc4047415. Fixes #15244.