### PR TITLE
osc.lua: observe playlist-count instead of playlist property

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2562,7 +2562,7 @@ end
 mp.register_event("shutdown", shutdown)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", "native", request_init)
-mp.observe_property("playlist", "native", request_init)
+mp.observe_property("playlist-count", "native", request_init)
 mp.observe_property("chapter-list", "native", function(_, list)
     list = list or {}  -- safety, shouldn't return nil
     table.sort(list, function(a, b) return a.time < b.time end)


### PR DESCRIPTION
Observing playlist property with "native" type is too expensive for
larger playlists, and we only observe this property to
activate/deactivate next/prev buttons on the osc. We actually only need
to know if the playlist-count has changed, nothing else.


Fixes: https://github.com/mpv-player/mpv/issues/15264
