### PR TITLE
player/main: free osd after msg component

### DIFF
--- a/player/main.c
+++ b/player/main.c
@@ -185,8 +185,6 @@ void mp_destroy(struct MPContext *mpctx)
 
     mp_clients_destroy(mpctx);
 
-    osd_free(mpctx->osd);
-
 #if HAVE_COCOA
     cocoa_set_input_context(NULL);
 #endif
@@ -202,6 +200,10 @@ void mp_destroy(struct MPContext *mpctx)
     uninit_libav(mpctx->global);
 
     mp_msg_uninit(mpctx->global);
+
+    osd_free(mpctx->osd);
+    mpctx->osd = NULL;
+
     assert(!mpctx->num_abort_list);
     talloc_free(mpctx->abort_list);
     mp_mutex_destroy(&mpctx->abort_lock);


### PR DESCRIPTION
There is something wrong going on here, we are leaking memory, which should be normally already freed. I couldn't reproduce locally, this only happens on fuzzing machines and I tried with exactly the same runner image, so probably some race is involved, that I don't see locally.