### PR TITLE
win32: support --input-ime 

### DIFF
--- a/DOCS/interface-changes/input.txt
+++ b/DOCS/interface-changes/input.txt
@@ -1,1 +1,2 @@
 add `--input-ime` to enable or disable the IME on supported VOs (Windows, Wayland)
+disable IME by default; set `--input-ime=yes` to enable it on demand

--- a/DOCS/interface-changes/input.txt
+++ b/DOCS/interface-changes/input.txt
@@ -1,1 +1,1 @@
-add `--input-ime` to enable or disable the IME on supported VOs (Wayland)
+add `--input-ime` to enable or disable the IME on supported VOs (Windows, Wayland)

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4494,8 +4494,7 @@ Input
     pre-edit inside of the input popup window if you cannot read the pre-edit
     text in the mpv window.
 
-    Wayland only. On Windows, the IME is currently always enabled. This option
-    is not applicable to terminal input.
+    Wayland and Windows only. This option is not applicable to terminal input.
 
 OSD
 ---

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4488,13 +4488,23 @@ Input
 
 ``--input-ime=<yes|no>``
     Enable keyboard input via an active input method (IME) connected to the VO.
-    (default: yes). The input popup window, if there is any, is always
+    (default: no). The input popup window, if there is any, is always
     positioned at the top left of the window. Whether pre-edit text is drawn
     depends on the platform. You may need to configure your IME to display the
     pre-edit inside of the input popup window if you cannot read the pre-edit
     text in the mpv window.
 
     Wayland and Windows only. This option is not applicable to terminal input.
+
+    .. note::
+
+        Enabling IME can cause problems with key bindings, because mpv cannot
+        detect any key presses when they go into the IME pre-edit area.
+        It is recommended to enable IME on demand only for the duration
+        while text input is expected.
+
+        The builtin console and input selector enable IME for the duration
+        of accepting text input.
 
 OSD
 ---

--- a/options/options.c
+++ b/options/options.c
@@ -261,7 +261,6 @@ const struct m_sub_options vo_sub_opts = {
         .keepaspect = true,
         .keepaspect_window = true,
         .native_fs = true,
-        .input_ime = true,
         .taskbar_progress = true,
         .show_in_taskbar = true,
         .border = true,

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -75,6 +75,7 @@ local repl_active = false
 local osd_msg_active = false
 local insert_mode = false
 local pending_update = false
+local ime_active = mp.get_property_bool('input-ime')
 local line = ''
 local cursor = 1
 local default_prompt = '>'
@@ -1758,6 +1759,8 @@ set_active = function (active)
         insert_mode = false
         define_key_bindings()
         mp.set_property_bool('user-data/mpv/console/open', true)
+        ime_active = mp.get_property_bool('input-ime')
+        mp.set_property_bool('input-ime', true)
 
         if not input_caller then
             prompt = default_prompt
@@ -1779,6 +1782,7 @@ set_active = function (active)
         undefine_key_bindings()
         mp.enable_messages('silent:terminal-default')
         mp.set_property_bool('user-data/mpv/console/open', false)
+        mp.set_property_bool('input-ime', ime_active)
 
         if input_caller then
             mp.commandv('script-message-to', input_caller, 'input-event',


### PR DESCRIPTION
This allows IME to be enabled/disabled with `--input-ime` option on Windows, like on Wayland. 

The default of `--input-ime` is changed to no since by default mpv isn't taking text input. `console.lua/mp.input` is changed to enable/disable IME when text input is activated/deactivated to ensure the suitable IME status is used depending on context. 

Fixes: https://github.com/mpv-player/mpv/issues/13666