### PR TITLE
github/issue_template: ask for last known working version 

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
@@ -33,7 +33,8 @@ body:
            - Mesa/GPU Driver Version: `glxinfo -B | grep "OpenGL version string"` or `vulkaninfo | grep driverInfo`
            - Window Manager and Version
            - Source of the mpv binary
-           - If known which version of mpv introduced the problem
+           - Latest version of mpv you know without the problem
+           - The time when the problem started to happen (after updating mpv, system, driver, etc.)
            - Possible screenshot or video of visual glitches
 
           If you're not using git master or the latest release, update.
@@ -45,7 +46,8 @@ body:
           - Mesa/GPU Driver Version:
           - Window Manager and Version:
           - Source of mpv:
-          - Introduced in version:
+          - Latest known working version:
+          - Issue started after the following happened:
       render: text
   validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
@@ -44,7 +44,7 @@ body:
           - GPU Model:
           - Mesa/GPU Driver Version:
           - Window Manager and Version:
-          - Source mpv:
+          - Source of mpv:
           - Introduced in version:
       render: text
   validations:

--- a/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
@@ -28,7 +28,8 @@ body:
       description: >
           - macOS Version: `system_profiler SPSoftwareDataType | sed -rn 's/^ *System Version: (.*$)/\1/p'`
            - Source of the mpv binary or bundle
-           - If known which version of mpv introduced the problem
+           - Latest version of mpv you know without the problem
+           - The time when the problem started to happen (after updating mpv, system, driver, etc.)
            - Possible screenshot or video of visual glitches
 
           If you're not using git master or the latest release, update.
@@ -38,7 +39,8 @@ body:
       value: |-
           - macOS version:
           - Source of mpv:
-          - Introduced in version:
+          - Latest known working version:
+          - Issue started after the following happened:
       render: text
   validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
@@ -30,7 +30,8 @@ body:
           `"$([Environment]::OSVersion)/$((gp 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name CurrentBuild).CurrentBuild).$((gp 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR)"` (PowerShell)
            - GPU model, driver and version
            - Source of the mpv binary
-           - If known which version of mpv introduced the problem
+           - Latest version of mpv you know without the problem
+           - The time when the problem started to happen (after updating mpv, system, driver, etc.)
            - Possible screenshot or video of visual glitches
 
           If you're not using git master or the latest release, update.
@@ -41,7 +42,8 @@ body:
           - Windows version:
           - GPU model, driver and version:
           - Source of mpv:
-          - Introduced in version:
+          - Latest known working version:
+          - Issue started after the following happened:
       render: text
   validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -29,7 +29,8 @@ body:
           - Platform and Version
            - GPU model, driver and version
            - Source of the mpv binary
-           - If known which version of mpv introduced the problem
+           - Latest version of mpv you know without the problem
+           - The time when the problem started to happen (after updating mpv, system, driver, etc.)
            - Possible screenshot or video of visual glitches
 
           If you're not using git master or the latest release, update.
@@ -38,7 +39,8 @@ body:
           - Platform version:
           - GPU model, driver and version:
           - Source of mpv:
-          - Introduced in version:
+          - Latest known working version:
+          - Issue started after the following happened:
       render: text
   validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -37,7 +37,7 @@ body:
       value: |-
           - Platform version:
           - GPU model, driver and version:
-          - Source:
+          - Source of mpv:
           - Introduced in version:
       render: text
   validations:

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -1,5 +1,5 @@
-name: "Report a different Issue"
-description: "Create a report for a runtime related Issue"
+name: "Report an Issue on other platforms"
+description: "Create a report for a runtime related Issue on other platforms"
 labels: []
 body:
 - type: textarea


### PR DESCRIPTION
Currently it asks which version introduced the problem, but users are unlikely to know if they don't update and test every single version released, and this field is rarely filled in practice by non-developers.

On the other hand, it's much easier to recall the last working version that they have used before.

So ask for the last known working version, which is useful information for developers to narrow down bisecting range.