### PR TITLE
mac: minor cleanups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1571,7 +1571,6 @@ if features['cocoa'] and features['swift']
                            'osdep/mac/clipboard.swift',
                            'osdep/mac/event_helper.swift',
                            'osdep/mac/input_helper.swift',
-                           'osdep/mac/libmpv_helper.swift',
                            'osdep/mac/log_helper.swift',
                            'osdep/mac/menu_bar.swift',
                            'osdep/mac/option_helper.swift',
@@ -1616,7 +1615,8 @@ macos_cocoa_cb = get_option('macos-cocoa-cb').require(
 )
 features += {'macos-cocoa-cb': macos_cocoa_cb.allowed()}
 if features['macos-cocoa-cb']
-    swift_sources += files('video/out/cocoa_cb_common.swift',
+    swift_sources += files('osdep/mac/libmpv_helper.swift',
+                           'video/out/cocoa_cb_common.swift',
                            'video/out/mac/gl_layer.swift')
 endif
 if features['cocoa'] and features['vulkan'] and features['swift']

--- a/osdep/mac/menu_bar.swift
+++ b/osdep/mac/menu_bar.swift
@@ -232,7 +232,7 @@ class MenuBar: NSObject {
             Config(type: .separator),
             Config(name: "Report Issue…", action: #selector(url(_:)), target: self, url: "https://github.com/mpv-player/mpv/issues/new/choose")
         ]
-        if ProcessInfo.processInfo.environment["MPVBUNDLE"] == "true" {
+        if AppHub.shared.isBundle {
             helpMenuConfigs += [
                 Config(name: "Show log File…", action: #selector(showFile(_:)), target: self, url: NSHomeDirectory() + "/Library/Logs/mpv.log")
             ]

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -358,7 +358,7 @@ class Common: NSObject {
     }
 
     func setAppIcon() {
-        if ProcessInfo.processInfo.environment["MPVBUNDLE"] != "true" {
+        if !AppHub.shared.isBundle {
             NSApp.applicationIconImage = AppHub.shared.getIcon()
         }
     }


### PR DESCRIPTION
1. after the cleanups and splits to the various other helpers, libmpv_helper is only ever used with cocoa-cb. so only build it with cocoa-cb
2. we have a dedicated function to check for bundle usage, so we should use it.