### PR TITLE
wayland: allow potential dragging of maximized windows

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3088,7 +3088,7 @@ static void begin_dragging(struct vo_wayland_state *wl)
 {
     struct vo_wayland_seat *s = wl->last_button_seat;
     if (!mp_input_test_dragging(wl->vo->input_ctx, wl->mouse_x, wl->mouse_y) &&
-        !wl->locked_size && s)
+        !wl->opts->fullscreen && s)
     {
         xdg_toplevel_move(wl->xdg_toplevel, s->seat, s->pointer_button_serial);
         wl->last_button_seat = NULL;


### PR DESCRIPTION
The locked_size restriction also prevents dragging from working on maximized and tiled windows. A compositor may choose to restrict this anyway (esp. tiling window managers), but there's no harm in sending the request if it supports it. The only thing we really need to block here is the fullscreen case. Fixes #16338.