### PR TITLE
console.lua: highlight matching parts of selectable items

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -218,6 +218,11 @@ Configurable Options
 
     The background color of the selected item.
 
+``match_color``
+    Default: ``#0088FF``
+
+    The color of characters that match the searched string.
+
 ``case_sensitive``
     Default: no on Windows, yes on other platforms.
 


### PR DESCRIPTION
fzy returns which characters matched the search for every item, so use this to highlight them.

Using color is complicated because it will become hard to differentiate depending on --osd-color and color blindless, so just underline the matched parts.

The returned positions are just bytes, so we can't put ASS tags or escape sequences around each byte because that would break displaying multibyte UTF-8 characters. Only put them around sequences of matched positions.