### PR TITLE
select.lua: display editions when before the first edition

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -238,6 +238,7 @@ mp.add_key_binding(nil, "select-edition", function ()
     end
 
     local editions = {}
+    local default_item = mp.get_property_native("current-edition")
 
     for i, edition in ipairs(edition_list) do
         editions[i] = edition.title or ("Edition " .. edition.id + 1)
@@ -246,7 +247,7 @@ mp.add_key_binding(nil, "select-edition", function ()
     input.select({
         prompt = "Select an edition:",
         items = editions,
-        default_item = mp.get_property_native("current-edition") + 1,
+        default_item = default_item > -1 and default_item + 1,
         submit = function (edition)
             mp.set_property("edition", edition - 1)
         end,


### PR DESCRIPTION
When the first edition is not at the start of the file but after the current time position, the current-edition property is -1, which prevented displaying any edition.

Fixes https://github.com/mpv-player/mpv/issues/16073#issuecomment-2787316609