### PR TITLE
[PoC] Live Text image analysis on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1563,6 +1563,7 @@ if features['cocoa'] and features['swift']
                            'osdep/mac/clipboard.swift',
                            'osdep/mac/dialog.swift',
                            'osdep/mac/event_helper.swift',
+                           'osdep/mac/image_conversion.swift',
                            'osdep/mac/input_helper.swift',
                            'osdep/mac/log_helper.swift',
                            'osdep/mac/menu_bar.swift',

--- a/osdep/mac/app_bridge_objc.h
+++ b/osdep/mac/app_bridge_objc.h
@@ -18,6 +18,8 @@
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
 
+#include <libswscale/swscale.h>
+
 #include "player/client.h"
 #include "video/out/libmpv.h"
 #include "mpv/render_gl.h"
@@ -26,10 +28,12 @@
 #include "player/core.h"
 #include "player/clipboard/clipboard.h"
 #include "common/global.h"
+#include "common/msg.h"
 #include "input/input.h"
 #include "input/event.h"
 #include "input/keycodes.h"
 #include "video/out/win_state.h"
+#include "video/sws_utils.h"
 
 #include "osdep/main-fn.h"
 #include "osdep/mac/app_bridge.h"

--- a/osdep/mac/image_conversion.swift
+++ b/osdep/mac/image_conversion.swift
@@ -1,0 +1,230 @@
+class ImageConversion {
+    var global: UnsafeMutablePointer<mpv_global>
+    var log: OpaquePointer
+
+    init(_ g: UnsafeMutablePointer<mpv_global>, _ l: OpaquePointer) {
+        global = g
+        log = l
+    }
+
+    private func getColorspaceName(_ plcsp: pl_color_space, gray: Bool) -> CFString? {
+        if gray {
+            if plcsp.transfer == PL_COLOR_TRC_LINEAR {
+                return CGColorSpace.linearGray
+            } else if plcsp.transfer == PL_COLOR_TRC_GAMMA22 {
+                return CGColorSpace.genericGrayGamma2_2
+            }
+        } else {
+            switch plcsp.primaries {
+            case PL_COLOR_PRIM_DISPLAY_P3:
+                if plcsp.transfer == PL_COLOR_TRC_BT_1886 {
+                    return CGColorSpace.displayP3
+                } else if plcsp.transfer == PL_COLOR_TRC_HLG {
+                    return CGColorSpace.displayP3_HLG
+                }
+            case PL_COLOR_PRIM_BT_709:
+                if plcsp.transfer == PL_COLOR_TRC_LINEAR {
+                    return CGColorSpace.linearSRGB
+                } else if plcsp.transfer == PL_COLOR_TRC_BT_1886 {
+                    return CGColorSpace.itur_709
+                } else if plcsp.transfer == PL_COLOR_TRC_SRGB {
+                    return CGColorSpace.sRGB
+                }
+            case PL_COLOR_PRIM_DCI_P3:
+                if plcsp.transfer == PL_COLOR_TRC_BT_1886 {
+                    return CGColorSpace.dcip3
+                }
+            case PL_COLOR_PRIM_BT_2020:
+                if plcsp.transfer == PL_COLOR_TRC_BT_1886 {
+                    return CGColorSpace.itur_2020
+                }
+            case PL_COLOR_PRIM_ADOBE:
+                return CGColorSpace.adobeRGB1998
+            case PL_COLOR_PRIM_APPLE:
+                if plcsp.transfer == PL_COLOR_TRC_LINEAR {
+                    return CGColorSpace.genericRGBLinear
+                }
+            default:
+                break
+            }
+        }
+
+        return nil
+    }
+
+    private func convertIntoRep(_ rep: NSBitmapImageRep, imgfmt: Int32, plcsp: pl_color_space, bps: Int32, image: mp_image) -> Bool {
+        var image = image
+        var dest = mp_image()
+        mp_image_setfmt(&dest, imgfmt)
+        mp_image_set_size(&dest, image.w, image.h)
+
+        let planes = UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>.allocate(capacity: 5)
+        rep.getBitmapDataPlanes(planes)
+
+        if !withUnsafeMutableBytes(of: &dest.stride, { (stridePtr) -> Bool in
+            return withUnsafeMutableBytes(of: &dest.planes) { (planesPtr) -> Bool in
+                guard let destStrides = stridePtr.baseAddress?.assumingMemoryBound(to: type(of: image.stride.0)) else {
+                    return false
+                }
+                guard let destPlanes = planesPtr.baseAddress?.assumingMemoryBound(to: type(of: image.planes.0)) else {
+                    return false
+                }
+
+                for i in 0..<Int(MP_MAX_PLANES) {
+                    destPlanes[i] = planes[i]
+                    destStrides[i] = Int32(rep.bytesPerRow)
+                }
+
+                return true
+            }
+        }) {
+            assert(false, "Binding pointer to stride or planes array failed; this should be impossible")
+            return false
+        }
+
+        dest.params.repr.sys = PL_COLOR_SYSTEM_RGB
+        dest.params.repr.levels = PL_COLOR_LEVELS_FULL
+        dest.params.repr.alpha = rep.hasAlpha ? (rep.bitmapFormat.contains(.alphaNonpremultiplied) ? PL_ALPHA_INDEPENDENT : PL_ALPHA_PREMULTIPLIED) : PL_ALPHA_UNKNOWN
+        dest.params.repr.bits.sample_depth = bps
+        dest.params.repr.bits.color_depth = bps
+
+        dest.params.color = plcsp
+
+        return mp_image_swscale(&dest, &image, global, log) >= 0
+    }
+
+    private func createImageRep(_ image: mp_image) -> NSBitmapImageRep? {
+        // Need it to nominally be mutable to pass to C functions later
+        var image = image
+        var imgfmt = image.imgfmt
+
+        var compatible = true
+        switch imgfmt {
+        case IMGFMT_YAP8, IMGFMT_YAP16, IMGFMT_Y8, IMGFMT_Y16, IMGFMT_ARGB, IMGFMT_RGBA, IMGFMT_RGB0, IMGFMT_RGBA64:
+            break
+        default:
+            compatible = false
+        }
+
+        if image.params.repr.levels != PL_COLOR_LEVELS_FULL {
+            compatible = false
+        }
+
+        if image.num_planes > 5 {
+            return nil
+        }
+
+        let planes = UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>.allocate(capacity: 5)
+        planes.initialize(repeating: nil, count: 5)
+
+        var bps = image.fmt.comps.0.size
+        var spp = mp_imgfmt_desc_get_num_comps(&image.fmt)
+        let alpha = (image.fmt.flags & MP_IMGFLAG_ALPHA) != 0
+        let gray = (image.fmt.flags & MP_IMGFLAG_GRAY) != 0
+        let csp: NSColorSpaceName = gray ? .calibratedWhite : .calibratedRGB
+        var formatFlags: NSBitmapImageRep.Format = []
+        if alpha && image.fmt.comps.3.plane == 0 && image.fmt.comps.3.offset == 0 {
+            formatFlags.insert(.alphaFirst)
+        }
+        if image.params.repr.alpha == PL_ALPHA_INDEPENDENT {
+            formatFlags.insert(.alphaNonpremultiplied)
+        }
+        var bpp = image.fmt.bpp.0
+        var bytesPerRow = image.stride.0
+        var planar = image.num_planes > 1
+
+        if !withUnsafeBytes(of: &image.stride, { (rawPtr) -> Bool in
+            let ptr = rawPtr.baseAddress!.assumingMemoryBound(to: type(of: image.stride.0))
+            for i in 0..<Int(image.num_planes) where ptr[i] != bytesPerRow {
+                return false
+            }
+            return true
+        }) {
+            compatible = false
+        }
+
+        if compatible {
+            withUnsafeBytes(of: &image.planes) { (rawPtr) in
+                let ptr = rawPtr.baseAddress!.assumingMemoryBound(to: type(of: image.planes.0))
+                for i in 0..<Int(image.num_planes) {
+                    planes[i] = ptr[i]
+                }
+            }
+
+            if bpp == 24 {
+                bpp = 32
+            }
+        } else {
+            bps = bps <= 8 ? 8 : 16
+            formatFlags.remove(.alphaFirst)
+            if gray {
+                if bps > 8 {
+                    imgfmt = alpha ? IMGFMT_YAP16 : IMGFMT_Y16
+                    bpp = 16
+                } else {
+                    imgfmt = alpha ? IMGFMT_YAP8 : IMGFMT_Y8
+                    bpp = 8
+                }
+            } else {
+                if bps > 8 {
+                    imgfmt = IMGFMT_RGBA64
+                    bpp = 64
+                } else {
+                    imgfmt = alpha ? IMGFMT_RGBA : IMGFMT_RGB0
+                    bpp = 32
+                }
+            }
+
+            bytesPerRow = 0
+            planar = (gray && alpha)
+            spp = (gray ? 1 : 3) + (alpha ? 1 : 0)
+        }
+
+        guard let rep = NSBitmapImageRep(bitmapDataPlanes: planes,
+            pixelsWide: Int(image.w),
+            pixelsHigh: Int(image.h),
+            bitsPerSample: Int(bps),
+            samplesPerPixel: Int(spp),
+            hasAlpha: alpha,
+            isPlanar: planar,
+            colorSpaceName: csp,
+            bitmapFormat: formatFlags,
+            bytesPerRow: Int(bytesPerRow),
+            bitsPerPixel: Int(bpp)) else {
+            return nil
+        }
+
+        var plcsp = image.params.color
+        let cgSpaceName = getColorspaceName(plcsp, gray: gray)
+
+        if cgSpaceName == nil {
+            compatible = false
+            plcsp.primaries = PL_COLOR_PRIM_BT_709
+            plcsp.transfer = PL_COLOR_TRC_SRGB
+        }
+
+        guard let nscsp = (!gray && image.icc_profile != nil) ?
+            NSColorSpace(iccProfileData: Data(bytes: image.icc_profile.pointee.data, count: image.icc_profile.pointee.size)) :
+            (CGColorSpace(name: cgSpaceName ?? CGColorSpace.sRGB).flatMap { NSColorSpace(cgColorSpace: $0) }) else {
+            return nil
+        }
+
+        guard let rep = rep.retagging(with: nscsp) else {
+            return nil
+        }
+
+        if !compatible && !convertIntoRep(rep, imgfmt: Int32(imgfmt.rawValue), plcsp: plcsp, bps: Int32(bps), image: image) {
+            return nil
+        }
+
+        return rep
+    }
+
+    func convertImage(_ image: mp_image) -> CGImage? {
+        guard let rep = createImageRep(image) else {
+            return .none
+        }
+
+        return rep.cgImage
+    }
+}

