### PR TITLE
win32, wayland: add clipboard support

### DIFF
--- a/DOCS/interface-changes/clipboard.txt
+++ b/DOCS/interface-changes/clipboard.txt
@@ -1,0 +1,2 @@
+add `--clipboard-enable` and `--clipboard-monitor` options
+add `clipboard` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3893,6 +3893,23 @@ Property list
 
     This property is read-only, and change notification is not supported.
 
+``clipboard``
+    The clipboard contents, only works when native clipboard
+    (``--clipboard-enable``) is supported on the platform.
+    Depending on the platform, some sub-properties, writing to properties,
+    or change notifications are not currently functional.
+
+    This has a number of sub-properties:
+
+    ``clipboard/text`` (RW)
+        The text content in the clipboard (Windows and Wayland only).
+        Writing to this property sets the text clipboard content (Windows only).
+
+    .. note::
+
+        On Wayland, the clipboard content is only updated when the compositor
+        sends a selection data offer (typically when VO window is focused).
+
 Inconsistencies between options and properties
 ----------------------------------------------
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7793,3 +7793,18 @@ Miscellaneous
     code is the same.)
 
     Conversion is not applied to metadata that is updated at runtime.
+
+``--clipboard-enable=<yes|no>``
+    (Windows and Wayland only)
+
+    Enable native clipboard support (default: yes). This allows reading and
+    writing to the ``clipboard`` property to get and set clipboard contents.
+
+``--clipboard-monitor=<yes|no>``
+    (Windows only)
+
+    Enable clipboard monitoring so that the ``clipboard`` property can be
+    observed for content changes (default: no). This only affects clipboard
+    implementations which use polling to monitor clipboard updates.
+    Other platforms currently ignore this option and always/never notify
+    changes.

