### PR TITLE
build: add early exit if git is not found

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -7,13 +7,15 @@ generate_ver = '''
 #!/usr/bin/env python3
 import os
 import sys
-from subprocess import DEVNULL, check_output
+from subprocess import DEVNULL, CalledProcessError, check_output
+if not sys.argv[1]:
+    sys.exit(1)
 git_cmd = [sys.argv[1], "--git-dir=" + os.path.join(sys.argv[2], ".git"),
            "--work-tree=" + sys.argv[2]]
 describe_cmd = git_cmd + ["describe", "--abbrev=9", "--tags", "--dirty"]
 try:
     ver = check_output(describe_cmd, stderr=DEVNULL, encoding="UTF-8")
-except Exception:
+except CalledProcessError:
     describe_cmd += ["--always"]
     ver = check_output(describe_cmd, stderr=DEVNULL, encoding="UTF-8")
     ver = f"v{sys.argv[3]}-dev-g{ver}"


### PR DESCRIPTION
Also fallback to `--always` only if first `git describe` returned errors, but were called successfully.