### PR TITLE
mac/compat: fix compatibility for deployment targets lower than SDK ver

### DIFF
--- a/osdep/mac/compat.h
+++ b/osdep/mac/compat.h
@@ -17,12 +17,17 @@
 
 #pragma once
 
+#include <AvailabilityMacros.h>
 #include "config.h"
 
 #ifndef GL_SILENCE_DEPRECATION
 #define GL_SILENCE_DEPRECATION
 #endif
 
-#if !HAVE_MACOS_12_FEATURES
+#ifndef MAC_OS_VERSION_12_0
+#define MAC_OS_VERSION_12_0 120000
+#endif
+
+#if !HAVE_MACOS_12_FEATURES || (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0)
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
 #endif

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -44,10 +44,6 @@ extension NSDraggingInfo {
 }
 #endif
 
-#if !HAVE_MACOS_12_FEATURES
-let kIOMainPortDefault: mach_port_t = kIOMasterPortDefault
-#endif
-
 #if !HAVE_MACOS_12_FEATURES && HAVE_MACOS_11_FEATURES
 @available(macOS 11.0, *)
 extension CGColorSpace {

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -281,13 +281,16 @@ class Common: NSObject {
     }
 
     func initLightSensor() {
-        let srv = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleLMUController"))
+        let mainPort: mach_port_t
+        if #available(macOS 12.0, *) { mainPort = kIOMainPortDefault } else { mainPort = kIOMasterPortDefault }
+
+        let srv = IOServiceGetMatchingService(mainPort, IOServiceMatching("AppleLMUController"))
         if srv == IO_OBJECT_NULL {
             log.verbose("Can't find an ambient light sensor")
             return
         }
 
-        lightSensorIOPort = IONotificationPortCreate(kIOMainPortDefault)
+        lightSensorIOPort = IONotificationPortCreate(mainPort)
         IONotificationPortSetDispatchQueue(lightSensorIOPort, queue)
         var n = io_object_t()
         IOServiceAddInterestNotification(lightSensorIOPort, srv, kIOGeneralInterest, lightSensorCallback,


### PR DESCRIPTION
the swift parts can't be nicely encapsulated in the compat file because it lags proper target version compile time checks.

Fixes #15292