### PR TITLE
wayland: always recalculate scaling if wl->current_output is not set

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1016,7 +1016,9 @@ static void surface_handle_preferred_buffer_scale(void *data,
 {
     struct vo_wayland_state *wl = data;
 
-    if (wl->fractional_scale_manager || wl->scaling == scale * WAYLAND_SCALE_FACTOR)
+    if (wl->fractional_scale_manager ||
+        (wl->scaling == scale * WAYLAND_SCALE_FACTOR &&
+         wl->current_output && wl->current_output->has_surface))
         return;
 
     wl->pending_scaling = scale * WAYLAND_SCALE_FACTOR;
@@ -1248,7 +1250,7 @@ static void preferred_scale(void *data,
                             uint32_t scale)
 {
     struct vo_wayland_state *wl = data;
-    if (wl->scaling == scale)
+    if (wl->scaling == scale && wl->current_output && wl->current_output->has_surface)
         return;
 
     wl->pending_scaling = scale;


### PR DESCRIPTION
If we lose the current output for any reason (unplug, turns off, etc.) and then later it comes back, mpv should always recalculate all the scaling stuff. The optimization to avoid needless scaling calculations didn't consider this case and would always exit since the scaling is the same. So just check wl->current_output's existence as well.

Fixes #15361.
