### PR TITLE
console.lua: disable cursor autohide while selector is open

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -107,6 +107,7 @@ local first_match_to_print = 1
 local default_item
 local item_positions = {}
 local max_item_width = 0
+local was_cursor_autohide
 
 local complete
 local cycle_through_completions
@@ -975,6 +976,11 @@ end
 local function unbind_mouse()
     mp.remove_key_binding('_console_mouse_move')
     mp.remove_key_binding('_console_mbtn_left')
+
+    if was_cursor_autohide ~= nil then
+        mp.set_property_native('cursor-autohide', was_cursor_autohide)
+        was_cursor_autohide = nil
+    end
 end
 
 -- Run the current command or select the current item
@@ -1050,6 +1056,11 @@ local function bind_mouse()
             set_active(false)
         end
     end)
+
+    if was_cursor_autohide == nil then
+        was_cursor_autohide = mp.get_property_native('cursor-autohide')
+    end
+    mp.set_property_native('cursor-autohide', false)
 end
 
 -- Go to the specified position in the command history


### PR DESCRIPTION
This is an improvement on #15145 .
If the cursor is automatically hidden, users may not know whether they are clicking on the inside or outside of selectable items,  the result after clicking is unclear to them.


