### PR TITLE
DOCS/man/input: remove stray newline

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -4043,7 +4043,6 @@ Property list
     See ``--clipboard-backends`` option for the list of available backends.
 
 ``clock``
-
     The current local time in hour:minutes format.
 
 Inconsistencies between options and properties


### PR DESCRIPTION
this breaks the html conversion

