### PR TITLE
fuzzer_options_parser: limit input size to 2048 bytes

### DIFF
--- a/fuzzers/fuzzer_options_parser.c
+++ b/fuzzers/fuzzer_options_parser.c
@@ -23,7 +23,7 @@
 
 int mpv_initialize_opts(mpv_handle *ctx, char **options);
 
-#define MAX_INPUT_SIZE (1 << 20)
+#define MAX_INPUT_SIZE 2048
 #define MAX_OPTS_NUM 10000
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)


### PR DESCRIPTION
To encourage fuzzing to mutate shorter test cases, avoid continuously adding more elements into a single input.