### PR TITLE
mac/option: fix type of global init variable

### DIFF
--- a/osdep/mac/app_bridge_objc.h
+++ b/osdep/mac/app_bridge_objc.h
@@ -24,6 +24,7 @@
 
 #include "options/m_config.h"
 #include "player/core.h"
+#include "common/global.h"
 #include "input/input.h"
 #include "input/event.h"
 #include "input/keycodes.h"

--- a/osdep/mac/option_helper.swift
+++ b/osdep/mac/option_helper.swift
@@ -38,7 +38,7 @@ class OptionHelper {
     var vo: mp_vo_opts { return voPtr.pointee }
     var mac: macos_opts { return macPtr.pointee }
 
-    init(_ taParent: UnsafeMutableRawPointer, _ global: OpaquePointer?) {
+    init(_ taParent: UnsafeMutableRawPointer, _ global: UnsafeMutablePointer<mpv_global>?) {
         voCachePtr = m_config_cache_alloc(taParent, global, AppHub.shared.getVoConf())
         macCachePtr = m_config_cache_alloc(taParent, global, AppHub.shared.getMacConf())
     }


### PR DESCRIPTION
clipboard/clipboard.h includes common/global.h where the mpv_global struct is defined. clipboard/clipboard.h furthermore is now included on player/core.h, which is included in the swift bridging header. because of this swift now knows the mpv_global struct and isn't treating it as an OpaquePointer anymore. this leads to a build error because swift is strongly typed.

properly type the global variable in the OptionHelper. also pre-emptively include the common/global.h file in the swift bridging header to prevent swift from 'forgetting' the mpv_global struct again, in the case the includes change.

Fixes e1d30c4
