### PR TITLE
ci/win32: don't use CMake 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,7 @@ jobs:
         id: build
         run: |
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' -and `
+                                                             $_ -ne 'C:\Program Files\CMake\bin' -and `
                                                              $_ -ne 'C:\Strawberry\c\bin' }) -join ';'
           $env:PATH += ';C:\Program Files\NASM'
           Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
@@ -180,6 +181,7 @@ jobs:
         id: tests
         run: |
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' -and `
+                                                             $_ -ne 'C:\Program Files\CMake\bin' -and `
                                                              $_ -ne 'C:\Strawberry\c\bin' }) -join ';'
           $env:PATH += ';C:\Program Files\NASM'
           Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"


### PR DESCRIPTION
CMake has been updated to 4.0 which breaks compatibility with all project targeting version < 3.5. See for more user stories: https://github.com/actions/runner-images/issues/11926

Remove 4.0 from path and use the one from VS installation which is working for now. Generally we want to use only tools from VS installation, but unfortunately Windows image provided by GHA have polluted PATH which already causes issues in the past, that's why we remove yet another directory from PATH.

The affected project in our case is https://github.com/webmproject/sjpeg which is build as part of libjxl.