### PR TITLE
DOCS/man/lua: fix spacing issues

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -174,7 +174,7 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     as possible), and upon completion, fn is called. fn has three arguments:
     ``fn(success, result, error)``:
 
-         ``success``
+        ``success``
             Always a Boolean and is true if the command was successful,
             otherwise false.
 
@@ -490,6 +490,7 @@ The ``mp`` module is preloaded, although it can be loaded manually with
     the timer is re-added after the function fn is run.
 
     Returns a timer object. The timer object provides the following methods:
+
         ``stop()``
             Disable the timer. Does nothing if the timer is already disabled.
             This will remember the current elapsed time when stopping, so that


### PR DESCRIPTION
This introduces an extra [block quote](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#block-quotes) that causes incorrect indentation in the rendered document:

https://github.com/mpv-player/mpv/blob/ed8954e8cf2d92d7f2df22aeeb9b6087f76ef89e/DOCS/man/lua.rst?plain=1#L177

This introduces an extra [definition list](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#definition-lists) that causes an unexpected bolding effect:

https://github.com/mpv-player/mpv/blob/ed8954e8cf2d92d7f2df22aeeb9b6087f76ef89e/DOCS/man/lua.rst?plain=1#L492-L493

(I found these when writing a [script](https://github.com/rkscv/dotfiles/blob/8399bfc77e75cf3491c2f541a50fa1d467da9012/mpv/mp/gen.py) to generate Lua language server [definition files](https://luals.github.io/wiki/definition-files/) from `lua.rst`.)
