### PR TITLE
console.lua: color the default item with --osd-selected-color

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -55,7 +55,6 @@ local styles = {
     fatal = '{\\1c&H5791f9&}',
     suggestion = '{\\1c&Hcc99cc&}',
     selected_suggestion = '{\\1c&H2fbdfa&\\b1}',
-    default_item = '{\\1c&H2fbdfa&}',
     disabled = '{\\1c&Hcccccc&}',
 }
 
@@ -446,16 +445,18 @@ local function populate_log_with_matches()
         local style = ''
         local terminal_style = ''
 
-        if matches[i].index == default_item then
-            style = styles.default_item
-            terminal_style = terminal_styles.default_item
-        end
-        if i == selected_match then
+        if i == selected_match or matches[i].index == default_item then
             local color, alpha = mpv_color_to_ass(mp.get_property('osd-selected-color'))
             local outline_color, outline_alpha =
                 mpv_color_to_ass(mp.get_property('osd-selected-outline-color'))
-            style = style .. "{\\b1\\1c&H" .. color .. "&\\1a&H" .. alpha ..
-                             "&\\3c&H" .. outline_color .. "&\\3a&H" .. outline_alpha .. "&}"
+            style = '{\\1c&H' .. color .. '&\\1a&H' .. alpha ..
+                    '&\\3c&H' .. outline_color .. '&\\3a&H' .. outline_alpha .. '&}'
+        end
+        if matches[i].index == default_item then
+            terminal_style = terminal_styles.default_item
+        end
+        if i == selected_match then
+            style = style .. '{\\b1}'
             terminal_style = terminal_style .. terminal_styles.selected_suggestion
         end
 


### PR DESCRIPTION
Currently if you change --osd-selected-color the preselected item stays yellow and can't be changed. Since the default item style was just chosen from the selected color without the bold, also make the default item follow --osd-selected-color.

Requested in
https://github.com/Samillion/ModernZ/issues/259#issuecomment-2556608926.