### PR TITLE
external swapchain simplifications and fixes

### DIFF
--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -62,6 +62,36 @@ struct ra_ctx_fns {
     void (*uninit)(struct ra_ctx *ctx);
 };
 
+// These are a set of helpers for ra_ctx providers based on ra_gl.
+// The init function also initializes ctx->ra and ctx->swapchain, so the user
+// doesn't have to do this manually. (Similarly, the uninit function will
+// clean them up)
+
+struct ra_ctx_params {
+    // For special contexts (i.e. wayland) that want to check visibility
+    // before drawing a frame.
+    bool (*check_visible)(struct ra_ctx *ctx);
+
+    // See ra_swapchain_fns.color_depth.
+    int (*color_depth)(struct ra_ctx *ctx);
+
+    // See ra_swapchain_fns.get_vsync.
+    void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
+
+    // Set to the platform-specific function to swap buffers, like
+    // glXSwapBuffers, eglSwapBuffers etc. This will be called by
+    // ra_gl_ctx_swap_buffers. Required unless you either never call that
+    // function or if you override it yourself.
+    void (*swap_buffers)(struct ra_ctx *ctx);
+
+    // If this is set to non-NULL, then the ra_gl_ctx will consider the GL
+    // implementation to be using an external swapchain, which disables the
+    // software simulation of --swapchain-depth. Any functions defined by this
+    // ra_swapchain_fns structs will entirely replace the equivalent ra_gl_ctx
+    // functions in the resulting ra_swapchain.
+    const struct ra_swapchain_fns *external_swapchain;
+};
+
 // Extra struct for the swapchain-related functions so they can be easily
 // inherited from helpers.
 struct ra_swapchain {

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -241,6 +241,10 @@ bool ra_gl_ctx_submit_frame(struct ra_swapchain *sw, const struct vo_frame *fram
     struct priv *p = sw->priv;
     GL *gl = p->gl;
 
+    // Dumb hack for drm_egl and vo_gpu_next.
+    if (vo_is_gpu_next(sw->ctx->vo))
+        return true;
+
     if (p->opts->use_glfinish)
         gl->Finish();
 

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -77,7 +77,7 @@ const struct m_sub_options opengl_conf = {
 struct priv {
     GL *gl;
     struct mp_log *log;
-    struct ra_gl_ctx_params params;
+    struct ra_ctx_params params;
     struct opengl_opts *opts;
     struct ra_swapchain_fns fns;
     GLuint main_fb;
@@ -125,7 +125,7 @@ void ra_gl_ctx_uninit(struct ra_ctx *ctx)
 
 static const struct ra_swapchain_fns ra_gl_swapchain_fns;
 
-bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_gl_ctx_params params)
+bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_ctx_params params)
 {
     struct ra_swapchain *sw = ctx->swapchain = talloc_ptrtype(NULL, sw);
     *sw = (struct ra_swapchain) {

--- a/video/out/opengl/context.h
+++ b/video/out/opengl/context.h
@@ -14,35 +14,8 @@ enum gles_mode {
 // Returns the gles mode based on the --opengl opts.
 enum gles_mode ra_gl_ctx_get_glesmode(struct ra_ctx *ctx);
 
-// These are a set of helpers for ra_ctx providers based on ra_gl.
-// The init function also initializes ctx->ra and ctx->swapchain, so the user
-// doesn't have to do this manually. (Similarly, the uninit function will
-// clean them up)
-
-struct ra_gl_ctx_params {
-    // For special contexts (i.e. wayland) that want to check visibility
-    // before drawing a frame.
-    bool (*check_visible)(struct ra_ctx *ctx);
-
-    // Set to the platform-specific function to swap buffers, like
-    // glXSwapBuffers, eglSwapBuffers etc. This will be called by
-    // ra_gl_ctx_swap_buffers. Required unless you either never call that
-    // function or if you override it yourself.
-    void (*swap_buffers)(struct ra_ctx *ctx);
-
-    // See ra_swapchain_fns.get_vsync.
-    void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
-
-    // If this is set to non-NULL, then the ra_gl_ctx will consider the GL
-    // implementation to be using an external swapchain, which disables the
-    // software simulation of --swapchain-depth. Any functions defined by this
-    // ra_swapchain_fns structs will entirely replace the equivalent ra_gl_ctx
-    // functions in the resulting ra_swapchain.
-    const struct ra_swapchain_fns *external_swapchain;
-};
-
 void ra_gl_ctx_uninit(struct ra_ctx *ctx);
-bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_gl_ctx_params params);
+bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_ctx_params params);
 
 // Call this any time the window size or main framebuffer changes
 void ra_gl_ctx_resize(struct ra_swapchain *sw, int w, int h, int fbo);

--- a/video/out/opengl/context_android.c
+++ b/video/out/opengl/context_android.c
@@ -90,7 +90,7 @@ static bool android_init(struct ra_ctx *ctx)
 
     mpegl_load_functions(&p->gl, ctx->log);
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .swap_buffers = android_swap_buffers,
     };
 

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -601,7 +601,7 @@ static bool angle_init(struct ra_ctx *ctx)
         .color_depth = angle_color_depth,
         .submit_frame = angle_submit_frame,
     };
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .swap_buffers = angle_swap_buffers,
         .external_swapchain = p->dxgi_swapchain ? &dxgi_swapchain_fns : NULL,
     };

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -511,31 +511,22 @@ static void egl_swap_buffers(struct ra_ctx *ctx)
 static void angle_swap_buffers(struct ra_ctx *ctx)
 {
     struct priv *p = ctx->priv;
-    if (p->dxgi_swapchain)
-        d3d11_swap_buffers(ctx);
-    else
-        egl_swap_buffers(ctx);
-}
-
-
-static int angle_color_depth(struct ra_swapchain *sw)
-{
-    // Only 8-bit output is supported at the moment
-    return 8;
-}
-
-static bool angle_submit_frame(struct ra_swapchain *sw,
-                               const struct vo_frame *frame)
-{
-    struct priv *p = sw->ctx->priv;
-    bool ret = ra_gl_ctx_submit_frame(sw, frame);
-    if (p->d3d11_context) {
+    if (p->dxgi_swapchain) {
         // DXGI Present doesn't flush the immediate context, which can make
         // timers inaccurate, since the end queries might not be sent until the
         // next frame. Fix this by flushing the context now.
         ID3D11DeviceContext_Flush(p->d3d11_context);
+        d3d11_swap_buffers(ctx);
+    } else {
+        egl_swap_buffers(ctx);
     }
-    return ret;
+}
+
+
+static int angle_color_depth(struct ra_ctx *ctx)
+{
+    // Only 8-bit output is supported at the moment
+    return 8;
 }
 
 static bool angle_init(struct ra_ctx *ctx)
@@ -596,14 +587,9 @@ static bool angle_init(struct ra_ctx *ctx)
     current_ctx = ctx;
     gl->SwapInterval = angle_swap_interval;
 
-    // Custom swapchain impl for the D3D11 swapchain-based surface
-    static const struct ra_swapchain_fns dxgi_swapchain_fns = {
-        .color_depth = angle_color_depth,
-        .submit_frame = angle_submit_frame,
-    };
     struct ra_ctx_params params = {
+        .color_depth = p->dxgi_swapchain ? angle_color_depth : NULL,
         .swap_buffers = angle_swap_buffers,
-        .external_swapchain = p->dxgi_swapchain ? &dxgi_swapchain_fns : NULL,
     };
 
     gl->flipped = p->flipped;

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -388,20 +388,6 @@ static void wait_fence(struct ra_ctx *ctx)
     }
 }
 
