### PR TITLE
autoload.lua: add function and keybind to call script manually

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -412,4 +412,10 @@ local function find_and_add_entries()
     end
 end
 
+local function enable()
+    o.disabled = false
+    find_and_add_entries()
+end
+
 mp.register_event("start-file", find_and_add_entries)
+mp.add_key_binding(nil, "enable", enable)


### PR DESCRIPTION
- New function enables current instance of the script then calls
  `find_and_add_entries()`
- Keybind has no default binding and calls the new function

Allows users who only want to run the autoload script occasionally to
set `disabled=yes` then call the script during playback by binding a
shortcut in input.conf, e.g.:
`ctrl+p script-binding autoload/enable ; show-text "Playlist loaded"`
Without this change, `find_and_add_entries()` is only called at the
start of a file. This means that it is still possible to enable the
script during playback, but it requires forcing the current file to
restart, e.g.:
`ctrl+p change-list script-opts append autoload-disabled=no ; playlist-play-index current`

This method is more seamless and should not affect users who do not
want this functionality, as it does not add any events which will cause
`find_and_add_entries()` to be called other than the keybind, which is
unbound by default.