### PR TITLE
playloop: only notify MP_EVENT_INPUT_PROCESSED when needed

### DIFF
--- a/input/cmd.h
+++ b/input/cmd.h
@@ -113,6 +113,7 @@ typedef struct mp_cmd {
     bool is_mouse_button : 1;
     bool repeated : 1;
     bool mouse_move : 1;
+    bool notify_event : 1;
     bool canceled : 1;
     bool coalesce : 1;
     int mouse_x, mouse_y;

--- a/input/input.c
+++ b/input/input.c
@@ -775,6 +775,8 @@ static void feed_key(struct input_ctx *ictx, int code, double scale,
         mp_cmd_t *cmd = get_cmd_from_keys(ictx, (bstr){0}, code);
         if (!cmd)  // queue dummy cmd so that mouse-pos can notify observers
             cmd = mp_input_parse_cmd(ictx, bstr0("ignore"), "<internal>");
+        if (cmd)
+            cmd->notify_event = true;
         queue_cmd(ictx, cmd);
         return;
     }
@@ -921,6 +923,7 @@ static void set_mouse_pos(struct input_ctx *ictx, int x, int y, bool quiet)
 
     if (cmd) {
         cmd->mouse_move = true;
+        cmd->notify_event = true;
         cmd->mouse_x = x;
         cmd->mouse_y = y;
         if (should_drop_cmd(ictx, cmd)) {
@@ -981,6 +984,8 @@ static void notify_touch_update(struct input_ctx *ictx)
 {
     // queue dummy cmd so that touch-pos can notify observers
     mp_cmd_t *cmd = mp_input_parse_cmd(ictx, bstr0("ignore"), "<internal>");
+    if (cmd)
+        cmd->notify_event = true;
     queue_cmd(ictx, cmd);
 }
 

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -108,16 +108,17 @@ void mp_core_unlock(struct MPContext *mpctx)
 // Process any queued user input.
 static void mp_process_input(struct MPContext *mpctx)
 {
-    int processed = 0;
+    bool notify = false;
     for (;;) {
         mp_cmd_t *cmd = mp_input_read_cmd(mpctx->input);
         if (!cmd)
             break;
+        if (cmd->notify_event)
+            notify = true;
         run_command(mpctx, cmd, NULL, NULL, NULL);
-        processed = 1;
     }
     mp_set_timeout(mpctx, mp_input_get_delay(mpctx->input));
-    if (processed)
+    if (notify)
         mp_notify(mpctx, MP_EVENT_INPUT_PROCESSED, NULL);
 }
 


### PR DESCRIPTION
MP_EVENT_INPUT_PROCESSED is used to notify mouse and touch position updates, but it is currently notified for all input commands even when they have nothing to do with mouse position. This results in unnecessary acquisition and comparision of mouse and touch positions for all commands.

Optimize this by checking whether the command is marked as requiring the event notification, and only notify if that is true.