### PR TITLE
demux_libarchive: escape '%' in stream URL path

### DIFF
--- a/demux/demux_libarchive.c
+++ b/demux/demux_libarchive.c
@@ -76,7 +76,7 @@ static int open_file(struct demuxer *demuxer, enum demux_check check)
     struct playlist *pl = talloc_zero(demuxer, struct playlist);
     demuxer->playlist = pl;
 
-    char *prefix = mp_normalize_path(NULL, mp_url_escape(mpa, demuxer->stream->url, "~|"));
+    char *prefix = mp_normalize_path(NULL, mp_url_escape(mpa, demuxer->stream->url, "~|%"));
 
     char **files = NULL;
     int num_files = 0;


### PR DESCRIPTION
Opening paths that are detected as archives which contain '%[0-9A-Fa-f][0-9A-Fa-f]' will fail, because such sequence is treated as a percent-encoded value when the path gets unescaped causing the path to be mangled. Escape '%' to prevent this from happening.

Fixes: 2b280f4522a288429253b396b778d60ed018312c ("stream: libarchive wrapper for reading compressed archives")
