### PR TITLE
Revert "ao: correctly set state.playing for non-gapless audio after eof"

### DIFF
--- a/audio/out/buffer.c
+++ b/audio/out/buffer.c
@@ -56,7 +56,6 @@ struct buffer_state {
     struct mp_filter *input;    // connected to queue
     struct mp_aframe *pending;  // last, not fully consumed output
 
-    bool got_eof;               // received eof in recent past
     bool streaming;             // AO streaming active
     bool playing;               // logically playing audio from buffer
     bool paused;                // logically paused
@@ -683,19 +682,13 @@ static bool ao_play_data(struct ao *ao)
             p->streaming = true;
             state.playing = true;
         }
-    } else if (p->streaming && p->got_eof && !samples) {
-        p->got_eof = false;
-        state.playing = false;
-        goto eof;
     }
 
     MP_TRACE(ao, "in=%d space=%d(%d) pl=%d, eof=%d\n",
              samples, space, state.free_samples, p->playing, got_eof);
 
-    if (got_eof) {
-        p->got_eof = got_eof;
+    if (got_eof)
         goto eof;
-    }
 
     return samples > 0 && (samples < space || ao->untimed);
 


### PR DESCRIPTION
There's no good explanation, but I can no longer reproduce the issue described in the commit. The code as is can cause a "File descriptor in bad state" message when looping or advancing in a playlist because it jumps a bit too early to the eof part. Perhaps something in alsa somehow changed, but the non-gapless audio freezing thing doesn't happen anymore. The audio state correctly updates on play/pause without these lines. Since this is known to cause problems elsewhere, just revert it for now. If the alsa problem crops up again in the future, we can revisit it then.

This reverts commit d33e54250e6643bdd20879eae1921fe18aecccd5.
