### PR TITLE
[RFC] options: add --{sub,audio,video}-file-priority options

### DIFF
--- a/DOCS/interface-changes/external-tracks.txt
+++ b/DOCS/interface-changes/external-tracks.txt
@@ -1,0 +1,1 @@
+deprecate `--autoload-files`

--- a/DOCS/interface-changes/external-tracks.txt
+++ b/DOCS/interface-changes/external-tracks.txt
@@ -1,1 +1,4 @@
 deprecate `--autoload-files`
+add `--sub-file-priority`
+add `--audio-file-priority`
+add `--video-file-priority`

--- a/DOCS/interface-changes/subs-with-matching-audio.txt
+++ b/DOCS/interface-changes/subs-with-matching-audio.txt
@@ -1,0 +1,1 @@
+`--subs-with-matching-audio` will now take effect even if `--slang` is not explicitly set

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2274,6 +2274,9 @@ Audio
     option will add a new audio track. The details are similar to how
     ``--sub-file`` works.
 
+``--audio-file-priority=<yes|no|never>``
+    Similar to ``--sub-file-priority`` but for external audio files.
+
 ``--audio-format=<format>``
     Select the sample format used for output from the audio filter layer to
     the sound card. The values that ``<format>`` can adopt are listed below in
@@ -2439,6 +2442,14 @@ Subtitles
     while  ``--sub-file`` takes a single filename, but can be used multiple
     times to add multiple files. Technically, ``--sub-file`` is a CLI/config
     file only alias for  ``--sub-files-append``.
+
+``--sub-file-priority=<yes|no|never>``
+    When loading any type of external subtitle track, choose whether to
+    prioritize its autoselection over other potential aspects of the track
+    (e.g. slang or various --subs-fallback options). This defaults to ``yes``
+    meaning that external subtitle files have priority over internal subtitles.
+    ``no`` removes any special prioritization whereas ``never`` will prefer
+    internal tracks.
 
 ``--secondary-sid=<ID|auto|no>``
     Select a secondary subtitle stream. This is similar to ``--sid``. If a
@@ -7770,6 +7781,9 @@ Miscellaneous
     Default: ``AlbumArt,Album,cover,front,AlbumArtSmall,Folder,.folder,thumb``
 
     This is a string list option. See `List Options`_ for details.
+
+``--video-file-priority=<yes|no|never>``
+    Similar to ``--sub-file-priority`` but for external video files.
 
 ``--video-exts=ext1,ext2,...``
     Video file extensions to try to match when using ``--autocreate-playlist`` or

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -154,14 +154,17 @@ Track Selection
 ``--subs-fallback=<yes|default|no>``
     When autoselecting a subtitle track, if no tracks match your preferred languages,
     select a full track even if it doesn't match your preferred subtitle language (default: default).
-    Setting this to `default` means that only streams flagged as `default` will be selected.
+    Setting this to ``default`` means that only streams flagged as ``default`` will be selected.
 
 ``--subs-fallback-forced=<yes|no|always>``
-    When autoselecting a subtitle track, the default value of `yes` will prefer using a forced
+    When autoselecting a subtitle track, the default value of ``yes`` will prefer using a forced
     subtitle track if the subtitle language matches the audio language and matches your list of
-    preferred languages. The special value `always` will only select forced subtitle tracks and
-    never fallback on a non-forced track. Conversely, `no` will never select a forced subtitle
-    track.
+    preferred languages. The special value ``always`` will always select forced subtitle tracks if
+    one exists regardless of the audio language matching or not. ``no`` will never select a forced
+    track. Note that this option acts independently of ``--subs-fallback`` and it is possible that
+    a track that is not selected by this option will get selected anyway because of
+    ``--subs-fallback``. E.g. a track that is tagged as default + forced would be selected with
+    ``--subs-fallback=default`` and ``--subs-fallback-forced=no``.
 
 
 Playback Control

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -137,10 +137,12 @@ Track Selection
 
 ``--subs-with-matching-audio=<yes|forced|no>``
     When autoselecting a subtitle track, select it even if the selected audio
