### PR TITLE
vd_lavc: don't hardware decode VC-1 by default

### DIFF
--- a/DOCS/interface-changes/vc1.txt
+++ b/DOCS/interface-changes/vc1.txt
@@ -1,0 +1,1 @@
+remove `vc1` from `hwdec-codecs`'s default value

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1787,9 +1787,9 @@ Video
     You can get the list of allowed codecs with ``mpv --vd=help``. Remove the
     prefix, e.g. instead of ``lavc:h264`` use ``h264``.
 
-    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1,prores``. Note that
-    the hardware acceleration special codecs like ``h264_vdpau`` are not
-    relevant anymore, and in fact have been removed from FFmpeg in this form.
+    By default, this is set to ``h264,hevc,vp8,vp9,av1,prores``. Note that the
+    hardware acceleration special codecs like ``h264_vdpau`` are not relevant
+    anymore, and in fact have been removed from FFmpeg in this form.
 
     This is usually only needed with broken GPUs, where a codec is reported
     as supported, but decoding causes more problems than it solves.

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -140,7 +140,7 @@ const struct m_sub_options vd_lavc_conf = {
         .framedrop = AVDISCARD_NONREF,
         .dr = -1,
         .hwdec_api = (char *[]){"no", NULL,},
-        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores",
+        .hwdec_codecs = "h264,hevc,vp8,vp9,av1,prores",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;
         // for example, if vo_gpu increases the number of reference surfaces for


### PR DESCRIPTION
vd_lavc: don't hardware decode VC-1 by default

VC-1 with nvdec shows a green screen, and users may not understand that it is caused by hwdec and that disabling it is the fix. It can break displaying videos on vaapi too (https://gitlab.freedesktop.org/mesa/mesa/-/issues/12525).

Also new AMD GPUs don't support hardware decoding VC-1 at all (https://en.wikipedia.org/wiki/Video_Core_Next). This slows down startup time if hardware decoding is attempted anyway, especially with --hwdec=auto.

Also there is no need to hardware decode VC-1 videos since nobody produces 4k VC-1 videos.

Just remove it from the default hwdec-codecs, it is not worth implementing a system to guess whether it will work depending on the GPU.

Fixes #15715.

(Github doesn't let me ropen #12407)