### PR TITLE
m_property: stop processing after 10 properties even in skip cases

### DIFF
--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -604,7 +604,11 @@ int ebml_read_element(struct stream *s, struct ebml_parse_ctx *ctx,
         MP_MSG(ctx, msglevel, "EBML element with unknown length - unsupported\n");
         return -1;
     }
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (length > (512 << 20)) {
+#else
+    if (length > (64 << 20)) {
+#endif
         MP_MSG(ctx, msglevel, "Element too big (%" PRIu64 " MiB) - skipping\n", length >> 20);
         return -1;
     }

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -313,11 +313,12 @@ char *m_properties_expand_string(const struct m_property *prop_list,
             str = bstr_cut(str, term_pos);
             bool have_fallback = bstr_eatstart0(&str, ":");
 
-            if (!skip) {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-                if (n++ > 10)
-                    break;
+            if (n++ > 10)
+                break;
 #endif
+
+            if (!skip) {
                 skip = expand_property(prop_list, &ret, &ret_len, name,
                                        have_fallback, ctx);
                 if (skip)

--- a/options/options.c
+++ b/options/options.c
@@ -456,14 +456,18 @@ static const m_option_t mp_opts[] = {
     // handled in command line pre-parser (parse_commandline.c)
     {"v", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     {"playlist", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_FILE, .offset = -1},
+#endif
     {"{", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
     {"}", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
 
     // handled in m_config.c
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     {"include", CONF_TYPE_STRING, M_OPT_FILE, .offset = -1},
+#endif
     {"profile", CONF_TYPE_STRING_LIST, 0, .offset = -1},
     {"show-profile", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_NOPROP |
         M_OPT_OPTIONAL_PARAM,  .offset = -1},


### PR DESCRIPTION
For OSS-Fuzz.

See: 2054d872d48f315d4658f0871d914061a35eda2a