-static bool drm_egl_start_frame(struct ra_swapchain *sw, struct ra_fbo *out_fbo)
-{
-    struct ra_ctx *ctx = sw->ctx;
-    struct priv *p = ctx->priv;
-    struct vo_drm_state *drm = ctx->vo->drm;
-
-    if (!drm->atomic_context->request) {
-        drm->atomic_context->request = drmModeAtomicAlloc();
-        p->drm_params.atomic_request_ptr = &drm->atomic_context->request;
-    }
-
-    return ra_gl_ctx_start_frame(sw, out_fbo);
-}
-
 static bool drm_egl_submit_frame(struct ra_swapchain *sw, const struct vo_frame *frame)
 {
     struct ra_ctx *ctx = sw->ctx;
@@ -418,6 +404,11 @@ static void drm_egl_swap_buffers(struct ra_swapchain *sw)
     struct priv *p = ctx->priv;
     struct vo_drm_state *drm = ctx->vo->drm;
     const bool drain = drm->paused || drm->still;  // True when we need to drain the swapchain
+
+    if (!drm->atomic_context->request) {
+        drm->atomic_context->request = drmModeAtomicAlloc();
+        p->drm_params.atomic_request_ptr = &drm->atomic_context->request;
+    }
 
     if (!drm->active)
         return;
@@ -452,7 +443,6 @@ static void drm_egl_swap_buffers(struct ra_swapchain *sw)
 }
 
 static const struct ra_swapchain_fns drm_egl_swapchain = {
-    .start_frame   = drm_egl_start_frame,
     .submit_frame  = drm_egl_submit_frame,
     .swap_buffers  = drm_egl_swap_buffers,
 };

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -682,7 +682,7 @@ static bool drm_egl_init(struct ra_ctx *ctx)
         MP_VERBOSE(ctx, "Could not find path to render node.\n");
     }
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .external_swapchain = &drm_egl_swapchain,
         .get_vsync          = &drm_egl_get_vsync,
     };

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -548,7 +548,7 @@ static bool dxgl_init(struct ra_ctx *ctx)
         goto fail;
 
     static const struct ra_swapchain_fns empty_swapchain_fns = {0};
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .swap_buffers = dxgl_swap_buffers,
         .external_swapchain = &empty_swapchain_fns,
     };

