### PR TITLE
m_option: reallow setting list options to no value to -clr them

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1417,7 +1417,7 @@ static char **separate_input_param(const m_option_t *opt, bstr param,
         str = bstr_cut(str, 1);
         n++;
     }
-    if (n == 0)
+    if (n == 0 && op != OP_NONE)
         return NULL;
 
     char **list = talloc_array(NULL, char *, n + 2);


### PR DESCRIPTION
d2c409c56b49252c85eefd340863fd59a36808d6 broke setting `--slang=` to effectively `-clr` the option. Restore the behavior because scripts rely on it.

Fixes: d2c409c56b49252c85eefd340863fd59a36808d6