### PR TITLE
mac/swift: fix global variables for upcoming swift 6 concurrency

### DIFF
--- a/osdep/mac/swift_extensions.swift
+++ b/osdep/mac/swift_extensions.swift
@@ -48,8 +48,8 @@ extension NSScreen {
 }
 
 extension NSEvent.ModifierFlags {
-    public static var optionLeft: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICELALTKEYMASK))
-    public static var optionRight: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICERALTKEYMASK))
+    public static let optionLeft: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICELALTKEYMASK))
+    public static let optionRight: NSEvent.ModifierFlags = .init(rawValue: UInt(NX_DEVICERALTKEYMASK))
 }
 
 extension mp_keymap {


### PR DESCRIPTION
fixes problems with upcoming features DisableOutwardActorInference, GlobalConcurrency and InferSendableFromCaptures for swift 6 strict concurrency. enabled with -enable-upcoming-feature flag.

this is just preparation work for the swift 6 migration.