### PR TITLE
vd_lavc: enable FFv1 hwaccel by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1832,7 +1832,7 @@ Video
     You can get the list of allowed codecs with ``mpv --vd=help``. Remove the
     prefix, e.g. instead of ``lavc:h264`` use ``h264``.
 
-    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1,prores``. Note that
+    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1,prores,ffv1``. Note that
     the hardware acceleration special codecs like ``h264_vdpau`` are not
     relevant anymore, and in fact have been removed from FFmpeg in this form.
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -163,7 +163,7 @@ const struct m_sub_options hwdec_conf = {
     .defaults = &(const struct hwdec_opts){
         .software_fallback = 3,
         .hwdec_api = (char *[]){"no", NULL,},
-        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores",
+        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores,ffv1",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;
         // for example, if vo_gpu increases the number of reference surfaces for


### PR DESCRIPTION
FFmpeg recently got a hardware accelerated decoder for FFv1. The decoder has been tested on all major vendors and operating systems. Intel support is currently disabled as all of their drivers have issues with buffer device addresses.
Since its a software-defined implementation, internal issues can be fixed and the overall implementation optimized further.

With that, I think it should be safe to enable it by default.
