### PR TITLE
vo_dmabuf_wayland: commit surfaces in correct order

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -649,8 +649,8 @@ static void flip_page(struct vo *vo)
 {
     struct vo_wayland_state *wl = vo->wl;
 
-    wl_surface_commit(wl->video_surface);
     wl_surface_commit(wl->osd_surface);
+    wl_surface_commit(wl->video_surface);
     wl_surface_commit(wl->surface);
 
     if (wl->opts->wl_internal_vsync)

--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -388,10 +388,6 @@ static void destroy_osd_buffers(struct vo *vo)
     if (!vo->wl)
         return;
 
-    // Remove any existing buffer before we destroy them.
-    wl_surface_attach(vo->wl->osd_surface, NULL, 0, 0);
-    wl_surface_commit(vo->wl->osd_surface);
-
     struct priv *p = vo->priv;
     struct osd_buffer *osd_buf, *tmp;
     wl_list_for_each_safe(osd_buf, tmp, &p->osd_buffer_list, link) {


### PR DESCRIPTION
osd_surface is a sync sub-surface of video_surface meaning that a commit
of osd_surface will not take effect until the next commit of
video_surface.

Some compositors (wlroots) do not implement sync sub-surface correctly,
meaning that the difference cannot be observed there. But it can easily
be seen on Jay and GNOME:

1. Open an mpv window.
2. Pause the video.
3. Enter the surface with the mouse.

Expected behavior:

1. The OSD shows up immediately.

Actual behavior:

1. Nothing happens for a few seconds.
2. The OSD shows up and immediately fades out.

This is because the fade-out commits cause the initial osd_surface
commit to become effective.