### PR TITLE
stats.lua: inherit --osd-shadow-offset

### DIFF
--- a/DOCS/man/stats.rst
+++ b/DOCS/man/stats.rst
@@ -175,12 +175,12 @@ Configurable Options
     Color of the text border.
 
 ``shadow_x_offset``
-    Default: 0
+    Default: same as ``--osd-shadow-offset``
 
     The horizontal distance from the text to position the shadow at.
 
 ``shadow_y_offset``
-    Default: 0
+    Default: same as ``--osd-shadow-offset``
 
     The vertical distance from the text to position the shadow at.
 

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -84,8 +84,6 @@ osd-outline-size=0
 osd-shadow-offset=4
 script-opt=console-border_size=0
 script-opt=stats-border_size=0
-script-opt=stats-shadow_x_offset=4
-script-opt=stats-shadow_y_offset=4
 
 [sub-box]
 sub-border-style=background-box

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -57,8 +57,8 @@ local o = {
     font_color = "",
     border_size = 1.65,
     border_color = "",
-    shadow_x_offset = 0.0,
-    shadow_y_offset = 0.0,
+    shadow_x_offset = math.huge,
+    shadow_y_offset = math.huge,
     shadow_color = "",
     alpha = "11",
     vidscale = "auto",
@@ -184,8 +184,15 @@ local function text_style()
             style = style .. "\\4c&H" .. o.shadow_color .. "&\\4a&H" .. o.alpha .. "&"
         end
 
-        return style .. "\\xshad" .. shadow_x_offset ..
-               "\\yshad" .. shadow_y_offset .. "}"
+        if o.shadow_x_offset < math.huge then
+            style = style .. "\\xshad" .. shadow_x_offset
+        end
+
+        if o.shadow_y_offset < math.huge then
+            style = style .. "\\yshad" .. shadow_y_offset
+        end
+
+        return style
     end
 end
 


### PR DESCRIPTION
Unlike font and border sizes, the default stats shadow offset is 0 like --osd-shadow-offset, so it can be inherited from it by default to not make users configure it in 2 places.

Since 0 and negative numbers are valid offsets, use infinity as the placeholder for unconfigured values.