### PR TITLE
filters: automatically flip video if displaymatrix indicates so

### DIFF
--- a/filters/f_auto_filters.h
+++ b/filters/f_auto_filters.h
@@ -6,6 +6,9 @@
 // hardware decode mode and the deinterlace user option.
 struct mp_filter *mp_deint_create(struct mp_filter *parent);
 
+// Flip according to mp_image.vflip
+struct mp_filter *mp_autovflip_create(struct mp_filter *parent);
+
 // Rotate according to mp_image.rotate and VO capabilities.
 struct mp_filter *mp_autorotate_create(struct mp_filter *parent);
 

--- a/filters/f_output_chain.c
+++ b/filters/f_output_chain.c
@@ -376,6 +376,7 @@ void mp_output_chain_set_vo(struct mp_output_chain *c, struct vo *vo)
 
     p->stream_info.hwdec_devs = vo ? vo->hwdec_devs : NULL;
     p->stream_info.osd = vo ? vo->osd : NULL;
+    p->stream_info.vflip = vo ? vo->driver->caps & VO_CAP_VFLIP : false;
     p->stream_info.rotate90 = vo ? vo->driver->caps & VO_CAP_ROTATE90 : false;
     p->stream_info.dr_vo = vo;
     p->vo = vo;
@@ -651,6 +652,13 @@ static void create_video_things(struct chain *p)
     if (!f->f)
         abort();
     MP_TARRAY_APPEND(p, p->pre_filters, p->num_pre_filters, f);
+
+    f = create_wrapper_filter(p);
+    f->name = "autovflip";
+    f->f = mp_autovflip_create(f->wrapper);
+    if (!f->f)
+        abort();
+    MP_TARRAY_APPEND(p, p->post_filters, p->num_post_filters, f);
 
     f = create_wrapper_filter(p);
     f->name = "autorotate";

--- a/filters/filter.h
+++ b/filters/filter.h
@@ -405,6 +405,7 @@ struct mp_stream_info {
 
     struct mp_hwdec_devices *hwdec_devs;
     struct osd_state *osd;
+    bool vflip;
     bool rotate90;
     struct vo *dr_vo; // for calling vo_get_image()
 };

--- a/video/mp_image.h
+++ b/video/mp_image.h
@@ -57,6 +57,8 @@ struct mp_image_params {
 
     enum mp_csp_light light;
     enum pl_chroma_location chroma_location;
+    // The image should be flipped vertically before rotating
+    bool vflip;
     // The image should be rotated clockwise (0-359 degrees).
     int rotate;
     enum mp_stereo3d_mode stereo3d; // image is encoded with this mode

--- a/video/out/gpu/libmpv_gpu.c
+++ b/video/out/gpu/libmpv_gpu.c
@@ -89,7 +89,7 @@ static int init(struct render_backend *ctx, mpv_render_param *params)
 
     ctx->hwdec_devs = hwdec_devices_create();
     gl_video_init_hwdecs(p->renderer, p->context->ra_ctx, ctx->hwdec_devs, true);
-    ctx->driver_caps = VO_CAP_ROTATE90;
+    ctx->driver_caps = VO_CAP_ROTATE90 | VO_CAP_VFLIP;
     return 0;
 }
 

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3737,6 +3737,7 @@ static bool pass_upload_image(struct gl_video *p, struct mp_image *mpi, uint64_t
                     .w = mp_image_plane_w(&layout, n),
                     .h = mp_image_plane_h(&layout, n),
                     .tex = tex[n],
+                    .flipped = layout.params.vflip,
                 };
             }
         } else {
@@ -3750,6 +3751,10 @@ static bool pass_upload_image(struct gl_video *p, struct mp_image *mpi, uint64_t
     mp_assert(mpi->num_planes == p->plane_count);
 
     timer_pool_start(p->upload_timer);
+
+    if (mpi->params.vflip)
+        mp_image_vflip(mpi);
+
     for (int n = 0; n < p->plane_count; n++) {
         struct texplane *plane = &vimg->planes[n];
         if (!plane->tex) {

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -579,6 +579,9 @@ static void check_vo_caps(struct vo *vo)
                    "video output does not support this.\n", rot);
         }
     }
+    if (vo->params->vflip && !(vo->driver->caps & VO_CAP_VFLIP))
+        MP_WARN(vo, "Video is flagged as vertically flipped, but the "
+                    "video output does not support this.\n");
 }
 
 static void run_reconfig(void *p)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -206,6 +206,8 @@ enum {
     VO_CAP_UNTIMED      = 1 << 4,
     // VO is responsible for freeing frames.
     VO_CAP_FRAMEOWNER   = 1 << 5,
+    // VO does handle mp_image_params.vflip
+    VO_CAP_VFLIP        = 1 << 6,
 };
 
 enum {

--- a/video/out/vo_gpu.c
+++ b/video/out/vo_gpu.c
@@ -327,7 +327,7 @@ err_out:
 const struct vo_driver video_out_gpu = {
     .description = "Shader-based GPU Renderer",
     .name = "gpu",
-    .caps = VO_CAP_ROTATE90,
+    .caps = VO_CAP_ROTATE90 | VO_CAP_VFLIP,
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -920,6 +920,14 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
     if (frame->still)
         params.frame_mixer = NULL;
 
+    if (frame->current && frame->current->params.vflip) {
+        pl_matrix2x2 m = { .m = {{1, 0}, {0, -1}}, };
+        pars->distort_params.transform.mat = m;
+        params.distort_params = &pars->distort_params;
+    } else {
+        params.distort_params = NULL;
+    }
+
     // pl_queue advances its internal virtual PTS and culls available frames
     // based on this value and the VPS/FPS ratio. Requesting a non-monotonic PTS
     // is an invalid use of pl_queue. Reset it if this happens in an attempt to
@@ -2344,6 +2352,7 @@ const struct vo_driver video_out_gpu_next = {
     .name = "gpu-next",
     .caps = VO_CAP_ROTATE90 |
             VO_CAP_FILM_GRAIN |
+            VO_CAP_VFLIP |
             0x0,
     .preinit = preinit,
     .query_format = query_format,

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -744,7 +744,7 @@ static int preinit(struct vo *vo)
 const struct vo_driver video_out_libmpv = {
     .description = "render API for libmpv",
     .name = "libmpv",
-    .caps = VO_CAP_ROTATE90,
+    .caps = VO_CAP_ROTATE90 | VO_CAP_VFLIP,
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,


### PR DESCRIPTION
Currently we check AV_FRAME_DATA_DISPLAYMATRIX for its rotation factor but not for its flip factor, which could happen with some input files. This commit adds and autovflip filter, which is applied before the autorotate filter to flip vertically before rotating. It also changes the displaymatrix reading code to output to mp_image->params.vflip so it can be autoinserted as necessary.
