### PR TITLE
meson: bump libdrm version to 2.4.109

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -946,7 +946,7 @@ if features['direct3d']
     sources += files('video/out/vo_direct3d.c')
 endif
 
-drm = dependency('libdrm', version: '>= 2.4.105', required: get_option('drm'))
+drm = dependency('libdrm', version: '>= 2.4.109', required: get_option('drm'))
 libdisplay_info = dependency('libdisplay-info', version: '>= 0.1.1', required: get_option('drm'))
 features += {'drm': drm.found() and libdisplay_info.found() and
              (features['vt.h'] or features['consio.h'] or features['wsdisplay-usl-io.h'])}


### PR DESCRIPTION
the previous check was incorrect since because drmGetDeviceFromDevId is only available since 2.4.109.

https://gitlab.freedesktop.org/mesa/drm/-/commit/57e0b0552e11b3f04e6d5704c1c7efea5f83ffe4

Fixes: 0d7b4d64a5ec9b9ef132c07c1fb6712b1653101f