### PR TITLE
console.lua: fix crash when pressing Ctrl+l

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1307,7 +1307,9 @@ end
 
 -- Empty the log buffer of all messages (Ctrl+L)
 local function clear_log_buffer()
-    log_buffers[id] = {}
+    if not selectable_items then
+        log_buffers[id] = {}
+    end
     render()
 end
 


### PR DESCRIPTION
Pressing Ctrl+l with selectable items without having called input.get() earlier caused a crash.

Fixes a6024b562a.