### PR TITLE
options: add --archive-exts and --playlist-exts

### DIFF
--- a/DOCS/interface-changes/exts.rst
+++ b/DOCS/interface-changes/exts.rst
@@ -1,2 +1,4 @@
 add `--archive-exts`
 add `archive` to `--directory-filter-types`' default
+add `--playlist-exts`
+add `playlist` to `--directory-filter-types`' default

--- a/DOCS/interface-changes/exts.rst
+++ b/DOCS/interface-changes/exts.rst
@@ -1,0 +1,2 @@
+add `--archive-exts`
+add `archive` to `--directory-filter-types`' default

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4212,9 +4212,10 @@ Demuxer
     all. The default is ``auto``, which behaves like ``recursive`` with
     ``--shuffle``, and like ``lazy`` otherwise.
 
-``--directory-filter-types=<video,audio,image>``
+``--directory-filter-types=<video,audio,image,archive>``
     Media file types to filter when opening directory. If the list is empty,
-    all files are added to the playlist. (Default: ``video,audio,image``)
+    all files are added to the playlist. (Default:
+    ``video,audio,image,archive``)
 
     This is a string list option. See `List Options`_ for details.
 
@@ -7730,6 +7731,13 @@ Miscellaneous
 
     This is a string list option. See `List Options`_ for details.
     Use ``--help=video-exts`` to see default extensions.
+
+``--archive-exts=ext1,ext2,...``
+    Archive file extentions to try to match when using ``--autocreate-playlist``
+    or ``--directory-filter-types``.
+
+    This is a string list option. See `List Options`_ for details. Use
+    ``--help=archive-exts`` to see the default extensions.
 
 ``--autoload-files=<yes|no>``
     Automatically load/select external files (default: yes).

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4212,10 +4212,10 @@ Demuxer
     all. The default is ``auto``, which behaves like ``recursive`` with
     ``--shuffle``, and like ``lazy`` otherwise.
 
-``--directory-filter-types=<video,audio,image,archive>``
+``--directory-filter-types=<video,audio,image,archive,playlist>``
     Media file types to filter when opening directory. If the list is empty,
     all files are added to the playlist. (Default:
-    ``video,audio,image,archive``)
+    ``video,audio,image,archive,playlist``)
 
     This is a string list option. See `List Options`_ for details.
 
@@ -7738,6 +7738,13 @@ Miscellaneous
 
     This is a string list option. See `List Options`_ for details. Use
     ``--help=archive-exts`` to see the default extensions.
+
+``--playlist-exts=ext1,ext2,...``
+    Playlist file extentions to try to match when using
+    ``--autocreate-playlist`` or ``--directory-filter-types``.
+
+    This is a string list option. See `List Options`_ for details. Use
+    ``--help=playlist-exts`` to see the default extensions.
 
 ``--autoload-files=<yes|no>``
     Automatically load/select external files (default: yes).

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -44,11 +44,12 @@ enum dir_mode {
 };
 
 enum autocreate_mode {
-    AUTO_NONE  = 0,
-    AUTO_VIDEO = 1 << 0,
-    AUTO_AUDIO = 1 << 1,
-    AUTO_IMAGE = 1 << 2,
-    AUTO_ANY   = 1 << 3,
+    AUTO_NONE    = 0,
+    AUTO_VIDEO   = 1 << 0,
+    AUTO_AUDIO   = 1 << 1,
+    AUTO_IMAGE   = 1 << 2,
+    AUTO_ARCHIVE = 1 << 3,
+    AUTO_ANY     = 1 << 4,
 };
 
 #define OPT_BASE_STRUCT struct demux_playlist_opts
@@ -72,7 +73,7 @@ struct m_sub_options demux_playlist_conf = {
     .defaults = &(const struct demux_playlist_opts){
         .dir_mode = DIR_AUTO,
         .directory_filter = (char *[]){
-            "video", "audio", "image", NULL
+            "video", "audio", "image", "archive", NULL
         },
     },
 };
@@ -437,6 +438,8 @@ static bool test_path(struct pl_parser *p, char *path, int autocreate)
         return true;
     if (autocreate & AUTO_IMAGE && str_in_list(ext, p->mp_opts->image_exts))
         return true;
+    if (autocreate & AUTO_ARCHIVE && str_in_list(ext, p->mp_opts->archive_exts))
+        return true;
 
     return false;
 }
@@ -520,6 +523,8 @@ static enum autocreate_mode get_directory_filter(struct pl_parser *p)
         autocreate |= AUTO_AUDIO;
     if (str_in_list(bstr0("image"), p->opts->directory_filter))
         autocreate |= AUTO_IMAGE;
+    if (str_in_list(bstr0("archive"), p->opts->directory_filter))
+        autocreate |= AUTO_ARCHIVE;
     return autocreate;
 }
 
@@ -542,6 +547,8 @@ static int parse_dir(struct pl_parser *p)
                 autocreate = AUTO_AUDIO;
             } else if (str_in_list(ext, p->mp_opts->image_exts)) {
                 autocreate = AUTO_IMAGE;
+            } else if (str_in_list(ext, p->mp_opts->archive_exts)) {
+                autocreate = AUTO_ARCHIVE;
             }
             break;
         }

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -44,12 +44,13 @@ enum dir_mode {
 };
 
 enum autocreate_mode {
-    AUTO_NONE    = 0,
-    AUTO_VIDEO   = 1 << 0,
-    AUTO_AUDIO   = 1 << 1,
-    AUTO_IMAGE   = 1 << 2,
-    AUTO_ARCHIVE = 1 << 3,
-    AUTO_ANY     = 1 << 4,
+    AUTO_NONE     = 0,
+    AUTO_VIDEO    = 1 << 0,
+    AUTO_AUDIO    = 1 << 1,
+    AUTO_IMAGE    = 1 << 2,
+    AUTO_ARCHIVE  = 1 << 3,
+    AUTO_PLAYLIST = 1 << 4,
+    AUTO_ANY      = 1 << 5,
 };
 
 #define OPT_BASE_STRUCT struct demux_playlist_opts
