### PR TITLE
console.lua: bind Ctrl+y to copy

### DIFF
--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -90,6 +90,9 @@ Ctrl+v
 Shift+INSERT
     Paste text (uses the primary selection on X11 and Wayland).
 
+Ctrl+y
+    Copy the current line to the clipboard.
+
 TAB and Ctrl+i
     Cycle through completions.
 

--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -28,6 +28,9 @@ PGUP and Ctrl+b
 PGDN and Ctrl+f
     Scroll down one page.
 
+Ctrl+y
+    Copy the focused item to the clipboard.
+
 MBTN_LEFT
     Select the item under the cursor, or close the console if clicking outside
     of the menu rectangle.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1357,6 +1357,21 @@ local function paste(clip)
     handle_edit()
 end
 
+local function copy()
+    if not selectable_items then
+        mp.set_property("clipboard/text", line)
+        mp.msg.info("Input line copied")
+    elseif matches[1] then
+        mp.set_property("clipboard/text", matches[focused_match].text)
+
+        if terminal_output() then
+            mp.msg.info("Item copied")
+        else
+            mp.osd_message("Item copied")
+        end
+    end
+end
+
 local function text_input(info)
     if info.key_text and (info.event == "press" or info.event == "down"
                           or info.event == "repeat")
@@ -1485,6 +1500,7 @@ local function get_bindings()
         { "ctrl+k",      del_to_eol                             },
         { "ctrl+l",      clear_log_buffer                       },
         { "ctrl+u",      del_to_start                           },
+        { "ctrl+y",      copy,                                  },
         { "ctrl+v",      function() paste(true) end             },
         { "meta+v",      function() paste(true) end             },
         { "ctrl+bs",     del_word                               },


### PR DESCRIPTION
Make Ctrl+y copy the input line to the clipboard, or the currently selected item in the menu.

The vi key to copy is used because Ctrl+c is already bound.

Alternative bindings are:
Ctrl+x to cut, but this also clears the line.
Ctrl+shift+c like in terminals, but this is harder to press, and this commit works differently from terminals anyway since you don't manually highlight characters, it just copies the whole line.
Alt+w, the emacs copy binding, but unless you use emacs this is weird and unfamiliar.