### PR TITLE
player/clipboard/clipboard: don't include global.h in header

### DIFF
--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -15,10 +15,12 @@
  * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "clipboard.h"
+
 #include "common/common.h"
+#include "common/global.h"
 #include "options/m_config.h"
 #include "player/core.h"
-#include "clipboard.h"
 
 struct clipboard_opts {
     bool enabled;

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -18,11 +18,11 @@
 #pragma once
 
 #include "common/common.h"
-#include "common/global.h"
-#include "video/mp_image.h"
 
 struct clipboard_ctx;
+struct mp_image;
 struct MPContext;
+struct mpv_global;
 
 #define CLIPBOARD_INIT_ENABLE_MONITORING (1 << 0)
 


### PR DESCRIPTION
This header should not be included except when really needed.

Fixes: e1d30c4c5a7443d08c7d4c183644917a340954b2