### PR TITLE
sub/osd: set osd-shaper to complex by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4818,7 +4818,7 @@ OSD
     Disabled by default. See also ``--sub-ass-prune-delay``.
 
 ``--osd-shaper=<simple|complex>``
-    Set the text layout engine used by libass for the OSD. Default: simple.
+    Set the text layout engine used by libass for the OSD. Default: complex.
     See also ``--sub-shaper``
 
 Screenshot

--- a/options/options.c
+++ b/options/options.c
@@ -424,6 +424,7 @@ const struct m_sub_options mp_osd_render_sub_opts = {
         .osd_selected_color = {250, 189, 47, 255},
         .osd_selected_outline_color = {0, 0, 0, 255},
         .osd_ass_prune_delay = -1.0,
+        .osd_shaper = 1,
     },
     .change_flags = UPDATE_OSD,
 };


### PR DESCRIPTION
I'd rather not argue about which is better so go back to status quo, users can use the more sensible option of "simple" if it doesn't break anything (which it won't).

Using simple has benefits of growing memory usage slower and much faster OSD rendering when complex isn't needed.

Simple breaks rendering complex glyphs like Material font icons