--- a/meson.build
+++ b/meson.build
@@ -173,6 +173,10 @@ sources = files(
     'player/sub.c',
     'player/video.c',
 
+    ## clipboard
+    'player/clipboard/clipboard.c',
+    'player/clipboard/clipboard-vo.c',
+
     ## Streams
     'stream/cookies.c',
     'stream/stream.c',
@@ -257,7 +261,7 @@ sources = files(
     ## tree_allocator
     'ta/ta.c',
     'ta/ta_talloc.c',
-    'ta/ta_utils.c'
+    'ta/ta_utils.c',
 )
 
 
@@ -525,6 +529,7 @@ if features['win32-desktop']
         sources += files('osdep/subprocess-dummy.c')
     endif
     sources += files('input/ipc-win.c',
+                     'player/clipboard/clipboard-win.c',
                      'osdep/language-win.c',
                      'osdep/terminal-win.c',
                      'video/out/w32_common.c',

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -458,7 +458,8 @@ char *format_file_size(int64_t size);
 #define UPDATE_SUB_EXTS         (1 << 23) // update internal list of sub exts
 #define UPDATE_VIDEO            (1 << 24) // force redraw if needed
 #define UPDATE_VO               (1 << 25) // reinit the VO
-#define UPDATE_OPT_LAST         (1 << 25)
+#define UPDATE_CLIPBOARD        (1 << 26) // reinit the clipboard
+#define UPDATE_OPT_LAST         (1 << 26)
 
 // All bits between _FIRST and _LAST (inclusive)
 #define UPDATE_OPTS_MASK \

--- a/options/options.c
+++ b/options/options.c
@@ -89,6 +89,7 @@ extern const struct m_obj_list vo_obj_list;
 extern const struct m_sub_options ao_conf;
 
 extern const struct m_sub_options dvd_conf;
+extern const struct m_sub_options clipboard_conf;
 
 extern const struct m_sub_options opengl_conf;
 extern const struct m_sub_options vulkan_conf;
@@ -864,6 +865,8 @@ static const m_option_t mp_opts[] = {
     {"", OPT_SUBSTRUCT(resample_opts, resample_conf)},
 
     {"", OPT_SUBSTRUCT(input_opts, input_config)},
+
+    {"clipboard", OPT_SUBSTRUCT(clipboard_opts, clipboard_conf)},
 
     {"", OPT_SUBSTRUCT(vo, vo_sub_opts)},
     {"", OPT_SUBSTRUCT(demux_opts, demux_conf)},

--- a/options/options.h
+++ b/options/options.h
@@ -356,6 +356,8 @@ typedef struct MPOpts {
 
     struct input_opts *input_opts;
 
+    struct clipboard_opts *clipboard_opts;
+
     struct encode_opts *encode_opts;
 
     char *ipc_path;

--- a/player/clipboard/clipboard-vo.c
+++ b/player/clipboard/clipboard-vo.c
@@ -1,0 +1,44 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/common.h"
+#include "clipboard.h"
+
+static int init(struct clipboard_ctx *cl, struct clipboard_init_params *params)
+{
+    return CLIPBOARD_FAILED;
+}
+
+static int get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *out, void *talloc_ctx)
+{
+    return CLIPBOARD_FAILED;
+}
+
+static int set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *data)
+{
+    return CLIPBOARD_FAILED;
+}
+
+const struct clipboard_backend clipboard_backend_vo = {
+    .name = "vo",
+    .desc = "VO clipboard",
+    .init = init,
+    .get_data = get_data,
+    .set_data = set_data,
+};

--- a/player/clipboard/clipboard-win.c
+++ b/player/clipboard/clipboard-win.c
@@ -1,0 +1,45 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <windows.h>
+#include "common/common.h"
+#include "clipboard.h"
+
+static int init(struct clipboard_ctx *cl, struct clipboard_init_params *params)
+{
+    return CLIPBOARD_FAILED;
+}
+
+static int get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *out, void *talloc_ctx)
+{
+    return CLIPBOARD_FAILED;
+}
+
+static int set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *data)
+{
+    return CLIPBOARD_FAILED;
+}
+
+const struct clipboard_backend clipboard_backend_win32 = {
+    .name = "win32",
+    .desc = "Windows clipboard",
+    .init = init,
+    .get_data = get_data,
+    .set_data = set_data,
+};

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -102,7 +102,8 @@ void reinit_clipboard(struct MPContext *mpctx)
 
     struct clipboard_opts *opts = mp_get_config_group(NULL, mpctx->global, &clipboard_conf);
     if (opts->enabled) {
-        mpctx->clipboard = mp_clipboard_create(&(struct clipboard_init_params){0}, mpctx->global);
+        struct clipboard_init_params params = {.mpctx = mpctx};
+        mpctx->clipboard = mp_clipboard_create(&params, mpctx->global);
     }
     talloc_free(opts);
 }

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/common.h"
+#include "options/m_config.h"
+#include "player/core.h"
+#include "clipboard.h"
+
+struct clipboard_opts {
+    bool enabled;
+};
+
+#define OPT_BASE_STRUCT struct clipboard_opts
+const struct m_sub_options clipboard_conf = {
+    .opts = (const struct m_option[]) {
+        {"enable", OPT_BOOL(enabled), .flags = UPDATE_CLIPBOARD},
+        {0}
+    },
+    .defaults = &(const struct clipboard_opts) {
+        .enabled = true,
+    },
+    .size = sizeof(struct clipboard_opts)
+};
+
+// backend list
+extern const struct clipboard_backend clipboard_backend_win32;
+extern const struct clipboard_backend clipboard_backend_vo;
+
+static const struct clipboard_backend *const clipboard_backend_list[] = {
+#if HAVE_WIN32_DESKTOP
+    &clipboard_backend_win32,
+#endif
+    &clipboard_backend_vo,
+};
+
+struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
+                                          struct mpv_global *global)
+{
+    struct clipboard_ctx *cl = talloc_ptrtype(NULL, cl);
+    *cl = (struct clipboard_ctx) {
+        .log = mp_log_new(cl, global->log, "clipboard"),
+        .global = global,
+    };
+
+    for (int i = 0; i < MP_ARRAY_SIZE(clipboard_backend_list); i++) {
+        const struct clipboard_backend *backend = clipboard_backend_list[i];
+        if (backend->init(cl, params) == CLIPBOARD_SUCCESS) {
+            MP_VERBOSE(cl, "Initialized %s clipboard backend.\n", backend->name);
+            cl->backend = backend;
+            goto success;
+        }
+    }
+
+    MP_WARN(cl, "Failed to initialize any clipboard backend.\n");
+    talloc_free(cl);
+    return NULL;
+success:
+    return cl;
+}
+
+void mp_clipboard_destroy(struct clipboard_ctx *cl)
+{
+    if (cl && cl->backend->uninit)
+        cl->backend->uninit(cl);
+    talloc_free(cl);
+}
+
+int mp_clipboard_get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                          struct clipboard_data *out, void *talloc_ctx)
+{
+    if (cl && cl->backend->get_data)
+        return cl->backend->get_data(cl, params, out, talloc_ctx);
+    return CLIPBOARD_FAILED;
+}
+
+int mp_clipboard_set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                          struct clipboard_data *data)
+{
+    if (cl && cl->backend->set_data)
+        return cl->backend->set_data(cl, params, data);
+    return CLIPBOARD_FAILED;
+}
+
+void reinit_clipboard(struct MPContext *mpctx)
+{
+    mp_clipboard_destroy(mpctx->clipboard);
+    mpctx->clipboard = NULL;
+
+    struct clipboard_opts *opts = mp_get_config_group(NULL, mpctx->global, &clipboard_conf);
+    if (opts->enabled) {
+        mpctx->clipboard = mp_clipboard_create(&(struct clipboard_init_params){0}, mpctx->global);
+    }
+    talloc_free(opts);
+}

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -49,6 +49,7 @@ struct clipboard_data {
 
 struct clipboard_init_params {
     int flags;
+    struct MPContext *mpctx; // For clipboard_vo only
 };
 
 struct clipboard_access_params {

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -1,0 +1,88 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/common.h"
+#include "common/global.h"
+#include "video/mp_image.h"
+
+struct clipboard_ctx;
+struct MPContext;
+
+enum clipboard_data_type {
+    CLIPBOARD_DATA_TEXT,
+    CLIPBOARD_DATA_IMAGE,
+};
+
+enum clipboard_target {
+    CLIPBOARD_TARGET_CLIPBOARD,
+    CLIPBOARD_TARGET_PRIMARY_SELECTION,
+};
+
+enum clipboard_result {
+    CLIPBOARD_SUCCESS = 0,
+    CLIPBOARD_FAILED = -1,
+};
+
+struct clipboard_data {
+    enum clipboard_data_type type;
+    union {
+        char *text;
+        struct mp_image *image;
+    } u;
+};
+
+struct clipboard_init_params {
+    int flags;
+};
+
+struct clipboard_access_params {
+    int flags;
+    enum clipboard_data_type type;
+    enum clipboard_target target;
+};
+
+struct clipboard_backend {
+    const char *name;
+    const char *desc;
+
+    // Return 0 on success, otherwise -1
+    int (*init)(struct clipboard_ctx *cl, struct clipboard_init_params *params);
+    void (*uninit)(struct clipboard_ctx *cl);
+    int (*get_data)(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *out, void *talloc_ctx);
+    int (*set_data)(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *data);
+};
+
+struct clipboard_ctx {
+    const struct clipboard_backend *backend; // clipboard description structure
+    struct mp_log *log;
+    void *priv;   // backend-specific internal data
+    struct mpv_global *global;
+};
+
+struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
+                                          struct mpv_global *global);
+void mp_clipboard_destroy(struct clipboard_ctx *cl);
+int mp_clipboard_get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                          struct clipboard_data *out, void *talloc_ctx);
+int mp_clipboard_set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                          struct clipboard_data *data);
+
+void reinit_clipboard(struct MPContext *mpctx);

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -24,7 +24,7 @@
 struct clipboard_ctx;
 struct MPContext;
 
