### PR TITLE
hwdec: add v4l2request hw context driver

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1503,6 +1503,15 @@ if features['videotoolbox-pl']
     sources += files('video/out/hwdec/hwdec_vt_pl.m')
 endif
 
+v4l2reqest = get_option('v4l2request').require(
+  cc.has_header('libavutil/hwcontext_v4l2request.h'),
+  error_message: 'need ffmpeg 7.1 with v4l2 request API',
+)
+features += {'v4l2request': v4l2reqest.allowed()}
+if features['v4l2request']
+    sources += files('video/out/hwdec/hwdec_v4l2request.c')
+endif
+
 
 # macOS features
 macos_sdk_version_py = ''

--- a/meson.options
+++ b/meson.options
@@ -60,6 +60,7 @@ option('d3d11', type: 'feature', value: 'auto', description: 'Direct3D 11 video 
 option('direct3d', type: 'feature', value: 'auto', description: 'Direct3D support')
 option('dmabuf-wayland', type: 'feature', value: 'auto', description: 'dmabuf-wayland video output')
 option('drm', type: 'feature', value: 'auto', description: 'Direct Rendering Manager (DRM)')
+option('v4l2request', type: 'feature', value: 'auto', description: 'FFmpeg v4l2 request API')
 option('egl', type: 'feature', value: 'auto', description: 'EGL 1.4')
 option('egl-android', type: 'feature', value: 'auto', description: 'Android EGL support')
 option('egl-angle', type: 'feature', value: 'auto', description: 'OpenGL ANGLE headers')

--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -38,6 +38,7 @@ extern const struct ra_hwdec_driver ra_hwdec_drmprime;
 extern const struct ra_hwdec_driver ra_hwdec_drmprime_overlay;
 extern const struct ra_hwdec_driver ra_hwdec_aimagereader;
 extern const struct ra_hwdec_driver ra_hwdec_vulkan;
+extern const struct ra_hwdec_driver ra_hwdec_v4l2request;
 
 const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
 #if HAVE_VAAPI
@@ -78,6 +79,9 @@ const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
 #endif
 #if HAVE_VULKAN
     &ra_hwdec_vulkan,
+#endif
+#if HAVE_V4L2REQUEST
+    &ra_hwdec_v4l2request,
 #endif
 
     NULL

--- a/video/out/hwdec/hwdec_v4l2request.c
+++ b/video/out/hwdec/hwdec_v4l2request.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixdesc.h>
+
+#include "config.h"
+
+#include "video/fmt-conversion.h"
+#include "video/out/gpu/hwdec.h"
+
+struct priv_owner {
+    struct mp_hwdec_ctx hwctx;
+    int *formats;
+};
+
+static void uninit(struct ra_hwdec *hw)
+{
+    struct priv_owner *p = hw->priv;
+    if (p->hwctx.driver_name)
+        hwdec_devices_remove(hw->devs, &p->hwctx);
+    av_buffer_unref(&p->hwctx.av_device_ref);
+}
+
+static int init(struct ra_hwdec *hw)
+{
+    struct priv_owner *p = hw->priv;
+
+
+    MP_VERBOSE(hw, "Using auto detect video device\n");
+
+    int ret = av_hwdevice_ctx_create(&p->hwctx.av_device_ref,
+                                     AV_HWDEVICE_TYPE_V4L2REQUEST,
+                                     NULL, NULL, 0);
+    if (ret != 0) {
+        MP_VERBOSE(hw, "Failed to create hwdevice_ctx: %s\n", av_err2str(ret));
+        return -1;
+    }
+
+    /*
+     * At the moment, there is no way to discover compatible formats
+     * from the hwdevice_ctx, and in fact the ffmpeg hwaccels hard-code
+     * formats too, so we're not missing out on anything.
+     */
+    int num_formats = 0;
+    MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_NV12);
+    MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_420P);
+    MP_TARRAY_APPEND(p, p->formats, num_formats, pixfmt2imgfmt(AV_PIX_FMT_NV16));
+    MP_TARRAY_APPEND(p, p->formats, num_formats, IMGFMT_P010);
+#ifdef AV_PIX_FMT_P210
+    MP_TARRAY_APPEND(p, p->formats, num_formats, pixfmt2imgfmt(AV_PIX_FMT_P210));
+#endif
+
+
+    MP_TARRAY_APPEND(p, p->formats, num_formats, 0); // terminate it
+
+    p->hwctx.hw_imgfmt = IMGFMT_DRMPRIME;
+    p->hwctx.supported_formats = p->formats;
+    p->hwctx.driver_name = hw->driver->name;
+    hwdec_devices_add(hw->devs, &p->hwctx);
+
+    return 0;
+}
+
+const struct ra_hwdec_driver ra_hwdec_v4l2request = {
+    .name = "v4l2request",
+    .priv_size = sizeof(struct priv_owner),
+    .imgfmts = {IMGFMT_DRMPRIME, 0},
+    .device_type = AV_HWDEVICE_TYPE_V4L2REQUEST,
+    .init = init,
+    .uninit = uninit,
+};


### PR DESCRIPTION
v4l2request API patch[0] for ffmpeg 7.1 added new AVHWDeviceType: AV_HWDEVICE_TYPE_V4L2REQUEST. thus MPV player also need a driver to support this new device type. otherwise fail to use this hwdec.

this patch add a meson build option v4l2request, a new feature, default value is auto. and auto detect logic meson.build.

add new hwdec_v4l2request driver to support new
AV_HWDEVICE_TYPE_V4L2REQUEST.

tesed with mpv git and 0.40 on RK3288.

[0] https://github.com/jernejsk/FFmpeg/tree/v4l2-request-n7.1

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
