### PR TITLE
sd_ass: fix fix_margins calculation

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -617,9 +617,10 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         if (override_playres) {
             int vidw = dim->w - (dim->ml + dim->mr);
             int vidh = dim->h - (dim->mt + dim->mb);
-            int old_playresx = track->PlayResX;
             track->PlayResX = track->PlayResY * (double)vidw / MPMAX(vidh, 1);
-            double fix_margins = track->PlayResX / (double)old_playresx;
+            // ffmpeg and mpv use a default PlayResX of 384 when it is not known,
+            // this comes from VSFilter.
+            double fix_margins = track->PlayResX / (double)MP_ASS_FONT_PLAYRESX;
             for (int n = 0; n < track->n_styles; n++) {
                 track->styles[n].MarginL = lrint(track->styles[n].MarginL * fix_margins);
                 track->styles[n].MarginR = lrint(track->styles[n].MarginR * fix_margins);


### PR DESCRIPTION
Saving old playresx method is incorrect for the first draw after the subtitle is loaded.

Fixes: f862d3b6cd66abee98f2af21c36255ef7361cb80
Fixes: https://github.com/mpv-player/mpv/issues/15523