### PR TITLE
DOCS/man/input.rst: add sections to categorize commands

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1530,7 +1530,7 @@ Remember to quote string arguments in input.conf (see `Flat command syntax`_).
 Undocumented commands: ``ao-reload`` (experimental/internal).
 
 List of events
-~~~~~~~~~~~~~~
+--------------
 
 This is a partial list of events. This section describes what
 ``mpv_event_to_node()`` returns, and which is what scripting APIs and the JSON
@@ -1723,7 +1723,7 @@ The following events also happen, but are deprecated: ``idle``, ``tick``
 Use ``mpv_observe_property()`` (Lua: ``mp.observe_property()``) instead.
 
 Hooks
-~~~~~
+-----
 
 Hooks are synchronous events between player core and a script or similar. This
 applies to client API (including the Lua scripting interface). Normally,


### PR DESCRIPTION
mpv has too many commands and they are unorganized in the documentation, making it difficult to navigate.

This commit completely reorganizes the commands into several categories to make the documentation easier to navigate.
The following categories are defined:

- Playback Control: Seeking and stepping.
- Property Manipulation: Changing property values.
- Playlist Manipulation: Playlist navigation and editing.
- Track Manipulation: Track navigation and editing.
- Text Manipulation: Text printing, expansion, escaping.
- Configuration: General configuration and related files.
- OSD: Displaying contents as OSD.
- Input and Keybind: Input configuration and key bindings.
- Execution: Execution of mpv and subprocesses.
- Scripting: Script loading and communication.
- Screenshot: Taking screenshots.
- Miscellaneous: Other commands.