### PR TITLE
console.lua: fix crash when pressing Ctrl+c with select

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -76,7 +76,7 @@ local prompt
 local id
 
 local histories = {}
-local history
+local history = {}
 local history_pos = 1
 local searching_history = false
 local history_paths = {}


### PR DESCRIPTION
Pressing ctrl+c in select mode crashes if console wasn't opened in free-form text mode before.

This also makes the type of the history variable clear.

Fixes a6024b562a.