### PR TITLE
stream_file: make appending:// URLs more useful

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1403,7 +1403,10 @@ PROTOCOLS
     Play a local file, but assume it's being appended to. This is useful for
     example for files that are currently being downloaded to disk. This will
     block playback, and stop playback only if no new data was appended after
-    a timeout of about 2 seconds.
+    a timeout.
+
+    The timeout span depends on the values of ``--appending-max-retries`` and
+    ``--appending-retry-timeout`` options.
 
     Using this is still a bit of a bad idea, because there is no way to detect
     if a file is actually being appended, or if it's still written. If you're

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7674,6 +7674,34 @@ Miscellaneous
     Input file type for ``mf://`` (available: jpeg, png, tga, sgi). By default,
     this is guessed from the file extension.
 
+``--appending-max-retries=<max-retries>``
+    Number of retries to read newly appended data at the end of a file, before
+    assuming it's not being appended to anymore (default: 10).
+
+    .. warning::
+
+        Setting this to a high value could significantly slow-down media
+        loading/seeking.
+
+    .. note::
+
+        Only applicable to ``appending://`` URLs, or files that get detected as
+        being appended to.
+
+``--appending-retry-timeout=<retry-timeout>``
+    Timeout in seconds between attempts to read newly appended data at the end
+    of a file (default: 0.2).
+
+    .. warning::
+
+        Setting this to a high value could significantly slow-down media
+        loading/seeking.
+
+    .. note::
+
+        Only applicable to ``appending://`` URLs, or files that get detected as
+        being appended to.
+
 ``--stream-dump=<destination-filename>``
     Instead of playing a file, read its byte stream and write it to the given
     destination file. The destination is overwritten. Can be useful to test

--- a/options/options.c
+++ b/options/options.c
@@ -58,6 +58,7 @@ static void print_version(struct mp_log *log)
 }
 
 extern const struct m_sub_options tv_params_conf;
+extern const struct m_sub_options stream_appending_conf;
 extern const struct m_sub_options stream_bluray_conf;
 extern const struct m_sub_options stream_cdda_conf;
 extern const struct m_sub_options stream_dvb_conf;
@@ -559,6 +560,7 @@ static const m_option_t mp_opts[] = {
 
 // ------------------------- stream options --------------------
 
+    {"appending", OPT_SUBSTRUCT(stream_appending_opts, stream_appending_conf)},
 #if HAVE_DVDNAV
     {"dvd", OPT_SUBSTRUCT(dvd_opts, dvd_conf)},
 #endif

--- a/options/options.h
+++ b/options/options.h
@@ -345,6 +345,7 @@ typedef struct MPOpts {
     int w32_priority;
     bool media_controls;
 
+    struct appending_opts *stream_appending_opts;
     struct bluray_opts *stream_bluray_opts;
     struct cdda_opts *stream_cdda_opts;
     struct dvb_opts *stream_dvb_opts;

--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -36,6 +36,7 @@
 #include "misc/thread_tools.h"
 #include "stream.h"
 #include "options/m_option.h"
+#include "options/m_config.h"
 #include "options/path.h"
 
 #if HAVE_BSD_FSTATFS
@@ -85,6 +86,26 @@ typedef enum _FSINFOCLASS {
 #endif
 #endif
 
+
+struct appending_opts {
+    double retry_timeout;
+    int max_retries;
+};
+
+#define OPT_BASE_STRUCT struct appending_opts
+const struct m_sub_options stream_appending_conf = {
+    .opts = (const struct m_option[]) {
+        {"retry-timeout", OPT_DOUBLE(retry_timeout), M_RANGE(0.1, 1.0)},
+        {"max-retries", OPT_INT(max_retries), M_RANGE(2, 1000)},
+        {0},
+    },
+    .size = sizeof(struct appending_opts),
+    .defaults = &(const struct appending_opts){
+        .retry_timeout = 0.2,
+        .max_retries = 10,
+    },
+};
+
 struct priv {
     int fd;
     bool close;
@@ -93,11 +114,8 @@ struct priv {
     bool appending;
     int64_t orig_size;
     struct mp_cancel *cancel;
+    struct appending_opts *opts;
 };
-
-// Total timeout = RETRY_TIMEOUT * MAX_RETRIES
-#define RETRY_TIMEOUT 0.2
-#define MAX_RETRIES 10
 
 static int64_t get_size(stream_t *s)
 {
@@ -129,13 +147,20 @@ static int fill_buffer(stream_t *s, void *buffer, int max_len)
     }
 #endif
 
-    for (int retries = 0; retries < MAX_RETRIES; retries++) {
+    int max_retries = p->opts->max_retries;
+    double retry_timeout = p->opts->retry_timeout;
+
+    for (int retries = 0; retries < max_retries; retries++) {
+        int64_t size = get_size(s);
+
+        MP_TRACE(s, "appending retry %d/%d @ pos %"PRId64"/%"PRId64" (timeout=%lf)\n",
+                retries, max_retries, s->pos, size, retry_timeout);
+
         int r = read(p->fd, buffer, max_len);
         if (r > 0)
             return r;
 
         // Try to detect and handle files being appended during playback.
-        int64_t size = get_size(s);
         if (p->regular_file && size > p->orig_size && !p->appending) {
             MP_WARN(s, "File is apparently being appended to, will keep "
                     "retrying with timeouts.\n");
@@ -145,7 +170,7 @@ static int fill_buffer(stream_t *s, void *buffer, int max_len)
         if (!p->appending || p->use_poll)
             break;
 
-        if (mp_cancel_wait(p->cancel, RETRY_TIMEOUT))
+        if (mp_cancel_wait(p->cancel, retry_timeout))
             break;
     }
 
@@ -279,6 +304,8 @@ static int open_f(stream_t *stream, const struct stream_open_args *args)
     *p = (struct priv) {
         .fd = -1,
     };
+    p->opts = mp_get_config_group(stream, stream->global,
+            &stream_appending_conf);
     stream->priv = p;
     stream->is_local_fs = true;
 


### PR DESCRIPTION
  By exposing the two parameters that control the *timeout* as options.

  `--appending-max-retries` replaces the `MAX_RETRIES` constant. And
  `--appending-retry-timeout` replaces the `RETRY-TIMEOUT`.

  The options have the same default values as the removed constants. So
  nothing should change behavior wise.