### PR TITLE
build: clean up easier `Wpedantic` warnings

### DIFF
--- a/audio/filter/af_scaletempo.c
+++ b/audio/filter/af_scaletempo.c
@@ -183,7 +183,7 @@ static int best_overlap_offset_float(struct priv *s)
     float *target = (float *)s->buf_overlap + num_channels;
     int num_samples = s->samples_overlap - num_channels;
     int step_size = 3;
-    float history[3] = {};
+    float history[3] = {0};
 
     float best_distance = FLT_MAX;
     int best_offset_approx = 0;
@@ -232,7 +232,7 @@ static int best_overlap_offset_s16(struct priv *s)
     int16_t *target = (int16_t *)s->buf_overlap + num_channels;
     int num_samples = s->samples_overlap - num_channels;
     int step_size = 3;
-    int32_t history[3] = {};
+    int32_t history[3] = {0};
 
     int32_t best_distance = INT32_MAX;
     int best_offset_approx = 0;

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -884,7 +884,7 @@ static void hotplug_uninit(struct ao *ao)
 
 static void list_devs(struct ao *ao, struct ao_device_list *list)
 {
-    ao_device_list_add(list, ao, &(struct ao_device_desc){});
+    ao_device_list_add(list, ao, &(struct ao_device_desc){0});
 
     if (for_each_sink(ao, add_device_to_list, list) < 0)
         MP_WARN(ao, "Could not list devices, list may be incomplete\n");

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -152,7 +152,7 @@ void bstr_xappend(void *talloc_ctx, bstr *s, bstr append);
 
 static inline void bstr_xappend0(void *talloc_ctx, bstr *s, const char *append)
 {
-    return bstr_xappend(talloc_ctx, s, bstr0(append));
+    bstr_xappend(talloc_ctx, s, bstr0(append));
 }
 
 /**

--- a/test/json.c
+++ b/test/json.c
@@ -26,11 +26,17 @@ struct entry {
     &(struct mpv_node_list) {                                               \
         .num = sizeof(VAL_LIST(__VA_ARGS__)) / sizeof(struct mpv_node),     \
         .values = VAL_LIST(__VA_ARGS__)}}}
+#define EMPTY_NODE_ARRAY {.format = MPV_FORMAT_NODE_ARRAY, .u = { .list =    \
+    &(struct mpv_node_list) {                                               \
+        .num = 0}}}
 #define NODE_MAP(k, v) {.format = MPV_FORMAT_NODE_MAP, .u = { .list =       \
     &(struct mpv_node_list) {                                               \
         .num = sizeof(VAL_LIST(v)) / sizeof(struct mpv_node),               \
         .values = VAL_LIST(v),                                              \
         .keys = (char**)(const char *[]){k}}}}
+#define EMPTY_NODE_MAP {.format = MPV_FORMAT_NODE_MAP, .u = { .list =       \
+    &(struct mpv_node_list) {                                               \
+        .num = 0}}}
 
 static const struct entry entries[] = {
     { "null", "null", NODE_NONE()},
@@ -44,12 +50,12 @@ static const struct entry entries[] = {
     { TEXT("a\u2c29"), TEXT("aⰩ"), NODE_STR("a\342\260\251")},
     { "[1,2,3]", "[1,2,3]",
         NODE_ARRAY(NODE_INT64(1), NODE_INT64(2), NODE_INT64(3))},
-    { "[ ]", "[]", NODE_ARRAY()},
+    { "[ ]", "[]", EMPTY_NODE_ARRAY},
     { "[1,,2]", .expect_fail = true},
     { "[,]", .expect_fail = true},
     { TEXT({"a":1, "b":2}), TEXT({"a":1,"b":2}),
         NODE_MAP(L("a", "b"), L(NODE_INT64(1), NODE_INT64(2)))},
-    { "{ }", "{}", NODE_MAP(L(), L())},
+    { "{ }", "{}", EMPTY_NODE_MAP},
     { TEXT({"a":b}), .expect_fail = true},
     { TEXT({1a:"b"}), .expect_fail = true},
 

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -137,13 +137,13 @@ void assert_memcmp_impl(const char *file, int line,
 struct mp_log *const mp_null_log;
 const char *mp_help_text;
 
-void mp_msg(struct mp_log *log, int lev, const char *format, ...) {};
-int mp_msg_find_level(const char *s) {return 0;};
-int mp_msg_level(struct mp_log *log) {return 0;};
-void mp_msg_set_max_level(struct mp_log *log, int lev) {};
-int mp_console_vfprintf(void *wstream, const char *format, va_list args) {return 0;};
-int mp_console_write(void *wstream, bstr str) {return 0;};
-bool mp_check_console(void *handle) { return false; };
-void mp_set_avdict(AVDictionary **dict, char **kv) {};
+void mp_msg(struct mp_log *log, int lev, const char *format, ...) {}
+int mp_msg_find_level(const char *s) {return 0;}
+int mp_msg_level(struct mp_log *log) {return 0;}
+void mp_msg_set_max_level(struct mp_log *log, int lev) {}
+int mp_console_vfprintf(void *wstream, const char *format, va_list args) {return 0;}
+int mp_console_write(void *wstream, bstr str) {return 0;}
+bool mp_check_console(void *handle) { return false; }
+void mp_set_avdict(AVDictionary **dict, char **kv) {}
 struct mp_log *mp_log_new(void *talloc_ctx, struct mp_log *parent,
-                          const char *name) { return NULL; };
+                          const char *name) { return NULL; }

--- a/video/hwdec.h
+++ b/video/hwdec.h
@@ -5,9 +5,7 @@
 #include <libavutil/hwcontext.h>
 
 #include "options/m_option.h"
-
-struct mp_image_pool;
-enum mp_imgfmt;
+#include "video/img_format.h"
 
 struct mp_conversion_filter {
     // Name of the conversion filter.

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -309,7 +309,7 @@ static void open_render_fd(struct ra_ctx *ctx, const char *render_path)
 static bool drm_setup(struct ra_ctx *ctx, int display_idx,
                       VkPhysicalDevicePCIBusInfoPropertiesEXT *pci_props)
 {
-    drmDevice *devs[32] = {};
+    drmDevice *devs[32] = {0};
     int count = drmGetDevices2(0, devs, MP_ARRAY_SIZE(devs));
     for (int i = 0; i < count; i++) {
         drmDevice *dev = devs[i];


### PR DESCRIPTION
Gets most of the easier pedantic warnings present, but not all. There are a lot of `dlsym` related ones in our code base which I do not have the ability to tackle at the moment. There are also a lot of warnings from my local install of `libspa`? Not sure if that's something occurring in other build environments.