### PR TITLE
player: store external filenames as normalized

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -2000,9 +2000,6 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
     struct MPContext *mpctx = ctx;
     struct track *track = mpctx->tracks[item];
 
-    char *external_filename = mp_normalize_user_path(NULL, mpctx->global,
-                                                     track->external_filename);
-
     struct mp_codec_params p =
         track->stream ? *track->stream->codec : (struct mp_codec_params){0};
 
@@ -2054,8 +2051,8 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
         {"external",    SUB_PROP_BOOL(track->is_external)},
         {"selected",    SUB_PROP_BOOL(track->selected)},
         {"main-selection", SUB_PROP_INT(order), .unavailable = order < 0},
-        {"external-filename", SUB_PROP_STR(external_filename),
-                        .unavailable = !external_filename},
+        {"external-filename", SUB_PROP_STR(track->external_filename),
+                        .unavailable = !track->external_filename},
         {"ff-index",    SUB_PROP_INT(track->ff_index)},
         {"hls-bitrate", SUB_PROP_INT(track->hls_bitrate),
                         .unavailable = !track->hls_bitrate},
@@ -2129,7 +2126,6 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
     }
 
 done:
-    talloc_free(external_filename);
     talloc_free(tag_list);
     return ret;
 }

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -906,7 +906,7 @@ int mp_add_external_file(struct MPContext *mpctx, char *filename,
         } else {
             t->title = talloc_strdup(t, mp_basename(disp_filename));
         }
-        t->external_filename = talloc_strdup(t, filename);
+        t->external_filename = mp_normalize_user_path(t, mpctx->global, filename);
         t->no_default = sh->type != filter;
         t->no_auto_select = t->no_default;
         // if we found video, and we are loading cover art, flag as such.


### PR DESCRIPTION
Instead of re-normalizing the external filenames of tracks anytime the property is read, store it normalized in the first place.