@@ -73,7 +74,7 @@ struct m_sub_options demux_playlist_conf = {
     .defaults = &(const struct demux_playlist_opts){
         .dir_mode = DIR_AUTO,
         .directory_filter = (char *[]){
-            "video", "audio", "image", "archive", NULL
+            "video", "audio", "image", "archive", "playlist", NULL
         },
     },
 };
@@ -440,6 +441,8 @@ static bool test_path(struct pl_parser *p, char *path, int autocreate)
         return true;
     if (autocreate & AUTO_ARCHIVE && str_in_list(ext, p->mp_opts->archive_exts))
         return true;
+    if (autocreate & AUTO_PLAYLIST && str_in_list(ext, p->mp_opts->playlist_exts))
+        return true;
 
     return false;
 }
@@ -525,6 +528,8 @@ static enum autocreate_mode get_directory_filter(struct pl_parser *p)
         autocreate |= AUTO_IMAGE;
     if (str_in_list(bstr0("archive"), p->opts->directory_filter))
         autocreate |= AUTO_ARCHIVE;
+    if (str_in_list(bstr0("playlist"), p->opts->directory_filter))
+        autocreate |= AUTO_PLAYLIST;
     return autocreate;
 }
 
@@ -549,6 +554,8 @@ static int parse_dir(struct pl_parser *p)
                 autocreate = AUTO_IMAGE;
             } else if (str_in_list(ext, p->mp_opts->archive_exts)) {
                 autocreate = AUTO_ARCHIVE;
+            } else if (str_in_list(ext, p->mp_opts->playlist_exts)) {
+                autocreate = AUTO_PLAYLIST;
             }
             break;
         }

--- a/options/options.c
+++ b/options/options.c
@@ -704,6 +704,7 @@ static const m_option_t mp_opts[] = {
     {"cover-art-auto-exts", OPT_ALIAS("image-exts")},
     {"cover-art-whitelist", OPT_STRINGLIST(coverart_whitelist)},
     {"video-exts", OPT_STRINGLIST(video_exts)},
+    {"archive-exts", OPT_STRINGLIST(archive_exts)},
 
     {"", OPT_SUBSTRUCT(subs_rend, mp_subtitle_sub_opts)},
     {"", OPT_SUBSTRUCT(subs_shared, mp_subtitle_shared_sub_opts)},
@@ -1036,6 +1037,9 @@ static const struct MPOpts mp_default_opts = {
     .image_exts = (char *[]){
         "avif", "bmp", "gif", "heic", "heif", "j2k", "jp2", "jpeg", "jpg",
         "jxl", "png", "qoi", "svg", "tga", "tif", "tiff", "webp", NULL
+    },
+    .archive_exts = (char *[]){
+        "zip", "rar", "7z", "cbz", "cbr", NULL
     },
 
     .sub_auto_exts = (char *[]){

--- a/options/options.c
+++ b/options/options.c
@@ -705,6 +705,7 @@ static const m_option_t mp_opts[] = {
     {"cover-art-whitelist", OPT_STRINGLIST(coverart_whitelist)},
     {"video-exts", OPT_STRINGLIST(video_exts)},
     {"archive-exts", OPT_STRINGLIST(archive_exts)},
+    {"playlist-exts", OPT_STRINGLIST(playlist_exts)},
 
     {"", OPT_SUBSTRUCT(subs_rend, mp_subtitle_sub_opts)},
     {"", OPT_SUBSTRUCT(subs_shared, mp_subtitle_shared_sub_opts)},
@@ -1040,6 +1041,9 @@ static const struct MPOpts mp_default_opts = {
     },
     .archive_exts = (char *[]){
         "zip", "rar", "7z", "cbz", "cbr", NULL
+    },
+    .playlist_exts = (char *[]){
+        "m3u", "m3u8", "pls", "edl", NULL
     },
 
     .sub_auto_exts = (char *[]){

--- a/options/options.h
+++ b/options/options.h
@@ -332,6 +332,7 @@ typedef struct MPOpts {
     char **image_exts;
     char **coverart_whitelist;
     char **video_exts;
+    char **archive_exts;
     bool osd_bar_visible;
 
     int w32_priority;

--- a/options/options.h
+++ b/options/options.h
@@ -333,6 +333,7 @@ typedef struct MPOpts {
     char **coverart_whitelist;
     char **video_exts;
     char **archive_exts;
+    char **playlist_exts;
     bool osd_bar_visible;
 
     int w32_priority;


### PR DESCRIPTION
options: add --archive-exts

And add archive to --directory-filter-types' default.

Fixes #15550, fixes #15096.

options: add --playlist-exts

And add playlist to --directory-filter-types' default.

Fixes https://github.com/mpv-player/mpv/issues/15096#issuecomment-2466695186, fixes https://github.com/mpv-player/mpv/discussions/15508