### PR TITLE
wayland: log when direct scanout is active

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -144,6 +144,7 @@ struct vo_wayland_state {
     bool present_clock;
     bool present_v2;
     bool use_present;
+    int last_zero_copy;
 
     /* single-pixel-buffer */
     struct wp_single_pixel_buffer_manager_v1 *single_pixel_manager;


### PR DESCRIPTION
Useful for debugging issues with certain AMD GPUs that have problems that are only present in zero copy scenarios
