### PR TITLE
github/workflows: drop mingw32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,7 +505,6 @@ jobs:
       matrix:
         sys:
           - clang64
-          - mingw32
           - mingw64
           - ucrt64
     defaults:
@@ -524,8 +523,10 @@ jobs:
           update: true
           install: git
           pacboy: >-
+            angleproject:p
             ca-certificates:p
             cc:p
+            cppwinrt:p
             ffmpeg:p
             lcms2:p
             libarchive:p
@@ -539,16 +540,13 @@ jobs:
             ninja:p
             pkgconf:p
             python:p
+            rst2pdf:p
+            rubberband:p
             shaderc:p
             spirv-cross:p
             uchardet:p
             vapoursynth:p
             vulkan-devel:p
-
-      - name: Install dependencies
-        if: ${{ matrix.sys != 'mingw32' }}
-        run: |
-          pacboy --noconfirm -S {angleproject,cppwinrt,rst2pdf,rubberband}:p
 
       - name: Build with meson
         id: build

--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -5,9 +5,6 @@
 args=(
   -D{cdda,d3d-hwaccel,d3d11,dvdnav,jpeg,lcms2,libarchive}=enabled
   -D{libbluray,lua,shaderc,spirv-cross,uchardet,vapoursynth}=enabled
-)
-
-[[ "$SYS" != "mingw32" ]] && args+=(
   -D{egl-angle-lib,egl-angle-win32,pdf-build,rubberband,win32-smtc}=enabled
 )
 


### PR DESCRIPTION
Upstream dropped libplacebo* so we're pretty much out of luck here. It's not worth it to bother building a subproject for just this one.

*: https://github.com/msys2/MINGW-packages/commit/c3a79e8ae9a8e7f2215db210ba3f44d91d7e23b6

Of course, the CI is failing anyways for some other reason.