### PR TITLE
osdep/threads: prefer using thread_local

### DIFF
--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -22,6 +22,10 @@
 #define MP_UNUSED
 #endif
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ < 202311L) && !defined(thread_local)
+#define thread_local _Thread_local
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #define PRINTF_ATTRIBUTE(a1, a2) __attribute__((format(printf, a1, a2)))
 #define SCANF_ATTRIBUTE(a1, a2) __attribute__((format(scanf, a1, a2)))

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -721,7 +721,7 @@ int mp_ftruncate64(int fd, off_t length)
     return -1;
 }
 
-_Thread_local
+thread_local
 static struct {
     DWORD errcode;
     char *errstring;

--- a/osdep/threads.h
+++ b/osdep/threads.h
@@ -9,4 +9,6 @@
 #include "threads-posix.h"
 #endif
 
+#include "osdep/compiler.h"  // for thread_local
+
 #endif


### PR DESCRIPTION
C11 uses _Thread_local as the keyword, which thread_local macro is defined to (inside of <threads.h>, which mpv doesn't use): https://port70.net/~nsz/c/c11/n1570.html#7.26.1p3

C23 promotes thread_local to a keyword and marks _Thread_local as obsolete and to be avoided in new code:
https://www.iso-9899.info/n3220.html#6.4.1p3

so just use thread_local directly, which is future-proof while having a fallback define in osdep/threads.h for pre-C23 cases.

- - -

This came up during the https://github.com/mpv-player/mpv/pull/16164 discussion in IRC a couple days ago.