### PR TITLE
misc/language: mark arrays as nonstring for GCC 15

### DIFF
--- a/misc/language.c
+++ b/misc/language.c
@@ -26,8 +26,8 @@
 #define L(s) { #s, sizeof(#s) - 1 }
 
 static const struct lang {
-    struct { const char s[3]; uint8_t l; } match;
-    struct { const char s[3]; uint8_t l; } canonical;
+    struct { const char s[3] MP_NONSTRING; uint8_t l; } match;
+    struct { const char s[3] MP_NONSTRING; uint8_t l; } canonical;
 } langmap[] = {
     {L(aa), L(aar)},
     {L(ab), L(abk)},

--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -26,6 +26,16 @@
 #define thread_local _Thread_local
 #endif
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(nonstring)
+#define MP_NONSTRING __attribute__((nonstring))
+#else
+#define MP_NONSTRING
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #define PRINTF_ATTRIBUTE(a1, a2) __attribute__((format(printf, a1, a2)))
 #define SCANF_ATTRIBUTE(a1, a2) __attribute__((format(scanf, a1, a2)))

--- a/osdep/win32/smtc.cpp
+++ b/osdep/win32/smtc.cpp
@@ -23,7 +23,14 @@
 
 #include <windows.h>
 #include <systemmediatransportcontrolsinterop.h>
+#if defined(__GNUC__) && !defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wtemplate-body"
+#endif
 #include <winrt/Windows.Foundation.h>
+#if defined(__GNUC__) && !defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Storage.h>

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -1500,7 +1500,7 @@ static size_t vbuf_upload(struct ra *ra, void *data, size_t size)
     return offset;
 }
 
-static const char cache_magic[4] = "RD11";
+static const char cache_magic[4] MP_NONSTRING = "RD11";
 static const uint32_t cache_version = 4;
 
 struct cache_header {


### PR DESCRIPTION
Fixes unterminated-string-initialization warnings.