### PR TITLE
TOOLS/mpv_identify.sh: handle forward slash in property names

### DIFF
--- a/TOOLS/mpv_identify.sh
+++ b/TOOLS/mpv_identify.sh
@@ -94,7 +94,7 @@ EOF
     local key
     for key in $allprops; do
         propstr="${propstr}X-MIDENTIFY: $key \${=$key}$LF"
-        key="$(printf '%s\n' "$key" | tr - _)"
+        key="$(printf '%s\n' "$key" | tr /- __)"
         unset "$nextprefix$key"
     done
 
@@ -112,7 +112,7 @@ EOF
                     fileindex="$((fileindex+1))"
                     nextprefix="${nextprefix}${fileindex}_"
                     for key in $allprops; do
-                        key="$(printf '%s\n' "$key" | tr - _)"
+                        key="$(printf '%s\n' "$key" | tr /- __)"
                         unset "$nextprefix$key"
                     done
                 else
@@ -126,7 +126,7 @@ EOF
                 local key="${line#X-MIDENTIFY: }"
                 local value="${key#* }"
                 key="${key%% *}"
-                key="$(printf '%s\n' "$key" | tr - _)"
+                key="$(printf '%s\n' "$key" | tr /- __)"
                 if [ -n "$nextprefix" ]; then
                     if [ -z "$prefix" ]; then
                         echo >&2 "Got X-MIDENTIFY: without X-MIDENTIFY-START:"


### PR DESCRIPTION
Property names contain '-' characters, which are translated into underscores because POSIX shell variables cannot contain hyphens.

We should do the same thing for forward slash characters (i.e. '/') because these also cannot be present in the names of shell variables.

Fixes: #15782