### PR TITLE
select.lua: change the --save-watch-history warning text

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -390,7 +390,7 @@ mp.add_key_binding(nil, "select-watch-history", function ()
     if not history_file then
         show_warning(mp.get_property_native("save-watch-history")
                      and error_message
-                     or "Enable --save-watch-history")
+                     or "Enable --save-watch-history to jump to recently played files.")
         return
     end
 


### PR DESCRIPTION
The current warning was fine when you select history directly, but giving more information can be useful when you happen to see it by right clicking the title without prior information.

Fixes https://github.com/mpv-player/mpv/pull/15655#discussion_r1948053973
