### PR TITLE
github/workflows/lint: add pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: editorconfig-checker/action-editorconfig-checker@main
       - run: editorconfig-checker -config .editorconfig-checker.json
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+    - id: check-case-conflict
+    - id: check-executables-have-shebangs
+    - id: check-illegal-windows-names
+    - id: check-json
+    - id: check-shebang-scripts-are-executable
+    - id: check-xml
+    - id: check-yaml
+    - id: end-of-file-fixer
+      exclude: ^TOOLS/osxbundle/mpv.app/Contents/PkgInfo$
+    - id: fix-byte-order-marker
+    - id: mixed-line-ending
+    - id: trailing-whitespace
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.3.0
+  hooks:
+    - id: codespell
+      args: ["--ignore-words-list", "datas,DNE,enew,HDA,numer,ontop,optionA,Paeth,pathc,inout"]
+      exclude: ^misc/language.c$


### PR DESCRIPTION
Tests some basic errors in files like, trailing white-spaces. Additionally check the spelling with codespell.