### PR TITLE
console.lua: set a high z in select mode

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -89,6 +89,7 @@ local searching_history = false
 local log_buffers = {[id] = {}}
 local key_bindings = {}
 local dont_bind_up_down = false
+local overlay = mp.create_osd_overlay('ass-events')
 local global_margins = { t = 0, b = 0 }
 local was_playing = true
 local input_caller
@@ -480,6 +481,21 @@ local function populate_log_with_matches()
     end
 end
 
+local function update_overlay(data, res_x, res_y, z)
+    if overlay.data == data and
+       overlay.res_x == res_x and
+       overlay.res_y == res_y and
+       overlay.z == z then
+        return
+    end
+
+    overlay.data = data
+    overlay.res_x = res_x
+    overlay.res_y = res_y
+    overlay.z = z
+    overlay:update()
+end
+
 local function print_to_terminal()
     -- Clear the log after closing the console.
     if not repl_active then
@@ -541,7 +557,7 @@ local function update()
 
     -- Clear the OSD if the REPL is not active
     if not repl_active then
-        mp.set_osd_ass(0, 0, '')
+        update_overlay('', 0, 0, 0)
         return
     end
 
@@ -629,7 +645,8 @@ local function update()
     ass:append(cglyph)
     ass:append(style .. '{\\alpha&HFF&}' .. after_cur)
 
-    mp.set_osd_ass(osd_w, osd_h, ass.text)
+    -- z with selectable_items needs to be greater than the OSC's.
+    update_overlay(ass.text, osd_w, osd_h, selectable_items and 2000 or 0)
 end
 
 local update_timer = nil

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2502,7 +2502,7 @@ local function render()
 
     -- submit
     set_osd(osc_param.playresy * osc_param.display_aspect,
-            osc_param.playresy, ass.text, user_opts.layout == "box" and -1 or 1000)
+            osc_param.playresy, ass.text, 1000)
 end
 
 -- called by mpv on every frame


### PR DESCRIPTION
Revert "osc.lua: draw box layout below console"

This reverts commit 2dd5bd4cd1d87e6e3b6e73f1976d060e64781d38.

Instead of drawing the box layout below any other overlay with z >= 0 which may not be wanted, the next commit will increase console's z only in select mode instead.

console.lua: set a high z in select mode

Give console's overlay a high z only in select mode, since in this case you want to click it so it should be above other overlays. In particular console should be above the OSC's box layout with visibility=always when you show it by clicking its buttons.

Keep using z=0 otherwise when it doesn't handle clicks, to avoid unintuitive behavior of overlays handling clicks like the OSC being drawn below console.

Since the legacy mp.set_osd_ass() doesn't accept z, we need to repeat its caching logic, like 490b3ba007 and 86d24b069b did for the OSC.