### PR TITLE
options: remove old compatibility definitions

### DIFF
--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -76,7 +76,7 @@ struct mux_stream {
 #define OPT_BASE_STRUCT struct encode_opts
 const struct m_sub_options encode_config = {
     .opts = (const m_option_t[]) {
-        {"o", OPT_STRING(file), .flags = CONF_NOCFG | CONF_PRE_PARSE | M_OPT_FILE},
+        {"o", OPT_STRING(file), .flags = M_OPT_NOCFG | M_OPT_PRE_PARSE | M_OPT_FILE},
         {"of", OPT_STRING(format)},
         {"ofopts", OPT_KEYVALUELIST(fopts), .flags = M_OPT_HAVE_HELP},
         {"ovc", OPT_STRING(vcodec)},

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -482,10 +482,6 @@ char *format_file_size(int64_t size);
 // Like M_OPT_TYPE_OPTIONAL_PARAM.
 #define M_OPT_OPTIONAL_PARAM    (1 << 30)
 
-// These are kept for compatibility with older code.
-#define CONF_NOCFG              M_OPT_NOCFG
-#define CONF_PRE_PARSE          M_OPT_PRE_PARSE
-
 // These flags are used to describe special parser capabilities or behavior.
 
 // The parameter is optional and by default no parameter is preferred. If

--- a/options/options.c
+++ b/options/options.c
@@ -454,26 +454,26 @@ const struct m_sub_options filter_conf = {
 
 static const m_option_t mp_opts[] = {
     // handled in command line pre-parser (parse_commandline.c)
-    {"v", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
+    {"v", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
-    {"playlist", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_FILE, .offset = -1},
-    {"{", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
+    {"playlist", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_FILE, .offset = -1},
+    {"{", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
-    {"}", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
+    {"}", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
      .offset = -1},
 
     // handled in m_config.c
     {"include", CONF_TYPE_STRING, M_OPT_FILE, .offset = -1},
     {"profile", CONF_TYPE_STRING_LIST, 0, .offset = -1},
-    {"show-profile", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP |
+    {"show-profile", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_NOPROP |
         M_OPT_OPTIONAL_PARAM,  .offset = -1},
-    {"list-options", &m_option_type_dummy_flag, CONF_NOCFG | M_OPT_NOPROP,
+    {"list-options", &m_option_type_dummy_flag, M_OPT_NOCFG | M_OPT_NOPROP,
         .offset = -1},
     {"list-properties", OPT_BOOL(property_print_help),
-     .flags = CONF_NOCFG | M_OPT_NOPROP},
-    {"help", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
+     .flags = M_OPT_NOCFG | M_OPT_NOPROP},
+    {"help", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
         .offset = -1},
-    {"h", CONF_TYPE_STRING, CONF_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
+    {"h", CONF_TYPE_STRING, M_OPT_NOCFG | M_OPT_NOPROP | M_OPT_OPTIONAL_PARAM,
         .offset = -1},
 
     {"list-protocols", OPT_PRINT(stream_print_proto_list)},
@@ -489,16 +489,16 @@ static const m_option_t mp_opts[] = {
 // ------------------------- common options --------------------
     {"quiet", OPT_BOOL(quiet)},
     {"really-quiet", OPT_BOOL(msg_really_quiet),
-        .flags = CONF_PRE_PARSE | UPDATE_TERM},
-    {"terminal", OPT_BOOL(use_terminal), .flags = CONF_PRE_PARSE | UPDATE_TERM},
+        .flags = M_OPT_PRE_PARSE | UPDATE_TERM},
+    {"terminal", OPT_BOOL(use_terminal), .flags = M_OPT_PRE_PARSE | UPDATE_TERM},
     {"msg-level", OPT_MSGLEVELS(msg_levels),
-        .flags = CONF_PRE_PARSE | UPDATE_TERM},
+        .flags = M_OPT_PRE_PARSE | UPDATE_TERM},
     {"dump-stats", OPT_STRING(dump_stats),
-        .flags = UPDATE_TERM | CONF_PRE_PARSE | M_OPT_FILE},
-    {"msg-color", OPT_BOOL(msg_color), .flags = CONF_PRE_PARSE | UPDATE_TERM},
+        .flags = UPDATE_TERM | M_OPT_PRE_PARSE | M_OPT_FILE},
+    {"msg-color", OPT_BOOL(msg_color), .flags = M_OPT_PRE_PARSE | UPDATE_TERM},
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     {"log-file", OPT_STRING(log_file),
-        .flags = CONF_PRE_PARSE | M_OPT_FILE | UPDATE_TERM},
+        .flags = M_OPT_PRE_PARSE | M_OPT_FILE | UPDATE_TERM},
 #endif
     {"msg-module", OPT_BOOL(msg_module), .flags = UPDATE_TERM},
     {"msg-time", OPT_BOOL(msg_time), .flags = UPDATE_TERM},
@@ -515,9 +515,9 @@ static const m_option_t mp_opts[] = {
 #endif
     {"media-controls", OPT_CHOICE(media_controls,
         {"no", 0}, {"player", 1}, {"yes", 2})},
-    {"config", OPT_BOOL(load_config), .flags = CONF_PRE_PARSE},
+    {"config", OPT_BOOL(load_config), .flags = M_OPT_PRE_PARSE},
     {"config-dir", OPT_STRING(force_configdir),
-        .flags = CONF_NOCFG | CONF_PRE_PARSE | M_OPT_FILE},
+        .flags = M_OPT_NOCFG | M_OPT_PRE_PARSE | M_OPT_FILE},
     {"reset-on-next-file", OPT_STRINGLIST(reset_options)},
 
 #if HAVE_LUA || HAVE_JAVASCRIPT || HAVE_CPLUGINS


### PR DESCRIPTION
This makes things more readable.