### PR TITLE
select.lua: fix select-edition crash on non-MKVs

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -226,7 +226,7 @@ end)
 mp.add_key_binding(nil, "select-edition", function ()
     local edition_list = mp.get_property_native("edition-list")
 
-    if edition_list == nil or #edition_list == 1 then
+    if edition_list == nil or #edition_list < 2 then
         show_error("No available editions.")
         return
     end


### PR DESCRIPTION
In files other than MKVs edition-list is an empty table, not nil. It is current-edition that is nil.

However nil still needs to be checked to not crash with mpv --idle.
