### PR TITLE
demux: remove AVPacket global side data injection

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -767,7 +767,6 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
             const AVDOVIDecoderConfigurationRecord *cfg = (void *) sd;
             MP_VERBOSE(demuxer, "Found Dolby Vision config record: profile "
                        "%d level %d\n", cfg->dv_profile, cfg->dv_level);
-            av_format_inject_global_side_data(avfc);
             sh->codec->dovi = true;
             sh->codec->dv_profile = cfg->dv_profile;
             sh->codec->dv_level = cfg->dv_level;

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -90,7 +90,8 @@ struct mp_codec_params {
     unsigned char *extradata;   // codec specific per-stream header
     int extradata_size;
 
-    // Codec specific header data (set by demux_lavf.c only)
+    // Codec specific header data (set by demux_{lavf,mkv,raw}, useful to pass
+    // through stream global side data)
     struct AVCodecParameters *lav_codecpar;
 
     // Timestamp granularity for converting double<->rational timestamps.


### PR DESCRIPTION
This process has been deprecated since avformat 60.15.100 and
since avcodec 60.30.101 AV_PKT_DATA_DOVI_CONF has been read from
AVCodecContext's coded_side_data. Additionally, the HEVC decoder
is the only one which currently reads this side data from packets,
the native AV1 decoder as well as the libdav1d wrapper instead only
support the newer propagation method via codec context's side data.

How this currently is supposed to propagate is:
* demuxer copies the codec parameters into sh_stream's lav_codecpar.
* {ad,sd,vd}_lavc call mp_set_avctx_codec_headers that calls
  avcodec_parameters_to_context, which then sets global side data
  to the codec context.

As this logic is already in place, so no additional changes are required
for things to work and the deprecated function call can just be
cleaned up.

Ref: https://github.com/FFmpeg/FFmpeg/commit/5432d2aacad5fa7420fe2d9369ed061d521e92d6
Ref: https://github.com/FFmpeg/FFmpeg/commit/804be7f9e3c52ba38efb13e2ef1737061b2e9d0f
Ref: https://github.com/FFmpeg/FFmpeg/commit/12e5116872557c8d9cea9408d05867ef08e0bfc4