### PR TITLE
console.lua: implement exact matching

### DIFF
--- a/DOCS/interface-changes/console-exact_match.txt
+++ b/DOCS/interface-changes/console-exact_match.txt
@@ -1,1 +1,2 @@
 add `console-exact_match` script-opt
+make `console-case_sensitive` only affect exact searches and change the to default to no on platforms other than Windows

--- a/DOCS/interface-changes/console-exact_match.txt
+++ b/DOCS/interface-changes/console-exact_match.txt
@@ -1,0 +1,1 @@
+add `console-exact_match` script-opt

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -199,6 +199,12 @@ Configurable Options
 
     The color of characters that match the searched string.
 
+``exact_match``
+    Default: no
+
+    Whether to match menu search queries exactly instead of fuzzily. Without
+    this option, prefixing queries with ``'`` enables exact matching.
+
 ``case_sensitive``
     Default: no on Windows, yes on other platforms.
 

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -206,9 +206,9 @@ Configurable Options
     this option, prefixing queries with ``'`` enables exact matching.
 
 ``case_sensitive``
-    Default: no on Windows, yes on other platforms.
+    Default: no
 
-    Whether autocompletion is case sensitive. Only works with ASCII characters.
+    Whether exact searches are case sensitive. Only works with ASCII characters.
 
 ``history_dedup``
     Default: true

--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -10,9 +10,8 @@ console and do operations on the selected item. It can be disabled using the
 Key bindings
 ------------
 
-When using ``mp.input.select``, typing printable characters does a fuzzy search
-of the presented items, and key bindings listed in `CONSOLE`_ are extended with
-the following:
+When using ``mp.input.select``, the key bindings listed in `CONSOLE`_ are
+extended with the following:
 
 ENTER, Ctrl+j and Ctrl+m
     Confirm the selection of the highlighted item.
@@ -38,6 +37,12 @@ WHEEL_UP
 
 WHEEL_DOWN
     Scroll down.
+
+Typing printable characters does a fuzzy search of the presented items.
+
+If the query starts with ``'``, only exact matches are filtered. You can also
+specify multiple search terms delimited by spaces, and only items matching all
+terms are filtered.
 
 Script bindings
 ---------------

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -44,7 +44,7 @@ local opts = {
     selected_back_color = "#FFFFFF",
     match_color = "#0088FF",
     exact_match = false,
-    case_sensitive = platform ~= "windows" and true or false,
+    case_sensitive = false,
     history_dedup = true,
     font_hw_ratio = "auto",
 }
@@ -452,8 +452,8 @@ local function format_grid(list, width_max, rows_max)
     return table.concat(rows, ass_escape("\n")), row_count
 end
 
-local function fuzzy_find(needle, haystacks, case_sensitive)
-    local result = require "mp.fzy".filter(needle, haystacks, case_sensitive)
+local function fuzzy_find(needle, haystacks)
+    local result = require "mp.fzy".filter(needle, haystacks)
     table.sort(result, function (i, j)
         if i[3] ~= j[3] then
             return i[3] > j[3]


### PR DESCRIPTION
console.lua: implement exact matching

Allow matching items exactly instead of fuzzily when prefixing the search with ' (like in fzf) or with --script-opt=console-exact_match=yes.

This is mainly useful to filter history entries chronologically.

You can also specify multiple search terms delimited by spaces. But ' makes every term an exact match, unlike fzf where you need to place it before every word, since we can't hook into fzy's algorithm.

Closes #14587.


console.lua: repurpose case_sensitive to only affect exact searches

case_sensitive originally only affected Tab completion. It defaulted to yes outside of Windows just to emulate the bad defaults of bash and zsh (not fish, which has better defaults and defaults to case-insensitive completion). This was already silly, but then it affected the fuzzy autocompletion and case-sensitive fuzzy completion is even more silly. And since 0b3cc3a167, it accidentally stopped affecting even that, because the completion via script message never checked for the option. Nobody even noticed this, meaning that nobody was relying on fuzzy autocompletion being case-sensitive.

Just make case_sensitive only affect the new exact search, and make it default to no on all platforms. Though IMO the search could just always be case-insensitive.