### PR TITLE
mac: add build-apple-silicon.sh to allow build on Apple Silicon Macs

### DIFF
--- a/build-apple-silicon.sh
+++ b/build-apple-silicon.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+meson setup build
+meson compile -C build
+
+./build/mpv --version
+
+./TOOLS/osxbundle.py --skip-deps build/mpv
+if [[ $1 == "--static" ]]; then
+    dylibbundler
+        --bundle-deps
+        --dest-dir build/mpv.app/Contents/MacOS/lib/
+        --install-path @executable_path/lib/
+        --fix-file build/mpv.app/Contents/MacOS/mpv
+    ./build/mpv.app/Contents/MacOS/mpv --version
+fi


### PR DESCRIPTION
This bash script allows to natively  build mpv on Apple Silicon Macs. Tested on M3 Pro MBP.