### PR TITLE
select.lua: select from the watch history with g-h

### DIFF
--- a/DOCS/interface-changes/watch-history.txt
+++ b/DOCS/interface-changes/watch-history.txt
@@ -1,0 +1,1 @@
+add `--save-watch-history` and `--watch-history-path` options

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -328,6 +328,9 @@ g-l
 g-d
     Select an audio device.
 
+g-h
+    Select a file from the watch history. Requires ``--save-watch-history``.
+
 g-w
     Select a file from watch later config files (see `RESUMING PLAYBACK`_) to
     resume playing. Requires ``--write-filename-in-watch-later-config``. This

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1152,7 +1152,8 @@ Watch History
 -------------
 
 ``--save-watch-history``
-    Whether to save which files are played.
+    Whether to save which files are played. These can be then selected with the
+    default ``g-h`` key binding.
 
     .. warning::
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1148,6 +1148,25 @@ Watch Later
     Ignore path (i.e. use filename only) when using watch later feature.
     (Default: disabled)
 
+Watch History
+-------------
+
+``--save-watch-history``
+    Whether to save which files are played.
+
+    .. warning::
+
+        This option may expose privacy-sensitive information and is thus
+        disabled by default.
+
+``--watch-history-path=<path>``
+    The path in which to store the watch history. Default:
+    ``~~state/watch_history.jsonl`` (see `PATHS`_).
+
+    This file contains one JSON object per line. Its ``time`` field is the UNIX
+    timestamp when the file was opened, its ``path`` field is the normalized
+    path, and its ``title`` field is the title when it was available.
+
 Video
 -----
 

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -187,6 +187,7 @@
 #g-e script-binding select/select-edition
 #g-l script-binding select/select-subtitle-line
 #g-d script-binding select/select-audio-device
+#g-h script-binding select/select-watch-history
 #g-w script-binding select/select-watch-later
 #g-b script-binding select/select-binding
 #g-r script-binding select/show-properties

--- a/misc/json.c
+++ b/misc/json.c
@@ -289,7 +289,7 @@ static void add_indent(bstr *b, int indent)
         bstr_xappend(NULL, b, bstr0(" "));
 }
 
