### PR TITLE
player/loadfile: we shouldn't unescape inplace

### DIFF
--- a/stream/stream.c
+++ b/stream/stream.c
@@ -156,6 +156,13 @@ void mp_url_unescape_inplace(char *url)
     }
 }
 
+char *mp_url_unescape(void *talloc_ctx, char *url)
+{
+    char *unescaped = talloc_strdup(talloc_ctx, url);
+    mp_url_unescape_inplace(unescaped);
+    return unescaped;
+}
+
 static const char hex_digits[] = "0123456789ABCDEF";
 
 

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -260,6 +260,7 @@ struct stream *stream_create(const char *url, int flags,
 stream_t *open_output_stream(const char *filename, struct mpv_global *global);
 
 void mp_url_unescape_inplace(char *buf);
+char *mp_url_unescape(void *talloc_ctx, char *url);
 char *mp_url_escape(void *talloc_ctx, const char *s, const char *ok);
 
 // stream_memory.c


### PR DESCRIPTION
I got mesmerized by the simplicity of the original commit, but in fact it was not a correct thing to do.

Fixes: c0366cfa4208c24eeccfbe99c26a15b6434b8e75