### PR TITLE
stats.lua: use fixed naming for single invocation key bindings

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1734,7 +1734,7 @@ for k, _ in pairs(pages) do
     mp.add_key_binding(nil, "display-page-" .. k .. "-toggle", function()
         curr_page = k
         process_key_binding(false)
-    end, {repeatable=true})
+    end, {repeatable=false})
 end
 
 -- Reprint stats immediately when VO was reconfigured, only when toggled

--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1431,12 +1431,12 @@ cache_recorder_timer:kill()
 -- Current page and <page key>:<page function> mapping
 curr_page = o.key_page_1
 pages = {
-    [o.key_page_1] = { f = default_stats, desc = "Default" },
-    [o.key_page_2] = { f = vo_stats, desc = "Extended Frame Timings", scroll = true },
-    [o.key_page_3] = { f = cache_stats, desc = "Cache Statistics" },
-    [o.key_page_4] = { f = keybinding_info, desc = "Active Key Bindings", scroll = true },
-    [o.key_page_5] = { f = track_info, desc = "Selected Tracks Info", scroll = true },
-    [o.key_page_0] = { f = perf_stats, desc = "Internal Performance Info", scroll = true },
+    [o.key_page_1] = { idx = 1, f = default_stats, desc = "Default" },
+    [o.key_page_2] = { idx = 2, f = vo_stats, desc = "Extended Frame Timings", scroll = true },
+    [o.key_page_3] = { idx = 3, f = cache_stats, desc = "Cache Statistics" },
+    [o.key_page_4] = { idx = 4, f = keybinding_info, desc = "Active Key Bindings", scroll = true },
+    [o.key_page_5] = { idx = 5, f = track_info, desc = "Selected Tracks Info", scroll = true },
+    [o.key_page_0] = { idx = 0, f = perf_stats, desc = "Internal Performance Info", scroll = true },
 }
 
 
@@ -1721,17 +1721,17 @@ mp.add_key_binding(nil, "display-stats", function() process_key_binding(true) en
 mp.add_key_binding(nil, "display-stats-toggle", function() process_key_binding(false) end,
     {repeatable=false})
 
-for k, _ in pairs(pages) do
+for k, page in pairs(pages) do
     -- Single invocation key bindings for specific pages, e.g.:
     -- "e script-binding stats/display-page-2"
-    mp.add_key_binding(nil, "display-page-" .. k, function()
+    mp.add_key_binding(nil, "display-page-" .. page.idx, function()
         curr_page = k
         process_key_binding(true)
     end, {repeatable=true})
 
     -- Key bindings to toggle a specific page, e.g.:
     -- "h script-binding stats/display-page-4-toggle".
-    mp.add_key_binding(nil, "display-page-" .. k .. "-toggle", function()
+    mp.add_key_binding(nil, "display-page-" .. page.idx .. "-toggle", function()
         curr_page = k
         process_key_binding(false)
     end, {repeatable=false})


### PR DESCRIPTION
The names of single invocation key bindings for specific pages will be changed if defines user key bindings, then original invocation fails.

e.g. : when user defines `key_page_4=F4`, then key binding name
`stats/display-page-4-toggle`
becomes
`stats/display-page-F4-toggle`,
and OSC menu `Help` fails.

---

This patch fixed the issue, tested in f9271fb build, with following configs.
```ini
; mpv.conf
[default]
load-stats-overlay=no  ; disable the built-in script to use a patched user script
```

```ini
; script-opts/osc.conf
key_page_4=F4
```

A patched scripts/stats.lua file.