### PR TITLE
video/sws_utils: remove unused mp_image_swscale

### DIFF
--- a/video/sws_utils.c
+++ b/video/sws_utils.c
@@ -424,16 +424,6 @@ int mp_sws_scale(struct mp_sws_context *ctx, struct mp_image *dst,
     return 0;
 }
 
-int mp_image_swscale(struct mp_image *dst, struct mp_image *src,
-                     int my_sws_flags)
-{
-    struct mp_sws_context *ctx = mp_sws_alloc(NULL);
-    ctx->flags = my_sws_flags;
-    int res = mp_sws_scale(ctx, dst, src);
-    talloc_free(ctx);
-    return res;
-}
-
 int mp_image_sw_blur_scale(struct mp_image *dst, struct mp_image *src,
                            float gblur)
 {

--- a/video/sws_utils.h
+++ b/video/sws_utils.h
@@ -17,9 +17,6 @@ extern const int mp_sws_fast_flags;
 
 bool mp_sws_supported_format(int imgfmt);
 
-int mp_image_swscale(struct mp_image *dst, struct mp_image *src,
-                     int my_sws_flags);
-
 int mp_image_sw_blur_scale(struct mp_image *dst, struct mp_image *src,
                            float gblur);
 


### PR DESCRIPTION
This has been used before 2c43d2b75a88b8e0e8f0a715f993ffc1c8977d13. Now that we have also zimg support, using swscale directly may not be wanted depending on the user options.