### PR TITLE
demux_disc: expose titles as editions

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2219,8 +2219,10 @@ Property list
     Current chapter number. The number of the first chapter is 0.
 
 ``edition`` (RW)
-    Current MKV edition number. Setting this property to a different value will
+    Current edition number. Setting this property to a different value will
     restart playback. The number of the first edition is 0.
+
+    For Matroska files, this is the edition. For DVD/Blu-ray, this is the title.
 
     Before mpv 0.31.0, this showed the actual edition selected at runtime, if
     you didn't set the option or property manually. With mpv 0.31.0 and later,
@@ -2238,7 +2240,7 @@ Property list
     Number of chapters.
 
 ``editions``
-    Number of MKV editions.
+    Number of editions.
 
 ``edition-list``
     List of editions, current entry marked.

--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -273,6 +273,30 @@ static bool d_read_packet(struct demuxer *demuxer, struct demux_packet **out_pkt
     return 1;
 }
 
+static void add_stream_editions(struct demuxer *demuxer)
+{
+    unsigned titles = 0;
+    if (stream_control(demuxer->stream, STREAM_CTRL_GET_NUM_TITLES, &titles) != STREAM_OK)
+        return;
+    for (unsigned title = 0; title < titles; ++title) {
+        double duration = title;
+        if (stream_control(demuxer->stream, STREAM_CTRL_GET_TITLE_LENGTH, &duration) != STREAM_OK)
+            continue;
+
+        struct demux_edition new = {
+            .demuxer_id = title,
+            .default_edition = false,
+            .metadata = talloc_zero(demuxer, struct mp_tags),
+        };
+        MP_TARRAY_APPEND(demuxer, demuxer->editions, demuxer->num_editions, new);
+
+        char *time = mp_format_time(duration, true);
+        mp_tags_set_str(new.metadata, "TITLE",
+                        mp_tprintf(42, "title: %u (%s)", title + 1, time));
+        talloc_free(time);
+    }
+}
+
 static void add_stream_chapters(struct demuxer *demuxer)
 {
     int num = 0;
@@ -335,10 +359,15 @@ static int d_open(demuxer_t *demuxer, enum demux_check check)
     add_dvd_streams(demuxer);
     add_streams(demuxer);
     add_stream_chapters(demuxer);
+    add_stream_editions(demuxer);
 
     double len;
     if (stream_control(demuxer->stream, STREAM_CTRL_GET_TIME_LENGTH, &len) >= 1)
         demuxer->duration = len;
+
+    unsigned title;
+    if (stream_control(demuxer->stream, STREAM_CTRL_GET_CURRENT_TITLE, &title) >= 1)
+        demuxer->edition = title;
 
     return 0;
 }

--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -291,6 +291,9 @@ static void add_stream_editions(struct demuxer *demuxer)
         MP_TARRAY_APPEND(demuxer, demuxer->editions, demuxer->num_editions, new);
 
         char *time = mp_format_time(duration, true);
