### PR TITLE
vo_kitty: fix segfault, add multiplexer passthrough + QOL fixes

### DIFF
--- a/DOCS/interface-changes/kitty-passthrough.txt
+++ b/DOCS/interface-changes/kitty-passthrough.txt
@@ -1,0 +1,1 @@
+add `--vo-kitty-auto-multiplexer-passthrough=<yes|no>`

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -455,6 +455,14 @@ Available video output drivers are:
 
         This option is not implemented on Windows.
 
+    ``--vo-kitty-auto-multiplexer-passthrough=<yes|no>`` (default: no)
+        Automatically detect terminal multiplexer to passthrough escape
+        sequences. This allows the image protocol to work in multiplexers that
+        might not support the kitty image protocol by passing through the
+        escape sequences directly to the terminal.
+
+        Currently only supports tmux and GNU screen.
+
 ``sixel``
     Graphical output for the terminal, using sixels. Tested with ``mlterm`` and
     ``xterm``.

--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -213,6 +213,8 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     if (mp_sws_reinit(p->sws) < 0)
         return -1;
 
+    p->cmd.start = talloc_zero(NULL, char);
+
     if (!p->opts.use_shm) {
         p->buffer = talloc_array(NULL, uint8_t, p->buffer_size);
         p->output = talloc_array(NULL, char, p->output_size);


### PR DESCRIPTION
This PR contains a total of 4 major changes:

1. Fix a SEGFAULT in kitty video output
  This was caused by a use-after-free of `priv->cmd.start` which was
  `free`'d in `reconfig` and used later in `flip_page`.
  This could be triggered by running mpv with kitty vo and sending a
  `SIGWINCH` signal.
2. Adding support for multiplexer passthrough
  Only tmux and GNU screen supported at this time. This allows the kitty
  image protocol to work when running mpv within these multiplexers.
3. Remove trailing `NULL` byte in payload
  This is a very specific issue, currently this only causes problems in
  the Ghostty terminal emulator but still is nice to fix nonetheless.
  So the issue was that the write function was changed to use `bstr.len`
  from `strlen`, now `av_base64_encode` outputs a `NULL` terminated
  base64 string, which then leads to this `NULL` byte to be written to
  stdout, to put it nicely, it doesn't mix well with Ghostty
4. Writing a final `\033_Gm=0;` sequence if the output was ≤4096 bytes

This PR has been tested on
- Ghostty
- Kitty
- Konsole
- tmux (`--vo-kitty-auto-multiplexer-passthrough`)
- GNU Screen (`--vo-kitty-auto-multiplexer-passthrough`)

Both with and without `--vo-kitty-use-shm`
Although I couldn't get tmux to work without an SHM (it crashed) screen
on the other hand worked perfectly fine.
To be honest using kitty vo without an SHM is pretty much a crime :^)
