### PR TITLE
x11: simplify --geometry and --auto-window-resize logic

### DIFF
--- a/video/out/x11_common.h
+++ b/video/out/x11_common.h
@@ -115,15 +115,11 @@ struct vo_x11_state {
      * stays the same (even if that size is different from the current
      * window size after the user modified the latter). */
     int old_dw, old_dh;
-    int old_x, old_y;
     /* Video size changed during fullscreen when we couldn't tell the new
      * size to the window manager. Must set window size when turning
      * fullscreen off. */
     bool size_changed_during_fs;
     bool pos_changed_during_fs;
-
-    /* One of the autofit/geometry options changed at runtime. */
-    bool geometry_change;
 
     XComposeStatus compose_status;
 


### PR DESCRIPTION
There were a few pitfalls with the way this was previously implemented because --geometry implicitly depended on --auto-window-resize being enabled to operate in a few cases. Instead, let's change the logic a bit so that instead we choose whether or not to reuse the old rc (i.e. don't resize) and use the wh_valid and xy_valid fields within the m_geometry struct instead of using x11->geometry_change. This fixes several edge cases involving setting the position with --geometry when using --auto-window-resize=no.
