### PR TITLE
select.lua: select files with watch later files with g-w

### DIFF
--- a/DOCS/interface-changes/current-watch-later-dir.txt
+++ b/DOCS/interface-changes/current-watch-later-dir.txt
@@ -1,0 +1,1 @@
+add `current-watch-later-dir` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3737,6 +3737,11 @@ Property list
     The working directory of the mpv process. Can be useful for JSON IPC users,
     because the command line player usually works with relative paths.
 
+``current-watch-later-dir``
+    The directory in which watch later config files are stored. This returns
+    ``--watch-later-dir``, or the default directory if ``--watch-later-dir`` has
+    not been modified, with tilde placeholders expanded.
+
 ``protocol-list``
     List of protocol prefixes potentially recognized by the player. They are
     returned without trailing ``://`` suffix (which is still always required).

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -326,6 +326,11 @@ g-l
 g-d
     Select an audio device.
 
+g-w
+    Select a file from watch later config files (see `RESUMING PLAYBACK`_) to
+    resume playing. Requires ``--write-filename-in-watch-later-config``. This
+    doesn't work with ``--ignore-path-in-watch-later-config``.
+
 g-b
     Select a defined input binding.
 

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -187,6 +187,7 @@
 #g-e script-binding select/select-edition
 #g-l script-binding select/select-subtitle-line
 #g-d script-binding select/select-audio-device
+#g-w script-binding select/select-watch-later
 #g-b script-binding select/select-binding
 #g-r script-binding select/show-properties
 

--- a/player/command.c
+++ b/player/command.c
@@ -3528,6 +3528,13 @@ static int mp_property_cwd(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
+static int mp_property_current_watch_later_dir(void *ctx, struct m_property *prop,
+                                               int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    return m_property_strdup_ro(action, arg, mp_get_playback_resume_dir(mpctx));
+}
+
 static int mp_property_protocols(void *ctx, struct m_property *prop,
                                  int action, void *arg)
 {
@@ -4388,6 +4395,7 @@ static const struct m_property mp_properties_base[] = {
     {"ambient-light", mp_property_ambient_light},
 
     {"working-directory", mp_property_cwd},
+    {"current-watch-later-dir", mp_property_current_watch_later_dir},
 
     {"protocol-list", mp_property_protocols},
     {"decoder-list", mp_property_decoders},

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -197,7 +197,7 @@ static bool copy_mtime(const char *f1, const char *f2)
     return true;
 }
 
-static char *mp_get_playback_resume_dir(struct MPContext *mpctx)
+char *mp_get_playback_resume_dir(struct MPContext *mpctx)
 {
     char *wl_dir = mpctx->opts->watch_later_dir;
     if (wl_dir && wl_dir[0]) {

--- a/player/core.h
+++ b/player/core.h
@@ -510,6 +510,7 @@ void audio_start_ao(struct MPContext *mpctx);
 void mp_parse_cfgfiles(struct MPContext *mpctx);
 void mp_load_auto_profiles(struct MPContext *mpctx);
 bool mp_load_playback_resume(struct MPContext *mpctx, const char *file);
+char *mp_get_playback_resume_dir(struct MPContext *mpctx);
 void mp_write_watch_later_conf(struct MPContext *mpctx);
 void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file);
 struct playlist_entry *mp_check_playlist_resume(struct MPContext *mpctx,

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -18,6 +18,13 @@ License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 local utils = require "mp.utils"
 local input = require "mp.input"
 
+local function show_warning(message)
+    mp.msg.warn(message)
+    if mp.get_property_native("vo-configured") then
+        mp.osd_message(message)
+    end
+end
+
 local function show_error(message)
     mp.msg.error(message)
     if mp.get_property_native("vo-configured") then
@@ -51,7 +58,7 @@ mp.add_key_binding(nil, "select-playlist", function ()
     end
 
     if #playlist == 0 then
-        show_error("The playlist is empty.")
+        show_warning("The playlist is empty.")
         return
     end
 
@@ -118,7 +125,7 @@ mp.add_key_binding(nil, "select-track", function ()
     end
 
     if #tracks == 0 then
-        show_error("No available tracks.")
+        show_warning("No available tracks.")
         return
     end
 
@@ -134,7 +141,7 @@ mp.add_key_binding(nil, "select-track", function ()
     })
 end)
 
-local function select_track(property, type, prompt, error)
+local function select_track(property, type, prompt, warning)
     local tracks = {}
     local items = {}
     local default_item
@@ -152,7 +159,7 @@ local function select_track(property, type, prompt, error)
     end
 
     if #items == 0 then
-        show_error(error)
+        show_warning(warning)
         return
     end
 
@@ -203,7 +210,7 @@ mp.add_key_binding(nil, "select-chapter", function ()
     local default_item = mp.get_property_native("chapter")
 
     if default_item == nil then
-        show_error("No available chapters.")
+        show_warning("No available chapters.")
         return
     end
 
@@ -227,7 +234,7 @@ mp.add_key_binding(nil, "select-edition", function ()
     local edition_list = mp.get_property_native("edition-list")
 
     if edition_list == nil or #edition_list < 2 then
-        show_error("No available editions.")
+        show_warning("No available editions.")
         return
     end
 
@@ -251,7 +258,7 @@ mp.add_key_binding(nil, "select-subtitle-line", function ()
     local sub = mp.get_property_native("current-tracks/sub")
 
     if sub == nil then
-        show_error("No subtitle is loaded.")
+        show_warning("No subtitle is loaded.")
         return
     end
 
@@ -324,7 +331,7 @@ mp.add_key_binding(nil, "select-audio-device", function ()
     local default_item
 
     if #devices == 0 then
-        show_error("No available audio devices.")
+        show_warning("No available audio devices.")
         return
     end
 


### PR DESCRIPTION
Implement selection of files with watch later config files. Requires --write-filename-in-watch-later-config.

Suggested by llyyr. He also suggested showing this when mpv opens, but it completely covers the logo and the text, and stays open after dropping a file. Alternatively "Drop files or URLs to play here." could also suggest pressing g-h.