### PR TITLE
hwdec_d3d11va: align image mapper dimensions to a multiple of 2

### DIFF
--- a/video/out/d3d11/hwdec_d3d11va.c
+++ b/video/out/d3d11/hwdec_d3d11va.c
@@ -149,6 +149,10 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
         for (int i = 0; i < desc.num_planes; i++)
             p->fmt[i] = desc.planes[i];
     } else {
+        // Minimal alignment requirement for NV12 and P010
+        mapper->dst_params.w = MP_ALIGN_UP(mapper->dst_params.w, 2);
+        mapper->dst_params.h = MP_ALIGN_UP(mapper->dst_params.h, 2);
+
         struct mp_image layout = {0};
         mp_image_set_params(&layout, &mapper->dst_params);
 
@@ -197,8 +201,12 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
     struct priv *p = mapper->priv;
     ID3D11Texture2D *tex = (void *)mapper->src->planes[0];
     int subresource = (intptr_t)mapper->src->planes[1];
+    D3D11_TEXTURE2D_DESC desc2d;
+    ID3D11Texture2D_GetDesc(tex, &desc2d);
 
     if (p->copy_tex) {
+        mp_require(desc2d.Width >= mapper->dst_params.w &&
+                   desc2d.Height >= mapper->dst_params.h);
         ID3D11DeviceContext1_CopySubresourceRegion1(p->ctx,
             (ID3D11Resource *)p->copy_tex, 0, 0, 0, 0,
             (ID3D11Resource *)tex, subresource, (&(D3D11_BOX) {
@@ -213,9 +221,6 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
         // We no longer need the original texture after copying it.
         mp_image_unrefp(&mapper->src);
     } else {
-        D3D11_TEXTURE2D_DESC desc2d;
-        ID3D11Texture2D_GetDesc(tex, &desc2d);
-
         for (int i = 0; i < p->num_planes; i++) {
             // The video decode texture may include padding, so the size of the
             // ra_tex needs to be determined by the actual size of the Tex2D


### PR DESCRIPTION
This is required for creating a copy texture. Note that alignment is applied only when making a copy; if mapping the texture directly, the native texture size is used as-is. The texture itself may be larger depending on the coded dimensions, but we only copy the "interesting" part of the image.

Fixes playback of videos with odd dimensions.