### PR TITLE
demux_lavf: detect heif/heic as images

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -675,7 +675,9 @@ static bool is_image(AVStream *st, bool attached_picture, const AVInputFormat *a
         strcmp(avif->name, "gif") == 0 ||
         strcmp(avif->name, "ico") == 0 ||
         strcmp(avif->name, "image2pipe") == 0 ||
-        (st->codecpar->codec_id == AV_CODEC_ID_AV1 && st->nb_frames == 1)
+        ((st->codecpar->codec_id == AV_CODEC_ID_HEVC ||
+          st->codecpar->codec_id == AV_CODEC_ID_AV1)
+         && st->nb_frames == 1)
     );
 }
 


### PR DESCRIPTION
Like 565e7d906c did for avif, consider 1-frame HEVC as images, as HEVC videos have nb_frames 0 or > 1.

Specifically, in the FATE suite:

nb_frames = 0 and are images:
cbf_cr_cb_TUDepth_4_circle.h265 food.hevc hdr10_plus_h265_sample.hevc hdr_vivid_h265_sample.hevc hevc-monochrome.hevc

nb_frames = 0 and are videos:
mv_nuh_layer_id.bit paired_fields.hevc
paramchange_yuv420p_yuv420p10.hevc pir.hevc

nb_frames > 0:
dv84.mov extradata-reload-multi-stsd.mov multiview.mov two_first_slice.mp4

As with other video codecs, the hevc images with nb_frames = 0 which are really frames cut from a video are not detected as images, but you will only find these files in FATE.