### PR TITLE
select.lua: fix LSP warning

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -248,7 +248,7 @@ mp.add_key_binding(nil, "select-edition", function ()
     local editions = {}
 
     for i, edition in ipairs(edition_list) do
-        editions[i] = edition.title or "Edition " .. (edition.id + 1)
+        editions[i] = edition.title or ("Edition " .. edition.id + 1)
     end
 
     input.select({


### PR DESCRIPTION
I don't know why I didn't get it before but Lua's LSP now complains with

Compute `"Edition " .. (edition.id + 1)` first. You may need to add brackets. [ambiguity-1].

Just move the parenthesis to make it happy.