### PR TITLE
demux/stheader: use atomic types for mp_codec_params names

### DIFF
--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -18,6 +18,7 @@
 #ifndef MPLAYER_STHEADER_H
 #define MPLAYER_STHEADER_H
 
+#include <stdatomic.h>
 #include <stdbool.h>
 
 #include "common/common.h"
@@ -70,19 +71,19 @@ struct mp_codec_params {
     enum stream_type type;
 
     // E.g. "h264" (usually corresponds to AVCodecDescriptor.name)
-    const char *codec;
+    const char *_Atomic codec;
 
     // Usually corresponds to AVCodecDescriptor.long_name
-    const char *codec_desc;
+    const char *_Atomic codec_desc;
 
     // Corresponding codec profile
-    const char *codec_profile;
+    const char *_Atomic codec_profile;
 
     // E.g. "h264" (usually corresponds to AVCodec.name)
-    const char *decoder;
+    const char *_Atomic decoder;
 
     // Usually corresponds to AVCodec.long_name
-    const char *decoder_desc;
+    const char *_Atomic decoder_desc;
 
     // Usually a FourCC, exact meaning depends on codec.
     unsigned int codec_tag;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -316,7 +316,7 @@ static int init(struct sd *sd)
     ctx->packer = mp_ass_packer_alloc(ctx);
 
     // Subtitles does not have any profile value, so put the converted type as a profile.
-    const char **desc = ctx->converter ? &sd->codec->codec_profile : &sd->codec->codec_desc;
+    const char *_Atomic *desc = ctx->converter ? &sd->codec->codec_profile : &sd->codec->codec_desc;
     switch (ctx->ass_track->track_type) {
     case TRACK_TYPE_ASS:
         *desc = "Advanced Sub Station Alpha";


### PR DESCRIPTION
Notably they are exchanged between demux and decode thread. It's fine because we know those pointers will be alive as long as avctx is alive. And only the value may change during decoding in rare situations. Make those pointers atomic for the sake of it.

It shouldn't change anything, except some codegen.

From https://www.gnu.org/software/libc/manual/html_node/Atomic-Types.html#Atomic-Types:

In practice, you can assume that int is atomic. You can also assume that pointer types are atomic; that is very convenient. Both of these assumptions are true on all of the machines that the GNU C Library supports and on all POSIX systems we know of.