### PR TITLE
osc.lua: fix volume icon not updating while paused

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2738,6 +2738,8 @@ end)
 
 mp.observe_property("display-fps", "number", set_tick_delay)
 mp.observe_property("pause", "bool", pause_state)
+mp.observe_property("volume", "number", request_tick)
+mp.observe_property("mute", "bool", request_tick)
 mp.observe_property("demuxer-cache-state", "native", cache_state)
 mp.observe_property("vo-configured", "bool", request_tick)
 mp.observe_property("playback-time", "number", request_tick)


### PR DESCRIPTION
The volume icon in the OSC did not update when mute toggled or
volume changed while playback was paused and mouse was idle.

This commit adds observers for mute and volume properties to
request_tick(), ensuring OSC updates immediately on mute or
volume changes, even if playback is paused and mouse is idle.