### PR TITLE
Revert "vo_gpu_next: set --target-colorspace-hint to `yes` by default"

### DIFF
--- a/DOCS/interface-changes/target-hint.txt
+++ b/DOCS/interface-changes/target-hint.txt
@@ -1,1 +1,0 @@
-change `target-colorspace-hint` default to `auto`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6907,9 +6907,9 @@ them.
 ``--target-colorspace-hint=<auto|yes|no>``
     Automatically configure the output colorspace of the display to pass
     through the input values of the stream (e.g. for HDR passthrough), if
-    possible. In ``auto`` mode (the default), the target colorspace is only set,
+    possible. In ``auto`` mode, the target colorspace is only set,
     if the display signals support for HDR colorspace.
-    Requires a supporting driver and ``--vo=gpu-next``. (Default: ``auto``)
+    Requires a supporting driver and ``--vo=gpu-next``. (Default: ``no``)
 
 ``--target-prim=<value>``
     Specifies the primaries of the display. Video colors will be adapted to

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -205,7 +205,6 @@ const struct m_sub_options gl_next_conf = {
     .defaults = &(struct gl_next_opts) {
         .border_background = BACKGROUND_COLOR,
         .inter_preserve = true,
-        .target_hint = -1,
     },
     .size = sizeof(struct gl_next_opts),
     .change_flags = UPDATE_VIDEO,


### PR DESCRIPTION
HDR or any color-space pass-through should be opt-in, as we cannot control the user's compositor or display. Allowing HDR signals to be pushed by default may lead to surprising results for some users. Additionally, for an optimal experience, this option should be paired with the target-peak of the display.

Make the pass-through opt-in and let the user decide if they want or need it. By default, mpv should render a safe and consistent sRGB output. mpv's tone mapping is generally of higher quality than any external solution.

This reverts commit 23843b4aa594dc8c885575f3d237cde3c29398a2.