### PR TITLE
console.lua: add margin script-opts

### DIFF
--- a/DOCS/interface-changes/console-margins.txt
+++ b/DOCS/interface-changes/console-margins.txt
@@ -1,0 +1,1 @@
+add `console-margin-x` and `console-margin-y` script-opts

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -169,6 +169,16 @@ Configurable Options
 
     Set the font border size used for the REPL and the console.
 
+``margin_x``
+    Default: same as ``--osd-margin-x``
+
+    The margin from the left of the window.
+
+``margin_y``
+    Default: same as ``--osd-margin-y``
+
+    The margin from the bottom of the window.
+
 ``scale_with_window``
     Default: ``auto``
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -32,6 +32,8 @@ local opts = {
     font = "",
     font_size = 24,
     border_size = 1.65,
+    margin_x = -1,
+    margin_y = -1,
     scale_with_window = "auto",
     case_sensitive = platform ~= 'windows' and true or false,
     history_dedup = true,
@@ -126,6 +128,15 @@ local function get_font()
     end
 
     return 'monospace'
+end
+
+local function get_margin_x()
+    return opts.margin_x > -1 and opts.margin_x or mp.get_property_native('osd-margin-x')
+end
+
+
+local function get_margin_y()
+    return opts.margin_y > -1 and opts.margin_y or mp.get_property_native('osd-margin-y')
 end
 
 
@@ -276,7 +287,7 @@ local function calculate_max_log_lines()
 
     return math.floor((select(2, get_scaled_osd_dimensions())
                        * (1 - global_margins.t - global_margins.b)
-                       - mp.get_property_native('osd-margin-y'))
+                       - get_margin_y())
                       / opts.font_size
                       -- Subtract 1 for the input line and 0.5 for the empty
                       -- line between the log and the input line.
@@ -524,8 +535,8 @@ local function update()
 
     local screenx, screeny = get_scaled_osd_dimensions()
 
-    local marginx = mp.get_property_native('osd-margin-x')
-    local marginy = mp.get_property_native('osd-margin-y')
+    local marginx = get_margin_x()
+    local marginy = get_margin_y()
 
     local coordinate_top = math.floor(global_margins.t * screeny + 0.5)
     local clipping_coordinates = '0,' .. coordinate_top .. ',' ..
@@ -567,8 +578,9 @@ local function update()
         -- Even with bottom-left anchoring,
         -- libass/ass_render.c:ass_render_event() subtracts --osd-margin-x from
         -- the maximum text width twice.
-        local width_max = math.floor((screenx - marginx - marginx * 2 / scale_factor())
-                                     / opts.font_size * get_font_hw_ratio())
+        local width_max = math.floor(
+            (screenx - marginx - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
+            / opts.font_size * get_font_hw_ratio())
 
         local suggestions, rows = format_table(suggestion_buffer, width_max, lines_max)
         lines_max = lines_max - rows
@@ -854,7 +866,7 @@ local function determine_hovered_item()
     local height = select(2, get_scaled_osd_dimensions())
     local y = mp.get_property_native('mouse-pos').y / scale_factor()
     local log_bottom_pos = height * (1 - global_margins.b)
-                           - mp.get_property_native('osd-margin-y')
+                           - get_margin_y()
                            - 1.5 * opts.font_size
 
     if y > log_bottom_pos then


### PR DESCRIPTION
Allow configuring the margin from the bottom indipendently of --osd-margin-y.

Fixes #15478.