### PR TITLE
stats.lua: enable runtime script-opt changes

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -7,7 +7,6 @@
 -- visible.
 
 local mp = require 'mp'
-local options = require 'mp.options'
 local utils = require 'mp.utils'
 local input = require 'mp.input'
 
@@ -89,7 +88,11 @@ local o = {
 
     bindlist = "no",  -- print page 4 to the terminal on startup and quit mpv
 }
-options.read_options(o)
+
+local update_scale
+require "mp.options".read_options(o, nil, function ()
+    update_scale()
+end)
 
 local format = string.format
 local max = math.max
@@ -1476,7 +1479,7 @@ local function print_page(page, after_scroll)
     end
 end
 
-local function update_scale(osd_height)
+update_scale = function ()
     local scale_with_video
     if o.vidscale == "auto" then
         scale_with_video = mp.get_property_native("osd-scale-by-window")
@@ -1487,6 +1490,7 @@ local function update_scale(osd_height)
     -- Calculate scaled metrics.
     -- Make font_size=n the same size as --osd-font-size=n.
     local scale = 288 / 720
+    local osd_height = mp.get_property_native("osd-height")
     if not scale_with_video and osd_height > 0 then
         scale = 288 / osd_height
     end
@@ -1498,14 +1502,6 @@ local function update_scale(osd_height)
     if display_timer:is_enabled() then
         print_page(curr_page)
     end
-end
-
-local function handle_osd_height_update(_, osd_height)
-    update_scale(osd_height)
-end
-
-local function handle_osd_scale_by_window_update()
-    update_scale(mp.get_property_native("osd-height"))
 end
 
 local function clear_screen()
@@ -1766,5 +1762,5 @@ if o.bindlist ~= "no" then
     end)
 end
 
-mp.observe_property('osd-height', 'native', handle_osd_height_update)
-mp.observe_property('osd-scale-by-window', 'native', handle_osd_scale_by_window_update)
+mp.observe_property("osd-height", "native", update_scale)
+mp.observe_property("osd-scale-by-window", "native", update_scale)


### PR DESCRIPTION
This doesn't work for changing page key script-opts at runtime because they are used as the indexes of the pages variable, but nothing actually breaks if you do, it just uses the initial values. This is still useful for conditionally changing sizes at runtime or for trying out the osd-box profile by applying it from the console.