### PR TITLE
w32_common: Implement --screen-name

### DIFF
--- a/DOCS/interface-changes/display-name-friendly.txt
+++ b/DOCS/interface-changes/display-name-friendly.txt
@@ -1,0 +1,1 @@
+add `display-name/friendly` property on Windows to obtain display names from EDID

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2930,6 +2930,11 @@ Property list
     version >= 4 is used (LVDS-1, HDMI-A-1, X11-1, etc.), or the wl_output model
     reported by the geometry event if protocol version < 4 is used.
 
+    ``display-names/friendly``
+        These are the human-friendly names obtained from the monitor EDID
+        (Dell AW3223DW, LC34G55T, etc.). These follow the same order as
+        ``display-names`` (Windows only)
+
 ``display-fps``
     The refresh rate of the current display. Currently, this is the lowest FPS
     of any display covered by the video, as retrieved by the underlying system

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -106,6 +106,10 @@ enum mp_voctrl {
     // names for displays the window is on
     VOCTRL_GET_DISPLAY_NAMES,
 
+    // char *** (NULL terminated array compatible with CONF_TYPE_STRING_LIST)
+    // human-friendly names for displays the window is on
+    VOCTRL_GET_DISPLAY_NAMES_FRIENDLY,
+
     // Retrieve window contents. (Normal screenshots use vo_get_current_frame().)
     // Deprecated for VOCTRL_SCREENSHOT with corresponding flags.
     VOCTRL_SCREENSHOT_WIN,              // struct mp_image**

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -2243,7 +2243,22 @@ struct disp_names_data {
     HMONITOR assoc;
     int count;
     char **names;
+    bool friendly;
 };
+
+static void disp_names_append(HMONITOR mon, struct disp_names_data *data)
+{
+    MONITORINFOEXW mi = { .cbSize = sizeof mi };
+    if (GetMonitorInfoW(mon, (MONITORINFO*)&mi)) {
+        wchar_t *friendly_name = NULL;
+        if (data->friendly) {
+            friendly_name = mp_w32_displayconfig_get_friendly_name_from_device(mi.szDevice);
+        }
+        wchar_t *name = friendly_name ? friendly_name : mi.szDevice;
+        MP_TARRAY_APPEND(NULL, data->names, data->count, mp_to_utf8(NULL, name));
+        talloc_free(friendly_name);
+    }
+}
 
 static BOOL CALLBACK disp_names_proc(HMONITOR mon, HDC dc, LPRECT r, LPARAM p)
 {
@@ -2253,30 +2268,25 @@ static BOOL CALLBACK disp_names_proc(HMONITOR mon, HDC dc, LPRECT r, LPARAM p)
     if (mon == data->assoc)
         return TRUE;
 
-    MONITORINFOEXW mi = { .cbSize = sizeof mi };
-    if (GetMonitorInfoW(mon, (MONITORINFO*)&mi)) {
-        MP_TARRAY_APPEND(NULL, data->names, data->count,
-                         mp_to_utf8(NULL, mi.szDevice));
-    }
+    disp_names_append(mon, data);
     return TRUE;
 }
 
-static char **get_disp_names(struct vo_w32_state *w32)
+static char **get_disp_names(struct vo_w32_state *w32, bool friendly)
 {
     // Get the client area of the window in screen space
     RECT rect = { 0 };
     GetClientRect(w32->window, &rect);
     MapWindowPoints(w32->window, NULL, (POINT*)&rect, 2);
 
-    struct disp_names_data data = { .assoc = w32->monitor };
+    struct disp_names_data data = {
+        .assoc = w32->monitor,
+        .friendly = friendly,
+    };
 
     // Make sure the monitor that Windows considers to be associated with the
     // window is first in the list
-    MONITORINFOEXW mi = { .cbSize = sizeof mi };
-    if (GetMonitorInfoW(data.assoc, (MONITORINFO*)&mi)) {
-        MP_TARRAY_APPEND(NULL, data.names, data.count,
-                         mp_to_utf8(NULL, mi.szDevice));
-    }
+    disp_names_append(data.assoc, &data);
 
     // Get the names of the other monitors that intersect the client rect
     EnumDisplayMonitors(NULL, &rect, disp_names_proc, (LPARAM)&data);
@@ -2300,6 +2310,7 @@ static bool gui_thread_control_supports(int request)
     case VOCTRL_GET_DISPLAY_FPS:
     case VOCTRL_GET_DISPLAY_RES:
     case VOCTRL_GET_DISPLAY_NAMES:
+    case VOCTRL_GET_DISPLAY_NAMES_FRIENDLY:
     case VOCTRL_GET_ICC_PROFILE:
     case VOCTRL_GET_FOCUSED:
     case VOCTRL_BEGIN_DRAGGING:
@@ -2447,7 +2458,10 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
         ((int *)arg)[1] = monrc.bottom - monrc.top;
         return VO_TRUE;
     case VOCTRL_GET_DISPLAY_NAMES:
-        *(char ***)arg = get_disp_names(w32);
+        *(char ***)arg = get_disp_names(w32, false);
+        return VO_TRUE;
+    case VOCTRL_GET_DISPLAY_NAMES_FRIENDLY:
+        *(char ***)arg = get_disp_names(w32, true);
         return VO_TRUE;
     case VOCTRL_GET_ICC_PROFILE:
         update_display_info(w32);

--- a/video/out/win32/displayconfig.h
+++ b/video/out/win32/displayconfig.h
@@ -30,4 +30,10 @@ double mp_w32_displayconfig_get_refresh_rate(const wchar_t *device);
 wchar_t *mp_w32_displayconfig_get_device_from_friendly_name(
     const wchar_t *monitor_friendly_device_name);
 
+// Given a GDI monitor device name, get a friendly monitor device name
+// using the DisplayConfig API. Returns NULL on failure.
+// The caller is responsible for releasing the result with talloc_free.
+wchar_t *mp_w32_displayconfig_get_friendly_name_from_device(
+    const wchar_t *device);
+
 #endif


### PR DESCRIPTION
Previously the --screen-name and --fs-screen-name options did nothing on Windows.

It now attempts to convert a friendly monitor name to the GDI device name using the DisplayConfig API first. The friendly name is the shown in Windows settings like "Dell AW3423DW". Otherwise, assume it's already a GDI device name like "\\.\DISPLAY1".

Edit: Added commit

w32_common: add display-names/friendly property

The `friendly` subkey return the same set of displays as `display-names`
but it attempts to convert the names to the human-friendly name that
DisplayConfig obtains from the EDID.
