### PR TITLE
m_option: fix parsing of OP_APPEND for string lists

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1408,7 +1408,7 @@ static char **separate_input_param(const m_option_t *opt, bstr param,
                                    int *len, int op)
 {
     char separator = opt->priv ? *(char *)opt->priv : OPTION_LIST_SEPARATOR;
-    if (op == OP_REMOVE)
+    if (op == OP_APPEND || op == OP_REMOVE)
         separator = 0; // specially handled
     struct bstr str = param;
     int n = *len;


### PR DESCRIPTION
While parsing through the separators, the OP_APPEND also needs to use 0 for the separator since it is supposed to be unescaped. This was missed in the code reorganization of d2c409c56b49252c85eefd340863fd59a36808d6. Keyvalue lists were unaffected because only OP_DELETE and OP_REMOVE use this code.
