### PR TITLE
test/libmpv_lifetime: suppress bogus leaks

### DIFF
--- a/test/libmpv_lifetime_suppr.txt
+++ b/test/libmpv_lifetime_suppr.txt
@@ -1,0 +1,1 @@
+leak:unknown module

--- a/test/meson.build
+++ b/test/meson.build
@@ -134,7 +134,9 @@ if get_option('libmpv')
     if shared
         exe = executable('libmpv-lifetime', sources: 'libmpv_lifetime.c',
                          include_directories: incdir)
-        test('libmpv-lifetime', exe, depends: mpvlib)
+        libmpv_lifetime_suppr = join_paths(source_root, 'test', 'libmpv_lifetime_suppr.txt')
+        test('libmpv-lifetime', exe, depends: mpvlib,
+             env: 'LSAN_OPTIONS=suppressions=' + libmpv_lifetime_suppr)
     endif
 endif
 


### PR DESCRIPTION
glibc will basically always report some bogus stuff if you build with asan and tests which makes this fail locally. It annoyed me so suppress it and hope nobody names something "unknown module".