### PR TITLE
console.lua: replace font script-opt with monospace_font

### DIFF
--- a/DOCS/interface-changes/console-font.txt
+++ b/DOCS/interface-changes/console-font.txt
@@ -1,0 +1,2 @@
+add `console-monospace_font` script-opt
+remove `console-font` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -124,12 +124,12 @@ option. The configuration syntax is described in `mp.options functions`_.
 Configurable Options
 ~~~~~~~~~~~~~~~~~~~~
 
-``font``
-    The font name.
+``monospace_font``
+    Default: platform dependent
 
-    When necessary to align completions in a grid, a monospace font depending on
-    the platform is the default. When there are no completions, ``--osd-font``
-    is the default.
+    The monospace font used when there are completions to align in a grid.
+
+    When there are no completions, ``--osd-font`` is used.
 
 ``font_size``
     Default: 24

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -29,7 +29,7 @@ local platform = detect_platform()
 
 -- Default options
 local opts = {
-    font = "",
+    monospace_font = "",
     font_size = 24,
     border_size = 1.65,
     background_alpha = 80,
@@ -123,12 +123,12 @@ local function get_property_cached(name, def)
 end
 
 local function get_font()
-    if opts.font ~= "" then
-        return opts.font
-    end
-
     if not has_completions then
         return
+    end
+
+    if opts.monospace_font ~= "" then
+        return opts.monospace_font
     end
 
     -- Pick a better default font for Windows and macOS


### PR DESCRIPTION
Allow configuring the monospace font without also changing the proportional font. The proportional font is configured with the standard --osd-font.