### PR TITLE
Revert "demux_edl: disallow nested edl to avoid infinite loop"

### DIFF
--- a/DOCS/interface-changes/edl.txt
+++ b/DOCS/interface-changes/edl.txt
@@ -1,1 +1,0 @@
-nested edl are no longer supported; flatten the edl or use a playlist with multiple edl entries

--- a/demux/demux_edl.c
+++ b/demux/demux_edl.c
@@ -451,10 +451,6 @@ static struct timeline_par *build_timeline(struct timeline *root,
         struct tl_part *part = &parts->parts[n];
         struct demuxer *source = NULL;
 
-        if (!bstrcasecmp0(mp_split_proto(bstr0(part->filename), NULL), "edl")) {
-            MP_ERR(root, "Nested EDL is not allowed.\n");
-            goto error;
-        }
         if (tl->dash) {
             part->offset = starttime;
             if (part->length <= 0)


### PR DESCRIPTION
Apparently there are some scripts that use nested edls instead of flattening them first, so let's live with this.

This reverts commit de42e11662f3f002033b28876b6a03e0313ba8a9.