### PR TITLE
DOCS/man/input: correct the mode flag of apply-profile command

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -802,7 +802,7 @@ Configuration Commands
 
     The mode argument:
 
-    ``default``
+    ``apply``
         Apply the profile. Default if the argument is omitted.
 
     ``restore``

--- a/player/lua/commands.lua
+++ b/player/lua/commands.lua
@@ -330,7 +330,7 @@ end
 
 local function command_flags_at_2nd_argument_list(command)
     local flags = {
-        ["apply-profile"] = {"default", "restore"},
+        ["apply-profile"] = {"apply", "restore"},
         ["frame-step"] = {"play", "seek", "mute"},
         ["loadfile"] = {"replace", "append", "append-play", "insert-next",
                         "insert-next-play", "insert-at", "insert-at-play"},


### PR DESCRIPTION
The default mode actually named `apply` instead of `default`, it's a mistake that has existed for a long time.

Fixes: 1f132c6