### PR TITLE
ci/freebsd: update to 14.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,10 +409,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test in OpenBSD VM
-      uses: cross-platform-actions/action@v0.25.0
+      uses: cross-platform-actions/action@v0.27.0
       with:
         operating_system: openbsd
-        version: '7.5'
+        version: '7.6'
         run: |
             sudo pkg_add -U \
                 cmake \
@@ -454,10 +454,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test in FreeBSD VM
-      uses: cross-platform-actions/action@v0.25.0
+      uses: cross-platform-actions/action@v0.27.0
       with:
         operating_system: freebsd
-        version: '14.1'
+        version: '14.2'
         run: |
             sudo pkg update
             sudo pkg install -y \


### PR DESCRIPTION
FreeBSD supports only two latest minor versions, since 14.3 has been released, packages for 14.1 are not longer available. Bump to 14.2, since action doesn't have images for 14.3 yet.