### PR TITLE
clipboard-wayland: create data sources in clipboard thread

### DIFF
--- a/player/clipboard/clipboard-wayland.c
+++ b/player/clipboard/clipboard-wayland.c
@@ -301,7 +301,6 @@ static void create_data_sources(struct clipboard_wayland_priv *wl)
             seat_create_data_source(seat, true);
         }
     }
-    wl_display_flush(wl->display);
 }
 
 static void clipboard_wayland_uninit(struct clipboard_wayland_priv *wl)


### PR DESCRIPTION
Fixes race when data sources are created while a seat is being added/removed. Also removes an unnecessary flush after the fix.