### PR TITLE
wayland: accept version 2 of the cursor-shape protocol

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1998,7 +1998,7 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
 
 #if HAVE_WAYLAND_PROTOCOLS_1_32
     if (!strcmp(interface, wp_cursor_shape_manager_v1_interface.name) && found++) {
-        ver = 1;
+        ver = MPMIN(ver, 2);
         wl->cursor_shape_manager = wl_registry_bind(reg, id, &wp_cursor_shape_manager_v1_interface, ver);
     }
 #endif


### PR DESCRIPTION
The version 2 changes only add some enums which makes zero difference to us so we can just allow the newer version.
