### PR TITLE
osc.lua: update mouse bindings

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -51,7 +51,7 @@ title
     =============   ================================================
     left-click      show file and track info
     middle-click    show the filename
-    right-click     open the playlist selector
+    right-click     show the path
     =============   ================================================
 
 cache
@@ -517,7 +517,7 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``title_mbtn_mid_command=show-text ${filename}``
 
-``title_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
+``title_mbtn_right_command=show-text ${path}``
 
 ``play_pause_mbtn_left_command=cycle pause``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -31,17 +31,17 @@ The Interface
 pl prev
     =============   ================================================
     left-click      play previous file in playlist
-    right-click     show the playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
+    right-click     open the playlist selector
     =============   ================================================
 
 pl next
     =============   ================================================
     left-click      play next file in playlist
-    right-click     show the playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
+    right-click     open the playlist selector
     =============   ================================================
 
 title
@@ -505,13 +505,13 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``playlist_prev_mbtn_mid_command=show-text ${playlist} 3000``
 
-``playlist_prev_mbtn_right_command=show-text ${playlist} 3000``
+``playlist_prev_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
 
 ``playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000``
 
 ``playlist_next_mbtn_mid_command=show-text ${playlist} 3000``
 
-``playlist_next_mbtn_right_command=show-text ${playlist} 3000``
+``playlist_next_mbtn_right_command=script-binding select/select-playlist; script-message-to osc osc-hide``
 
 ``title_mbtn_left_command=script-binding stats/display-page-5``
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -50,6 +50,7 @@ title
 
     =============   ================================================
     left-click      show file and track info
+    shift+L-click   show the filename
     middle-click    show the filename
     right-click     show the path
     =============   ================================================
@@ -66,15 +67,17 @@ play
 skip back
     =============   ================================================
     left-click      go to beginning of chapter / previous chapter
-    right-click     open the chapter selector
     shift+L-click   show chapters
+    middle-click    show chapters
+    right-click     open the chapter selector
     =============   ================================================
 
 skip frwd
     =============   ================================================
     left-click      go to next chapter
-    right-click     open the chapter selector
     shift+L-click   show chapters
+    middle-click    show chapters
+    right-click     open the chapter selector
     =============   ================================================
 
 time elapsed

--- a/etc/restore-osc-bindings.conf
+++ b/etc/restore-osc-bindings.conf
@@ -17,6 +17,9 @@ chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 
 chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000
 
 # restore behavior before select.lua usage
+playlist_prev_mbtn_right_command=show-text ${playlist} 3000
+playlist_next_mbtn_right_command=show-text ${playlist} 3000
+
 title=${media-title}
 title_mbtn_left_command=show-text "${!playlist-count==1:[${playlist-pos-1}/${playlist-count}] }${media-title}"
 title_mbtn_right_command=show-text ${filename}

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -73,11 +73,11 @@ local user_opts = {
     -- luacheck: max line length
     playlist_prev_mbtn_left_command = "playlist-prev",
     playlist_prev_mbtn_mid_command = "show-text ${playlist} 3000",
-    playlist_prev_mbtn_right_command = "show-text ${playlist} 3000",
+    playlist_prev_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
 
     playlist_next_mbtn_left_command = "playlist-next",
     playlist_next_mbtn_mid_command = "show-text ${playlist} 3000",
-    playlist_next_mbtn_right_command = "show-text ${playlist} 3000",
+    playlist_next_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
 
     title_mbtn_left_command = "script-binding stats/display-page-5",
     title_mbtn_mid_command = "show-text ${filename}",

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -81,7 +81,7 @@ local user_opts = {
 
     title_mbtn_left_command = "script-binding stats/display-page-5",
     title_mbtn_mid_command = "show-text ${filename}",
-    title_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
+    title_mbtn_right_command = "show-text ${path}",
 
     play_pause_mbtn_left_command = "cycle pause",
     play_pause_mbtn_mid_command = "",


### PR DESCRIPTION
osc.lua: open the playlist selector when right clicking playlist arrows

- It makes more sense to select a playlist entry from the buttons that navigate the playlist than from the title
- Provides different bindings for right and middle click
- Mirrors chapter button bindings

osc.lua: show the full path when right clicking the title

Right clicking playlist arrows already opens the playlist selector so bind something else to right clicking the title. Make it show the full path which is useful but not bound anywhere on either the keyboard or the OSC.

DOCS/man/osc: sort mouse bindings consistently

Always list in the order left shift+L middle right click.