### PR TITLE
stats.lua: cache some properties

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -131,6 +131,15 @@ local cache_ahead_buf, cache_speed_buf
 local perf_buffers = {}
 local process_key_binding
 
+local property_cache = {}
+
+local function get_property_cached(name, def)
+    if property_cache[name] ~= nil then
+        return property_cache[name]
+    end
+    return def
+end
+
 local function graph_add_value(graph, value)
     graph.pos = (graph.pos % graph.len) + 1
     graph[graph.pos] = value
@@ -909,8 +918,9 @@ local function add_video_out(s)
 
     append(s, "", {prefix="Display:", nl=o.nl .. o.nl, indent=""})
     append(s, vo, {prefix_sep="", nl="", indent=""})
-    append_property(s, "display-names", {prefix_sep="", prefix="(", suffix=")",
-                                         no_prefix_markup=true, nl="", indent=" "})
+
+    append(s, get_property_cached("display-names"), {prefix_sep="", prefix="(", suffix=")",
+           no_prefix_markup=true, nl="", indent=" "})
     append(s, mp.get_property_native("current-gpu-context"),
            {prefix="Context:", nl="", indent=o.prefix_sep .. o.prefix_sep})
     append_property(s, "avsync", {prefix="A-V:"})
@@ -928,7 +938,7 @@ local function add_video_out(s)
 
     local scale = nil
     if not mp.get_property_native("fullscreen") then
-        scale = mp.get_property_native("current-window-scale")
+        scale = get_property_cached("current-window-scale")
     end
 
     local od = mp.get_property_native("osd-dimensions")
@@ -975,9 +985,9 @@ local function add_video(s)
             append(s, track["decoder"], {prefix="[", nl="", indent=" ", prefix_sep="",
                    no_prefix_markup=true, suffix="]"})
         end
-        append_property(s, "hwdec-current", {prefix="HW:", nl="",
-                        indent=o.prefix_sep .. o.prefix_sep,
-                        no_prefix_markup=false, suffix=""}, {no=true, [""]=true})
+        append(s, get_property_cached("hwdec-current"), {prefix="HW:", nl="",
+               indent=o.prefix_sep .. o.prefix_sep,
+               no_prefix_markup=false, suffix=""}, {no=true, [""]=true})
     end
     local has_prefix = false
     if o.show_frame_info then
@@ -1770,3 +1780,11 @@ end
 
 mp.observe_property("osd-height", "native", update_scale)
 mp.observe_property("osd-scale-by-window", "native", update_scale)
+
+local function update_property_cache(name, value)
+    property_cache[name] = value
+end
+
+mp.observe_property('current-window-scale', 'native', update_property_cache)
+mp.observe_property('display-names', 'string', update_property_cache)
+mp.observe_property('hwdec-current', 'string', update_property_cache)


### PR DESCRIPTION
Some properties can take a long time to query, especially those which require voctrl like current-window-scale and display-names.

Similar to d37521b5ef69f4793a05583d634de286709a6806, make the script observe these properties and cache the values to avoid querying them on every refresh. This alleviates the issue when holding down "i" key for a while and releasing it results in stats being stuck on display for a long time because of the time required to query there properties.

Related: #6412
