### PR TITLE
command: make hook removal logging to verbose

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -216,7 +216,7 @@ static int invoke_hook_handler(struct MPContext *mpctx, struct hook_handler *h)
     char *name = mp_tprintf(22, "@%"PRIi64, h->client_id);
     int r = mp_client_send_event(mpctx, name, reply_id, MPV_EVENT_HOOK, m);
     if (r < 0) {
-        MP_WARN(mpctx, "Sending hook command failed. Removing hook.\n");
+        MP_VERBOSE(mpctx, "Sending hook command failed. Removing hook.\n");
         hook_remove(mpctx, h);
         mp_wakeup_core(mpctx); // repeat next iteration to finish
     }


### PR DESCRIPTION
Hooks are implicitly removed if the mpv_handle it was registered with is destroyed. This is documented in libmpv/client.h and is expected behavior for hook removal, so it should not be treated as a warning. Make it verbose instead.

The log level for "client removed during hook handling" is unchanged because the documentation says it should be avoided.
