### PR TITLE
various: remove redundant return

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -275,7 +275,6 @@ static void init_physical_format(struct ao *ao)
 
 coreaudio_error:
     talloc_free(tmp);
-    return;
 }
 
 static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd, AudioChannelLayout *layout, size_t layout_size)

--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -643,7 +643,6 @@ exit_label:
     SAFE_RELEASE(state->pSessionControl);
     MP_WARN(state, "Error setting audio session name: %s\n",
             mp_HRESULT_to_str(hr));
-    return;
 }
 
 static void init_volume_control(struct wasapi_state *state)

--- a/filters/f_hwtransfer.c
+++ b/filters/f_hwtransfer.c
@@ -654,7 +654,6 @@ static void hwdownload_process(struct mp_filter *f)
 
 passthrough:
     mp_pin_in_write(f->ppins[1], frame);
-    return;
 }
 
 static const struct mp_filter_info hwdownload_filter = {

--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -311,7 +311,6 @@ static void precreate_graph(struct lavfi *c, bool first_init)
 error:
     free_graph(c);
     c->failed = true;
-    return;
 }
 
 // Ensure to send EOF to each input pad, so the graph can be drained properly.

--- a/filters/f_swscale.c
+++ b/filters/f_swscale.c
@@ -125,7 +125,6 @@ static void sws_process(struct mp_filter *f)
 error:
     mp_frame_unref(&frame);
     mp_filter_internal_mark_failed(f);
-    return;
 }
 
 static const struct mp_filter_info sws_filter = {

--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -73,7 +73,6 @@ static void remove_seat(struct clipboard_wayland_seat *seat)
         ext_data_control_device_v1_destroy(seat->dcdev);
     wl_seat_destroy(seat->seat);
     talloc_free(seat);
-    return;
 }
 
 static void destroy_offer(struct clipboard_wayland_data_offer *o)

--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -130,8 +130,6 @@ static void copy_ass(struct sd_filter *sd, char **rpp, struct buffer *buf)
         }
     }
     *rpp = rp;
-
-    return;
 }
 
 static bool skip_enclosed(struct sd_filter *sd, char **rpp, struct buffer *buf,
@@ -219,8 +217,6 @@ static void skip_speaker_label(struct sd_filter *sd, char **rpp, struct buffer *
         return;
     }
     *rpp = rp;
-
-    return;
 }
 
 // Check for text enclosed in symbols, like (SOUND)

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -616,7 +616,6 @@ static void deallocate_xvimage(struct vo *vo, int foo)
     ctx->Shminfo[foo] = (XShmSegmentInfo){0};
 
     XSync(vo->x11->display, False);
-    return;
 }
 
 static inline void put_xvimage(struct vo *vo, XvImage *xvi)

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2543,7 +2543,6 @@ static void remove_output(struct vo_wayland_output *out)
     talloc_free(out->make);
     talloc_free(out->model);
     talloc_free(out);
-    return;
 }
 
 static void remove_seat(struct vo_wayland_seat *seat)
@@ -2580,7 +2579,6 @@ static void remove_seat(struct vo_wayland_seat *seat)
 
     wl_seat_destroy(seat->seat);
     talloc_free(seat);
-    return;
 }
 
 static void seat_create_dnd_ddev(struct vo_wayland_seat *seat)


### PR DESCRIPTION
void return type functions don't need a final return statement.
