### PR TITLE
m_option: add m_opt_choice_str_def

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -746,7 +746,7 @@ static void parse_trackvideo(struct demuxer *demuxer, struct mkv_track *track,
         MP_DBG(demuxer, "|   + Colorspace: %#"PRIx32"\n", track->colorspace);
     }
     if (video->n_stereo_mode) {
-        const char *name = MP_STEREO3D_NAME(video->stereo_mode);
+        const char *name = MP_STEREO3D_NAME_DEF(video->stereo_mode, NULL);
         if (name) {
             track->stereo_mode = video->stereo_mode;
             MP_DBG(demuxer, "|   + StereoMode: %s\n", name);

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -611,11 +611,20 @@ const m_option_type_t m_option_type_byte_size = {
 const char *m_opt_choice_str(const struct m_opt_choice_alternatives *choices,
                              int value)
 {
+    const char *val = m_opt_choice_str_def(choices, value, NULL);
+    if (val)
+        return val;
+    mp_require(false && "Invalid choice value!");
+}
+
+const char *m_opt_choice_str_def(const struct m_opt_choice_alternatives *choices,
+                                 int value, const char *def)
+{
     for (const struct m_opt_choice_alternatives *c = choices; c->name; c++) {
         if (c->value == value)
             return c->name;
     }
-    mp_require(false && "Invalid choice value!");
+    return def;
 }
 
 static void print_choice_values(struct mp_log *log, const struct m_option *opt)

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -193,6 +193,9 @@ struct m_opt_choice_alternatives {
 const char *m_opt_choice_str(const struct m_opt_choice_alternatives *choices,
                              int value);
 
+const char *m_opt_choice_str_def(const struct m_opt_choice_alternatives *choices,
+                                 int value, const char *def);
+
 typedef int (*m_opt_generic_validate_fn)(struct mp_log *log, const m_option_t *opt,
                                          struct bstr name, void *value);
 

--- a/video/csputils.h
+++ b/video/csputils.h
@@ -61,10 +61,7 @@ enum mp_stereo3d_mode {
 
 extern const struct m_opt_choice_alternatives mp_stereo3d_names[];
 
-#define MP_STEREO3D_NAME(x) m_opt_choice_str(mp_stereo3d_names, x)
-
-#define MP_STEREO3D_NAME_DEF(x, def) \
-    (MP_STEREO3D_NAME(x) ? MP_STEREO3D_NAME(x) : (def))
+#define MP_STEREO3D_NAME_DEF(x, def) m_opt_choice_str_def(mp_stereo3d_names, x, def)
 
 // For many colorspace conversions, in particular those involving HDR, an
 // implicit reference white level is needed. Since this magic constant shows up


### PR DESCRIPTION
Most users of this function doesn't expect it to return NULL, with exception of Stereo-3D video mode. Which is a list directly linked to Matroska specification, and used as value check in demux_mkv and also when printing format.

There already was a MP_STEREO3D_NAME_DEF macro, so just promote this to more generic function.

Fixes assert on invalid value found by OSS-Fuzz.
Fixes double evaluation in MP_STEREO3D_NAME_DEF macro.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
