### PR TITLE
console.lua: save commands in history after autocompletion

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -808,9 +808,6 @@ local function handle_enter()
     if line == '' and input_caller == nil then
         return
     end
-    if history[#history] ~= line and line ~= '' then
-        history_add(line)
-    end
 
     if selectable_items then
         if #matches > 0 then
@@ -834,6 +831,10 @@ local function handle_enter()
         else
             mp.command(line)
         end
+    end
+
+    if history[#history] ~= line and line ~= '' then
+        history_add(line)
     end
 
     clear()

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -367,7 +367,8 @@ local function format_table(list, width_max, rows_max)
                                   or '%-' .. math.min(column_widths[column], 99) .. 's'
             columns[column] = ass_escape(string.format(format_string, list[i]))
 
-            if i == selected_suggestion_index then
+            if i == selected_suggestion_index or
+               (i == 1 and selected_suggestion_index == 0) then
                 columns[column] = styles.selected_suggestion .. columns[column]
                                   .. '{\\b0}'.. styles.suggestion
             end


### PR DESCRIPTION
2f271a92de made it so that the first completion suggestion is automatically selected when pressing enter, but that was done after saving the command in the history. Save it to the history after expanding it, so re-running the previous command actually works, e.g. save "set vo gpu-next" instead of "set vo gn".