### PR TITLE
compile-windows: specify project directory for Meson commands

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -152,6 +152,7 @@ they will be automatically downloaded and built by Meson.
       ```
 2. Install Meson, as outlined in [Getting Meson](https://mesonbuild.com/Getting-meson.html):
 3. The following build script utilizes the Meson subprojects system to build mpv and its dependencies.
+   Before proceeding with the next steps, ensure that you run the following commands from the project directory where the `meson.build` file and the `build` folder are located.
    To make sure all dependency versions are up-to-date, update the subprojects database from Meson's WrapDB.
    Also explicitly download several wraps as some nested projects may pull older versions of them.
    ```


### PR DESCRIPTION
For making my first pull request last week I wanted to compile mpv myself to test out my fix.
This was my first time working with Meson and I ran into all kinds off issues because I executed the Meson commands and switched only afterwards in the project directory to execute the powershell script.
And this took me way too long to figure out.
So I thought we could clarify this for the future if anyone else tries compiling mpv for their first time and is also not familiar with Meson.
