### PR TITLE
Misc display sync fixes

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -780,7 +780,13 @@ static bool still_displaying(struct vo *vo)
     if (working)
         goto done;
 
-    int64_t frame_end = get_current_frame_end(vo);
+    int64_t frame_end = get_display_synced_frame_end(vo);
+    if (frame_end > 0) {
+        working = frame_end > in->base_vsync;
+        goto done;
+    }
+
+    frame_end = get_current_frame_end(vo);
     if (frame_end < 0)
         goto done;
     working = mp_time_ns() < frame_end;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -489,11 +489,14 @@ static void update_vsync_timing_after_swap(struct vo *vo,
     }
 
     in->num_successive_vsyncs++;
-    if (in->num_successive_vsyncs <= DELAY_VSYNC_SAMPLES)
+    if (in->num_successive_vsyncs <= DELAY_VSYNC_SAMPLES) {
+        in->base_vsync = vsync_time;
         return;
+    }
 
     if (vsync_time <= 0 || vsync_time <= prev_vsync) {
         in->prev_vsync = 0;
+        in->base_vsync = 0;
         return;
     }
 

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -758,6 +758,21 @@ static int64_t get_current_frame_end(struct vo *vo)
     return in->current_frame->pts + MPMAX(in->current_frame->duration, 0);
 }
 
+static int64_t get_display_synced_frame_end(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+    assert(!in->frame_queued);
+    int64_t res = 0;
+    if (in->base_vsync && in->vsync_interval > 1 && in->current_frame) {
+        res = in->base_vsync;
+        int extra = !!in->rendering;
+        res += (in->current_frame->num_vsyncs + extra) * in->vsync_interval;
+        if (!in->current_frame->display_synced)
+            res = 0;
+    }
+    return res;
+}
+
 static bool still_displaying(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
@@ -1338,15 +1353,7 @@ double vo_get_delay(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
     mp_mutex_lock(&in->lock);
-    assert (!in->frame_queued);
-    int64_t res = 0;
-    if (in->base_vsync && in->vsync_interval > 1 && in->current_frame) {
-        res = in->base_vsync;
-        int extra = !!in->rendering;
-        res += (in->current_frame->num_vsyncs + extra) * in->vsync_interval;
-        if (!in->current_frame->display_synced)
-            res = 0;
-    }
+    int64_t res = get_display_synced_frame_end(vo);
     mp_mutex_unlock(&in->lock);
     return res ? MP_TIME_NS_TO_S(res - mp_time_ns()) : 0;
 }


### PR DESCRIPTION
First two commits are entirely theoretical, it's more correct but it probably doesn't matter much because this code is only used to detect underruns and to wait for a frame to finish before applying new image_params.

Third commit fixes a real world problem with bad drivers that I encountered while testing various wip fifo-v1/commit-timing implementations. By not always updating base_vsync, we could potentially end up in a [permanent underflow state](https://github.com/mpv-player/mpv/blob/a61518db986dcd4babfae66cef017010a9eb5c88/video/out/vo.c#L461-L470) and never recover from it even once the driver has stopped giving us bogus values.