### PR TITLE
options/m_option: restore m_geometry_apply centering ability

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2217,7 +2217,7 @@ static char *print_geometry(const m_option_t *opt, const void *val)
 // scrw,scrh: width and height of the current screen
 // The input parameters should be set to a centered window (default fallbacks).
 void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
-                      int scrw, int scrh, struct m_geometry *gm)
+                      int scrw, int scrh, bool center, struct m_geometry *gm)
 {
     if (gm->wh_valid) {
         int prew = *widw, preh = *widh;
@@ -2231,6 +2231,10 @@ void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
             *widh = *widw / asp;
         } else if (!(gm->w > 0) && gm->h > 0) {
             *widw = *widh * asp;
+        }
+        if (center) {
+            *xpos += prew / 2 - *widw / 2;
+            *ypos += preh / 2 - *widh / 2;
         }
     }
 
@@ -2341,7 +2345,7 @@ void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm)
     *rc = (struct mp_rect){0, 0, w, h};
     if (!w || !h)
         return;
-    m_geometry_apply(&rc->x0, &rc->y0, &rc->x1, &rc->y1, w, h, gm);
+    m_geometry_apply(&rc->x0, &rc->y0, &rc->x1, &rc->y1, w, h, true, gm);
     if (!gm->xy_valid && gm->wh_valid && rc->x1 == 0 && rc->y1 == 0)
         return;
     if (!gm->wh_valid || rc->x1 == 0 || rc->x1 == INT_MIN)

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -105,7 +105,7 @@ struct m_geometry {
 };
 
 void m_geometry_apply(int *xpos, int *ypos, int *widw, int *widh,
-                      int scrw, int scrh, struct m_geometry *gm);
+                      int scrw, int scrh, bool center, struct m_geometry *gm);
 void m_rect_apply(struct mp_rect *rc, int w, int h, struct m_geometry *gm);
 
 struct m_channels {

--- a/video/out/win_state.c
+++ b/video/out/win_state.c
@@ -44,7 +44,7 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 
     int dummy = 0;
     int n_w = *w, n_h = *h;
-    m_geometry_apply(&dummy, &dummy, &n_w, &n_h, scr_w, scr_h, geo);
+    m_geometry_apply(&dummy, &dummy, &n_w, &n_h, scr_w, scr_h, true, geo);
 
     if (!allow_up && *w <= n_w && *h <= n_h)
         return;
@@ -125,16 +125,9 @@ void vo_calc_window_geometry(struct vo *vo, const struct mp_rect *screen,
     out_geo->win.x0 = (int)(scr_w - d_w) / 2;
     out_geo->win.y0 = (int)(scr_h - d_h) / 2;
 
-    int old_w = d_w;
-    int old_h = d_h;
-
+    bool center = (opts->force_window_position || force_center) && !opts->geometry.xy_valid;
     m_geometry_apply(&out_geo->win.x0, &out_geo->win.y0, &d_w, &d_h,
-                     scr_w, scr_h, &opts->geometry);
-
-    if ((opts->force_window_position || force_center) && !opts->geometry.xy_valid) {
-        out_geo->win.x0 += old_w / 2 - d_w / 2;
-        out_geo->win.y0 += old_h / 2 - d_h / 2;
-    }
+                     scr_w, scr_h, center, &opts->geometry);
 
     out_geo->win.x0 += screen->x0;
     out_geo->win.y0 += screen->y0;


### PR DESCRIPTION
This fixes geometry uses where it is expected to be centered. For example this fixes video-crop option.

Fixes: e01eab4385d8fe6a542dd9526f912e37b691f58e
Fixes: #15398