### PR TITLE
DOCS/man/options: Clarify what --tone-mapping=auto does

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7057,7 +7057,8 @@ them.
     Valid values are:
 
     auto
-        Choose the best curve according to internal heuristics. (Default)
+        Maps to ``bt.2390`` when using ``--vo=gpu``, and to ``spline`` with
+        ``--vo=gpu-next``. (Default)
     clip
         Hard-clip any out-of-range values. Use this when you care about
         perfect color accuracy for in-range values at the cost of completely


### PR DESCRIPTION
Since https://github.com/haasn/libplacebo/commit/5f630020046c9b039adc34bf520644b264776606, ``auto`` is defined as ``spline``