### PR TITLE
options: improve watch later menu

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1135,8 +1135,9 @@ Watch Later
           position.
 
 ``--write-filename-in-watch-later-config``
-    Prepend the watch later config files with the name of the file they refer
-    to. This is simply written as comment on the top of the file.
+    Prepend the watch later config files with the name and title of the
+    file they refer to. These are simply written as comments on the top of
+    the file.
 
     .. warning::
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1182,8 +1182,9 @@ Watch Later
           position.
 
 ``--write-filename-in-watch-later-config``
-    Prepend the watch later config files with the name of the file they refer
-    to. This is simply written as comment on the top of the file.
+    Prepend the watch later config files with the name and title of the
+    file they refer to. These are simply written as comments on the top of
+    the file.
 
     .. warning::
 

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -254,6 +254,19 @@ static void write_filename(struct MPContext *mpctx, void *talloc_ctx, bstr *s, c
     }
 }
 
+static void write_title(struct MPContext *mpctx, void *talloc_ctx, bstr *s)
+{
+    if (mpctx->opts->write_filename_in_watch_later_config) {
+        const char *title = mp_find_non_filename_media_title(mpctx);
+        if (title) {
+            char written_title[1024] = {0};
+            for (int n = 0; title[n] && n < sizeof(written_title) - 1; n++)
+                written_title[n] = (unsigned char)title[n] < 32 ? '_' : title[n];
+            bstr_xappend_asprintf(talloc_ctx, s, "# title: %s\n", written_title);
+        }
+    }
+}
+
 static void write_redirect(struct MPContext *mpctx, char *path)
 {
     char *conffile = mp_get_playback_resume_config_filename(mpctx, path);
@@ -318,6 +331,8 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
 
     bstr data = {0};
     write_filename(mpctx, conffile, &data, cur->filename);
+
+    write_title(mpctx, conffile, &data);
 
     bool write_start = true;
     double pos = get_playback_time(mpctx);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -254,16 +254,14 @@ static void write_filename(struct MPContext *mpctx, void *talloc_ctx, bstr *s, c
     }
 }
 
