### PR TITLE
--prefetch-playlist reverts

### DIFF
--- a/DOCS/interface-changes/prefetch-playlist.txt
+++ b/DOCS/interface-changes/prefetch-playlist.txt
@@ -1,0 +1,1 @@
+change `--prefetch-playlist` default to `no`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4228,7 +4228,7 @@ Demuxer
 
 ``--prefetch-playlist=<yes|no>``
     Prefetch next playlist entry while playback of the current entry is ending
-    (default: yes).
+    (default: no).
 
     This does not prefill the cache with the video data of the next URL.
     Prefetching video data is supported only for the current playlist entry,

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4228,16 +4228,16 @@ Demuxer
 
 ``--prefetch-playlist=<yes|no>``
     Prefetch next playlist entry while playback of the current entry is ending
-    (default: no).
-
-    This does not prefill the cache with the video data of the next URL.
-    Prefetching video data is supported only for the current playlist entry,
-    and depends on the demuxer cache settings (on by default). This merely
-    opens the URL of the next playlist entry as soon the current URL is fully
-    read.
+    (default: no). This merely opens the URL of the next playlist entry as soon
+    as the current URL is fully read.
 
     This does **not** work with URLs resolved by the ``youtube-dl`` wrapper,
     and it won't.
+
+    This does not affect HLS streams (``.m3u8`` URLs). Such stream by itself is
+    internally a playlist of data segments, but is treated as a single media
+    item by mpv. HLS prefetching depends on the demuxer cache settings and is
+    on by default.
 
     This can occasionally make wrong prefetching decisions. For example, it
     can't predict whether you go backwards in the playlist, and assumes you

--- a/options/options.c
+++ b/options/options.c
@@ -1008,7 +1008,6 @@ static const struct MPOpts mp_default_opts = {
     .demuxer_thread = true,
     .demux_termination_timeout = 0.1,
     .hls_bitrate = INT_MAX,
-    .prefetch_open = true,
     .cache_pause = true,
     .cache_pause_wait = 1.0,
     .ab_loop = {MP_NOPTS_VALUE, MP_NOPTS_VALUE},


### PR DESCRIPTION
This reverts decisions and documentation changes based on incorrect information on how `--prefetch-playlist` works. 