### PR TITLE
command: highlight selected list items with color

### DIFF
--- a/DOCS/interface-changes/selected-style.rst
+++ b/DOCS/interface-changes/selected-style.rst
@@ -1,0 +1,1 @@
+add `--osd-selected-color` and `--osd-selected-outline-color` options

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4592,6 +4592,14 @@ OSD
     Specify the color used for OSD.
     See ``--sub-color`` for details.
 
+``--osd-selected-color=<color>``
+    The color of the selected item in lists.
+    See ``--sub-color`` for details.
+
+``--osd-selected-outline-color=<color>``
+    The outline color of the selected item in lists.
+    See ``--sub-color`` for details.
+
 ``--osd-fractions``
     Show OSD times with fractions of seconds (in millisecond precision). Useful
     to see the exact timestamp of a video frame.

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -150,6 +150,11 @@ struct bstr bstr_strip_linebreaks(struct bstr str);
  */
 void bstr_xappend(void *talloc_ctx, bstr *s, bstr append);
 
+static inline void bstr_xappend0(void *talloc_ctx, bstr *s, const char *append)
+{
+    return bstr_xappend(talloc_ctx, s, bstr0(append));
+}
+
 /**
  * @brief Append a formatted string to the existing bstr.
  *

--- a/options/options.c
+++ b/options/options.c
@@ -397,6 +397,8 @@ const struct m_sub_options mp_osd_render_sub_opts = {
         {"osd-bar", OPT_SUBSTRUCT(osd_bar_style, osd_bar_style_conf)},
         {"osd-scale", OPT_FLOAT(osd_scale), M_RANGE(0, 100)},
         {"osd-scale-by-window", OPT_BOOL(osd_scale_by_window)},
+        {"osd-selected-color", OPT_COLOR(osd_selected_color)},
+        {"osd-selected-outline-color", OPT_COLOR(osd_selected_outline_color)},
         {"force-rgba-osd-rendering", OPT_BOOL(force_rgba_osd)},
         {0}
     },
@@ -404,6 +406,8 @@ const struct m_sub_options mp_osd_render_sub_opts = {
     .defaults = &(OPT_BASE_STRUCT){
         .osd_scale = 1,
         .osd_scale_by_window = true,
+        .osd_selected_color = {250, 189, 47, 255},
+        .osd_selected_outline_color = {0, 0, 0, 255},
     },
     .change_flags = UPDATE_OSD,
 };

--- a/options/options.h
+++ b/options/options.h
@@ -137,6 +137,8 @@ struct mp_subtitle_shared_opts {
 struct mp_osd_render_opts {
     float osd_scale;
     bool osd_scale_by_window;
+    struct m_color osd_selected_color;
+    struct m_color osd_selected_outline_color;
     struct osd_style_opts *osd_style;
     struct osd_bar_style_opts *osd_bar_style;
     bool force_rgba_osd;

--- a/osdep/terminal.h
+++ b/osdep/terminal.h
@@ -38,6 +38,9 @@
 #define TERM_ESC_ENABLE_MOUSE       "\033[?1003h"
 #define TERM_ESC_DISABLE_MOUSE      "\033[?1003l"
 
+#define TERM_ESC_REVERSE_COLORS     "\033[7m"
+#define TERM_ESC_CLEAR_COLORS       "\033[0m"
+
 struct input_ctx;
 
 /* Global initialization for terminal output. */

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -392,6 +392,11 @@ local function fuzzy_find(needle, haystacks, case_sensitive)
     return result
 end
 
+local function mpv_color_to_ass(color)
+    return color:sub(8,9) .. color:sub(6,7) ..  color:sub(4,5),
+           string.format('%x', 255 - tonumber('0x' .. color:sub(2,3)))
+end
+
 local function populate_log_with_matches()
     if not selectable_items or selected_match == 0 then
         return
@@ -433,13 +438,17 @@ local function populate_log_with_matches()
         local style = ''
         local terminal_style = ''
 
-        if i == selected_match then
-            style = styles.selected_suggestion
-            terminal_style = terminal_styles.selected_suggestion
-        end
         if matches[i].index == default_item then
-            style = style .. styles.default_item
-            terminal_style = terminal_style .. terminal_styles.default_item
+            style = styles.default_item
+            terminal_style = terminal_styles.default_item
+        end
+        if i == selected_match then
+            local color, alpha = mpv_color_to_ass(mp.get_property('osd-selected-color'))
+            local outline_color, outline_alpha =
+                mpv_color_to_ass(mp.get_property('osd-selected-outline-color'))
+            style = style .. "{\\b1\\1c&H" .. color .. "&\\1a&H" .. alpha ..
+                             "&\\3c&H" .. outline_color .. "&\\3a&H" .. outline_alpha .. "&}"
+            terminal_style = terminal_style .. terminal_styles.selected_suggestion
         end
 
         log[#log + 1] = {

--- a/player/misc.c
+++ b/player/misc.c
@@ -358,7 +358,6 @@ bool str_in_list(bstr str, char **list)
     bstr_xappend_asprintf(ctx, &dst, " %s%s", first ? "[" : "", flag); \
     first = false;                                                     \
 } while(0)
-#define bstr_xappend0(ctx, dst, s) bstr_xappend(ctx, dst, bstr0(s))
 
 char *mp_format_track_metadata(void *ctx, struct track *t, bool add_lang)
 {

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -185,8 +185,6 @@ void gl_sc_enable_extension(struct gl_shader_cache *sc, char *name)
     MP_TARRAY_APPEND(sc, sc->exts, sc->num_exts, talloc_strdup(sc, name));
 }
 
