### PR TITLE
ci/lint: disable isort checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ line-length = 100
 select = [
     "F", # pyflakes
     "E", "W", # pycodestyle
-    "I", # pycodestyle
     "N", # pep8-naming
     "UP", # pyupgrade
     "A", # flake8-builtins


### PR DESCRIPTION
The error message is completely incomprehensible and also inconsistent about whether it wants two newlines or just one after an import.

Consider this python script:
```
import sys

sys.stdout.write("garbage")
```
That passes the ruff isort check just fine. But this does not:
```
import sys

def fake_function():
    sys.stdout.write("garbage")

fake_function()
```
This will fail. Why? Because there should be two newlines after imports but only for functions. This is not explained or documented anywhere. You just get a cryptic "Import block is un-sorted or un-formatted" message. Although sometimes it appeared to have wanted two lines anyway even when there wasn't a function being defined after the imports* (link will expire eventually). Why?

Considering the amount of time I wasted trying to even understand this and I still don't. Just delete it. Please just alphabetically sort your python imports and don't do "from foo import *".

*: https://github.com/mpv-player/mpv/actions/runs/13165639053/job/36745000915