### PR TITLE
ao/avfoundation: fix memory leak

### DIFF
--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -83,7 +83,7 @@ static void feed(struct ao *ao)
         ao_stop_streaming(ao);
     }
     if (real_sample_count == 0) {
-        return;
+        goto finish;
     }
 
     if ((err = CMBlockBufferCreateWithMemoryBlock(


### PR DESCRIPTION
Fix memory leak in ao_avfoundation caused by audio device switching https://github.com/mpv-player/mpv/issues/16283