### PR TITLE
select.lua: display chapters when before the first chapter

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -230,7 +230,7 @@ mp.add_key_binding(nil, "select-chapter", function ()
     input.select({
         prompt = "Select a chapter:",
         items = chapters,
-        default_item = default_item + 1,
+        default_item = default_item > -1 and default_item + 1,
         submit = function (chapter)
             mp.set_property("chapter", chapter - 1)
         end,


### PR DESCRIPTION
When the first chapter is not at the start of the file but after the current time position, the chapter property is -1, which prevented displaying any chapter.

Fixes #16073.