### PR TITLE
player/command: don't synthesize property names with a trailing /

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2290,7 +2290,7 @@ static int mp_property_current_tracks(void *ctx, struct m_property *prop,
     }
     assert(index >= 0);
 
-    char *name = mp_tprintf(80, "track-list/%d/%s", index, rem);
+    char *name = mp_tprintf(80, "track-list/%d%s%s", index, *rem ? "/" : "", rem);
     return mp_property_do(name, ka->action, ka->arg, ctx);
 }
 


### PR DESCRIPTION
This is not only cosmetic, but also avoids dummy get key action with empty key. While this was allowed previously, I'm bit concerned about Hyrum's law. But let's be strict about it.

This commit fixes current-tracks property.

Fixes: 95019fc256d8df21994b20d2503b203ac09083cc

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
