### PR TITLE
video/out/wayland_common: fix crash with multi-seat drag and drop

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -166,9 +166,6 @@ struct vo_wayland_state {
 
     /* Data offer */
     struct wl_data_device_manager *devman;
-    struct vo_wayland_data_offer *pending_offer;
-    struct vo_wayland_data_offer *dnd_offer;
-    struct vo_wayland_data_offer *selection_offer;
     bstr selection_text;
 
     /* Cursor */


### PR DESCRIPTION
If you have two seats connected, both with the pointer capability, and use two hands to start a drag and drop operation with each pointer, then move one pointer to the mpv window, then the other, mpv fails the !wl->dnd_offer->offer assert in device.enter, because it expects that the compositor wouldn't just call device.enter again before device.leave or offer.finish.

The data device is per-seat, so this commit makes mpv track the data device's offers per-seat rather than in vo_wayland_state, which makes more sense and is easier to reason about when multi-seat is involved.