### PR TITLE
input: add a way to pipe multiple commands

### DIFF
--- a/input/cmd.c
+++ b/input/cmd.c
@@ -313,7 +313,7 @@ struct mp_cmd *mp_input_parse_cmd_node(struct mp_log *log, mpv_node *node)
 static bool read_token(bstr str, bstr *out_rest, bstr *out_token)
 {
     bstr t = bstr_lstrip(str);
-    int next = bstrcspn(t, WHITESPACE "#;");
+    int next = bstrcspn(t, WHITESPACE "#;|");
     if (!next)
         return false;
     *out_token = bstr_splice(t, 0, next);
@@ -417,11 +417,15 @@ static struct mp_cmd *parse_cmd_str(struct mp_log *log, void *tmp,
             break;
 
         struct mp_cmd_arg arg = {.type = opt};
-        r = m_option_parse(ctx->log, opt, bstr0(cmd->name), cur_token, &arg.v);
-        if (r < 0) {
-            MP_ERR(ctx, "Command %s: argument %d can't be parsed: %s.\n",
-                   cmd->name, i + 1, m_option_strerror(r));
-            goto error;
+        if (bstrcmp0(cur_token, "-") == 0) {
+            arg.substitute = true;
+        } else {
+            r = m_option_parse(ctx->log, opt, bstr0(cmd->name), cur_token, &arg.v);
+            if (r < 0) {
+                MP_ERR(ctx, "Command %s: argument %d can't be parsed: %s.\n",
+                       cmd->name, i + 1, m_option_strerror(r));
+                goto error;
+            }
         }
 
         MP_TARRAY_APPEND(cmd, cmd->args, cmd->nargs, arg);
@@ -465,7 +469,8 @@ mp_cmd_t *mp_input_parse_cmd_str(struct mp_log *log, bstr str, const char *loc)
         str = bstr_lstrip(str);
         // read_token just to check whether it's trailing whitespace only
         bstr u1, u2;
-        if (!bstr_eatstart0(&str, ";") || !read_token(str, &u1, &u2))
+        bool receive_pipe = bstr_startswith(str, bstr0("|"));
+        if ((!bstr_eatstart0(&str, ";") && !bstr_eatstart0(&str, "|")) || !read_token(str, &u1, &u2))
             break;
         // Multi-command. Since other input.c code uses queue_next for its
         // own purposes, a pseudo-command is used to wrap the command list.
@@ -489,6 +494,7 @@ mp_cmd_t *mp_input_parse_cmd_str(struct mp_log *log, bstr str, const char *loc)
             cmd = NULL;
             goto done;
         }
+        sub->receive_pipe = receive_pipe;
         talloc_steal(cmd, sub);
         *p_prev = sub;
         p_prev = &sub->queue_next;

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -97,6 +97,7 @@ struct mp_cmd_arg {
         char **str_list;
         void *p;
     } v;
+    bool substitute;
 };
 
 typedef struct mp_cmd {
@@ -114,6 +115,7 @@ typedef struct mp_cmd {
     bool repeated : 1;
     bool mouse_move : 1;
     bool canceled : 1;
+    bool receive_pipe : 1; // can read output from previous command
     int mouse_x, mouse_y;
     struct mp_cmd *queue_next;
     double scale;               // for scaling numeric arguments

--- a/player/command.c
+++ b/player/command.c
@@ -5296,11 +5296,42 @@ struct cmd_list_ctx {
     int num_sub;
 };
 
+static void substitute_args(struct MPContext *ctx, struct mp_cmd *cmd,
+                            struct mpv_node *replace)
+{
+    // TODO: Allow node array
+    if (!cmd->receive_pipe || replace->format != MPV_FORMAT_STRING)
+        return;
+
+    for (int i = 0; i < cmd->nargs; ++i) {
+        if (!cmd->args[i].substitute)
+            continue;
+        if (cmd->args[i].type->type == CONF_TYPE_BOOL ||
+            cmd->args[i].type->type == CONF_TYPE_FLAG ||
+            cmd->args[i].type->type == CONF_TYPE_INT ||
+            cmd->args[i].type->type == CONF_TYPE_INT64 ||
+            cmd->args[i].type->type == CONF_TYPE_FLOAT ||
+            cmd->args[i].type->type == CONF_TYPE_DOUBLE) {
+            m_option_parse(ctx->log, cmd->args[i].type, bstr0(cmd->name),
+                           bstr0(replace->u.string), &cmd->args[i].v);
+        } else if (cmd->args[i].type->type == CONF_TYPE_STRING) {
+            talloc_replace(cmd, cmd->args[i].v.s, replace->u.string);
+        } else if (cmd->args[i].type->type == CONF_TYPE_STRING_LIST) {
+            // TODO
+        }
+    }
+}
+
 static void continue_cmd_list(struct cmd_list_ctx *list);
 
 static void on_cmd_list_sub_completion(struct mp_cmd_ctx *cmd)
 {
     struct cmd_list_ctx *list = cmd->on_completion_priv;
+    if (cmd->cmd->receive_pipe)
+        mpv_free_node_contents(&list->parent->previous_result);
+
+    if (cmd->cmd->queue_next && cmd->cmd->queue_next->receive_pipe)
+        list->parent->previous_result = cmd->result;
 
     if (list->current_valid && mp_thread_id_equal(list->current_tid, mp_thread_current_id())) {
         list->completed_recursive = true;
@@ -5327,6 +5358,7 @@ static void continue_cmd_list(struct cmd_list_ctx *list)
             list->current_valid = true;
             list->current_tid = mp_thread_current_id();
 
+            substitute_args(list->mpctx, sub, &list->parent->previous_result);
             run_command(list->mpctx, sub, NULL, on_cmd_list_sub_completion, list);
 
             list->current_valid = false;
@@ -5376,7 +5408,8 @@ void mp_cmd_ctx_complete(struct mp_cmd_ctx *cmd)
         cmd->on_completion(cmd);
     if (cmd->abort)
         mp_abort_remove(cmd->mpctx, cmd->abort);
-    mpv_free_node_contents(&cmd->result);
+    if (!cmd->cmd->queue_next || !cmd->cmd->queue_next->receive_pipe)
+        mpv_free_node_contents(&cmd->result);
     talloc_free(cmd);
 }
 
@@ -5438,6 +5471,11 @@ void run_command(struct MPContext *mpctx, struct mp_cmd *cmd,
     if (ctx->abort) {
         ctx->abort->coupled_to_playback |= cmd->def->abort_on_playback_end;
         mp_abort_add(mpctx, ctx->abort);
+    }
+
+    if (ctx->on_completion_priv) {
+        struct cmd_list_ctx *list = ctx->on_completion_priv;
+        ctx->previous_result = list->parent->previous_result;
     }
 
     struct MPOpts *opts = mpctx->opts;

--- a/player/command.h
+++ b/player/command.h
@@ -52,6 +52,7 @@ struct mp_cmd_ctx {
     // completion callback).
     bool success;       // true by default
     struct mpv_node result;
+    struct mpv_node previous_result; // result from the previously run command
     // Command handlers can set this to false if returning from the command
     // handler does not complete the command. It stops the common command code
     // from signaling the completion automatically, and you can call


### PR DESCRIPTION
Very rough right now and needs work. But this is mainly to show that what I mentioned in https://github.com/mpv-player/mpv/pull/15845/files#r1962613721 is totally doable.

This lets you pipe multiple commands together in input.conf style syntax like: `expand-text "${chapters}" | show-text -` where `|` is the pipe of course and `-` tells the command to read the result from the preceding command. Chaining them together infinitely should work too: `expand-text "test" | expand-text - | expand-text - | expand-text - | show-text -` You can also specify `-` for multiple arguments to have the same thing substitute multiple times but not sure that has any practical use.

This only makes sense if the previous command outputs an actual result. AFAIK most of them don't, but you can use expand-text as `cat` basically so that's handy and the property expansion lets you do silly things like `expand-text "${seeking}" | set vo -`.

Main open question right now is: how many types should we even attempt to handle with this? I'm not even sure if any command right now returns anything other than a string in the result. I know in #15845 `file-dialog` stores a node array so that needs to be implemented here. But that's just a bunch of strings. I'm thinking the node won't ever realistically have anything other than a string or strings in it, but could be wrong.