### PR TITLE
vo_gpu_next: make --icc-profile-auto actually work on startup

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2327,6 +2327,8 @@ AV_NOWARN_DEPRECATED(
     }
 
     update_icc_opts(p, opts->icc_opts);
+    int events = 0;
+    update_auto_profile(p, &events);
 
     pars->params.num_hooks = 0;
     const struct pl_hook *hook;


### PR DESCRIPTION
Guess it's proof that nobody actually uses this option.