### PR TITLE
clipboard-mac: add macOS clipboard backend

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3944,7 +3944,7 @@ Property list
     This has a number of sub-properties:
 
     ``clipboard/text`` (RW)
-        The text content in the clipboard (Windows and Wayland only).
+        The text content in the clipboard (Windows, Wayland and macOS only).
         Writing to this property sets the text clipboard content (Windows only).
 
     .. note::

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7835,13 +7835,13 @@ Miscellaneous
     Conversion is not applied to metadata that is updated at runtime.
 
 ``--clipboard-enable=<yes|no>``
-    (Windows and Wayland only)
+    (Windows, Wayland and macOS only)
 
     Enable native clipboard support (default: yes). This allows reading and
     writing to the ``clipboard`` property to get and set clipboard contents.
 
 ``--clipboard-monitor=<yes|no>``
-    (Windows only)
+    (Windows and macOS only)
 
     Enable clipboard monitoring so that the ``clipboard`` property can be
     observed for content changes (default: no). This only affects clipboard

--- a/meson.build
+++ b/meson.build
@@ -415,7 +415,8 @@ if features['cocoa']
     sources += files('osdep/language-mac.c',
                      'osdep/path-mac.m',
                      'osdep/utils-mac.c',
-                     'osdep/mac/app_bridge.m')
+                     'osdep/mac/app_bridge.m',
+                     'player/clipboard/clipboard-mac.m')
     main_fn_source = files('osdep/main-fn-mac.c')
 endif
 
@@ -1567,6 +1568,7 @@ swift_sources = []
 if features['cocoa'] and features['swift']
     swift_sources += files('osdep/mac/application.swift',
                            'osdep/mac/app_hub.swift',
+                           'osdep/mac/clipboard.swift',
                            'osdep/mac/event_helper.swift',
                            'osdep/mac/input_helper.swift',
                            'osdep/mac/libmpv_helper.swift',

--- a/osdep/mac/app_bridge_objc.h
+++ b/osdep/mac/app_bridge_objc.h
@@ -24,6 +24,7 @@
 
 #include "options/m_config.h"
 #include "player/core.h"
+#include "player/clipboard/clipboard.h"
 #include "common/global.h"
 #include "input/input.h"
 #include "input/event.h"

--- a/osdep/mac/clipboard.swift
+++ b/osdep/mac/clipboard.swift
@@ -1,0 +1,76 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+class Clipboard: NSObject {
+    var pasteboard: NSPasteboard { return NSPasteboard.general }
+    var changeCount: Int = 0
+
+    @objc override init() {
+        super.init()
+        changeCount = pasteboard.changeCount
+    }
+
+    @objc func get(params: UnsafeMutablePointer<clipboard_access_params>,
+                   out: UnsafeMutablePointer<clipboard_data>,
+                   tallocCtx: UnsafeMutableRawPointer) -> clipboard_result {
+        switch params.pointee.type {
+        case CLIPBOARD_DATA_TEXT: return fillWithString(out, tallocCtx)
+        default: break
+        }
+
+        return CLIPBOARD_FAILED
+    }
+
+    @objc func set(params: UnsafeMutablePointer<clipboard_access_params>,
+                   data: UnsafeMutablePointer<clipboard_data>) -> clipboard_result {
+        switch (params.pointee.type, data.pointee.type) {
+        case (CLIPBOARD_DATA_TEXT, CLIPBOARD_DATA_TEXT): return setString(data)
+        default: break
+        }
+
+        return CLIPBOARD_FAILED
+    }
+
+    @objc func changed() -> Bool {
+        if changeCount != pasteboard.changeCount {
+            changeCount = pasteboard.changeCount
+            return true
+        }
+
+        return false
+    }
+
+    func fillWithString(_ out: UnsafeMutablePointer<clipboard_data>,
+                        _ tallocCtx: UnsafeMutableRawPointer) -> clipboard_result {
+        (pasteboard.string(forType: .string) ?? "").withCString {
+            out.pointee.type = CLIPBOARD_DATA_TEXT
+            out.pointee.u.text = ta_xstrdup(tallocCtx, $0)
+        }
+
+        return CLIPBOARD_SUCCESS
+    }
+
+    func setString(_ data: UnsafeMutablePointer<clipboard_data>) -> clipboard_result {
+        let text = String(cString: data.pointee.u.text)
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        return CLIPBOARD_SUCCESS
+    }
+}

--- a/player/clipboard/clipboard-mac.m
+++ b/player/clipboard/clipboard-mac.m
@@ -1,0 +1,59 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "clipboard.h"
+#include "osdep/mac/swift.h"
+
+struct clipboard_mac_priv {
+    Clipboard *clipboard;
+};
+
+static int init(struct clipboard_ctx *cl, struct clipboard_init_params *params)
+{
+    struct clipboard_mac_priv *p = cl->priv = talloc_zero(cl, struct clipboard_mac_priv);
+    p->clipboard = [[Clipboard alloc] init];
+    return CLIPBOARD_SUCCESS;
+}
+
+static bool data_changed(struct clipboard_ctx *cl)
+{
+    struct clipboard_mac_priv *p = cl->priv;
+    return [p->clipboard changed];
+}
+
+static int get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *out, void *talloc_ctx)
+{
+    struct clipboard_mac_priv *p = cl->priv;
+    return [p->clipboard getWithParams:params out:out tallocCtx:talloc_ctx];
+}
+
+static int set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *data)
+{
+    struct clipboard_mac_priv *p = cl->priv;
+    return [p->clipboard setWithParams:params data:data];
+}
+
+const struct clipboard_backend clipboard_backend_mac = {
+    .name = "mac",
+    .desc = "macOS clipboard",
+    .init = init,
+    .data_changed = data_changed,
+    .get_data = get_data,
+    .set_data = set_data,
+};

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -42,11 +42,15 @@ const struct m_sub_options clipboard_conf = {
 
 // backend list
 extern const struct clipboard_backend clipboard_backend_win32;
+extern const struct clipboard_backend clipboard_backend_mac;
 extern const struct clipboard_backend clipboard_backend_vo;
 
 static const struct clipboard_backend *const clipboard_backend_list[] = {
 #if HAVE_WIN32_DESKTOP
     &clipboard_backend_win32,
+#endif
+#if HAVE_COCOA
+    &clipboard_backend_mac,
 #endif
     &clipboard_backend_vo,
 };

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1139,16 +1139,8 @@ local function get_clipboard(clip)
         if not res.error then
             return res.stdout
         end
-    elseif platform == 'windows' then
+    elseif platform == 'windows' or platform == 'darwin' then
         return mp.get_property('clipboard/text', '')
-    elseif platform == 'darwin' then
-        local res = utils.subprocess({
-            args = { 'pbpaste' },
-            playback_only = false,
-        })
-        if not res.error then
-            return res.stdout
-        end
     end
     return ''
 end


### PR DESCRIPTION
follow up of #15355

maybe `osdep/mac/clipboard.swift` should be under a different location in `player/mac`, `player/clipboard` or `player/clipboard/mac`.