### PR TITLE
ci/win32: enable libaom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
         run: |
           python -m pip install meson
           choco install ccache nasm
+          ./ci/install-cmake.ps1 -arch ${{ matrix.arch }}
 
       - name: Update Meson WrapDB
         run: |
@@ -177,7 +178,7 @@ jobs:
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' -and `
                                                              $_ -ne 'C:\Program Files\CMake\bin' -and `
                                                              $_ -ne 'C:\Strawberry\c\bin' }) -join ';'
-          $env:PATH += ';C:\Program Files\NASM'
+          $env:PATH = "$pwd\cmake\bin;" + $env:PATH + ';C:\Program Files\NASM'
           Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
           Enter-VsDevShell -VsInstallPath $env:VS -SkipAutomaticLocation -DevCmdArguments "-arch=${{ matrix.arch }} -host_arch=${{ matrix.arch }}"
           ./ci/build-win32.ps1
@@ -193,7 +194,7 @@ jobs:
           $env:PATH = ($env:PATH -split ';' | Where-Object { $_ -ne 'C:\Program Files\LLVM\bin' -and `
                                                              $_ -ne 'C:\Program Files\CMake\bin' -and `
                                                              $_ -ne 'C:\Strawberry\c\bin' }) -join ';'
-          $env:PATH += ';C:\Program Files\NASM'
+          $env:PATH = "$pwd\cmake\bin;" + $env:PATH + ';C:\Program Files\NASM'
           Import-Module "$env:VS\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
           Enter-VsDevShell -VsInstallPath $env:VS -SkipAutomaticLocation -DevCmdArguments "-arch=${{ matrix.arch }} -host_arch=${{ matrix.arch }}"
           meson test -C build -t 2

--- a/ci/build-win32.ps1
+++ b/ci/build-win32.ps1
@@ -180,6 +180,15 @@ $projects = @(
         Path = "$subprojects/libjxl-cmake.wrap"
         URL = "https://github.com/libjxl/libjxl"
         Revision = "main"
+    },
+    @{
+        Path = "$subprojects/aom.wrap"
+        URL = "https://aomedia.googlesource.com/aom"
+        Revision = "main"
+        Method = "cmake"
+        Provides = @(
+            "aom = aom_dep"
+        )
     }
 )
 
@@ -214,6 +223,7 @@ meson setup build `
     -Dffmpeg:vulkan=auto `
     -Dffmpeg:libdav1d=enabled `
     -Dffmpeg:libjxl=enabled `
+    -Dffmpeg:libaom=enabled `
     -Dlcms2:fastfloat=true `
     -Dlcms2:jpeg=disabled `
     -Dlcms2:tiff=disabled `

--- a/ci/install-cmake.ps1
+++ b/ci/install-cmake.ps1
@@ -1,0 +1,16 @@
+param(
+    [string]$arch,
+    [string]$version = "4.0.2"
+)
+
+if ($arch -eq "x64") {
+    $arch = "x86_64"
+}
+
+$cmake_fullname = "cmake-$version-windows-$arch"
+
+$cmake_url = "https://github.com/Kitware/CMake/releases/download/v$version/$cmake_fullname.zip"
+
+Invoke-WebRequest $cmake_url -OutFile .\$cmake_fullname.zip
+Expand-Archive -Path .\$cmake_fullname.zip -DestinationPath .\ -Force
+Rename-Item -Path .\$cmake_fullname -NewName cmake


### PR DESCRIPTION
enable libaom for win32 msvc builds which used to encode avif screenshots.

fixed #16428 

Any idea to enable librav1e? I have tried a lot but cannot integrate it.
