### PR TITLE
mac/type: change array type from Any to Sendable

### DIFF
--- a/osdep/mac/event_helper.swift
+++ b/osdep/mac/event_helper.swift
@@ -42,7 +42,7 @@ extension EventHelper {
         let bool: Bool?
         let int: Int64?
         let double: Double?
-        let array: [Any?]
+        let array: [Sendable?]
 
         init(
             name: String = "",
@@ -51,8 +51,7 @@ extension EventHelper {
             bool: Bool? = nil,
             int: Int64? = nil,
             double: Double? = nil,
-            array: [Any?] = []
-
+            array: [Sendable?] = []
         ) {
             self.name = name
             self.format = format

--- a/osdep/mac/remote_command_center.swift
+++ b/osdep/mac/remote_command_center.swift
@@ -170,7 +170,7 @@ class RemoteCommandCenter: EventSubscriber {
         ]) { (_, new) in new }
     }
 
-    func updateCover(tracks: [Any?]) {
+    func updateCover(tracks: [Sendable?]) {
         coverLock.withLock {
             coverTime = mach_absolute_time()
             coverPath = nil
@@ -183,12 +183,12 @@ class RemoteCommandCenter: EventSubscriber {
         }
     }
 
-    func generateCover(tracks: [Any?], time: UInt64) {
+    func generateCover(tracks: [Sendable?], time: UInt64) {
         var imageCoverPath: String?
         var externalCoverPath: String?
 
         for item in tracks {
-            guard let track = item as? [String: Any?] else { continue }
+            guard let track = item as? [String: Sendable?] else { continue }
             if (track["image"] as? Bool) == true {
                 // opened file is an image
                 if track["external"] as? Bool == false && track["albumart"] as? Bool == false && imageCoverPath == nil {

--- a/osdep/mac/type_helper.swift
+++ b/osdep/mac/type_helper.swift
@@ -106,35 +106,35 @@ class TypeHelper {
     }
 
     // MPV_FORMAT_NODE > MPV_FORMAT_NODE_ARRAY
-    class func nodeToArray(_ node: mpv_node?) -> [Any?] {
-        var array: [Any?] = []
+    class func nodeToArray(_ node: mpv_node?) -> [Sendable?] {
+        var array: [Sendable?] = []
         guard let list = node?.u.list?.pointee,
               let values = list.values else { return array }
 
         for index in 0..<Int(list.num) {
-            array.append(TypeHelper.nodeToAny(values[index]))
+            array.append(TypeHelper.nodeToAnyValue(values[index]))
         }
 
         return array
     }
 
     // MPV_FORMAT_NODE > MPV_FORMAT_NODE_MAP
-    class func nodeToDict(_ node: mpv_node?) -> [String: Any?] {
-        var dict: [String: Any?] = [:]
+    class func nodeToDict(_ node: mpv_node?) -> [String: Sendable?] {
+        var dict: [String: Sendable?] = [:]
         guard let list = node?.u.list?.pointee,
               let values = list.values else { return dict }
 
         for index in 0..<Int(list.num) {
             guard let keyPtr = list.keys?[index] else { continue }
             let key = String(cString: keyPtr)
-            dict[key] = TypeHelper.nodeToAny(values[index])
+            dict[key] = TypeHelper.nodeToAnyValue(values[index])
         }
 
         return dict
     }
 
     // MPV_FORMAT_NODE
-    class func nodeToAny(_ node: mpv_node) -> Any? {
+    class func nodeToAnyValue(_ node: mpv_node) -> Sendable? {
         switch node.format {
         case MPV_FORMAT_STRING: return TypeHelper.nodeToString(node)
         case MPV_FORMAT_FLAG: return TypeHelper.nodeToBool(node)


### PR DESCRIPTION
all values mapped to the array are immutable or value type values, though the Any type implies any type including mutables or reference types. all mpv_node data can be represented as the former.

change Any to Sendable, which implies mutable or values type values.

this is also a preparation for swift 6 and strict concurrency support.