### PR TITLE
demux: use a slightly better hack when seeking with dvd/bd

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3819,9 +3819,6 @@ static bool queue_seek(struct demux_internal *in, double seek_pts, int flags,
     bool set_backwards = flags & SEEK_SATAN;
     flags &= ~(unsigned)SEEK_SATAN;
 
-    bool force_seek = flags & SEEK_FORCE;
-    flags &= ~(unsigned)SEEK_FORCE;
-
     bool block = flags & SEEK_BLOCK;
     flags &= ~(unsigned)SEEK_BLOCK;
 
@@ -3833,7 +3830,7 @@ static bool queue_seek(struct demux_internal *in, double seek_pts, int flags,
             MP_VERBOSE(in, "Cached seek not possible.\n");
             return false;
         }
-        if (!in->d_thread->seekable && !force_seek) {
+        if (!in->d_thread->seekable) {
             MP_WARN(in, "Cannot seek in this file.\n");
             return false;
         }

--- a/demux/demux.h
+++ b/demux/demux.h
@@ -95,8 +95,7 @@ struct demux_opts {
 #define SEEK_CACHED   (1 << 3)      // allow packet cache seeks only
 #define SEEK_SATAN    (1 << 4)      // enable backward demuxing
 #define SEEK_HR       (1 << 5)      // hr-seek (this is a weak hint only)
-#define SEEK_FORCE    (1 << 6)      // ignore unseekable flag
-#define SEEK_BLOCK    (1 << 7)      // upon successfully queued seek, block readers
+#define SEEK_BLOCK    (1 << 6)      // upon successfully queued seek, block readers
                                     // (simplifies syncing multiple reader threads)
 
 // Strictness of the demuxer open format check.
@@ -144,6 +143,7 @@ typedef struct demuxer_desc {
     // If *pkt is NULL (the value when this function is called), the call
     // will be repeated.
     bool (*read_packet)(struct demuxer *demuxer, struct demux_packet **pkt);
+    void (*drop_buffers)(struct demuxer *demuxer);
     void (*close)(struct demuxer *demuxer);
     void (*seek)(struct demuxer *demuxer, double rel_seek_secs, int flags);
     void (*switched_tracks)(struct demuxer *demuxer);

--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -177,15 +177,11 @@ static void d_seek(demuxer_t *demuxer, double seek_pts, int flags)
 
     MP_VERBOSE(demuxer, "seek to: %f\n", seek_pts);
 
-    // Supposed to induce a seek reset. Does it even work? I don't know.
-    // It will log some bogus error messages, since the demuxer will try a
-    // low level seek, which will obviously not work. But it will probably
-    // clear its internal buffers.
-    demux_seek(p->slave, 0, SEEK_FACTOR | SEEK_FORCE);
-    stream_drop_buffers(demuxer->stream);
-
     double seek_arg[] = {seek_pts, flags};
     stream_control(demuxer->stream, STREAM_CTRL_SEEK_TO_TIME, seek_arg);
+
+    if (p->slave->desc->drop_buffers)
+        p->slave->desc->drop_buffers(p->slave);
 
     p->seek_reinit = true;
 }


### PR DESCRIPTION
Basically just bits of a9d83eac40c94f44d19fab7b6955331f10efe301 that was removed and ported to here. Not really smart but it seems like flushing buffers during seek generally leads to better behavior and avoids some errors. The additional stream_seek call that was being performed is definitely bogus (will never work and spams errors). So that is skipped for bd/dvd. SEEK_FORCE is no longer needed. Instead demux_disc calls drop_buffers on the slave demuxer (i.e. lavf).
