### PR TITLE
clipboard-wayland: flush display after creating data sources

### DIFF
--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -298,6 +298,7 @@ static void create_data_sources(struct clipboard_wayland_priv *wl)
             seat_create_data_source(seat, true);
         }
     }
+    wl_display_flush(wl->display);
 }
 
 static void clipboard_wayland_uninit(struct clipboard_wayland_priv *wl)


### PR DESCRIPTION
The data source requests are prepared inside create_data_sources from a different thread than the clipboard thread, so it is necessary to flush here. Otherwise, if mpv is not already managing the current selection, we'll have to wait until the clipboard thread reenters clipboard_wayland_dispatch_events for the request to be sent to the compositor and have the other clients be sent new the new selection, which may take up to 10 seconds.