### PR TITLE
sub/osd_libass: don't blur the osd-bar

### DIFF
--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -386,6 +386,7 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
     style->Outline = opts->osd_bar_outline_size;
     // Rendering with shadow is broken (because there's more than one shape)
     style->Shadow = 0;
+    style->Blur = 0;
 
     style->Alignment = 5;
 


### PR DESCRIPTION
High --osd-blur values break the osd-bar by not drawing the filled portion, and even low values just make it look worse, so don't apply --osd-blur to the osd-bar.