### PR TITLE
DOCS/man/options: remove outdated wid embedding docs for cocoa

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3695,11 +3695,6 @@ Window
     not accept negative values. mpv will create its own window and set the
     wid window as parent, like with X11.
 
-    On macOS/Cocoa, the ID is interpreted as ``NSView*``. Pass it as value cast
-    to ``intptr_t``. mpv will create its own sub-view. Because macOS does not
-    support window embedding of foreign processes, this works only with libmpv,
-    and will crash when used from the command line.
-
     On Android, the ID is interpreted as ``android.view.Surface``. Pass it as a
     value cast to ``intptr_t``. Use with ``--vo=mediacodec_embed`` and
     ``--hwdec=mediacodec`` for direct rendering using MediaCodec, or with


### PR DESCRIPTION
forgot this in fc4db18 and meant to remove it when implementing wid embedding again. though it's better to fix the docs separately.