### PR TITLE
mac: implement VOCTRL_BEGIN_DRAGGING

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1558,8 +1558,9 @@ Miscellaneous Commands
     Begin window dragging if supported by the current VO. This command should
     only be called while a mouse button is being pressed, otherwise it will
     be ignored. The exact effect of this command depends on the VO implementation
-    of window dragging. For example, on Windows only the left mouse button can
-    begin window dragging, while X11 and Wayland allow other mouse buttons.
+    of window dragging. For example, on Windows and macOS only the left mouse
+    button can begin window dragging, while X11 and Wayland allow other mouse
+    buttons.
 
 ``context-menu``
     Show context menu on the video window. See `Context Menu`_ section for details.

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -139,8 +139,6 @@ class Common: NSObject {
             DispatchQueue.main.async {
                 self.window?.toggleFullScreen(nil)
             }
-        } else {
-            window?.isMovableByWindowBackground = true
         }
     }
 
@@ -646,6 +644,9 @@ class Common: NSObject {
             DispatchQueue.main.async {
                 self.title = title
             }
+            return VO_TRUE
+        case VOCTRL_BEGIN_DRAGGING:
+            self.window?.startDragging()
             return VO_TRUE
         default:
             return VO_NOTIMPL

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -23,6 +23,7 @@ class View: NSView, CALayerDelegate {
 
     var tracker: NSTrackingArea?
     var hasMouseDown: Bool = false
+    var lastMouseDownEvent: NSEvent?
 
     override var isFlipped: Bool { return true }
     override var acceptsFirstResponder: Bool { return true }
@@ -137,6 +138,7 @@ class View: NSView, CALayerDelegate {
     override func mouseDown(with event: NSEvent) {
         hasMouseDown = event.clickCount <= 1
         input?.processMouse(event: event)
+        lastMouseDownEvent = event
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -176,7 +178,6 @@ class View: NSView, CALayerDelegate {
         point = convertToBacking(point)
         point.y = -point.y
 
-        common.window?.updateMovableBackground(point)
         if !(common.window?.isMoving ?? false) {
             input?.setMouse(position: point)
         }

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -332,11 +332,13 @@ class Window: NSWindow, NSWindowDelegate {
         zoom(self)
     }
 
-    func updateMovableBackground(_ pos: NSPoint) {
-        if !isInFullscreen {
-            isMovableByWindowBackground = input?.draggable(at: pos) ?? true
-        } else {
-            isMovableByWindowBackground = false
+    func startDragging() {
+        guard let view = common.view, let event = view.lastMouseDownEvent else { return }
+        var pos = view.convert(event.locationInWindow, from: nil)
+        pos = convertPointToBacking(pos)
+
+        if input?.draggable(at: pos) ?? true {
+            performDrag(with: event)
         }
     }
 


### PR DESCRIPTION
only works with left clicks.

overlooked by me and follow up of #13582.
also resolves the possible blocker on #15314.

tested with `MBTN_LEFT cycle pause` and works as expected now. 
also tested with following test script that dragging can be triggered by a script with different binding.
```
local mp = require 'mp'

local function vo_drag()
    mp.command("begin-vo-dragging")
end
mp.add_forced_key_binding('alt+MBTN_LEFT', vo_drag, {complex=true, event=down})
```

