### PR TITLE
osc.lua: allow adding custom buttons

### DIFF
--- a/DOCS/interface-changes/osc-buttons.txt
+++ b/DOCS/interface-changes/osc-buttons.txt
@@ -2,3 +2,4 @@ change several OSC mouse bindings to select.lua functions
 add script-opts to configure what OSC buttons do when clicked
 remove `osc-playlist_osd` script-opt and behave as if it was off by default; `playlist_osd=yes` can be replicated with `osc-playlist_prev_mbtn_left_command=playlist-prev; show-text ${playlist} 3000` and `osc-playlist_next_mbtn_left_command=playlist-next; show-text ${playlist} 3000`
 remove `osc-chapters_osd` script-opt and behave as if it was off by default; `chapter_osd=yes` can be replicated with `osc-chapter_prev_mbtn_left_command=no-osd add chapter -1; show-text ${chapter-list} 3000` and `osc-chapter_next_mbtn_left_command=no-osd add chapter 1; show-text ${chapter-list} 3000`
+add script-opts to define custom buttons

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -576,6 +576,21 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``fullscreen_mbtn_right_command="cycle window-maximized"``
 
+Custom Buttons
+~~~~~~~~~~~~~~
+
+Additional script-opts are available to define custom buttons in ``bottombar``
+and ``topbar`` layouts.
+
+.. admonition:: Example to add loop and shuffle buttons
+
+    custom_button_1_content=🔁
+    custom_button_1_mbtn_left_command=cycle-values loop-file inf no
+    custom_button_1_mbtn_right_command=cycle-values loop-playlist inf no
+
+    custom_button_2_content=🔀
+    custom_button_2_mbtn_left_command=playlist-shuffle
+
 Script Commands
 ~~~~~~~~~~~~~~~
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -119,6 +119,13 @@ local user_opts = {
     -- luacheck: pop
 }
 
+for i = 1, 99 do
+    user_opts["custom_button_" .. i .. "_content"] = ""
+    user_opts["custom_button_" .. i .. "_mbtn_left_command"] = ""
+    user_opts["custom_button_" .. i .. "_mbtn_mid_command"] = ""
+    user_opts["custom_button_" .. i .. "_mbtn_right_command"] = ""
+end
+
 local osc_param = { -- calculated by osc_init()
     playresy = 0,                           -- canvas size Y
     playresx = 0,                           -- canvas size X
@@ -144,6 +151,7 @@ local window_control_box_width = 80
 local layouts = {}
 local is_december = os.date("*t").month == 12
 local UNICODE_MINUS = string.char(0xe2, 0x88, 0x92)  -- UTF-8 for U+2212 MINUS SIGN
+local last_custom_button = 0
 
 local function osc_color_convert(color)
     return color:sub(6,7) .. color:sub(4,5) ..  color:sub(2,3)
@@ -1574,14 +1582,25 @@ local function bar_layout(direction)
 
     local t_l = geo.x + geo.w + padX
 
+    -- Custom buttons
+    local t_r = osc_geo.x + osc_geo.w
+
+    for i = last_custom_button, 1, -1 do
+        t_r = t_r - padX
+        geo = { x = t_r, y = geo.y, an = 6, w = geo.w, h = geo.h }
+        t_r = t_r - geo.w
+        lo = add_layout("custom_button_" .. i)
+        lo.geometry = geo
+        lo.style = osc_styles.vidtitleBar
+    end
+
     -- Cache
-    geo = { x = osc_geo.x + osc_geo.w - padX, y = geo.y,
-            an = 6, w = 150, h = geo.h }
+    t_r = t_r - padX
+    geo = { x = t_r, y = geo.y, an = 6, w = 150, h = geo.h }
+    t_r = t_r - geo.w - padX
     lo = add_layout("cache")
     lo.geometry = geo
     lo.style = osc_styles.vidtitleBar
-
-    local t_r = geo.x - geo.w - padX*2
 
     -- Title
     geo = { x = t_l, y = geo.y, an = 4,
@@ -2063,6 +2082,19 @@ local function osc_init()
         end
     end
     bind_mouse_buttons("volume")
+
+
+    -- custom buttons
+    for i = 1, math.huge do
+        local content = user_opts["custom_button_" .. i .. "_content"]
+        if not content or content == "" then
+            break
+        end
+        ne = new_element("custom_button_" .. i, "button")
+        ne.content = content
+        bind_mouse_buttons("custom_button_" .. i)
+        last_custom_button = i
+    end
 
 
     -- load layout


### PR DESCRIPTION
Allow adding custom buttons without forking the whole OSC like in https://github.com/christoph-heinrich/mpv-quality-menu/blob/master/osc.patch

I tried to put these to the left of the cache text at first but the layout is determined at startup so you can't conditionally remove elements at runtime.

Emoji may not be perfectly aligned depending on the font used.

Example with:

```
custom_button_1_content=🔁
custom_button_1_mbtn_left_command=cycle-values loop-file inf no
custom_button_1_mbtn_right_command=cycle-values loop-playlist inf no

custom_button_2_content=🔂
custom_button_2_mbtn_left_command=cycle-values loop-file 1 no

custom_button_3_content=🔀
custom_button_3_mbtn_left_command=playlist-shuffle
```

![screenshot](https://github.com/user-attachments/assets/b2c24be5-1f32-4101-85ea-e999846addf9)