### PR TITLE
add full runtime support to ad_lavc and vd_lavc opts

### DIFF
--- a/DOCS/interface-changes/hwdec-software-fallback.txt
+++ b/DOCS/interface-changes/hwdec-software-fallback.txt
@@ -1,0 +1,1 @@
+rename `--vd-lavc-software-fallback` to `--hwdec-software-fallback`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1826,14 +1826,7 @@ Video
         ``mpv --hwdec=vdpau --hwdec-codecs=h264,mpeg2video``
             Enable vdpau decoding for h264 and mpeg2 only.
 
-``--vd-lavc-check-hw-profile=<yes|no>``
-    Check hardware decoder profile (default: yes). If ``no`` is set, the
-    highest profile of the hardware decoder is unconditionally selected, and
-    decoding is forced even if the profile of the video is higher than that.
-    The result is most likely broken decoding, but may also help if the
-    detected or reported profiles are somehow incorrect.
-
-``--vd-lavc-software-fallback=<yes|no|N>``
+``--hwdec-software-fallback=<yes|no|N>``
     Fallback to software decoding if the hardware-accelerated decoder fails
     (default: 3). If this is a number, then fallback will be triggered if
     N frames fail to decode in a row. 1 is equivalent to ``yes``.
@@ -1842,6 +1835,13 @@ Video
     a fallback happens, parts of the file will be skipped, approximately by to
     the number of packets that could not be decoded. Values below an unspecified
     count will not have this problem, because mpv retains the packets.
+
+``--vd-lavc-check-hw-profile=<yes|no>``
+    Check hardware decoder profile (default: yes). If ``no`` is set, the
+    highest profile of the hardware decoder is unconditionally selected, and
+    decoding is forced even if the profile of the video is higher than that.
+    The result is most likely broken decoding, but may also help if the
+    detected or reported profiles are somehow incorrect.
 
 ``--vd-lavc-film-grain=<auto|cpu|gpu>``
     Enables film grain application on the GPU. If video decoding is done on

--- a/audio/decode/ad_lavc.c
+++ b/audio/decode/ad_lavc.c
@@ -72,6 +72,7 @@ const struct m_sub_options ad_lavc_conf = {
         {"o", OPT_KEYVALUELIST(avopts)},
         {0}
     },
+    .change_flags = UPDATE_AD,
     .size = sizeof(struct ad_lavc_params),
     .defaults = &(const struct ad_lavc_params){
         .ac3drc = 0,

--- a/options/options.c
+++ b/options/options.c
@@ -72,6 +72,7 @@ extern const struct m_sub_options demux_lavf_conf;
 extern const struct m_sub_options demux_mkv_conf;
 extern const struct m_sub_options vd_lavc_conf;
 extern const struct m_sub_options ad_lavc_conf;
+extern const struct m_sub_options hwdec_conf;
 extern const struct m_sub_options input_config;
 extern const struct m_sub_options encode_config;
 extern const struct m_sub_options ra_ctx_conf;
@@ -670,6 +671,8 @@ static const m_option_t mp_opts[] = {
     {"", OPT_SUBSTRUCT(dec_wrapper, dec_wrapper_conf)},
     {"", OPT_SUBSTRUCT(vd_lavc_params, vd_lavc_conf)},
     {"ad-lavc", OPT_SUBSTRUCT(ad_lavc_params, ad_lavc_conf)},
+
+    {"", OPT_SUBSTRUCT(hwdec_opts, hwdec_conf)},
 
     {"", OPT_SUBSTRUCT(demux_lavf, demux_lavf_conf)},
     {"demuxer-rawaudio", OPT_SUBSTRUCT(demux_rawaudio, demux_rawaudio_conf)},

--- a/options/options.h
+++ b/options/options.h
@@ -363,6 +363,8 @@ typedef struct MPOpts {
     struct vd_lavc_params *vd_lavc_params;
     struct ad_lavc_params *ad_lavc_params;
 
+    struct hwdec_opts *hwdec_opts;
+
     struct input_opts *input_opts;
 
     struct clipboard_opts *clipboard_opts;

--- a/player/command.c
+++ b/player/command.c
@@ -7747,12 +7747,12 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (flags & UPDATE_DEMUXER)
         mpctx->demuxer_changed = true;
 
-    if (flags & UPDATE_AD) {
+    if (flags & UPDATE_AD && mpctx->ao_chain) {
         uninit_audio_chain(mpctx);
         reinit_audio_chain(mpctx);
     }
 
-    if (flags & UPDATE_VD) {
+    if (flags & UPDATE_VD && mpctx->vo_chain) {
         struct track *track = mpctx->current_track[0][STREAM_VIDEO];
         uninit_video_chain(mpctx);
         reinit_video_chain(mpctx);


### PR DESCRIPTION
Following up on the UPDATE_AD and UPDATE_VD stuff.