### PR TITLE
ci/build-win32.ps1: exit on errors from external commands early

### DIFF
--- a/ci/build-win32.ps1
+++ b/ci/build-win32.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version Latest
 
 $subprojects = "subprojects"


### PR DESCRIPTION
This requires PowerShell 7.4+ to work, but it's fine for our CI.