### PR TITLE
vo_gpu_next: add options to control subtitles peak for HDR output

### DIFF
--- a/DOCS/interface-changes/image-subs-hdr-peak.txt
+++ b/DOCS/interface-changes/image-subs-hdr-peak.txt
@@ -1,0 +1,1 @@
+add `--image-subs-hdr-peak` option

--- a/DOCS/interface-changes/sub-hdr-peak.txt
+++ b/DOCS/interface-changes/sub-hdr-peak.txt
@@ -1,0 +1,1 @@
+add `--sub-hdr-peak` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2779,6 +2779,20 @@ Subtitles
     canvas size. Can be useful to test broken subtitles, which often happen
     when the video was transcoded, while attempting to keep the old subtitles.
 
+``--image-subs-hdr-peak=<sdr|video|10-10000>``
+    Controls the image subtitle diffuse white level in cd/m² (nits) for HDR
+    output. ``sdr`` is 203 cd/m² for standard SDR white, while ``video``
+    uses video metadata. (``--vo=gpu-next`` only)
+
+    Default: sdr
+
+``--sub-hdr-peak=<sdr|10-10000>``
+    Controls the text subtitle and OSD diffuse white level in cd/m² (nits)
+    for HDR output. ``sdr`` is 203 cd/m² for standard SDR white.
+    (``--vo=gpu-next`` only)
+
+    Default: sdr
+
 ``--sub-ass=<yes|no>``
     Render ASS subtitles natively (default: yes).
 


### PR DESCRIPTION
Users may want darker subtitle brightness for HDR viewing

Closed https://github.com/mpv-player/mpv/issues/13680

