### PR TITLE
player: only coalesce callbacks from parsed config files

### DIFF
--- a/input/cmd.h
+++ b/input/cmd.h
@@ -114,6 +114,7 @@ typedef struct mp_cmd {
     bool repeated : 1;
     bool mouse_move : 1;
     bool canceled : 1;
+    bool coalesce : 1;
     int mouse_x, mouse_y;
     struct mp_cmd *queue_next;
     double scale;               // for scaling numeric arguments

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -737,6 +737,9 @@ int m_config_set_option_cli(struct m_config *config, struct bstr name,
         param = bstr0("no");
     }
 
+    if (flags & M_SETOPT_FROM_CONFIG_FILE)
+        co->coalesce = true;
+
     // This is the only mandatory function
     assert(co->opt->type->parse);
 

--- a/options/m_config_frontend.h
+++ b/options/m_config_frontend.h
@@ -49,6 +49,7 @@ struct m_config_option {
     bool is_set_from_config : 1;    // Set by a config file
     bool is_set_locally : 1;        // Has a backup entry
     bool warning_was_printed : 1;
+    bool coalesce : 1;              // Property changes should be coalesced
     int32_t opt_id;                 // For some m_config APIs
     const char *name;               // Full name (ie option-subopt)
     const struct m_option *opt;     // Option description

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -147,6 +147,8 @@ struct m_property {
     void *priv;
     // Special-case: mark options for which command.c uses the option-bridge
     bool is_option;
+    // Special-case: option-bridge properties should be coalesced
+    bool coalesce;
 };
 
 struct m_property *m_property_list_find(const struct m_property *list,

--- a/player/command.h
+++ b/player/command.h
@@ -87,7 +87,7 @@ int mp_property_do(const char* name, int action, void* val,
 
 void mp_option_change_callback(void *ctx, struct m_config_option *co, uint64_t flags,
                                bool self_update);
-void mp_option_run_callback(struct MPContext *mpctx, int index);
+void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *callback);
 
 void mp_notify(struct MPContext *mpctx, int event, void *arg);
 void mp_notify_property(struct MPContext *mpctx, const char *property);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -125,7 +125,7 @@ static void mp_process_input(struct MPContext *mpctx)
 void handle_option_callbacks(struct MPContext *mpctx)
 {
     for (int i = 0; i < mpctx->num_option_callbacks; i++)
-        mp_option_run_callback(mpctx, i);
+        mp_option_run_callback(mpctx, &mpctx->option_callbacks[i]);
     mpctx->num_option_callbacks = 0;
 }
 


### PR DESCRIPTION
cc @christoph-heinrich: I think with this you just need to do this (potential backwards compatibility handling ignored):
```
diff --git a/subtitle-lines.lua b/subtitle-lines.lua
index d836b83..556796f 100644
--- a/subtitle-lines.lua
+++ b/subtitle-lines.lua
@@ -130,7 +130,7 @@ local function acquire_subtitles()
     mp.set_property_bool(sub_strings.visibility, false)
 
     -- go to the first subtitle line
-    mp.commandv('set', sub_strings.delay, mp.get_property_number('duration', 0) + 365 * 24 * 60 * 60)
+    mp.commandv('immediate', 'set', sub_strings.delay, mp.get_property_number('duration', 0) + 365 * 24 * 60 * 60)
     mp.commandv('sub-step', 1, sub_strings.step)
 
     -- this shouldn't be necessary, but it's kept just in case there actually
@@ -207,7 +207,7 @@ local function acquire_subtitles()
         mp.commandv('sub-step', 1, sub_strings.step)
     end
 
-    mp.set_property_number(sub_strings.delay, sub_delay)
+    mp.commandv('immediate', 'set', sub_strings.delay, sub_delay)
     mp.set_property_bool(sub_strings.visibility, sub_visibility)
 
     for _, subtitle in ipairs(subtitles) do

```
And you'll get the old behavior back.