### PR TITLE
stream_file: don't allow to open standard streams during fuzzing

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -310,6 +310,10 @@ static int open_f(stream_t *stream, const struct stream_open_args *args)
             return STREAM_ERROR;
         }
 #endif
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        if (p->fd == STDIN_FILENO || p->fd == STDOUT_FILENO || p->fd == STDERR_FILENO)
+            return STREAM_ERROR;
+#endif
         if (is_fdclose)
             p->close = true;
     } else if (!strict_fs && !strcmp(filename, "-")) {


### PR DESCRIPTION
To avoid all sorts of I/O loops.