### PR TITLE
video/zimg: set alpha to ZIMG_ALPHA_STRAIGHT in all cases except premul

### DIFF
--- a/video/zimg.c
+++ b/video/zimg.c
@@ -198,18 +198,6 @@ static zimg_color_primaries_e mp_to_z_prim(enum pl_color_primaries prim)
     }
 }
 
-#if HAVE_ZIMG_ALPHA
-static zimg_alpha_type_e pl_to_z_alpha(enum pl_alpha_mode alpha)
-{
-    switch (alpha) {
-    case PL_ALPHA_UNKNOWN:       return ZIMG_ALPHA_STRAIGHT;
-    case PL_ALPHA_INDEPENDENT:   return ZIMG_ALPHA_STRAIGHT;
-    case PL_ALPHA_PREMULTIPLIED: return ZIMG_ALPHA_PREMULTIPLIED;
-    default:                     return ZIMG_ALPHA_NONE;
-    }
-}
-#endif
-
 static void destroy_zimg(struct mp_zimg_context *ctx)
 {
     for (int n = 0; n < ctx->num_states; n++) {
@@ -390,7 +378,8 @@ static bool setup_format(zimg_image_format *zfmt, struct mp_zimg_repack *r,
             r->z_planes[3] = n; // alpha, always plane 4 in zimg
 
 #if HAVE_ZIMG_ALPHA
-            zfmt->alpha = pl_to_z_alpha(fmt.repr.alpha);
+            zfmt->alpha = fmt.repr.alpha == PL_ALPHA_PREMULTIPLIED
+                ? ZIMG_ALPHA_PREMULTIPLIED : ZIMG_ALPHA_STRAIGHT;
 #else
             return false;
 #endif


### PR DESCRIPTION
Fixes: 6a96b15cf48e75a1f2b17dccddf7ada95f3e0fcf ("video/csputils: add missing alpha choice")
Fixes: #16255