### PR TITLE
DOCS/man/vo.rst: xx-color-management-v4 -> color-management-v1

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -302,7 +302,7 @@ Available video output drivers are:
     as ``auto-safe``. It can still work in some circumstances without ``--hwdec`` due to
     mpv's internal conversion filters, but this is not recommended as it's a needless
     extra step. Correct output depends on support from your GPU, drivers, and compositor.
-    This requires the compositor and mpv to support ``xx-color-management-v4`` to
+    This requires the compositor and mpv to support ``color-management-v1`` to
     accurately display colorspaces that are different from the compositor
     default (bt.601 in most cases).
 


### PR DESCRIPTION
minor fix to the vo manpage, since color-management-v1 landed with 6bfbaf6bc6f2161, rename xx-color-management-v4 to color-management-v1