### PR TITLE
ci/linux: enable leak detector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,6 @@ jobs:
       env:
         CC: "${{ matrix.config.cc }}"
         CXX: "${{ matrix.config.cxx }}"
-        ASAN_OPTIONS: "halt_on_error=1:abort_on_error=1:print_summary=1:detect_leaks=0"
     strategy:
       matrix:
         config:
@@ -318,6 +317,7 @@ jobs:
       - name: Run meson tests
         id: tests
         run: |
+          export LSAN_OPTIONS="suppressions=${GITHUB_WORKSPACE}/.lsan_suppressions"
           meson test -C build
 
       - name: Print meson test log

--- a/.lsan_suppressions
+++ b/.lsan_suppressions
@@ -1,0 +1,1 @@
+leak:FcFontSetSort


### PR DESCRIPTION
The leak detector has been disabled due to a libass leak that was causing the test to fail. I initially expected this change to be temporary until a patch release of libass became available and we could update it. However, it has been a few months without a release. Instead of waiting, re-enable the leak detector and add a suppression file for this specific leak.

Fixes: d6eb85bb1a027aa52a7f48b162757763c9dcc875