### PR TITLE
[RFC] DOCS/contribute.md: add guidelines for Swift and Objective-C

### DIFF
--- a/DOCS/contribute.md
+++ b/DOCS/contribute.md
@@ -255,6 +255,11 @@ General coding
 - If you add features that require intrusive changes, discuss them on the dev
   channel first. There might be a better way to add a feature and it can avoid
   wasted work.
+- Newly added code for any Apple Platform (macOS, iOS, etc), that uses Cocoa or
+  any other object-oriented Framework or API, should be written in Swift instead
+  of Objective-C. This also includes complete rewrites/refactors of existing
+  code. Plain C API usages may stay as C, but can be written in Swift. Existing
+  Objective-C code can stay as is, though Swift rewrites are welcome.
 
 Code of Conduct
 ---------------


### PR DESCRIPTION
something that should be discussed. this is only meant for Apple Platforms and should not affect other Platforms. right now we don't have any 'official' guidelines how to deal with newly added code for swift/obj-c. personally i would like to avoid an even bigger mix of obj-c and swift in the future and my goal is to eventually have no/nearly no obj-c code anymore.

some random points:
- i put a great amount of work into migrating a lot of the osdep code to Swift and refactoring it at the same time, trying to decrease complexity and code amount
- currently all video backends/contexts are majorly written in swift
- swift was made mandatory for a fully working mpv build
- the swift parts have been in wide use for many years now and seem pretty stable
- swift itself got ABI stable with version 5
- i encountered a few obj-c APIs that were broken in some SDKs where the corresponding/equivalent swift API wasn't
- few APIs that are only available in swift
- Apple is migrating away from obj-c to swift
- makes everything a lot more maintainable in the future

maybe i am being a bit too pushy or egoistical here, though i do think we should have an official stance on this, that is clear and beneficial to our code base.