### PR TITLE
clipboard-wayland: prevent reading from hung up fd

### DIFF
--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -348,6 +348,12 @@ static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl,
     if (fds[1].revents & POLLIN)
         return false;
 
+    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
+        destroy_offer(wl->selection_offer);
+
+    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
+        destroy_offer(wl->primary_selection_offer);
+
     if (fds[2].revents & POLLIN)
         get_selection_data(wl, wl->selection_offer, false);
 


### PR DESCRIPTION
This causes mpv to use up 100% of a core if there's an offer for a mime_type that mpv doesn't accept with ext_data_control clipboard backend.

Fixes: #16139