### PR TITLE
options/m_option: fix REL_TIME_CHAPTER printing

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2276,6 +2276,14 @@ Property list
 
 ``chapter`` (RW)
     Current chapter number. The number of the first chapter is 0.
+    A value of -1 indicates that the current playback position is before the
+    start of the first chapter,
+
+    Setting this property results in an absolute seek to the start of the
+    chapter. However, if the property is changed with ``add`` or ``cycle``
+    command which results in a decrement in value, it may go to the start of
+    the current chapter instead of the previous chapter.
+    See ``--chapter-seek-threshold`` for details.
 
 ``edition`` (RW)
     Current edition number. Setting this property to a different value will

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -419,6 +419,10 @@ Property Manipulation
     Add the given value to the property or option. On overflow or underflow,
     clamp the property to the maximum. If ``<value>`` is omitted, assume ``1``.
 
+    Whether or not key-repeat is enabled by default depends on the property.
+    Currently properties with continuous values are repeatable by default (like
+    ``volume``), while discrete values are not (like ``osd-level``).
+
     This is a scalable command. See the documentation of ``nonscalable`` input
     command prefix in `Input Command Prefixes`_ for details.
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2906,7 +2906,7 @@ static char *print_rel_time(const m_option_t *opt, const void *val)
     case REL_TIME_RELATIVE:
         return talloc_asprintf(NULL, "%+g", t->pos);
     case REL_TIME_CHAPTER:
-        return talloc_asprintf(NULL, "#%g", t->pos);
+        return talloc_asprintf(NULL, "#%g", t->pos + 1);
     case REL_TIME_PERCENT:
         return talloc_asprintf(NULL, "%g%%", t->pos);
     }


### PR DESCRIPTION
Also adds missing details of the `chapter` property. 
