### PR TITLE
input: fix memory leak with scalable input and nonscalable commands

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -672,8 +672,11 @@ static void interpret_key(struct input_ctx *ictx, int code, double scale,
         scale_units = MPMIN(scale_units, 20);
         for (int i = 0; i < scale_units - 1; i++)
             queue_cmd(ictx, mp_cmd_clone(cmd));
-        if (scale_units)
+        if (scale_units) {
             queue_cmd(ictx, cmd);
+        } else {
+            talloc_free(cmd);
+        }
     }
 }
 


### PR DESCRIPTION
With scalable input source, scale_units can be 0, and cmd is not freed. Fix this by freeing cmd when scale_units is 0.

Fixes: 937128697fbbef6b21e2d23a4785f1334f62b9e3
