### PR TITLE
osxbundle: add new vulkan loader homebrew path

### DIFF
--- a/TOOLS/dylib_unhell.py
+++ b/TOOLS/dylib_unhell.py
@@ -228,7 +228,8 @@ def process_vulkan_loader(binary, loader_name, loader_relative_folder, library_n
         os.path.join(os.path.expanduser("~"), ".local/share", loader_relative_folder),
         os.path.join("/usr/local/share", loader_relative_folder),
         os.path.join("/usr/share/vulkan", loader_relative_folder),
-        os.path.join(get_homebrew_prefix(), "share", loader_relative_folder),
+        os.path.join(get_homebrew_prefix(), "etc", loader_relative_folder),
+        os.path.join(get_homebrew_prefix(), "share", loader_relative_folder), # old location
     ]
 
     loader_system_folder = ""


### PR DESCRIPTION
for now just fixing the bundling with vulkan. current nightly builds don't include the vulkan driver because homebrew changed the location (https://github.com/Homebrew/homebrew-core/commit/0c6a7238e7c3457af8d2cc7a997a3d2732ab2751).

in future changes we should probably fail on bundle creation when vulkan can't be bundled, at least for our CI. though making the failing optional, since bundles without bundled vulkan drivers are still a valid case.