### PR TITLE
mac/vulkan: set --macos-render-timer to feedback by default

### DIFF
--- a/DOCS/interface-changes/macos-render-timer.txt
+++ b/DOCS/interface-changes/macos-render-timer.txt
@@ -1,0 +1,1 @@
+Set `--macos-render-timer` to `feedback` by default.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6851,7 +6851,7 @@ them.
     macOS only.
 
 ``--macos-render-timer=<timer>``
-    Sets the mode (default: callback) for syncing the rendering of frames to the display's
+    Sets the mode (default: feedback) for syncing the rendering of frames to the display's
     vertical refresh rate.
     macOS and Vulkan (macvk) only.
 

--- a/osdep/mac/app_bridge.m
+++ b/osdep/mac/app_bridge.m
@@ -94,7 +94,7 @@ const struct m_sub_options macos_conf = {
     .defaults = &(const struct macos_opts){
         .macos_title_bar_color = {0, 0, 0, 0},
         .macos_fs_animation_duration = -1,
-        .macos_render_timer = RENDER_TIMER_CALLBACK,
+        .macos_render_timer = RENDER_TIMER_PRESENTATION_FEEDBACK,
         .macos_menu_shortcuts = true,
         .macos_bundle_path = (char *[]){
             "/usr/local/bin", "/usr/local/sbin", "/opt/local/bin", "/opt/local/sbin",


### PR DESCRIPTION
This changes frame timing mode to presentation feedback by default on macOS.

From #13825:

>in the long run this is supposed to be the default
>on my end this works a lot better on higher refresh rate displays (>120hz)
