### PR TITLE
add "native" wayland clipboard backend and several related properties

### DIFF
--- a/DOCS/interface-changes/clipboard.txt
+++ b/DOCS/interface-changes/clipboard.txt
@@ -1,2 +1,3 @@
 add `--clipboard-enable` and `--clipboard-monitor` options
 add `clipboard` property
+add `current-clipboard-backend` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3968,10 +3968,36 @@ Property list
         The text content in the clipboard (Windows, Wayland and macOS only).
         Writing to this property sets the text clipboard content (Windows only).
 
+    ``clipboard/text-primary``
+        The text content in the primary selection (Wayland only).
+
     .. note::
 
-        On Wayland, the clipboard content is only updated when the compositor
-        sends a selection data offer (typically when VO window is focused).
+        On Wayland with the ``vo`` clipboard backend, the clipboard content is
+        only updated when the compositor sends a selection data offer
+        (typically when VO window is focused). The ``wayland`` backend typically
+        does not have this limitation.
+        See ``current-clipboard-backend`` property for more details.
+
+``current-clipboard-backend``
+    A string containing the currently active clipboard backend.
+    The following clipboard backends are implemented:
+
+    ``win32``
+        Windows backend.
+
+    ``mac``
+        macOS backend.
+
+    ``wayland``
+        Wayland backend. This backend is only available if the compositor
+        supports the ``zwlr_data_control_manager_v1`` protocol.
+
+    ``vo``
+        VO backend. Requires an active VO window, and support differs across
+        platforms. Currently, this is used as a fallback for Wayland
+        compositors without support for the ``zwlr_data_control_manager_v1``
+        protocol.
 
 Inconsistencies between options and properties
 ----------------------------------------------

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7871,10 +7871,14 @@ Miscellaneous
     writing to the ``clipboard`` property to get and set clipboard contents.
 
 ``--clipboard-monitor=<yes|no>``
-    (Windows and macOS only)
+    (Windows, Wayland and macOS only)
 
     Enable clipboard monitoring so that the ``clipboard`` property can be
     observed for content changes (default: no). This only affects clipboard
     implementations which use polling to monitor clipboard updates.
     Other platforms currently ignore this option and always/never notify
     changes.
+
+    On Wayland, this option only has effect on the ``wayland`` backend, and
+    not for the ``vo`` backend. See ``current-clipboard-backend`` property for
+    more details.

--- a/meson.build
+++ b/meson.build
@@ -1048,6 +1048,15 @@ if features['wayland']
     subdir(join_paths('video', 'out'))
 endif
 
+foreach v: ['1.39']
+    features += {'wayland-protocols-' + v.replace('.', '-'):
+        wayland['deps'][2].version().version_compare('>=' + v)}
+endforeach
+
+if features['wayland-protocols-1-39']
+    sources += files('player/clipboard/clipboard-wayland.c')
+endif
+
 features += {'memfd-create': false}
 if features['wayland']
     features += {'memfd-create': cc.has_function('memfd_create',

--- a/player/clipboard/clipboard-vo.c
+++ b/player/clipboard/clipboard-vo.c
@@ -22,12 +22,14 @@
 
 struct clipboard_vo_priv {
     struct MPContext *mpctx;
+    struct mp_log *log;
 };
 
 static int init(struct clipboard_ctx *cl, struct clipboard_init_params *params)
 {
     struct clipboard_vo_priv *priv = talloc_ptrtype(cl, priv);
     priv->mpctx = params->mpctx;
+    priv->log = mp_log_new(priv, cl->log, "vo"),
     cl->priv = priv;
     return CLIPBOARD_SUCCESS;
 }
@@ -52,10 +54,10 @@ static int get_data(struct clipboard_ctx *cl, struct clipboard_access_params *pa
         return CLIPBOARD_SUCCESS;
     case VO_NOTAVAIL:
     case VO_NOTIMPL:
-        MP_VERBOSE(cl, "VO does not support getting clipboard in the requested format.\n");
+        MP_VERBOSE(priv, "VO does not support getting clipboard in the requested format.\n");
         return CLIPBOARD_UNAVAILABLE;
     default:
-        MP_WARN(cl, "Failed getting VO clipboard.\n");
+        MP_WARN(priv, "Failed getting VO clipboard.\n");
         return CLIPBOARD_FAILED;
     }
 }
@@ -78,10 +80,10 @@ static int set_data(struct clipboard_ctx *cl, struct clipboard_access_params *pa
         return CLIPBOARD_SUCCESS;
     case VO_NOTAVAIL:
     case VO_NOTIMPL:
-        MP_VERBOSE(cl, "VO does not support setting clipboard in the requested format.\n");
+        MP_VERBOSE(priv, "VO does not support setting clipboard in the requested format.\n");
         return CLIPBOARD_UNAVAILABLE;
     default:
-        MP_WARN(cl, "Failed setting VO clipboard.\n");
+        MP_WARN(priv, "Failed setting VO clipboard.\n");
         return CLIPBOARD_FAILED;
     }
 }

