### PR TITLE
osc.lua: cycle sub/audio on left-click, select on right-click

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -104,10 +104,10 @@ audio and sub
     | Displays selected track and amount of available tracks
 
     =============   ================================================
-    left-click      open the audio/sub track selector
+    left-click      cycle audio/sub tracks forward
     shift+L-click   show available audio/sub tracks
     middle-click    show available audio/sub tracks
-    right-click     show available audio/sub tracks
+    right-click     open the audio/sub track selector
     mouse wheel     cycle audio/sub tracks forward/backwards
     =============   ================================================
 
@@ -532,21 +532,21 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``chapter_next_mbtn_right_command=script-binding select/select-chapter; script-message-to osc osc-hide``
 
-``audio_track_mbtn_left_command=script-binding select/select-aid; script-message-to osc osc-hide``
+``audio_track_mbtn_left_command=cycle audio``
 
 ``audio_track_mbtn_mid_command=show-text ${track-list/audio} 3000``
 
-``audio_track_mbtn_right_command=cycle audio``
+``audio_track_mbtn_right_command=script-binding select/select-aid; script-message-to osc osc-hide``
 
 ``audio_track_wheel_down_command=cycle audio``
 
 ``audio_track_wheel_up_command=cycle audio down``
 
-``sub_track_mbtn_left_command=script-binding select/select-sid; script-message-to osc osc-hide``
+``sub_track_mbtn_left_command=cycle sub``
 
 ``sub_track_mbtn_mid_command=show-text ${track-list/sub} 3000``
 
-``sub_track_mbtn_right_command=cycle sub``
+``sub_track_mbtn_right_command=script-binding select/select-sid; script-message-to osc osc-hide``
 
 ``sub_track_wheel_down_command=cycle sub``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -105,7 +105,7 @@ audio and sub
 
     =============   ================================================
     left-click      cycle audio/sub tracks forward
-    shift+L-click   show available audio/sub tracks
+    shift+L-click   cycle audio/sub tracks backwards
     middle-click    show available audio/sub tracks
     right-click     open the audio/sub track selector
     mouse wheel     cycle audio/sub tracks forward/backwards
@@ -534,7 +534,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``audio_track_mbtn_left_command=cycle audio``
 
-``audio_track_mbtn_mid_command=show-text ${track-list/audio} 3000``
+``audio_track_mbtn_mid_command=cycle audio down``
 
 ``audio_track_mbtn_right_command=script-binding select/select-aid; script-message-to osc osc-hide``
 
@@ -544,7 +544,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``sub_track_mbtn_left_command=cycle sub``
 
-``sub_track_mbtn_mid_command=show-text ${track-list/sub} 3000``
+``sub_track_mbtn_mid_command=cycle sub down``
 
 ``sub_track_mbtn_right_command=script-binding select/select-sid; script-message-to osc osc-hide``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -49,9 +49,9 @@ title
       title, or the target chapter name while hovering the seekbar.
 
     =============   ================================================
-    left-click      open the playlist selector
+    left-click      show file and track info
     middle-click    show the filename
-    right-click     show file and track info
+    right-click     open the playlist selector
     =============   ================================================
 
 cache
@@ -496,11 +496,11 @@ Configurable Options
 The following options configure what commands are run when the buttons are
 clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
-``title_mbtn_left_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+``title_mbtn_left_command=script-binding stats/display-page-5``
 
 ``title_mbtn_mid_command=show-text ${filename}``
 
-``title_mbtn_right_command=script-binding stats/display-page-5``
+``title_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
 
 ``playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000``
 

--- a/etc/restore-osc-bindings.conf
+++ b/etc/restore-osc-bindings.conf
@@ -25,5 +25,7 @@ chapter_prev_mbtn_right_command=show-text ${chapter-list} 3000
 chapter_next_mbtn_right_command=show-text ${chapter-list} 3000
 
 audio_track_mbtn_right_command=cycle audio down
+audio_track_mbtn_mid_command=show-text ${track-list/audio} 3000
 
 sub_track_mbtn_right_command=cycle sub down
+sub_track_mbtn_mid_command=show-text ${track-list/sub} 3000

--- a/etc/restore-osc-bindings.conf
+++ b/etc/restore-osc-bindings.conf
@@ -24,8 +24,6 @@ title_mbtn_right_command=show-text ${filename}
 chapter_prev_mbtn_right_command=show-text ${chapter-list} 3000
 chapter_next_mbtn_right_command=show-text ${chapter-list} 3000
 
-audio_track_mbtn_left_command=cycle audio
 audio_track_mbtn_right_command=cycle audio down
 
-sub_track_mbtn_left_command=cycle sub
 sub_track_mbtn_right_command=cycle sub down

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -94,15 +94,15 @@ local user_opts = {
     chapter_next_mbtn_mid_command = "show-text ${chapter-list} 3000",
     chapter_next_mbtn_right_command = "script-binding select/select-chapter; script-message-to osc osc-hide",
 
-    audio_track_mbtn_left_command = "script-binding select/select-aid; script-message-to osc osc-hide",
+    audio_track_mbtn_left_command = "cycle audio",
     audio_track_mbtn_mid_command = "show-text ${track-list/audio} 3000",
-    audio_track_mbtn_right_command = "cycle audio",
+    audio_track_mbtn_right_command = "script-binding select/select-aid; script-message-to osc osc-hide",
     audio_track_wheel_down_command = "cycle audio",
     audio_track_wheel_up_command = "cycle audio down",
 
-    sub_track_mbtn_left_command = "script-binding select/select-sid; script-message-to osc osc-hide",
+    sub_track_mbtn_left_command = "cycle sub",
     sub_track_mbtn_mid_command = "show-text ${track-list/sub} 3000",
-    sub_track_mbtn_right_command = "cycle sub",
+    sub_track_mbtn_right_command = "script-binding select/select-sid; script-message-to osc osc-hide",
     sub_track_wheel_down_command = "cycle sub",
     sub_track_wheel_up_command = "cycle sub down",
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -95,13 +95,13 @@ local user_opts = {
     chapter_next_mbtn_right_command = "script-binding select/select-chapter; script-message-to osc osc-hide",
 
     audio_track_mbtn_left_command = "cycle audio",
-    audio_track_mbtn_mid_command = "show-text ${track-list/audio} 3000",
+    audio_track_mbtn_mid_command = "cycle audio down",
     audio_track_mbtn_right_command = "script-binding select/select-aid; script-message-to osc osc-hide",
     audio_track_wheel_down_command = "cycle audio",
     audio_track_wheel_up_command = "cycle audio down",
 
     sub_track_mbtn_left_command = "cycle sub",
-    sub_track_mbtn_mid_command = "show-text ${track-list/sub} 3000",
+    sub_track_mbtn_mid_command = "cycle sub down",
     sub_track_mbtn_right_command = "script-binding select/select-sid; script-message-to osc osc-hide",
     sub_track_wheel_down_command = "cycle sub",
     sub_track_wheel_up_command = "cycle sub down",

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -70,9 +70,9 @@ local user_opts = {
 
     -- luacheck: push ignore
     -- luacheck: max line length
-    title_mbtn_left_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
+    title_mbtn_left_command = "script-binding stats/display-page-5",
     title_mbtn_mid_command = "show-text ${filename}",
-    title_mbtn_right_command = "script-binding stats/display-page-5",
+    title_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
 
     playlist_prev_mbtn_left_command = "playlist-prev",
     playlist_prev_mbtn_mid_command = "show-text ${playlist} 3000",


### PR DESCRIPTION
Alternative to #15186. To not complicate things and make it easier to transition form previous bindings.