### PR TITLE
console.lua: add user-data/mpv/console/open

### DIFF
--- a/DOCS/interface-changes/console-pause-on-open.txt
+++ b/DOCS/interface-changes/console-pause-on-open.txt
@@ -1,1 +1,0 @@
-add `console-pause_on_open` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -201,9 +201,3 @@ Configurable Options
     The ratio of font height to font width.
     Adjusts grid width of completions.
     Values in the range 1.8..2.5 make sense for common monospace fonts.
-
-``pause_on_open``
-    Default: no
-
-    Whether to pause playback when the console opens, and resume it when the
-    console is closed, if playback was not already paused.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3698,6 +3698,16 @@ Property list
     The player itself does not use any data in it (although some builtin scripts may).
     The property is not preserved across player restarts.
 
+    Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
+    read, written, or observed.
+
+    The top-level object itself cannot be written directly; write to sub-paths instead.
+
+    Converting this property or its sub-properties to strings will give a JSON
+    representation. If converting a leaf-level object (i.e. not a map or array)
+    and not using raw mode, the underlying content will be given (e.g. strings will be
+    printed directly, rather than quoted and JSON-escaped).
+
     The following sub-paths are reserved for internal uses or have special semantics:
     ``user-data/osc``, ``user-data/mpv``. Unless noted otherwise, the semantics of
     any properties under these sub-paths can change at any time and may not be relied
@@ -3711,16 +3721,6 @@ Property list
         occupies. Its sub-properties ``l``, ``r``, ``t``, and ``b`` should all be set to
         the left, right, top, and bottom margins respectively.
         Values are between 0.0 and 1.0, normalized to window width/height.
-
-    Sub-paths can be accessed directly; e.g. ``user-data/my-script/state/a`` can be
-    read, written, or observed.
-
-    The top-level object itself cannot be written directly; write to sub-paths instead.
-
-    Converting this property or its sub-properties to strings will give a JSON
-    representation. If converting a leaf-level object (i.e. not a map or array)
-    and not using raw mode, the underlying content will be given (e.g. strings will be
-    printed directly, rather than quoted and JSON-escaped).
 
     ``user-data/mpv/ytdl``
         Data shared by the builtin ytdl hook script.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1754,8 +1754,8 @@ This list uses the event name field value, and the C API symbol in brackets:
     Start of playback after seek or after file was loaded.
 
 ``shutdown`` (``MPV_EVENT_SHUTDOWN``)
-    Sent when the player quits, and the script should terminate. Normally
-    handled automatically. See `Details on the script initialization and lifecycle`_.
+    Sent when the player quits or when a script terminates. Normally handled
+    automatically. See `Details on the script initialization and lifecycle`_.
 
 ``log-message`` (``MPV_EVENT_LOG_MESSAGE``)
     Receives messages enabled with ``mpv_request_log_messages()`` (Lua:

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3735,6 +3735,9 @@ Property list
             loaded. The format is the same as ``subprocess``'s result, capturing
             stdout and stderr.
 
+    ``user-data/mpv/console/open``
+        Whether the console is open.
+
 ``menu-data`` (RW)
     This property stores the raw menu definition. See `Context Menu`_ section for details.
 

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -404,6 +404,3 @@ non-negligible duration to complete, so we re-calculate ``wait`` afterwards.
 
 ``mp.peek_timers_wait()`` returns the same values as ``mp.process_timers()``
 but without doing anything. Invalid result if called from a timer callback.
-
-Note: ``exit()`` is also registered for the ``shutdown`` event, and its
-implementation is a simple ``mp.keep_running = false``.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -38,7 +38,6 @@ local opts = {
     case_sensitive = platform ~= 'windows' and true or false,
     history_dedup = true,
     font_hw_ratio = 'auto',
-    pause_on_open = false,
 }
 
 local styles = {
@@ -91,7 +90,6 @@ local key_bindings = {}
 local dont_bind_up_down = false
 local overlay = mp.create_osd_overlay('ass-events')
 local global_margins = { t = 0, b = 0 }
-local was_playing = true
 local input_caller
 
 local completion_buffer = {}
@@ -1764,21 +1762,12 @@ local function undefine_key_bindings()
     key_bindings = {}
 end
 
-local function pause_playback()
-    was_playing = not mp.get_property_native('pause')
-
-    if opts.pause_on_open and was_playing then
-        mp.set_property_native('pause', true)
-    end
-end
-
 -- Set the REPL visibility ("enable", Esc)
 set_active = function (active)
     if active == repl_active then return end
     if active then
         repl_active = true
         insert_mode = false
-        pause_playback()
         define_key_bindings()
         mp.set_property_bool('user-data/mpv/console/open', true)
 
@@ -1797,10 +1786,6 @@ set_active = function (active)
         log_buffers[id] = {}
         unbind_mouse()
     else
-        if opts.pause_on_open and was_playing then
-            mp.set_property_native('pause', false)
-        end
-
         repl_active = false
         completion_buffer = {}
         undefine_key_bindings()

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1780,6 +1780,7 @@ set_active = function (active)
         insert_mode = false
         pause_playback()
         define_key_bindings()
+        mp.set_property_bool('user-data/mpv/console/open', true)
 
         if not input_caller then
             prompt = default_prompt
@@ -1804,6 +1805,7 @@ set_active = function (active)
         completion_buffer = {}
         undefine_key_bindings()
         mp.enable_messages('silent:terminal-default')
+        mp.set_property_bool('user-data/mpv/console/open', false)
 
         if input_caller then
             mp.commandv('script-message-to', input_caller, 'input-event',
@@ -1996,6 +1998,10 @@ mp.register_event('log-message', function(e)
     -- Use color for debug/v/warn/error/fatal messages.
     log_add('[' .. e.prefix .. '] ' .. e.text:sub(1, -2), styles[e.level],
             terminal_styles[e.level])
+end)
+
+mp.register_event('shutdown', function ()
+    mp.del_property('user-data/mpv/console')
 end)
 
 require 'mp.options'.read_options(opts, nil, render)


### PR DESCRIPTION
DOCS/man/input: reorder user-data's docs

user-data/mpv/ytdl was documented out of nowhere instead of together with user-data/osc.


console.lua: add user-data/mpv/console/open

Fixes #15762.


Revert "console.lua: add pause_on_open script-opt"

This reverts commit 850e03d29f2e2ef59e844b93a5deb87f1826888e.

The previous commit solved this in a more general way. You can do:

[open-console]
profile-cond=p['user-data/mpv/console/open'] and p['current-tracks/video/albumart'] == false
profile-restore=copy
pause

Thankfully pause_on_open was just added and has not been in a release so we can remove it.