### PR TITLE
console.lua: don't reinsert the next characters on complete

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1424,7 +1424,8 @@ cycle_through_suggestions = function (backwards)
 
     local before_cur = line:sub(1, completion_pos - 1) ..
                        suggestion_buffer[selected_suggestion_index] .. completion_append
-    line = before_cur .. strip_common_characters(line:sub(cursor), completion_append)
+    line = before_cur .. strip_common_characters(line:sub(cursor),
+        suggestion_buffer[selected_suggestion_index] .. completion_append)
     cursor = before_cur:len() + 1
     update()
 end


### PR DESCRIPTION
This avoids inserting the characters in front of the cursor again when completing to text already in front of the cursor.

This is important after 2f271a92de made Enter automatically insert the first completion.