### PR TITLE
command: fix spammy events when frame stepping forward with seek

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5688,7 +5688,10 @@ static void cmd_frame_step(void *p)
         return;
     }
 
-    if (frames > 0 && !flags && cmd->cmd->is_up_down) {
+    if (flags) {
+        if (!cmd->cmd->is_up)
+            add_step_frame(mpctx, frames, flags);
+    } else {
         if (cmd->cmd->is_up) {
             if (mpctx->step_frames < 1)
                 set_pause_state(mpctx, true);
@@ -5699,8 +5702,6 @@ static void cmd_frame_step(void *p)
                 add_step_frame(mpctx, frames, flags);
             }
         }
-    } else {
-        add_step_frame(mpctx, frames, flags);
     }
 }
 


### PR DESCRIPTION
The frame-step command also signals on up events. This is only useful when using the default "play" mode. For seek mode, it triggers another frame step which is not what you want. Rearrange the logic so the up event is ignored for the seek flag. The frames check is also not needed since add_step_frame already handles it.

Fixes 9661a3839ba5af79e5620ce87acedf6cdaa244c1
