### PR TITLE
options.c cleanup

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -88,6 +88,8 @@ extern const struct m_obj_list vo_obj_list;
 
 extern const struct m_sub_options ao_conf;
 
+extern const struct m_sub_options dvd_conf;
+
 extern const struct m_sub_options opengl_conf;
 extern const struct m_sub_options vulkan_conf;
 extern const struct m_sub_options vulkan_display_conf;
@@ -421,22 +423,6 @@ const struct m_sub_options cuda_conf = {
 };
 
 #undef OPT_BASE_STRUCT
-#define OPT_BASE_STRUCT struct dvd_opts
-
-const struct m_sub_options dvd_conf = {
-    .opts = (const struct m_option[]){
-        {"dvd-device", OPT_STRING(device), .flags = M_OPT_FILE},
-        {"dvd-speed", OPT_INT(speed)},
-        {"dvd-angle", OPT_INT(angle), M_RANGE(1, 99)},
-        {0}
-    },
-    .size = sizeof(struct dvd_opts),
-    .defaults = &(const struct dvd_opts){
-        .angle = 1,
-    },
-};
-
-#undef OPT_BASE_STRUCT
 #define OPT_BASE_STRUCT struct filter_opts
 
 const struct m_sub_options filter_conf = {
@@ -556,7 +542,7 @@ static const m_option_t mp_opts[] = {
 // ------------------------- stream options --------------------
 
 #if HAVE_DVDNAV
-    {"", OPT_SUBSTRUCT(dvd_opts, dvd_conf)},
+    {"dvd", OPT_SUBSTRUCT(dvd_opts, dvd_conf)},
 #endif
     {"edition", OPT_CHOICE(edition_id, {"auto", -1}), M_RANGE(0, 8190)},
 #if HAVE_LIBBLURAY

--- a/options/options.c
+++ b/options/options.c
@@ -101,6 +101,8 @@ extern const struct m_sub_options wingl_conf;
 extern const struct m_sub_options vaapi_conf;
 extern const struct m_sub_options egl_conf;
 
+extern const struct m_sub_options mp_sub_filter_opts;
+
 static const struct m_sub_options screenshot_conf = {
     .opts = image_writer_opts,
     .size = sizeof(struct image_writer_opts),
@@ -273,29 +275,6 @@ const struct m_sub_options vo_sub_opts = {
         .swapchain_depth = 3,
         .focus_on = 1,
     },
-};
-
-#undef OPT_BASE_STRUCT
-#define OPT_BASE_STRUCT struct mp_sub_filter_opts
-
-const struct m_sub_options mp_sub_filter_opts = {
-    .opts = (const struct m_option[]){
-        {"sub-filter-sdh", OPT_BOOL(sub_filter_SDH)},
-        {"sub-filter-sdh-harder", OPT_BOOL(sub_filter_SDH_harder)},
-        {"sub-filter-sdh-enclosures", OPT_STRING(sub_filter_SDH_enclosures)},
-        {"sub-filter-regex-enable", OPT_BOOL(rf_enable)},
-        {"sub-filter-regex-plain", OPT_BOOL(rf_plain)},
-        {"sub-filter-regex", OPT_STRINGLIST(rf_items)},
-        {"sub-filter-jsre", OPT_STRINGLIST(jsre_items)},
-        {"sub-filter-regex-warn", OPT_BOOL(rf_warn)},
-        {0}
-    },
-    .size = sizeof(OPT_BASE_STRUCT),
-    .defaults = &(OPT_BASE_STRUCT){
-        .sub_filter_SDH_enclosures = "([\uFF08",
-        .rf_enable = true,
-    },
-    .change_flags = UPDATE_SUB_FILT,
 };
 
 #undef OPT_BASE_STRUCT
@@ -747,7 +726,7 @@ static const m_option_t mp_opts[] = {
 
     {"", OPT_SUBSTRUCT(subs_rend, mp_subtitle_sub_opts)},
     {"", OPT_SUBSTRUCT(subs_shared, mp_subtitle_shared_sub_opts)},
-    {"", OPT_SUBSTRUCT(subs_filt, mp_sub_filter_opts)},
+    {"sub-filter", OPT_SUBSTRUCT(subs_filt, mp_sub_filter_opts)},
     {"", OPT_SUBSTRUCT(osd_rend, mp_osd_render_sub_opts)},
 
     {"osd-bar", OPT_BOOL(osd_bar_visible), .flags = UPDATE_OSD},

--- a/options/options.c
+++ b/options/options.c
@@ -390,17 +390,8 @@ const struct m_sub_options mp_subtitle_shared_sub_opts = {
 
 const struct m_sub_options mp_osd_render_sub_opts = {
     .opts = (const struct m_option[]){
-        {"osd-bar-align-x", OPT_FLOAT(osd_bar_align_x), M_RANGE(-1.0, +1.0)},
-        {"osd-bar-align-y", OPT_FLOAT(osd_bar_align_y), M_RANGE(-1.0, +1.0)},
-        {"osd-bar-w", OPT_FLOAT(osd_bar_w), M_RANGE(1, 100)},
-        {"osd-bar-h", OPT_FLOAT(osd_bar_h), M_RANGE(0.1, 50)},
-        {"osd-bar-outline-size", OPT_FLOAT(osd_bar_outline_size), M_RANGE(0, 1000.0)},
-        {"osd-bar-border-size", OPT_ALIAS("osd-bar-outline-size")},
-        {"osd-bar-marker-scale", OPT_FLOAT(osd_bar_marker_scale), M_RANGE(0, 100.0)},
-        {"osd-bar-marker-min-size", OPT_FLOAT(osd_bar_marker_min_size), M_RANGE(0, 1000.0)},
-        {"osd-bar-marker-style", OPT_CHOICE(osd_bar_marker_style,
-            {"none", 0}, {"triangle", 1}, {"line", 2})},
         {"osd", OPT_SUBSTRUCT(osd_style, osd_style_conf)},
+        {"osd-bar", OPT_SUBSTRUCT(osd_bar_style, osd_bar_style_conf)},
         {"osd-scale", OPT_FLOAT(osd_scale), M_RANGE(0, 100)},
         {"osd-scale-by-window", OPT_BOOL(osd_scale_by_window)},
         {"force-rgba-osd-rendering", OPT_BOOL(force_rgba_osd)},
@@ -408,13 +399,6 @@ const struct m_sub_options mp_osd_render_sub_opts = {
     },
     .size = sizeof(OPT_BASE_STRUCT),
     .defaults = &(OPT_BASE_STRUCT){
-        .osd_bar_align_y = 0.5,
-        .osd_bar_w = 75.0,
-        .osd_bar_h = 3.125,
-        .osd_bar_outline_size = 0.5,
-        .osd_bar_marker_scale = 1.3,
-        .osd_bar_marker_min_size = 1.6,
-        .osd_bar_marker_style = 1,
         .osd_scale = 1,
         .osd_scale_by_window = true,
     },

--- a/options/options.c
+++ b/options/options.c
@@ -507,17 +507,17 @@ static const m_option_t mp_opts[] = {
      .offset = -1},
 
     // handled in m_config.c
-    { "include", CONF_TYPE_STRING, M_OPT_FILE, .offset = -1},
-    { "profile", CONF_TYPE_STRING_LIST, 0, .offset = -1},
-    { "show-profile", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP |
+    {"include", CONF_TYPE_STRING, M_OPT_FILE, .offset = -1},
+    {"profile", CONF_TYPE_STRING_LIST, 0, .offset = -1},
+    {"show-profile", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP |
         M_OPT_OPTIONAL_PARAM,  .offset = -1},
-    { "list-options", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
+    {"list-options", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
         .offset = -1},
     {"list-properties", OPT_BOOL(property_print_help),
      .flags = CONF_NOCFG | M_OPT_NOPROP},
-    { "help", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
+    {"help", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
         .offset = -1},
-    { "h", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
+    {"h", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
         .offset = -1},
 
     {"list-protocols", OPT_PRINT(stream_print_proto_list)},

--- a/options/options.h
+++ b/options/options.h
@@ -134,17 +134,6 @@ struct mp_subtitle_shared_opts {
     int ass_style_override[2];
 };
 
-struct mp_sub_filter_opts {
-    bool sub_filter_SDH;
-    bool sub_filter_SDH_harder;
-    char *sub_filter_SDH_enclosures;
-    bool rf_enable;
-    bool rf_plain;
-    char **rf_items;
-    char **jsre_items;
-    bool rf_warn;
-};
-
 struct mp_osd_render_opts {
     float osd_bar_align_x;
     float osd_bar_align_y;
@@ -424,7 +413,6 @@ extern const struct m_sub_options cuda_conf;
 extern const struct m_sub_options dvd_conf;
 extern const struct m_sub_options mp_subtitle_sub_opts;
 extern const struct m_sub_options mp_subtitle_shared_sub_opts;
-extern const struct m_sub_options mp_sub_filter_opts;
 extern const struct m_sub_options mp_osd_render_sub_opts;
 extern const struct m_sub_options filter_conf;
 extern const struct m_sub_options resample_conf;

--- a/options/options.h
+++ b/options/options.h
@@ -135,17 +135,10 @@ struct mp_subtitle_shared_opts {
 };
 
 struct mp_osd_render_opts {
-    float osd_bar_align_x;
-    float osd_bar_align_y;
-    float osd_bar_w;
-    float osd_bar_h;
-    float osd_bar_outline_size;
-    float osd_bar_marker_scale;
-    float osd_bar_marker_min_size;
-    int osd_bar_marker_style;
     float osd_scale;
     bool osd_scale_by_window;
     struct osd_style_opts *osd_style;
+    struct osd_bar_style_opts *osd_bar_style;
     bool force_rgba_osd;
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -390,12 +390,6 @@ struct cuda_opts {
     int cuda_device;
 };
 
-struct dvd_opts {
-    int angle;
-    int speed;
-    char *device;
-};
-
 struct filter_opts {
     int deinterlace;
     int field_parity;
@@ -403,7 +397,6 @@ struct filter_opts {
 
 extern const struct m_sub_options vo_sub_opts;
 extern const struct m_sub_options cuda_conf;
-extern const struct m_sub_options dvd_conf;
 extern const struct m_sub_options mp_subtitle_sub_opts;
 extern const struct m_sub_options mp_subtitle_shared_sub_opts;
 extern const struct m_sub_options mp_osd_render_sub_opts;

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -72,6 +72,27 @@ struct priv {
     struct dvd_opts *opts;
 };
 
+struct dvd_opts {
+    int angle;
+    int speed;
+    char *device;
+};
+
+#define OPT_BASE_STRUCT struct dvd_opts
+
+const struct m_sub_options dvd_conf = {
+    .opts = (const struct m_option[]){
+        {"device", OPT_STRING(device), .flags = M_OPT_FILE},
+        {"speed", OPT_INT(speed)},
+        {"angle", OPT_INT(angle), M_RANGE(1, 99)},
+        {0}
+    },
+    .size = sizeof(struct dvd_opts),
+    .defaults = &(const struct dvd_opts){
+        .angle = 1,
+    },
+};
+
 #define DNE(e) [e] = # e
 static const char *const mp_dvdnav_events[] = {
     DNE(DVDNAV_BLOCK_OK),

--- a/sub/osd.c
+++ b/sub/osd.c
@@ -116,6 +116,37 @@ const struct m_sub_options sub_style_conf = {
     .change_flags = UPDATE_OSD,
 };
 
+#undef OPT_BASE_STRUCT
+#define OPT_BASE_STRUCT struct osd_bar_style_opts
+static const m_option_t bar_style_opts[] = {
+    {"align-x", OPT_FLOAT(align_x), M_RANGE(-1.0, +1.0)},
+    {"align-y", OPT_FLOAT(align_y), M_RANGE(-1.0, +1.0)},
+    {"w", OPT_FLOAT(w), M_RANGE(1, 100)},
+    {"h", OPT_FLOAT(h), M_RANGE(0.1, 50)},
+    {"outline-size", OPT_FLOAT(outline_size), M_RANGE(0, 1000.0)},
+    {"border-size", OPT_ALIAS("osd-bar-outline-size")},
+    {"marker-scale", OPT_FLOAT(marker_scale), M_RANGE(0, 100.0)},
+    {"marker-min-size", OPT_FLOAT(marker_min_size), M_RANGE(0, 1000.0)},
+    {"marker-style", OPT_CHOICE(marker_style,
+        {"none", 0}, {"triangle", 1}, {"line", 2})},
+    {0}
+};
+
+const struct m_sub_options osd_bar_style_conf = {
+    .opts = bar_style_opts,
+    .size = sizeof(struct osd_bar_style_opts),
+    .defaults = &(const struct osd_bar_style_opts){
+        .align_y = 0.5,
+        .w = 75.0,
+        .h = 3.125,
+        .outline_size = 0.5,
+        .marker_scale = 1.3,
+        .marker_min_size = 1.6,
+        .marker_style = 1,
+    },
+    .change_flags = UPDATE_OSD,
+};
+
 bool osd_res_equals(struct mp_osd_res a, struct mp_osd_res b)
 {
     return a.w == b.w && a.h == b.h && a.ml == b.ml && a.mt == b.mt

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -163,8 +163,20 @@ struct osd_style_opts {
     char *fonts_dir;
 };
 
+struct osd_bar_style_opts {
+    float align_x;
+    float align_y;
+    float w;
+    float h;
+    float outline_size;
+    float marker_scale;
+    float marker_min_size;
+    int marker_style;
+};
+
 extern const struct m_sub_options osd_style_conf;
 extern const struct m_sub_options sub_style_conf;
+extern const struct m_sub_options osd_bar_style_conf;
 
 struct osd_state;
 struct osd_object;

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -363,6 +363,7 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
                             float *o_border)
 {
     struct mp_osd_render_opts *opts = osd->opts;
+    struct osd_bar_style_opts *bar_opts = opts->osd_bar_style;
 
     create_ass_track(osd, obj, &obj->ass);
     ASS_Track *track = obj->ass.track;
@@ -380,10 +381,10 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
     // and each bar ass event gets its own opaque box - breaking the bar.
     style->BorderStyle = 1; // outline
 
-    *o_w = track->PlayResX * (opts->osd_bar_style->w / 100.0);
-    *o_h = track->PlayResY * (opts->osd_bar_style->h / 100.0);
+    *o_w = track->PlayResX * (bar_opts->w / 100.0);
+    *o_h = track->PlayResY * (bar_opts->h / 100.0);
 
-    style->Outline = opts->osd_bar_style->outline_size;
+    style->Outline = bar_opts->outline_size;
     // Rendering with shadow is broken (because there's more than one shape)
     style->Shadow = 0;
     style->Blur = 0;
@@ -392,8 +393,8 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
 
     *o_border = style->Outline;
 
-    *o_x = get_align(opts->osd_bar_style->align_x, track->PlayResX, *o_w, *o_border);
-    *o_y = get_align(opts->osd_bar_style->align_y, track->PlayResY, *o_h, *o_border);
+    *o_x = get_align(bar_opts->align_x, track->PlayResX, *o_w, *o_border);
+    *o_y = get_align(bar_opts->align_y, track->PlayResY, *o_h, *o_border);
 }
 
 static void update_progbar(struct osd_state *osd, struct osd_object *obj)
@@ -469,14 +470,15 @@ static void update_progbar(struct osd_state *osd, struct osd_object *obj)
     // the "hole"
     ass_draw_rect_ccw(d, 0, 0, width, height);
 
+    struct osd_bar_style_opts *bar_opts = osd->opts->osd_bar_style;
     // chapter marks
-    if (osd->opts->osd_bar_style->marker_style) {
+    if (bar_opts->marker_style) {
         for (int n = 0; n < obj->progbar_state.num_stops; n++) {
             float s = obj->progbar_state.stops[n] * width;
-            float size = MPMAX(border * osd->opts->osd_bar_style->marker_scale,
-                               osd->opts->osd_bar_style->marker_min_size);
+            float size = MPMAX(border * bar_opts->marker_scale,
+                               bar_opts->marker_min_size);
 
-            if (osd->opts->osd_bar_style->marker_style == 2 &&
+            if (bar_opts->marker_style == 2 &&
                 s > size / 2 && s < width - size / 2)
             { // line
                 ass_draw_rect_cw(d, s - size / 2, 0, s + size / 2, height);

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -380,10 +380,10 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
     // and each bar ass event gets its own opaque box - breaking the bar.
     style->BorderStyle = 1; // outline
 
-    *o_w = track->PlayResX * (opts->osd_bar_w / 100.0);
-    *o_h = track->PlayResY * (opts->osd_bar_h / 100.0);
+    *o_w = track->PlayResX * (opts->osd_bar_style->w / 100.0);
+    *o_h = track->PlayResY * (opts->osd_bar_style->h / 100.0);
 
-    style->Outline = opts->osd_bar_outline_size;
+    style->Outline = opts->osd_bar_style->outline_size;
     // Rendering with shadow is broken (because there's more than one shape)
     style->Shadow = 0;
     style->Blur = 0;
@@ -392,8 +392,8 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
 
     *o_border = style->Outline;
 
-    *o_x = get_align(opts->osd_bar_align_x, track->PlayResX, *o_w, *o_border);
-    *o_y = get_align(opts->osd_bar_align_y, track->PlayResY, *o_h, *o_border);
+    *o_x = get_align(opts->osd_bar_style->align_x, track->PlayResX, *o_w, *o_border);
+    *o_y = get_align(opts->osd_bar_style->align_y, track->PlayResY, *o_h, *o_border);
 }
 
 static void update_progbar(struct osd_state *osd, struct osd_object *obj)
@@ -470,13 +470,13 @@ static void update_progbar(struct osd_state *osd, struct osd_object *obj)
     ass_draw_rect_ccw(d, 0, 0, width, height);
 
     // chapter marks
-    if (osd->opts->osd_bar_marker_style) {
+    if (osd->opts->osd_bar_style->marker_style) {
         for (int n = 0; n < obj->progbar_state.num_stops; n++) {
             float s = obj->progbar_state.stops[n] * width;
-            float size = MPMAX(border * osd->opts->osd_bar_marker_scale,
-                               osd->opts->osd_bar_marker_min_size);
+            float size = MPMAX(border * osd->opts->osd_bar_style->marker_scale,
+                               osd->opts->osd_bar_style->marker_min_size);
 
-            if (osd->opts->osd_bar_marker_style == 2 &&
+            if (osd->opts->osd_bar_style->marker_style == 2 &&
                 s > size / 2 && s < width - size / 2)
             { // line
                 ass_draw_rect_cw(d, s - size / 2, 0, s + size / 2, height);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -67,6 +67,17 @@ bool lavc_conv_is_styled(struct lavc_conv *priv);
 void lavc_conv_reset(struct lavc_conv *priv);
 void lavc_conv_uninit(struct lavc_conv *priv);
 
+struct mp_sub_filter_opts {
+    bool sub_filter_SDH;
+    bool sub_filter_SDH_harder;
+    char *sub_filter_SDH_enclosures;
+    bool rf_enable;
+    bool rf_plain;
+    char **rf_items;
+    char **jsre_items;
+    bool rf_warn;
+};
+
 struct sd_filter {
     struct mpv_global *global;
     struct mp_log *log;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -67,6 +67,29 @@ struct seen_packet {
     double pts;
 };
 
+#undef OPT_BASE_STRUCT
+#define OPT_BASE_STRUCT struct mp_sub_filter_opts
+
+const struct m_sub_options mp_sub_filter_opts = {
+    .opts = (const struct m_option[]){
+        {"sdh", OPT_BOOL(sub_filter_SDH)},
+        {"sdh-harder", OPT_BOOL(sub_filter_SDH_harder)},
+        {"sdh-enclosures", OPT_STRING(sub_filter_SDH_enclosures)},
+        {"regex-enable", OPT_BOOL(rf_enable)},
+        {"regex-plain", OPT_BOOL(rf_plain)},
+        {"regex", OPT_STRINGLIST(rf_items)},
+        {"jsre", OPT_STRINGLIST(jsre_items)},
+        {"regex-warn", OPT_BOOL(rf_warn)},
+        {0}
+    },
+    .size = sizeof(OPT_BASE_STRUCT),
+    .defaults = &(OPT_BASE_STRUCT){
+        .sub_filter_SDH_enclosures = "([\uFF08",
+        .rf_enable = true,
+    },
+    .change_flags = UPDATE_SUB_FILT,
+};
+
 static void mangle_colors(struct sd *sd, struct sub_bitmaps *parts);
 static void fill_plaintext(struct sd *sd, double pts);
 


### PR DESCRIPTION
Move several option definitions to the respective modules and use common prefix if possible. 