### PR TITLE
vo_gpu_next: fix corrupted SDR output on HDR display device

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -995,7 +995,9 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
         target_csp.hdr.min_luma = 0;
     }
 
-    float target_peak = opts->target_peak ? opts->target_peak : target_csp.hdr.max_luma;
+    float target_peak = opts->target_peak
+                      ? opts->target_peak
+                      : (p->next_opts->target_hint ? target_csp.hdr.max_luma : 0);
     struct pl_color_space hint;
     bool target_hint = p->next_opts->target_hint == 1 ||
                        (p->next_opts->target_hint == -1 &&


### PR DESCRIPTION
always specify a default target-peak of 203 for the SDR output to ensure a good display

Fixes https://github.com/mpv-player/mpv/issues/15411
See-Also https://github.com/mpv-player/mpv/issues/16360#issuecomment-2891038681

