### PR TITLE
sd_ass: handle past subs with unknown duration on every decode

### DIFF
--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -476,17 +476,19 @@ static void decode(struct sd *sd, struct demux_packet *packet)
             };
             filter_and_add(sd, &pkt2);
         }
-        if (sub_duration == UNKNOWN_DURATION) {
-            for (int n = track->n_events - 2; n >= 0; n--) {
-                if (track->events[n].Duration == UNKNOWN_DURATION * 1000) {
-                    if (track->events[n].Start != track->events[n + 1].Start) {
-                        track->events[n].Duration = track->events[n + 1].Start -
-                                                    track->events[n].Start;
-                    } else {
-                        track->events[n].Duration = track->events[n + 1].Duration;
-                    }
+        for (int n = track->n_events - 1; n >= 0; n--) {
+            if (track->events[track->n_events - 1].Start == track->events[n].Start)
+                continue;
+            if (track->events[n].Duration == UNKNOWN_DURATION * 1000) {
+                if (track->events[n].Start < track->events[n + 1].Start) {
+                    track->events[n].Duration = track->events[n + 1].Start -
+                                                track->events[n].Start;
+                } else if (track->events[n].Start == track->events[n + 1].Start) {
+                    track->events[n].Duration = track->events[n + 1].Duration;
                 }
             }
+            if (n > 0 && track->events[n].Start != track->events[n - 1].Start)
+                break;
         }
     } else {
         // Note that for this packet format, libass has an internal mechanism


### PR DESCRIPTION
Commit 77239b8 came to fix the unknown duration subtitle handling where once a packet with an unknown duration is found, then the entire context is flagged, which will trigger the redecoding sub logic to loop through all the packets again on every future packet decodes. This is true and we want to avoid having a loop that will go through all the packets that have been decoded in the past on every decode call, especially if the packets had their duration corrected already. But the mentioned commit also stated "packets with known durations get treated as if they were unknown," which is not entirely accurate.

The unknown duration subtitle handling works by altering the duration value of already decoded packets, not the newest packet. So when the context is flagged and caused new packets with known duration to still trigger the redecoding sub logic, it does not equal to "packets with known durations get treated as if they were unknown." Packets with known duration still need to trigger the redecoding sub logic anyways because there might still be old packets with unknown duration that are not corrected yet.

### Behavior before 77239b8.

**Newest packet has an unknown duration.**
- Before handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 2147483000 |

- After handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2469 |
| 1 | 5400 | 2469 |
| 2 | 7869 | 2147483000 |

**Newest packet has a known duration.**
- Before handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 3838 |

- After handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2469 |
| 1 | 5400 | 2469 |
| 2 | 7869 | 3838 |

### Behavior after 77239b8.

**Newest packet has an unknown duration.**
- Before handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 2147483000 |

- After handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2469 |
| 1 | 5400 | 2469 |
| 2 | 7869 | 2147483000 |

**Newest packet has a known duration.**
- Before handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 3838 |

- After handling,

| track->events[n] | Start | Duration |
| :--------------: | :---: | :------: |
| 0 | 5400 | 2147483000 |
| 1 | 5400 | 2147483000 |
| 2 | 7869 | 3838 |

This PR aims to bring back the expected behavior without having to rely on context flagging.