### PR TITLE
clipboard: add --clipboard-backends option

### DIFF
--- a/DOCS/interface-changes/clipboard.txt
+++ b/DOCS/interface-changes/clipboard.txt
@@ -1,4 +1,4 @@
-add `--clipboard-enable` and `--clipboard-monitor` options
+add `--clipboard-monitor` option
 add `clipboard` property
 add `current-clipboard-backend` property
 add `--clipboard-backends` option

--- a/DOCS/interface-changes/clipboard.txt
+++ b/DOCS/interface-changes/clipboard.txt
@@ -1,3 +1,4 @@
 add `--clipboard-enable` and `--clipboard-monitor` options
 add `clipboard` property
 add `current-clipboard-backend` property
+add `--clipboard-backends` option

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -4009,23 +4009,7 @@ Property list
 
 ``current-clipboard-backend``
     A string containing the currently active clipboard backend.
-    The following clipboard backends are implemented:
-
-    ``win32``
-        Windows backend.
-
-    ``mac``
-        macOS backend.
-
-    ``wayland``
-        Wayland backend. This backend is only available if the compositor
-        supports the ``ext-data-control-v1`` protocol.
-
-    ``vo``
-        VO backend. Requires an active VO window, and support differs across
-        platforms. Currently, this is used as a fallback for Wayland
-        compositors without support for the ``ext-data-control-v1``
-        protocol.
+    See ``--clipboard-backends`` option for the list of available backends.
 
 ``clock``
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7914,3 +7914,30 @@ Miscellaneous
     On Wayland, this option only has effect on the ``wayland`` backend, and
     not for the ``vo`` backend. See ``current-clipboard-backend`` property for
     more details.
+
+``--clipboard-backends=<backend1,backend2,...[,]>``
+    Specify a priority list of the clipboard backends to be used.
+    You can also pass ``help`` to get a complete list of compiled in backends.
+
+    Note that the default clipboard backends are subject to change,
+    and must not be relied upon.
+
+    The following clipboard backends are implemented:
+
+    ``win32``
+        Windows backend.
+
+    ``mac``
+        macOS backend.
+
+    ``wayland``
+        Wayland backend. This backend is only available if the compositor
+        supports the ``ext-data-control-v1`` protocol.
+
+    ``vo``
+        VO backend. Requires an active VO window, and support differs across
+        platforms. Currently, this is used as a fallback for Wayland
+        compositors without support for the ``ext-data-control-v1``
+        protocol, or if the ``wayland`` backend is disabled.
+
+    This is an object settings list option. See `List Options`_ for details.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7896,28 +7896,16 @@ Miscellaneous
 
     Conversion is not applied to metadata that is updated at runtime.
 
-``--clipboard-enable=<yes|no>``
-    (Windows, Wayland and macOS only)
-
-    Enable native clipboard support (default: yes). This allows reading and
-    writing to the ``clipboard`` property to get and set clipboard contents.
-
-``--clipboard-monitor=<yes|no>``
-    (Windows, Wayland and macOS only)
-
-    Enable clipboard monitoring so that the ``clipboard`` property can be
-    observed for content changes (default: no). This only affects clipboard
-    implementations which use polling to monitor clipboard updates.
-    Other platforms currently ignore this option and always/never notify
-    changes.
-
-    On Wayland, this option only has effect on the ``wayland`` backend, and
-    not for the ``vo`` backend. See ``current-clipboard-backend`` property for
-    more details.
-
 ``--clipboard-backends=<backend1,backend2,...[,]>``
     Specify a priority list of the clipboard backends to be used.
     You can also pass ``help`` to get a complete list of compiled in backends.
+
+    If the list is not empty, it enables native clipboard support for the
+    specified backends. This allows reading and writing to the ``clipboard``
+    property to get and set clipboard contents.
+
+    Native clipboard support is enabled by default. To disable this, remove
+    all backends in this list with ``--clipboard-backends-clr``.
 
     Note that the default clipboard backends are subject to change,
     and must not be relied upon.
@@ -7941,3 +7929,16 @@ Miscellaneous
         protocol, or if the ``wayland`` backend is disabled.
 
     This is an object settings list option. See `List Options`_ for details.
+
+``--clipboard-monitor=<yes|no>``
+    (Windows, Wayland and macOS only)
+
+    Enable clipboard monitoring so that the ``clipboard`` property can be
+    observed for content changes (default: no). This only affects clipboard
+    implementations which use polling to monitor clipboard updates.
+    Other platforms currently ignore this option and always/never notify
+    changes.
+
+    On Wayland, this option only has effect on the ``wayland`` backend, and
+    not for the ``vo`` backend. See ``current-clipboard-backend`` property for
+    more details.

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -25,19 +25,7 @@
 struct clipboard_opts {
     bool enabled;
     bool monitor;
-};
-
-#define OPT_BASE_STRUCT struct clipboard_opts
-const struct m_sub_options clipboard_conf = {
-    .opts = (const struct m_option[]) {
-        {"enable", OPT_BOOL(enabled), .flags = UPDATE_CLIPBOARD},
-        {"monitor", OPT_BOOL(monitor), .flags = UPDATE_CLIPBOARD},
-        {0}
-    },
-    .defaults = &(const struct clipboard_opts) {
-        .enabled = true,
-    },
-    .size = sizeof(struct clipboard_opts)
+    struct m_obj_settings *backends;
 };
 
 // backend list
@@ -59,6 +47,48 @@ static const struct clipboard_backend *const clipboard_backend_list[] = {
     &clipboard_backend_vo,
 };
 
