### PR TITLE
mp_image: set repr.alpha and repr.bits when mapping AVFrame

### DIFF
--- a/filters/f_swscale.c
+++ b/filters/f_swscale.c
@@ -105,6 +105,7 @@ static void sws_process(struct mp_filter *f)
         goto error;
 
     mp_image_copy_attributes(dst, src);
+    mp_image_setfmt(dst, dstfmt);
 
     if (s->use_out_params)
         dst->params = s->out_params;


### PR DESCRIPTION
Fixes invalid colors with gpu-next direct mapping of some formats.