### PR TITLE
ytdl_hook.lua: fix false chapter detections

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -251,11 +251,11 @@ end
 local function time_to_secs(time_string)
     local ret
 
-    local a, b, c = time_string:match("(%d+):(%d%d?):(%d%d)")
+    local a, b, c = time_string:match("(%d+):(%d%d?):(%d%d)%p*%s")
     if a ~= nil then
         ret = (a*3600 + b*60 + c)
     else
-        a, b = time_string:match("(%d%d?):(%d%d)")
+        a, b = time_string:match("(%d%d?):(%d%d)%p*%s")
         if a ~= nil then
             ret = (a*60 + b)
         end


### PR DESCRIPTION
Not checking for whitespace or punctuation characters like ":" after timestamps when extracting chapters from ytdl video descriptions can result in false positives.

Fixes false positive mentioned in #16081.