### PR TITLE
console.lua: keep --osd-{,outline}-color's alpha component for styles

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -58,7 +58,7 @@ local styles = {
     disabled = '{\\1c&Hcccccc&}',
 }
 for key, style in pairs(styles) do
-    styles[key] = style .. '{\\1a&H00&\\3c&H111111&\\3a&H00&}'
+    styles[key] = style .. '{\\3c&H111111&}'
 end
 
 local terminal_styles = {


### PR DESCRIPTION
There is no need to override this for colored lines.