### PR TITLE
loadfile: fix --loop-playlist=N with --prefetch-playlist

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5636,7 +5636,7 @@ static void cmd_playlist_next_prev(void *p)
     int dir = *(int *)cmd->priv;
     int force = cmd->args[0].v.i;
 
-    struct playlist_entry *e = mp_next_file(mpctx, dir, force);
+    struct playlist_entry *e = mp_next_file(mpctx, dir, force, true);
     if (!e && !force) {
         cmd->success = false;
         return;

--- a/player/core.h
+++ b/player/core.h
@@ -531,7 +531,7 @@ struct track *mp_track_by_tid(struct MPContext *mpctx, enum stream_type type,
 void add_demuxer_tracks(struct MPContext *mpctx, struct demuxer *demuxer);
 bool mp_remove_track(struct MPContext *mpctx, struct track *track);
 struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
-                                    bool force);
+                                    bool force, bool update_loop);
 void mp_set_playlist_entry(struct MPContext *mpctx, struct playlist_entry *e);
 void mp_play_files(struct MPContext *mpctx);
 void update_demuxer_properties(struct MPContext *mpctx);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1250,11 +1250,11 @@ cancel:
 
 void prefetch_next(struct MPContext *mpctx)
 {
-    if (!mpctx->opts->prefetch_open)
+    if (!mpctx->opts->prefetch_open || mpctx->open_active)
         return;
 
     struct playlist_entry *new_entry = mp_next_file(mpctx, +1, false, false);
-    if (new_entry && !mpctx->open_active && new_entry->filename) {
+    if (new_entry && new_entry->filename) {
         MP_VERBOSE(mpctx, "Prefetching: %s\n", new_entry->filename);
         start_open(mpctx, new_entry->filename, new_entry->stream_flags, true);
     }

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1935,8 +1935,11 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
         next->playlist_prev_attempt = true;
     if (!next && mpctx->opts->loop_times != 1) {
         if (direction > 0) {
-            if (mpctx->opts->shuffle)
+            if (mpctx->opts->shuffle) {
+                if (!update_loop)
+                    return NULL;
                 playlist_shuffle(mpctx->playlist);
+            }
             next = playlist_get_first(mpctx->playlist);
             if (next && mpctx->opts->loop_times > 1 && update_loop) {
                 mpctx->opts->loop_times--;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1253,7 +1253,7 @@ void prefetch_next(struct MPContext *mpctx)
     if (!mpctx->opts->prefetch_open)
         return;
 
-    struct playlist_entry *new_entry = mp_next_file(mpctx, +1, false);
+    struct playlist_entry *new_entry = mp_next_file(mpctx, +1, false, false);
     if (new_entry && !mpctx->open_active && new_entry->filename) {
         MP_VERBOSE(mpctx, "Prefetching: %s\n", new_entry->filename);
         start_open(mpctx, new_entry->filename, new_entry->stream_flags, true);
@@ -1914,7 +1914,7 @@ terminate_playback:
     process_hooks(mpctx, "on_after_end_file");
 
     if (playlist_prev_continue) {
-        struct playlist_entry *e = mp_next_file(mpctx, -1, false);
+        struct playlist_entry *e = mp_next_file(mpctx, -1, false, true);
         if (e) {
             mp_set_playlist_entry(mpctx, e);
             play_current_file(mpctx);
@@ -1926,8 +1926,9 @@ terminate_playback:
 // it can have side-effects and mutate mpctx.
 //  direction: -1 (previous) or +1 (next)
 //  force: if true, don't skip playlist entries marked as failed
+//  update_loop: whether to decrement --loop-playlist=N if it was specified
 struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
-                                    bool force)
+                                    bool force, bool update_loop)
 {
     struct playlist_entry *next = playlist_get_next(mpctx->playlist, direction);
     if (next && direction < 0 && !force)
@@ -1937,7 +1938,7 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
             if (mpctx->opts->shuffle)
                 playlist_shuffle(mpctx->playlist);
             next = playlist_get_first(mpctx->playlist);
-            if (next && mpctx->opts->loop_times > 1) {
+            if (next && mpctx->opts->loop_times > 1 && update_loop) {
                 mpctx->opts->loop_times--;
                 m_config_notify_change_opt_ptr(mpctx->mconfig,
                                                &mpctx->opts->loop_times);
@@ -1996,7 +1997,7 @@ void mp_play_files(struct MPContext *mpctx)
         if (mpctx->stop_play == PT_NEXT_ENTRY || mpctx->stop_play == PT_ERROR ||
             mpctx->stop_play == AT_END_OF_FILE)
         {
-            new_entry = mp_next_file(mpctx, +1, false);
+            new_entry = mp_next_file(mpctx, +1, false, true);
         } else if (mpctx->stop_play == PT_CURRENT_ENTRY) {
             new_entry = mpctx->playlist->current;
         }


### PR DESCRIPTION
With --prefetch-playlist, mp_next_file() is called continously since the last second of playback or when viewing an image, which decreases --loop-playlist=N to 1.

Fix this by adding a flag to mp_next_file() to specify whether to decrement --loop-playlist=N. The first playlist entry is still prefetched when it's the next one, but without decrementing --loop-playlist=N.
