### PR TITLE
{osd,msg}: use Unicode PU{1,2} for escape codes instead of invalid Unicode

### DIFF
--- a/common/msg.h
+++ b/common/msg.h
@@ -25,7 +25,9 @@
 
 #include "osdep/compiler.h"
 
-#define TERM_MSG_0 "\xFC"
+// Escape code for TERM_MSG codes. PU2 (U+0092) followed by 't'.
+#define TERM_MSG_ESCAPE "\xC2\x92" "t"
+#define TERM_MSG_0 TERM_MSG_ESCAPE "0"
 
 struct mp_log;
 

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -110,6 +110,8 @@ bool osd_res_equals(struct mp_osd_res a, struct mp_osd_res b);
 
 // Start of OSD symbols in osd_font.pfb
 #define OSD_CODEPOINTS 0xE000
+// Escape code for OSD symbols. PU1 (U+0091)
+#define OSD_CODEPOINTS_ESCAPE "\xC2\x91"
 
 // OSD symbols. osd_font.pfb has them starting from codepoint OSD_CODEPOINTS.
 // Symbols with a value >= 32 are normal unicode codepoints.
@@ -128,11 +130,11 @@ enum mp_osd_font_codepoints {
     OSD_PANSCAN = 0x50,
 };
 
-
-// Never valid UTF-8, so we expect it's free for use.
+// Escape code for OSD_ASS codes. PU2 (U+0092) followed by 'a'.
+#define OSD_ASS_ESCAPE "\xC2\x92" "a"
 // Specially interpreted by osd_libass.c, in order to allow/escape ASS tags.
-#define OSD_ASS_0 "\xFD"
-#define OSD_ASS_1 "\xFE"
+#define OSD_ASS_0 OSD_ASS_ESCAPE "0"
+#define OSD_ASS_1 OSD_ASS_ESCAPE "1"
 
 struct osd_style_opts {
     char *font;

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -184,9 +184,7 @@ static void clear_ass(struct ass_state *ass)
 
 void osd_get_function_sym(char *buffer, size_t buffer_size, int osd_function)
 {
-    // 0xFF is never valid UTF-8, so we can use it to escape OSD symbols.
-    // (Same trick as OSD_ASS_0/OSD_ASS_1.)
-    snprintf(buffer, buffer_size, "\xFF%c", osd_function);
+    snprintf(buffer, buffer_size, OSD_CODEPOINTS_ESCAPE "%c", osd_function);
 }
 
 void osd_mangle_ass(bstr *dst, const char *in, bool replace_newlines)
@@ -195,20 +193,29 @@ void osd_mangle_ass(bstr *dst, const char *in, bool replace_newlines)
     bool escape_ass = true;
     while (*in) {
         // As used by osd_get_function_sym().
-        if (in[0] == '\xFF' && in[1]) {
+        size_t len = strlen(OSD_CODEPOINTS_ESCAPE);
+        if (!strncmp(in, OSD_CODEPOINTS_ESCAPE, len) && in[len]) {
             bstr_xappend(NULL, dst, bstr0(ASS_USE_OSD_FONT));
-            mp_append_utf8_bstr(NULL, dst, OSD_CODEPOINTS + in[1]);
+            mp_append_utf8_bstr(NULL, dst, OSD_CODEPOINTS + in[len]);
             bstr_xappend(NULL, dst, bstr0("{\\r}"));
-            in += 2;
+            in += len + 1;
             continue;
         }
-        if (*in == OSD_ASS_0[0] || *in == OSD_ASS_1[0]) {
-            escape_ass = *in == OSD_ASS_1[0];
-            in += 1;
+        len = strlen(OSD_ASS_0);
+        if (!strncmp(in, OSD_ASS_0, len)) {
+            escape_ass = false;
+            in += len;
             continue;
         }
-        if (*in == TERM_MSG_0[0]) {
-            in += 1;
+        len = strlen(OSD_ASS_1);
+        if (!strncmp(in, OSD_ASS_1, len)) {
+            escape_ass = true;
+            in += len;
+            continue;
+        }
+        len = strlen(TERM_MSG_0);
+        if (!strncmp(in, TERM_MSG_0, len)) {
+            in += len;
             continue;
         }
         if (escape_ass && *in == '{')


### PR DESCRIPTION
Some languages actually require strings to be valid UTF-8, unlike C which couldn't care less as long as it is NULL terminated.

Change triggered by Python support, but is also useful for Rust and Java.