### PR TITLE
demux_mkv: limit RealAudio packet size to 128 MiB

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1944,6 +1944,13 @@ static int demux_mkv_open_audio(demuxer_t *demuxer, mkv_track_t *track)
             goto error;
         }
 
+        // Limit buffer size to 128 MiB to avoid excessive memory allocation on malformed files.
+        if (track->sub_packet_h * track->audiopk_size > (128 << 20)) {
+            MP_WARN(demuxer, "RealAudio packet size too big (%" PRIu32 " MiB) - skipping track\n",
+                    track->sub_packet_h * track->audiopk_size);
+            goto error;
+        }
+
         track->audio_buf =
             talloc_array_size(track, track->sub_packet_h, track->audiopk_size);
         track->audio_timestamp =


### PR DESCRIPTION
It should be more than enough for this and avoids some huge allocations on broken files. 128 MiB is already huge for audio buffer, but better than 4 GiB...