### PR TITLE
Add ``application/x-font-otf`` to font_mimetypes

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -133,6 +133,7 @@ static void mp_ass_add_default_styles(ASS_Track *track, struct mp_subtitle_opts 
 static const char *const font_mimetypes[] = {
     "application/x-truetype-font",
     "application/vnd.ms-opentype",
+    "application/x-font-otf",
     "application/x-font-ttf",
     "application/x-font", // probably incorrect
     "application/font-sfnt",


### PR DESCRIPTION
mkvtoolnix recently introduced this mimetype in https://gitlab.com/mbunkus/mkvtoolnix/-/commit/d858c2bf138009b8316b32c4554397ecb609d938 which is available since the version 88.0, so I tought we would also need it.