--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -1,0 +1,463 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <wayland-client.h>
+
+#include "ext-data-control-v1.h"
+
+#include "clipboard.h"
+#include "common/common.h"
+#include "common/msg.h"
+#include "misc/bstr.h"
+#include "osdep/io.h"
+#include "osdep/poll_wrapper.h"
+#include "osdep/threads.h"
+
+struct clipboard_wayland_data_offer {
+    struct ext_data_control_offer_v1 *offer;
+    char *mime_type;
+    int fd;
+};
+
+struct clipboard_wayland_priv {
+    mp_mutex lock;
+    // accessed by both threads
+    int death_pipe[2];
+    bstr selection_text;
+    bstr primary_selection_text;
+    bool data_changed;
+    // only accessed by the core thread
+    mp_thread thread;
+    // only accessed by the clipboard thread
+    struct mp_log *log;
+    int display_fd;
+    struct wl_display *display;
+    struct wl_registry *registry;
+    struct wl_list seat_list;
+    struct ext_data_control_manager_v1 *dcman;
+    struct clipboard_wayland_data_offer *selection_offer;
+    struct clipboard_wayland_data_offer *primary_selection_offer;
+};
+
+struct clipboard_wayland_seat {
+    struct clipboard_wayland_priv *wl;
+    struct wl_seat *seat;
+    struct wl_list link;
+    uint32_t id;
+    struct ext_data_control_device_v1 *dcdev;
+    bool offered_plain_text;
+};
+
+static void remove_seat(struct clipboard_wayland_seat *seat)
+{
+    if (!seat)
+        return;
+
+    MP_VERBOSE(seat->wl, "Deregistering seat 0x%x\n", seat->id);
+    wl_list_remove(&seat->link);
+    if (seat->dcdev)
+        ext_data_control_device_v1_destroy(seat->dcdev);
+    wl_seat_destroy(seat->seat);
+    talloc_free(seat);
+    return;
+}
+
+static void destroy_offer(struct clipboard_wayland_data_offer *o)
+{
+    TA_FREEP(&o->mime_type);
+    if (o->fd != -1)
+        close(o->fd);
+    if (o->offer)
+        ext_data_control_offer_v1_destroy(o->offer);
+    *o = (struct clipboard_wayland_data_offer){.fd = -1};
+}
+
+
+static void handle_selection(void *data,
+                             struct ext_data_control_device_v1 *dcdev,
+                             struct ext_data_control_offer_v1 *id,
+                             struct clipboard_wayland_data_offer *o)
+{
+    struct clipboard_wayland_seat *s = data;
+    struct clipboard_wayland_priv *wl = s->wl;
+    if (o->offer) {
+        destroy_offer(o);
+        MP_VERBOSE(wl, "Received a new selection offer. Releasing the previous offer.\n");
+    }
+    o->offer = id;
+    if (!id)
+        return;
+
+    int pipefd[2];
+
+    if (pipe2(pipefd, O_CLOEXEC) == -1) {
+        MP_ERR(wl, "Failed to create selection pipe!\n");
+        return;
+    }
+
+    // Only receive plain text for now, may expand later.
+    if (s->offered_plain_text) {
+        ext_data_control_offer_v1_receive(o->offer, "text/plain;charset=utf-8", pipefd[1]);
+        s->offered_plain_text = false;
+    }
+    close(pipefd[1]);
+    o->fd = pipefd[0];
+}
+
+static void data_offer_handle_offer(void *data,
+                                    struct ext_data_control_offer_v1 *ext_data_control_offer_v1,
+                                    const char *mime_type)
+{
+    struct clipboard_wayland_seat *s = data;
+    if (!s->offered_plain_text)
+        s->offered_plain_text = !strcmp(mime_type, "text/plain;charset=utf-8");
+}
+
+static const struct ext_data_control_offer_v1_listener data_offer_listener = {
+    data_offer_handle_offer,
+};
+
+static void data_device_handle_data_offer(void *data,
+                                          struct ext_data_control_device_v1 *dcdev,
+                                          struct ext_data_control_offer_v1 *id)
+{
+    struct clipboard_wayland_seat *s = data;
+    ext_data_control_offer_v1_add_listener(id, &data_offer_listener, s);
+}
+
+static void data_device_handle_selection(void *data,
+                                         struct ext_data_control_device_v1 *dcdev,
+                                         struct ext_data_control_offer_v1 *id)
+{
+    struct clipboard_wayland_seat *s = data;
+    struct clipboard_wayland_priv *wl = s->wl;
+    handle_selection(data, dcdev, id, wl->selection_offer);
+}
+
+static void data_device_handle_finished(void *data,
+                                        struct ext_data_control_device_v1 *dcdev)
+{
+    struct clipboard_wayland_seat *s = data;
+    ext_data_control_device_v1_destroy(dcdev);
+    s->dcdev = NULL;
+}
+
+static void data_device_handle_primary_selection(void *data,
+                                                 struct ext_data_control_device_v1 *dcdev,
+                                                 struct ext_data_control_offer_v1 *id)
+{
+    struct clipboard_wayland_seat *s = data;
+    struct clipboard_wayland_priv *wl = s->wl;
+    handle_selection(data, dcdev, id, wl->primary_selection_offer);
+}
+
+static const struct ext_data_control_device_v1_listener data_device_listener = {
+    data_device_handle_data_offer,
+    data_device_handle_selection,
+    data_device_handle_finished,
+    data_device_handle_primary_selection,
+};
+
+static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id,
+                                const char *interface, uint32_t ver)
+{
+    int found = 1;
+    struct clipboard_wayland_priv *wl = data;
+
+    if (!strcmp(interface, wl_seat_interface.name) && found++) {
+        ver = MPMIN(ver, 8);
+        struct clipboard_wayland_seat *seat = talloc_zero(wl, struct clipboard_wayland_seat);
+        seat->wl   = wl;
+        seat->id   = id;
+        seat->seat = wl_registry_bind(reg, id, &wl_seat_interface, ver);
+        wl_list_insert(&wl->seat_list, &seat->link);
+    }
+
+    if (!strcmp(interface, ext_data_control_manager_v1_interface.name) && found++) {
+        ver = MPMIN(ver, 2);
+        wl->dcman = wl_registry_bind(reg, id, &ext_data_control_manager_v1_interface, ver);
+    }
+
+    if (found > 1)
+        MP_VERBOSE(wl, "Registered interface %s at version %d\n", interface, ver);
+}
+
+static void registry_handle_remove(void *data, struct wl_registry *reg, uint32_t id)
+{
+    struct clipboard_wayland_priv *wl = data;
+    struct clipboard_wayland_seat *seat, *seat_tmp;
+    wl_list_for_each_safe(seat, seat_tmp, &wl->seat_list, link) {
+        if (seat->id == id) {
+            remove_seat(seat);
+            return;
+        }
+    }
+}
+
+static const struct wl_registry_listener registry_listener = {
+    registry_handle_add,
+    registry_handle_remove,
+};
+
+static void clipboard_wayland_uninit(struct clipboard_wayland_priv *wl)
+{
+    if (!wl)
+        return;
+
+    destroy_offer(wl->selection_offer);
+    destroy_offer(wl->primary_selection_offer);
+
+    struct clipboard_wayland_seat *seat, *seat_tmp;
+    wl_list_for_each_safe(seat, seat_tmp, &wl->seat_list, link)
+        remove_seat(seat);
+
+    if (wl->dcman)
+        ext_data_control_manager_v1_destroy(wl->dcman);
+    if (wl->registry)
+        wl_registry_destroy(wl->registry);
+    if (wl->display)
+        wl_display_disconnect(wl->display);
+}
+
+static bool clipboard_wayland_init(struct clipboard_wayland_priv *wl)
+{
+    if (!getenv("WAYLAND_DISPLAY") && !getenv("WAYLAND_SOCKET"))
+        goto err;
+
+    wl->display = wl_display_connect(NULL);
+    if (!wl->display)
+        goto err;
+
+    wl->registry = wl_display_get_registry(wl->display);
+    wl_registry_add_listener(wl->registry, &registry_listener, wl);
+
+    /* Do a roundtrip to run the registry */
+    wl_display_roundtrip(wl->display);
+
+    if (wl->dcman) {
+        struct clipboard_wayland_seat *seat;
+        wl_list_for_each(seat, &wl->seat_list, link) {
+            seat->dcdev = ext_data_control_manager_v1_get_data_device(wl->dcman, seat->seat);
+            ext_data_control_device_v1_add_listener(seat->dcdev, &data_device_listener, seat);
+        }
+    } else {
+        MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
+                   ext_data_control_manager_v1_interface.name);
+        goto err;
+    }
+
+    wl->display_fd = wl_display_get_fd(wl->display);
+
+    /* Do another roundtrip to ensure all of the above is initialized
+     * before mpv does anything else. */
+    wl_display_roundtrip(wl->display);
+
+    return true;
+
+err:
+    clipboard_wayland_uninit(wl);
+    return false;
+}
+
+static void get_selection_data(struct clipboard_wayland_priv *wl, struct clipboard_wayland_data_offer *o,
+                               bool is_primary)
+{
+    ssize_t data_read = 0;
+    const size_t chunk_size = 256;
+    bstr content = {
+        .start = talloc_zero_size(wl, chunk_size),
+    };
+
+    while (1) {
+        data_read = read(o->fd, content.start + content.len, chunk_size);
+        if (data_read == -1 && errno == EINTR)
+            continue;
+        else if (data_read <= 0)
+            break;
+        content.len += data_read;
+        content.start = talloc_realloc_size(wl, content.start, content.len + chunk_size);
+        memset(content.start + content.len, 0, chunk_size);
+    }
+
+    if (data_read == -1) {
+        MP_VERBOSE(wl, "data offer aborted (read error)\n");
+    } else {
+        MP_VERBOSE(wl, "Read %zu bytes from the data offer fd\n", content.len);
+        // Update clipboard text content
+        mp_mutex_lock(&wl->lock);
+        if (is_primary) {
+            talloc_free(wl->primary_selection_text.start);
+            wl->primary_selection_text = content;
+        } else {
+            talloc_free(wl->selection_text.start);
+            wl->selection_text = content;
+        }
+        wl->data_changed = true;
+        mp_mutex_unlock(&wl->lock);
+        content = (bstr){0};
+    }
+
+    talloc_free(content.start);
+    destroy_offer(o);
+}
+
+static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl, int64_t timeout_ns)
+{
+    if (wl->display_fd == -1)
+        return false;
+
+    struct pollfd fds[] = {
+        {.fd = wl->display_fd,    .events = POLLIN },
+        {.fd = wl->death_pipe[0], .events = POLLIN },
+        {.fd = wl->selection_offer->fd, .events = POLLIN },
+        {.fd = wl->primary_selection_offer->fd, .events = POLLIN },
+    };
+
+    while (wl_display_prepare_read(wl->display) != 0)
+        wl_display_dispatch_pending(wl->display);
+    wl_display_flush(wl->display);
+
+    mp_poll(fds, MP_ARRAY_SIZE(fds), timeout_ns);
+
+    if (fds[0].revents & POLLIN) {
+        wl_display_read_events(wl->display);
+    } else {
+        wl_display_cancel_read(wl->display);
+    }
+
+    if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        MP_FATAL(wl, "Error occurred on the display fd\n");
+        wl->display_fd = -1;
+        return false;
+    }
+
+    if (fds[1].revents & POLLIN)
+        return false;
+
+    if (fds[2].revents & POLLIN)
+        get_selection_data(wl, wl->selection_offer, false);
+
+    if (fds[3].revents & POLLIN)
+        get_selection_data(wl, wl->primary_selection_offer, true);
+
+    wl_display_dispatch_pending(wl->display);
+    return true;
+}
+
+static void clipboard_wayland_run(struct clipboard_wayland_priv *wl)
+{
+    while (clipboard_wayland_dispatch_events(wl, MP_TIME_S_TO_NS(10)))
+        ;
+
+    clipboard_wayland_uninit(wl);
+}
+
+static MP_THREAD_VOID clipboard_thread(void *p)
+{
+    struct clipboard_wayland_priv *priv = p;
+    clipboard_wayland_run(priv);
+    MP_THREAD_RETURN();
+}
+
+static int init(struct clipboard_ctx *cl, struct clipboard_init_params *params)
+{
+    cl->priv = talloc_zero(cl, struct clipboard_wayland_priv);
+    struct clipboard_wayland_priv *priv = cl->priv;
+    priv->death_pipe[0] = priv->death_pipe[1] = priv->display_fd = -1;
+    priv->log = mp_log_new(priv, cl->log, "wayland");
+    priv->selection_offer = talloc_zero(priv, struct clipboard_wayland_data_offer),
+    priv->primary_selection_offer = talloc_zero(priv, struct clipboard_wayland_data_offer),
+    wl_list_init(&priv->seat_list);
+    mp_mutex_init(&priv->lock);
+
+    if (mp_make_wakeup_pipe(priv->death_pipe) < 0)
+        goto pipe_err;
+    if (!clipboard_wayland_init(priv))
+        goto init_err;
+    if (mp_thread_create(&priv->thread, clipboard_thread, cl->priv))
+        goto thread_err;
+    return CLIPBOARD_SUCCESS;
+
+thread_err:
+    clipboard_wayland_uninit(priv);
+init_err:
+    close(priv->death_pipe[0]);
+    close(priv->death_pipe[1]);
+pipe_err:
+    mp_mutex_destroy(&priv->lock);
+    TA_FREEP(&cl->priv);
+    return CLIPBOARD_FAILED;
+}
+
+static void uninit(struct clipboard_ctx *cl)
+{
+    struct clipboard_wayland_priv *priv = cl->priv;
+    if (!priv)
+        return;
+    (void)write(priv->death_pipe[1], &(char){0}, 1);
+    mp_thread_join(priv->thread);
+    close(priv->death_pipe[0]);
+    close(priv->death_pipe[1]);
+    mp_mutex_destroy(&priv->lock);
+    TA_FREEP(&cl->priv);
+}
+
+static bool data_changed(struct clipboard_ctx *cl)
+{
+    struct clipboard_wayland_priv *priv = cl->priv;
+    bool res;
+    mp_mutex_lock(&priv->lock);
+    res = priv->data_changed;
+    if (res)
+        priv->data_changed = false;
+    mp_mutex_unlock(&priv->lock);
+    return res;
+}
+
+static int get_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
+                    struct clipboard_data *out, void *talloc_ctx)
+{
+    if (params->type != CLIPBOARD_DATA_TEXT)
+        return CLIPBOARD_FAILED;
+
+    int ret = CLIPBOARD_FAILED;
+    struct clipboard_wayland_priv *priv = cl->priv;
+    mp_mutex_lock(&priv->lock);
+    switch (params->target) {
+    case CLIPBOARD_TARGET_CLIPBOARD:
+        out->type = CLIPBOARD_DATA_TEXT;
+        out->u.text = bstrto0(talloc_ctx, priv->selection_text);
+        ret = CLIPBOARD_SUCCESS;
+        break;
+    case CLIPBOARD_TARGET_PRIMARY_SELECTION:
+        out->type = CLIPBOARD_DATA_TEXT;
+        out->u.text = bstrto0(talloc_ctx, priv->primary_selection_text);
+        ret = CLIPBOARD_SUCCESS;
+        break;
+    }
+    mp_mutex_unlock(&priv->lock);
+    return ret;
+}
+
+const struct clipboard_backend clipboard_backend_wayland = {
+    .name = "wayland",
+    .desc = "Wayland clipboard (Data control protocol)",
+    .init = init,
+    .uninit = uninit,
+    .data_changed = data_changed,
+    .get_data = get_data,
+};

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -114,6 +114,11 @@ int mp_clipboard_set_data(struct clipboard_ctx *cl, struct clipboard_access_para
     return CLIPBOARD_UNAVAILABLE;
 }
 
