### PR TITLE
win32: fix the issue of menu click failure caused by excessive menu-data updates

### DIFF
--- a/video/out/win32/menu.c
+++ b/video/out/win32/menu.c
@@ -41,6 +41,9 @@ static int append_menu(HMENU hmenu, UINT fMask, UINT fType, UINT fState,
     mii.cbSize = sizeof(mii);
     mii.fMask = MIIM_ID | fMask;
     mii.wID = id++;
+    // menu id must be less than 0xF000 and greater than WM_USER
+    if (id >= 0xF000)
+        id = WM_USER + 100;
 
     if (fMask & MIIM_FTYPE)
         mii.fType = fType;
@@ -218,7 +221,7 @@ void mp_win32_menu_show(struct menu_ctx *ctx, HWND hwnd)
 void mp_win32_menu_update(struct menu_ctx *ctx, struct mpv_node *data)
 {
     while (GetMenuItemCount(ctx->menu) > 0)
-        RemoveMenu(ctx->menu, 0, MF_BYPOSITION);
+        DeleteMenu(ctx->menu, 0, MF_BYPOSITION);
     talloc_free_children(ctx->ta_data);
 
     build_menu(ctx->ta_data, ctx->menu, data);


### PR DESCRIPTION
basically a copy of tsl0922/mpv-menu-plugin#77

if you have 200+ menu items and update `menu-data` about 400 times, clicking menu item will not execute any command, the reason is that the menu identifier greater than the max value of 16-bit unsigned integer.

1. make menu id always less than 0xF000 as mpv-player/mpv@861908c7 said
2. old menu items are never reused, should delete by DeleteMenu() instead of RemoveMenu(), destroys the handle and frees the memory