### PR TITLE
github/workflows/lint: update astral-sh/ruff-action to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,9 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - name: Check
+        id: check
+        uses: astral-sh/ruff-action@v3
         with:
           src: ". TOOLS/umpv"
+      - name: Suggested changes
+        if: ${{ failure() && steps.check.outcome == 'failure' }}
+        run: ruff check . TOOLS/umpv --diff
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v2
+      - uses: astral-sh/ruff-action@v3
         with:
           src: ". TOOLS/umpv"
 


### PR DESCRIPTION
This enables GitHub style output, along with other improvements.