### PR TITLE
options/m_config_frontend: don't allow recursive profile inclusion

### DIFF
--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -986,8 +986,14 @@ static struct m_profile *find_check_profile(struct m_config *config, char *name)
         MP_WARN(config, "Unknown profile '%s'.\n", name);
         return NULL;
     }
-    if (config->profile_depth > MAX_PROFILE_DEPTH) {
-        MP_WARN(config, "WARNING: Profile inclusion too deep.\n");
+    for (size_t i = 0; i < config->profile_stack_depth; ++i) {
+        if (strcmp(config->profile_stack[i], name))
+            continue;
+        MP_WARN(config, "Profile '%s' has already been applied.\n", name);
+        return NULL;
+    }
+    if (config->profile_stack_depth > MAX_PROFILE_DEPTH) {
+        MP_WARN(config, "Profile inclusion too deep.\n");
         return NULL;
     }
     return p;
@@ -995,11 +1001,6 @@ static struct m_profile *find_check_profile(struct m_config *config, char *name)
 
 int m_config_set_profile(struct m_config *config, char *name, int flags)
 {
-    if ((flags & M_SETOPT_FROM_CONFIG_FILE) && !strcmp(name, "default")) {
-        MP_WARN(config, "Ignoring profile=%s from config file.\n", name);
-        return 0;
-    }
-
     MP_VERBOSE(config, "Applying profile '%s'...\n", name);
     struct m_profile *p = find_check_profile(config, name);
     if (!p)
@@ -1010,14 +1011,18 @@ int m_config_set_profile(struct m_config *config, char *name, int flags)
         config->profile_backup_flags = p->restore_mode == 2 ? BACKUP_NVAL : 0;
     }
 
-    config->profile_depth++;
+    char *profile_name = talloc_strdup(NULL, name);
+    // Note that we don't check if profile applied correctly, it doesn't matter.
+    MP_TARRAY_APPEND(config, config->profile_stack, config->profile_stack_depth, profile_name);
+    talloc_steal(config->profile_stack, profile_name);
     for (int i = 0; i < p->num_opts; i++) {
         m_config_set_option_cli(config,
                                 bstr0(p->opts[2 * i]),
                                 bstr0(p->opts[2 * i + 1]),
                                 flags | M_SETOPT_FROM_CONFIG_FILE);
     }
-    config->profile_depth--;
+    if (MP_TARRAY_POP(config->profile_stack, config->profile_stack_depth, &profile_name))
+        talloc_free(profile_name);
 
     if (config->profile_backup_tmp == &p->backups) {
         config->profile_backup_tmp = NULL;

--- a/options/m_config_frontend.h
+++ b/options/m_config_frontend.h
@@ -69,6 +69,8 @@ typedef struct m_config {
     struct m_profile *profiles;
     // Depth when recursively including profiles.
     int profile_depth;
+    char **profile_stack;
+    size_t profile_stack_depth;
     // Temporary during profile application.
     struct m_opt_backup **profile_backup_tmp;
     int profile_backup_flags;


### PR DESCRIPTION
It is easy to craft a config file that loads a profile recursively. To prevent this, not only check the depth of the current inclusion but also ignore already-seen profile names.