### PR TITLE
ao/pulse: only print server protocol after connection

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -316,8 +316,6 @@ static int pa_init_boilerplate(struct ao *ao)
     MP_VERBOSE(ao, "Library version: %s\n", pa_get_library_version());
     MP_VERBOSE(ao, "Proto: %lu\n",
         (long)pa_context_get_protocol_version(priv->context));
-    MP_VERBOSE(ao, "Server proto: %lu\n",
-        (long)pa_context_get_server_protocol_version(priv->context));
 
     pa_context_set_state_callback(priv->context, context_state_cb, ao);
     pa_context_set_subscribe_callback(priv->context, subscribe_cb, ao);
@@ -334,6 +332,9 @@ static int pa_init_boilerplate(struct ao *ao)
             goto fail;
         pa_threaded_mainloop_wait(priv->mainloop);
     }
+
+    MP_VERBOSE(ao, "Server proto: %lu\n",
+        (long)pa_context_get_server_protocol_version(priv->context));
 
     pa_threaded_mainloop_unlock(priv->mainloop);
     return 0;


### PR DESCRIPTION
The server's protocol version is not available until a connection is properly established. Currently the value of `PA_INVALID_INDEX` is printed due to calling `pa_context_get_server_protocol_version()` before connecting.

Fix this by doing the call after the connection has been set up.

Fixes: f744aadb776d ("ao_pulse: dump library version etc.")
