### PR TITLE
Revert "console.lua: disable cursor autohide while selector is open"

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -107,7 +107,6 @@ local first_match_to_print = 1
 local default_item
 local item_positions = {}
 local max_item_width = 0
-local was_cursor_autohide
 
 local complete
 local cycle_through_completions
@@ -976,11 +975,6 @@ end
 local function unbind_mouse()
     mp.remove_key_binding('_console_mouse_move')
     mp.remove_key_binding('_console_mbtn_left')
-
-    if was_cursor_autohide ~= nil then
-        mp.set_property_native('cursor-autohide', was_cursor_autohide)
-        was_cursor_autohide = nil
-    end
 end
 
 -- Run the current command or select the current item
@@ -1056,11 +1050,6 @@ local function bind_mouse()
             set_active(false)
         end
     end)
-
-    if was_cursor_autohide == nil then
-        was_cursor_autohide = mp.get_property_native('cursor-autohide')
-    end
-    mp.set_property_native('cursor-autohide', false)
 end
 
 -- Go to the specified position in the command history


### PR DESCRIPTION
In retrospect, this isn't so great because no neccesarily everyone would want the mouse to show with the menu and said menu can be navigated with the keyboard anyway.

This reverts commit a8f5beb5a38e0ed169a9fb9faff6c5ca0a43dfee.
