### PR TITLE
osc.lua: update OSC on playlist position changes

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2651,6 +2651,7 @@ mp.register_event("shutdown", shutdown)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", "native", request_init)
 mp.observe_property("playlist-count", "native", request_init)
+mp.observe_property("playlist-pos", "native", request_init)
 mp.observe_property("chapter-list", "native", function(_, list)
     list = list or {}  -- safety, shouldn't return nil
     table.sort(list, function(a, b) return a.time < b.time end)


### PR DESCRIPTION
This ensures that the next/previous buttons are appropriately enabled/disabled when the position of the currently playing entry is changed.
