### PR TITLE
osc.lua: add slimbottombar and slimtopbar layouts

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -170,7 +170,8 @@ Configurable Options
     Default: bottombar
 
     The layout for the OSC. Currently available are: box, slimbox,
-    bottombar and topbar. Default pre-0.21.0 was 'box'.
+    bottombar, topbar, slimbottombar and slimtopbar. Default pre-0.21.0 was
+    'box'.
 
 ``seekbarstyle``
     Default: bar
@@ -286,7 +287,8 @@ Configurable Options
 ``barmargin``
     Default: 0
 
-    Margin from bottom (bottombar) or top (topbar), in pixels
+    Margin from bottom (bottombar, slimbottombar) or top (topbar, slimtopbar),
+    in pixels.
 
 ``boxalpha``
     Default: 80
@@ -369,10 +371,10 @@ Configurable Options
     default values.) Additionally, ``visibility`` must be set to ``always``.
     Otherwise, this option does nothing.
 
-    Currently, this is supported for the ``bottombar`` and ``topbar`` layout
-    only. The other layouts do not change if this option is set. Separately,
-    if window controls are present (see below), they will be affected
-    regardless of which osc layout is in use.
+    Currently, this is supported for the ``bottombar``, ``slimbottombar``,
+    ``topbar`` and ``slimtopbar`` layouts only. The other layouts do not change
+    if this option is set. Separately, if window controls are present (see
+    below), they will be affected regardless of which osc layout is in use.
 
     The border is static and appears even if the OSC is configured to appear
     only on mouse interaction. If the OSC is invisible, the border is simply


### PR DESCRIPTION
Add layouts with only the top line of bottombar to be used with images.

This was requested by some users, and is meant to be added to the image profile.

![lavfi:testsrc-3](https://github.com/user-attachments/assets/da97b756-4568-43a1-bf14-583b69aca8dc)