### PR TITLE
select.lua: show the ID of editions without title

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -241,7 +241,7 @@ mp.add_key_binding(nil, "select-edition", function ()
     local editions = {}
 
     for i, edition in ipairs(edition_list) do
-        editions[i] = edition.title
+        editions[i] = edition.title or "Edition " .. (edition.id + 1)
     end
 
     input.select({


### PR DESCRIPTION
MKV editions can have no title. Print their IDs instead of showing an empty selection.