### PR TITLE
mp_image: always force RGB formats to full-range RGB

### DIFF
--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -960,10 +960,8 @@ void mp_image_params_guess_csp(struct mp_image_params *params)
         if (params->color.transfer == PL_COLOR_TRC_UNKNOWN)
             params->color.transfer = PL_COLOR_TRC_BT_1886;
     } else if (forced_csp == PL_COLOR_SYSTEM_RGB) {
-        if (params->repr.sys == PL_COLOR_SYSTEM_UNKNOWN)
-            params->repr.sys = PL_COLOR_SYSTEM_RGB;
-        if (params->repr.levels == PL_COLOR_LEVELS_UNKNOWN)
-            params->repr.levels = PL_COLOR_LEVELS_FULL;
+        params->repr.sys = PL_COLOR_SYSTEM_RGB;
+        params->repr.levels = PL_COLOR_LEVELS_FULL;
 
         // The majority of RGB content is either sRGB or (rarely) some other
         // color space which we don't even handle, like AdobeRGB or


### PR DESCRIPTION
It turns out mpv doesn't tag at all when doing conversions, so we just re-tag here and hope for the best. This should be improved, but there are many different code paths when conversion can happen, so for now revert to previous behavior.

Fixes: 4e5cc9cf1dd7471eca3c9c43c60fbf680dea2aa6