### PR TITLE
meson: disable stack protector for mpv.com

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1820,7 +1820,7 @@ if get_option('cplayer')
 
     if win32 and get_option('win32-subsystem') != 'console'
         wrapper_sources= 'osdep/win32-console-wrapper.c'
-        executable('mpv', wrapper_sources, c_args: ['-municode', '-fno-asynchronous-unwind-tables'],
+        executable('mpv', wrapper_sources, c_args: ['-municode', '-fno-asynchronous-unwind-tables', '-fno-stack-protector'],
                    link_args: ['-municode', '-nostartfiles', '-nodefaultlibs'],
                    override_options: ['b_sanitize=none'],
                    name_suffix: 'com', install: true)


### PR DESCRIPTION
This is bare runner for mpv.exe. There is no need for stack protector here and when it forced to be added by -fno-stack-protector it complains about missing symbols, because we don't link any standard libs here.

Fixes:
undefined symbol: __stack_chk_fail
undefined symbol: __stack_chk_guard

We could define those, but this mpv.com wrapper doesn't need it.