### PR TITLE
command: print circles at the beginning of lines in chapter-list

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -1056,10 +1056,9 @@ static int mp_property_list_chapters(void *ctx, struct m_property *prop,
             char *name = chapter_name(mpctx, n);
             double t = chapter_start_time(mpctx, n);
             char* time = mp_format_time(t, false);
-            res = talloc_asprintf_append(res, "%s", time);
-            talloc_free(time);
             const char *m = n == cur ? list_current : list_normal;
-            res = talloc_asprintf_append(res, "  %s%s\n", m, name);
+            res = talloc_asprintf_append(res, "%s%s  %s\n", m, time, name);
+            talloc_free(time);
         }
 
         *(char **)arg = count ? cut_osd_list(mpctx, "Chapters", res, cur) : res;


### PR DESCRIPTION
Timestamps don't have equal width in proportional fonts, so circles and titles are misaligned. By placing circles first at least the circles are aligned.

Before:
![old](https://github.com/user-attachments/assets/f38c6adf-7d92-4710-ba23-9c38adbb9dd9)

After:
![new](https://github.com/user-attachments/assets/ab29d495-d456-4aca-9f37-7d13f5a28186)