### PR TITLE
ios/macos: use non-exclusive audio session

### DIFF
--- a/DOCS/interface-changes/audiounit-exclusive.txt
+++ b/DOCS/interface-changes/audiounit-exclusive.txt
@@ -1,0 +1,1 @@
+add --audio-exclusive option support for ao=audiounit and make non-exclusive the new default

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2001,8 +2001,8 @@ Audio
     Enable exclusive output mode. In this mode, the system is usually locked
     out, and only mpv will be able to output audio.
 
-    This only works for some audio outputs, such as ``wasapi``, ``coreaudio``
-    and ``pipewire``. Other audio outputs silently ignore this option.
+    This only works for some audio outputs, such as ``wasapi``, ``coreaudio``,
+    ``pipewire`` and ``audiounit``. Other audio outputs silently ignore this option.
     They either have no concept of exclusive mode, or the mpv side of the
     implementation is missing.
 

--- a/audio/out/ao_audiounit.m
+++ b/audio/out/ao_audiounit.m
@@ -115,7 +115,12 @@ static bool init_audiounit(struct ao *ao)
 
     MP_VERBOSE(ao, "max channels: %ld, requested: %d\n", maxChannels, (int)ao->channels.num);
 
-    [instance setCategory:AVAudioSessionCategoryPlayback error:nil];
+    AVAudioSessionCategoryOptions options = 0;
+    if (!(ao->init_flags & AO_INIT_EXCLUSIVE)) {
+        options |= AVAudioSessionCategoryOptionMixWithOthers;
+    }
+
+    [instance setCategory:AVAudioSessionCategoryPlayback withOptions:options error:nil];
     [instance setMode:AVAudioSessionModeMoviePlayback error:nil];
     [instance setActive:YES error:nil];
     [instance setPreferredOutputNumberOfChannels:prefChannels error:nil];


### PR DESCRIPTION
Using this option means the OS  won't pause other
sources of audio when playback starts in MPV.

This matches the behaviour on other platforms.
