### PR TITLE
build: fix installation directory for encoding-profiles.conf

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1786,7 +1786,6 @@ endif
 
 if get_option('cplayer')
     datadir = get_option('datadir')
-    confdir = get_option('sysconfdir')
 
     conf_files = ['etc/mpv.conf', 'etc/input.conf',
                   'etc/mplayer-input.conf', 'etc/restore-old-bindings.conf',
@@ -1803,7 +1802,7 @@ if get_option('cplayer')
     install_data('etc/mpv.fish', install_dir: fish_install_dir, rename: 'mpv.fish')
 
     install_data('etc/mpv.metainfo.xml', install_dir: join_paths(datadir, 'metainfo'))
-    install_data('etc/encoding-profiles.conf', install_dir: join_paths(confdir, 'mpv'))
+    install_data('etc/encoding-profiles.conf', install_dir: conf_data.get_unquoted('MPV_CONFDIR'))
 
     foreach size: ['16x16', '32x32', '64x64', '128x128']
         icon_dir = join_paths(datadir, 'icons', 'hicolor', size, 'apps')


### PR DESCRIPTION
The 'sysconfdir' option value is not correct to use here because it is not guaranteed to be an absolute path. What we actually want is to install the file in the same location where mpv will read the global configuration path. So instead we can just use the value in the configuration data generated earlier for the directory here.

Ref #16430.
