### PR TITLE
[RFC] input.conf: duplicate some keybind to keypad siblings

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -53,11 +53,11 @@ default, the ? key toggles the display of this list.
 Keyboard Control
 ----------------
 
-LEFT and RIGHT
+LEFT / KP_LEFT and RIGHT / KP_RIGHT
     Seek backward/forward 5 seconds. Shift+arrow does a 1 second exact seek
     (see ``--hr-seek``).
 
-UP and DOWN
+UP / KP_UP and DOWN / KP_DOWN
     Seek forward/backward 1 minute. Shift+arrow does a 5 second exact seek (see
     ``--hr-seek``).
 
@@ -92,10 +92,10 @@ Shift+Ctrl+BACKSPACE
 < and >
     Go backward/forward in the playlist.
 
-ENTER
+ENTER and KP_ENTER
     Go forward in the playlist.
 
-Shift+HOME and Shift+END
+Shift+HOME / Shift+KP_HOME and Shift+END / Shift+KP_END
     Go to the first/last playlist entry.
 
 p and SPACE
@@ -207,15 +207,15 @@ Ctrl+s
     Take a screenshot, as the window shows it (with subtitles, OSD, and scaled
     video).
 
-HOME
+HOME and KP_HOME
     Seek to the beginning of the file.
 
-PGUP and PGDWN
+PGUP / KP_PGUP and PGDWN / KP_PGDWN
     Seek to the beginning of the previous/next chapter. In most cases,
     "previous" will actually go to the beginning of the current chapter; see
     ``--chapter-seek-threshold``.
 
-Shift+PGUP and Shift+PGDWN
+Shift+PGUP / Shift+KP_PGUP and Shift+PGDWN / Shift+KP_PGDWN
     Seek backward or forward by 10 minutes. (This used to be mapped to
     PGUP/PGDWN without Shift.)
 
@@ -263,7 +263,7 @@ i and I
     Toggle an overlay displaying the active key bindings. See `STATS`_ for more
     information.
 
-DEL
+DEL and KP_DEL
     Cycle OSC visibility between never / auto (mouse-move) / always
 
 \`

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -49,6 +49,10 @@
 #LEFT  seek -5                          # seek 5 seconds backward
 #UP    seek  60                         # seek 1 minute forward
 #DOWN  seek -60                         # seek 1 minute backward
+#KP_RIGHT seek  5                       # seek 5 seconds forward
+#KP_LEFT  seek -5                       # seek 5 seconds backward
+#KP_UP    seek  60                      # seek 1 minute forward
+#KP_DOWN  seek -60                      # seek 1 minute backward
 # Do smaller, always exact (non-keyframe-limited), seeks with shift.
 # Don't show them on the OSD (no-osd).
 #Shift+RIGHT no-osd seek  1 exact       # seek exactly 1 second forward
@@ -67,16 +71,21 @@
 #ZOOMIN    add video-zoom   0.1         # zoom in
 #Alt+-     add video-zoom  -0.1         # zoom out
 #ZOOMOUT   add video-zoom  -0.1         # zoom out
-#Alt+KP_ADD      add video-zoom  0.1    # zoom in
-#Alt+KP_SUBTRACT add video-zoom -0.1    # zoom out
+#Alt+KP_ADD      add video-zoom   0.1   # zoom in
+#Alt+KP_SUBTRACT add video-zoom  -0.1   # zoom out
 #Ctrl+WHEEL_UP   script-binding positioning/cursor-centric-zoom  0.1 # zoom in towards the cursor
 #Ctrl+WHEEL_DOWN script-binding positioning/cursor-centric-zoom -0.1 # zoom out towards the cursor
 #Alt+BS set video-zoom 0; no-osd set panscan 0; no-osd set video-pan-x 0; no-osd set video-pan-y 0; no-osd set video-align-x 0; no-osd set video-align-y 0 # reset zoom and pan settings
 #HOME seek 0 absolute                   # seek to the start
+#KP_HOME seek 0 absolute                # seek to the start
 #PGUP add chapter 1                     # seek to the next chapter
 #PGDWN add chapter -1                   # seek to the previous chapter
+#KP_PGUP add chapter 1                  # seek to the next chapter
+#KP_PGDWN add chapter -1                # seek to the previous chapter
 #Shift+PGUP seek 600                    # seek 10 minutes forward
 #Shift+PGDWN seek -600                  # seek 10 minutes backward
+#Shift+KP_PGUP seek 600                 # seek 10 minutes forward
+#Shift+KP_PGDWN seek -600               # seek 10 minutes backward
 #[ multiply speed 1/1.1                 # decrease the playback speed
 #] multiply speed 1.1                   # increase the playback speed
 #{ multiply speed 0.5                   # halve the playback speed
@@ -95,9 +104,12 @@
 #SPACE cycle pause                      # toggle pause/playback mode
 #> playlist-next                        # skip to the next file
 #ENTER playlist-next                    # skip to the next file
+#KP_ENTER playlist-next                 # skip to the next file
 #< playlist-prev                        # skip to the previous file
 #Shift+HOME no-osd set playlist-pos 0   # skip to the first file
 #Shift+END  no-osd set playlist-pos-1 ${playlist-count} # skip to the last file
+#Shift+KP_HOME no-osd set playlist-pos 0                   # skip to the first file
+#Shift+KP_END  no-osd set playlist-pos-1 ${playlist-count} # skip to the last file
 #O no-osd cycle-values osd-level 3 1    # toggle displaying the OSD on user interaction or always
 #o show-progress                        # show playback progress
 #P show-progress                        # show playback progress
@@ -178,6 +190,7 @@
 #ctrl+c quit 4
 #Ctrl+v loadfile ${clipboard/text} append-play; show-text '+ ${clipboard/text}' # append the copied path
 #DEL script-binding osc/visibility      # cycle OSC visibility between never, auto (mouse-move) and always
+#KP_DEL script-binding osc/visibility   # cycle OSC visibility between never, auto (mouse-move) and always
 #ctrl+h cycle-values hwdec "no" "auto"  # toggle hardware decoding
 #F8 show-text ${playlist}               # show the playlist
 #F9 show-text ${track-list}             # show the list of video, audio and sub tracks


### PR DESCRIPTION
They still can be remapped individually by users, but let's duplicate them by default.

Same as 8c6ad1dc81596f2f4482f761fdb22b3c0fc72f89.
Fixes: #15993