### PR TITLE
DOCS/man/input: edition-list/N/id is not writable

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2268,9 +2268,8 @@ Property list
         Number of editions. If there are no editions, this can be 0 or 1 (1
         if there's a useless dummy edition).
 
-    ``edition-list/N/id`` (RW)
-        Edition ID as integer. Use this to set the ``edition`` property.
-        Currently, this is the same as the edition index.
+    ``edition-list/N/id``
+        Edition ID as integer. Currently, this is the same as the edition index.
 
     ``edition-list/N/default``
         Whether this is the default edition.


### PR DESCRIPTION
I added RW to edition-list/N/id in 34f2143e8f because in #8077 it was assumed that it is writable from the wording of the docs. But what the docs actually meant is that you can retrieve edition-list/N/id and then use the retrieved value to set the edition property.

Remove RW and the ambiguous sentence.