### PR TITLE
select.lua: set ao with audio-device

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -556,22 +556,22 @@ void ao_device_list_add(struct ao_device_list *list, struct ao *ao,
                         struct ao_device_desc *e)
 {
     struct ao_device_desc c = *e;
-    const char *dname = ao->driver->name;
+    c.ao = ao->driver->name;
     char buf[80];
     if (!c.desc || !c.desc[0]) {
         if (c.name && c.name[0]) {
             c.desc = c.name;
         } else if (list->num_devices) {
             // Assume this is the default device.
-            snprintf(buf, sizeof(buf), "Default (%s)", dname);
+            snprintf(buf, sizeof(buf), "Default (%s)", c.ao);
             c.desc = buf;
         } else {
             // First default device (and maybe the only one).
             c.desc = "Default";
         }
     }
-    c.name = (c.name && c.name[0]) ? talloc_asprintf(list, "%s/%s", dname, c.name)
-                                   : talloc_strdup(list, dname);
+    c.name = (c.name && c.name[0]) ? talloc_asprintf(list, "%s/%s", c.ao, c.name)
+                                   : talloc_strdup(list, c.ao);
     c.desc = talloc_strdup(list, c.desc);
     MP_TARRAY_APPEND(list, list->devices, list->num_devices, c);
 }

--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -63,6 +63,7 @@ enum {
 struct ao_device_desc {
     const char *name;   // symbolic name; will be set on ao->device
     const char *desc;   // verbose human readable name
+    const char *ao;   // ao name; will be set on ao
 };
 
 struct ao_device_list {

--- a/player/command.c
+++ b/player/command.c
@@ -1795,6 +1795,7 @@ static int get_device_entry(int item, int action, void *arg, void *ctx)
     struct m_sub_property props[] = {
         {"name",        SUB_PROP_STR(entry->name)},
         {"description", SUB_PROP_STR(entry->desc)},
+        {"ao", SUB_PROP_STR(entry->ao)},
         {0}
     };
 

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -344,11 +344,12 @@ mp.add_key_binding(nil, "select-audio-device", function ()
     end
 
     input.select({
-        prompt = "Select an audio device:",
+        prompt = "Select an audio device (and ao):",
         items = items,
         default_item = default_item,
         submit = function (id)
             mp.set_property("audio-device", devices[id].name)
+            mp.set_property("ao", devices[id].ao)
         end,
     })
 end)


### PR DESCRIPTION
 This is arguably the expected and useful behavior. And there
 is no logical reason we should be bound to setting only one
 property here.