### PR TITLE
ci/win32: enable tests for dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,9 +181,10 @@ jobs:
         run: |
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' -and `
                                                              $_ -ne 'C:\Strawberry\c\bin' }) -join ';'
+          $env:PATH += ';C:\Program Files\NASM'
           Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
           Enter-VsDevShell -VsInstallPath $env:VS -SkipAutomaticLocation -DevCmdArguments "-arch=x64 -host_arch=x64"
-          meson test -C build mpv:
+          meson test -C build
 
       - name: Print meson test log
         if: ${{ failure() && steps.tests.outcome == 'failure' }}

--- a/ci/build-win32.ps1
+++ b/ci/build-win32.ps1
@@ -205,7 +205,7 @@ meson setup build `
     -Dtests=true `
     -Dgpl=true `
     -Dffmpeg:gpl=enabled `
-    -Dffmpeg:tests=disabled `
+    -Dffmpeg:tests=enabled `
     -Dffmpeg:programs=disabled `
     -Dffmpeg:sdl2=disabled `
     -Dffmpeg:vulkan=auto `
@@ -214,11 +214,13 @@ meson setup build `
     -Dlcms2:fastfloat=true `
     -Dlcms2:jpeg=disabled `
     -Dlcms2:tiff=disabled `
+    -Dlibass:test=enabled `
     -Dlibusb:tests=false `
     -Dlibusb:examples=false `
     -Dlibplacebo:demos=false `
     -Dlibplacebo:lcms=enabled `
     -Dlibplacebo:shaderc=enabled `
+    -Dlibplacebo:tests=true `
     -Dlibplacebo:vulkan=enabled `
     -Dlibplacebo:d3d11=enabled `
     -Dxxhash:inline-all=true `


### PR DESCRIPTION
We build and ship this code, so it makes sense to make sure it is ok.

Tests for libass and libplacebo are explicitly enabled. The rest is in default state, so if tests are enabled by default, they will run.

FFmpeg tests and currently disabled, because they are failing on Windows. Once the patch is merged upstream, we can back-port it to our build. See: https://ffmpeg.org/pipermail/ffmpeg-devel/2024-December/337262.html