### PR TITLE
Revert "stream_{bluray,cdda,dvdnav}: deprecate setting device after schema"

### DIFF
--- a/DOCS/interface-changes/optical-device.txt
+++ b/DOCS/interface-changes/optical-device.txt
@@ -1,1 +1,0 @@
-specifying an optical device after the schema for the `cdda://`, `dvd://` and `bd://` protocols is deprecated, use the appropriate option (`--cdda-device`) instead

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1304,7 +1304,7 @@ PROTOCOLS
 
     Play a path from  Samba share. (Requires FFmpeg support.)
 
-``bd://[title]`` ``--bluray-device=PATH``
+``bd://[title][/device]`` ``--bluray-device=PATH``
 
     Play a Blu-ray disc. Since libbluray 1.0.1, you can read from ISO files
     by passing them to ``--bluray-device``.
@@ -1316,7 +1316,7 @@ PROTOCOLS
 
     ``bluray://`` is an alias.
 
-``dvd://[title]`` ``--dvd-device=PATH``
+``dvd://[title][/device]`` ``--dvd-device=PATH``
 
     Play a DVD. DVD menus are not supported. If no title is given, the longest
     title is auto-selected. Without ``--dvd-device``, it will probably try
@@ -1344,7 +1344,7 @@ PROTOCOLS
     ``image-2.jpg`` and ``image-10.jpg``, provided that there are no big gaps
     between the files.
 
-``cdda://`` ``--cdda-device=PATH``
+``cdda://[device]`` ``--cdrom-device=PATH`` ``--cdda-...``
 
     Play CD. You can select a specific range of tracks to play by using the
     ``--start`` and ``--end`` options and specifying chapters. Navigating

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -414,8 +414,6 @@ static int bluray_stream_open_internal(stream_t *s)
     char *device = NULL;
     /* find the requested device */
     if (b->cfg_device && b->cfg_device[0]) {
-        MP_WARN(s, "Setting the device after the schema is deprecated. "
-                "Use --bluray-device instead.\n");
         device = b->cfg_device;
     } else if (b->opts->bluray_device && b->opts->bluray_device[0]) {
         device = b->opts->bluray_device;

--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -252,8 +252,6 @@ static int open_cdda(stream_t *st)
     int last_track;
 
     if (st->path[0]) {
-        MP_WARN(st, "Setting the device after the schema is deprecated. "
-                "Use --cdda-device instead.\n");
         p->device = talloc_strdup(priv, st->path);
     } else if (p->cdda_device && p->cdda_device[0]) {
         p->device = mp_get_user_path(priv, st->global, p->cdda_device);

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -582,15 +582,12 @@ static int open_s_internal(stream_t *stream)
 
     p->opts = mp_get_config_group(stream, stream->global, &dvd_conf);
 
-    if (p->device && p->device[0]) {
-        MP_WARN(stream, "Setting the device after the schema is deprecated. "
-                "Use --dvd-device instead.\n");
+    if (p->device && p->device[0])
         filename = p->device;
-    } else if (p->opts->device && p->opts->device[0]) {
+    else if (p->opts->device && p->opts->device[0])
         filename = p->opts->device;
-    } else {
+    else
         filename = DEFAULT_OPTICAL_DEVICE;
-    };
     if (!new_dvdnav_stream(stream, filename)) {
         MP_ERR(stream, "Couldn't open DVD device: %s\n",
                 filename);


### PR DESCRIPTION
This reverts part of PR #15899 (commit dd6e3a0ece22b351c8815cf57d18c2d90f1360ee).

"Why is this even useful?": It's very useful for multi-disc playlists. Compare:
`mpv bd:///DISC{1..4}`
`mpv -\{ bd:// --bluray-device=DISC1 -\} -\{ bd:// --bluray-device=DISC2 -\} -\{ bd:// --bluray-device=DISC3 -\} -\{ bd:// --bluray-device=DISC4 -\}`
