### PR TITLE
console.lua,wayland_common: also detect Wayland if WAYLAND_SOCKET set

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -19,7 +19,7 @@ local function detect_platform()
     local platform = mp.get_property_native('platform')
     if platform == 'darwin' or platform == 'windows' then
         return platform
-    elseif os.getenv('WAYLAND_DISPLAY') then
+    elseif os.getenv('WAYLAND_DISPLAY') or os.getenv('WAYLAND_SOCKET') then
         return 'wayland'
     end
     return 'x11'

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3024,7 +3024,7 @@ bool vo_wayland_valid_format(struct vo_wayland_state *wl, uint32_t drm_format, u
 
 bool vo_wayland_init(struct vo *vo)
 {
-    if (!getenv("WAYLAND_DISPLAY"))
+    if (!getenv("WAYLAND_DISPLAY") && !getenv("WAYLAND_SOCKET"))
         goto err;
 
     vo->wl = talloc_zero(NULL, struct vo_wayland_state);


### PR DESCRIPTION
This resolves a feature request that I made, in https://github.com/mpv-player/mpv/issues/15330 ; the issue gives more background and motivation.

To test: in a Wayland session, run mpv under a tool that sets WAYLAND_SOCKET, like `waypipe` with the `--oneshot` flag, or using the attached test script: [wldisplaytosocket.py.txt](https://github.com/user-attachments/files/17792476/wldisplaytosocket.py.txt). With this PR, `./wldisplaytosocket.py mpv path/to/video` should now behave the same as `mpv path/to/video`.


