### PR TITLE
wayland: Support `xdg-activation`

### DIFF
--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -9,6 +9,7 @@ protocols = [[wl_protocol_dir, 'stable/presentation-time/presentation-time.xml']
              [wl_protocol_dir, 'staging/content-type/content-type-v1.xml'],
              [wl_protocol_dir, 'staging/fractional-scale/fractional-scale-v1.xml'],
              [wl_protocol_dir, 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml'],
+             [wl_protocol_dir, 'staging/xdg-activation/xdg-activation-v1.xml'],
              ['protocols', 'xx-color-management-v4.xml']]
 wl_protocols_source = []
 wl_protocols_headers = []

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -23,6 +23,7 @@
 #include "input/event.h"
 #include "video/mp_image.h"
 #include "vo.h"
+#include "xdg-activation-v1.h"
 
 struct compositor_format;
 struct vo_wayland_seat;
@@ -142,6 +143,9 @@ struct vo_wayland_state {
 
     /* single-pixel-buffer */
     struct wp_single_pixel_buffer_manager_v1 *single_pixel_manager;
+
+    /* xdg-activation */
+    struct xdg_activation_v1 *xdg_activation;
 
     /* xdg-decoration */
     struct zxdg_decoration_manager_v1 *xdg_decoration_manager;


### PR DESCRIPTION
Tested on [niri](https://github.com/YaLTeR/niri) with [strict-new-window-focus-policy](https://github.com/YaLTeR/niri/wiki/Configuration:-Debug-Options#strict-new-window-focus-policy).
Should we show a warning when `xdg-activation` isn't available? (showing one when `XDG_ACTIVATION_TOKEN` is not an option because currently that will always be the starting from a terminal, and the protocol doesn't respond if the activation succeeded or not)