### PR TITLE
Revert "input.conf: bind MBTN_MID to align-to-cursor"

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -383,9 +383,6 @@ Left double click
 Right click
     Toggle pause on/off.
 
-Middle click
-    Pan through the whole video while holding the button.
-
 Forward/Back button
     Skip to next/previous entry in playlist.
 

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -31,7 +31,6 @@
 #MBTN_LEFT     ignore              # don't do anything
 #MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
 #MBTN_RIGHT    cycle pause         # toggle pause/playback mode
-#MBTN_MID      script-binding positioning/align-to-cursor # pan the whole video
 #MBTN_BACK     playlist-prev       # skip to the previous file
 #MBTN_FORWARD  playlist-next       # skip to the next file
 #Ctrl+MBTN_LEFT script-binding positioning/drag-to-pan # pan around the clicked point


### PR DESCRIPTION
For symmetry with drag-to-pan. Use MBTN_MID to reset the video position.