### PR TITLE
demux_timeline: don't close segments during demuxing

### DIFF
--- a/demux/demux_timeline.c
+++ b/demux/demux_timeline.c
@@ -210,11 +210,9 @@ static void reopen_lazy_segments(struct demuxer *demuxer,
     if (src->current->d)
         return;
 
-    // Note: in delay_open mode, we must _not_ close segments during demuxing,
+    // Note: we must _not_ close segments during demuxing,
     // because demuxed packets have demux_packet.codec set to objects owned
     // by the segments. Closing them would create dangling pointers.
-    if (!src->delay_open)
-        close_lazy_segments(demuxer, src);
 
     struct demuxer_params params = {
         .init_fragment = src->tl->init_fragment,


### PR DESCRIPTION
add_tl() when creating virtual_stream list is referencing sh->codec which is owned by the demuxer. Don't close it to avoid dangling pointers. The comment is right, but this happens regardless of delay_open as we can clearly see in the add_tl() function.