### PR TITLE
osdep/subprocess-win: fix inheritance of NUL handles in child processes

### DIFF
--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -350,6 +350,7 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
                                             FILE_SHARE_READ | FILE_SHARE_WRITE,
                                             &sa, OPEN_EXISTING, 0, NULL);
             fd_data[n].handle_close = true;
+            share_hndls[share_hndl_count++] = fd_data[n].handle;
         }
 
         switch (opts->fds[n].fd) {


### PR DESCRIPTION
When a stream is not set to passthrough and there is no data to read or write, a handle to the NUL file is created. However, these handles were not included in the list of inheritable handles for the child process. This commit ensures they are properly inherited.

Fixes: 83fec9bafb13d4b506c41c0a4394ce6869f5b4f3
Fixes: #15982