### PR TITLE
command: add unload-input-conf command

### DIFF
--- a/DOCS/interface-changes/unload-input-conf.txt
+++ b/DOCS/interface-changes/unload-input-conf.txt
@@ -1,0 +1,1 @@
+add `unload-input-conf` command

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1068,6 +1068,10 @@ Input and Keybind Commands
     the file was already included, its previous bindings are not reset before it
     is reparsed.
 
+``unload-input-conf <filename>``
+    Remove the key bindings of an input configuration file previously loaded
+    with ``load-input-conf``.
+
 Execution Commands
 ~~~~~~~~~~~~~~~~~~
 

--- a/input/input.h
+++ b/input/input.h
@@ -193,6 +193,7 @@ void mp_input_load_config(struct input_ctx *ictx);
 
 // Load a specific input.conf file.
 bool mp_input_load_config_file(struct input_ctx *ictx, char *file);
+bool mp_input_unload_config_file(struct input_ctx *ictx, char *file);
 
 void mp_input_update_opts(struct input_ctx *ictx);
 

--- a/player/command.c
+++ b/player/command.c
@@ -6623,6 +6623,18 @@ static void cmd_load_input_conf(void *p)
     cmd->success = mp_input_load_config_file(mpctx->input, config_file);
 }
 
+static void cmd_unload_input_conf(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+    char *config_file = cmd->args[0].v.s;
+
+    if (!mp_input_unload_config_file(mpctx->input, config_file)) {
+        cmd->success = false;
+        MP_ERR(mpctx, "No key bindings from %s were loaded.\n", config_file);
+    }
+}
+
 static void cmd_load_script(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -7208,6 +7220,7 @@ const struct mp_cmd_def mp_cmds[] = {
     { "load-config-file", cmd_load_config_file, {{"filename", OPT_STRING(v.s)}} },
 
     { "load-input-conf", cmd_load_input_conf, {{"filename", OPT_STRING(v.s)}} },
+    { "unload-input-conf", cmd_unload_input_conf, {{"filename", OPT_STRING(v.s)}} },
 
     { "load-script", cmd_load_script, {{"filename", OPT_STRING(v.s)}} },
 


### PR DESCRIPTION
Add a command to remove bindings previously loaded with load-input-conf. This lets you load and then remove an input.conf without relying on deprecated input sections - at least externally, internally it still uses input sections, but this can be changed later without changing the API. This is mainly useful to load different key bindings for images and then restore the regular key bindings when switching to a video.

First, we need to assign key bindings loaded with a load-input-conf to a new input section instead of the default one, because bind_keys() permanently deallocates bindings in the same input section with the same key. This way if you bind a key in input.conf and load and unload another config file which binds the same key, the input.conf binding is restored. enable_section() is split from mp_input_enable_section() to avoid recursive locking.

The input section name is the path of the config file. It is not normalized to not break ~ expansion in parse_config_file().

unload-input-conf then deletes the input section whose name is the path argument. It is basically like the disable-section command. In theory you can also disable other input sections with unload-input-conf, but they are unlikely to clash with filenames with slashes and dots in practice, and it is not worth implementing much validation if we plan to discard input section code later.