### PR TITLE
player/loadfile: limit playlist length to 3 for fuzzing

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1670,7 +1670,7 @@ static void play_current_file(struct MPContext *mpctx)
     reset_playback_state(mpctx);
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    if (mpctx->playlist->num_entries > 10)
+    if (mpctx->playlist->num_entries > 3)
         goto terminate_playback;
 #endif
 


### PR DESCRIPTION
We have 5 seconds limit for file playback, so 10 items it's bit much. 3 should be enough to cover some file switching and so on.