+static bool get_desc(struct m_obj_desc *dst, int index)
+{
+    if (index >= MP_ARRAY_SIZE(clipboard_backend_list))
+        return false;
+    const struct clipboard_backend *backend = clipboard_backend_list[index];
+    *dst = (struct m_obj_desc) {
+        .name = backend->name,
+        .description = backend->desc,
+    };
+    return true;
+}
+
+static const struct m_obj_list backend_obj_list = {
+    .get_desc = get_desc,
+    .description = "clipboard backends",
+    .allow_trailer = true,
+    .disallow_positional_parameters = true,
+    .use_global_options = true,
+};
+
+#define OPT_BASE_STRUCT struct clipboard_opts
+const struct m_sub_options clipboard_conf = {
+    .opts = (const struct m_option[]) {
+        {"enable", OPT_BOOL(enabled), .flags = UPDATE_CLIPBOARD},
+        {"monitor", OPT_BOOL(monitor), .flags = UPDATE_CLIPBOARD},
+        {"backends", OPT_SETTINGSLIST(backends, &backend_obj_list),
+         .flags = UPDATE_CLIPBOARD},
+        {0}
+    },
+    .defaults = &(const struct clipboard_opts) {
+        .enabled = true,
+        .backends = (struct m_obj_settings[]) {
+            {.name = "win32", .enabled = true},
+            {.name = "mac", .enabled = true},
+            {.name = "wayland", .enabled = true},
+            {.name = "vo", .enabled = true},
+            {0}
+        }
+    },
+    .size = sizeof(struct clipboard_opts)
+};
+
 struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
                                           struct mpv_global *global)
 {
@@ -68,10 +98,15 @@ struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
         .monitor = params->flags & CLIPBOARD_INIT_ENABLE_MONITORING,
     };
 
-    for (int i = 0; i < MP_ARRAY_SIZE(clipboard_backend_list); i++) {
-        const struct clipboard_backend *backend = clipboard_backend_list[i];
-        if (backend->init(cl, params) == CLIPBOARD_SUCCESS) {
-            MP_VERBOSE(cl, "Initialized %s clipboard backend.\n", backend->name);
+    for (int n = 0; params->backends && params->backends[n].name; n++) {
+        if (!params->backends[n].enabled)
+            continue;
+        for (int i = 0; i < MP_ARRAY_SIZE(clipboard_backend_list); i++) {
+            const struct clipboard_backend *backend = clipboard_backend_list[i];
+            if (strcmp(params->backends[n].name, backend->name))
+                continue;
+            if (backend->init(cl, params) != CLIPBOARD_SUCCESS)
+                break;
             cl->backend = backend;
             goto success;
         }
@@ -81,6 +116,7 @@ struct clipboard_ctx *mp_clipboard_create(struct clipboard_init_params *params,
     talloc_free(cl);
     return NULL;
 success:
+    MP_VERBOSE(cl, "Initialized %s clipboard backend.\n", cl->backend->name);
     return cl;
 }
 
@@ -129,6 +165,7 @@ void reinit_clipboard(struct MPContext *mpctx)
         struct clipboard_init_params params = {
             .mpctx = mpctx,
             .flags = opts->monitor ? CLIPBOARD_INIT_ENABLE_MONITORING : 0,
+            .backends = opts->backends,
         };
         mpctx->clipboard = mp_clipboard_create(&params, mpctx->global);
     }

--- a/player/clipboard/clipboard.c
+++ b/player/clipboard/clipboard.c
@@ -23,7 +23,6 @@
 #include "player/core.h"
 
 struct clipboard_opts {
-    bool enabled;
     bool monitor;
     struct m_obj_settings *backends;
 };
@@ -70,14 +69,12 @@ static const struct m_obj_list backend_obj_list = {
 #define OPT_BASE_STRUCT struct clipboard_opts
 const struct m_sub_options clipboard_conf = {
     .opts = (const struct m_option[]) {
-        {"enable", OPT_BOOL(enabled), .flags = UPDATE_CLIPBOARD},
         {"monitor", OPT_BOOL(monitor), .flags = UPDATE_CLIPBOARD},
         {"backends", OPT_SETTINGSLIST(backends, &backend_obj_list),
          .flags = UPDATE_CLIPBOARD},
         {0}
     },
     .defaults = &(const struct clipboard_opts) {
-        .enabled = true,
         .backends = (struct m_obj_settings[]) {
             {.name = "win32", .enabled = true},
             {.name = "mac", .enabled = true},
@@ -161,7 +158,7 @@ void reinit_clipboard(struct MPContext *mpctx)
     mpctx->clipboard = NULL;
 
     struct clipboard_opts *opts = mp_get_config_group(NULL, mpctx->global, &clipboard_conf);
-    if (opts->enabled) {
+    if (opts->backends && opts->backends[0].name) {
         struct clipboard_init_params params = {
             .mpctx = mpctx,
             .flags = opts->monitor ? CLIPBOARD_INIT_ENABLE_MONITORING : 0,

--- a/player/clipboard/clipboard.h
+++ b/player/clipboard/clipboard.h
@@ -53,6 +53,7 @@ struct clipboard_data {
 struct clipboard_init_params {
     int flags;
     struct MPContext *mpctx; // For clipboard_vo only
+    struct m_obj_settings *backends;
 };
 
 struct clipboard_access_params {


### PR DESCRIPTION
This allows specifying a priority list of clipboard backends to use. This is mostly useful on Linux where multiple clipboard backends exist.

