### PR TITLE
Revert "input: allow input.conf bindings to be declared as builtin"

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -25,9 +25,6 @@
 # uncommented (unless '#' is followed by a space) - thus this file defines the
 # default key bindings.
 
-# If this is enabled, treat all the following bindings as default.
-#default-bindings start
-
 #MBTN_LEFT     ignore              # don't do anything
 #MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
 #MBTN_RIGHT    cycle pause         # toggle pause/playback mode

--- a/input/input.c
+++ b/input/input.c
@@ -1407,17 +1407,6 @@ static int parse_config(struct input_ctx *ictx, bool builtin, bstr data,
         line = bstr_lstrip(line);
         if (line.len == 0 || bstr_startswith0(line, "#"))
             continue;
-        if (bstr_eatstart0(&line, "default-bindings ")) {
-            bstr orig = line;
-            bstr_split_tok(line, "#", &line, &(bstr){0});
-            line = bstr_strip(line);
-            if (bstr_equals0(line, "start")) {
-                builtin = true;
-            } else {
-                MP_ERR(ictx, "Broken line: %.*s at %s\n", BSTR_P(orig), cur_loc);
-            }
-            continue;
-        }
         struct bstr command;
         // Find the key name starting a line
         struct bstr keyname = bstr_split(line, WHITESPACE, &command);


### PR DESCRIPTION
This reverts commit 70ff543029068188a3de39a80a764267c6671e7c.

This never did anything because mp_input_load_config() always already called parse_config() with builtin = true for builtin_input_conf. And we already have compatibility input.conf files without depending on this line. So unless someone can decipher what wm4 meant, it can be removed.