### PR TITLE
input.conf: navigate the playlist with n N p and P

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -89,13 +89,16 @@ Shift+Ctrl+BACKSPACE
     use this to seek around in the file and then return to the exact position
     where you left off.
 
-< and >
+p and n, < and >
     Go backward/forward in the playlist.
+
+P and N
+    Go to the previous/next sub-playlist (e.g. directory or archive).
 
 ENTER
     Go forward in the playlist.
 
-p and SPACE
+SPACE
     Pause (pressing again unpauses).
 
 \.
@@ -148,7 +151,7 @@ w and W
     Decrease/increase pan-and-scan range. The ``e`` key does the same as
     ``W`` currently, but use is discouraged.
 
-o and P
+o
     Show progression bar, elapsed time and total duration on the OSD.
 
 O

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -84,16 +84,18 @@
 #q {encode} quit 4
 #ESC set fullscreen no                  # leave fullscreen
 #ESC {encode} quit 4
-#p cycle pause                          # toggle pause/playback mode
 #. frame-step                           # advance one frame and pause
 #, frame-back-step                      # go back by one frame and pause
 #SPACE cycle pause                      # toggle pause/playback mode
+#n playlist-next                        # skip to the next file
+#p playlist-prev                        # skip to the previous file
 #> playlist-next                        # skip to the next file
 #ENTER playlist-next                    # skip to the next file
 #< playlist-prev                        # skip to the previous file
+#N playlist-next-playlist               # skip to the next sub-playlist
+#P playlist-prev-playlist               # skip to the previous sub-playlist
 #O no-osd cycle-values osd-level 3 1    # toggle displaying the OSD on user interaction or always
 #o show-progress                        # show playback progress
-#P show-progress                        # show playback progress
 #i script-binding stats/display-stats   # display information and statistics
 #I script-binding stats/display-stats-toggle # toggle displaying information and statistics
 #? script-binding stats/display-page-4-toggle # toggle displaying key bindings

--- a/etc/restore-old-bindings.conf
+++ b/etc/restore-old-bindings.conf
@@ -9,6 +9,11 @@
 #
 # Older installations use ~/.mpv/input.conf instead.
 
+# changed in mpv 0.40.0
+
+#p cycle pause                         # toggle pause/playback mode
+#P show-progress                       # show playback progress
+
 # changed in mpv 0.37.0
 
 WHEEL_UP      seek 10                  # seek 10 seconds forward


### PR DESCRIPTION
Because:

- No need to hold shift for a fundamental feature when intuitive keys are available
- Space is already easier to press than p to pause
- Consistent with VLC key bindings, which was the main reason for rebinding the wheel to change volume
- n and p can be bound with shift to navigate sub-playlists as a variation of the same feature
- o is already easier to press than shift+p to show the playback position, I didn't even remember this binding exists
- If we add key bindings optimized for images it is worth having these to navigate the playlist without shift regardless because you do it much more often, so if these also works for videos, that makes mpv easier to use
