### PR TITLE
stream_cdda: subtract first sector when calculating chapter times

### DIFF
--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -225,7 +225,7 @@ static int control(stream_t *stream, int cmd, void *arg)
         track += start_track;
         if (track > end_track)
             return STREAM_ERROR;
-        int64_t sector = p->cd->disc_toc[track].dwStartSector;
+        int64_t sector = p->cd->disc_toc[track].dwStartSector - p->start_sector;
         int64_t pos = sector * CDIO_CD_FRAMESIZE_RAW;
         // Assume standard audio CD: 44.1khz, 2 channels, s16 samples
         *(double *)arg = pos / (44100.0 * 2 * 2);


### PR DESCRIPTION
Sometimes a CD can have non-audio data at the start that is not playable. libcdio/paranoia is smart enough to already skip this, but our calculations for when the tracks/chapters start completely fall apart. The beginning bytes are not valid CD audio so it should just be subtracted and ignored. This probably doesn't work if a CD somehow has its audio tracks in a non-continuous manner with non-audio data in between tracks at random points. There's likely not much we could do in such a case, and probably nobody has an audio CD like that anyways.

Ref: #8322
