### PR TITLE
empty proxy should be passed

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -954,7 +954,7 @@ local function run_ytdl_hook(url)
 
     for param, arg in pairs(raw_options) do
         table.insert(command, "--" .. param)
-        if arg ~= "" then
+        if arg ~= "" or param == "proxy" then
             table.insert(command, arg)
         end
         if (param == "sub-lang" or param == "sub-langs" or param == "srt-lang") and (arg ~= "") then


### PR DESCRIPTION
According to yt-dlp empty proxy is used to disable proxy setting `Pass in an empty string (--proxy "") for direct connection`. Currently ytdl_hook.lua don't pass any empty args.

mpv currently translate
`mpv --ytdl-raw-options=proxy= https://music.163.com/song?id=28754103`
into
`/usr/bin/python /usr/bin/yt-dlp --no-warnings -J --flat-playlist --sub-format ass/srt/best --format bestvideo+bestaudio/best --proxy --sub-langs all --write-srt --no-playlist -- https://music.163.com/song?id=28754103`
with nothing provided to `--proxy`. This end up an error.
```
[ytdl_hook] ERROR: [netease:song] 28754103: Unable to download JSON metadata: ('Cannot connect to proxy.', NewConnectionError('<urllib3.connection.HTTPConnection object at 0x774e8f8c8500>: Failed to establish a new connection: [Errno -2] Name or service not known')) (caused by ProxyError("('Cannot connect to proxy.', NewConnectionError('<urllib3.connection.HTTPConnection object at 0x774e8f8c8500>: Failed to establish a new connection: [Errno -2] Name or service not known'))")); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[ytdl_hook] youtube-dl failed: unexpected error occurred
```

this pr passes empty proxy setting, the command is correctly translated into `/usr/bin/python /usr/bin/yt-dlp --no-warnings -J --flat-playlist --sub-format ass/srt/best --format bestvideo+bestaudio/best --proxy  --sub-langs all --write-srt --no-playlist -- https://music.163.com/song?id=28754103` . Note the additional empty space after `--proxy`