### PR TITLE
player/loadfile: prefer non-image when selecting video track

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -491,6 +491,8 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs, bool
         return l1 > l2;
     if (t1->attached_picture != t2->attached_picture)
         return !t1->attached_picture;
+    if (t1->image != t2->image)
+        return !t1->image;
     if (t1->stream && t2->stream && opts->hls_bitrate >= 0 &&
         t1->stream->hls_bitrate != t2->stream->hls_bitrate)
     {


### PR DESCRIPTION
This fixes `ytdl_hook`, which would start playback with the thumbnail track selected. This issue occurs because the thumbnail track is added first. If the main track is not marked as default afterward, which it isn't for single streams, the first track (the image track) would be selected.

In general, if a non-image track is available, it should be preferred.