--- a/video/out/opengl/context_dxinterop.c
+++ b/video/out/opengl/context_dxinterop.c
@@ -547,10 +547,8 @@ static bool dxgl_init(struct ra_ctx *ctx)
     if (d3d_size_dependent_create(ctx) < 0)
         goto fail;
 
-    static const struct ra_swapchain_fns empty_swapchain_fns = {0};
     struct ra_ctx_params params = {
         .swap_buffers = dxgl_swap_buffers,
-        .external_swapchain = &empty_swapchain_fns,
     };
 
     gl->flipped = true;

--- a/video/out/opengl/context_glx.c
+++ b/video/out/opengl/context_glx.c
@@ -290,7 +290,7 @@ static bool glx_init(struct ra_ctx *ctx)
     if (!success)
         goto uninit;
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .check_visible = glx_check_visible,
         .swap_buffers = glx_swap_buffers,
         .get_vsync    = glx_get_vsync,

--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -104,7 +104,7 @@ static bool egl_create_context(struct ra_ctx *ctx)
 
     mpegl_load_functions(&p->gl, wl->log);
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .check_visible      = wayland_egl_check_visible,
         .swap_buffers       = wayland_egl_swap_buffers,
         .get_vsync          = wayland_egl_get_vsync,

--- a/video/out/opengl/context_win.c
+++ b/video/out/opengl/context_win.c
@@ -312,7 +312,7 @@ static bool wgl_init(struct ra_ctx *ctx)
     gl->SwapInterval = wgl_swap_interval;
     p->current_swapinterval = -1;
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .swap_buffers = wgl_swap_buffers,
     };
 

--- a/video/out/opengl/context_x11egl.c
+++ b/video/out/opengl/context_x11egl.c
@@ -163,7 +163,7 @@ static bool mpegl_init(struct ra_ctx *ctx)
 
     mpegl_load_functions(&p->gl, ctx->log);
 
