### PR TITLE
console.lua: update the select layout

### DIFF
--- a/DOCS/interface-changes/console-menu.txt
+++ b/DOCS/interface-changes/console-menu.txt
@@ -1,0 +1,1 @@
+add `console-background_alpha` `console-menu_outline_size` `console-menu_outline_color` `console-corner_radius` script-opts

--- a/DOCS/interface-changes/console-menu.txt
+++ b/DOCS/interface-changes/console-menu.txt
@@ -1,1 +1,1 @@
-add `console-background_alpha` `console-menu_outline_size` `console-menu_outline_color` `console-corner_radius` script-opts
+add `console-background_alpha` `console-menu_outline_size` `console-menu_outline_color` `console-corner_radius` `console-selected_color` and `console-selected_back_color` script-opts

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -100,9 +100,6 @@ Shift+TAB
 Ctrl+l
     Clear all log messages from the console.
 
-MBTN_RIGHT
-    Hide the console.
-
 MBTN_MID
     Paste text (uses the primary selection on X11 and Wayland).
 

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -169,6 +169,32 @@ Configurable Options
 
     Set the font border size used for the REPL and the console.
 
+``background_alpha``
+    Default: 20
+
+    The transparency of the menu's background. Ranges from 0 (opaque) to 255
+    (fully transparent).
+
+``padding``
+    Default: 10
+
+    The padding of the menu.
+
+``menu_outline_size``
+    Default: 0
+
+    The size of the menu's border.
+
+``menu_outline_color``
+    Default: #FFFFFF
+
+    The color of the menu's border.
+
+``corner_radius``
+    Default: 8
+
+    The radius of the menu's corners.
+
 ``margin_x``
     Default: same as ``--osd-margin-x``
 

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -208,6 +208,16 @@ Configurable Options
     Whether to scale the console with the window height. Can be ``yes``, ``no``,
     or ``auto``, which follows the value of ``--osd-scale-by-window``.
 
+``selected_color``
+    Default: ``#222222``
+
+    The color of the selected item.
+
+``selected_back_color``
+    Default: ``#FFFFFF``
+
+    The background color of the selected item.
+
 ``case_sensitive``
     Default: no on Windows, yes on other platforms.
 

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -289,13 +289,13 @@ Alt+2 (and Command+2 on macOS)
 Command + f (macOS only)
     Toggle fullscreen (see also ``--fs``).
 