--- a/player/client.c
+++ b/player/client.c
@@ -41,6 +41,7 @@
 #include "osdep/threads.h"
 #include "osdep/timer.h"
 #include "osdep/io.h"
+#include "player/screenshot.h"
 #include "stream/stream.h"
 
 #include "command.h"
@@ -1332,6 +1333,11 @@ int mpv_set_property(mpv_handle *ctx, const char *name, mpv_format format,
     };
     run_locked(ctx, setproperty_fn, &req);
     return req.status;
+}
+
+struct mp_image *mp_take_screenshot(mpv_handle *ctx, int mode)
+{
+    return capture_screenshot(ctx->mpctx, mode);
 }
 
 int mpv_del_property(mpv_handle *ctx, const char *name)

--- a/player/client.h
+++ b/player/client.h
@@ -35,6 +35,7 @@ struct mpv_handle *mp_new_client(struct mp_client_api *clients, const char *name
 void mp_client_set_weak(struct mpv_handle *ctx);
 struct mp_log *mp_client_get_log(struct mpv_handle *ctx);
 struct mpv_global *mp_client_get_global(struct mpv_handle *ctx);
+struct mp_image *mp_take_screenshot(struct mpv_handle *ctx, int mode);
 
 void mp_client_broadcast_event_external(struct mp_client_api *api, int event,
                                         void *data);

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -422,6 +422,11 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
     return image;
 }
 
