### PR TITLE
auto_profiles.lua: make profiles apply with higher priority

### DIFF
--- a/DOCS/interface-changes/auto-profiles-prio.txt
+++ b/DOCS/interface-changes/auto-profiles-prio.txt
@@ -1,0 +1,1 @@
+Change auto profiles hook priority from 50 to 5

--- a/player/lua/auto_profiles.lua
+++ b/player/lua/auto_profiles.lua
@@ -203,5 +203,5 @@ end)
 
 mp.register_idle(on_idle)
 for _, name in ipairs({"on_load", "on_preloaded", "on_before_start_file"}) do
-    mp.add_hook(name, 50, on_hook)
+    mp.add_hook(name, 5, on_hook)
 end


### PR DESCRIPTION
This increases the priority from 50 (which is neutral) to ensure that profiles are applied before other scripts.

In general, applying profiles before other scripts makes sense. This was already the case for external scripts with default priority because they would load after auto_profiles.

This commit primarily fixes ytdl_hook.lua to respond to profile changes. In most cases, profile conditions are triggered by external conditions, not the output from the ytdl hook, so this is fine.

I acknowledge that this will change the order if a script previously had a priority lower than 50. However, injecting itself before profiles are evaluated is a very obscure use case, if there is even a valid one.