### PR TITLE
console.lua: allow subsequent mp.input calls

### DIFF
--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -664,9 +664,6 @@ function register_event_handler(t) {
                             JSON.stringify(result[0]), result[1]);
             }
         }
-
-        if (type == "closed")
-            mp.unregister_script_message("input-event");
     })
 }
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1837,8 +1837,9 @@ mp.register_script_message('type', function(text, cursor_pos)
 end)
 
 mp.register_script_message('get-input', function (script_name, args)
-    if repl_active then
-        return
+    if repl_active and input_caller and script_name ~= input_caller then
+        mp.commandv('script-message-to', input_caller, 'input-event',
+                    'closed', utils.format_json({line, cursor}))
     end
 
     input_caller = script_name
@@ -1854,6 +1855,7 @@ mp.register_script_message('get-input', function (script_name, args)
     end
     history = histories[id]
     history_pos = #history + 1
+    searching_history = false
 
     if args.items then
         selectable_items = {}
@@ -1863,6 +1865,9 @@ mp.register_script_message('get-input', function (script_name, args)
         default_item = args.default_item
         handle_edit()
         bind_mouse()
+    else
+        selectable_items = nil
+        unbind_mouse()
     end
 
     set_active(true)

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -41,10 +41,6 @@ local function register_event_handler(t)
                             utils.format_json(suggestions), completion_start_position)
             end
         end
-
-        if type == "closed" then
-            mp.unregister_script_message("input-event")
-        end
     end)
 end
 


### PR DESCRIPTION
Currently using mp.input while the console is open doesn't do anything. We can allow using mp.input multiple times in a row by keeping the console open, and sending a closed event only when the previous calling script is different from the current one. If it is the same, sending a closed event would unregister the new input-event listener, so it is just never sent in this case as there is no sane way to do it.

Fixes #15795.