### PR TITLE
various: upgrade option flags to uint64_t

### DIFF
--- a/options/m_config_core.c
+++ b/options/m_config_core.c
@@ -496,7 +496,7 @@ static void add_sub_group(struct m_config_shadow *shadow, const char *name_prefi
     }
 
     // You can only use UPDATE_ flags here.
-    assert(!(subopts->change_flags & ~(unsigned)UPDATE_OPTS_MASK));
+    assert(!(subopts->change_flags & ~UPDATE_OPTS_MASK));
 
     assert(parent_group_index >= -1 && parent_group_index < shadow->num_groups);
 

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -383,7 +383,7 @@ const char *m_config_get_positional_option(const struct m_config *config, int p)
 static int handle_set_opt_flags(struct m_config *config,
                                 struct m_config_option *co, int flags)
 {
-    int optflags = co->opt->flags;
+    uint64_t optflags = co->opt->flags;
     bool set = !(flags & M_SETOPT_CHECK_ONLY);
 
     if ((flags & M_SETOPT_PRE_PARSE_ONLY) && !(optflags & M_OPT_PRE_PARSE))

--- a/options/m_config_frontend.h
+++ b/options/m_config_frontend.h
@@ -87,7 +87,7 @@ typedef struct m_config {
     // m_config_notify_change_opt_ptr(). If false, it's caused either by
     // m_config_set_option_*() (and similar) calls or external updates.
     void (*option_change_callback)(void *ctx, struct m_config_option *co,
-                                   int flags, bool self_update);
+                                   uint64_t flags, bool self_update);
     void *option_change_callback_ctx;
 
     // For the command line parser

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -215,7 +215,7 @@ struct m_sub_options {
     const void *defaults;
     // Change flags passed to mp_option_change_callback() if any option that is
     // directly or indirectly part of this group is changed.
-    int change_flags;
+    uint64_t change_flags;
     // Return further sub-options, for example for optional components. If set,
     // this is called with increasing index (starting from 0), as long as true
     // is returned. If true is returned and *sub is set in any of these calls,
@@ -385,7 +385,7 @@ struct m_option {
     const m_option_type_t *type;
 
     // See \ref OptionFlags.
-    unsigned int flags;
+    uint64_t flags;
 
     // Always force an option update even if the written value does not change.
     bool force_update;
@@ -425,63 +425,63 @@ char *format_file_size(int64_t size);
 
 // The following are also part of the M_OPT_* flags, and are used to update
 // certain groups of options.
-#define UPDATE_TERM             (1 << 0)   // terminal options
-#define UPDATE_SUB_FILT         (1 << 1)   // subtitle filter options
-#define UPDATE_OSD              (1 << 2)   // related to OSD rendering
-#define UPDATE_BUILTIN_SCRIPTS  (1 << 3)   // osc/ytdl/stats
-#define UPDATE_IMGPAR           (1 << 4)   // video image params overrides
-#define UPDATE_INPUT            (1 << 5)   // mostly --input-* options
-#define UPDATE_AUDIO            (1 << 6)   // --audio-channels etc.
-#define UPDATE_PRIORITY         (1 << 7)   // --priority (Windows-only)
-#define UPDATE_SCREENSAVER      (1 << 8)   // --stop-screensaver
-#define UPDATE_VOL              (1 << 9)   // softvol related options
-#define UPDATE_LAVFI_COMPLEX    (1 << 10)  // --lavfi-complex
-#define UPDATE_HWDEC            (1 << 11)  // --hwdec
-#define UPDATE_DVB_PROG         (1 << 12)  // some --dvbin-...
-#define UPDATE_SUB_HARD         (1 << 13)  // subtitle opts. that need full reinit
-#define UPDATE_SUB_EXTS         (1 << 14)  // update internal list of sub exts
-#define UPDATE_VIDEO            (1 << 15)  // force redraw if needed
-#define UPDATE_VO               (1 << 16)  // reinit the VO
-#define UPDATE_CLIPBOARD        (1 << 17)  // reinit the clipboard
-#define UPDATE_DEMUXER          (1 << 18)  // invalidate --prefetch-playlist's data
-#define UPDATE_AD               (1 << 19)  // reinit audio chain and decoder
-#define UPDATE_VD               (1 << 20)  // reinit video chain and decoder
-#define UPDATE_OPT_LAST         (1 << 20)
+#define UPDATE_TERM             (UINT64_C(1) << 0)   // terminal options
+#define UPDATE_SUB_FILT         (UINT64_C(1) << 1)   // subtitle filter options
+#define UPDATE_OSD              (UINT64_C(1) << 2)   // related to OSD rendering
+#define UPDATE_BUILTIN_SCRIPTS  (UINT64_C(1) << 3)   // osc/ytdl/stats
+#define UPDATE_IMGPAR           (UINT64_C(1) << 4)   // video image params overrides
+#define UPDATE_INPUT            (UINT64_C(1) << 5)   // mostly --input-* options
+#define UPDATE_AUDIO            (UINT64_C(1) << 6)   // --audio-channels etc.
+#define UPDATE_PRIORITY         (UINT64_C(1) << 7)   // --priority (Windows-only)
+#define UPDATE_SCREENSAVER      (UINT64_C(1) << 8)   // --stop-screensaver
+#define UPDATE_VOL              (UINT64_C(1) << 9)   // softvol related options
+#define UPDATE_LAVFI_COMPLEX    (UINT64_C(1) << 10)  // --lavfi-complex
+#define UPDATE_HWDEC            (UINT64_C(1) << 11)  // --hwdec
+#define UPDATE_DVB_PROG         (UINT64_C(1) << 12)  // some --dvbin-...
+#define UPDATE_SUB_HARD         (UINT64_C(1) << 13)  // subtitle opts. that need full reinit
+#define UPDATE_SUB_EXTS         (UINT64_C(1) << 14)  // update internal list of sub exts
+#define UPDATE_VIDEO            (UINT64_C(1) << 15)  // force redraw if needed
+#define UPDATE_VO               (UINT64_C(1) << 16)  // reinit the VO
+#define UPDATE_CLIPBOARD        (UINT64_C(1) << 17)  // reinit the clipboard
+#define UPDATE_DEMUXER          (UINT64_C(1) << 18)  // invalidate --prefetch-playlist's data
+#define UPDATE_AD               (UINT64_C(1) << 19)  // reinit audio chain and decoder
+#define UPDATE_VD               (UINT64_C(1) << 20)  // reinit video chain and decoder
+#define UPDATE_OPT_LAST         (UINT64_C(1) << 20)
 
 // All bits between of UPDATE_ flags
 #define UPDATE_OPTS_MASK        ((UPDATE_OPT_LAST << 1) - 1)
 
 // The option is forbidden in config files.
-#define M_OPT_NOCFG             (1 << 30)
+#define M_OPT_NOCFG             (UINT64_C(1) << 63)
 
 // The option should be set during command line pre-parsing
-#define M_OPT_PRE_PARSE         (1 << 29)
+#define M_OPT_PRE_PARSE         (UINT64_C(1) << 62)
 
 // The option expects a file name (or a list of file names)
-#define M_OPT_FILE              (1 << 28)
+#define M_OPT_FILE              (UINT64_C(1) << 61)
 
 // Do not add as property.
-#define M_OPT_NOPROP            (1 << 27)
+#define M_OPT_NOPROP            (UINT64_C(1) << 60)
 
 // Enable special semantics for some options when parsing the string "help".
-#define M_OPT_HAVE_HELP         (1 << 26)
+#define M_OPT_HAVE_HELP         (UINT64_C(1) << 59)
 
 // type_float/type_double: string "default" is parsed as NaN (and reverse)
-#define M_OPT_DEFAULT_NAN       (1 << 25)
+#define M_OPT_DEFAULT_NAN       (UINT64_C(1) << 58)
 
 // type time: string "no" maps to MP_NOPTS_VALUE (if unset, NOPTS is rejected)
 // and
 // parsing: "--no-opt" is parsed as "--opt=no"
-#define M_OPT_ALLOW_NO          (1 << 24)
+#define M_OPT_ALLOW_NO          (UINT64_C(1) << 57)
 
 // type channels: disallow "auto" (still accept ""), limit list to at most 1 item.
-#define M_OPT_CHANNELS_LIMITED  (1 << 23)
+#define M_OPT_CHANNELS_LIMITED  (UINT64_C(1) << 56)
 
 // type_float/type_double: controls if pretty print should trim trailing zeros
-#define M_OPT_FIXED_LEN_PRINT   (1 << 22)
+#define M_OPT_FIXED_LEN_PRINT   (UINT64_C(1) << 55)
 
 // Like M_OPT_TYPE_OPTIONAL_PARAM.
-#define M_OPT_OPTIONAL_PARAM    (1 << 21)
+#define M_OPT_OPTIONAL_PARAM    (UINT64_C(1) << 54)
 
 static_assert(!(UPDATE_OPTS_MASK & M_OPT_OPTIONAL_PARAM), "");
 

--- a/player/command.c
+++ b/player/command.c
@@ -7631,7 +7631,7 @@ static void update_track_switch(struct MPContext *mpctx, int order, int type)
     mp_wakeup_core(mpctx);
 }
 
-void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
+void mp_option_change_callback(void *ctx, struct m_config_option *co, uint64_t flags,
                                bool self_update)
 {
     struct MPContext *mpctx = ctx;
@@ -7655,8 +7655,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
             struct track *track = mpctx->current_track[n][STREAM_SUB];
             struct dec_sub *sub = track ? track->d_sub : NULL;
             if (sub) {
-                int ret = sub_control(sub, SD_CTRL_UPDATE_OPTS,
-                                      (void *)(uintptr_t)flags);
+                int ret = sub_control(sub, SD_CTRL_UPDATE_OPTS, &flags);
                 if (ret == CONTROL_OK && flags & (UPDATE_SUB_FILT | UPDATE_SUB_HARD)) {
                     sub_redecode_cached_packets(sub);
                     sub_reset(sub);

--- a/player/command.h
+++ b/player/command.h
@@ -80,7 +80,7 @@ void property_print_help(struct MPContext *mpctx);
 int mp_property_do(const char* name, int action, void* val,
                    struct MPContext *mpctx);
 
-void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
+void mp_option_change_callback(void *ctx, struct m_config_option *co, uint64_t flags,
                                bool self_update);
 
 void mp_notify(struct MPContext *mpctx, int event, void *arg);

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -515,7 +515,7 @@ int sub_control(struct dec_sub *sub, enum sd_ctrl cmd, void *arg)
         break;
     }
     case SD_CTRL_UPDATE_OPTS: {
-        int flags = (uintptr_t)arg;
+        uint64_t flags = *(uint64_t *)arg;
         if (m_config_cache_update(sub->opts_cache))
             update_subtitle_speed(sub);
         m_config_cache_update(sub->shared_opts_cache);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -1022,7 +1022,7 @@ static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
         ctx->video_params = *(struct mp_image_params *)arg;
         return CONTROL_OK;
     case SD_CTRL_UPDATE_OPTS: {
-        int flags = (uintptr_t)arg;
+        uint64_t flags = *(uint64_t *)arg;
         if (flags & UPDATE_SUB_FILT) {
             filters_destroy(sd);
             filters_init(sd);


### PR DESCRIPTION
UPDATE_CLIPBOARD currently has the same value as M_OPT_DEFAULT_NAN, so increment all constants after UPDATE_OPT_LAST. But increment them by 5 so we can add a few more UPDATE flags without either forgetting to increase them like in e1d30c4c5a, or having to increase them each time like in a5937ac7e3.
