### PR TITLE
DOCS/man/options: fix missing space in hwdec doc

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1430,7 +1430,7 @@ Video
        only the ``vaapi``, ``nvdec``, ``cuda`` and ``vulkan`` methods work with
        Vulkan.
 
-    The ``vaapi`` mode, if used with ``--vo=gpu``or ``--vo=gpu-next`` most
+    The ``vaapi`` mode, if used with ``--vo=gpu`` or ``--vo=gpu-next`` most
     likely works with Intel and AMD GPUs only. It requires the opengl EGL
     backend if the GPU does not support drm modifiers.
 


### PR DESCRIPTION
Fixes: d7159e4662000457b74272ec448897ad21826061