-(The following keybindings open a selector in the console that lets you choose
-from a list of items by typing part of the desired item, by clicking the desired
+(The following keybindings open a menu in the console that lets you choose from
+a list of items by typing part of the desired item, by clicking the desired
 item, or by navigating them with keybindings: ``Down`` and ``Ctrl+n`` go down,
 ``Up`` and ``Ctrl+p`` go up, ``Page down`` and ``Ctrl+f`` scroll down one page,
 and ``Page up`` and ``Ctrl+b`` scroll up one page.)
 
-In track selectors, selecting the current tracks disables it.
+In track menus, selecting the current tracks disables it.
 
 g-p
     Select a playlist entry.

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -218,7 +218,7 @@ Configurable Options
     seekbar or separately if ``seekbarstyle`` is set to ``bar``.
 
 ``seekrangealpha``
-    Default: 200
+    Default: 20
 
     Alpha of the seekable ranges, 0 (opaque) to 255 (fully transparent).
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -38,7 +38,7 @@ pl prev
     left-click      play previous file in playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
-    right-click     open the playlist selector
+    right-click     open the playlist menu
     =============   ================================================
 
 pl next
@@ -46,7 +46,7 @@ pl next
     left-click      play next file in playlist
     shift+L-click   show the playlist
     middle-click    show the playlist
-    right-click     open the playlist selector
+    right-click     open the playlist menu
     =============   ================================================
 
 title
@@ -57,7 +57,7 @@ title
     left-click      show file and track info
     shift+L-click   show the path
     middle-click    show the path
-    right-click     open the history selector
+    right-click     open the history menu
     =============   ================================================
 
 cache
@@ -76,7 +76,7 @@ skip back
     left-click      go to beginning of chapter / previous chapter
     shift+L-click   show chapters
     middle-click    show chapters
-    right-click     open the chapter selector
+    right-click     open the chapter menu
     =============   ================================================
 
 skip frwd
@@ -84,7 +84,7 @@ skip frwd
     left-click      go to next chapter
     shift+L-click   show chapters
     middle-click    show chapters
-    right-click     open the chapter selector
+    right-click     open the chapter menu
     =============   ================================================
 
 time elapsed
@@ -117,14 +117,14 @@ audio and sub
     left-click      cycle audio/sub tracks forward
     shift+L-click   cycle audio/sub tracks backwards
     middle-click    cycle audio/sub tracks backwards
-    right-click     open the audio/sub track selector
+    right-click     open the audio/sub track menu
     mouse wheel     cycle audio/sub tracks forward/backwards
     =============   ================================================
 
 vol
     =============   ================================================
     left-click      toggle mute
-    right-click     open the audio device selector
+    right-click     open the audio device menu
     mouse wheel     volume up/down
     =============   ================================================
 

--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -31,7 +31,7 @@ PGDN and Ctrl+f
 
 MBTN_LEFT
     Confirm the selection of the highlighted item, or close the console if
-    clicking above the first item or below the last item.
+    clicking outside of the menu rectangle.
 
 WHEEL_UP
     Scroll up.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -610,8 +610,10 @@ local function render()
         -- Even with bottom-left anchoring,
         -- libass/ass_render.c:ass_render_event() subtracts --osd-margin-x from
         -- the maximum text width twice.
+        -- TODO: --osd-margin-x should scale with osd-width and PlayResX to make
+        -- the calculation accurate.
         local width_max = math.floor(
-            (osd_w - x - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
+            (osd_w - x - mp.get_property_native('osd-margin-x') * 2)
             / opts.font_size * get_font_hw_ratio())
 
         local completions, rows = format_grid(completion_buffer, width_max, max_lines)

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1777,7 +1777,6 @@ local function get_bindings()
         { 'ins',         handle_ins                             },
         { 'shift+ins',   function() paste(false) end            },
         { 'mbtn_mid',    function() paste(false) end            },
-        { 'mbtn_right',  function() set_active(false) end       },
         { 'left',        function() prev_char() end             },
         { 'ctrl+b',      function() page_up_or_prev_char() end  },
         { 'right',       function() next_char() end             },

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -980,10 +980,19 @@ local function handle_enter()
 end
 
 local function determine_hovered_item()
-    local y = mp.get_property_native('mouse-pos').y / scale_factor()
+    local osd_w, _ = get_scaled_osd_dimensions()
+    local scale = scale_factor()
+    local mouse_pos = mp.get_property_native('mouse-pos')
+    local mouse_x = mouse_pos.x / scale
+    local mouse_y = mouse_pos.y / scale
+    local item_x0 = searching_history and get_margin_x() or (osd_w - max_item_width) / 2
+
+    if mouse_x < item_x0 or mouse_x > item_x0 + max_item_width then
+        return
+    end
 
     for i, positions in ipairs(item_positions) do
-        if y >= positions[1] and y <= positions[2] then
+        if mouse_y >= positions[1] and mouse_y <= positions[2] then
             return first_match_to_print - 1 + i
         end
     end


### PR DESCRIPTION
console.lua: improve the hovered item calculation with background-box

Follow up to c438732b23 which improved the calculation with the default outline-and-shadow. We can make the calculation accurate for background-box too without making semitransparent rectangle backgrounds overlap by adding margin between items.

We could calculate the height of each item to make them perfectly adjacent by rendering each one with compute_bounds, but that takes 15ms per render, so 20 lines would take 300ms, which is too slow.

Instead add a fixed 0.1 * opts.font_size to each item's height. This ensures the backgrounds don't overlap with tall CJK text or track circles and --osd-shadow-offset=0. Add this to outline-and-shadow too since it looks better with some margin between the items. Then add the rectangle offset to the height depending on the border style.