### PR TITLE
console.lua: say focused instead of selected

### DIFF
--- a/DOCS/interface-changes/console-focused-color.txt
+++ b/DOCS/interface-changes/console-focused-color.txt
@@ -1,0 +1,2 @@
+rename `console-selected_color` script-opt to `console-focused_color`
+rename `console-selected_back_color` script-opt to `console-focused_back_color`

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -184,15 +184,15 @@ Configurable Options
     Whether to scale the console with the window height. Can be ``yes``, ``no``,
     or ``auto``, which follows the value of ``--osd-scale-by-window``.
 
-``selected_color``
+``focused_color``
     Default: ``#222222``
 
-    The color of the selected item.
+    The color of the focused item.
 
-``selected_back_color``
+``focused_back_color``
     Default: ``#FFFFFF``
 
-    The background color of the selected item.
+    The background color of the focused item.
 
 ``match_color``
     Default: ``#0088FF``

--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -15,13 +15,13 @@ of the presented items, and key bindings listed in `CONSOLE`_ are extended with
 the following:
 
 ENTER, Ctrl+j and Ctrl+m
-    Confirm the selection of the highlighted item.
+    Select the focused item.
 
 UP and Ctrl+p
-    Select the item above, or the last one when the first item is selected.
+    Focus the item above, or the last one when the first item is selected.
 
 DOWN and Ctrl+n
-    Select the item below, or the first one when the last item is selected.
+    Focus the item below, or the first one when the last item is selected.
 
 PGUP and Ctrl+b
     Scroll up one page.
@@ -30,8 +30,8 @@ PGDN and Ctrl+f
     Scroll down one page.
 
 MBTN_LEFT
-    Confirm the selection of the highlighted item, or close the console if
-    clicking outside of the menu rectangle.
+    Select the item under the cursor, or close the console if clicking outside
+    of the menu rectangle.
 
 WHEEL_UP
     Scroll up.


### PR DESCRIPTION
The selected term was causing confusion e.g. in
https://github.com/mpv-player/mpv/pull/15711#issuecomment-2676060139. Saying either focused or current makes more sense since the item is not actually selected until you click or press Enter.
