### PR TITLE
ytdl_hook: use the new max_request_size AVOption if needed

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -894,6 +894,18 @@ local function add_single_video(json)
         stream_opts["cookies"] = serialize_cookies_for_avformat(existing_cookies)
     end
 
+    local chunk_size = math.huge
+    if has_requested_formats then
+        for _, f in pairs(requested_formats) do
+            if f.downloader_options and f.downloader_options.http_chunk_size then
+                chunk_size = math.min(chunk_size, tonumber(f.downloader_options.http_chunk_size))
+            end
+        end
+    end
+    if chunk_size < math.huge then
+        stream_opts = append_libav_opt(stream_opts, "max_request_size", tostring(chunk_size))
+    end
+
     mp.set_property_native("file-local-options/stream-lavf-o", stream_opts)
 end
 


### PR DESCRIPTION
Some sites throttle requests, but throttling can be avoided with many small range requests. yt-dlp implements a "http_chunk_size" key in its -J output to inform us of the ideal size.

With the appropriate[1] FFmpeg addition, we can properly implement this now, which greatly speeds up how fast YouTube videos get loaded into the cache by mpv.

Should the FFmpeg that mpv is built against lack the max_request_size AVOption, then this will silently not do anything new, so no version checks are needed.

Fixes #8655.

- 1: https://patchwork.ffmpeg.org/project/ffmpeg/patch/20250101204126.748587-1-ffmpeg@fratti.ch/

Draft until the FFmpeg patch gets applied, should not be merged before that because the way we implement this might change during the review process.