### PR TITLE
demux_cue: ignore mcn

### DIFF
--- a/demux/cue.c
+++ b/demux/cue.c
@@ -59,6 +59,7 @@ static const struct {
     { CUE_UNUSED, "REM" },
     { CUE_UNUSED, "SONGWRITER" },
     { CUE_UNUSED, "MESSAGE" },
+    { CUE_UNUSED, "MCN" },
     { -1 },
 };
 


### PR DESCRIPTION
It is found in cue files output by cyanrip which currently can't be opened by mpv.
```
....
REM MEDIA_TYPE "CD"
REM COMMENT "cyanrip 0.9.3"
MCN "0000000000000"
TITLE "Unknown disc (...)"
FILE "1 - Unknown track.flac" WAVE
  TRACK 01 AUDIO
    TITLE "Unknown track"
    INDEX 01 00:00:00
```