### PR TITLE
console.lua: default prompt to an empty string

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1554,7 +1554,7 @@ mp.register_script_message("get-input", function (script_name, args)
 
     input_caller = script_name
     args = utils.parse_json(args)
-    prompt = args.prompt
+    prompt = args.prompt or ""
     line = args.default_text or ""
     cursor = tonumber(args.cursor_position) or line:len() + 1
     keep_open = args.keep_open


### PR DESCRIPTION
Calling input.select() without a prompt argument was failing due to attempting to concatenate a nil value.

Before mpv 0.40 the prompt defaulted to ">" so this is expected to work as evident from the example code.