-    stream matches you preferred subtitle language (default: yes). If this
-    option is set to ``no``, then no subtitle track that matches the audio
+    stream matches a preferred subtitle language selected with ``--slang``
+    (default: yes). If no ``--slang`` is explicitly set, then this option will
+    instead check for a match between the audio stream and subtitle track. If
+    this option is set to ``no``, then no subtitle track that matches the audio
     language will ever be autoselected by mpv regardless of ``--slang`` or
-    ``subs-fallback``. If set to ``forced``, then only forced subtitles
+    ``--subs-fallback``. If set to ``forced``, then only forced subtitles
     will be selected.
 
 ``--subs-match-os-language=<yes|no>``

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -417,8 +417,7 @@ Playback Control
     On older FFmpeg versions, this will not work in some cases. Some FFmpeg
     demuxers might not respect this option.
 
-    This option does not prevent opening of paired subtitle files and such. Use
-    ``--autoload-files=no`` to prevent this.
+    This option does not prevent opening of paired subtitle files and such.
 
     This option does not always work if you open non-files (for example using
     ``dvd://directory`` would open a whole bunch of files in the given
@@ -7792,17 +7791,6 @@ Miscellaneous
 
     This is a string list option. See `List Options`_ for details. Use
     ``--help=playlist-exts`` to see the default extensions.
-
-``--autoload-files=<yes|no>``
-    Automatically load/select external files (default: yes).
-
-    If set to ``no``, then do not automatically load external files as specified
-    by ``--sub-auto``, ``--audio-file-auto`` and ``--cover-art-auto``. If
-    external files are forcibly added (like with ``--sub-files``), they will
-    not be auto-selected.
-
-    This does not affect playlist expansion, redirection, or other loading of
-    referenced files like with ordered chapters.
 
 ``--stream-record=<file>``
     Write received/read data from the demuxer to the given output file. The

--- a/options/options.c
+++ b/options/options.c
@@ -697,6 +697,13 @@ static const m_option_t mp_opts[] = {
     {"autoload-files", OPT_BOOL(autoload_files),
         .deprecation_message = "this option is deprecated and does nothing"},
 
+    {"sub-file-priority", OPT_CHOICE(sub_file_priority,
+        {"below", -1}, {"normal", 0}, {"above", 1})},
+    {"audio-file-priority", OPT_CHOICE(audio_file_priority,
+        {"below", -1}, {"normal", 0}, {"above", 1})},
+    {"video-file-priority", OPT_CHOICE(video_file_priority,
+        {"below", -1}, {"normal", 0}, {"above", 1})},
+
     {"sub-auto", OPT_CHOICE(sub_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
     {"sub-auto-exts", OPT_STRINGLIST(sub_auto_exts), .flags = UPDATE_SUB_EXTS},
@@ -1033,6 +1040,9 @@ static const struct MPOpts mp_default_opts = {
     .playback_speed = 1.,
     .playback_pitch = 1.,
     .pitch_correction = true,
+    .sub_file_priority = true,
+    .audio_file_priority = true,
+    .video_file_priority = true,
     .audiofile_auto = -1,
     .osd_bar_visible = true,
     .screenshot_template = "mpv-shot%n",

--- a/options/options.c
+++ b/options/options.c
@@ -694,7 +694,8 @@ static const m_option_t mp_opts[] = {
 
     {"external-files", OPT_PATHLIST(external_files), .flags = M_OPT_FILE},
     {"external-file", OPT_CLI_ALIAS("external-files-append")},
-    {"autoload-files", OPT_BOOL(autoload_files)},
+    {"autoload-files", OPT_BOOL(autoload_files),
+        .deprecation_message = "this option is deprecated and does nothing"},
 
     {"sub-auto", OPT_CHOICE(sub_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
@@ -997,7 +998,6 @@ static const struct MPOpts mp_default_opts = {
     .load_config = true,
     .position_resume = true,
     .watch_history_path = "~~state/watch_history.jsonl",
-    .autoload_files = true,
     .demuxer_thread = true,
     .demux_termination_timeout = 0.1,
     .hls_bitrate = INT_MAX,

--- a/options/options.h
+++ b/options/options.h
@@ -328,6 +328,9 @@ typedef struct MPOpts {
     char **coverart_files;
     char **external_files;
     bool autoload_files;
+    int sub_file_priority;
+    int audio_file_priority;
+    int video_file_priority;
     int sub_auto;
     char **sub_auto_exts;
     int audiofile_auto;

--- a/player/command.c
+++ b/player/command.c
@@ -6228,9 +6228,7 @@ static void cmd_track_add(void *p)
 
     for (int n = first; n < mpctx->num_tracks; n++) {
         struct track *t = mpctx->tracks[n];
-        if (cmd->args[1].v.i == 1) {
-            t->no_default = true;
-        } else if (n == first) {
+        if (cmd->args[1].v.i != 1 && n == first) {
             if (mpctx->playback_initialized) {
                 mp_switch_track(mpctx, t->type, t, FLAG_MARK_SELECTION);
             } else {

--- a/player/core.h
+++ b/player/core.h
@@ -128,7 +128,6 @@ struct track {
 
     // If this track is from an external file (e.g. subtitle file).
     bool is_external;
-    bool no_default;            // pretend it's not external for auto-selection
     bool no_auto_select;
     char *external_filename;
     bool auto_loaded;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -437,13 +437,26 @@ void add_demuxer_tracks(struct MPContext *mpctx, struct demuxer *demuxer)
         add_stream_track(mpctx, demuxer, demux_get_stream(demuxer, n));
 }
 
+static int get_external_file_priority(struct MPOpts *opts, struct track *track)
+{
+    switch (track->type) {
+    case STREAM_VIDEO:
+        return opts->video_file_priority;
+    case STREAM_AUDIO:
+        return opts->audio_file_priority;
+    case STREAM_SUB:
+        return opts->sub_file_priority;
+    }
+    return 0;
+}
+
 /* Get the track wanted by the user.
  * tid is the track ID requested by the user (-2: deselect, -1: default)
  * lang is a string list, NULL is same as empty list
  * Sort tracks based on the following criteria, and pick the first:
   *0a) track matches tid (always wins)
- * 0b) track is not from --external-file
- * 1) track is external
+ * 0b) track is not from --external-file and external files are preferred
+ * 1) track is external (no_default cancels this) and external files are preferred
  * 1b) track was passed explicitly (is not an auto-loaded subtitle)
  * 1c) track matches the program ID of the video
  * 2) earlier match in lang list but not if we're using os_langs
@@ -463,14 +476,14 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs, bool
                           bool forced, struct MPOpts *opts, int preferred_program)
 {
     bool sub = t2->type == STREAM_SUB;
+    int external_file_priority = get_external_file_priority(opts, t1);
     if (t1->is_external != t2->is_external) {
-        if (t1->attached_picture && t2->attached_picture
-            && opts->audio_display == 1)
-            return !t1->is_external;
-        return t1->is_external;
+        if (t1->attached_picture && t2->attached_picture)
+            return t1->is_external && opts->audio_display == 2;
+        return t1->is_external && external_file_priority == 1;
     }
-    if (t1->auto_loaded != t2->auto_loaded)
-        return !t1->auto_loaded;
+    if (external_file_priority && t1->auto_loaded != t2->auto_loaded)
+        return !t1->auto_loaded && external_file_priority == -1;
     if (preferred_program != -1 && t1->program_id != -1 && t2->program_id != -1) {
         if ((t1->program_id == preferred_program) !=
             (t2->program_id == preferred_program))
@@ -595,13 +608,13 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
             bool audio_matches = audio_lang && track->lang && !strcasecmp(audio_lang, track->lang);
             bool forced = track->forced_track && (opts->subs_fallback_forced == 2 ||
                           (audio_matches && opts->subs_fallback_forced == 1));
+            bool external = track->is_external && get_external_file_priority(opts, track) >= 0;
             bool slang_match = !os_langs && mp_match_lang(langs, track->lang) > 0;
-            bool subs_fallback = track->is_external || opts->subs_fallback == 2 ||
-                                 (opts->subs_fallback == 1 && track->default_track);
+            bool subs_fallback = opts->subs_fallback == 2 || (opts->subs_fallback == 1 && track->default_track);
             bool subs_no_match = !os_langs ? !mp_match_lang(langs, audio_lang) : !audio_matches;
             bool subs_matching_audio = (subs_no_match || opts->subs_with_matching_audio == 2 ||
                                         (opts->subs_with_matching_audio == 1 && track->forced_track));
-            if (subs_matching_audio && ((!pick && (forced || slang_match || subs_fallback)) ||
+            if (subs_matching_audio && ((!pick && (forced || external || slang_match || subs_fallback)) ||
                 (pick && compare_track(track, pick, langs, os_langs, forced, mpctx->opts, preferred_program))))
             {
                 pick = track;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -463,7 +463,7 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs, bool
                           bool forced, struct MPOpts *opts, int preferred_program)
 {
     bool sub = t2->type == STREAM_SUB;
-    if (!opts->autoload_files && t1->is_external != t2->is_external)
+    if (t1->is_external != t2->is_external)
         return !t1->is_external;
     bool ext1 = t1->is_external && !t1->no_default;
     bool ext2 = t2->is_external && !t2->no_default;
@@ -617,8 +617,6 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
     }
 
     if (pick && pick->attached_picture && !mpctx->opts->audio_display)
-        pick = NULL;
-    if (pick && !opts->autoload_files && pick->is_external)
         pick = NULL;
 cleanup:
     talloc_free(langs);
@@ -952,7 +950,7 @@ void autoload_external_files(struct MPContext *mpctx, struct mp_cancel *cancel)
 
     if (opts->sub_auto < 0 && opts->audiofile_auto < 0 && opts->coverart_auto < 0)
         return;
-    if (!opts->autoload_files || strcmp(mpctx->filename, "-") == 0)
+    if (strcmp(mpctx->filename, "-") == 0)
         return;
 
     void *tmp = talloc_new(NULL);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -599,12 +599,13 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
             bool audio_matches = audio_lang && track->lang && !strcasecmp(audio_lang, track->lang);
             bool forced = track->forced_track && (opts->subs_fallback_forced == 2 ||
                           (audio_matches && opts->subs_fallback_forced == 1));
-            bool lang_match = !os_langs && mp_match_lang(langs, track->lang) > 0;
+            bool slang_match = !os_langs && mp_match_lang(langs, track->lang) > 0;
             bool subs_fallback = (track->is_external && !track->no_default) || opts->subs_fallback == 2 ||
                                  (opts->subs_fallback == 1 && track->default_track);
-            bool subs_matching_audio = (!mp_match_lang(langs, audio_lang) || opts->subs_with_matching_audio == 2 ||
+            bool subs_no_match = !os_langs ? !mp_match_lang(langs, audio_lang) : !audio_matches;
+            bool subs_matching_audio = (subs_no_match || opts->subs_with_matching_audio == 2 ||
                                         (opts->subs_with_matching_audio == 1 && track->forced_track));
-            if (subs_matching_audio && ((!pick && (forced || lang_match || subs_fallback)) ||
+            if (subs_matching_audio && ((!pick && (forced || slang_match || subs_fallback)) ||
                 (pick && compare_track(track, pick, langs, os_langs, forced, mpctx->opts, preferred_program))))
             {
                 pick = track;

--- a/test/libmpv_test_track_selection.c
+++ b/test/libmpv_test_track_selection.c
@@ -53,8 +53,20 @@ static void test_track_selection(char *file, char *path)
         wait_for_file_load();
         check_string("current-tracks/sub/selected", "yes");
 
-        // --subs-falback=no
+        // --subs-fallback=no
         check_api_error(mpv_set_property_string(ctx, "subs-fallback", "no"));
+        check_api_error(mpv_command(ctx, cmd));
+        wait_for_file_load();
+        check_string("track-list/2/selected", "no");
+    } else if (strcmp(file, "eng_default_audio.mkv") == 0) {
+        // --subs-with-matching-audio=no
+        check_api_error(mpv_set_property_string(ctx, "subs-with-matching-audio", "no"));
+        check_api_error(mpv_command(ctx, cmd));
+        wait_for_file_load();
+        check_string("track-list/2/selected", "no");
+
+        // --subs-with-matching-audio=forced
+        check_api_error(mpv_set_property_string(ctx, "subs-with-matching-audio", "forced"));
         check_api_error(mpv_command(ctx, cmd));
         wait_for_file_load();
         check_string("track-list/2/selected", "no");
@@ -69,6 +81,12 @@ static void test_track_selection(char *file, char *path)
         check_api_error(mpv_command(ctx, cmd));
         wait_for_file_load();
         check_string("current-tracks/sub/selected", "yes");
+
+        // --subs-with-matching-audio=forced
+        check_api_error(mpv_set_property_string(ctx, "subs-with-matching-audio", "forced"));
+        check_api_error(mpv_command(ctx, cmd));
+        wait_for_file_load();
+        check_string("track-list/2/selected", "yes");
     } else if (strcmp(file, "eng_forced_no_matching_audio.mkv") == 0) {
         // forced track should not be selected
         check_api_error(mpv_command(ctx, cmd));

--- a/test/libmpv_test_track_selection.c
+++ b/test/libmpv_test_track_selection.c
@@ -58,18 +58,12 @@ static void test_track_selection(char *file, char *path)
         check_api_error(mpv_command(ctx, cmd));
         wait_for_file_load();
         check_string("track-list/2/selected", "no");
-
-        // reset options to defaults
-        check_api_error(mpv_set_property_string(ctx, "subs-fallback", "default"));
     } else if (strcmp(file, "eng_default_forced.mkv") == 0) {
         // --subs-fallback-forced=no
         check_api_error(mpv_set_property_string(ctx, "subs-fallback-forced", "no"));
         check_api_error(mpv_command(ctx, cmd));
         wait_for_file_load();
         check_string("current-tracks/sub/selected", "yes");
-
-        // reset options to defaults
-        check_api_error(mpv_set_property_string(ctx, "subs-fallback-forced", "yes"));
     } else if (strcmp(file, "eng_forced_matching_audio.mkv") == 0) {
         // select forced track
         check_api_error(mpv_command(ctx, cmd));
@@ -97,9 +91,6 @@ static void test_track_selection(char *file, char *path)
         check_api_error(mpv_command(ctx, cmd));
         wait_for_file_load();
         check_string("current-tracks/sub/selected", "yes");
-
-        // reset options to defaults
-        check_api_error(mpv_set_property_string(ctx, "subs-fallback", "default"));
     } else if (strcmp(file, "multilang.mkv") == 0) {
         // --alang=jpn should select forced jpn subs
         check_api_error(mpv_set_property_string(ctx, "alang", "jpn"));

--- a/test/samples/meson.build
+++ b/test/samples/meson.build
@@ -20,6 +20,9 @@ common_args = ['-v', 'error', '-y', '-i', video, '-i', audio,
 samples = {
     'eng_default.mkv':
         [ffmpeg, common_args, '-disposition:s:0', 'default', '@OUTPUT@'],
+    'eng_default_audio.mkv':
+        [ffmpeg, common_args, '-metadata:s:a:0', 'language=eng',
+         '-disposition:s:0', 'default', '@OUTPUT@'],
     'eng_default_forced.mkv':
         [ffmpeg, common_args, '-disposition:s:0', 'default+forced', '@OUTPUT@'],
     'eng_forced_matching_audio.mkv':


### PR DESCRIPTION
Based off of the branch in #15854 since that touches the same general code places and presumably I'll merge it reasonably soon.

Did some minor internal cleanups and added options to allow customization of whether or not external tracks should be preferred. I kind of feel like the default should be `no`. In other words, external tracks are treated exactly like internal tracks and there is no preference either way but the PR currently has it set to `yes` for compatibility reasons. Not sure how people feel about that.

Obviously needs tests. Will do that later.