### PR TITLE
DOCS/man/options: document target-prim display-p3

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6993,6 +6993,8 @@ them.
         CIE 1931 RGB (not to be confused with CIE XYZ)
     dci-p3
         DCI-P3 (Digital Cinema Colorspace), SMPTE RP431-2
+    display-p3
+        DCI-P3 with a D65 white point
     v-gamut
         Panasonic V-Gamut (VARICAM) primaries
     s-gamut


### PR DESCRIPTION
This is common in most consumer "wide gamut" displays since everyone copies Apple.

