### PR TITLE
m_option: fix string list printing for empty lists

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1572,15 +1572,15 @@ static void copy_str_list(const m_option_t *opt, void *dst, const void *src)
 static char *print_str_list(const m_option_t *opt, const void *src)
 {
     char **lst = NULL;
-    char *ret = NULL;
+    char *ret = talloc_strdup(NULL, "");
     const char sep = opt->priv ? *(char *)opt->priv : OPTION_LIST_SEPARATOR;
 
     if (!(src && VAL(src)))
-        return talloc_strdup(NULL, "");
+        return ret;
     lst = VAL(src);
 
     for (int i = 0; lst[i]; i++) {
-        if (ret)
+        if (i > 0)
             ret = talloc_strndup_append_buffer(ret, &sep, 1);
         ret = talloc_strdup_append_buffer(ret, lst[i]);
     }


### PR DESCRIPTION
When converting list options to strings and the value is empty, an empty string is returned. This is true for key value list and object settings list options. However, for string list options, there is an edge case: if the list exists but has no element (which can happen when using change-list command), it behaves as if the property does not exist and returns "(error)". This causes confusing messages when toggling glsl-shaders at runtime and seeing "(error)" printed as the value when all shaders are toggled off, for example.

8461143ed7c0088fe08379898e74a7fbcf0a9d1e attempted to fix it, which fixed the case for unset string list, but not for a list with no element.

Fix this by making sure an empty string is returned in this case.

Fixes: https://github.com/mpv-player/mpv/issues/16101