### PR TITLE
console.lua: fix mp.input.get clients that don't specify completions

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1444,6 +1444,7 @@ complete = function ()
         completion_old_cursor = cursor
         mp.commandv('script-message-to', input_caller, 'input-event',
                     'complete', utils.format_json({line:sub(1, cursor - 1)}))
+        update()
         return
     end
 


### PR DESCRIPTION
Actually update the rendered text when typing with an input.get client that didn't specify a complete callback.

Fixes #15430, fixes 57b73f1af6.