### PR TITLE
console.lua: improve the hovered item calculation

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -547,8 +547,8 @@ local function update()
 
     local osd_w, osd_h = get_scaled_osd_dimensions()
 
-    local margin_x = get_margin_x()
-    local margin_y = get_margin_y()
+    local x = get_margin_x()
+    local y = osd_h * (1 - global_margins.b) - get_margin_y()
 
     local coordinate_top = math.floor(global_margins.t * osd_h + 0.5)
     local clipping_coordinates = '0,' .. coordinate_top .. ',' ..
@@ -589,7 +589,7 @@ local function update()
         -- libass/ass_render.c:ass_render_event() subtracts --osd-margin-x from
         -- the maximum text width twice.
         local width_max = math.floor(
-            (osd_w - margin_x - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
+            (osd_w - x - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
             / opts.font_size * get_font_hw_ratio())
 
         local suggestions, rows = format_table(suggestion_buffer, width_max, max_lines)
@@ -608,7 +608,7 @@ local function update()
 
     ass:new_event()
     ass:an(1)
-    ass:pos(margin_x, osd_h - margin_y - global_margins.b * osd_h)
+    ass:pos(x, y)
     ass:append(log_ass .. '\\N')
     ass:append(suggestion_ass)
     ass:append(style .. ass_escape(prompt) .. ' ' .. before_cur)
@@ -619,7 +619,7 @@ local function update()
     -- cursor appear in front of the text.
     ass:new_event()
     ass:an(1)
-    ass:pos(margin_x, osd_h - margin_y - global_margins.b * osd_h)
+    ass:pos(x, y)
     ass:append(style .. '{\\alpha&HFF&}' .. ass_escape(prompt) .. ' ' .. before_cur)
     ass:append(cglyph)
     ass:append(style .. '{\\alpha&HFF&}' .. after_cur)

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -581,7 +581,7 @@ local function update()
     -- Render log messages as ASS.
     -- This will render at most screeny / font_size - 1 messages.
 
-    local lines_max = calculate_max_log_lines()
+    local max_lines = calculate_max_log_lines()
     local suggestion_ass = ''
     if next(suggestion_buffer) then
         -- Estimate how many characters fit in one line
@@ -592,8 +592,8 @@ local function update()
             (osd_w - margin_x - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
             / opts.font_size * get_font_hw_ratio())
 
-        local suggestions, rows = format_table(suggestion_buffer, width_max, lines_max)
-        lines_max = lines_max - rows
+        local suggestions, rows = format_table(suggestion_buffer, width_max, max_lines)
+        max_lines = max_lines - rows
         suggestion_ass = style .. styles.suggestion .. suggestions .. '\\N'
     end
 
@@ -601,12 +601,7 @@ local function update()
 
     local log_ass = ''
     local log_buffer = log_buffers[id]
-    local log_messages = #log_buffer
-    local log_max_lines = math.max(0, lines_max)
-    if log_max_lines < log_messages then
-        log_messages = log_max_lines
-    end
-    for i = #log_buffer - log_messages + 1, #log_buffer do
+    for i = #log_buffer - math.min(max_lines, #log_buffer) + 1, #log_buffer do
         log_ass = log_ass .. style .. log_buffer[i].style ..
                   ass_escape(log_buffer[i].text) .. '\\N'
     end


### PR DESCRIPTION
console.lua: improve the hovered item calculation

Currently determine_hovered_item() assumes that each item is opts.font_size pixels tall, which usually works well. This breaks with fonts that get drawn taller than that, such as Japanese text, which makes the calculation inaccurate for the top items and clips the counter. A couple of users reported that it is inaccurate for them for the top items even with ASCII characters in track selectors, presumably because the circles are taken from a different font and make all lines taller.

To fix this place each selectable item in its own ASS event positioned like determine_hovered_item() expects.

Unfortunately this breaks --profile=box, so keep placing every item in one ASS event with it.

This should fix @sfan5's issue.