-    struct ra_gl_ctx_params params = {
+    struct ra_ctx_params params = {
         .check_visible = mpegl_check_visible,
         .swap_buffers = mpegl_swap_buffers,
         .get_vsync    = mpegl_get_vsync,

--- a/video/out/opengl/libmpv_gl.c
+++ b/video/out/opengl/libmpv_gl.c
@@ -40,7 +40,7 @@ static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
     };
 
     static const struct ra_swapchain_fns empty_swapchain_fns = {0};
-    struct ra_gl_ctx_params gl_params = {
+    struct ra_ctx_params gl_params = {
         // vo_libmpv is essentially like a gigantic external swapchain where
         // the user is in charge of presentation / swapping etc. But we don't
         // actually need to provide any of these functions, since we can just

--- a/video/out/opengl/libmpv_gl.c
+++ b/video/out/opengl/libmpv_gl.c
@@ -39,17 +39,13 @@ static int init(struct libmpv_gpu_context *ctx, mpv_render_param *params)
         .allow_sw = true,
     };
 
-    static const struct ra_swapchain_fns empty_swapchain_fns = {0};
-    struct ra_ctx_params gl_params = {
-        // vo_libmpv is essentially like a gigantic external swapchain where
-        // the user is in charge of presentation / swapping etc. But we don't
-        // actually need to provide any of these functions, since we can just
-        // not call them to begin with - so just set it to an empty object to
-        // signal to ra_gl_p that we don't care about its latency emulation
-        // functionality
-        .external_swapchain = &empty_swapchain_fns
-    };
-
+    // vo_libmpv is essentially like a gigantic external swapchain where
+    // the user is in charge of presentation / swapping etc. But we don't
+    // actually need to provide any of these functions, since we can just
+    // not call them to begin with - so just set it to an empty object to
+    // signal to ra_gl_p that we don't care about its latency emulation
+    // functionality
+    struct ra_ctx_params gl_params = {0};
     p->gl->SwapInterval = NULL; // we shouldn't randomly change this, so lock it
     if (!ra_gl_ctx_init(p->ra_ctx, p->gl, gl_params))
         return MPV_ERROR_UNSUPPORTED;

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -860,6 +860,12 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts)
     return r;
 }
 
+// Needed by egl_drm
+bool vo_is_gpu_next(struct vo *vo)
+{
+    return vo && vo->driver && vo->driver == &video_out_gpu_next;
+}
+
 // Check if the VO reports that the mpv window is visible.
 bool vo_is_visible(struct vo *vo)
 {

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -532,6 +532,7 @@ int vo_reconfig2(struct vo *vo, struct mp_image *img);
 
 int vo_control(struct vo *vo, int request, void *data);
 void vo_control_async(struct vo *vo, int request, void *data);
+bool vo_is_gpu_next(struct vo *vo);
 bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts);
 bool vo_is_visible(struct vo *vo);
 void vo_queue_frame(struct vo *vo, struct vo_frame *frame);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1170,6 +1170,7 @@ done:
     if (!valid) // clear with purple to indicate error
         pl_tex_clear(gpu, swframe.fbo, (float[4]){ 0.5, 0.0, 1.0, 1.0 });
 
+    sw->fns->submit_frame(sw, frame); // for drm_egl
     pl_gpu_flush(gpu);
     p->frame_pending = true;
     return VO_TRUE;

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -134,7 +134,7 @@ const struct m_sub_options vulkan_conf = {
 struct priv {
     struct mpvk_ctx *vk;
     struct vulkan_opts *opts;
-    struct ra_vk_ctx_params params;
+    struct ra_ctx_params params;
     struct ra_tex proxy_tex;
 };
 
@@ -249,7 +249,7 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
 }
 
 bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
