### PR TITLE
meson: define _UCRT_NOISY_NAN to workaround the non-constant NAN define

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -318,6 +318,9 @@ mswin_flags = ['-D_WIN32_WINNT=0x0A00', '-DWINVER=0x0A00', '-DUNICODE',
                '-D_CRT_DECLARE_NONSTDC_NAMES', '-D_CRT_NONSTDC_NO_WARNINGS',
                '-D_CRT_SECURE_NO_WARNINGS', '-DWINRT_NO_SOURCE_LOCATION']
 
+# https://developercommunity.visualstudio.com/t/NAN-is-no-longer-compile-time-constant-i/10688907
+mswin_flags += '-D_UCRT_NOISY_NAN'
+
 if host_machine.system() == 'windows'
     flags += [mswin_flags]
     flags_c += ['-U__STRICT_ANSI__']


### PR DESCRIPTION
Windows SDK 10.0.26100.0 defines the NAN macro in a non-constant manner. This violates the C/C++ standard and breaks the compilation of initializers with Clang.

See:
https://developercommunity.visualstudio.com/t/NAN-is-no-longer-compile-time-constant-i/10688907