-#define bstr_xappend0(sc, b, s) bstr_xappend(sc, b, bstr0(s))
-
 void gl_sc_add(struct gl_shader_cache *sc, const char *text)
 {
     bstr_xappend0(sc, &sc->text, text);

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -41,7 +41,6 @@
 #define DEFAULT_WIDTH 80
 #define DEFAULT_HEIGHT 25
 
-static const bstr TERM_ESC_CLEAR_COLORS    = bstr0_lit("\033[0m");
 static const bstr TERM_ESC_COLOR256_BG     = bstr0_lit("\033[48;5");
 static const bstr TERM_ESC_COLOR256_FG     = bstr0_lit("\033[38;5");
 static const bstr TERM_ESC_COLOR24BIT_BG   = bstr0_lit("\033[48;2");
@@ -160,7 +159,7 @@ static void write_plain(bstr *frame,
             if (buffering <= VO_TCT_BUFFER_PIXEL)
                 print_buffer(frame);
         }
-        bstr_xappend(NULL, frame, TERM_ESC_CLEAR_COLORS);
+        bstr_xappend(NULL, frame, (bstr)bstr0_lit(TERM_ESC_CLEAR_COLORS));
         if (buffering <= VO_TCT_BUFFER_LINE)
             print_buffer(frame);
     }
@@ -197,7 +196,7 @@ static void write_half_blocks(bstr *frame,
             if (buffering <= VO_TCT_BUFFER_PIXEL)
                 print_buffer(frame);
         }
-        bstr_xappend(NULL, frame, TERM_ESC_CLEAR_COLORS);
+        bstr_xappend(NULL, frame, (bstr)bstr0_lit(TERM_ESC_CLEAR_COLORS));
         if (buffering <= VO_TCT_BUFFER_LINE)
             print_buffer(frame);
     }

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -118,14 +118,14 @@ static void print_seq3(bstr *frame, struct lut_item *lut, bstr prefix,
     bstr_xappend(NULL, frame, (bstr){ lut[r].str, lut[r].width });
     bstr_xappend(NULL, frame, (bstr){ lut[g].str, lut[g].width });
     bstr_xappend(NULL, frame, (bstr){ lut[b].str, lut[b].width });
-    bstr_xappend(NULL, frame, (bstr)bstr0_lit("m"));
+    bstr_xappend0(NULL, frame, "m");
 }
 
 static void print_seq1(bstr *frame, struct lut_item *lut, bstr prefix, uint8_t c)
 {
     bstr_xappend(NULL, frame, prefix);
     bstr_xappend(NULL, frame, (bstr){ lut[c].str, lut[c].width });
-    bstr_xappend(NULL, frame, (bstr)bstr0_lit("m"));
+    bstr_xappend0(NULL, frame, "m");
 }
 
 static void print_buffer(bstr *frame)
@@ -155,11 +155,11 @@ static void write_plain(bstr *frame,
             } else {
                 print_seq3(frame, lut, TERM_ESC_COLOR24BIT_BG, r, g, b);
             }
-            bstr_xappend(NULL, frame, (bstr)bstr0_lit(" "));
+            bstr_xappend0(NULL, frame, " ");
             if (buffering <= VO_TCT_BUFFER_PIXEL)
                 print_buffer(frame);
         }
-        bstr_xappend(NULL, frame, (bstr)bstr0_lit(TERM_ESC_CLEAR_COLORS));
+        bstr_xappend0(NULL, frame, TERM_ESC_CLEAR_COLORS);
         if (buffering <= VO_TCT_BUFFER_LINE)
             print_buffer(frame);
     }
@@ -196,7 +196,7 @@ static void write_half_blocks(bstr *frame,
             if (buffering <= VO_TCT_BUFFER_PIXEL)
                 print_buffer(frame);
         }
-        bstr_xappend(NULL, frame, (bstr)bstr0_lit(TERM_ESC_CLEAR_COLORS));
+        bstr_xappend0(NULL, frame, TERM_ESC_CLEAR_COLORS);
         if (buffering <= VO_TCT_BUFFER_LINE)
             print_buffer(frame);
     }
@@ -288,7 +288,7 @@ static void flip_page(struct vo *vo)
             p->opts.term256, p->lut, p->opts.buffering);
     }
 
-    bstr_xappend(NULL, &p->frame_buf, (bstr)bstr0_lit("\n"));
+    bstr_xappend0(NULL, &p->frame_buf, "\n");
     if (p->opts.buffering <= VO_TCT_BUFFER_FRAME)
         print_buffer(&p->frame_buf);
 


### PR DESCRIPTION
Instead of printing circles in show-text ${playlist}, ${chapter-list} and ${edition-list}, introduce --osd-selected-color and --osd-selected-outline-color to reduce clutter, make the selected item easier to differentiate, and have visual consistency with select.lua.

The defaults are taken from the style of the selected item in the console. These new options are also used there, replacing the hardcoded styles. Due to being user-configurable, selected item styles are changed to take priority over default item styles.

The default selected style is yellow and bold. The bold (hardcoded) allows differentiating the selected item with color blindness. There is also a separate --osd-selected-outline-color option defaulting to black, since without it if the user changes --osd-outline-color yellow text becomes unreadable without a black border. --osd-selected-back-color is omitted for now.

Text and background colors are inverted for the selected item in the terminal. This is hardcoded, adding an option is overkill.

A disadvantage of this commit is that if you run print-text ${playlist} with a VO, the selected style ASS is printed to the terminal (but ASS printed in the console is interpreted). This commit avoids printing the reset ASS sequence for non-selected items to reduce clutter in this case.
