### PR TITLE
github/workflows: make macos matrix job-names more telling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,22 +210,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cc:
-          - "clang"
-        cxx:
-          - "clang++"
         os:
           - "macos-13"
           - "macos-14"
           - "macos-15"
+        arch:
+          - "arm"
+          - "intel"
+        exclude:
+          - arch: "arm"
+            os: "macos-13"
+          - arch: "intel"
+            os: "macos-14"
+          - arch: "intel"
+            os: "macos-15"
         include:
-          - os: "macos-13"
-            arch: "intel"
           - os: "macos-14"
-            arch: "arm"
             xcode: "Xcode_15.2"
-          - os: "macos-15"
-            arch: "arm"
     steps:
       - uses: actions/checkout@v4
 
@@ -254,8 +255,8 @@ jobs:
         run: |
           ./ci/build-macos.sh
         env:
-          CC: "${{ matrix.cc }}"
-          CXX: "${{ matrix.cxx }}"
+          CC: "clang"
+          CXX: "clang++"
           TRAVIS_OS_NAME: "${{ matrix.os }}"
 
       - name: Create App Bundle


### PR DESCRIPTION
the cc/cxx values as part of the matrix don't differenciate the jobs, while the architecture does. Since cc/cxx are the same in all cases, just set them directly. In turn make the architecture value part of the job-labels and use exclude statements instead of include to limit the jobs accordingly.

While the other PR that adds a custom ffmpeg build w/libzvbi has been rejected, I think this one is still beneficial on its own.
instead of "clang, clang++, macos-13" and "clang, clang++, macos-14" having  "macos-13, intel" and "macos-14, arm" is more useful.