### PR TITLE
alsa edgecase fixes

### DIFF
--- a/player/audio.c
+++ b/player/audio.c
@@ -389,11 +389,6 @@ static int reinit_audio_filters_and_output(struct MPContext *mpctx)
         return 0;
     }
 
-    // Wait until all played.
-    if (mpctx->ao && ao_is_playing(mpctx->ao)) {
-        talloc_free(out_fmt);
-        return 0;
-    }
     // Format change during syncing. Force playback start early, then wait.
     if (ao_c->ao_queue && mp_async_queue_get_frames(ao_c->ao_queue) &&
         mpctx->audio_status == STATUS_SYNCING)


### PR DESCRIPTION
See commits. Basically alsa was bugged with different samplerates in a playlist since probably b74c09efbf7c6969fc053265f72cc0501b840ce1 but it was not noticed because most people's devices probably default to the highest sampling rate, resample anything upwards, and that is used throughout the entire playlist. To test, you would need to specify `--audio-device` since it seems using `auto` (or `default` as it is internally called in alsa) is different and happens to work in a way that doesn't have this problem.