### PR TITLE
command: fix frame step with mouse buttons

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5750,7 +5750,10 @@ static void cmd_frame_step(void *p)
     }
 
     if (flags == 1) {
-        if (!cmd->cmd->is_up)
+        // frame-step command has on_updown set so it is called on both down
+        // and up, but stepping should only be triggered when it matches the
+        // emit_on_up flag.
+        if (cmd->cmd->is_up == cmd->cmd->emit_on_up)
             add_step_frame(mpctx, frames, true);
     } else {
         if (cmd->cmd->is_up) {


### PR DESCRIPTION
c7c09fdb8b5ccfb91b44cb3d1e5184c92ef7a070 made frame step with seek flag ignore key ups. However, for commands with emit_on_up flag set, which can happen with mouse buttons, command should only be triggered on key ups. This results in frame-step command with seek flag triggered on mouse down instead of mouse up, and frame-back-step command not working with mouse.

Fix this by making sure that step is triggered depending on the emit_on_up flag.

Fixes: c7c09fdb8b5ccfb91b44cb3d1e5184c92ef7a070
Fixes: #16391