### PR TITLE
console.lua: rename some things

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -15,8 +15,8 @@ ESC and Ctrl+[
     Hide the console.
 
 ENTER, Ctrl+j and Ctrl+m
-    Expand the first completion suggestion if present and if none was selected,
-    and run the typed command.
+    Select the first completion if one wasn't already manually selected, and run
+    the typed command.
 
 Shift+ENTER
     Type a literal newline character.
@@ -90,7 +90,7 @@ Shift+INSERT
     Paste text (uses the primary selection on X11 and Wayland).
 
 TAB and Ctrl+i
-    Cycle through completion suggestions.
+    Cycle through completions.
 
 Shift+TAB
     Cycle through the completions backwards.
@@ -150,8 +150,7 @@ Configurable Options
     Default: a monospace font depending on the platform
 
     Set the font used for the console.
-    A monospaced font is necessary to align completion suggestions correctly in
-    a grid.
+    A monospaced font is necessary to align completions correctly in a grid.
     If the console was opened by calling ``mp.input.select`` and no font was
     configured, ``--osd-font`` is used, as alignment is not necessary in that
     case.
@@ -198,7 +197,7 @@ Configurable Options
     Default: auto
 
     The ratio of font height to font width.
-    Adjusts table width of completion suggestions.
+    Adjusts grid width of completions.
     Values in the range 1.8..2.5 make sense for common monospace fonts.
 
 ``pause_on_open``

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -320,7 +320,7 @@ end
 -- The result contains at least one column.
 -- Rows are cut off from the top if rows_max is specified.
 -- returns a string containing the formatted table and the row count
-local function format_table(list, width_max, rows_max)
+local function format_grid(list, width_max, rows_max)
     if #list == 0 then
         return '', 0
     end
@@ -591,7 +591,7 @@ local function render()
             (osd_w - x - mp.get_property_native('osd-margin-x') * 2 / scale_factor())
             / opts.font_size * get_font_hw_ratio())
 
-        local completions, rows = format_table(completion_buffer, width_max, max_lines)
+        local completions, rows = format_grid(completion_buffer, width_max, max_lines)
         max_lines = max_lines - rows
         completion_ass = style .. styles.completion .. completions .. '\\N'
     end


### PR DESCRIPTION
console.lua: rename update() to render()

It is not clear what update() updates, in fact this rename allows removing the comment explaining it. render() is clearer and is the same term used by the OSC.

console.lua: always say completions instead of suggestions

Both completions and suggestions were being used inconsistently. Just always use completions which is much more common.

console.lua: rename format_table() to format_grid()

Since there is no table header or predetermined columns.