+struct mp_image *capture_screenshot(struct MPContext *mpctx, int mode)
+{
+    return screenshot_get(mpctx, mode, false);
+}
+
 struct mp_image *convert_image(struct mp_image *image, int destfmt,
                                struct mpv_global *global, struct mp_log *log)
 {

--- a/player/screenshot.h
+++ b/player/screenshot.h
@@ -31,6 +31,8 @@ void screenshot_init(struct MPContext *mpctx);
 // Called by the playback core on each iteration.
 void handle_each_frame_screenshot(struct MPContext *mpctx);
 
+struct mp_image *capture_screenshot(struct MPContext *mpctx, int mode);
+
 /* Return the image converted to the given format. If the pixel aspect ratio is
  * not 1:1, the image is scaled as well. Returns NULL on failure.
  * If global!=NULL, use command line scaler options etc.

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -16,14 +16,20 @@
  */
 
 import Cocoa
+import VisionKit
 
-class View: NSView, CALayerDelegate {
+class View: NSView, CALayerDelegate, ImageAnalysisOverlayViewDelegate, EventSubscriber {
     unowned var common: Common
     var input: InputHelper? { return common.input }
 
     var tracker: NSTrackingArea?
     var hasMouseDown: Bool = false
     var lastMouseDownEvent: NSEvent?
+    private var analyzer: ImageAnalyzer?
+    private var analyzerConfig: ImageAnalyzer.Configuration?
+    private var analysisOverlayView: ImageAnalysisOverlayView?
+    private var isPaused: Bool = false { didSet { updateAnalysis() } }
+    private var imageConverter: ImageConversion?
 
     override var isFlipped: Bool { return true }
     override var acceptsFirstResponder: Bool { return true }
@@ -35,6 +41,86 @@ class View: NSView, CALayerDelegate {
         wantsBestResolutionOpenGLSurface = true
         wantsExtendedDynamicRangeOpenGLSurface = true
         registerForDraggedTypes([ .fileURL, .URL, .string ])
+        self.autoresizesSubviews = true
+
+        if #available(macOS 13, *) {
+            if ImageAnalyzer.isSupported {
+                analyzer = ImageAnalyzer()
+                analyzerConfig = ImageAnalyzer.Configuration([.text])
+                let overlayView = ImageAnalysisOverlayView()
+                overlayView.preferredInteractionTypes = [.automaticTextOnly]
+                overlayView.autoresizingMask = [.width, .height]
+                overlayView.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
+                overlayView.isSupplementaryInterfaceHidden = true
+                overlayView.delegate = self
+                analysisOverlayView = overlayView
+                addSubview(overlayView)
+
+                imageConverter = ImageConversion(mp_client_get_global(AppHub.shared.mpv)!, mp_client_get_log(AppHub.shared.mpv)!)
+
+                setupAnalysisEvents()
+            }
+        }
+    }
+
+    @available(macOS 13, *)
+    func overlayView(_ overlayView: ImageAnalysisOverlayView,
+        shouldBeginAt point: CGPoint,
+        forAnalysisType analysisType: ImageAnalysisOverlayView.InteractionTypes
+    ) -> Bool {
+        return true
+    }
+
+    @available(macOS 13, *)
+    private func setImageAnalysis(_ analysis: ImageAnalysis?) {
+        if let analysisView = analysisOverlayView {
+            analysisView.resetSelection()
+            analysisView.analysis = isPaused ? analysis : .none
+        }
+    }
+
+    @available(macOS 13, *)
+    private func setupAnalysisEvents() {
+        if let event = AppHub.shared.event {
+            event.subscribe(self, event: .init(name: "pause", format: MPV_FORMAT_FLAG))
+            event.subscribe(self, event: .init(name: "video-target-params/w", format: MPV_FORMAT_INT64))
+            event.subscribe(self, event: .init(name: "video-target-params/h", format: MPV_FORMAT_INT64))
+        }
+    }
+
+    func handle(event: EventHelper.Event) {
+        switch event.name {
+        case "pause": isPaused = event.bool ?? false
+        case "video-target-params/w", "video-target-params/h": if #available(macOS 13, *) {
+            if let overlayView = analysisOverlayView {
+                overlayView.setContentsRectNeedsUpdate()
+            }
+            updateAnalysis()
+        }
+        default: break
+        }
+    }
+
+    private func updateAnalysis() {
+        if #available(macOS 13, *) {
+            if !isPaused {
+                setImageAnalysis(.none)
+            } else {
+                if let mpv = AppHub.shared.mpv, let a = analyzer, let config = analyzerConfig, let converter = imageConverter {
+                    if let image = mp_take_screenshot(mpv, 1) {
+                        if let converted = converter.convertImage(image.pointee) {
+                            Task {
+                                do {
+                                    setImageAnalysis(try await a.analyze(converted, orientation: .up, configuration: config))
+                                } catch {
+                                    setImageAnalysis(.none)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -89,7 +175,7 @@ class View: NSView, CALayerDelegate {
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        return true
+        return false
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -105,6 +191,7 @@ class View: NSView, CALayerDelegate {
             input?.put(key: SWIFT_KEY_MOUSE_ENTER)
         }
         common.updateCursorVisibility()
+        super.mouseEntered(with: event)
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -113,27 +200,32 @@ class View: NSView, CALayerDelegate {
         }
         common.titleBar?.hide()
         common.setCursorVisibility(true)
+        super.mouseExited(with: event)
     }
 
     override func mouseMoved(with event: NSEvent) {
         signalMouseMovement(event)
         common.titleBar?.show()
+        super.mouseMoved(with: event)
     }
 
     override func mouseDragged(with event: NSEvent) {
         signalMouseMovement(event)
+        super.mouseDragged(with: event)
     }
 
     override func mouseDown(with event: NSEvent) {
         hasMouseDown = event.clickCount <= 1
         input?.processMouse(event: event)
         lastMouseDownEvent = event
+        super.mouseDown(with: event)
     }
 
     override func mouseUp(with event: NSEvent) {
         hasMouseDown = false
         common.window?.isMoving = false
         input?.processMouse(event: event)
+        super.mouseUp(with: event)
     }
 
     override func rightMouseDown(with event: NSEvent) {
@@ -163,6 +255,14 @@ class View: NSView, CALayerDelegate {
     }
 
     func signalMouseMovement(_ event: NSEvent) {
+        if #available(macOS 13, *) {
+            if let overlayView = analysisOverlayView, hasMouseDown {
+                if overlayView.hasInteractiveItem(at: event.locationInWindow) {
+                    return
+                }
+            }
+        }
+
         var point = convert(event.locationInWindow, from: nil)
         point = convertToBacking(point)
         point.y = -point.y
@@ -174,6 +274,14 @@ class View: NSView, CALayerDelegate {
 
     override func scrollWheel(with event: NSEvent) {
         input?.processWheel(event: event)
+    }
+
+    func contentView(for overlayView: ImageAnalysisOverlayView) -> NSView? {
+        return self
+    }
+
+    func contentsRect(for overlayView: ImageAnalysisOverlayView) -> CGRect {
+        return CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
     }
 
     func containsMouseLocation() -> Bool {

--- a/video/sws_utils.c
+++ b/video/sws_utils.c
@@ -424,6 +424,18 @@ int mp_sws_scale(struct mp_sws_context *ctx, struct mp_image *dst,
     return 0;
 }
 
+int mp_image_swscale(struct mp_image *dst, struct mp_image *src,
+                     struct mpv_global *global, struct mp_log *log)
+{
+    struct mp_sws_context *ctx = mp_sws_alloc(NULL);
+    ctx->log = log;
+    if (global)
+        mp_sws_enable_cmdline_opts(ctx, global);
+    int res = mp_sws_scale(ctx, dst, src);
+    talloc_free(ctx);
+    return res;
+}
+
 int mp_image_sw_blur_scale(struct mp_image *dst, struct mp_image *src,
                            float gblur)
 {

--- a/video/sws_utils.h
+++ b/video/sws_utils.h
@@ -17,6 +17,9 @@ extern const int mp_sws_fast_flags;
 
 bool mp_sws_supported_format(int imgfmt);
 
+int mp_image_swscale(struct mp_image *dst, struct mp_image *src,
+                     struct mpv_global *global, struct mp_log *log);
+
 int mp_image_sw_blur_scale(struct mp_image *dst, struct mp_image *src,
                            float gblur);
 


### PR DESCRIPTION
This is a draft for discussion; this feature is not mergeable in its current state.

This adds support for the Live Text API on macOS, which allows the user to select text within a video.

In this demo, I select some Japanese text from a video file:

https://github.com/user-attachments/assets/89767311-c106-4e56-a9ac-17661d7138b2

The copied text is:
> トゲナシトゲアリ「雑踏、僕らの街」
> Produced by 玉井健二
> 作詞・作曲：大濱健悟
> 編曲：玉井 健二，大濱 健悟
> Product of agehasprings

Which is largely correct modulo spacing.

This will need a number of changes before it's mergeable, some of which I'd like to get some discussion started on:
- The API calls required to capture the image and convert it to a form usable by the system APIs are largely hacked in haphazardly right now; I'm not sure what the best solution for some of this is
- Currently, I'm capturing a `window` screenshot (so OSD is included), but I'm not informed when the OSD updates, so it becomes outdated easily; the simplest solution might be to simply not support the OSD (which would mean taking a `subtitles` screenshot and configuring the overlay view to be aware of the video's margins within the window)
- This will presumably want to be gated behind a setting
- Long-term, https://github.com/libass/libass/pull/856 should provide the text metrics we'd need to implement our own selection functionality for text drawn using libass, at which point we'd want to switch this to use a `video` screenshot
- This reuses some image conversion utility routines out of #15568, pulled out into their own new file; that'll need to be reconciled once either feature lands
- The system only analyzes text in the user's configured languages by default; we should grab the list of languages that could plausibly be in the video or displayed subtitles (video stream language, all audio stream languages, and selected subtitle stream language seems like a reasonable set?) and signal those to the analyzer