### PR TITLE
osc.lua: bind right clicking the title to show history

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -55,9 +55,9 @@ title
 
     =============   ================================================
     left-click      show file and track info
-    shift+L-click   show the filename
-    middle-click    show the filename
-    right-click     show the path
+    shift+L-click   show the path
+    middle-click    show the path
+    right-click     open the history selector
     =============   ================================================
 
 cache
@@ -539,9 +539,9 @@ clicked. ``mbtn_mid`` commands are also triggered with ``shift+mbtn_left``.
 
 ``title_mbtn_left_command=script-binding stats/display-page-5``
 
-``title_mbtn_mid_command=show-text ${filename}``
+``title_mbtn_mid_command=show-text ${path}``
 
-``title_mbtn_right_command=show-text ${path}``
+``title_mbtn_right_command=script-binding select/select-watch-history; script-message-to osc osc-hide``
 
 ``play_pause_mbtn_left_command=cycle pause``
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -85,8 +85,8 @@ local user_opts = {
     playlist_next_mbtn_right_command = "script-binding select/select-playlist; script-message-to osc osc-hide",
 
     title_mbtn_left_command = "script-binding stats/display-page-5",
-    title_mbtn_mid_command = "show-text ${filename}",
-    title_mbtn_right_command = "show-text ${path}",
+    title_mbtn_mid_command = "show-text ${path}",
+    title_mbtn_right_command = "script-binding select/select-watch-history; script-message-to osc osc-hide",
 
     play_pause_mbtn_left_command = "cycle pause",
     play_pause_mbtn_mid_command = "cycle-values loop-playlist inf no",


### PR DESCRIPTION
And move show-text ${path} to middle click. This is more useful than the replaced show-text ${filename} binding since the left click stats binding already shows the filename, and it matches how right clicking other buttons shows menus. Alternatively middle click could also be bound to select-watch-later.