### PR TITLE
various: define builtin options and key bindings for images

### DIFF
--- a/DOCS/interface-changes/apply-image-profile.txt
+++ b/DOCS/interface-changes/apply-image-profile.txt
@@ -1,0 +1,1 @@
+add `--apply-image-profile` option

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -402,6 +402,29 @@ Ctrl+Wheel up/down
     Change video zoom keeping the part of the video hovered by the cursor under
     it.
 
+Image Bindings
+--------------
+
+When viewing images, the following key bindings optimized for image viewing are
+added. Key bindings not listed here, or those configured by the user in
+``input.conf``, keep behaving like with non-image files.
+
+LEFT, RIGHT, UP, DOWN
+    Pan the image when it is larger than the window.
+
+Shift+LEFT, Shift+RIGHT, Shift+UP, Shift+DOWN
+    Slowly pan the image when it is larger than the window.
+
+Ctrl+LEFT, Ctrl+RIGHT, Ctrl+UP, Ctrl+DOWN
+    Align the image to one of the boundaries of the window when it is larger
+    than the window.
+
+Middle click
+    Pan through the whole video while holding the button. See `POSITIONING`_ for
+    more information.
+
+See `Image profile`_ for image viewing tips.
+
 USAGE
 =====
 
@@ -1061,6 +1084,80 @@ example, ``math`` is defined and gives access to the Lua standard math library.
 
     This feature is subject to change indefinitely. You might be forced to
     adjust your profiles on mpv updates.
+
+Image profile
+-------------
+
+mpv has a builtin profile called ``builtin-image`` that is automatically applied
+to images and restored when switching to a video or audio file. It enables
+options optimal for image viewing, such as a smaller OSC layout optimized for
+images. Its full contents can be listed with ``mpv
+--show-profile=builtin-image``. It can be disabled with
+``--apply-image-profile=no``.
+
+It can be extended in mpv.conf without overwriting it completely:
+
+.. admonition:: Example to loop image playlists
+
+    ::
+
+        [builtin-image]
+        loop-playlist
+
+``--apply-image-profile`` also enables the image specific key bindings listed in
+`Keyboard Control`_. Additional image key bindings can be specified in the
+``image`` section in ``input.conf``, for example:
+
+    SPACE {image} repeatable playlist-next force
+    MBTN_LEFT {image} script-binding positioning/drag-to-pan
+
+Drag to pan on ``MBTN_LEFT`` requires adding ``window-dragging=no`` to
+``builtin-image``.
+
+See the `INPUT.CONF`_ section for more information on how to define key
+bindings.
+
+To reset zoom, alignment and rotation between images, it is recommended to place
+``reset-on-next-file=video-zoom,panscan,video-unscaled,video-align-x,video-align-y,video-rotate``
+in the top level of mpv.conf, as enabling it in the ``builtin-image`` profile
+makes it take effect only from the second image.
+
+To start viewing images and videos bigger than the window from the top left
+corner, these options can be set in the top level of mpv.conf along with
+``--reset-on-next-file``:
+
+.. admonition:: Start from the top left:
+
+    ::
+
+        video-align-x=-1
+        video-align-y=-1
+        video-recenter
+
+To enable the screensaver only when images are kept open forever, this profile
+can be added to mpv.conf:
+
+.. admonition:: Example to enable the screensaver:
+
+    ::
+
+        [screensaver]
+        profile-cond=p['current-tracks/video/image'] and not p['current-tracks/video/albumart'] and image_display_duration == math.huge
+        profile-restore=copy
+        stop-screensaver=no
+
+To display images larger than the max texture size of the GPU API, a VO with
+software rendering can be used as fallback:
+
+.. admonition:: Example to display huge images on Wayland:
+
+    ::
+
+        [huge]
+        profile-cond=width > 16384 or height > 16384
+        vo=wlshm
+
+maxImageExtent may be 8192 instead on old iGPUs.
 
 Legacy auto profiles
 --------------------

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -874,6 +874,11 @@ Program Behavior
     Show the description and content of a profile. Lists all profiles if no
     parameter is provided.
 
+``--apply-image-profile=<yes|no>``
+    Whether to apply the ``builtin-image`` profile and enable the ``image``
+    input section when viewing an image without audio, and to restore them when
+    switching to a video or audio file (default: yes).
+
 ``--use-filedir-conf``
     Look for a file-specific configuration file in the same directory as the
     file that is being played. See `File-specific Configuration Files`_.
@@ -1624,7 +1629,7 @@ Video
                 aspect ratio is not set. This is apparently the default behavior
                 with XBMC/kodi, at least with Matroska.
     :ignore:    Disable aspect ratio handling, pretend the video has square
