### PR TITLE
wayland: compare vo_wayland_output structs instead of wl_output

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -909,7 +909,7 @@ static void output_handle_done(void *data, struct wl_output *wl_output)
     /* If we satisfy this conditional, something about the current
      * output must have changed (resolution, scale, etc). All window
      * geometry and scaling should be recalculated. */
-    if (wl->current_output && wl->current_output->output == wl_output) {
+    if (wl->current_output && wl->current_output == o) {
         set_surface_scaling(wl);
         set_geometry(wl, false);
         prepare_resize(wl);


### PR DESCRIPTION
When a surface is overlapping two outputs, and one of the outputs is disconnected then reconnected again, this condition is never satisfied upon reconnection causing us to use incorrect output geometry/scaling etc.