-#define CLIPBOARD_INIT_ENABLE_MONITORING 1
+#define CLIPBOARD_INIT_ENABLE_MONITORING (1 << 0)
 
 enum clipboard_data_type {
     CLIPBOARD_DATA_TEXT,

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -24,6 +24,8 @@
 struct clipboard_ctx;
 struct MPContext;
 
+#define CLIPBOARD_INIT_ENABLE_MONITORING 1
+
 enum clipboard_data_type {
     CLIPBOARD_DATA_TEXT,
     CLIPBOARD_DATA_IMAGE,
@@ -65,6 +67,7 @@ struct clipboard_backend {
     // Return 0 on success, otherwise -1
     int (*init)(struct clipboard_ctx *cl, struct clipboard_init_params *params);
     void (*uninit)(struct clipboard_ctx *cl);
+    bool (*data_changed)(struct clipboard_ctx *cl);
     int (*get_data)(struct clipboard_ctx *cl, struct clipboard_access_params *params,
                     struct clipboard_data *out, void *talloc_ctx);
     int (*set_data)(struct clipboard_ctx *cl, struct clipboard_access_params *params,
@@ -76,11 +79,13 @@ struct clipboard_ctx {
     struct mp_log *log;
     void *priv;   // backend-specific internal data
     struct mpv_global *global;
+    bool monitor;
 };
 
 struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
                                           struct mpv_global *global);
 void mp_clipboard_destroy(struct clipboard_ctx *cl);
+bool mp_clipboard_data_changed(struct clipboard_ctx *cl);
 int mp_clipboard_get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
                           struct clipboard_data *out, void *talloc_ctx);
 int mp_clipboard_set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,

--- a/player/command.c
+++ b/player/command.c
@@ -6857,6 +6857,14 @@ static void cmd_flush_status_line(void *p)
     mp_msg_flush_status_line(mpctx->log, cmd->args[0].v.b);
 }
 
+static void cmd_notify_property(void *p)
+{
+    struct mp_cmd_ctx *cmd = p;
+    struct MPContext *mpctx = cmd->mpctx;
+
+    mp_notify_property(mpctx, cmd->args[0].v.s);
+}
+
 /* This array defines all known commands.
  * The first field the command name used in libmpv and input.conf.
  * The second field is the handler function (see mp_cmd_def.handler and
@@ -7334,6 +7342,8 @@ const struct mp_cmd_def mp_cmds[] = {
     { "context-menu", cmd_context_menu },
 
     { "flush-status-line", cmd_flush_status_line, { {"clear", OPT_BOOL(v.b)} } },
+
+    { "notify-property", cmd_notify_property, { {"property", OPT_STRING(v.s)} } },
 
     {0}
 };

--- a/player/command.c
+++ b/player/command.c
@@ -32,6 +32,7 @@
 
 #include "mpv_talloc.h"
 #include "client.h"
+#include "clipboard/clipboard.h"
 #include "external_files.h"
 #include "common/av_common.h"
 #include "common/codecs.h"
@@ -7489,6 +7490,9 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 
     if (flags & UPDATE_INPUT)
         mp_input_update_opts(mpctx->input);
+
+    if (flags & UPDATE_CLIPBOARD)
+        reinit_clipboard(mpctx);
 
     if (flags & UPDATE_SUB_EXTS)
         mp_update_subtitle_exts(mpctx->opts);

--- a/player/core.h
+++ b/player/core.h
@@ -24,6 +24,7 @@
 #include "libmpv/client.h"
 
 #include "audio/aframe.h"
+#include "clipboard/clipboard.h"
 #include "common/common.h"
 #include "filters/f_output_chain.h"
 #include "filters/filter.h"
@@ -285,6 +286,8 @@ typedef struct MPContext {
     enum stop_play_reason stop_play;
     bool playback_initialized; // playloop can be run/is running
     int error_playing;
+
+    struct clipboard_ctx *clipboard;
 
     // Return code to use with PT_QUIT
     int quit_custom_rc;

--- a/player/main.c
+++ b/player/main.c
@@ -197,6 +197,7 @@ void mp_destroy(struct MPContext *mpctx)
     }
 
     mp_input_uninit(mpctx->input);
+    mp_clipboard_destroy(mpctx->clipboard);
 
     uninit_libav(mpctx->global);
 

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1211,6 +1211,12 @@ static void handle_eof(struct MPContext *mpctx)
     }
 }
 
+static void handle_clipboard_updates(struct MPContext *mpctx)
+{
+    if (mp_clipboard_data_changed(mpctx->clipboard))
+        mp_notify_property(mpctx, "clipboard");
+}
+
 void run_playloop(struct MPContext *mpctx)
 {
     if (encode_lavc_didfail(mpctx->encode_lavc_ctx)) {
@@ -1235,6 +1241,8 @@ void run_playloop(struct MPContext *mpctx)
     handle_playback_time(mpctx);
 
     handle_dummy_ticks(mpctx);
+
+    handle_clipboard_updates(mpctx);
 
     update_osd_msg(mpctx);
 
@@ -1276,6 +1284,7 @@ void run_playloop(struct MPContext *mpctx)
 void mp_idle(struct MPContext *mpctx)
 {
     handle_dummy_ticks(mpctx);
+    handle_clipboard_updates(mpctx);
     mp_wait_events(mpctx);
     mp_process_input(mpctx);
     handle_command_updates(mpctx);

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -30,6 +30,7 @@
 #include "common/common.h"
 #include "options/options.h"
 #include "osdep/threads.h"
+#include "player/clipboard/clipboard.h"
 
 enum {
     // VO needs to redraw
@@ -129,6 +130,10 @@ enum mp_voctrl {
     // Native context menu
     VOCTRL_SHOW_MENU,
     VOCTRL_UPDATE_MENU,
+
+    // Clipboard
+    VOCTRL_GET_CLIPBOARD,               // struct voctrl_clipboard*
+    VOCTRL_SET_CLIPBOARD,
 };
 
 // Helper to expose what kind of content is currently playing to the VO.
@@ -178,6 +183,12 @@ struct voctrl_performance_data {
 struct voctrl_screenshot {
     bool scaled, subs, osd, high_bit_depth, native_csp;
     struct mp_image *res;
+};
+
+struct voctrl_clipboard {
+    struct clipboard_data data;
+    struct clipboard_access_params params;
+    void *talloc_ctx;
 };
 
 enum {

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3019,6 +3019,15 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         return set_screensaver_inhibitor(wl, true);
     case VOCTRL_RESTORE_SCREENSAVER:
         return set_screensaver_inhibitor(wl, false);
+    case VOCTRL_GET_CLIPBOARD: {
+        struct voctrl_clipboard *vc = arg;
+        // TODO: add primary selection support
+        if (vc->params.target != CLIPBOARD_TARGET_CLIPBOARD || vc->params.type != CLIPBOARD_DATA_TEXT)
+            return VO_NOTAVAIL;
+        vc->data.type = CLIPBOARD_DATA_TEXT;
+        vc->data.u.text = bstrto0(vc->talloc_ctx, wl->selection_text);
+        return VO_TRUE;
+    }
     }
 
     return VO_NOTIMPL;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1864,9 +1864,8 @@ static void destroy_offer(struct vo_wayland_data_offer *o)
     *o = (struct vo_wayland_data_offer){.fd = -1, .action = -1};
 }
 
-static void check_dnd_fd(struct vo_wayland_state *wl)
+static void check_fd(struct vo_wayland_state *wl, struct vo_wayland_data_offer *o, bool is_dnd)
 {
-    struct vo_wayland_data_offer *o = wl->dnd_offer;
     if (o->fd == -1)
         return;
 
@@ -1877,41 +1876,43 @@ static void check_dnd_fd(struct vo_wayland_state *wl)
     if (fdp.revents & POLLIN) {
         ssize_t data_read = 0;
         const size_t chunk_size = 256;
-        bstr file_list = {
-            .start = talloc_zero_size(NULL, chunk_size),
+        bstr content = {
+            .start = talloc_zero_size(wl, chunk_size),
         };
 
         while (1) {
-            data_read = read(o->fd, file_list.start + file_list.len, chunk_size);
+            data_read = read(o->fd, content.start + content.len, chunk_size);
             if (data_read == -1 && errno == EINTR)
                 continue;
             else if (data_read <= 0)
                 break;
-            file_list.len += data_read;
-            file_list.start = talloc_realloc_size(NULL, file_list.start, file_list.len + chunk_size);
-            memset(file_list.start + file_list.len, 0, chunk_size);
+            content.len += data_read;
+            content.start = talloc_realloc_size(wl, content.start, content.len + chunk_size);
+            memset(content.start + content.len, 0, chunk_size);
         }
 
         if (data_read == -1) {
-            MP_VERBOSE(wl, "DND aborted (read error)\n");
+            MP_VERBOSE(wl, "data offer aborted (read error)\n");
         } else {
-            MP_VERBOSE(wl, "Read %zu bytes from the DND fd\n", file_list.len);
+            MP_VERBOSE(wl, "Read %zu bytes from the data offer fd\n", content.len);
 
-            if (o->offer)
-                wl_data_offer_finish(o->offer);
+            if (is_dnd) {
+                if (o->offer)
+                    wl_data_offer_finish(o->offer);
 
-            assert(o->action >= 0);
-            mp_event_drop_mime_data(wl->vo->input_ctx, o->mime_type,
-                                    file_list, o->action);
+                assert(o->action >= 0);
+                mp_event_drop_mime_data(wl->vo->input_ctx, o->mime_type,
+                                        content, o->action);
+            }
         }
 
-        talloc_free(file_list.start);
+        talloc_free(content.start);
         destroy_offer(o);
     }
 
     if (fdp.revents & (POLLIN | POLLERR | POLLHUP)) {
         if (o->action >= 0)
-            MP_VERBOSE(wl, "DND aborted (hang up or error)\n");
+            MP_VERBOSE(wl, "data offer aborted (hang up or error)\n");
         destroy_offer(o);
     }
 }
@@ -2856,7 +2857,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
 
     switch (request) {
     case VOCTRL_CHECK_EVENTS: {
-        check_dnd_fd(wl);
+        check_fd(wl, wl->dnd_offer, true);
         *events |= wl->pending_vo_events;
         if (*events & VO_EVENT_RESIZE) {
             *events |= VO_EVENT_EXPOSE;

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1923,6 +1923,10 @@ static void check_fd(struct vo_wayland_state *wl, struct vo_wayland_data_offer *
                 talloc_free(wl->selection_text.start);
                 wl->selection_text = content;
                 content = (bstr){0};
+                mp_cmd_t *cmd = mp_input_parse_cmd(
+                    wl->vo->input_ctx, bstr0("notify-property clipboard"), "<internal>"
+                );
+                mp_input_queue_cmd(wl->vo->input_ctx, cmd);
             }
         }
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -166,6 +166,7 @@ struct vo_wayland_state {
     struct vo_wayland_data_offer *pending_offer;
     struct vo_wayland_data_offer *dnd_offer;
     struct vo_wayland_data_offer *selection_offer;
+    bstr selection_text;
 
     /* Cursor */
     struct wl_cursor_theme *cursor_theme;


### PR DESCRIPTION
Alternative to https://github.com/mpv-player/mpv/pull/13837.

This adds a general internal clipboard API with support for different formats, targets, and autoprobing backends, and implements 2 clipboard backends (win32and VO) and Wayland support for the VO backend. The clipboard can be interacted publicly with the `clipboard` property, with change notification support. The internal API provides a polling interface for clipboard backends which use polling for notification. Other backends monitors changes in the backgrounds and notify the property when changes are detected.

Currently, only text format and clipboard target is implemented, but image formats and primary selection target can be added later. 

`console.lua` is changed to use the clipboard property when supported. 

Fixes: https://github.com/mpv-player/mpv/issues/14373
Partially fixes (currently Windows, other platforms can be added later): https://github.com/mpv-player/mpv/issues/7361