-                pixels.
+                pixels. This is the default for images.
 
     The current default for mpv is ``container``.
 
@@ -1721,11 +1726,11 @@ Video
     when the video becomes smaller than the window in the respective direction
 
     After zooming in until the video is bigger than the window, panning with
-    `--video-align-x` and/or `--video-align-y`, and zooming out until the video
-    is smaller than the window, this is useful to recenter the video in the
-    window.
+    ``--video-align-x`` and/or ``--video-align-y``, and zooming out until the
+    video is smaller than the window, this is useful to recenter the video in
+    the window.
 
-    Default: no.
+    Default: no. The default is changed to yes for images.
 
 ``--video-margin-ratio-left=<val>``, ``--video-margin-ratio-right=<val>``, ``--video-margin-ratio-top=<val>``, ``--video-margin-ratio-bottom=<val>``
     Set extra video margins on each border (default: 0). Each value is a ratio
@@ -3442,7 +3447,7 @@ Window
     (Windows only)
     Enable/disable playback progress rendering in taskbar (Windows 7 and above).
 
-    Enabled by default.
+    Enabled by default, except for images.
 
 ``--snap-window``
     (Windows only) Snap the player window to screen edges.
@@ -4556,6 +4561,9 @@ Input
 
     Note that disabling the preprocessing does not affect any filtering done
     by the OS/driver before these events are delivered to mpv, if any.
+
+    This defaults to no for images to allow diagonal panning when the touchpad
+    is bound to pan commands.
 
 ``--input-right-alt-gr=<yes|no>``
     (macOS and Windows only)

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -178,6 +178,8 @@ Configurable Options
     bottombar, topbar, slimbottombar and slimtopbar. Default pre-0.21.0 was
     'box'.
 
+    slimbottombar is the default for images.
+
 ``seekbarstyle``
     Default: bar
 
@@ -239,6 +241,8 @@ Configurable Options
     of the window it will span. Values between 0.0 and 1.0, where 0 means the
     OSC will always popup with mouse movement in the window, and 1 means the
     OSC will only show up when the mouse hovers it. Default pre-0.21.0 was 0.
+
+    0.9 is the default for images.
 
 ``minmousemove``
     Default: 0

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -99,3 +99,12 @@ sub-shadow-offset=4
 [box]
 profile=osd-box
 profile=sub-box
+
+[builtin-image]
+profile-restore=copy-equal
+script-opt=osc-layout=slimbottombar
+script-opt=osc-deadzonesize=0.9
+video-recenter
+video-aspect-method=ignore
+input-preprocess-wheel=no
+taskbar-progress=no

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -245,3 +245,28 @@
 
 # ? cycle sub-forced-events-only        # display only DVD/PGS forced subtitle events
 # ? stop                                # stop playback (quit or enter idle mode)
+
+#
+# Image bindings
+#
+#MBTN_MID {image} script-binding positioning/align-to-cursor # pan the whole video
+
+#LEFT        {image} script-binding positioning/pan-x -0.1 # pan left
+#DOWN        {image} script-binding positioning/pan-y  0.1 # pan down
+#UP          {image} script-binding positioning/pan-y -0.1 # pan up
+#RIGHT       {image} script-binding positioning/pan-x  0.1 # pan right
+#Shift+LEFT  {image} script-binding positioning/pan-x -0.01 # pan left slowly
+#Shift+DOWN  {image} script-binding positioning/pan-y  0.01 # pan down slowly
+#Shift+UP    {image} script-binding positioning/pan-y -0.01 # pan up slowly
+#Shift+RIGHT {image} script-binding positioning/pan-x  0.01 # pan right slowly
+
+# Recommended on a touchpad:
+# WHEEL_UP    {image} script-binding positioning/pan-y -0.1 # pan up
+# WHEEL_DOWN  {image} script-binding positioning/pan-y  0.1 # pan down
+# WHEEL_LEFT  {image} script-binding positioning/pan-x -0.1 # pan left
+# WHEEL_RIGHT {image} script-binding positioning/pan-x  0.1 # pan right
+
+#Ctrl+LEFT   {image} no-osd set video-align-x -1 # align to the left
+#Ctrl+DOWN   {image} no-osd set video-align-y  1 # align to the bottom
+#Ctrl+UP     {image} no-osd set video-align-y -1 # align to the top
+#Ctrl+RIGHT  {image} no-osd set video-align-x  1 # align to the right

