### PR TITLE
defaults.{lua,js}: mark only wheel script-bindings as nonscalable

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1888,12 +1888,17 @@ prefixes can be specified. They are separated by whitespace.
     For some commands, keeping a key pressed runs the command repeatedly.
     This prefix forces disabling key repeat in any case.
 ``nonscalable``
-    When some commands (e.g. ``add``) are bound to scalable keys associated to a
-    high-precision input device like a touchpad (e.g. ``WHEEL_UP``), the value
-    specified in the command is scaled to smaller steps based on the high
-    resolution input data if available.
+    When some commands (e.g. ``add``) are bound to ``WHEEL_UP``, ``WHEEL_DOWN``,
+    ``WHEEL_LEFT`` or ``WHEEL_RIGHT``, plus any modifiers, and used with a
+    high-precision input device like a touchpad, the value specified in the
+    command is scaled to smaller steps based on the high resolution input data
+    if available.
     This prefix forces disabling this behavior, so the value is always changed
     in the discrete unit specified in the key binding.
+    The exact list of scalable commands can be checked by seeing which commands
+    under `List of Input Commands`_ mention that they are scalable.
+    See also ``mp.add_key_binding`` documentation for how it behaves with high
+    precision scaling.
 ``async``
     Allow asynchronous execution (if possible). Note that only a few commands
     will support this (usually this is explicitly documented). Some commands

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -333,9 +333,13 @@ function add_binding(forced, key, name, fn, opts) {
         }
     }
 
-    var prefix = key_data.scalable ? "" : " nonscalable";
-    if (key)
+    if (key) {
+        // noncritical: only add nonscalable with scalable keys, i.e. WHEEL_*,
+        // to not print nonscalable in scripts that read input-bindings. See
+        // nonscalable docs for more information.
+        var prefix = (key_data.scalable || !(/WHEEL/i).test(key)) ? "" : " nonscalable";
         key_data.input = key + prefix + " script-binding " + mp.script_name + "/" + name;
+    }
     binds[name] = key_data;  // used by user and/or our (key) script-binding
     sched_bindings_flush();
 }

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -237,8 +237,11 @@ local function add_binding(attrs, key, name, fn, rp)
         end
         msg_cb = fn
     end
-    local prefix = scalable and "" or " nonscalable"
     if key and #key > 0 then
+        -- noncritical: only add nonscalable with scalable keys, i.e. WHEEL_*,
+        -- to not print nonscalable in scripts that read input-bindings. See
+        -- nonscalable docs for more information.
+        local prefix = (scalable or not key:upper():find("WHEEL")) and "" or " nonscalable"
         attrs.bind = key .. prefix .. " script-binding " .. mp.script_name .. "/" .. name
     end
     attrs.name = name


### PR DESCRIPTION
In mp.add_key_binding, prepend nonscalable only to wheel bindings which are the only ones that can be scalable. This is just a cosmetic change to not unnecessarily print nonscalable before every binding added with mp.add_key_binding in scripts that read input-bindings like stats.

AXIS_ aliases are not matched because they have been deprecated for 5 years since 1649ba15ab.