+        double playlist = title;
+        if (stream_control(demuxer->stream, STREAM_CTRL_GET_TITLE_PLAYLIST, &playlist) == STREAM_OK)
+            time = talloc_asprintf_append(time, ") (%05.0f.mpls", playlist);
         mp_tags_set_str(new.metadata, "TITLE",
                         mp_tprintf(42, "title: %u (%s)", title + 1, time));
         talloc_free(time);

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -86,7 +86,8 @@ enum stream_ctrl {
     STREAM_CTRL_GET_ANGLE,
     STREAM_CTRL_SET_ANGLE,
     STREAM_CTRL_GET_NUM_TITLES,
-    STREAM_CTRL_GET_TITLE_LENGTH,       // double* (in: title number, out: len)
+    STREAM_CTRL_GET_TITLE_LENGTH,    // double* (in: title number, out: len)
+    STREAM_CTRL_GET_TITLE_PLAYLIST,  // double* (in: title number, out: playlist)
     STREAM_CTRL_GET_LANG,
     STREAM_CTRL_GET_CURRENT_TITLE,
     STREAM_CTRL_SET_CURRENT_TITLE,

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -42,6 +42,7 @@
 #include "common/common.h"
 #include "common/msg.h"
 #include "options/m_config.h"
+#include "options/options.h"
 #include "options/path.h"
 #include "stream.h"
 #include "osdep/timer.h"
@@ -503,7 +504,13 @@ static int bluray_stream_open(stream_t *s)
 
     b->cfg_title = BLURAY_DEFAULT_TITLE;
 
-    if (bstr_equals0(title, "longest") || bstr_equals0(title, "first")) {
+    struct MPOpts *opts = mp_get_config_group(s, s->global, &mp_opt_root);
+    int edition_id = opts->edition_id;
+    talloc_free(opts);
+
+    if (edition_id >= 0) {
+        b->cfg_title = edition_id;
+    } else if (bstr_equals0(title, "longest") || bstr_equals0(title, "first")) {
         b->cfg_title = BLURAY_DEFAULT_TITLE;
     } else if (bstr_equals0(title, "menu")) {
         b->cfg_title = BLURAY_MENU_TITLE;

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -276,6 +276,16 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
         *(double *)arg = BD_TIME_TO_MP(ti->duration);
         return STREAM_OK;
     }
+    case STREAM_CTRL_GET_TITLE_PLAYLIST: {
+        int title = *(double *)arg;
+        if (!b->bd || title < 0 || title >= b->num_titles)
+            return STREAM_UNSUPPORTED;
+        const BLURAY_TITLE_INFO *ti = bd_get_title_info(b->bd, title, 0);
+        if (!ti)
+            return STREAM_UNSUPPORTED;
+        *(double *)arg = ti->playlist;
+        return STREAM_OK;
+    }
     case STREAM_CTRL_GET_LANG: {
         const BLURAY_TITLE_INFO *ti = b->title_info;
         if (ti && ti->clip_count) {

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -265,6 +265,16 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
         bd_seamless_angle_change(b->bd, angle);
         return STREAM_OK;
     }
+    case STREAM_CTRL_GET_TITLE_LENGTH: {
+        int title = *(double *)arg;
+        if (!b->bd || title < 0 || title >= b->num_titles)
+            return STREAM_UNSUPPORTED;
+        const BLURAY_TITLE_INFO *ti = bd_get_title_info(b->bd, title, 0);
+        if (!ti)
+            return STREAM_UNSUPPORTED;
+        *(double *)arg = BD_TIME_TO_MP(ti->duration);
+        return STREAM_OK;
+    }
     case STREAM_CTRL_GET_LANG: {
         const BLURAY_TITLE_INFO *ti = b->title_info;
         if (ti && ti->clip_count) {

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -659,7 +659,13 @@ static int open_s(stream_t *stream)
 
     priv->track = TITLE_LONGEST;
 
-    if (bstr_equals0(title, "longest") || bstr_equals0(title, "first")) {
+    struct MPOpts *opts = mp_get_config_group(stream, stream->global, &mp_opt_root);
+    int edition_id = opts->edition_id;
+    talloc_free(opts);
+
+    if (edition_id >= 0) {
+        priv->track = edition_id;
+    } else if (bstr_equals0(title, "longest") || bstr_equals0(title, "first")) {
         priv->track = TITLE_LONGEST;
     } else if (bstr_equals0(title, "menu")) {
         priv->track = TITLE_MENU;


### PR DESCRIPTION
This allows to select DVD/Blu-Ray title easily. Titles are listed as
editions with their duration and number.

I wanted to include Angles also in this selection, but currently Angles
are not that well supported, so let's stick with titles and leave the
rest for the future changes.

We might migrate to lavf demuxer for DVD/Blu-Ray in the future, the mpv
implementation is rotted anyway.

Fixes https://github.com/mpv-player/mpv/issues/14586