### PR TITLE
zsh-completion: complete av://lavfi:testsrc and av://lavfi:sine

### DIFF
--- a/etc/_mpv.zsh
+++ b/etc/_mpv.zsh
@@ -33,6 +33,10 @@ local -a tag_order
 zstyle -a ":completion:*:*:$service:*" tag-order tag_order ||
   zstyle  ":completion:*:*:$service:*" tag-order '!urls'
 
+local -a urls
+zstyle -a ":completion:*:*:$service:*:urls" urls urls ||
+  zstyle ":completion:*:*:$service:*:urls" urls av://lavfi:testsrc av://lavfi:sine
+
 typeset -ga _mpv_completion_arguments _mpv_completion_protocols
 
 function _mpv_generate_arguments {


### PR DESCRIPTION
It is annoying to type these over and over.