### PR TITLE
encode: simplify all initial blocking logic for encoding

### DIFF
--- a/audio/out/ao.c
+++ b/audio/out/ao.c
@@ -362,7 +362,7 @@ int ao_query_and_reset_events(struct ao *ao, int events)
 }
 
 // Returns events that were set by this calls.
-int ao_add_events(struct ao *ao, int events)
+static int ao_add_events(struct ao *ao, int events)
 {
     unsigned prev_events = atomic_fetch_or(&ao->events_, events);
     unsigned new = events & ~prev_events;

--- a/audio/out/ao.h
+++ b/audio/out/ao.h
@@ -43,7 +43,6 @@ enum aocontrol {
 enum {
     AO_EVENT_RELOAD = 1,
     AO_EVENT_HOTPLUG = 2,
-    AO_EVENT_INITIAL_UNBLOCK = 4,
 };
 
 enum {
@@ -104,8 +103,6 @@ bool ao_is_playing(struct ao *ao);
 struct mp_async_queue;
 struct mp_async_queue *ao_get_queue(struct ao *ao);
 int ao_query_and_reset_events(struct ao *ao, int events);
-int ao_add_events(struct ao *ao, int events);
-void ao_unblock(struct ao *ao);
 void ao_request_reload(struct ao *ao);
 void ao_hotplug_event(struct ao *ao);
 

--- a/audio/out/internal.h
+++ b/audio/out/internal.h
@@ -131,10 +131,6 @@ struct ao_driver {
     const char *name;
     // Description shown with --ao=help.
     const char *description;
-    // This requires waiting for a AO_EVENT_INITIAL_UNBLOCK event before the
-    // first write() call is done. Encode mode uses this, and push mode
-    // respects it automatically (don't use with pull mode).
-    bool initially_blocked;
     // If true, write units of entire frames. The write() call is modified to
     // use data==mp_aframe. Useful for encoding AO only.
     bool write_frames;

--- a/common/encode_lavc.h
+++ b/common/encode_lavc.h
@@ -97,18 +97,12 @@ struct encoder_context *encoder_context_alloc(struct encode_lavc_context *ctx,
 
 // After setting your codec parameters on p->encoder, you call this to "open"
 // the encoder. This also initializes p->mux_stream. Returns false on failure.
-// on_ready is called as soon as the muxer has been initialized. Then you are
-// allowed to write packets with encoder_encode().
-// Warning: the on_ready callback is called asynchronously, so you need to
-// make sure to properly synchronize everything.
-bool encoder_init_codec_and_muxer(struct encoder_context *p,
-                                  void (*on_ready)(void *ctx), void *ctx);
+bool encoder_init_codec_and_muxer(struct encoder_context *p);
 
 // Encode the frame and write the packet. frame is ref'ed as need.
 bool encoder_encode(struct encoder_context *p, AVFrame *frame);
 
-// Return muxer timebase (only available after on_ready() has been called).
-// Caller needs to acquire encode_lavc_context.lock (or call it from on_ready).
+// Return muxer timebase (only available if p->mux_stream is initialized).
 AVRational encoder_get_mux_timebase_unlocked(struct encoder_context *p);
 
 void encoder_update_log(struct mpv_global *global);

--- a/player/audio.c
+++ b/player/audio.c
@@ -873,10 +873,6 @@ void fill_audio_out_buffers(struct MPContext *mpctx)
     if (mpctx->ao && ao_query_and_reset_events(mpctx->ao, AO_EVENT_RELOAD))
         reload_audio_output(mpctx);
 
-    if (mpctx->ao && ao_query_and_reset_events(mpctx->ao,
-                                               AO_EVENT_INITIAL_UNBLOCK))
-        ao_unblock(mpctx->ao);
-
     update_throttle(mpctx);
 
     struct ao_chain *ao_c = mpctx->ao_chain;

--- a/player/video.c
+++ b/player/video.c
@@ -1221,6 +1221,10 @@ void write_video(struct MPContext *mpctx)
     if (!vo_is_ready_for_frame(vo, mpctx->display_sync_active ? -1 : pts))
         return;
 
+    // In encoding mode, wait for the ao to finish initializing.
+    if (mpctx->encode_lavc_ctx && mpctx->current_track[0][STREAM_AUDIO] && !mpctx->ao)
+        return;
+
     mp_assert(mpctx->num_next_frames >= 1);
 
     if (mpctx->num_past_frames >= MAX_NUM_VO_PTS)

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -841,9 +841,7 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts)
 {
     struct vo_internal *in = vo->in;
     mp_mutex_lock(&in->lock);
-    bool blocked = vo->driver->initially_blocked &&
-                   !(in->internal_events & VO_EVENT_INITIAL_UNBLOCK);
-    bool r = vo->config_ok && !in->frame_queued && !blocked &&
+    bool r = vo->config_ok && !in->frame_queued &&
              (!in->current_frame || in->current_frame->num_vsyncs < 1);
     if (r && next_pts >= 0) {
         // Don't show the frame too early - it would basically freeze the

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -47,14 +47,11 @@ enum {
     VO_EVENT_LIVE_RESIZING              = 1 << 5,
     // For VOCTRL_GET_HIDPI_SCALE changes.
     VO_EVENT_DPI                        = 1 << 6,
-    // Special thing for encode mode (vo_driver.initially_blocked).
-    // Part of VO_EVENTS_USER to make vo_is_ready_for_frame() work properly.
-    VO_EVENT_INITIAL_UNBLOCK            = 1 << 7,
-    VO_EVENT_FOCUS                      = 1 << 8,
+    VO_EVENT_FOCUS                      = 1 << 7,
 
     // Set of events the player core may be interested in.
     VO_EVENTS_USER = VO_EVENT_RESIZE | VO_EVENT_WIN_STATE | VO_EVENT_DPI |
-                     VO_EVENT_INITIAL_UNBLOCK | VO_EVENT_FOCUS | VO_EVENT_AMBIENT_LIGHTING_CHANGED,
+                     VO_EVENT_FOCUS | VO_EVENT_AMBIENT_LIGHTING_CHANGED,
 };
 
 enum mp_voctrl {
@@ -320,12 +317,6 @@ struct vo_vsync_info {
 struct vo_driver {
     // Encoding functionality, which can be invoked via --o only.
     bool encode;
-
-    // This requires waiting for a VO_EVENT_INITIAL_UNBLOCK event before the
-    // first frame can be sent. Doing vo_reconfig*() calls is allowed though.
-    // Encode mode uses this, the core uses vo_is_ready_for_frame() to
-    // implicitly check for this.
-    bool initially_blocked;
 
     // VO_CAP_* bits
     int caps;

--- a/video/out/vo_lavc.c
+++ b/video/out/vo_lavc.c
@@ -62,13 +62,6 @@ static void uninit(struct vo *vo)
         encoder_encode(enc, NULL); // finish encoding
 }
 
-static void on_ready(void *ptr)
-{
-    struct vo *vo = ptr;
-
-    vo_event(vo, VO_EVENT_INITIAL_UNBLOCK);
-}
-
 static int reconfig2(struct vo *vo, struct mp_image *img)
 {
     struct priv *vc = vo->priv;
@@ -150,7 +143,7 @@ static int reconfig2(struct vo *vo, struct mp_image *img)
     else
         encoder->framerate = (AVRational){ 240, 1 };
 
-    if (!encoder_init_codec_and_muxer(vc->enc, on_ready, vo))
+    if (!encoder_init_codec_and_muxer(vc->enc))
         goto error;
 
     return 0;
@@ -260,7 +253,6 @@ const struct vo_driver video_out_lavc = {
     .description = "video encoding using libavcodec",
     .name = "lavc",
     .caps = VO_CAP_UNTIMED,
-    .initially_blocked = true,
     .priv_size = sizeof(struct priv),
     .preinit = preinit,
     .query_format = query_format,


### PR DESCRIPTION
cc @kasper93. I wrote this months ago and forgot about. After a quicker refresher, I *think* that all that needs to happen is for VO to wait until the AO is ready before it starts pushing frames. Because of mpv's initialization ordering, the VO will always be reconfigured first. But let me know if I misunderstood something here.