### PR TITLE
mac/option: explicitly include and define type of global init variable

### DIFF
--- a/osdep/mac/app_bridge_objc.h
+++ b/osdep/mac/app_bridge_objc.h
@@ -24,6 +24,7 @@
 
 #include "options/m_config.h"
 #include "player/core.h"
+#include "common/global.h"
 #include "input/input.h"
 #include "input/event.h"
 #include "input/keycodes.h"

--- a/osdep/mac/option_helper.swift
+++ b/osdep/mac/option_helper.swift
@@ -38,7 +38,7 @@ class OptionHelper {
     var vo: mp_vo_opts { return voPtr.pointee }
     var mac: macos_opts { return macPtr.pointee }
 
-    init(_ taParent: UnsafeMutableRawPointer, _ global: OpaquePointer?) {
+    init(_ taParent: UnsafeMutableRawPointer, _ global: UnsafeMutablePointer<mpv_global>?) {
         voCachePtr = m_config_cache_alloc(taParent, global, AppHub.shared.getVoConf())
         macCachePtr = m_config_cache_alloc(taParent, global, AppHub.shared.getMacConf())
     }


### PR DESCRIPTION
looked into all the OpaquePointers and additional to `mpv_global` we only use these structs that are all private: [struct mpv_handle](https://github.com/mpv-player/mpv/blob/master/player/client.c#L106-L161),  [struct input_ctx](https://github.com/mpv-player/mpv/blob/master/input/input.c#L99-L168), [struct mpv_render_context](https://github.com/mpv-player/mpv/blob/master/video/out/vo_libmpv.c#L60-L112), [struct mp_log](https://github.com/mpv-player/mpv/blob/master/common/msg.c#L100-L109).

so there actually is nothing else to do besides what was already done in #15395. had to open a new PR because github didn't like me force pushing to the same branch when the PR was closed.