### PR TITLE
console.lua: add pause_on_open script-opt

### DIFF
--- a/DOCS/interface-changes/console-pause-on-open.rst
+++ b/DOCS/interface-changes/console-pause-on-open.rst
@@ -1,0 +1,1 @@
+add `console-pause_on_open` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -200,3 +200,9 @@ Configurable Options
     The ratio of font height to font width.
     Adjusts table width of completion suggestions.
     Values in the range 1.8..2.5 make sense for common monospace fonts.
+
+``pause_on_open``
+    Default: no
+
+    Whether to pause playback when the console opens, and resume it when the
+    console is closed, if playback was not already paused.


### PR DESCRIPTION
Add a script-opt to pause when console opens and unpause when it closes, disabled by default.

This is particularly useful for selectors that take several seconds to open so you don't have to guess when to pause, like the subtitle line selector with embedded subtitles, or my script which lets you select which lyrics to download after requesting them with curl.