### PR TITLE
github/workflows: replace ruff-action with a maintained one

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v2
 
   editorconfig-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See: https://github.com/ChartBoost/ruff-action/commit/c413c59d2aa0f58662aec40228cd7c8dfb69cbc1