### PR TITLE
threads: remove unused recursive mutex support

### DIFF
--- a/osdep/threads-posix.h
+++ b/osdep/threads-posix.h
@@ -106,22 +106,13 @@ typedef pthread_t       mp_thread;
 #define MP_STATIC_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 #define MP_STATIC_ONCE_INITIALIZER PTHREAD_ONCE_INIT
 
-static inline int mp_mutex_init_type_internal(mp_mutex *mutex, enum mp_mutex_type mtype)
+static inline int mp_mutex_init(mp_mutex *mutex)
 {
-    int mutex_type;
-    switch (mtype) {
-    case MP_MUTEX_RECURSIVE:
-        mutex_type = PTHREAD_MUTEX_RECURSIVE;
-        break;
-    case MP_MUTEX_NORMAL:
-    default:
 #ifndef NDEBUG
-        mutex_type = PTHREAD_MUTEX_ERRORCHECK;
+    int mutex_type = PTHREAD_MUTEX_ERRORCHECK;
 #else
-        mutex_type = PTHREAD_MUTEX_DEFAULT;
+    int mutex_type = PTHREAD_MUTEX_DEFAULT;
 #endif
-        break;
-    }
 
     int ret = 0;
     pthread_mutexattr_t attr;

--- a/osdep/threads.h
+++ b/osdep/threads.h
@@ -3,17 +3,6 @@
 
 #include "config.h"
 
-enum mp_mutex_type {
-    MP_MUTEX_NORMAL = 0,
-    MP_MUTEX_RECURSIVE,
-};
-
-#define mp_mutex_init(mutex) \
-    mp_mutex_init_type(mutex, MP_MUTEX_NORMAL)
-
-#define mp_mutex_init_type(mutex, mtype) \
-    mp_mutex_init_type_internal(mutex, mtype)
-
 #if HAVE_WIN32_THREADS
 #include "threads-win32.h"
 #else


### PR DESCRIPTION
The only use of `MP_MUTEX_RECURSIVE` is in vdpau.c. If it is disabled, remove the unused code. This simplifies the win32 implementation by eliminating unnecessary critical section references.