### PR TITLE
command: disallow trailing / in track-list/N/metadata

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2113,15 +2113,15 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
             bstr key = {0};
             char *rem = "";
             m_property_split_path(ka->key, &key, &rem);
-            ka->key = !rem[0] ? "metadata" : rem;
-            if (rem[0]) {
-                if (!tags || tags->num_keys == 0) {
-                    ret = M_PROPERTY_UNAVAILABLE;
-                } else {
-                    ret = tag_property(action, (void *)ka, tags);
-                }
-                goto done;
+            ka->key = rem;
+            if (!rem[0]) {
+                ret = M_PROPERTY_ERROR;
+            } else if (!tags || tags->num_keys == 0) {
+                ret = M_PROPERTY_UNAVAILABLE;
+            } else {
+                ret = tag_property(action, (void *)ka, tags);
             }
+            goto done;
         }
         MP_FALLTHROUGH;
     default:


### PR DESCRIPTION
To have consistency with 95019fc256d8df21994b20d2503b203ac09083cc