### PR TITLE
vo_dmabuf_wayland: don't resize if dst rect is 0

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -517,8 +517,9 @@ static void resize(struct vo *vo)
 
     const int width = mp_rect_w(wl->geometry);
     const int height = mp_rect_h(wl->geometry);
+    vo_get_src_dst_rects(vo, &src, &dst, &p->screen_osd_res);
 
-    if (width == 0 || height == 0)
+    if (width == 0 || height == 0 || mp_rect_w(dst) == 0 || mp_rect_h(dst) == 0)
         return;
 
     vo_wayland_set_opaque_region(wl, false);


### PR DESCRIPTION
Evidently it is possible for some compositors to trigger an external resize before the very first initial reconfig. This can't work and will fail in various ways. Check this case and bail out. Fixes #16202.