### PR TITLE
ci/lint-commit-msg.py: remove .py from allowed extension skips.

### DIFF
--- a/ci/lint-commit-msg.py
+++ b/ci/lint-commit-msg.py
@@ -106,7 +106,7 @@ def line_too_long(body):
     "Prefix should not include file extension (use `vo_gpu: ...` not `vo_gpu.c: ...`)",
 )
 def no_file_exts(body):
-    return not re.search(r"[a-z0-9]\.([chm]|cpp|swift|py): ", body[0])
+    return not re.search(r"[a-z0-9]\.([chm]|cpp|swift): ", body[0])
 
 ################################################################################
 

--- a/ci/lint-commit-msg.py
+++ b/ci/lint-commit-msg.py
@@ -106,7 +106,7 @@ def line_too_long(body):
     "Prefix should not include file extension (use `vo_gpu: ...` not `vo_gpu.c: ...`)",
 )
 def no_file_exts(body):
-    return not re.search(r"[a-z0-9]\.([chm]|cpp|swift): ", body[0])
+    return not re.search(r"[a-z0-9]\.([chm]|cpp|swift|rst): ", body[0])
 
 ################################################################################
 


### PR DESCRIPTION
Allow extension skip only on core files c/cpp/h/m/swift, for the rest require ext.