-static void write_title(struct MPContext *mpctx, void *talloc_ctx, bstr *s)
+static void write_title(struct MPContext *mpctx, void *talloc_ctx, bstr *s,
+                        const char *title)
 {
-    if (mpctx->opts->write_filename_in_watch_later_config) {
-        const char *title = mp_find_non_filename_media_title(mpctx);
-        if (title) {
-            char written_title[1024] = {0};
-            for (int n = 0; title[n] && n < sizeof(written_title) - 1; n++)
-                written_title[n] = (unsigned char)title[n] < 32 ? '_' : title[n];
-            bstr_xappend_asprintf(talloc_ctx, s, "# title: %s\n", written_title);
-        }
+    if (mpctx->opts->write_filename_in_watch_later_config && title) {
+        char written_title[1024] = {0};
+        for (int n = 0; title[n] && n < sizeof(written_title) - 1; n++)
+            written_title[n] = (unsigned char)title[n] < 32 ? '_' : title[n];
+        bstr_xappend_asprintf(talloc_ctx, s, "# title: %s\n", written_title);
     }
 }
 
@@ -274,6 +272,10 @@ static void write_redirect(struct MPContext *mpctx, char *path)
         bstr data = {0};
         bstr_xappend0(conffile, &data, "# redirect entry\n");
         write_filename(mpctx, conffile, &data, path);
+        if (mpctx->demuxer) {
+            write_title(mpctx, conffile, &data,
+                        mp_tags_get_str(mpctx->demuxer->metadata, "ytdl_playlist_title"));
+        }
         bool ok = mp_save_to_file(conffile, data.start, data.len);
         if (!ok)
             MP_WARN(mpctx, "Can't save redirect to %s\n", conffile);
@@ -332,7 +334,7 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
     bstr data = {0};
     write_filename(mpctx, conffile, &data, cur->filename);
 
-    write_title(mpctx, conffile, &data);
+    write_title(mpctx, conffile, &data, mp_find_non_filename_media_title(mpctx));
 
     bool write_start = true;
     double pos = get_playback_time(mpctx);

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -479,19 +479,31 @@ mp.add_key_binding(nil, "select-watch-later", function ()
         local file_handle = io.open(watch_later_file)
         if file_handle then
             local line1 = file_handle:read()
-            if line1 and line1 ~= "# redirect entry" and line1:find("^#") then
-                local entry = {
-                    path = line1:sub(3),
-                    time = utils.file_info(watch_later_file).mtime
-                }
+            local is_redirect = false
+
+            if line1 == "# redirect entry" then
+                is_redirect = true
+                line1 = file_handle:read()
+            end
+
+            if line1 and line1:find("^#") then
+                local entry = {}
+
                 for line in file_handle:lines() do
                     if line:find("^# title: ") then
                         entry.title = line:sub(10)
                         break
                     end
                 end
-                files[#files + 1] = entry
+
+                if not is_redirect or entry.title then
+                    entry.path = line1:sub(3)
+                    entry.time = utils.file_info(watch_later_file).mtime
+
+                    files[#files + 1] = entry
+                end
             end
+
             file_handle:close()
         end
     end

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -478,9 +478,19 @@ mp.add_key_binding(nil, "select-watch-later", function ()
     for _, watch_later_file in pairs(watch_later_files) do
         local file_handle = io.open(watch_later_file)
         if file_handle then
-            local line = file_handle:read()
-            if line and line ~= "# redirect entry" and line:find("^#") then
-                files[#files + 1] = {line:sub(3), utils.file_info(watch_later_file).mtime}
+            local line1 = file_handle:read()
+            if line1 and line1 ~= "# redirect entry" and line1:find("^#") then
+                local entry = {
+                    path = line1:sub(3),
+                    time = utils.file_info(watch_later_file).mtime
+                }
+                for line in file_handle:lines() do
+                    if line:find("^# title: ") then
+                        entry.title = line:sub(10)
+                        break
+                    end
+                end
+                files[#files + 1] = entry
             end
             file_handle:close()
         end
@@ -494,19 +504,19 @@ mp.add_key_binding(nil, "select-watch-later", function ()
     end
 
     table.sort(files, function (i, j)
-        return i[2] > j[2]
+        return i.time > j.time
     end)
 
     local items = {}
-    for i, file in ipairs(files) do
-        items[i] = os.date("(%Y-%m-%d) ", file[2]) .. file[1]
+    for i, entry in ipairs(files) do
+        items[i] = format_history_entry(entry)
     end
 
     input.select({
         prompt = "Select a file:",
         items = items,
         submit = function (i)
-            mp.commandv("loadfile", files[i][1])
+            mp.commandv("loadfile", files[i].path)
         end,
     })
 end)

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -561,9 +561,19 @@ mp.add_key_binding(nil, "select-watch-later", function (t)
     for _, watch_later_file in pairs(watch_later_files) do
         local file_handle = io.open(watch_later_file)
         if file_handle then
-            local line = file_handle:read()
-            if line and line ~= "# redirect entry" and line:find("^#") then
-                files[#files + 1] = {line:sub(3), utils.file_info(watch_later_file).mtime}
+            local line1 = file_handle:read()
+            if line1 and line1 ~= "# redirect entry" and line1:find("^#") then
+                local entry = {
+                    path = line1:sub(3),
+                    time = utils.file_info(watch_later_file).mtime
+                }
+                for line in file_handle:lines() do
+                    if line:find("^# title: ") then
+                        entry.title = line:sub(10)
+                        break
+                    end
+                end
+                files[#files + 1] = entry
             end
             file_handle:close()
         end
@@ -577,12 +587,12 @@ mp.add_key_binding(nil, "select-watch-later", function (t)
     end
 
     table.sort(files, function (i, j)
-        return i[2] > j[2]
+        return i.time > j.time
     end)
 
     local items = {}
-    for i, file in ipairs(files) do
-        items[i] = os.date("(%Y-%m-%d) ", file[2]) .. file[1]
+    for i, entry in ipairs(files) do
+        items[i] = format_history_entry(entry)
     end
 
     input.select({
@@ -590,7 +600,7 @@ mp.add_key_binding(nil, "select-watch-later", function (t)
         items = items,
         keep_open = keep_open,
         submit = function (i)
-            mp.commandv("loadfile", files[i][1])
+            mp.commandv("loadfile", files[i].path)
         end,
     })
 end, { complex = true })


### PR DESCRIPTION
The History menu (CTRL-P -> History) displays the titles of previously played files, but the Watch later menu displays a list of filenames.

This PR adds `--write-title-in-watch-later-config`. With the option set, `save-position-on-quit` inserts the playing file's title in a comment below the filename in the file's watch_later entry. The Watch later picker then displays these titles instead of filenames when they are available. 


## Examples
<ul>
<li><code>mpv --write-filename-in-watch-later-config</code>:</li>
<pre># https://example.com/?v=foobar<br>start=35<br>gamma=1</pre>
<li><code>mpv --write-filename-in-watch-later-config --write-title-in-watch-later-config</code>:</li>
<pre># https://example.com/?v=foobar<br># FooBar (HD Video)<br>start=35<br>gamma=1</pre>
<li><code>mpv --write-title-in-watch-later-config</code>:</li>
<pre>start=35<br>gamma=1</pre>
</ul>


## Notes:
- `--write-title-in-watch-later-config` silently no-ops if  `--write-filename-in-watch-later config` is not set.  The Watch later menu is disabled without `--write-filename-in-watch-later-config` anyway, so this seems like a reasonable behaviour to me. If it is preferred that `--write-title...` automatically enables `--write-filename...` or emits an error, let me know.

- These changes are backwards compatible with older versions of MPV, since, forcing `--write-filename...` to be set ensures that a title comment will never be inserted without a filename comment above it. Title comments will never be misinterpreted as paths to a file by older versions.

- Titles are displayed instead of filenames in the Watch later menu if `--write-title-in-watch-later-config` is set, otherwise existing behaviour is preserved. Perhaps this should be separated out into its own option, applying to both the History and Watch later menus?

- I acknowledge this is a hacky solution. If breaking backwards compatibility is an option, it might be nice to replace the watch_later system with a structured data format in line with `watch_history.jsonl`.