-static int json_append(bstr *b, const struct mpv_node *src, int indent)
+int json_append(bstr *b, const struct mpv_node *src, int indent)
 {
     switch (src->format) {
     case MPV_FORMAT_NONE:

--- a/misc/json.h
+++ b/misc/json.h
@@ -23,7 +23,10 @@
 
 #define MAX_JSON_DEPTH 50
 
+struct bstr;
+
 int json_parse(void *ta_parent, struct mpv_node *dst, char **src, int max_depth);
+int json_append(struct bstr *b, const struct mpv_node *src, int indent);
 void json_skip_whitespace(char **src);
 int json_write(char **s, struct mpv_node *src);
 int json_write_pretty(char **s, struct mpv_node *src);

--- a/options/options.c
+++ b/options/options.c
@@ -813,6 +813,9 @@ static const m_option_t mp_opts[] = {
     {"watch-later-directory", OPT_ALIAS("watch-later-dir")},
     {"watch-later-options", OPT_STRINGLIST(watch_later_options)},
 
+    {"save-watch-history", OPT_BOOL(save_watch_history)},
+    {"watch-history-path", OPT_STRING(watch_history_path), .flags = M_OPT_FILE},
+
     {"ordered-chapters", OPT_BOOL(ordered_chapters)},
     {"ordered-chapters-files", OPT_STRING(ordered_chapters_files),
         .flags = M_OPT_FILE},
@@ -988,6 +991,7 @@ static const struct MPOpts mp_default_opts = {
     .sync_max_factor = 5,
     .load_config = true,
     .position_resume = true,
+    .watch_history_path = "~~state/watch_history.jsonl",
     .autoload_files = true,
     .demuxer_thread = true,
     .demux_termination_timeout = 0.1,

--- a/options/options.h
+++ b/options/options.h
@@ -277,6 +277,8 @@ typedef struct MPOpts {
     bool ignore_path_in_watch_later_config;
     char *watch_later_dir;
     char **watch_later_options;
+    bool save_watch_history;
+    char *watch_history_path;
     bool pause;
     int keep_open;
     bool keep_open_pause;

--- a/player/command.c
+++ b/player/command.c
@@ -577,32 +577,11 @@ static int mp_property_file_size(void *ctx, struct m_property *prop,
     return m_property_int64_ro(action, arg, size);
 }
 
-static const char *find_non_filename_media_title(MPContext *mpctx)
-{
-    const char *name = mpctx->opts->media_title;
-    if (name && name[0])
-        return name;
-    if (mpctx->demuxer) {
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "service_name");
-        if (name && name[0])
-            return name;
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "title");
-        if (name && name[0])
-            return name;
-        name = mp_tags_get_str(mpctx->demuxer->metadata, "icy-title");
-        if (name && name[0])
-            return name;
-    }
-    if (mpctx->playing && mpctx->playing->title)
-        return mpctx->playing->title;
-    return NULL;
-}
-
 static int mp_property_media_title(void *ctx, struct m_property *prop,
                                    int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    const char *name = find_non_filename_media_title(mpctx);
+    const char *name = mp_find_non_filename_media_title(mpctx);
     if (name && name[0])
         return m_property_strdup_ro(action, arg, name);
     return mp_property_filename(ctx, prop, action, arg);
@@ -7556,7 +7535,7 @@ static void command_event(struct MPContext *mpctx, int event, void *arg)
     if (event == MP_EVENT_METADATA_UPDATE) {
         struct playlist_entry *const pe = mpctx->playing;
         if (pe && !pe->title) {
-            const char *const name = find_non_filename_media_title(mpctx);
+            const char *const name = mp_find_non_filename_media_title(mpctx);
             if (name && name[0]) {
                 pe->title = talloc_strdup(pe, name);
                 mp_notify_property(mpctx, "playlist");

--- a/player/core.h
+++ b/player/core.h
@@ -576,6 +576,7 @@ int stream_dump(struct MPContext *mpctx, const char *source_filename);
 double get_track_seek_offset(struct MPContext *mpctx, struct track *track);
 bool str_in_list(bstr str, char **list);
 char *mp_format_track_metadata(void *ctx, struct track *t, bool add_lang);
+const char *mp_find_non_filename_media_title(MPContext *mpctx);
 
 // osd.c
 void set_osd_bar(struct MPContext *mpctx, int type,

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include <assert.h>
+#include <time.h>
 
 #include <libavutil/avutil.h>
 
@@ -44,6 +45,7 @@
 #include "common/encode.h"
 #include "common/stats.h"
 #include "input/input.h"
+#include "misc/json.h"
 #include "misc/language.h"
 
 #include "audio/out/ao.h"
@@ -1521,6 +1523,89 @@ static void load_external_opts(struct MPContext *mpctx)
     mp_waiter_wait(&wait);
 }
 
+static void append_to_watch_history(struct MPContext *mpctx)
+{
+    if (!mpctx->opts->save_watch_history)
+        return;
+
+    void *ctx = talloc_new(NULL);
+    char *history_path = mp_get_user_path(ctx, mpctx->global,
+                                          mpctx->opts->watch_history_path);
+    FILE *history_file = fopen(history_path, "ab");
+
+    if (!history_file) {
+        MP_ERR(mpctx, "Failed to open history file: %s\n",
+               mp_strerror(errno));
+        goto done;
+    }
+
+    char *title = (char *)mp_find_non_filename_media_title(mpctx);
+
+    mpv_node_list *list = talloc_zero(ctx, mpv_node_list);
+    mpv_node node = {
+        .format = MPV_FORMAT_NODE_MAP,
+        .u.list = list,
+    };
+    list->num = title ? 3 : 2;
+    list->keys = talloc_array(ctx, char*, list->num);
+    list->values = talloc_array(ctx, mpv_node, list->num);
+    list->keys[0] = "time";
+    list->values[0] = (struct mpv_node) {
+        .format = MPV_FORMAT_INT64,
+        .u.int64 = time(NULL),
+    };
+    list->keys[1] = "path";
+    list->values[1] = (struct mpv_node) {
+        .format = MPV_FORMAT_STRING,
+        .u.string = mp_normalize_path(ctx, mpctx->filename),
+    };
+    if (title) {
+        list->keys[2] = "title";
+        list->values[2] = (struct mpv_node) {
+            .format = MPV_FORMAT_STRING,
+            .u.string = title,
+        };
+    }
+
+    bstr dst = {0};
+    json_append(&dst, &node, -1);
+    talloc_steal(ctx, dst.start);
+    if (!dst.len) {
+        MP_ERR(mpctx, "Failed to serialize history entry\n");
+        goto done;
+    }
+    bstr_xappend0(ctx, &dst, "\n");
+
+    int seek = fseek(history_file, 0, SEEK_END);
+    off_t history_size = ftell(history_file);
+    if (seek != 0 || history_size == -1) {
+        MP_ERR(mpctx, "Failed to get history file size: %s\n",
+               mp_strerror(errno));
+        fclose(history_file);
+        goto done;
+    }
+
+    bool failed = fwrite(dst.start, dst.len, 1, history_file) != 1 ||
+                  fflush(history_file) != 0;
+
+    if (failed) {
+        MP_ERR(mpctx, "Failed to write to history file: %s\n",
+               mp_strerror(errno));
+
+        int fd = fileno(history_file);
+        if (fd == -1 || ftruncate(fd, history_size) == -1)
+            MP_ERR(mpctx, "Failed to roll-back history file: %s\n",
+                   mp_strerror(errno));
+    }
+
+    if (fclose(history_file) != 0)
+        MP_ERR(mpctx, "Failed to close history file: %s\n",
+               mp_strerror(errno));
+
+done:
+    talloc_free(ctx);
+}
+
 // Start playing the current playlist entry.
 // Handle initialization and deinitialization.
 static void play_current_file(struct MPContext *mpctx)
@@ -1771,6 +1856,8 @@ static void play_current_file(struct MPContext *mpctx)
 
     if (watch_later)
         mp_delete_watch_later_conf(mpctx, mpctx->filename);
+
+    append_to_watch_history(mpctx);
 
     if (mpctx->max_frames == 0) {
         if (!mpctx->stop_play)

--- a/player/misc.c
+++ b/player/misc.c
@@ -413,3 +413,24 @@ char *mp_format_track_metadata(void *ctx, struct track *t, bool add_lang)
 
     return bstrto0(ctx, dst);
 }
+
+const char *mp_find_non_filename_media_title(MPContext *mpctx)
+{
+    const char *name = mpctx->opts->media_title;
+    if (name && name[0])
+        return name;
+    if (mpctx->demuxer) {
+        name = mp_tags_get_str(mpctx->demuxer->metadata, "service_name");
+        if (name && name[0])
+            return name;
+        name = mp_tags_get_str(mpctx->demuxer->metadata, "title");
+        if (name && name[0])
+            return name;
+        name = mp_tags_get_str(mpctx->demuxer->metadata, "icy-title");
+        if (name && name[0])
+            return name;
+    }
+    if (mpctx->playing && mpctx->playing->title)
+        return mpctx->playing->title;
+    return NULL;
+}


### PR DESCRIPTION
Implement saving watched paths and selecting them.

--osd-playlist-entry determines whether titles and/or filenames are shown. But unlike in show-text ${playlist} and select-playlist, "file" and "both" print full paths because history is much more likely to have files from completely different directories, so showing the directory conveys where files are located. This is particularly helpful for filenames like 1.jpg.

The last entry in the selector deletes the history file, as requested by Samillion.

The history could be formatted as CSV, but this requires escaping the separator in the fields and doesn't work with paths and titles with newlines, or as JSON, but it is inefficient to reread and rewrite the whole history on each new file, and doing so overwrites the history with an empty file when writing without disk space left. I went with an hybrid of one JSON array per line to get the best of both worlds. And I discovered afterwards that this was an existing thing called NDJSON or JSONL. Since there are these 2 competing standards it is not clear if the file extension should be ndjson or jsonl, so I just used txt.

watch_history_path is awkwardly documented along with the key binding because I don't think it's worth adding a select.lua section to the manual just for this. I will add it and move it there if I add more script-opts in the future.