### PR TITLE
console.lua: inherit OSD styles in the cursor

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -561,11 +561,12 @@ local function update()
     -- of the drawing. So the cursor doesn't affect layout too much, make it as
     -- thin as possible and make it appear to be 1px wide by giving it 0.5px
     -- horizontal borders.
+    local color, alpha = mpv_color_to_ass(mp.get_property('osd-color'))
     local cheight = opts.font_size * 8
     local cglyph = '{\\rDefault' ..
                    (mp.get_property_native('focused') == false
-                    and '\\alpha&HFF&' or '\\1a&H44&\\3a&H44&') ..
-                   '\\1c&Heeeeee&\\3c&Heeeeee&' ..
+                    and '\\alpha&HFF&' or '\\1a&H44&\\3a&H' .. alpha .. '&') ..
+                   '\\1c&Heeeeee&\\3c&H' .. color .. '&' ..
                    '\\xbord0.5\\ybord0\\xshad0\\yshad1\\p4\\pbo24}' ..
                    'm 0 0 l 1 0 l 1 ' .. cheight .. ' l 0 ' .. cheight ..
                    '{\\p0}'

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -563,7 +563,7 @@ local function update()
     -- horizontal borders.
     local color, alpha = mpv_color_to_ass(mp.get_property('osd-color'))
     local cheight = opts.font_size * 8
-    local cglyph = '{\\rDefault' ..
+    local cglyph = '{\\r\\blur0' ..
                    (mp.get_property_native('focused') == false
                     and '\\alpha&HFF&' or '\\1a&H44&\\3a&H' .. alpha .. '&') ..
                    '\\1c&Heeeeee&\\3c&H' .. color .. '&' ..

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -565,8 +565,8 @@ local function update()
     local cheight = opts.font_size * 8
     local cglyph = '{\\r\\blur0' ..
                    (mp.get_property_native('focused') == false
-                    and '\\alpha&HFF&' or '\\1a&H44&\\3a&H' .. alpha .. '&') ..
-                   '\\1c&Heeeeee&\\3c&H' .. color .. '&' ..
+                    and '\\alpha&HFF&' or '\\3a&H' .. alpha .. '&') ..
+                   '\\3c&H' .. color .. '&' ..
                    '\\xbord0.5\\ybord0\\xshad0\\yshad1\\p4\\pbo24}' ..
                    'm 0 0 l 1 0 l 1 ' .. cheight .. ' l 0 ' .. cheight ..
                    '{\\p0}'


### PR DESCRIPTION
console.lua: inherit --osd-color in the cursor

Following up 19537a4996, also respect the user-specified color in the cursor. But the cursor is drawn as a border, so we actually need to use --osd-color as the border color.

console.lua: inherit --osd-back-color in the cursor

3dcc661de7 made the cursor reset to Default style to not apply the blur, but \blur0 achieves that without resetting every user style. The cursor can thus respect the user's --osd-back/shadow-color.

console.lua: don't set the cursor color

This makes no visible difference, only the border color is visible, as the border is drawn on top of the regular color.
