### PR TITLE
osxbundle: fix Vulkan dylib install name

### DIFF
--- a/TOOLS/dylib_unhell.py
+++ b/TOOLS/dylib_unhell.py
@@ -273,6 +273,8 @@ def process_vulkan_loader(binary, loader_name, loader_relative_folder, library_n
         os.makedirs(framework_bundle_folder)
     library_target_path = os.path.join(framework_bundle_folder, loader_library_name)
     shutil.copy(library_system_path, library_target_path)
+    library_install_name = os.path.join("@rpath", loader_library_name)
+    install_name_tool_id(library_install_name, library_target_path)
 
 def remove_dev_tools_rapths(binary):
     for path in get_rpaths_dev_tools(binary):


### PR DESCRIPTION
MoltenVK from Homebrew hardcodes the install name of libMoltenVK.dylib to point to the Homebrew prefix:

```
$ otool -l mpv.app/Contents/Frameworks/libMoltenVK.dylib | grep -A2 LC_ID_DYLIB
          cmd LC_ID_DYLIB
      cmdsize 72
         name /usr/local/opt/molten-vk/lib/libMoltenVK.dylib (offset 24)
```

Update dylib_unhell to update the install name in libMoltenVK.dylib to avoid depending on the Homebrew prefix.