### PR TITLE
select.lua: don't print the clipboard warning when showing properties

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -396,8 +396,9 @@ mp.add_key_binding(nil, "show-properties", function ()
 
     -- Don't log errors for renamed and removed properties.
     local msg_level_backup = mp.get_property("msg-level")
-    mp.set_property("msg-level", msg_level_backup == "" and "cplayer=no"
-                                 or msg_level_backup .. ",cplayer=no")
+    local level = "cplayer=no,clipboard=error"
+    mp.set_property("msg-level", msg_level_backup == "" and level
+                                 or msg_level_backup .. "," .. level)
 
     for _, property in pairs(mp.get_property_native("property-list")) do
         add_property(property)


### PR DESCRIPTION
Prevent printing "[clipboard] VO is not initialized, or it does not support getting clipboard." when using the property list in the terminal or VOs that don't support the clipboard property.