+const char *mp_clipboard_get_backend_name(struct clipboard_ctx *cl)
+{
+    return cl ? cl->backend->name : NULL;
+}
+
 void reinit_clipboard(struct MPContext *mpctx)
 {
     mp_clipboard_destroy(mpctx->clipboard);

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -43,6 +43,7 @@ const struct m_sub_options clipboard_conf = {
 // backend list
 extern const struct clipboard_backend clipboard_backend_win32;
 extern const struct clipboard_backend clipboard_backend_mac;
+extern const struct clipboard_backend clipboard_backend_wayland;
 extern const struct clipboard_backend clipboard_backend_vo;
 
 static const struct clipboard_backend *const clipboard_backend_list[] = {
@@ -51,6 +52,9 @@ static const struct clipboard_backend *const clipboard_backend_list[] = {
 #endif
 #if HAVE_COCOA
     &clipboard_backend_mac,
+#endif
+#if HAVE_WAYLAND_PROTOCOLS_1_39
+    &clipboard_backend_wayland,
 #endif
     &clipboard_backend_vo,
 };

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -61,7 +61,6 @@ struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
     struct clipboard_ctx *cl = talloc_ptrtype(NULL, cl);
     *cl = (struct clipboard_ctx) {
         .log = mp_log_new(cl, global->log, "clipboard"),
-        .global = global,
         .monitor = params->flags & CLIPBOARD_INIT_ENABLE_MONITORING,
     };
 

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -90,5 +90,6 @@ int mp_clipboard_get_data(struct clipboard_ctx *cl, struct clipboard_access_para
                           struct clipboard_data *out, void *talloc_ctx);
 int mp_clipboard_set_data(struct clipboard_ctx *cl, struct clipboard_access_params *params,
                           struct clipboard_data *data);
+const char *mp_clipboard_get_backend_name(struct clipboard_ctx *cl);
 
 void reinit_clipboard(struct MPContext *mpctx);

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -79,7 +79,6 @@ struct clipboard_ctx {
     const struct clipboard_backend *backend; // clipboard description structure
     struct mp_log *log;
     void *priv;   // backend-specific internal data
-    struct mpv_global *global;
     bool monitor;
 };
 

--- a/player/command.c
+++ b/player/command.c
@@ -4104,6 +4104,13 @@ static int mp_property_udata(void *ctx, struct m_property *prop,
     return ret;
 }
 
+static int mp_property_current_clipboard_backend(void *ctx, struct m_property *p,
+                                                 int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    return m_property_strdup_ro(action, arg, mp_clipboard_get_backend_name(mpctx->clipboard));
+}
+
 static int get_clipboard(struct MPContext *mpctx, void *arg,
                          struct clipboard_access_params *params)
 {
@@ -4431,6 +4438,7 @@ static const struct m_property mp_properties_base[] = {
     {"term-size", mp_property_term_size},
 
     {"clipboard", mp_property_clipboard},
+    {"current-clipboard-backend", mp_property_current_clipboard_backend},
 
     M_PROPERTY_ALIAS("video", "vid"),
     M_PROPERTY_ALIAS("audio", "aid"),

--- a/player/command.c
+++ b/player/command.c
@@ -4171,6 +4171,12 @@ static int mp_property_clipboard(void *ctx, struct m_property *prop,
             node_map_add_string(&node, "text", data);
             talloc_free(data);
         }
+        params.target = CLIPBOARD_TARGET_PRIMARY_SELECTION;
+        data = NULL;
+        if (get_clipboard(mpctx, &data, &params) == M_PROPERTY_OK) {
+            node_map_add_string(&node, "text-primary", data);
+            talloc_free(data);
+        }
         *(struct mpv_node *)arg = node;
         return M_PROPERTY_OK;
     }
@@ -4178,7 +4184,9 @@ static int mp_property_clipboard(void *ctx, struct m_property *prop,
         struct m_property_action_arg *act = arg;
         const char *key = act->key;
 
-        if (strcmp(key, "text"))
+        if (!strcmp(key, "text-primary"))
+            params.target = CLIPBOARD_TARGET_PRIMARY_SELECTION;
+        else if (strcmp(key, "text"))
             return M_PROPERTY_UNKNOWN;
 
         switch (act->action) {

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1179,7 +1179,11 @@ local function get_clipboard(clip)
             return res.stdout
         end
     elseif platform == 'wayland' then
-        -- Wayland clipboard is only updated on window focus
+        if mp.get_property('current-clipboard-backend') == 'wayland' then
+            local property = clip and 'clipboard/text' or 'clipboard/text-primary'
+            return mp.get_property(property, '')
+        end
+        -- Wayland VO clipboard is only updated on window focus
         if clip and mp.get_property_native('focused') then
             return mp.get_property('clipboard/text', '')
         end

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1231,7 +1231,7 @@ local function property_list()
         properties[#properties + 1] = 'current-tracks/' .. sub_property
     end
 
-    for _, sub_property in pairs({'text'}) do
+    for _, sub_property in pairs({'text', 'text-primary'}) do
         properties[#properties + 1] = 'clipboard/' .. sub_property
     end
 

--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -13,7 +13,7 @@ protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml']
 wl_protocols_source = []
 wl_protocols_headers = []
 
-foreach v: ['1.32']
+foreach v: ['1.32', '1.39']
     features += {'wayland-protocols-' + v.replace('.', '-'):
         wayland['deps'][2].version().version_compare('>=' + v)}
 endforeach
@@ -21,6 +21,10 @@ endforeach
 if features['wayland-protocols-1-32']
     protocols += [[wl_protocol_dir, 'staging/cursor-shape/cursor-shape-v1.xml'],
                   [wl_protocol_dir, 'unstable/tablet/tablet-unstable-v2.xml']] # required by cursor-shape
+endif
+
+if features['wayland-protocols-1-39']
+    protocols += [[wl_protocol_dir, 'staging/ext-data-control/ext-data-control-v1.xml']]
 endif
 
 foreach p: protocols


### PR DESCRIPTION
This adds a "native" Wayland clipboard backend based on the `wlr-data-control-unstable-v1/ext-data-control-v1` protocol. 

This backend overcomes the limitation of the VO (Wayland core protocol) backend, and does not require the presence of the VO window to receive clipboard updates. The backend runs in a separate thread, so clipboard reading does not stall the player like the VO backend.

This backend also supports primary selection if supported by the compositor. The `clipboard/text-primary` property is added for primary selection text.

Also add `current-clipboard-backend` property to make the current backend detectable, and update console.lua to use the new backend if available. 