### PR TITLE
stream_mpv: fix issue that paths requiring ytdl hook fail to open

### DIFF
--- a/stream/stream_mpv.c
+++ b/stream/stream_mpv.c
@@ -29,6 +29,6 @@ static int open_mpv(stream_t *st)
 const stream_info_t stream_info_mpv = {
     .name = "mpv",
     .open = open_mpv,
-    .stream_origin = STREAM_ORIGIN_NET,
+    .stream_origin = STREAM_ORIGIN_FS,
     .protocols = (const char*const[]){"mpv", NULL},
 };


### PR DESCRIPTION
Details in issue https://github.com/mpv-player/mpv/issues/16342.

> The cause of the issue seems to be that when the mpv URL is sent to ytdl, it is resolved into some edl streams. And since mpv stream has [STREAM_ORIGIN_NET](https://github.com/mpv-player/mpv/blob/f9ec3d2c25ce8f7377f6494270467ca89bea9fc9/stream/stream_mpv.c#L32), edl stream has [STREAM_ORIGIN_FS](https://github.com/mpv-player/mpv/blob/f9ec3d2c25ce8f7377f6494270467ca89bea9fc9/stream/stream_edl.c#L17), and [mpv doesn't allow network stream to open non-network stream](https://github.com/mpv-player/mpv/blob/f9ec3d2c25ce8f7377f6494270467ca89bea9fc9/stream/stream.c#L234), the stream will fail to open. Obviously I can workaround by changing mpv stream's origin to STREAM_ORIGIN_FS, but is it the right approach? I guess the only other option is to allow NET stream to open FS stream, but I don't know the history why the restriction is there to begin with.