### PR TITLE
github/workflows: switch from pkg-config to pkgconf for macOS and Ubuntu mingw-w64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install -q autoconf automake pkg-config libtool python freetype fribidi little-cms2 \
+          brew install -q autoconf automake pkgconf libtool python freetype fribidi little-cms2 \
             luajit libass ffmpeg meson uchardet mujs libplacebo molten-vk vulkan-loader vulkan-headers
 
       - name: Build with meson

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,10 @@ jobs:
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete -print
           brew unlink python && brew link --overwrite python
 
+      - name: Unlink pkg-config if the CI runner happens to have it already installed
+        run: |
+          find "$(brew config | grep HOMEBREW_PREFIX | cut -f 2- -d ' ')/bin" -lname '*/pkg-config@0*/*' -print -exec brew unlink pkg-config@0.29.2 \; -quit
+
       - name: Change Xcode version
         if: ${{ matrix.xcode != '' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y ccache g++-mingw-w64 gcc-multilib meson nasm ninja-build pkg-config ${{ matrix.wine }}
+          sudo apt-get install -y ccache g++-mingw-w64 gcc-multilib meson nasm ninja-build pkgconf ${{ matrix.wine }}
 
       - name: Install Meson Wraps
         run: |

--- a/ci/lint-commit-msg.py
+++ b/ci/lint-commit-msg.py
@@ -4,7 +4,8 @@ import os
 import re
 import subprocess
 import sys
-from typing import Callable, Dict, Optional, Tuple
+from collections.abc import Callable
+from typing import Optional
 
 
 def call(cmd) -> str:
@@ -12,7 +13,7 @@ def call(cmd) -> str:
     ret = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, text=True)
     return ret.stdout
 
-lint_rules: Dict[str, Tuple[Callable, str]] = {}
+lint_rules: dict[str, tuple[Callable, str]] = {}
 
 # A lint rule should return True if everything is okay
 def lint_rule(description: str):


### PR DESCRIPTION
Latter is now available, and pkg-config as a package has been deprecated.

Additionally, attempt to work around recent GHA image breakage.