### PR TITLE
console.lua: inherit --osd-shadow-offset

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -549,10 +549,8 @@ local function update()
     local clipping_coordinates = '0,' .. coordinate_top .. ',' ..
                                  osd_w .. ',' .. osd_h
     local ass = assdraw.ass_new()
-    local has_shadow = mp.get_property('osd-border-style'):find('box$') == nil
     local font = get_font()
     local style = '{\\r' ..
-                  (has_shadow and '\\xshad0\\yshad1' or '') ..
                   (font and '\\fn' .. font or '') ..
                   '\\fs' .. opts.font_size ..
                   '\\bord' .. opts.border_size .. '\\fsp0' ..


### PR DESCRIPTION
It was requested in
https://github.com/Samillion/ModernZ/issues/259#issuecomment-2556608926 to make console's shadow offset consistent with --osd-shadow-offset. Not specifying shadow offsets achieves that. This disables console's shadow by default but there is no reason console should default to having shadows but the rest of the OSD shouldn't. Users who want shadows can enable them in the whole OSD with --osd-shadow-offset. console-specific shadow_{x,y}_offset script-opts can be added if someone requests them later.