### PR TITLE
player: coalesce option updates and drop redundant ones

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7693,8 +7693,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
 {
     struct MPContext *mpctx = ctx;
     struct MPOpts *opts = mpctx->opts;
-    bool init = !co;
-    void *opt_ptr = init ? NULL : co->data; // NULL on start
+    void *opt_ptr = !co ? NULL : co->data; // NULL on start
 
     if (co)
         mp_notify_property(mpctx, co->name);
@@ -7747,7 +7746,7 @@ void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
     if (flags & UPDATE_SUB_EXTS)
         mp_update_subtitle_exts(mpctx->opts);
 
-    if (init || opt_ptr == &opts->ipc_path || opt_ptr == &opts->ipc_client) {
+    if (opt_ptr == &opts->ipc_path || opt_ptr == &opts->ipc_client) {
         mp_uninit_ipc(mpctx->ipc_ctx);
         mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
     }

--- a/player/command.h
+++ b/player/command.h
@@ -66,6 +66,11 @@ struct mp_cmd_ctx {
     void *on_completion_priv; // for free use by on_completion callback
 };
 
+struct mp_option_callback {
+    struct m_config_option *co;
+    int flags;
+};
+
 void run_command(struct MPContext *mpctx, struct mp_cmd *cmd,
                  struct mp_abort_entry *abort,
                  void (*on_completion)(struct mp_cmd_ctx *cmd),
@@ -82,6 +87,7 @@ int mp_property_do(const char* name, int action, void* val,
 
 void mp_option_change_callback(void *ctx, struct m_config_option *co, int flags,
                                bool self_update);
+void mp_option_run_callback(struct MPContext *mpctx, int index);
 
 void mp_notify(struct MPContext *mpctx, int event, void *arg);
 void mp_notify_property(struct MPContext *mpctx, const char *property);

--- a/player/core.h
+++ b/player/core.h
@@ -441,6 +441,9 @@ typedef struct MPContext {
     struct command_ctx *command_ctx;
     struct encode_lavc_context *encode_lavc_ctx;
 
+    struct mp_option_callback *option_callbacks;
+    int num_option_callbacks;
+
     struct mp_ipc_ctx *ipc_ctx;
 
     int64_t builtin_script_ids[6];

--- a/player/main.c
+++ b/player/main.c
@@ -412,6 +412,8 @@ int mp_initialize(struct MPContext *mpctx, char **options)
         mp_smtc_init(mp_new_client(mpctx->clients, "SystemMediaTransportControls"));
 #endif
 
+    mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
+
     if (opts->encode_opts->file && opts->encode_opts->file[0]) {
         mpctx->encode_lavc_ctx = encode_lavc_init(mpctx->global);
         if(!mpctx->encode_lavc_ctx) {

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -121,6 +121,14 @@ static void mp_process_input(struct MPContext *mpctx)
         mp_notify(mpctx, MP_EVENT_INPUT_PROCESSED, NULL);
 }
 
+// Process any queued option callbacks.
+static void handle_option_callbacks(struct MPContext *mpctx)
+{
+    for (int i = 0; i < mpctx->num_option_callbacks; i++)
+        mp_option_run_callback(mpctx, i);
+    mpctx->num_option_callbacks = 0;
+}
+
 double get_relative_time(struct MPContext *mpctx)
 {
     int64_t new_time = mp_time_ns();
@@ -1289,6 +1297,8 @@ void run_playloop(struct MPContext *mpctx)
 
     mp_process_input(mpctx);
 
+    handle_option_callbacks(mpctx);
+
     handle_chapter_change(mpctx);
 
     handle_force_window(mpctx, false);
@@ -1300,6 +1310,7 @@ void mp_idle(struct MPContext *mpctx)
     handle_clipboard_updates(mpctx);
     mp_wait_events(mpctx);
     mp_process_input(mpctx);
+    handle_option_callbacks(mpctx);
     handle_command_updates(mpctx);
     handle_update_cache(mpctx);
     handle_cursor_autohide(mpctx);


### PR DESCRIPTION
Could use some more testing for sure, but it seems like the dumb way of just processing these in the playloop does the trick.

Stuff like `input-commands` or `hwdec` are good to test since it's obvious if those do repeated executions. e.g. consider these config files.
```
hwdec=auto
hwdec=auto-safe
hwdec=auto
hwdec=auto-safe
hwdec=auto
hwdec=auto-safe
hwdec=auto
hwdec=auto-safe
```

```
input-commands=loadfile ${options}${playlist/0}${playlist/0}${playlist/0}
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
input-commands-pre=a
```

Load them at runtime with `load-config-file`. On master, the first one spams the terminal with garbage because of constant probing. The second one freezes the player and probably will OOM. With this PR, only the last hwdec is processed on the first config file and the second one just quits the player since you're giving loadfile garbage.

Bonus:
```
input-commands=show-text b
input-commands-append=show-text a
input-commands-append=show-text a
input-commands-append=show-text a
```

Results in this on master:
```
[   4.947][v][cplayer] Setting option 'input-commands' = 'show-text b' (flags = 4)
[   4.947][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   4.966][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   4.967][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   4.968][t][cplayer] Run command: show-text, flags=73, args=[text="b", duration="-1", level="0"]
[   4.968][t][cplayer] Run command: show-text, flags=73, args=[text="b", duration="-1", level="0"]
[   4.969][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   4.969][t][cplayer] Run command: show-text, flags=73, args=[text="b", duration="-1", level="0"]
[   4.970][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   4.971][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   4.971][t][cplayer] Run command: show-text, flags=73, args=[text="b", duration="-1", level="0"]
[   4.972][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   4.972][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   4.973][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
```

With this PR:
```
[   1.360][v][cplayer] Setting option 'input-commands' = 'show-text b' (flags = 4)
[   1.361][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   1.361][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   1.362][v][cplayer] Setting option 'input-commands-append' = 'show-text a' (flags = 4)
[   1.363][t][cplayer] video_output_image: r=2/eof=0/st=playing
[   1.363][t][cplayer] s=1.000950 vsyncs=3 dur=0.041708 ratio=2.500000 err=-0.00833375002083428656 (-0.500000/-0.200000)
[   1.363][t][cplayer] frametime=0.041
[   1.366][t][cplayer] Run command: show-text, flags=73, args=[text="b", duration="-1", level="0"]
[   1.366][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   1.366][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
[   1.366][t][cplayer] Run command: show-text, flags=73, args=[text="a", duration="-1", level="0"]
```