### PR TITLE
build: remove ta-leak-report option

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1549,10 +1549,7 @@ behavior of mpv.
 
 ``MPV_LEAK_REPORT``
     If set to ``1``, enable internal talloc leak reporting. If set to another
-    value, disable leak reporting. If unset, use the default, which normally is
-    ``0``. If mpv was built with ``--enable-ta-leak-report``, the default is
-    ``1``. If leak reporting was disabled at compile time (``NDEBUG`` in
-    custom ``CFLAGS``), this environment variable is ignored.
+    value, disable leak reporting.
 
 ``LADSPA_PATH``
     Specifies the search path for LADSPA plugins. If it is unset, fully

--- a/DOCS/tech-overview.txt
+++ b/DOCS/tech-overview.txt
@@ -68,7 +68,6 @@ ta.h & ta.c:
     as in it doesn't require valgrind.) You can enable it by setting the
     MPV_LEAK_REPORT environment variable to "1":
         export MPV_LEAK_REPORT=1
-    Or permanently by building with --enable-ta-leak-report.
     This will list all unfree'd allocations on exit.
 
     Documentation can be found here:

--- a/meson.build
+++ b/meson.build
@@ -352,7 +352,6 @@ if not features['build-date']
     flags += '-DNO_BUILD_TIMESTAMPS'
 endif
 
-features += {'ta-leak-report': get_option('ta-leak-report')}
 features += {'disable-packet-pool': get_option('disable-packet-pool')}
 
 libdl = dependency('dl', required: false)

--- a/meson.options
+++ b/meson.options
@@ -5,9 +5,6 @@ option('libmpv', type: 'boolean', value: false, description: 'libmpv library')
 option('build-date', type: 'boolean', value: true, description: 'include compile timestamp in binary')
 option('tests', type: 'boolean', value: false, description: 'meson unit tests')
 option('fuzzers', type: 'boolean', value: false, description: 'fuzzer binaries')
-# Reminder: normally always built, but enabled by MPV_LEAK_REPORT.
-# Building it can be disabled only by defining NDEBUG through CFLAGS.
-option('ta-leak-report', type: 'boolean', value: false, description: 'enable ta leak report by default (development only)')
 option('disable-packet-pool', type: 'boolean', value: false, description: 'disable packet pool (development only)')
 
 # misc features

--- a/player/main.c
+++ b/player/main.c
@@ -260,9 +260,7 @@ struct MPContext *mp_create(void)
     }
 
     char *enable_talloc = getenv("MPV_LEAK_REPORT");
-    if (!enable_talloc)
-        enable_talloc = HAVE_TA_LEAK_REPORT ? "1" : "0";
-    if (strcmp(enable_talloc, "1") == 0)
+    if (enable_talloc && strcmp(enable_talloc, "1") == 0)
         talloc_enable_leak_report();
 
     mp_time_init();


### PR DESCRIPTION
We already have more than enough options. This doesn't need to exist. Just use the environment variable if you really want to use this for some reason.