### PR TITLE
ytdl_hook.lua: fix boolean comparision

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -1204,7 +1204,7 @@ end
 
 local function on_load_hook(load_fail)
     local url = mp.get_property("stream-open-filename", "")
-    local force = url:find("^ytdl://")
+    local force = url:find("^ytdl://") ~= nil
     local early = force or o.try_ytdl_first or is_whitelisted(url)
     if early == load_fail then
         return


### PR DESCRIPTION
Make sure the `early` variable is boolean. The issue was that if url have `ytdl://`, find() would return position `1`. This makes `early` also `1`. And now we try to compare `early == load_fail`, which for `1 == true` is false, while we expect it to be true. Make sure we compare booleans.