### PR TITLE
player: run all update handlers on init

### DIFF
--- a/player/core.h
+++ b/player/core.h
@@ -600,6 +600,7 @@ void mp_wakeup_core(struct MPContext *mpctx);
 void mp_wakeup_core_cb(void *ctx);
 void mp_core_lock(struct MPContext *mpctx);
 void mp_core_unlock(struct MPContext *mpctx);
+void handle_option_callbacks(struct MPContext *mpctx);
 double get_relative_time(struct MPContext *mpctx);
 void reset_playback_state(struct MPContext *mpctx);
 void set_pause_state(struct MPContext *mpctx, bool user_pause);

--- a/player/main.c
+++ b/player/main.c
@@ -383,6 +383,7 @@ int mp_initialize(struct MPContext *mpctx, char **options)
     m_config_set_update_dispatch_queue(mpctx->mconfig, mpctx->dispatch);
     // Run all update handlers.
     mp_option_change_callback(mpctx, NULL, UPDATE_OPTS_MASK, false);
+    handle_option_callbacks(mpctx);
 
     if (handle_help_options(mpctx))
         return 1; // help

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -122,7 +122,7 @@ static void mp_process_input(struct MPContext *mpctx)
 }
 
 // Process any queued option callbacks.
-static void handle_option_callbacks(struct MPContext *mpctx)
+void handle_option_callbacks(struct MPContext *mpctx)
 {
     for (int i = 0; i < mpctx->num_option_callbacks; i++)
         mp_option_run_callback(mpctx, i);


### PR DESCRIPTION
The refactoring in bbac628a1b01261766459c6556e36d2443a42534 missed that the initial update handler didn't immediately run all the triggered callbacks but would instead delay it until the next playloop. This subtly breaks things of course like hooks, force window handling, etc. Ensure that we immediately run all the callbacks like before on startup.

Fixes bbac628a1b01261766459c6556e36d2443a42534
Fixes https://github.com/mpv-player/mpv/pull/15828#issuecomment-2663830477
