### PR TITLE
player/command: disable input-commands for fuzzing

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -869,7 +869,9 @@ static const m_option_t mp_opts[] = {
     {"idle", OPT_CHOICE(player_idle_mode,
         {"no",   0}, {"once", 1}, {"yes",  2})},
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     {"input-commands", OPT_STRINGLIST(input_commands)},
+#endif
     {"input-terminal", OPT_BOOL(consolecontrols), .flags = UPDATE_TERM},
 
     {"input-ipc-server", OPT_STRING(ipc_path), .flags = M_OPT_FILE},


### PR DESCRIPTION
Updating input-commands string list causes all commands to be rerun. This happens during load-config-file command, so even with few commands it is easy to amplify single command to run hundreds of times instead of one. This causes timeouts and OOMs when specific command for example reopens current playlist appending an item.