### PR TITLE
Prevent WebM WebVTT sub corruption after switching subtitle tracks

### DIFF
--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -37,7 +37,7 @@ struct lavc_conv {
     AVCodecContext *avctx;
     AVPacket *avpkt;
     AVPacket *avpkt_vtt;
-    char *codec;
+    const char *codec;
     char *extradata;
     AVSubtitle cur;
     char **cur_list;
@@ -60,7 +60,7 @@ struct lavc_conv *lavc_conv_create(struct sd *sd)
     priv->log = sd->log;
     priv->opts = sd->opts;
     priv->cur_list = talloc_array(priv, char*, 0);
-    priv->codec = talloc_strdup(priv, sd->codec->codec);
+    priv->codec = sd->codec->codec;
     AVCodecContext *avctx = NULL;
     AVDictionary *opts = NULL;
     const char *fmt = get_lavc_format(priv->codec);

--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -104,6 +104,8 @@ struct lavc_conv *lavc_conv_create(struct sd *sd)
     priv->extradata = talloc_strndup(priv, avctx->subtitle_header,
                                      avctx->subtitle_header_size);
     mp_codec_info_from_av(avctx, sd->codec);
+    // Keep original codec name, which get_lavc_format() may have transformed
+    sd->codec->codec = priv->codec;
     return priv;
 
  error:


### PR DESCRIPTION
WebVTT subtitles in WebM require special logic, and we signal that using the `webvtt-webm` codec name, which is not part of FFmpeg. That worked fine until #14330 added a call to `mp_codec_info_from_av()`, which overwrites our codec name with FFmpeg's the first time the subtitle decoder is initialized. As a result, subsequent initializations (when the subtitle track is changed at runtime) use the wrong codec name and don't take the WebM code path.

Fix the issue and also get rid of an unnecessary allocation.