### PR TITLE
demux_lavf: remove obsolete defines

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -55,13 +55,6 @@
 #include "options/m_option.h"
 #include "options/path.h"
 
-#ifndef AV_DISPOSITION_TIMED_THUMBNAILS
-#define AV_DISPOSITION_TIMED_THUMBNAILS 0
-#endif
-#ifndef AV_DISPOSITION_STILL_IMAGE
-#define AV_DISPOSITION_STILL_IMAGE 0
-#endif
-
 #define INITIAL_PROBE_SIZE STREAM_BUFFER_SIZE
 #define PROBE_BUF_SIZE (10 * 1024 * 1024)
 


### PR DESCRIPTION
AV_DISPOSITION_TIMED_THUMBNAILS was added in FFmpeg 3.2 and AV_DISPOSITION_STILL_IMAGE in FFmpeg 4.1, and we require FFmpeg 6.1.