### PR TITLE
ao_openal: Fix null pointer dereference when creating OpenAL context

### DIFF
--- a/audio/out/ao_openal.c
+++ b/audio/out/ao_openal.c
@@ -192,6 +192,11 @@ static int init(struct ao *ao)
         goto err_out;
     }
     ctx = alcCreateContext(dev, attribs);
+    if (!ctx) {
+        MP_FATAL(ao, "Failed to create OpenAL context\n");
+        alcCloseDevice(dev);
+        goto err_out;
+    }
     alcMakeContextCurrent(ctx);
     alListenerfv(AL_POSITION, position);
     alListenerfv(AL_ORIENTATION, direction);


### PR DESCRIPTION
When the monitor goes to sleep, the OpenAL context was not properly handled, resulting in a null pointer dereference and a crash. This fix ensures that the OpenAL context is created and set correctly before proceeding. This avoids the crash under these conditions.

Fixes: #15648
Also fixes #[8307](https://github.com/SubtitleEdit/subtitleedit/issues/8307) of Subtitle Edit that utilizes Libmpv

Afterwards the important log part looks like this (can be compared to the log in #15648):

[ 108.517][d][ao/wasapi] Find device ''
[ 108.520][v][ao/wasapi] No device specified. Selecting default.
[ 108.534][v][ao/wasapi] Selecting device '{4d7dd748-07de-421c-9960-81369cb0b289}' (42 FHD_LCD-TV (NVIDIA High Definition Audio))
[ 108.534][v][ao/wasapi] Monitoring changes in device {0.0.0.00000000}.{4d7dd748-07de-421c-9960-81369cb0b289}
[ 108.540][d][ao/wasapi] Init wasapi thread
[ 108.540][d][ao/wasapi] Activating pAudioClient interface
[ 108.540][d][ao/wasapi] Probing formats
[ 108.548][v][ao/wasapi] Trying stereo float (32/32 bits) @ 48000hz (shared) -> AUDCLNT_E_DEVICE_INVALIDATED (0x88890004)
[ 108.548][e][ao/wasapi] Error finding shared mode format: AUDCLNT_E_DEVICE_INVALIDATED (0x88890004)
[ 108.548][d][ao/wasapi] Thread shutdown
[ 108.548][d][ao/wasapi] Uninit wasapi
[ 108.548][d][ao/wasapi] Thread uninit done
[ 108.548][d][ao/wasapi] Thread return
[ 108.548][d][ao/wasapi] Uninit wasapi done
[ 108.548][v][ao] Trying audio driver 'openal'
[ 108.548][v][ao/openal] requested format: 48000 Hz, stereo channels, floatp
[ 108.581][w][ao/openal] Direct channels aren't supported by this version of OpenAL
[ 108.581][f][ao/openal] Failed to create OpenAL context
[ 108.581][v][ao] Trying audio driver 'sdl'
...

The newly added check prevents LibMPV from crashing and LibMPV proceeds normally now..

Logfile with the fix in place:
[output.txt](https://github.com/user-attachments/files/18310571/output.txt)
