### PR TITLE
ytdl_hook.lua: fix duplicated chapters

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -818,6 +818,7 @@ local function add_single_video(json)
     -- add chapters
     if json.chapters then
         msg.debug("Adding pre-parsed chapters")
+        chapter_list = {}
         for i = 1, #json.chapters do
             local chapter = json.chapters[i]
             local title = chapter.title or ""


### PR DESCRIPTION
Sometimes when opening a YouTube video with chapters, the chapter-list ended up having all the chapters twice, despite the json from yt-dlp only containing them once. That must mean that sometimes add_single_video() runs twice before the chapter_list table gets cleared in the on_preloaded hook.

This can be avoided by replacing chapter_list with a new table before adding entries to it.

I don't understand why add_single_video() sometimes runs twice before the table gets cleared in on_preloaded, and it happens so rarely that I can't really debug it, but this change should at least prevent the problem with the chapters.