### PR TITLE
ytdl_hook: trigger hook only after profiles application

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -1215,7 +1215,8 @@ local function on_load_hook(load_fail)
     run_ytdl_hook(url)
 end
 
-mp.add_hook("on_load", 10, function() on_load_hook(false) end)
+-- ensure ytdl hook triggers AFTER profiles have been applied
+mp.add_hook("on_load", 60, function() on_load_hook(false) end)
 mp.add_hook("on_load_fail", 10, function() on_load_hook(true) end)
 
 mp.add_hook("on_load", 20, function ()


### PR DESCRIPTION
ytdl_hook and auto_profiles hook trigger in incorrect order leading to unexpected behavior like in #13515. This PR fixes the issue by ensuring that the ytdl_hook is always triggered after profiles have been applied.