### PR TITLE
options/path: only log mp_get_user_path if the path expands

### DIFF
--- a/options/path.c
+++ b/options/path.c
@@ -215,9 +215,11 @@ char *mp_get_user_path(void *talloc_ctx, struct mpv_global *global,
             }
         }
     }
-    if (!res)
+    if (!res) {
         res = talloc_strdup(talloc_ctx, path);
-    MP_DBG(global, "user path: '%s' -> '%s'\n", path, res);
+    } else {
+        MP_DBG(global, "user path: '%s' -> '%s'\n", path, res);
+    }
     return res;
 }
 


### PR DESCRIPTION
Having path -> path in the log is kind of useless. If someone happens to call this on memory://, it will also flood the log with garbage. Only print it at a debug level if the path actually changes/get expanded. Otherwise set it at trace.