### PR TITLE
wayland: round values instead of implicitly casting float to int

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2624,18 +2624,24 @@ static void set_color_management(struct vo_wayland_state *wl)
     struct pl_hdr_metadata hdr = wl->target_params.color.hdr;
     if (wl->supports_display_primaries) {
         wp_image_description_creator_params_v1_set_mastering_display_primaries(image_creator_params,
-                hdr.prim.red.x * WAYLAND_COLOR_FACTOR, hdr.prim.red.y * WAYLAND_COLOR_FACTOR, hdr.prim.green.x * WAYLAND_COLOR_FACTOR,
-                hdr.prim.green.y * WAYLAND_COLOR_FACTOR, hdr.prim.blue.x * WAYLAND_COLOR_FACTOR, hdr.prim.blue.y * WAYLAND_COLOR_FACTOR,
-                hdr.prim.white.x * WAYLAND_COLOR_FACTOR, hdr.prim.white.y * WAYLAND_COLOR_FACTOR);
+                lrintf(hdr.prim.red.x * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.red.y * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.green.x * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.green.y * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.blue.x * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.blue.y * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.white.x * WAYLAND_COLOR_FACTOR),
+                lrintf(hdr.prim.white.y * WAYLAND_COLOR_FACTOR));
 
         if (hdr.min_luma < hdr.max_luma)
-            wp_image_description_creator_params_v1_set_mastering_luminance(image_creator_params, hdr.min_luma * WAYLAND_MIN_LUM_FACTOR, hdr.max_luma);
+            wp_image_description_creator_params_v1_set_mastering_luminance(image_creator_params,
+                lrintf(hdr.min_luma * WAYLAND_MIN_LUM_FACTOR), lrintf(hdr.max_luma));
 
         if (hdr.max_cll > hdr.min_luma && hdr.max_cll <= hdr.max_luma)
-            wp_image_description_creator_params_v1_set_max_cll(image_creator_params, hdr.max_cll);
+            wp_image_description_creator_params_v1_set_max_cll(image_creator_params, lrintf(hdr.max_cll));
 
         if (hdr.max_fall > hdr.min_luma && hdr.max_fall <= hdr.max_luma && hdr.max_fall <= hdr.max_cll)
-            wp_image_description_creator_params_v1_set_max_fall(image_creator_params, hdr.max_fall);
+            wp_image_description_creator_params_v1_set_max_fall(image_creator_params, lrintf(hdr.max_fall));
     }
     struct wp_image_description_v1 *image_description = wp_image_description_creator_params_v1_create(image_creator_params);
     wp_image_description_v1_add_listener(image_description, &image_description_listener, wl);


### PR DESCRIPTION
This matches the behavior of mpv's own drm backend when setting hdr
metadata, as well as Mesa's vulkan wsi's behavior when communicating
VK_EXT_hdr_metadata values to the compositor