### PR TITLE
osd: remove unused constants

### DIFF
--- a/sub/osd.h
+++ b/sub/osd.h
@@ -116,7 +116,6 @@ bool osd_res_equals(struct mp_osd_res a, struct mp_osd_res b);
 enum mp_osd_font_codepoints {
     OSD_PLAY = 0x01,
     OSD_PAUSE = 0x02,
-    OSD_STOP = 0x03,
     OSD_REW = 0x04,
     OSD_FFW = 0x05,
     OSD_CLOCK = 0x06,
@@ -125,14 +124,8 @@ enum mp_osd_font_codepoints {
     OSD_VOLUME = 0x09,
     OSD_BRIGHTNESS = 0x0A,
     OSD_HUE = 0x0B,
-    OSD_BALANCE = 0x0C,
     OSD_REV = 0x0D,
     OSD_PANSCAN = 0x50,
-
-    OSD_PB_START = 0x10,
-    OSD_PB_0 = 0x11,
-    OSD_PB_END = 0x12,
-    OSD_PB_1 = 0x13,
 };
 
 


### PR DESCRIPTION
OSD_STOP was never used.
OSD_BALANCE is unused since 3d27a0792b.
OSD_PB_* are unused since ef3c0e6eda.