### PR TITLE
build: move check for DXGI_DEBUG_D3D11 down

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1005,7 +1005,6 @@ features += {'d3d11': d3d11.allowed()}
 if features['d3d11']
     sources += files('video/out/d3d11/context.c',
                      'video/out/d3d11/ra_d3d11.c')
-    features += {'dxgi-debug-d3d11': cc.has_header_symbol('d3d11sdklayers.h', 'DXGI_DEBUG_D3D11')}
 endif
 
 wayland = {
@@ -1200,6 +1199,7 @@ endif
 
 if features['d3d11'] or features['egl-angle-win32']
     sources += files('video/out/gpu/d3d11_helpers.c')
+    features += {'dxgi-debug-d3d11': cc.has_header_symbol('d3d11sdklayers.h', 'DXGI_DEBUG_D3D11')}
 endif
 
 egl = dependency('egl', version: '>= 1.4.0', required: get_option('egl'))


### PR DESCRIPTION
video/out/gpu/d3d11_helpers.c requires it as well, and it's possible to have egl-angle-win32 enabled without d3d11.

