### PR TITLE
vo: don't burn cpu in paused state for untimed VOs

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1076,12 +1076,17 @@ static void do_redraw(struct vo *vo)
 {
     struct vo_internal *in = vo->in;
 
-    if (!vo->config_ok || (vo->driver->caps & VO_CAP_NORETAIN) ||
-        (vo->driver->caps & VO_CAP_UNTIMED))
+    if (!vo->config_ok)
         return;
 
     mp_mutex_lock(&in->lock);
     in->request_redraw = false;
+
+    if (vo->driver->caps & (VO_CAP_NORETAIN | VO_CAP_UNTIMED)) {
+        mp_mutex_unlock(&in->lock);
+        return;
+    }
+
     bool full_redraw = in->dropped_frame;
     struct vo_frame *frame = vo_frame_ref(in->current_frame);
     if (frame)


### PR DESCRIPTION
Fixes VO thread busy looping in paused state for untimed VOs.

One example is vo_lavc (encoding mode), used commonly to extract thumbnail by scripts.

Example command that was affected:
mpv --ovc=rawvideo --of=image2 --ofopts=update=1 --o=test --pause <file>

We have to update frame parameters that it is still and shouldn't be repeated again. This has been skipped by early exit.

Fixes: 8798cec7fa14bbeb35c7b711db3a41d336f78a69