### PR TITLE
vo: reject gpu-next from autoprobing, if blend-subtitles=video is used

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -38,6 +38,10 @@ Available video output drivers are:
 
     https://github.com/mpv-player/mpv/wiki/GPU-Next-vs-GPU
 
+    ``gpu-next`` won't be automatically selected if the ``--blend-subtitles=video``
+    option is set, as it does not support blending subtitles at video resolution.
+    It can still be selected, if  ``--vo=gpu-next`` is specified explicitly.
+
 ``gpu``
     General purpose, customizable, GPU-accelerated video output driver. It
     supports extended scaling methods, dithering, color management, custom


### PR DESCRIPTION
Apparently it's critical for mpv to be anime media player and after d21b1f159c7700945b4e75843d68bee881c229a7 there is a worry in community that mpv is not longer anime enough, as it doesn't support VSFilter style blending subtitles into video in default config.

As this is important use-case to ensure correct subtitle rendering and blending, remove gpu-next from autoprobing if not explicity requrested by user and blend-subtitles=video is set.

Fixes: d21b1f159c7700945b4e75843d68bee881c229a7

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
