### PR TITLE
player/command: fix flags type in mp_option_run_callback

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7726,7 +7726,7 @@ void mp_option_run_callback(struct MPContext *mpctx, int index)
     struct MPOpts *opts = mpctx->opts;
     struct m_config_option *co = mpctx->option_callbacks[index].co;
     void *opt_ptr = co ? co->data : NULL;
-    int flags = mpctx->option_callbacks[index].flags;
+    uint64_t flags = mpctx->option_callbacks[index].flags;
 
     if (flags & UPDATE_TERM)
         mp_update_logging(mpctx, false);

--- a/player/command.h
+++ b/player/command.h
@@ -68,7 +68,7 @@ struct mp_cmd_ctx {
 
 struct mp_option_callback {
     struct m_config_option *co;
-    int flags;
+    uint64_t flags;
 };
 
 void run_command(struct MPContext *mpctx, struct mp_cmd *cmd,


### PR DESCRIPTION
PR #15457 has not been rebased after merge of #15828 resulting in type mismatch.

Fixes: f57c0af5f2b8de922e4d32764c5fdc1f4e2f6f2a