### PR TITLE
osc.lua: move title mbtn script-opts below playlist_next's

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -501,12 +501,6 @@ Configurable Options
 The following options configure what commands are run when the buttons are
 clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
-``title_mbtn_left_command=script-binding stats/display-page-5``
-
-``title_mbtn_mid_command=show-text ${filename}``
-
-``title_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
-
 ``playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000``
 
 ``playlist_prev_mbtn_mid_command=show-text ${playlist} 3000``
@@ -518,6 +512,12 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 ``playlist_next_mbtn_mid_command=show-text ${playlist} 3000``
 
 ``playlist_next_mbtn_right_command=show-text ${playlist} 3000``
+
+``title_mbtn_left_command=script-binding stats/display-page-5``
+
+``title_mbtn_mid_command=show-text ${filename}``
+
+``title_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
 
 ``play_pause_mbtn_left_command=cycle pause``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -71,10 +71,6 @@ local user_opts = {
 
     -- luacheck: push ignore
     -- luacheck: max line length
-    title_mbtn_left_command = "script-binding stats/display-page-5",
-    title_mbtn_mid_command = "show-text ${filename}",
-    title_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
-
     playlist_prev_mbtn_left_command = "playlist-prev",
     playlist_prev_mbtn_mid_command = "show-text ${playlist} 3000",
     playlist_prev_mbtn_right_command = "show-text ${playlist} 3000",
@@ -82,6 +78,10 @@ local user_opts = {
     playlist_next_mbtn_left_command = "playlist-next",
     playlist_next_mbtn_mid_command = "show-text ${playlist} 3000",
     playlist_next_mbtn_right_command = "show-text ${playlist} 3000",
+
+    title_mbtn_left_command = "script-binding stats/display-page-5",
+    title_mbtn_mid_command = "show-text ${filename}",
+    title_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
 
     play_pause_mbtn_left_command = "cycle pause",
     play_pause_mbtn_mid_command = "",


### PR DESCRIPTION
Sort mbtn script-opts according to how they are shown to the user in bar layout instead of how they are defined in osc_init().