### PR TITLE
DOCS/man/options: explain the difference between panscan and zoom

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -146,7 +146,8 @@ T
 
 w and W
     Decrease/increase pan-and-scan range. The ``e`` key does the same as
-    ``W`` currently, but use is discouraged.
+    ``W`` currently, but use is discouraged. See ``--panscan`` for more
+    information.
 
 o and P
     Show progression bar, elapsed time and total duration on the OSD.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1572,6 +1572,11 @@ Video
 
     This option has no effect if ``--video-unscaled`` option is used.
 
+    The difference between ``--panscan`` and ``--video-zoom`` is that
+    ``--panscan`` can only zoom in until either the video width or height fills
+    the window, while ``--video-zoom`` can zoom in or out arbitrary amounts, and
+    also works with ``--video-unscaled``.
+
 ``--video-aspect-override=<ratio|no|original>``
     Override video aspect ratio, in case aspect information is incorrect or
     missing in the file being played.


### PR DESCRIPTION
Also suggest checking --panscan docs from its key bindings.

Requested by avih.