### PR TITLE
build: use a more user-friendly version string for shallow clones

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -1,8 +1,27 @@
+git = find_program('git', required: false)
+if not git.found()
+    git = ''
+endif
+
+generate_ver = '''
+#!/usr/bin/env python3
+import os
+import sys
+from subprocess import DEVNULL, check_output
+git_cmd = [sys.argv[1], "--git-dir=" + os.path.join(sys.argv[2], ".git"),
+           "--work-tree=" + sys.argv[2]]
+describe_cmd = git_cmd + ["describe", "--abbrev=9", "--tags", "--dirty"]
+try:
+    ver = check_output(describe_cmd, stderr=DEVNULL, encoding="UTF-8")
+except Exception:
+    describe_cmd += ["--always"]
+    ver = check_output(describe_cmd, stderr=DEVNULL, encoding="UTF-8")
+    ver = f"v{sys.argv[3]}-dev-g{ver}"
+sys.stdout.write(ver)
+'''
+
 version_h = vcs_tag(
-    command: ['git',
-        '--git-dir=' + join_paths(source_root, '.git'),
-        '--work-tree=' + source_root,
-        'describe', '--always', '--tags', '--dirty'],
+    command: [python, '-c', generate_ver, git, source_root, meson.project_version().replace('-UNKNOWN', '')],
     fallback: 'v' + meson.project_version(),
     input: 'version.h.in',
     output: 'version.h',

--- a/common/meson.build
+++ b/common/meson.build
@@ -3,6 +3,7 @@ version_h = vcs_tag(
         '--git-dir=' + join_paths(source_root, '.git'),
         '--work-tree=' + source_root,
         'describe', '--always', '--tags', '--dirty'],
+    fallback: 'v' + meson.project_version(),
     input: 'version.h.in',
     output: 'version.h',
     replace_string: '@VERSION@',


### PR DESCRIPTION
Also for release tarball builds, put a 'v' in front of the number so it matches the formatting of the git tags.