### PR TITLE
video/out/wayland_common: fix dnd with focus follow mouse

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3070,6 +3070,7 @@ bool vo_wayland_init(struct vo *vo)
         .cursor_visible = true,
         .opts_cache = m_config_cache_alloc(wl, vo->global, &vo_sub_opts),
     };
+    wl->pending_offer->fd = wl->dnd_offer->fd = wl->selection_offer->fd = -1;
     wl->opts = wl->opts_cache->opts;
 
     wl_list_init(&wl->output_list);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -162,8 +162,10 @@ struct vo_wayland_state {
     struct xkb_context *xkb_context;
 
     /* Data offer */
-    struct wl_data_device_manager *dnd_devman;
+    struct wl_data_device_manager *devman;
+    struct vo_wayland_data_offer *pending_offer;
     struct vo_wayland_data_offer *dnd_offer;
+    struct vo_wayland_data_offer *selection_offer;
 
     /* Cursor */
     struct wl_cursor_theme *cursor_theme;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -27,6 +27,7 @@
 struct compositor_format;
 struct vo_wayland_seat;
 struct vo_wayland_tranche;
+struct vo_wayland_data_offer;
 
 struct drm_format {
     uint32_t format;
@@ -160,13 +161,9 @@ struct vo_wayland_state {
     struct wl_list seat_list;
     struct xkb_context *xkb_context;
 
-    /* DND */
+    /* Data offer */
     struct wl_data_device_manager *dnd_devman;
-    struct wl_data_offer *dnd_offer;
-    int dnd_action; // actually enum mp_dnd_action
-    char *dnd_mime_type;
-    int dnd_fd;
-    int dnd_mime_score;
+    struct vo_wayland_data_offer *dnd_offer;
 
     /* Cursor */
     struct wl_cursor_theme *cursor_theme;


### PR DESCRIPTION
Whenever mpv window gains focus, a new data offer is sent for the selection. However, mpv currently treats it the same as dnd data offers, which results in wrong handling. One bug which results from this is when focus follow mouse is enabled, dropping the dnd file results in the window being focused and selection offer being sent, freeing the existing dnd offer. This results in dnd being broken on at least GTK3.

Fix this by separating selection and dnd offer handling. Since there is no way to know whether an offer introduced by data_device_handle_data_offer is a selection or dnd offer, make it pending, and move them once the identity is confirmed.

Fixes: https://github.com/mpv-player/mpv/issues/9789
Fixes: https://github.com/mpv-player/mpv/issues/13498