### PR TITLE
DOCS/man/options: remove bogus messages about the client API

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -47,7 +47,6 @@ Track Selection
     ``--audio`` is an alias for ``--aid``.
 
     ``--aid=no`` or ``--audio=no`` disables audio playback.
-    (The latter variant does not work with the client API.)
 
     .. note::
 
@@ -103,7 +102,6 @@ Track Selection
     ``--sub`` is an alias for ``--sid``.
 
     ``--sid=no`` or ``--sub=no`` disables subtitle decoding.
-    (The latter variant does not work with the client API.)
 
 ``--vid=<ID|auto|no>``
     Select video channel. ``auto`` selects the default, ``no`` disables video.
@@ -111,7 +109,6 @@ Track Selection
     ``--video`` is an alias for ``--vid``.
 
     ``--vid=no`` or ``--video=no`` disables video playback.
-    (The latter variant does not work with the client API.)
 
     If video is disabled, mpv will try to download the audio only if media is
     streamed with youtube-dl, because it saves bandwidth. This is done by


### PR DESCRIPTION
The messages referred to "no" prefixes like --no-audio not working with the client API. The language was removed in b1ee92ad4aec81dd31408d0c1223f0e9ea3cb738.

Remove the messages which are bogus and incorrect now.
