### PR TITLE
player: add an optional mute flag when framestepping

### DIFF
--- a/DOCS/interface-changes/frame-step.txt
+++ b/DOCS/interface-changes/frame-step.txt
@@ -1,1 +1,2 @@
 - add optional `frames` and `flags` arguments to `frame-step` command controlling the direction and amount of frames mpv steps through
+- add optional `mute` flag to `frame-step` command which mutes the player during the duration of the frame step

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -370,6 +370,9 @@ Playback Control
         Perform a very exact seek that attempts to seek by the desired amount
         of frames. If ``<frames>`` is ``-1``, this will go exactly to the
         previous frame.
+    mute
+        The same as ``play`` but mutes the audio stream if there is any during
+        the duration of the frame step.
 
     Note that the default frameskip mode, play, is more accurate but can be
     slow depending on how many frames you are skipping (i.e. skipping forward

--- a/player/audio.c
+++ b/player/audio.c
@@ -170,21 +170,26 @@ static float compute_replaygain(struct MPContext *mpctx)
     return rgain;
 }
 
-// Called when opts->softvol_volume or opts->softvol_mute were changed.
-void audio_update_volume(struct MPContext *mpctx)
+float audio_get_gain(struct MPContext *mpctx)
 {
     struct MPOpts *opts = mpctx->opts;
-    struct ao_chain *ao_c = mpctx->ao_chain;
-    if (!ao_c || !ao_c->ao)
-        return;
-
     float gain = MPMAX(opts->softvol_volume / 100.0, 0);
     gain = pow(gain, 3);
     gain *= compute_replaygain(mpctx);
     gain *= db_gain(opts->softvol_gain);
     if (opts->softvol_mute)
         gain = 0.0;
+    return gain;
+}
 
+// Called when opts->softvol_volume or opts->softvol_mute were changed.
+void audio_update_volume(struct MPContext *mpctx)
+{
+    struct ao_chain *ao_c = mpctx->ao_chain;
+    if (!ao_c || !ao_c->ao)
+        return;
+
+    float gain = audio_get_gain(mpctx);
     ao_set_gain(ao_c->ao, gain);
 }
 

--- a/player/command.c
+++ b/player/command.c
@@ -5735,18 +5735,20 @@ static void cmd_frame_step(void *p)
         return;
     }
 
-    if (flags) {
+    if (flags == 1) {
         if (!cmd->cmd->is_up)
-            add_step_frame(mpctx, frames, flags);
+            add_step_frame(mpctx, frames, true);
     } else {
         if (cmd->cmd->is_up) {
             if (mpctx->step_frames < 1)
                 set_pause_state(mpctx, true);
         } else {
+            if (flags == 2)
+                step_frame_mute(mpctx, true);
             if (cmd->cmd->repeated) {
                 set_pause_state(mpctx, false);
             } else {
-                add_step_frame(mpctx, frames, flags);
+                add_step_frame(mpctx, frames, false);
             }
         }
     }
@@ -7042,7 +7044,8 @@ const struct mp_cmd_def mp_cmds[] = {
             {"frames", OPT_INT(v.i), OPTDEF_INT(1)},
             {"flags", OPT_CHOICE(v.i,
                     {"play", 0},
-                    {"seek", 1}),
+                    {"seek", 1},
+                    {"mute", 2}),
                     .flags = MP_CMD_OPT_ARG},
         },
         .allow_auto_repeat = true,

--- a/player/core.h
+++ b/player/core.h
@@ -503,6 +503,7 @@ void update_playback_speed(struct MPContext *mpctx);
 void uninit_audio_out(struct MPContext *mpctx);
 void uninit_audio_chain(struct MPContext *mpctx);
 void reinit_audio_chain_src(struct MPContext *mpctx, struct track *track);
+float audio_get_gain(struct MPContext *mpctx);
 void audio_update_volume(struct MPContext *mpctx);
 void reload_audio_output(struct MPContext *mpctx);
 void audio_start_ao(struct MPContext *mpctx);
@@ -603,6 +604,7 @@ void set_pause_state(struct MPContext *mpctx, bool user_pause);
 void update_internal_pause_state(struct MPContext *mpctx);
 void update_core_idle_state(struct MPContext *mpctx);
 void add_step_frame(struct MPContext *mpctx, int dir, bool use_seek);
+void step_frame_mute(struct MPContext *mpctx, bool mute);
 void queue_seek(struct MPContext *mpctx, enum seek_type type, double amount,
                 enum seek_precision exact, int flags);
 double get_time_length(struct MPContext *mpctx);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -218,6 +218,15 @@ void add_step_frame(struct MPContext *mpctx, int dir, bool use_seek)
     }
 }
 
+void step_frame_mute(struct MPContext *mpctx, bool mute)
+{
+    if (!mpctx->ao_chain || !mpctx->ao_chain->ao)
+        return;
+
+    float gain = mute ? 0 : audio_get_gain(mpctx);
+    ao_set_gain(mpctx->ao_chain->ao, gain);
+}
+
 // Clear some playback-related fields on file loading or after seeks.
 void reset_playback_state(struct MPContext *mpctx)
 {

--- a/player/video.c
+++ b/player/video.c
@@ -1294,8 +1294,10 @@ void write_video(struct MPContext *mpctx)
     if (mpctx->video_status != STATUS_EOF) {
         if (mpctx->step_frames > 0) {
             mpctx->step_frames--;
-            if (!mpctx->step_frames)
+            if (!mpctx->step_frames) {
                 set_pause_state(mpctx, true);
+                step_frame_mute(mpctx, false);
+            }
         }
         if (mpctx->max_frames == 0 && !mpctx->stop_play)
             mpctx->stop_play = AT_END_OF_FILE;


### PR DESCRIPTION
Need to shuffle some stuff around but it's pretty simple. Mute the audio stream before the frame step and then unmute it when we're done. It's exactly the same as the default play mode otherwise.
