### PR TITLE
ao_pipewire: reactivate cubic volume control

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -273,12 +273,12 @@ static void on_state_changed(void *userdata, enum pw_stream_state old, enum pw_s
 
 static float spa_volume_to_mp_volume(float vol)
 {
-        return vol * 100;
+        return 100 * pow(vol, 1/3.); // pow(x, 1/n) is the nth root of x, in lieu of cbrt()
 }
 
 static float mp_volume_to_spa_volume(float vol)
 {
-        return vol / 100;
+        return pow(vol/100, 3); // use cubic volume
 }
 
 static float volume_avg(float* vols, uint32_t n)


### PR DESCRIPTION
Commit c7b17be by @wtay disabled cubic volume control. This reintroduces it. There must have been a misunderstanding. *Because* pipewire uses linear scale volume and we *want* cubic volume control this translates between the two.

Otherwise we would just adjust volume on a linear scale which is the worst way to do it, because loudness is measured on a logarithmic scale. In lieu of that a cubic curve is a good enough approximation until such time as actual logarithmic volume control becomes a possibility/reality. This makes volume control in ao_pipewire the same as in ao_pulse.

This author does know that @wtay is the author of PipeWire but believes that he misunderstood the intent in a drive-by included in a collection of fixes.

Fixes: #11065
Probably fixes: #12223

I have read this:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md