### PR TITLE
vf_format: fix format=dolbyvision=no metadata stripping

### DIFF
--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -84,7 +84,7 @@ static void set_params(struct vf_format_opts *p, struct mp_image_params *out,
             out->light = MP_CSP_LIGHT_AUTO;
         }
     }
-    if (p->colormatrix != PL_COLOR_SYSTEM_DOLBYVISION && !p->dovi) {
+    if (out->repr.sys != PL_COLOR_SYSTEM_DOLBYVISION) {
         out->primaries_orig = out->color.primaries;
         out->transfer_orig = out->color.transfer;
         out->sys_orig = out->repr.sys;


### PR DESCRIPTION
If p->colormatrix is 0 if not set by user, so it would always override _orig parameters with Dolby Vision ones and restore that erroneously.

Fixes: e2365bfeceeef8939d159780b607698d05073910