### PR TITLE
defaults.js: fix the opened event with mp.input.get

### DIFF
--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -654,7 +654,7 @@ function register_event_handler(t) {
     mp.register_script_message("input-event", function (type, args) {
         if (t[type]) {
             args = args ? JSON.parse(args) : [];
-            var result = t[type](args[0], args[1]);
+            var result = t[type].apply(null, args);
 
             if (type == "complete" && result) {
                 mp.commandv("script-message-to", "console", "complete",

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -653,7 +653,7 @@ mp.options = { read_options: read_options };
 function register_event_handler(t) {
     mp.register_script_message("input-event", function (type, args) {
         if (t[type]) {
-            args = JSON.parse(args)
+            args = args ? JSON.parse(args) : [];
             var result = t[type](args[0], args[1]);
 
             if (type == "complete" && result) {


### PR DESCRIPTION
The opened event doesn't send any arguments. Don't call JSON.parse(undefined) in that case because it errors.

Fixes eb4c6be630, fixes #15301.