### PR TITLE
configfiles: don't use the basename of urls

### DIFF
--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -215,7 +215,7 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     char *res = NULL;
     void *tmp = talloc_new(NULL);
     const char *path = NULL;
-    if (opts->ignore_path_in_watch_later_config && !mp_is_url(bstr0(path))) {
+    if (opts->ignore_path_in_watch_later_config && !mp_is_url(bstr0(fname))) {
         path = mp_basename(fname);
     } else {
         path = mp_normalize_path(tmp, fname);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -215,7 +215,9 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     char *res = NULL;
     void *tmp = talloc_new(NULL);
     const char *path = NULL;
-    if (opts->ignore_path_in_watch_later_config && !mp_is_url(bstr0(fname))) {
+    if (mp_is_url(bstr0(fname))) {
+        path = fname;
+    } else if (opts->ignore_path_in_watch_later_config) {
         path = mp_basename(fname);
     } else {
         path = mp_normalize_path(tmp, fname);


### PR DESCRIPTION
With --ignore-path-in-watch-later-config the basename of files is used for watch later files, but since 1d640c9887 this was checking the wrong variable to determine if the file is a URL and thus also taking the basename of URLs, when URLs should use the full path regardless of this option.