### PR TITLE
DOCS/man/input.rst: remove input commands subject to change heading

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -970,10 +970,6 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 ``context-menu``
     Show context menu on the video window. See `Context Menu`_ section for details.
 
-
-Input Commands that are Possibly Subject to Change
---------------------------------------------------
-
 ``af <operation> <value>``
     Change audio filter chain. See ``vf`` command.
 


### PR DESCRIPTION
Most of the commands list here are several years old and we will probably never change them. And it is already stated in the description of individual commands if they are deprecated or subject to change.

Furthermore, it is easy to add new commands at the end of this section by accident. I added load-config-file and load-input-conf here without realizing it's a separate section, and I assume this was also the case for begin-vo-dragging.
