### PR TITLE
osc.lua: add option to enable fade-in effect

### DIFF
--- a/DOCS/interface-changes/osc-fadein.txt
+++ b/DOCS/interface-changes/osc-fadein.txt
@@ -1,0 +1,1 @@
+add `osc-fadein` script-opt

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -297,7 +297,12 @@ Configurable Options
 ``fadeduration``
     Default: 200
 
-    Duration of fade out in ms, 0 = no fade
+    Duration of fade effects in ms, 0 = no fade.
+
+``fadein``
+    Default: no
+
+    Enable fade-in.
 
 ``title``
     Default: ${!playlist-count==1:[${playlist-pos-1}/${playlist-count}] }${media-title}

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -22,7 +22,8 @@ local user_opts = {
     hidetimeout = 500,          -- duration in ms until the OSC hides if no
                                 -- mouse movement. enforced non-negative for the
                                 -- user, but internally negative is "always-on".
-    fadeduration = 200,         -- duration of fade out in ms, 0 = no fade
+    fadeduration = 200,         -- duration of fade out (and fade in, if enabled) in ms, 0 = no fade
+    fadein = false,             -- whether to enable fade-in effect
     deadzonesize = 0.5,         -- size of deadzone
     minmousemove = 0,           -- minimum amount of pixels the mouse has to
                                 -- move between ticks to make the OSC show up
@@ -2111,9 +2112,15 @@ local function show_osc()
     --remember last time of invocation (mouse move)
     state.showtime = mp.get_time()
 
-    osc_visible(true)
-
-    if user_opts.fadeduration > 0 then
+    if user_opts.fadeduration <= 0 then
+        osc_visible(true)
+    elseif user_opts.fadein then
+        if not state.osc_visible then
+            state.anitype = "in"
+            request_tick()
+        end
+    else
+        osc_visible(true)
         state.anitype = nil
     end
 end


### PR DESCRIPTION
Fade in is already implemented, so I enabled it.
Is there a reason it's already implemented but not currently used?