### PR TITLE
commands.lua: add remember_input script-opt

### DIFF
--- a/DOCS/interface-changes/commands-remember-input.txt
+++ b/DOCS/interface-changes/commands-remember-input.txt
@@ -1,0 +1,1 @@
+add `commands-remember_input` script-opt

--- a/DOCS/man/commands.rst
+++ b/DOCS/man/commands.rst
@@ -50,3 +50,9 @@ Configurable Options
     Default: ``~~state/command_history.txt``
 
     The file path for ``persist_history`` (see `PATHS`_).
+
+``remember_input``
+    Default: yes
+
+    Whether to remember the input line and cursor position when closing the
+    console, and prefill it the next time it is opened.

--- a/player/lua/commands.lua
+++ b/player/lua/commands.lua
@@ -18,6 +18,7 @@ License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 local options = {
     persist_history = false,
     history_path = "~~state/command_history.txt",
+    remember_input = true,
 }
 
 local input = require "mp.input"
@@ -137,8 +138,10 @@ end
 local function closed(text, cursor_position)
     mp.enable_messages("silent:terminal-default")
 
-    last_text = text
-    last_cursor_position = cursor_position
+    if options.remember_input then
+        last_text = text
+        last_cursor_position = cursor_position
+    end
 end
 
 local function command_list()


### PR DESCRIPTION
Allow clearing the input line on close. Fixes #16104.