### PR TITLE
mac: add support for --force-window-position

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3569,7 +3569,7 @@ Window
 ``--force-window-position``
     Forcefully move mpv's video output window to default location whenever
     there is a change in video parameters, video stream or file. This used to
-    be the default behavior. Currently only affects X11 and SDL VOs.
+    be the default behavior. Currently only affects X11, macvk and SDL VOs.
 
 ``--auto-window-resize=<yes|no>``
     By default, mpv will automatically resize itself if the video's size changes

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -47,8 +47,7 @@ class MacCommon: Common {
             let previousActiveApp = getActiveApp()
             initApp()
 
-            let (_, wr, _) = getInitProperties(vo)
-
+            let (_, wr, forcePosition) = getInitProperties(vo)
             guard let layer = self.layer else {
                 log.error("Something went wrong, no MetalLayer was initialized")
                 exit(1)
@@ -60,7 +59,9 @@ class MacCommon: Common {
                 initWindowState()
             }
 
-            if option.vo.auto_window_resize {
+            if forcePosition {
+                window?.updateFrame(wr)
+            } else if option.vo.auto_window_resize {
                 window?.updateSize(wr.size)
             }
 


### PR DESCRIPTION
(that's a lot less changes than i anticipated.)

This pull request includes a bug fix and adds support for a feature.

*****

1. In `Common::getWindowGeometry -> (NSRect, Bool)`
https://github.com/mpv-player/mpv/blob/dbb3291e8e9729fb3488a82e21622dafb5a68910/video/out/mac/common.swift#L440-L440

`Int32(VO_WIN_FORCE_POS)` is always a constant 1, irrespective of `--force-window-position`. As a result, whenever `--geometry` is passed, `forcePosition` is returned as 1.

You can easily verify this by:
a) Adding a breakpoint just before the return statement, or
b) Including a debug line such as `print("Bool", Bool(geo.flags & Int32(VO_WIN_FORCE_POS)))`
Then:
```
build/mpv --geometry=500:500 '/Users/neko/Downloads/test.mp4'
build/mpv --geometry=500:500 --force-window-position '/Users/neko/Downloads/test.mp4'
```
***** 
[Notice] The objc func `control` used variable `forcePosition` in one case within a switch statement. However, I don't know the corresponding trigger condition. Could someone who knows provide the related code or help me test it?
https://github.com/mpv-player/mpv/blob/dbb3291e8e9729fb3488a82e21622dafb5a68910/video/out/mac/common.swift#L537-L537

*****

2. Add support for --force-window-position
simple.
https://developer.apple.com/documentation/appkit/nswindow/ismovable