### PR TITLE
options: remove the `player` argument from `--media-controls`

### DIFF
--- a/DOCS/interface-changes/media-controls-player.txt
+++ b/DOCS/interface-changes/media-controls-player.txt
@@ -1,0 +1,1 @@
+remove `player` argument form `--media-controls`, it's handled internally now.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7646,12 +7646,10 @@ Miscellaneous
 
     .. warning:: Using realtime priority can cause system lockup.
 
-``--media-controls=<yes|player|no>``
+``--media-controls=<yes|no>``
     (Windows only)
     Enable integration of media control interface SystemMediaTransportControls.
-    If set to ``player``, only the player will use the controls. Setting it to
-    ``yes`` will also enable the controls for libmpv integrations.
-    (default: ``player``)
+    Default: yes (except for libmpv)
 
 ``--force-media-title=<string>``
     Force the contents of the ``media-title`` property to this value. Useful

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -28,6 +28,7 @@ input-default-bindings=no
 input-vo-keyboard=no
 # macOS global input hooks
 input-media-keys=no
+media-controls=no
 
 [encoding]
 vo=lavc

--- a/options/options.c
+++ b/options/options.c
@@ -517,8 +517,7 @@ static const m_option_t mp_opts[] = {
         {"idle",        IDLE_PRIORITY_CLASS}),
         .flags = UPDATE_PRIORITY},
 #endif
-    {"media-controls", OPT_CHOICE(media_controls,
-        {"no", 0}, {"player", 1}, {"yes", 2})},
+    {"media-controls", OPT_BOOL(media_controls)},
     {"config", OPT_BOOL(load_config), .flags = M_OPT_PRE_PARSE},
     {"config-dir", OPT_STRING(force_configdir),
         .flags = M_OPT_NOCFG | M_OPT_PRE_PARSE | M_OPT_FILE},
@@ -1026,7 +1025,7 @@ static const struct MPOpts mp_default_opts = {
     .osd_bar_visible = true,
     .screenshot_template = "mpv-shot%n",
     .play_dir = 1,
-    .media_controls = 1,
+    .media_controls = true,
     .video_exts = (char *[]){
         "3g2", "3gp", "avi", "flv", "m2ts", "m4v", "mj2", "mkv", "mov", "mp4",
         "mpeg", "mpg", "ogv", "rmvb", "ts", "webm", "wmv", "y4m", NULL

--- a/options/options.h
+++ b/options/options.h
@@ -337,7 +337,7 @@ typedef struct MPOpts {
     bool osd_bar_visible;
 
     int w32_priority;
-    int media_controls;
+    bool media_controls;
 
     struct bluray_opts *stream_bluray_opts;
     struct cdda_opts *stream_cdda_opts;

--- a/player/main.c
+++ b/player/main.c
@@ -406,7 +406,7 @@ int mp_initialize(struct MPContext *mpctx, char **options)
 #endif
 
 #if HAVE_WIN32_SMTC
-    if (opts->media_controls == 2 || (mpctx->is_cli && opts->media_controls == 1))
+    if (opts->media_controls)
         mp_smtc_init(mp_new_client(mpctx->clients, "SystemMediaTransportControls"));
 #endif
 


### PR DESCRIPTION
It is now handled internally by the libmpv profile.

Since `player` was the default option, the impact should be minimal, as it is uncommon to override the default option with the same value. yes/no args will function the same way as before this commit.

API users might be affected though.