### PR TITLE
stats.lua: only reprint stats on video-reconfig when toggled

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1737,7 +1737,7 @@ end
 -- Reprint stats immediately when VO was reconfigured, only when toggled
 mp.register_event("video-reconfig",
     function()
-        if display_timer:is_enabled() then
+        if display_timer:is_enabled() and not display_timer.oneshot then
             print_page(curr_page)
         end
     end)


### PR DESCRIPTION
Make this behave like the comment says it should, because currently when you show oneshot stats and change file, stats are printed again and hide --osd-playing-msg. This happens even if you hide the stats by show-texting something else and change file before the timer expires.