### PR TITLE
input: add quiet arg to mp_input_set_mouse_pos for wayland

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -887,7 +887,7 @@ bool mp_input_vo_keyboard_enabled(struct input_ctx *ictx)
     return r;
 }
 
-static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
+static void set_mouse_pos(struct input_ctx *ictx, int x, int y, bool quiet)
 {
     MP_TRACE(ictx, "mouse move %d/%d\n", x, y);
 
@@ -909,7 +909,8 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
         MP_TRACE(ictx, "-> %d/%d\n", x, y);
     }
 
-    ictx->mouse_event_counter++;
+    if (!quiet)
+        ictx->mouse_event_counter++;
     ictx->mouse_vo_x = x;
     ictx->mouse_vo_y = y;
 
@@ -955,15 +956,15 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y)
 void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y)
 {
     input_lock(ictx);
-    set_mouse_pos(ictx, x, y);
+    set_mouse_pos(ictx, x, y, false);
     input_unlock(ictx);
 }
 
-void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y)
+void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y, bool quiet)
 {
     input_lock(ictx);
     if (ictx->opts->enable_mouse_movements)
-        set_mouse_pos(ictx, x, y);
+        set_mouse_pos(ictx, x, y, quiet);
     input_unlock(ictx);
 }
 
@@ -993,7 +994,7 @@ static void update_touch_point(struct input_ctx *ictx, int idx, int id, int x, i
     ictx->touch_points[idx].y = y;
     // Emulate mouse input from the primary touch point (the first one added)
     if (ictx->opts->touch_emulate_mouse && idx == 0)
-        set_mouse_pos(ictx, x, y);
+        set_mouse_pos(ictx, x, y, false);
     notify_touch_update(ictx);
 }
 
@@ -1012,7 +1013,7 @@ void mp_input_add_touch_point(struct input_ctx *ictx, int id, int x, int y)
                          (struct touch_point){id, x, y});
         // Emulate MBTN_LEFT down if this is the only touch point
         if (ictx->opts->touch_emulate_mouse && ictx->num_touch_points == 1) {
-            set_mouse_pos(ictx, x, y);
+            set_mouse_pos(ictx, x, y, false);
             feed_key(ictx, MP_MBTN_LEFT | MP_KEY_STATE_DOWN, 1, false);
         }
         notify_touch_update(ictx);

--- a/input/input.h
+++ b/input/input.h
@@ -95,7 +95,7 @@ void mp_input_put_key_utf8(struct input_ctx *ictx, int mods, struct bstr t);
 void mp_input_put_wheel(struct input_ctx *ictx, int direction, double value);
 
 // Update mouse position (in window coordinates).
-void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y);
+void mp_input_set_mouse_pos(struct input_ctx *ictx, int x, int y, bool quiet);
 
 // Like mp_input_set_mouse_pos(), but ignore mouse disable option.
 void mp_input_set_mouse_pos_artificial(struct input_ctx *ictx, int x, int y);

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -171,7 +171,7 @@ class InputHelper: NSObject {
         if !mouseEnabled() { return }
         lock.withLock {
             guard let input = input else { return }
-            mp_input_set_mouse_pos(input, Int32(position.x), Int32(position.y))
+            mp_input_set_mouse_pos(input, Int32(position.x), Int32(position.y), false)
         }
     }
 

--- a/osdep/terminal-unix.c
+++ b/osdep/terminal-unix.c
@@ -306,7 +306,7 @@ static void process_input(struct input_ctx *input_ctx, bool timeout)
             terminal_get_size2(&num_rows, &num_cols, &total_px_width, &total_px_height);
             mp_input_set_mouse_pos(input_ctx,
                 (buf.b[4] - 32.5) * (total_px_width / num_cols),
-                (buf.b[5] - 32.5) * (total_px_height / num_rows));
+                (buf.b[5] - 32.5) * (total_px_height / num_rows), false);
         }
         if (match->type != ENTRY_TYPE_MOUSE_MOVE)
             mp_input_put_key(input_ctx, buf.mods | match->mpkey);

--- a/osdep/terminal-win.c
+++ b/osdep/terminal-win.c
@@ -198,7 +198,7 @@ static void read_input(HANDLE in)
                 int w = 0, h = 0;
                 if (get_font_size(&w, &h)) {
                     mp_input_set_mouse_pos(input_ctx, w * (record->dwMousePosition.X + 0.5),
-                                                      h * (record->dwMousePosition.Y + 0.5));
+                                                      h * (record->dwMousePosition.Y + 0.5), false);
                 }
                 break;
             }

--- a/video/out/vo_caca.c
+++ b/video/out/vo_caca.c
@@ -185,7 +185,7 @@ static void check_events(struct vo *vo)
             mp_input_put_key(vo->input_ctx, MP_KEY_CLOSE_WIN);
             break;
         case CACA_EVENT_MOUSE_MOTION:
-            mp_input_set_mouse_pos(vo->input_ctx, cev.data.mouse.x, cev.data.mouse.y);
+            mp_input_set_mouse_pos(vo->input_ctx, cev.data.mouse.x, cev.data.mouse.y, false);
             break;
         case CACA_EVENT_MOUSE_PRESS:
             mp_input_put_key(vo->input_ctx,

--- a/video/out/vo_sdl.c
+++ b/video/out/vo_sdl.c
@@ -608,7 +608,7 @@ static void wait_events(struct vo *vo, int64_t until_time_ns)
             break;
         }
         case SDL_MOUSEMOTION:
-            mp_input_set_mouse_pos(vo->input_ctx, ev.motion.x, ev.motion.y);
+            mp_input_set_mouse_pos(vo->input_ctx, ev.motion.x, ev.motion.y, false);
             break;
         case SDL_MOUSEBUTTONDOWN: {
             int i;

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1668,7 +1668,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             w32->mouse_x = x;
             w32->mouse_y = y;
             if (!should_ignore_mouse_event(w32))
-                mp_input_set_mouse_pos(w32->input_ctx, x, y);
+                mp_input_set_mouse_pos(w32->input_ctx, x, y, false);
         }
         break;
     }

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -288,8 +288,8 @@ static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
     wl->mouse_x = handle_round(wl->scaling, wl_fixed_to_int(sx));
     wl->mouse_y = handle_round(wl->scaling, wl_fixed_to_int(sy));
 
-    if (!wl->toplevel_configured)
-        mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y,
+                           wl->toplevel_configured);
     wl->toplevel_configured = false;
 }
 
@@ -310,8 +310,8 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
     wl->mouse_x = handle_round(wl->scaling, wl_fixed_to_int(sx));
     wl->mouse_y = handle_round(wl->scaling, wl_fixed_to_int(sy));
 
-    if (!wl->toplevel_configured)
-        mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y);
+    mp_input_set_mouse_pos(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y,
+                           wl->toplevel_configured);
     wl->toplevel_configured = false;
 }
 

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1311,7 +1311,7 @@ void vo_x11_check_events(struct vo *vo)
             break;
         case MotionNotify:
             mp_input_set_mouse_pos(x11->input_ctx, Event.xmotion.x,
-                                                   Event.xmotion.y);
+                                                   Event.xmotion.y, false);
             break;
         case LeaveNotify:
             if (Event.xcrossing.mode != NotifyNormal)


### PR DESCRIPTION
Setting the mouse position always updates the cursor visibility state in the core, but that's not always desired by the caller. Make it optional. In practice, this is for wayland. Fixes #15967.