### PR TITLE
wayland: unvoid some wayland protocol structs

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -196,8 +196,7 @@ struct vo_wayland_seat {
     struct vo_wayland_data_offer *dnd_offer;
     struct vo_wayland_data_offer *selection_offer;
     struct vo_wayland_text_input *text_input;
-    /* TODO: unvoid this if required wayland protocols is bumped to 1.32+ */
-    void *cursor_shape_device;
+    struct wp_cursor_shape_device_v1 *cursor_shape_device;
     uint32_t pointer_enter_serial;
     uint32_t pointer_button_serial;
     struct xkb_keymap  *xkb_keymap;

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -111,8 +111,7 @@ struct vo_wayland_state {
     int current_content_type;
 
     /* cursor-shape */
-    /* TODO: unvoid these if required wayland protocols is bumped to 1.32+ */
-    void *cursor_shape_manager;
+    struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
 
     /* fifo */
     bool has_fifo;


### PR DESCRIPTION
I started doing this in f5944824513f3081ac01484c85960324bdaabda1 for protocol objects that were newer than the lowest version, but I can't remember why (some waf-related reason?). This wasn't even followed for other PRs merged recently like ext-data-control and color-management. Anyways, it's not needed and works fine if you're on wayland-protocols 1.31 so stop doing this void weirdness.
