### PR TITLE
clipboard-wayland: read already sent data when the fd is hung up

### DIFF
--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -348,17 +348,17 @@ static bool clipboard_wayland_dispatch_events(struct clipboard_wayland_priv *wl,
     if (fds[1].revents & POLLIN)
         return false;
 
-    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
-        destroy_offer(wl->selection_offer);
-
-    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
-        destroy_offer(wl->primary_selection_offer);
-
     if (fds[2].revents & POLLIN)
         get_selection_data(wl, wl->selection_offer, false);
 
     if (fds[3].revents & POLLIN)
         get_selection_data(wl, wl->primary_selection_offer, true);
+
+    if (fds[2].revents & (POLLERR | POLLHUP | POLLNVAL))
+        destroy_offer(wl->selection_offer);
+
+    if (fds[3].revents & (POLLERR | POLLHUP | POLLNVAL))
+        destroy_offer(wl->primary_selection_offer);
 
     wl_display_dispatch_pending(wl->display);
     return true;


### PR DESCRIPTION
A "hung up" fd only indicates that the other end of the pipe is closed. This can happen when the other client has already sent some data into the pipe and closed its end. This should not be treated as an error, and reading data should proceed until read() returns 0 or -1.

Premuturely destroying offer in this case breaks getting selection data. Change it so that the cleanup on error happens after the selection data is read.

Fixes: d20ded876d27497d3fe6a9494add8106b507a45c
