### PR TITLE
fix OPT_FLOAT range handling

### DIFF
--- a/audio/filter/af_scaletempo.c
+++ b/audio/filter/af_scaletempo.c
@@ -652,10 +652,10 @@ const struct mp_user_filter_entry af_scaletempo = {
             .scale_nominal = 1.0,
         },
         .options = (const struct m_option[]) {
-            {"scale", OPT_FLOAT(scale_nominal), M_RANGE(0.01, DBL_MAX)},
-            {"stride", OPT_FLOAT(ms_stride), M_RANGE(0.01, DBL_MAX)},
+            {"scale", OPT_FLOAT(scale_nominal), M_RANGE(0.01, FLT_MAX)},
+            {"stride", OPT_FLOAT(ms_stride), M_RANGE(0.01, FLT_MAX)},
             {"overlap", OPT_FLOAT(factor_overlap), M_RANGE(0, 1)},
-            {"search", OPT_FLOAT(ms_search), M_RANGE(0, DBL_MAX)},
+            {"search", OPT_FLOAT(ms_search), M_RANGE(0, FLT_MAX)},
             {"speed", OPT_CHOICE(speed_opt,
                 {"pitch", SCALE_PITCH},
                 {"tempo", SCALE_TEMPO},

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1049,7 +1049,7 @@ static void add_double(const m_option_t *opt, void *val, double add, bool wrap)
 
 static void multiply_double(const m_option_t *opt, void *val, double f)
 {
-    *(double *)val *= f;
+    VAL(val) *= f;
     clamp_double(opt, val);
 }
 
@@ -1066,14 +1066,14 @@ static int double_set(const m_option_t *opt, void *dst, struct mpv_node *src)
     }
     if (clamp_double(opt, &val) < 0)
         return M_OPT_OUT_OF_RANGE;
-    *(double *)dst = val;
+    VAL(dst) = val;
     return 1;
 }
 
 static int double_get(const m_option_t *opt, void *ta_parent,
                       struct mpv_node *dst, void *src)
 {
-    double f = *(double *)src;
+    double f = VAL(src);
     if (isnan(f) && (opt->flags & M_OPT_DEFAULT_NAN)) {
         dst->format = MPV_FORMAT_STRING;
         dst->u.string = talloc_strdup(ta_parent, "default");

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -398,9 +398,9 @@ struct m_option {
     // Most numeric types restrict the range to [min, max] if min<max (this
     // implies that if min/max are not set, the full range is used). In all
     // cases, the actual range is clamped to the type's native range.
-    // Float types use [DBL_MIN, DBL_MAX], though by setting min or max to
-    // -/+INFINITY, the range can be extended to INFINITY. (This part is buggy
-    // for "float".)
+    // Float type uses [FLT_MIN, FLT_MAX], and double type uses
+    // [DBL_MIN, DBL_MAX], though by setting min or max to -/+INFINITY,
+    // the range can be extended to INFINITY.
     // Preferably use M_RANGE() to set these fields.
     double min, max;
 

--- a/options/options.c
+++ b/options/options.c
@@ -634,7 +634,7 @@ static const m_option_t mp_opts[] = {
     {"prefetch-playlist", OPT_BOOL(prefetch_open)},
     {"cache-pause", OPT_BOOL(cache_pause)},
     {"cache-pause-initial", OPT_BOOL(cache_pause_initial)},
-    {"cache-pause-wait", OPT_FLOAT(cache_pause_wait), M_RANGE(0, DBL_MAX)},
+    {"cache-pause-wait", OPT_FLOAT(cache_pause_wait), M_RANGE(0, FLT_MAX)},
 
 #if HAVE_DVBIN
     {"dvbin", OPT_SUBSTRUCT(stream_dvb_opts, stream_dvb_conf)},


### PR DESCRIPTION
OPT_FLOAT values currently reuses OPT_DOUBLE handling, but if a finite double value is produced which is out of the float range,
it results in UB.

If the floating point implementation is IEEE-754, then the value is converted to infinity and stored in the float. However, this still
does not work as intended, as infinity is rejected for OPT_DOUBLE unless infinity is explicitly specified as the min/max range.

Fix this by adding another clamping stage after operating the values as double. Finite double values are clamped between FLT_MIN and FLT_MAX, and out of range error is signaled when suitable.

Also fixes OPT_FLOAT options with incorrect DBL_MAX range. 