### PR TITLE
DOCS: misc fixes

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3,8 +3,7 @@ COMMAND INTERFACE
 
 The mpv core can be controlled with commands and properties. A number of ways
 to interact with the player use them: key bindings (``input.conf``), OSD
-(showing information with properties), JSON IPC, the client API (``libmpv``),
-and the classic slave mode.
+(showing information with properties), JSON IPC and the client API (``libmpv``).
 
 input.conf
 ----------

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -4019,8 +4019,8 @@ Property list
     This property is read-only, and change notification is not supported.
 
 ``clipboard``
-    The clipboard contents, only works when native clipboard
-    (``--clipboard-enable``) is supported on the platform.
+    The clipboard contents. Only works when native clipboard is supported on the
+    platform.
     Depending on the platform, some sub-properties, writing to properties,
     or change notifications are not currently functional.
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -7,7 +7,6 @@ mpv provides the built-in module ``mp``, which contains functions to send
 commands to the mpv core and to retrieve information about playback state, user
 settings, file information, and so on.
 
-These scripts can be used to control mpv in a similar way to slave mode.
 Technically, the Lua code uses the client API internally.
 
 Example

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1993,7 +1993,7 @@ Audio
     If this is enabled (default), playing with a speed different from normal
     automatically inserts the ``scaletempo2`` audio filter. You can insert
     filters besides ``scaletempo2`` and modify their params using
-    `Conditional auto profiles`:
+    `Conditional auto profiles`_:
 
     ::
 


### PR DESCRIPTION
DOCS: remove references to the removed slave mode

DOCS/man/input: remove reference to the removed --clipboard-enable

DOCS/man/options: fix link to Conditional auto profiles