### PR TITLE
command: make playlist-play-index accept file-local-options

### DIFF
--- a/DOCS/interface-changes/playlist-play-index-options.txt
+++ b/DOCS/interface-changes/playlist-play-index-options.txt
@@ -1,0 +1,1 @@
+add an options argument to `playlist-play-index`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -474,7 +474,7 @@ Playlist Manipulation
     Go to the first of the previous entries on the playlist with a different
     ``playlist-path``.
 
-``playlist-play-index <integer|current|none>``
+``playlist-play-index <integer|current|none> [<options>]``
     Start (or restart) playback of the given playlist index. In addition to the
     0-based playlist entry index, it supports the following values:
 
@@ -487,6 +487,13 @@ Playlist Manipulation
     <none>
         Playback is stopped. If idle mode (``--idle``) is enabled, the player
         will enter idle mode, otherwise it will exit.
+
+    The second argument is a list of options and values which should be set
+    while the file is playing. It is of the form ``opt1=value1,opt2=value2,..``.
+    When using the client API, this can be a ``MPV_FORMAT_NODE_MAP`` (or a Lua
+    table), however the values themselves must be strings currently. These
+    options are set during playback, and restored to the previous value at end
+    of playback (see `Per-File Options`_).
 
     This command is similar to ``loadfile`` in that it only manipulates the
     state of what to play next, without waiting until the current file is

--- a/player/command.c
+++ b/player/command.c
@@ -5792,7 +5792,15 @@ static void cmd_playlist_play_index(void *p)
     if (pos == -2)
         pos = playlist_entry_to_index(pl, pl->current);
 
-    mp_set_playlist_entry(mpctx, playlist_entry_from_index(pl, pos));
+    struct playlist_entry *entry = playlist_entry_from_index(pl, pos);
+
+    if (entry && cmd->args[1].v.str_list) {
+        char **pairs = cmd->args[1].v.str_list;
+        for (int i = 0; pairs[i] && pairs[i + 1]; i += 2)
+            playlist_entry_add_param(entry, bstr0(pairs[i]), bstr0(pairs[i + 1]));
+    }
+
+    mp_set_playlist_entry(mpctx, entry);
     if (cmd->on_osd & MP_ON_OSD_MSG)
         mpctx->add_osd_seek_info |= OSD_SEEK_INFO_CURRENT_FILE;
 }
@@ -7016,6 +7024,7 @@ const struct mp_cmd_def mp_cmds[] = {
         {
             {"index", OPT_CHOICE(v.i, {"current", -2}, {"none", -1}),
                 M_RANGE(-1, INT_MAX)},
+            {"options", OPT_KEYVALUELIST(v.str_list), .flags = MP_CMD_OPT_ARG},
         }
     },
     { "playlist-shuffle", cmd_playlist_shuffle, },


### PR DESCRIPTION
Works like loadfile. The documentation is copied from it.

This allows reloading the current file from the same time-pos without hacks.

Not sure if this is worth it.