-                    struct ra_vk_ctx_params params,
+                    struct ra_ctx_params params,
                     VkPresentModeKHR preferred_mode)
 {
     struct ra_swapchain *sw = ctx->swapchain = talloc_zero(NULL, struct ra_swapchain);

--- a/video/out/vulkan/context.h
+++ b/video/out/vulkan/context.h
@@ -3,25 +3,10 @@
 #include "video/out/gpu/context.h"
 #include "common.h"
 
-struct ra_vk_ctx_params {
-    // See ra_swapchain_fns.get_vsync.
-    void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
-
-    // For special contexts (i.e. wayland) that want to check visibility
-    // before drawing a frame.
-    bool (*check_visible)(struct ra_ctx *ctx);
-
-    // In case something special needs to be done on the buffer swap.
-    void (*swap_buffers)(struct ra_ctx *ctx);
-
-    // See ra_swapchain_fns.color_depth.
-    int (*color_depth)(struct ra_ctx *ctx);
-};
-
 // Helpers for ra_ctx based on ra_vk. These initialize ctx->ra and ctx->swchain.
 void ra_vk_ctx_uninit(struct ra_ctx *ctx);
 bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
-                    struct ra_vk_ctx_params params,
+                    struct ra_ctx_params params,
                     VkPresentModeKHR preferred_mode);
 
 // Helper for initializing mpvk_ctx->vulkan

--- a/video/out/vulkan/context_android.c
+++ b/video/out/vulkan/context_android.c
@@ -53,7 +53,7 @@ static bool android_init(struct ra_ctx *ctx)
          .window = vo_android_native_window(ctx->vo)
     };
 
-    struct ra_vk_ctx_params params = {0};
+    struct ra_ctx_params params = {0};
 
     VkInstance inst = vk->vkinst->instance;
     VkResult res = vkCreateAndroidSurfaceKHR(inst, &info, NULL, &vk->surface);

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -441,7 +441,7 @@ static bool display_init(struct ra_ctx *ctx)
     p->height = mode->parameters.visibleRegion.height;
     p->refresh_rate = mode->parameters.refreshRate;
 
-    struct ra_vk_ctx_params params = {0};
+    struct ra_ctx_params params = {0};
     if (!ra_vk_ctx_init(ctx, vk, params, VK_PRESENT_MODE_FIFO_KHR))
         goto error;
 

--- a/video/out/vulkan/context_mac.m
+++ b/video/out/vulkan/context_mac.m
@@ -80,7 +80,7 @@ static bool mac_vk_init(struct ra_ctx *ctx)
         .pLayer = p->vo_mac.layer,
     };
 
-    struct ra_vk_ctx_params params = {
+    struct ra_ctx_params params = {
         .swap_buffers = mac_vk_swap_buffers,
         .get_vsync = mac_vk_get_vsync,
         .color_depth = mac_vk_color_depth,

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -79,7 +79,7 @@ static bool wayland_vk_init(struct ra_ctx *ctx)
          .surface = ctx->vo->wl->surface,
     };
 
-    struct ra_vk_ctx_params params = {
+    struct ra_ctx_params params = {
         .check_visible = wayland_vk_check_visible,
         .swap_buffers = wayland_vk_swap_buffers,
         .get_vsync = wayland_vk_get_vsync,

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -59,7 +59,7 @@ static bool win_init(struct ra_ctx *ctx)
          .hwnd = vo_w32_hwnd(ctx->vo),
     };
 
-    struct ra_vk_ctx_params params = {0};
+    struct ra_ctx_params params = {0};
 
     VkInstance inst = vk->vkinst->instance;
     VkResult res = vkCreateWin32SurfaceKHR(inst, &wininfo, NULL, &vk->surface);

--- a/video/out/vulkan/context_xlib.c
+++ b/video/out/vulkan/context_xlib.c
@@ -75,7 +75,7 @@ static bool xlib_init(struct ra_ctx *ctx)
          .window = ctx->vo->x11->window,
     };
 
-    struct ra_vk_ctx_params params = {
+    struct ra_ctx_params params = {
         .check_visible = xlib_check_visible,
         .swap_buffers = xlib_vk_swap_buffers,
         .get_vsync = xlib_vk_get_vsync,


### PR DESCRIPTION
This fixes the delayed osd rendering thing on `vo_gpu_next` and `drm_egl`. One thing is that I really dislike this weird external swapchain API we have (only opengl even has code to deal with it), and I kind of want to remove it, but `drm_egl` is the sole legitimate user of it. I'm not entirely sure if the custom fencing stuff it has is really needed today. Maybe I might follow up on that later, but this would be a quick fix to the actual bug.