### PR TITLE
sub/osd_libass: don't rerender OSD if not changed

### DIFF
--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -685,8 +685,14 @@ static void append_ass(struct ass_state *ass, struct mp_osd_res *res,
 struct sub_bitmaps *osd_object_get_bitmaps(struct osd_state *osd,
                                            struct osd_object *obj, int format)
 {
-    if (obj->type == OSDTYPE_OSD && obj->osd_changed)
-        update_osd(osd, obj);
+    if (obj->type == OSDTYPE_OSD) {
+        if (obj->osd_changed) {
+            update_osd(osd, obj);
+        } else {
+            mp_require(obj->ass_packer);
+            goto done;
+        }
+    }
 
     if (!obj->ass_packer)
         obj->ass_packer = mp_ass_packer_alloc(obj);
@@ -704,6 +710,7 @@ struct sub_bitmaps *osd_object_get_bitmaps(struct osd_state *osd,
         }
     }
 
+done:;
     struct sub_bitmaps out_imgs = {0};
     mp_ass_packer_pack(obj->ass_packer, obj->ass_imgs, obj->num_externals + 1,
                        obj->changed, false, format, &out_imgs);


### PR DESCRIPTION
Rendering OSD on every frame draw is quite heavy, even if some of the rendering parts are cached, it still takes significant amount of time, depending of payload can take 8-10 ms just to do the text shaping.

Instead render only when we need it.