### PR TITLE
stream_dvb: allow to enforce DVB-S/T for old zap format channels.conf

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5623,8 +5623,11 @@ DVB
 ``--dvbin-file=<filename>``
     Instructs mpv to read the channels list from ``<filename>``. The default is
     in the mpv configuration directory (usually ``~/.config/mpv``) with the
-    filename ``channels.conf.{sat,ter,cbl,atsc,isdbt}`` (based on your card
-    type) or ``channels.conf`` as a last resort.
+    filename ``channels.conf.{sat,sat1,ter,ter1,cbl,atsc,isdbt}`` (based on your
+    card type) or ``channels.conf`` as a last resort.
+    For cards supporting multiple delivery systems of the same kind, i.e.
+    DVB-T/T2 or DVB-S/S2, T2/S2 is assumed, unless the file extension
+    is ``ter1`` or ``sat1``.
     Please note that using specific file name with card type is recommended,
     since the legacy channel format is not fully standardized
     so autodetection of the delivery system may fail otherwise.

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -1090,9 +1090,12 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                     conf_file_name = "channels.conf.atsc";
                     break;
                 case SYS_DVBT:
-                    if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBT2))
-                        continue; /* Add all channels later with T2. */
-                    conf_file_name = "channels.conf.ter";
+                    if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBT2)) {
+                        // only if ter1 is present, interpret as DVB-T, else will be loaded as DVB-T2
+                        conf_file_name = "channels.conf.ter1";
+                    } else {
+                        conf_file_name = "channels.conf.ter";
+                    }
                     break;
                 case SYS_DVBT2:
                     conf_file_name = "channels.conf.ter";
@@ -1101,9 +1104,12 @@ dvb_state_t *dvb_get_state(stream_t *stream)
                     conf_file_name = "channels.conf.isdbt";
                     break;
                 case SYS_DVBS:
-                    if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBS2))
-                        continue; /* Add all channels later with S2. */
-                    conf_file_name = "channels.conf.sat";
+                    if (DELSYS_IS_SET(delsys_mask[f], SYS_DVBS2)) {
+                        // only if sat1 is present, interpret as DVB-S, else will be loaded as DVB-S2
+                        conf_file_name = "channels.conf.sat1";
+                    } else {
+                        conf_file_name = "channels.conf.sat";
+                    }
                     break;
                 case SYS_DVBS2:
                     conf_file_name = "channels.conf.sat";


### PR DESCRIPTION
If a card supports both DVB-T/T2 or DVB-S/S2, `channels.conf.{sat,ter}` was always interpreted as DVB-T2 / DVB-S2 before this change. After this change, using `channels.conf.{sat1,ter1}` will enforce interpretation as DVB-S/T.
The superior VDR channel config format is still the recommended solution for such cards as it allows to specify the delivery system variant per channel, but enforcing T2/S2 for cards supporting it whenever the zap format is used does not seem reasonable.

Solves the question described in #16467 , in which the commit was also tested with real hardware, without breaking backwards compatibility. 