### PR TITLE
meson: use swiftc instead of swift for building

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1539,7 +1539,7 @@ endif
 xcrun = find_program('xcrun', required: get_option('swift-build').require(darwin))
 swift_ver = '0.0'
 if xcrun.found()
-    swift_prog = find_program(run_command(xcrun, '-find', 'swift', check: true).stdout().strip())
+    swift_prog = find_program(run_command(xcrun, '-find', 'swiftc', check: true).stdout().strip())
     swift_ver_string = run_command(swift_prog, '-version', check: true).stdout()
     verRe = '''
 #!/usr/bin/env python3

--- a/osdep/mac/meson.build
+++ b/osdep/mac/meson.build
@@ -4,8 +4,8 @@ header = join_paths(build_root, 'osdep/mac/swift.h')
 module = join_paths(build_root, 'osdep/mac/swift.swiftmodule')
 target = join_paths(build_root, 'osdep/mac/swift.o')
 
-swift_flags = ['-frontend', '-c', '-sdk', macos_sdk_path,
-               '-enable-objc-interop', '-emit-objc-header', '-parse-as-library']
+swift_flags = ['-c', '-emit-library', '-static', '-sdk', macos_sdk_path,
+               '-emit-objc-header', '-parse-as-library']
 
 if swift_ver.version_compare('>=6.0')
     swift_flags += ['-swift-version', '5']


### PR DESCRIPTION
Use swiftc instead of swift for building on macOS. This is requested in https://github.com/mpv-player/mpv/issues/13608.

The compile has been tested and successfully passed on M1 Air running Sequoia 15.1.1(Swift version 6.0.2).

Ref doc: https://github.com/swiftlang/swift/blob/main/docs/Driver.md