### PR TITLE
refactor M_OPT_FILE options so they are always automatically expanded 

### DIFF
--- a/audio/out/ao_pcm.c
+++ b/audio/out/ao_pcm.c
@@ -28,7 +28,6 @@
 #include "mpv_talloc.h"
 
 #include "options/m_option.h"
-#include "options/path.h"
 #include "audio/format.h"
 #include "ao.h"
 #include "internal.h"
@@ -110,7 +109,7 @@ static int init(struct ao *ao)
 {
     struct priv *priv = ao->priv;
 
-    char *outputfilename = mp_get_user_path(priv, ao->global, priv->outputfilename);
+    char *outputfilename = priv->outputfilename;
     if (!outputfilename) {
         outputfilename = talloc_strdup(priv, priv->waveheader ? "audiodump.wav"
                                                               : "audiodump.pcm");

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -31,7 +31,6 @@
 #include "options/m_config.h"
 #include "options/m_option.h"
 #include "options/options.h"
-#include "options/path.h"
 #include "osdep/timer.h"
 #include "video/out/vo.h"
 #include "mpv_talloc.h"
@@ -134,9 +133,7 @@ struct encode_lavc_context *encode_lavc_init(struct mpv_global *global)
 
     p->muxer->oformat = ctx->oformat;
 
-    char *path = mp_get_user_path(NULL, global, filename);
-    p->muxer->url = av_strdup(path);
-    talloc_free(path);
+    p->muxer->url = av_strdup(filename);
     MP_HANDLE_OOM(p->muxer->url);
 
     return ctx;

--- a/common/playlist.c
+++ b/common/playlist.c
@@ -404,12 +404,11 @@ struct playlist *playlist_parse_file(const char *file, struct mp_cancel *cancel,
     struct mp_log *log = mp_log_new(NULL, global->log, "!playlist_parser");
     mp_verbose(log, "Parsing playlist file %s...\n", file);
 
-    char *path = mp_get_user_path(NULL, global, file);
     struct demuxer_params p = {
         .force_format = "playlist",
         .stream_flags = STREAM_ORIGIN_DIRECT,
     };
-    struct demuxer *d = demux_open_url(path, &p, cancel, global);
+    struct demuxer *d = demux_open_url(file, &p, cancel, global);
     struct playlist *ret = NULL;
     if (!d)
         goto done;
@@ -436,7 +435,6 @@ struct playlist *playlist_parse_file(const char *file, struct mp_cancel *cancel,
 
 done:
     talloc_free(log);
-    talloc_free(path);
     return ret;
 }
 

--- a/demux/cache.c
+++ b/demux/cache.c
@@ -105,7 +105,7 @@ struct demux_cache *demux_cache_create(struct mpv_global *global,
 
     char *cache_dir = cache->opts->cache_dir;
     if (cache_dir && cache_dir[0]) {
-        cache_dir = mp_get_user_path(NULL, global, cache_dir);
+        cache_dir = talloc_strdup(NULL, cache_dir);
     } else {
         cache_dir = mp_find_user_file(NULL, global, "cache", "");
     }
@@ -116,6 +116,7 @@ struct demux_cache *demux_cache_create(struct mpv_global *global,
     mp_mkdirp(cache_dir);
     cache->filename = mp_path_join(cache, cache_dir, "mpv-cache-XXXXXX.dat");
     cache->fd = mp_mkostemps(cache->filename, 4, O_CLOEXEC);
+    talloc_free(cache_dir);
     if (cache->fd < 0) {
         MP_ERR(cache, "Failed to create cache temporary file.\n");
         goto fail;

--- a/input/input.c
+++ b/input/input.c
@@ -1649,8 +1649,6 @@ static bool parse_config_file(struct input_ctx *ictx, char *file)
     bool r = false;
     void *tmp = talloc_new(NULL);
 
-    file = mp_get_user_path(tmp, ictx->global, file);
-
     bstr data = stream_read_file2(file, tmp, STREAM_ORIGIN_DIRECT | STREAM_READ,
                                   ictx->global, 1000000);
     if (data.start) {

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -389,7 +389,7 @@ struct mp_ipc_ctx *mp_init_ipc(struct mp_client_api *client_api,
     *arg = (struct mp_ipc_ctx){
         .log        = mp_log_new(arg, global->log, "ipc"),
         .client_api = client_api,
-        .path       = mp_get_user_path(arg, global, opts->ipc_path),
+        .path       = talloc_strdup(arg, opts->ipc_path),
         .death_pipe = {-1, -1},
     };
 

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -635,7 +635,7 @@ int m_config_set_option_raw(struct m_config *config,
 
     m_config_mark_co_flags(co, flags);
 
-    m_option_copy(co->opt, co->data, data);
+    m_option_copy_and_expand(config->global, co->opt, co->data, data);
     if (m_config_cache_write_opt(config->cache, co->data))
         force_self_notify_change_opt(config, co, false);
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -43,6 +43,7 @@
 #include "misc/node.h"
 #include "m_option.h"
 #include "m_config_frontend.h"
+#include "path.h"
 
 #if HAVE_DOS_PATHS
 #define OPTION_PATH_SEPARATOR ';'
@@ -1270,6 +1271,15 @@ static void copy_str(const m_option_t *opt, void *dst, const void *src)
         talloc_replace(NULL, VAL(dst), VAL(src));
 }
 
+static void expand_str(struct mpv_global *global, const m_option_t *opt,
+                       void *dst, const void *src)
+{
+    if (dst && src) {
+        talloc_free(VAL(dst));
+        VAL(dst) = mp_get_user_path(NULL, global, VAL(src));
+    }
+}
+
 static int str_set(const m_option_t *opt, void *dst, struct mpv_node *src)
 {
     if (src->format != MPV_FORMAT_STRING)
@@ -1303,15 +1313,16 @@ static void free_str(void *src)
 }
 
 const m_option_type_t m_option_type_string = {
-    .name  = "String",
-    .size  = sizeof(char *),
-    .parse = parse_str,
-    .print = print_str,
-    .copy  = copy_str,
-    .free  = free_str,
-    .set   = str_set,
-    .get   = str_get,
-    .equal = str_equal,
+    .name   = "String",
+    .size   = sizeof(char *),
+    .parse  = parse_str,
+    .print  = print_str,
+    .copy   = copy_str,
+    .expand = expand_str,
+    .free   = free_str,
+    .set    = str_set,
+    .get    = str_get,
+    .equal  = str_equal,
 };
 
 //////////// String list
@@ -1547,7 +1558,8 @@ static int parse_str_list_impl(struct mp_log *log, const m_option_t *opt,
     return 1;
 }
 
-static void copy_str_list(const m_option_t *opt, void *dst, const void *src)
+static void copy_str_list_impl(struct mpv_global *global, const m_option_t *opt,
+                               void *dst, const void *src)
 {
     int n;
     char **d, **s;
@@ -1567,10 +1579,26 @@ static void copy_str_list(const m_option_t *opt, void *dst, const void *src)
     for (n = 0; s[n] != NULL; n++)
         /* NOTHING */;
     d = talloc_array(NULL, char *, n + 1);
-    for (; n >= 0; n--)
-        d[n] = talloc_strdup(NULL, s[n]);
+    for (; n >= 0; n--) {
+        if (global) {
+            d[n] = mp_get_user_path(NULL, global, s[n]);
+        } else {
+            d[n] = talloc_strdup(NULL, s[n]);
+        }
+    }
 
     VAL(dst) = d;
+}
+
+static void copy_str_list(const m_option_t *opt, void *dst, const void *src)
+{
+    copy_str_list_impl(NULL, opt, dst, src);
+}
+
+static void expand_str_list(struct mpv_global *global, const m_option_t *opt,
+                            void *dst, const void *src)
+{
+    copy_str_list_impl(global, opt, dst, src);
 }
 
 static char *print_str_list(const m_option_t *opt, const void *src)
@@ -1652,15 +1680,16 @@ static bool str_list_equal(const m_option_t *opt, void *a, void *b)
 }
 
 const m_option_type_t m_option_type_string_list = {
-    .name  = "String list",
-    .size  = sizeof(char **),
-    .parse = parse_str_list,
-    .print = print_str_list,
-    .copy  = copy_str_list,
-    .free  = free_str_list,
-    .get   = str_list_get,
-    .set   = str_list_set,
-    .equal = str_list_equal,
+    .name   = "String list",
+    .size   = sizeof(char **),
+    .parse  = parse_str_list,
+    .print  = print_str_list,
+    .copy   = copy_str_list,
+    .expand = expand_str_list,
+    .free   = free_str_list,
+    .get    = str_list_get,
+    .set    = str_list_set,
+    .equal  = str_list_equal,
     .actions = (const struct m_option_action[]){
         {"add"},
         {"append"},

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -332,6 +332,12 @@ struct m_option_type {
      */
     void (*copy)(const m_option_t *opt, void *dst, const void *src);
 
+    // Exactly the same as copy but will potentially perform a path expansion if
+    // the underlying option is a string with paths (M_OPT_FILE). This is for
+    // options that take paths as argument values.
+    void (*expand)(struct mpv_global *global, const m_option_t *opt,
+                   void *dst, const void *src);
+
     // Free the data allocated for a save slot.
     /** This is only needed for dynamic types like strings.
      *  \param dst Pointer to the data, usually a pointer that should be freed and
@@ -573,6 +579,17 @@ static inline void m_option_copy(const m_option_t *opt, void *dst,
 {
     if (opt->type->copy)
         opt->type->copy(opt, dst, src);
+}
+
+// Expand and copy the string if M_OPT_FILE. Do a raw copy otherwise.
+static inline void m_option_copy_and_expand(struct mpv_global *global, const m_option_t *opt,
+                                            void *dst, const void *src)
+{
+    if (opt->flags & M_OPT_FILE && opt->type->expand) {
+        opt->type->expand(global, opt, dst, src);
+    } else {
+        m_option_copy(opt, dst, src);
+    }
 }
 
 // Helper around \ref m_option_type::free.

--- a/options/path.c
+++ b/options/path.c
@@ -115,7 +115,7 @@ void mp_init_paths(struct mpv_global *global, struct MPOpts *opts)
     if (!opts->load_config)
         force_configdir = "";
 
-    global->configdir = mp_get_user_path(global, global, force_configdir);
+    global->configdir = talloc_strdup(global, force_configdir);
 }
 
 char *mp_find_user_file(void *talloc_ctx, struct mpv_global *global,

--- a/player/command.c
+++ b/player/command.c
@@ -6950,8 +6950,9 @@ static void cmd_load_input_conf(void *p)
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
 
-    char *config_file = cmd->args[0].v.s;
+    char *config_file = mp_get_user_path(NULL, mpctx->global, cmd->args[0].v.s);
     cmd->success = mp_input_load_config_file(mpctx->input, config_file);
+    talloc_free(config_file);
 }
 
 static void cmd_load_script(void *p)

--- a/player/command.c
+++ b/player/command.c
@@ -3632,7 +3632,10 @@ static int mp_property_current_watch_later_dir(void *ctx, struct m_property *pro
                                                int action, void *arg)
 {
     MPContext *mpctx = ctx;
-    return m_property_strdup_ro(action, arg, mp_get_playback_resume_dir(mpctx));
+    char *dir = mp_get_playback_resume_dir(mpctx);
+    int r = m_property_strdup_ro(action, arg, dir);
+    talloc_free(dir);
+    return r;
 }
 
 static int mp_property_protocols(void *ctx, struct m_property *prop,

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -201,7 +201,7 @@ char *mp_get_playback_resume_dir(struct MPContext *mpctx)
 {
     char *wl_dir = mpctx->opts->watch_later_dir;
     if (wl_dir && wl_dir[0]) {
-        wl_dir = mp_get_user_path(mpctx, mpctx->global, wl_dir);
+        wl_dir = talloc_strdup(mpctx, wl_dir);
     } else {
         wl_dir = mp_find_user_file(mpctx, mpctx->global, "state", MP_WATCH_LATER_CONF);
     }

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -201,9 +201,9 @@ char *mp_get_playback_resume_dir(struct MPContext *mpctx)
 {
     char *wl_dir = mpctx->opts->watch_later_dir;
     if (wl_dir && wl_dir[0]) {
-        wl_dir = talloc_strdup(mpctx, wl_dir);
+        wl_dir = talloc_strdup(NULL, wl_dir);
     } else {
-        wl_dir = mp_find_user_file(mpctx, mpctx->global, "state", MP_WATCH_LATER_CONF);
+        wl_dir = mp_find_user_file(NULL, mpctx->global, "state", MP_WATCH_LATER_CONF);
     }
     return wl_dir;
 }
@@ -233,6 +233,7 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     char *wl_dir = mp_get_playback_resume_dir(mpctx);
     if (wl_dir && wl_dir[0])
         res = mp_path_join(NULL, wl_dir, conf);
+    talloc_free(wl_dir);
 
 exit:
     talloc_free(tmp);
@@ -326,6 +327,7 @@ void mp_write_watch_later_conf(struct MPContext *mpctx)
 
     char *wl_dir = mp_get_playback_resume_dir(mpctx);
     mp_mkdirp(wl_dir);
+    talloc_free(wl_dir);
 
     MP_INFO(mpctx, "Saving state.\n");
 

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -247,13 +247,10 @@ static void load_paths(struct mpv_global *global, struct MPOpts *opts,
                        char **paths, char *cfg_path, int type)
 {
     for (int i = 0; paths && paths[i]; i++) {
-        char *expanded_path = mp_get_user_path(NULL, global, paths[i]);
-        char *path = mp_path_join_bstr(
-            *slist, mp_dirname(fname),
-            bstr0(expanded_path ? expanded_path : paths[i]));
+        char *path = mp_path_join_bstr(*slist, mp_dirname(fname),
+                                       bstr0(paths[i]));
         append_dir_subtitles(global, opts, slist, nsubs, bstr0(path),
                              fname, 0, type);
-        talloc_free(expanded_path);
     }
 
     // Load subtitles in ~/.mpv/sub (or similar) limiting sub fuzziness

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -857,11 +857,8 @@ int mp_add_external_file(struct MPContext *mpctx, char *filename,
 
     mp_core_unlock(mpctx);
 
-    char *path = mp_get_user_path(NULL, mpctx->global, filename);
     struct demuxer *demuxer =
-        demux_open_url(path, &params, cancel, mpctx->global);
-    talloc_free(path);
-
+        demux_open_url(filename, &params, cancel, mpctx->global);
     if (demuxer)
         enable_demux_thread(mpctx, demuxer);
 
@@ -1079,7 +1076,7 @@ static void load_chapters(struct MPContext *mpctx)
     bool free_src = false;
     char *chapter_file = mpctx->opts->chapter_file;
     if (chapter_file && chapter_file[0]) {
-        chapter_file = mp_get_user_path(NULL, mpctx->global, chapter_file);
+        chapter_file = talloc_strdup(NULL, chapter_file);
         mp_core_unlock(mpctx);
         struct demuxer_params p = {
             .stream_flags = STREAM_ORIGIN_DIRECT,

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1545,8 +1545,7 @@ static void append_to_watch_history(struct MPContext *mpctx)
         return;
 
     void *ctx = talloc_new(NULL);
-    char *history_path = mp_get_user_path(ctx, mpctx->global,
-                                          mpctx->opts->watch_history_path);
+    char *history_path = mpctx->opts->watch_history_path;
     char *history_path_dir = bstrto0(ctx, mp_dirname(history_path));
     mp_mkdirp(history_path_dir);
 

--- a/player/misc.c
+++ b/player/misc.c
@@ -31,7 +31,6 @@
 #include "options/options.h"
 #include "options/m_property.h"
 #include "options/m_config.h"
-#include "options/path.h"
 #include "common/common.h"
 #include "common/encode.h"
 #include "common/playlist.h"
@@ -270,7 +269,6 @@ int stream_dump(struct MPContext *mpctx, const char *source_filename)
     struct MPOpts *opts = mpctx->opts;
     bool ok = false;
 
-    char *filename = mp_get_user_path(NULL, mpctx->global, opts->stream_dump);
     stream_t *stream = stream_create(source_filename,
                                      STREAM_ORIGIN_DIRECT | STREAM_READ,
                                      mpctx->playback_abort, mpctx->global);
@@ -279,7 +277,7 @@ int stream_dump(struct MPContext *mpctx, const char *source_filename)
 
     int64_t size = stream_get_size(stream);
 
-    FILE *dest = fopen(filename, "wb");
+    FILE *dest = fopen(opts->stream_dump, "wb");
     if (!dest) {
         MP_ERR(mpctx, "Error opening dump file: %s\n", mp_strerror(errno));
         goto done;
@@ -307,7 +305,6 @@ int stream_dump(struct MPContext *mpctx, const char *source_filename)
     ok &= fclose(dest) == 0;
 done:
     free_stream(stream);
-    talloc_free(filename);
     return ok ? 0 : -1;
 }
 

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -297,7 +297,6 @@ static char *gen_fname(struct mp_cmd_ctx *cmd, const char *file_ext)
         char *dir = ctx->mpctx->opts->screenshot_dir;
         if (dir && dir[0]) {
             void *t = fname;
-            dir = mp_get_user_path(t, ctx->mpctx->global, dir);
             fname = mp_path_join(NULL, dir, fname);
 
             mp_mkdirp(dir);

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -280,7 +280,7 @@ bool mp_load_scripts(struct MPContext *mpctx)
     char **files = mpctx->opts->script_files;
     for (int n = 0; files && files[n]; n++) {
         if (files[n][0])
-            ok &= mp_load_user_script(mpctx, files[n]) >= 0;
+            ok &= mp_load_script(mpctx, files[n]) >= 0;
     }
     if (!mpctx->opts->auto_load_scripts)
         return ok;

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -431,9 +431,7 @@ static int bluray_stream_open_internal(stream_t *s)
         bd_set_debug_mask(0);
 
     /* open device */
-    char *device_tmp = mp_get_user_path(NULL, s->global, device);
-    BLURAY *bd = bd_open(device_tmp, NULL);
-    talloc_free(device_tmp);
+    BLURAY *bd = bd_open(device, NULL);
     if (!bd) {
         MP_ERR(s, "Couldn't open Blu-ray device: %s\n", device);
         ret = STREAM_UNSUPPORTED;

--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -38,7 +38,6 @@
 #include "options/m_option.h"
 #include "options/m_config.h"
 #include "options/options.h"
-#include "options/path.h"
 
 #if !HAVE_GPL
 #error GPL only
@@ -254,11 +253,11 @@ static int open_cdda(stream_t *st)
     int last_track;
 
     if (st->path[0]) {
-        p->device = talloc_strdup(priv, st->path);
+        p->device = st->path;
     } else if (p->cdda_device && p->cdda_device[0]) {
-        p->device = mp_get_user_path(priv, st->global, p->cdda_device);
+        p->device = p->cdda_device;
     } else {
-        p->device = talloc_strdup(priv, DEFAULT_OPTICAL_DEVICE);
+        p->device = DEFAULT_OPTICAL_DEVICE;
     }
 
 #if defined(__NetBSD__)

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -1112,11 +1112,12 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                     continue;
                 }
 
-                void *talloc_ctx = talloc_new(NULL);
+                void *talloc_ctx = NULL;
                 char *conf_file;
                 if (priv->opts->cfg_file && priv->opts->cfg_file[0]) {
-                    conf_file = mp_get_user_path(talloc_ctx, global, priv->opts->cfg_file);
+                    conf_file = priv->opts->cfg_file;
                 } else {
+                    talloc_ctx = talloc_new(NULL);
                     conf_file = mp_find_config_file(talloc_ctx, global, conf_file_name);
                     if (conf_file) {
                         mp_verbose(log, "Ignoring other channels.conf files.\n");

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -552,7 +552,7 @@ static struct priv *new_dvdnav_stream(stream_t *stream, char *filename)
     if (!filename)
         return NULL;
 
-    if (!(priv->filename = mp_get_user_path(priv, stream->global, filename)))
+    if (!(priv->filename = talloc_strdup(priv, filename)))
         return NULL;
 
     priv->dvd_speed = priv->opts->speed;

--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -199,18 +199,12 @@ void mp_setup_av_network_options(AVDictionary **dict, const char *target_fmt,
             av_dict_set(dict, "cookies", cookies, 0);
     }
     av_dict_set(dict, "tls_verify", opts->tls_verify ? "1" : "0", 0);
-    if (opts->tls_ca_file) {
-        char *file = mp_get_user_path(temp, global, opts->tls_ca_file);
-        av_dict_set(dict, "ca_file", file, 0);
-    }
-    if (opts->tls_cert_file) {
-        char *file = mp_get_user_path(temp, global, opts->tls_cert_file);
-        av_dict_set(dict, "cert_file", file, 0);
-    }
-    if (opts->tls_key_file) {
-        char *file = mp_get_user_path(temp, global, opts->tls_key_file);
-        av_dict_set(dict, "key_file", file, 0);
-    }
+    if (opts->tls_ca_file)
+        av_dict_set(dict, "ca_file", opts->tls_ca_file, 0);
+    if (opts->tls_cert_file)
+        av_dict_set(dict, "cert_file", opts->tls_cert_file, 0);
+    if (opts->tls_key_file)
+        av_dict_set(dict, "key_file", opts->tls_key_file, 0);
     char *cust_headers = talloc_strdup(temp, "");
     if (opts->referrer) {
         cust_headers = talloc_asprintf_append(cust_headers, "Referer: %s\r\n",

--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -131,7 +131,7 @@ ASS_Library *mp_ass_init(struct mpv_global *global,
                          struct osd_style_opts *opts, struct mp_log *log)
 {
     char *path = opts->fonts_dir && opts->fonts_dir[0] ?
-                 mp_get_user_path(NULL, global, opts->fonts_dir) :
+                 talloc_strdup(NULL, opts->fonts_dir) :
                  mp_find_config_file(NULL, global, "fonts");
     mp_dbg(log, "ASS library version: 0x%x (runtime 0x%x)\n",
            (unsigned)LIBASS_VERSION, ass_library_version());

--- a/test/meson.build
+++ b/test/meson.build
@@ -22,8 +22,10 @@ test_utils_files = [
     'options/m_config_core.c',
     'options/m_config_frontend.c',
     'options/m_option.c',
+    'options/path.c',
     'osdep/io.c',
     'osdep/timer.c',
+    path_source,
     timer_source,
     'ta/ta.c',
     'ta/ta_talloc.c',
@@ -110,9 +112,7 @@ codepoint_width = executable('codepoint-width', files('codepoint_width.c'),
                              include_directories: incdir, link_with: test_utils)
 test('codepoint-width', codepoint_width)
 
-paths_objects = libmpv.extract_objects('options/path.c', path_source)
-paths = executable('paths', 'paths.c', include_directories: incdir,
-                   objects: paths_objects, link_with: test_utils)
+paths = executable('paths', 'paths.c', include_directories: incdir, link_with: test_utils)
 test('paths', paths)
 
 if get_option('libmpv')

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -750,7 +750,7 @@ static struct mp_filter *vf_vapoursynth_create(struct mp_filter *parent,
         MP_FATAL(p, "'file' parameter must be set.\n");
         goto error;
     }
-    p->script_path = mp_get_user_path(p, f->global, p->opts->file);
+    p->script_path = talloc_strdup(p, p->opts->file);
 
     p->max_requests = p->opts->maxrequests;
     if (p->max_requests < 0)

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -44,7 +44,6 @@
 #include "common/msg.h"
 #include "misc/ctype.h"
 #include "options/m_config.h"
-#include "options/path.h"
 #include "osdep/io.h"
 #include "osdep/poll_wrapper.h"
 #include "osdep/timer.h"
@@ -944,7 +943,7 @@ static bool card_has_connection(const char *path)
 static void get_primary_device_path(struct vo_drm_state *drm)
 {
     if (drm->opts->device_path) {
-        drm->card_path = mp_get_user_path(drm, drm->vo->global, drm->opts->device_path);
+        drm->card_path = talloc_strdup(drm, drm->opts->device_path);
         return;
     }
 

--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -73,11 +73,10 @@ static void load_profile(struct gl_lcms *p)
     if (!p->opts->profile || !p->opts->profile[0])
         return;
 
-    char *fname = mp_get_user_path(NULL, p->global, p->opts->profile);
+    char *fname = p->opts->profile;
     MP_VERBOSE(p, "Opening ICC profile '%s'\n", fname);
     struct bstr iccdata = stream_read_file(fname, p, p->global,
                                            100000000); // 100 MB
-    talloc_free(fname);
     if (!iccdata.len)
         return;
 
@@ -365,7 +364,7 @@ bool gl_lcms_get_lut3d(struct gl_lcms *p, struct lut3d **result_lut3d,
 
         char *cache_dir = p->opts->cache_dir;
         if (cache_dir && cache_dir[0]) {
-            cache_dir = mp_get_user_path(tmp, p->global, cache_dir);
+            cache_dir = talloc_strdup(tmp, cache_dir);
         } else {
             cache_dir = mp_find_user_file(tmp, p->global, "cache", "");
         }

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -559,7 +559,7 @@ void gl_sc_set_cache_dir(struct gl_shader_cache *sc, char *dir)
 {
     talloc_free(sc->cache_dir);
     if (dir && dir[0]) {
-        dir = mp_get_user_path(NULL, sc->global, dir);
+        dir = talloc_strdup(NULL, dir);
     } else {
         dir = mp_find_user_file(NULL, sc->global, "cache", "");
     }

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -583,9 +583,7 @@ static struct bstr load_cached_file(struct gl_video *p, const char *path)
             return p->files[n].body;
     }
     // not found -> load it
-    char *fname = mp_get_user_path(NULL, p->global, path);
-    struct bstr s = stream_read_file(fname, p, p->global, 1000000000); // 1GB
-    talloc_free(fname);
+    struct bstr s = stream_read_file(path, p, p->global, 1000000000); // 1GB
     if (s.len) {
         struct cached_file new = {
             .path = talloc_strdup(p, path),

--- a/video/out/vo_image.c
+++ b/video/out/vo_image.c
@@ -66,16 +66,13 @@ struct priv {
     struct vo_image_opts *opts;
 
     struct mp_image *current;
-    char *dir;
     int frame;
 };
 
 static bool checked_mkdir(struct vo *vo, const char *buf)
 {
-    struct priv *p = vo->priv;
-    p->dir = mp_get_user_path(vo, vo->global, buf);
-    MP_INFO(vo, "Creating output directory '%s'...\n", p->dir);
-    if (mkdir(p->dir, 0755) < 0) {
+    MP_INFO(vo, "Creating output directory '%s'...\n", buf);
+    if (mkdir(buf, 0755) < 0) {
         char *errstr = mp_strerror(errno);
         if (errno == EEXIST) {
             struct stat stat_p;
@@ -120,8 +117,8 @@ static void flip_page(struct vo *vo)
     char *filename = talloc_asprintf(t, "%08d.%s", p->frame,
                                      image_writer_file_ext(p->opts->opts));
 
-    if (p->dir && strlen(p->dir))
-        filename = mp_path_join(t, p->dir, filename);
+    if (p->opts->outdir && strlen(p->opts->outdir))
+        filename = mp_path_join(t, p->opts->outdir, filename);
 
     MP_INFO(vo, "Saving %s\n", filename);
     write_image(p->current, p->opts->opts, filename, vo->global, vo->log, true);


### PR DESCRIPTION
It should work the same as before but please test. The idea is that any option flagged with M_OPT_FILE will automatically have its path expanded in the core option parsing/setting. So any code that deals with `opt->some_path` no longer has to manually expand itself. I went ahead and reverted/cleaned up all the redundancy.