### PR TITLE
player/command: remove /100 from sub-pos print

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -3169,8 +3169,9 @@ static int mp_property_sub_pos(void *ctx, struct m_property *prop,
     MPContext *mpctx = ctx;
     struct MPOpts *opts = mpctx->opts;
     int track_ind = *(int *)prop->priv;
-    if (action == M_PROPERTY_PRINT) {
-        *(char **)arg = talloc_asprintf(NULL, "%4.2f%%/100", opts->subs_shared->sub_pos[track_ind]);
+    if (action == M_PROPERTY_PRINT || action == M_PROPERTY_FIXED_LEN_PRINT) {
+        *(char **)arg = mp_format_double(NULL, opts->subs_shared->sub_pos[track_ind], 2,
+                                         false, true, action != M_PROPERTY_FIXED_LEN_PRINT);
         return M_PROPERTY_OK;
     }
     return mp_property_generic_option(mpctx, prop, action, arg);


### PR DESCRIPTION
It already prints %, so no need for /100. Also use print helper while at it.