### PR TITLE
vo: signal VOCTRL_REDRAW in a less sensitive spot

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1098,7 +1098,6 @@ static void do_redraw(struct vo *vo)
     mp_mutex_unlock(&in->lock);
 
     vo->driver->draw_frame(vo, frame);
-    vo->driver->control(vo, VOCTRL_REDRAW, NULL);
     vo->driver->flip_page(vo);
 
     if (frame != &dummy && !vo->driver->frame_owner)
@@ -1180,6 +1179,7 @@ static MP_THREAD_VOID vo_thread(void *ptr)
         if (send_pause)
             vo->driver->control(vo, vo_paused ? VOCTRL_PAUSE : VOCTRL_RESUME, NULL);
         if (wait_until > now && redraw) {
+            vo->driver->control(vo, VOCTRL_REDRAW, NULL);
             do_redraw(vo); // now is a good time
             continue;
         }


### PR DESCRIPTION
Windows works totally differently than the other backends and is sensitive to synchronization issues since it runs its control on a separate thread. The spot where this was originally placed was a perfect storm of causing resize weirdness because it was before the flip and right after the redraw. Ideally, this is known to the windowing backend before the flip actually happens so just move this out to before the do_redraw call. It makes no practical difference for the one user of this and sidesteps the implementation differences that exist on Windows. Fixes fc9d1ca182125efa4f16bf3ed0fec8357806b3a7.