### PR TITLE
osc.lua: simplify track ID retrival

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1856,13 +1856,8 @@ local function osc_init()
 
     ne.enabled = audio_track_count > 0
     ne.content = function ()
-        local aid = mp.get_property("aid")
-        if aid == "no" or aid == "auto" then
-            aid = "-"
-        end
-
         return ("\238\132\134" .. osc_styles.smallButtonsLlabel .. " " ..
-               aid .. "/" .. audio_track_count)
+               mp.get_property_number("aid", "-") .. "/" .. audio_track_count)
     end
     bind_mouse_buttons("audio_track")
 
@@ -1871,13 +1866,8 @@ local function osc_init()
 
     ne.enabled = sub_track_count > 0
     ne.content = function ()
-        local sid = mp.get_property("sid")
-        if sid == "no" or sid == "auto" then
-            sid = "-"
-        end
-
         return ("\238\132\135" .. osc_styles.smallButtonsLlabel .. " " ..
-               sid .. "/" .. sub_track_count)
+               mp.get_property_number("sid", "-") .. "/" .. sub_track_count)
     end
     bind_mouse_buttons("sub_track")
 


### PR DESCRIPTION
When track IDs are auto mp.get_property_native() returns "auto", but mp.get_property_number() returns nil.

Follow up to 1a558bf5c2 and 897c04afe1.