--- a/options/options.c
+++ b/options/options.c
@@ -498,6 +498,7 @@ static const m_option_t mp_opts[] = {
     {"profile", CONF_TYPE_STRING_LIST, 0, .offset = -1},
     {"show-profile", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_NOPROP |
         M_OPT_OPTIONAL_PARAM,  .offset = -1},
+    {"apply-image-profile", OPT_BOOL(apply_image_profile)},
     {"list-options", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
         .offset = -1},
     {"list-properties", OPT_BOOL(property_print_help),
@@ -1052,6 +1053,7 @@ static const struct MPOpts mp_default_opts = {
     .rebase_start_time = true,
     .keep_open_pause = true,
     .image_display_duration = 5.0,
+    .apply_image_profile = true,
     .stream_id = { { [STREAM_AUDIO] = -1,
                      [STREAM_VIDEO] = -1,
                      [STREAM_SUB] = -1, },

--- a/options/options.h
+++ b/options/options.h
@@ -302,6 +302,7 @@ typedef struct MPOpts {
     int keep_open;
     bool keep_open_pause;
     double image_display_duration;
+    bool apply_image_profile;
     char *lavfi_complex;
     int stream_id[2][STREAM_TYPE_COUNT];
     char **stream_lang[STREAM_TYPE_COUNT];

--- a/player/core.h
+++ b/player/core.h
@@ -436,6 +436,8 @@ typedef struct MPContext {
     // playback rate. Used to avoid showing it multiple times.
     bool drop_message_shown;
 
+    bool image_profile_applied;
+
     struct screenshot_ctx *screenshot_ctx;
     struct command_ctx *command_ctx;
     struct encode_lavc_context *encode_lavc_ctx;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1566,6 +1566,29 @@ static void load_external_opts(struct MPContext *mpctx)
     mp_waiter_wait(&wait);
 }
 
+static void toggle_image_profile(struct MPContext *mpctx)
+{
+    if (!mpctx->opts->apply_image_profile)
+        return;
+
+    if (!mpctx->image_profile_applied &&
+        mpctx->current_track[0][STREAM_VIDEO] &&
+        mpctx->current_track[0][STREAM_VIDEO]->image &&
+        !mpctx->current_track[0][STREAM_AUDIO]) {
+        m_config_set_profile(mpctx->mconfig, "builtin-image", 0);
+        mp_input_enable_section(mpctx->input, "image",
+                                MP_INPUT_ALLOW_HIDE_CURSOR|MP_INPUT_ALLOW_VO_DRAGGING);
+        mpctx->image_profile_applied = true;
+    } else if (mpctx->image_profile_applied &&
+        (!mpctx->current_track[0][STREAM_VIDEO] ||
+         !mpctx->current_track[0][STREAM_VIDEO]->image ||
+         mpctx->current_track[0][STREAM_AUDIO])) {
+        m_config_restore_profile(mpctx->mconfig, "builtin-image");
+        mp_input_disable_section(mpctx->input, "image");
+        mpctx->image_profile_applied = false;
+    }
+}
+
 static void append_to_watch_history(struct MPContext *mpctx)
 {
     if (!mpctx->opts->save_watch_history)
@@ -1883,6 +1906,8 @@ static void play_current_file(struct MPContext *mpctx)
 
     if (!mpctx->vo_chain)
         handle_force_window(mpctx, true);
+
+    toggle_image_profile(mpctx);
 
     MP_VERBOSE(mpctx, "Starting playback...\n");
 


### PR DESCRIPTION
This makes mpv usable as an image viewer out of the box, as it is currently hard to setup. Using mpv as an image viewer has several advantages, the biggest one is that it's the best program at browsing directories of mixed videos and images.

It adds a builtin image ~~conditional~~ profile that users can extend in mpv.conf. It is written to not restore and reapply the options on each image change, because that is slow for certain options (e.g. --d3d11-flip=no restarts the VO), and causes visible flicker when options like gamma are unapplied before changing image and reapplied on the next image. But it still restores the previous options after switching to a video or audio file.

~~etc/image-input.conf defines default key bindings for image, and \~/.config/mpv/image-input.conf can override them.~~

~~Files called image-input.conf are added to an input section called image, and builtin.conf enables it for images and disables it for non-images. Because enable-section and disable-section are only called in builtin.conf, they can be replaced with a different mechanism when deprecated input sections are removed without a breaking change.~~

~~Alternative to #15344, gives proper builtin support to image-input.conf instead of adding a new command to let user handle it. Input sections are only really useful for images, and it is fine to remove them if we support different image key bindings out of the box, and later disable them with a different mechanism, e.g. delete key bindings whose location contains image-input.conf. We already have many mechanisms to add key bindings anyway, input.conf, load-input-conf, mp.add_key_binding, the keybind command.~~

~~If this approach is considered good we can then actually decide the bindings and options.~~

Default image key bindings are now defined in the image input section so it's all in one input.conf.

Closes #7983.