### PR TITLE
player/command: add mpv-full-configuration property

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3875,6 +3875,11 @@ Property list
     meson version used to compile mpv is older than 1.1.0, then a hardcoded
     string of a few, arbitrary options is displayed instead.
 
+``mpv-full-configuration``
+    The full list of enabled features available in the current build. The
+    feature names are listed in ``meson.options`` and the string is space
+    separated.
+
 ``ffmpeg-version``
     The contents of the ``av_version_info()`` API call. This is a string which
     identifies the build in some way, either through a release version number,

--- a/player/command.c
+++ b/player/command.c
@@ -3653,6 +3653,12 @@ static int mp_property_configuration(void *ctx, struct m_property *prop,
     return m_property_strdup_ro(action, arg, CONFIGURATION);
 }
 
+static int mp_property_full_configuration(void *ctx, struct m_property *prop,
+                                     int action, void *arg)
+{
+    return m_property_strdup_ro(action, arg, FULLCONFIG);
+}
+
 static int mp_property_ffmpeg(void *ctx, struct m_property *prop,
                                int action, void *arg)
 {
@@ -4444,6 +4450,7 @@ static const struct m_property mp_properties_base[] = {
 
     {"mpv-version", mp_property_version},
     {"mpv-configuration", mp_property_configuration},
+    {"mpv-full-configuration", mp_property_full_configuration},
     {"ffmpeg-version", mp_property_ffmpeg},
     {"libass-version", mp_property_libass_version},
     {"platform", mp_property_platform},


### PR DESCRIPTION
This allows the available mpv build features to be available as a property for scripts