### PR TITLE
console.lua: increase the opacity of the default item background

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -790,7 +790,7 @@ local function render()
             ass:append('{\\blur0\\bord0\\4aH&ff&\\1c&H' ..
                        option_color_to_ass(opts.selected_back_color) .. '&}')
             if first_match_to_print - 1 + i ~= selected_match then
-                ass:append('{\\1aH&dd&}')
+                ass:append('{\\1aH&cc&}')
             end
             ass:draw_start()
             ass:rect_cw(-opts.padding, 0, max_item_width + opts.padding, line_height)


### PR DESCRIPTION
This needs to strike a fine balance between being visible and having contrast with the text color and not taking attention away from the selected item. Make it slightly more opaque to differentiate it more easily.

Fixes https://github.com/mpv-player/mpv/pull/15711#issuecomment-2676015561

![screenshot](https://github.com/user-attachments/assets/a6771c54-5c42-4ad8-a1e2-66c42876164c)