### PR TITLE
mac/dialog: release all input keys when modal steals key input

### DIFF
--- a/osdep/mac/dialog.swift
+++ b/osdep/mac/dialog.swift
@@ -66,10 +66,7 @@ class Dialog {
         let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
         input.placeholderString = "URL"
         alert.accessoryView = input
-
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
-            input.becomeFirstResponder()
-        }
+        alert.window.initialFirstResponder = input
 
         if alert.runModal() == .alertFirstButtonReturn && input.stringValue.count > 0 {
             return input.stringValue

--- a/osdep/mac/dialog.swift
+++ b/osdep/mac/dialog.swift
@@ -18,7 +18,7 @@
 import Cocoa
 import UniformTypeIdentifiers
 
-class Dialog {
+class Dialog: NSObject, NSWindowDelegate, NSOpenSavePanelDelegate {
     var option: OptionHelper?
 
     init(_ option: OptionHelper? = nil) {
@@ -48,6 +48,7 @@ class Dialog {
         panel.canChooseDirectories = directories
         panel.allowsMultipleSelection = multiple
         panel.allowedContentTypes = types
+        panel.delegate = self
 
         if panel.runModal() == .OK {
             return panel.urls.map { $0.path }
@@ -82,5 +83,9 @@ class Dialog {
         alert.icon = AppHub.shared.getIcon()
         alert.addButton(withTitle: "Ok")
         alert.runModal()
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        AppHub.shared.input.put(key: MP_INPUT_RELEASE_ALL)
     }
 }


### PR DESCRIPTION
@kasper93 a heads up, this might lead to some merge conflicts with your dialog branch. also the save function needs the panel delegate set too (eg `panel.delegate = self`).

modal dialogs steal the key/mouse input and possibly eat corresponding key up events when opening via key binding. this leads to key sequence ends to not reported and key bindings not being triggered if no key up event was triggered after closing the modal.