### PR TITLE
DOCS/man/input: only sequence prefixes need to be unbound

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -74,10 +74,25 @@ It's also possible to bind a command to a sequence of keys:
 
 (This is not shown in the general command syntax.)
 
-If ``a`` or ``a-b`` or ``b`` are already bound, this will run the first command
-that matches, and the multi-key command will never be called. Intermediate keys
-can be remapped to ``ignore`` in order to avoid this issue. The maximum number
-of (non-modifier) keys for combinations is currently 4.
+Key matching
+------------
+
+mpv maintains key press history. If the current key completes one or more bound
+sequences (including single-key bindings), then mpv chooses the longest. If this
+sequence is bound to ``ignore``, then tracking continues as if nothing was
+matched. Otherwise, it triggers the command bound to this sequence and clears
+the key history.
+
+Note that while single-key bindings override builtin bindings, this is not the
+case with multi-key sequences. For example, a ``b-c`` sequence in input.conf
+would be overridden by a builtin binding ``b``. In this case, if you don't care
+about ``b``, you can bind it to ``ignore``.
+
+As a more complex example, if you want to bind both ``b`` and ``a-b-c``, then it
+won't work, because ``b`` would override ``a-b-c``. However, binding ``a-b`` to
+``ignore`` would allow that, because after ``a-b`` the longest match ``a-b`` is
+ignored, and a following ``c`` would trigger the sequence ``a-b-c`` while ``b``
+alone would still work.
 
 Key names
 ---------


### PR DESCRIPTION
DOCS/man/input: only sequence prefixes need to be unbound

Make it clear that as long as a and a-b are not bound, the a-b-c binding works even if b is bound.

The 4-key limit for sequences was raised to 16 by a5dbf34094, because MP_MAX_KEY_DOWN is used for both the number of keys that can be held down and for the key history size. Just remove the related sentence since you're never going to need sequences longer than 16 keys.