### PR TITLE
DOCS/man/mpv: document alt+v to toggle secondary sub track visibility

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -161,6 +161,9 @@ O
 v
     Toggle subtitle visibility.
 
+Alt+v
+    Toggle secondary subtitle visibility.
+
 j and J
     Cycle through the available subtitles.
 


### PR DESCRIPTION
Fixes: 62f225ef9d6e ("sub/osd: hide secondary subtitles if secondary-sub-visibility is false")

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
