### PR TITLE
console.lua: select fixes

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1814,7 +1814,7 @@ mp.register_script_message('get-input', function (script_name, args)
     if args.items then
         selectable_items = {}
         for i, item in ipairs(args.items) do
-            selectable_items[i] = item:gsub("[\r\n].*", "⋯")
+            selectable_items[i] = item:gsub("[\r\n].*", "⋯"):sub(1, 300)
         end
 
         matches = {}

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1811,8 +1811,12 @@ mp.register_script_message('get-input', function (script_name, args)
     history = histories[id]
     history_pos = #history + 1
 
-    selectable_items = args.items
-    if selectable_items then
+    if args.items then
+        selectable_items = {}
+        for i, item in ipairs(args.items) do
+            selectable_items[i] = item:gsub("[\r\n].*", "⋯")
+        end
+
         matches = {}
         selected_match = args.default_item or 1
         default_item = args.default_item


### PR DESCRIPTION
console.lua: strip multiple lines in selectable items

If an item contains newlines, it hides the top items. This is often the case for sub-ass-extradata and metadata/ytdl_description in the property list. So keep only the first line.


console.lua: limit the length of selectable items

Giving very long lines to libass freezes mpv and makes the CPU spin (though it's fine with terminal output). This is often the case user-data/mpv/ytdl/json-subprocess-result in the property list. So limit the length of selectable items to 300 characters (not Unicode aware). This is enough to fill a 1920x1080 window with font_size=16 and Japanese text.