### PR TITLE
build: install encoding-profiles.conf into the system data directory

### DIFF
--- a/DOCS/encoding.rst
+++ b/DOCS/encoding.rst
@@ -97,12 +97,9 @@ Device targets
 As the options for various devices can get complex, profiles can be used.
 
 An example profile file for encoding is provided in
-etc/encoding-profiles.conf in the source tree. This file is installed and loaded
-by default. If you want to modify it, you can replace and it with your own copy
-by doing::
-
-  mkdir -p ~/.mpv
-  cp /etc/mpv/encoding-profiles.conf ~/.mpv/encoding-profiles.conf
+etc/encoding-profiles.conf in the source tree. mpv will read any file
+named ``encoding-profiles.conf`` in either the local or system
+configuration directories.
 
 Keep in mind that the default profile is the playback one. If you want to add
 options that apply only in encoding mode, put them into a ``[encoding]``

--- a/DOCS/interface-changes/encoding-profiles.txt
+++ b/DOCS/interface-changes/encoding-profiles.txt
@@ -1,0 +1,1 @@
+`encoding-profiles.conf` is no longer installed by default into the system configuration directory and is instead installed in the data directory

--- a/etc/encoding-profiles.conf
+++ b/etc/encoding-profiles.conf
@@ -6,10 +6,9 @@
 # encoding profile file #
 #########################
 #
-# Note: by default, this file is installed to /etc/mpv/encoding-profiles.conf
-# (or a different location, depending on --prefix). mpv will load it by
-# default on program start. If ~/.mpv/encoding-profiles.conf exists, this file
-# will be loaded instead.
+# Note: This file contains predefined encoding-related profiles that were
+# installed and loaded by default in old versions of mpv. Consider this a
+# historical reference.
 #
 # Then, list all profiles by
 #   mpv --profile=help | grep enc-

--- a/meson.build
+++ b/meson.build
@@ -1786,9 +1786,8 @@ endif
 
 if get_option('cplayer')
     datadir = get_option('datadir')
-    confdir = get_option('sysconfdir')
 
-    conf_files = ['etc/mpv.conf', 'etc/input.conf',
+    conf_files = ['etc/mpv.conf', 'etc/encoding-profiles.conf', 'etc/input.conf',
                   'etc/mplayer-input.conf', 'etc/restore-old-bindings.conf',
                   'etc/restore-osc-bindings.conf']
     install_data(conf_files, install_dir: join_paths(datadir, 'doc', 'mpv'))
@@ -1803,7 +1802,6 @@ if get_option('cplayer')
     install_data('etc/mpv.fish', install_dir: fish_install_dir, rename: 'mpv.fish')
 
     install_data('etc/mpv.metainfo.xml', install_dir: join_paths(datadir, 'metainfo'))
-    install_data('etc/encoding-profiles.conf', install_dir: join_paths(confdir, 'mpv'))
 
     foreach size: ['16x16', '32x32', '64x64', '128x128']
         icon_dir = join_paths(datadir, 'icons', 'hicolor', size, 'apps')


### PR DESCRIPTION
fd4e3af740fc00804e3f1b932462b44f795b1095 originally started installing it, and we've been doing it ever since then. The value of having all of these encoding profiles predefined by default is pretty dubious since a lot of them are pretty old ('MP4 for Nokia N900' being a shining example) and mpv is not really a good encoding tool anyways. Let's treat it like the other conf files in etc and install it in the data directory for reference. If someone really uses these, they can copy the file over locally to their mpv config directory and it'll still work fine.

Alternative to #16526.