### PR TITLE
m_option: fix float option values <= 0

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1147,8 +1147,8 @@ static int clamp_float(const m_option_t *opt, double *val)
         v = FLT_MAX;
         r = M_OPT_OUT_OF_RANGE;
     }
-    if (isfinite(v) && v < FLT_MIN) {
-        v = FLT_MIN;
+    if (isfinite(v) && v < -FLT_MAX) {
+        v = -FLT_MAX;
         r = M_OPT_OUT_OF_RANGE;
     }
     *val = v;


### PR DESCRIPTION
FLT_MIN is a small positive number (1.175494e-38), so the check v < FLT_MIN introduced in 0e7f9c39dc made all 0 and negative float option values error, e.g. panscan=0 or video-align-y=-1.

Fixes #15728.