### PR TITLE
drm: use VOCTRL_REDRAW when flipping buffers

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -1046,10 +1046,9 @@ int vo_drm_control(struct vo *vo, int *events, int request, void *arg)
     }
     case VOCTRL_PAUSE:
         vo->want_redraw = true;
-        drm->paused = true;
         return VO_TRUE;
-    case VOCTRL_RESUME:
-        drm->paused = false;
+    case VOCTRL_REDRAW:
+        drm->redraw = true;
         return VO_TRUE;
     }
     return VO_NOTIMPL;

--- a/video/out/drm_common.h
+++ b/video/out/drm_common.h
@@ -141,8 +141,7 @@ struct vo_drm_state {
     bool supported_colorspace;
 
     bool active;
-    bool paused;
-    bool still;
+    bool redraw;
     bool vt_switcher_active;
     bool waiting_for_flip;
 

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -241,10 +241,6 @@ bool ra_gl_ctx_submit_frame(struct ra_swapchain *sw, const struct vo_frame *fram
     struct priv *p = sw->priv;
     GL *gl = p->gl;
 
-    // Dumb hack for drm_egl and vo_gpu_next.
-    if (vo_is_gpu_next(sw->ctx->vo))
-        return true;
-
     if (p->opts->use_glfinish)
         gl->Finish();
 

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -860,12 +860,6 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts)
     return r;
 }
 
-// Needed by egl_drm
-bool vo_is_gpu_next(struct vo *vo)
-{
-    return vo && vo->driver && vo->driver == &video_out_gpu_next;
-}
-
 // Check if the VO reports that the mpv window is visible.
 bool vo_is_visible(struct vo *vo)
 {

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1104,6 +1104,7 @@ static void do_redraw(struct vo *vo)
     mp_mutex_unlock(&in->lock);
 
     vo->driver->draw_frame(vo, frame);
+    vo->driver->control(vo, VOCTRL_REDRAW, NULL);
     vo->driver->flip_page(vo);
 
     if (frame != &dummy && !vo->driver->frame_owner)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -66,6 +66,8 @@ enum mp_voctrl {
     VOCTRL_PAUSE,
     /* start/resume playback */
     VOCTRL_RESUME,
+    /* signal a redraw occurred */
+    VOCTRL_REDRAW,
 
     VOCTRL_SET_PANSCAN,
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -534,7 +534,6 @@ int vo_reconfig2(struct vo *vo, struct mp_image *img);
 
 int vo_control(struct vo *vo, int request, void *data);
 void vo_control_async(struct vo *vo, int request, void *data);
-bool vo_is_gpu_next(struct vo *vo);
 bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts);
 bool vo_is_visible(struct vo *vo);
 void vo_queue_frame(struct vo *vo, struct vo_frame *frame);

--- a/video/out/vo_drm.c
+++ b/video/out/vo_drm.c
@@ -308,8 +308,6 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
     if (!drm->active)
         goto done;
 
-    drm->still = frame->still;
-
     // we redraw the entire image when OSD needs to be redrawn
     struct framebuffer *fb =  p->bufs[p->front_buf];
     const bool repeat = frame->repeat && !frame->redraw;
@@ -341,12 +339,11 @@ static void flip_page(struct vo *vo)
 {
     struct priv *p = vo->priv;
     struct vo_drm_state *drm = vo->drm;
-    const bool drain = drm->paused || drm->still;
 
     if (!drm->active)
         return;
 
-    while (drain || p->fb_queue_len > vo->opts->swapchain_depth) {
+    while (drm->redraw || p->fb_queue_len > vo->opts->swapchain_depth) {
         if (drm->waiting_for_flip) {
             vo_drm_wait_on_flip(vo->drm);
             swapchain_step(vo);
@@ -360,6 +357,7 @@ static void flip_page(struct vo *vo)
         }
         queue_flip(vo, p->fb_queue[1]);
     }
+    drm->redraw = false;
 }
 
 static void get_vsync(struct vo *vo, struct vo_vsync_info *info)

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1170,7 +1170,6 @@ done:
     if (!valid) // clear with purple to indicate error
         pl_tex_clear(gpu, swframe.fbo, (float[4]){ 0.5, 0.0, 1.0, 1.0 });
 
-    sw->fns->submit_frame(sw, frame); // for drm_egl
     pl_gpu_flush(gpu);
     p->frame_pending = true;
     return VO_TRUE;


### PR DESCRIPTION
I changed my mind. These are the first two commits from #15948 extracted to here since it's just a plain better solution and fixes 0959cdeb038de6484f75eada21f674bcc2407b89