### PR TITLE
global path and M_OPT_FILE refactoring

### DIFF
--- a/DOCS/interface-changes/watch-history-path.txt
+++ b/DOCS/interface-changes/watch-history-path.txt
@@ -1,0 +1,2 @@
+change `--watch-history-path` to be unset by default
+use the `current-watch-history-path` property to get the path instead

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3880,6 +3880,11 @@ Property list
     The working directory of the mpv process. Can be useful for JSON IPC users,
     because the command line player usually works with relative paths.
 
+``current-watch-history-path``
+    The path in which the watch history file is stored. This will return the
+    value of ``--watch-history-path`` or the default path if
+    ``--watch-history-path`` has not been set with tilde placeholders expanded.
+
 ``current-watch-later-dir``
     The directory in which watch later config files are stored. This returns
     ``--watch-later-dir``, or the default directory if ``--watch-later-dir`` has

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1165,8 +1165,11 @@ Watch History
         disabled by default.
 
 ``--watch-history-path=<path>``
-    The path in which to store the watch history. Default:
-    ``~~state/watch_history.jsonl`` (see `FILES`_).
+    The path in which to store the watch history.
+
+    If this option is unset, the file will be stored as ``watch_history.jsonl``
+    in the local state directory. This is usually ``~/.local/state/mpv/`` (see
+    `FILES`_).
 
     This file contains one JSON object per line. Its ``time`` field is the UNIX
     timestamp when the file was opened, its ``path`` field is the normalized

--- a/common/msg.c
+++ b/common/msg.c
@@ -760,7 +760,7 @@ static bool check_new_path(struct mpv_global *global, char *opt,
     void *tmp = talloc_new(NULL);
     bool res = false;
 
-    char *new_path = mp_get_user_path(tmp, global, opt);
+    char *new_path = mp_get_user_path(tmp, global, bstr0(opt));
     if (!new_path)
         new_path = "";
 

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -137,16 +137,16 @@ void mp_print_cmd_list(struct mp_log *out);
 
 // Parse text and return corresponding struct mp_cmd.
 // The location parameter is for error messages.
-struct mp_cmd *mp_input_parse_cmd_str(struct mp_log *log, bstr str,
+struct mp_cmd *mp_input_parse_cmd_str(struct mpv_global *global, bstr str,
                                       const char *loc);
 
 // Similar to mp_input_parse_cmd(), but takes a list of strings instead.
 // Also, MP_ON_OSD_AUTO | MP_EXPAND_PROPERTIES are not set by default.
 // Keep in mind that these functions (naturally) don't take multiple commands,
 // i.e. a ";" argument does not start a new command.
-struct mp_cmd *mp_input_parse_cmd_strv(struct mp_log *log, const char **argv);
+struct mp_cmd *mp_input_parse_cmd_strv(struct mpv_global *global, const char **argv);
 
-struct mp_cmd *mp_input_parse_cmd_node(struct mp_log *log, struct mpv_node *node);
+struct mp_cmd *mp_input_parse_cmd_node(struct mpv_global *global, struct mpv_node *node);
 
 // After getting a command from mp_input_get_cmd you need to free it using this
 // function

--- a/input/input.c
+++ b/input/input.c
@@ -350,7 +350,7 @@ static mp_cmd_t *handle_test(struct input_ctx *ictx, int code)
             "CLOSE_WIN was received. This pseudo key can be remapped too,\n"
             "but --input-test will always quit when receiving it.\n");
         const char *args[] = {"quit", NULL};
-        mp_cmd_t *res = mp_input_parse_cmd_strv(ictx->log, args);
+        mp_cmd_t *res = mp_input_parse_cmd_strv(ictx->global, args);
         return res;
     }
 
@@ -378,7 +378,7 @@ static mp_cmd_t *handle_test(struct input_ctx *ictx, int code)
 
     MP_INFO(ictx, "%s\n", msg);
     const char *args[] = {"show-text", msg, NULL};
-    mp_cmd_t *res = mp_input_parse_cmd_strv(ictx->log, args);
+    mp_cmd_t *res = mp_input_parse_cmd_strv(ictx->global, args);
     talloc_free(msg);
     return res;
 }
@@ -517,7 +517,7 @@ static mp_cmd_t *get_cmd_from_keys(struct input_ctx *ictx, bstr force_section,
         cmd = find_any_bind_for_key(ictx, force_section, MP_KEY_UNMAPPED);
     if (!cmd) {
         if (code == MP_KEY_CLOSE_WIN)
-            return mp_input_parse_cmd_strv(ictx->log, (const char*[]){"quit", 0});
+            return mp_input_parse_cmd_strv(ictx->global, (const char*[]){"quit", 0});
         int msgl = MSGL_WARN;
         if (MP_KEY_IS_MOUSE_MOVE(code))
             msgl = MSGL_TRACE;
@@ -1810,13 +1810,13 @@ bool mp_input_use_media_keys(struct input_ctx *ictx)
 struct mp_cmd *mp_input_parse_cmd(struct input_ctx *ictx, bstr str,
                                   const char *location)
 {
-    return mp_input_parse_cmd_str(ictx->log, str, location);
+    return mp_input_parse_cmd_str(ictx->global, str, location);
 }
 
 void mp_input_run_cmd(struct input_ctx *ictx, const char **cmd)
 {
     input_lock(ictx);
-    queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
+    queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->global, cmd));
     input_unlock(ictx);
 }
 
@@ -2034,7 +2034,7 @@ void mp_input_src_feed_cmd_text(struct mp_input_src *src, char *buf, size_t len)
             if (term) {
                 bstr s = {in->cmd_buffer, in->cmd_buffer_size};
                 s = bstr_strip(s);
-                struct mp_cmd *cmd = mp_input_parse_cmd_str(src->log, s, "<>");
+                struct mp_cmd *cmd = mp_input_parse_cmd_str(src->global, s, "<>");
                 if (cmd) {
                     input_lock(src->input_ctx);
                     queue_cmd(src->input_ctx, cmd);

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -635,7 +635,7 @@ int m_config_set_option_raw(struct m_config *config,
 
     m_config_mark_co_flags(co, flags);
 
-    m_option_copy_and_expand(config->global, co->opt, co->data, data);
+    m_option_copy(co->opt, co->data, data);
     if (m_config_cache_write_opt(config->cache, co->data))
         force_self_notify_change_opt(config, co, false);
 
@@ -759,7 +759,7 @@ int m_config_set_option_cli(struct m_config *config, struct bstr name,
     if (co->data)
         m_option_copy(co->opt, &val, co->data);
 
-    r = m_option_parse(config->log, co->opt, name, param, &val);
+    r = m_option_parse(config->global, config->log, co->opt, name, param, &val);
 
     if (r >= 0)
         r = m_config_set_option_raw(config, co, &val, flags);
@@ -788,7 +788,7 @@ int m_config_set_option_node(struct m_config *config, bstr name,
     // the old value, as opposed to e.g. appending to lists.
     union m_option_value val = m_option_value_default;
 
-    r = m_option_set_node_or_string(mp_null_log, co->opt, name, &val, data);
+    r = m_option_set_node_or_string(config->global, co->opt, name, &val, data);
     if (r >= 0)
         r = m_config_set_option_raw(config, co, &val, flags);
 
@@ -959,7 +959,7 @@ int m_config_set_profile_option(struct m_config *config, struct m_profile *p,
         return 0;
     }
     if (bstr_equals0(name, profile_restore_mode_opt.name)) {
-        return m_option_parse(config->log, &profile_restore_mode_opt, name, val,
+        return m_option_parse(config->global, config->log, &profile_restore_mode_opt, name, val,
                               &p->restore_mode);
     }
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1276,7 +1276,7 @@ static void expand_str(struct mpv_global *global, const m_option_t *opt,
 {
     if (dst && src) {
         talloc_free(VAL(dst));
-        VAL(dst) = mp_get_user_path(NULL, global, VAL(src));
+        VAL(dst) = mp_get_user_path(NULL, global, bstr0(VAL(src)));
     }
 }
 
@@ -1581,7 +1581,7 @@ static void copy_str_list_impl(struct mpv_global *global, const m_option_t *opt,
     d = talloc_array(NULL, char *, n + 1);
     for (; n >= 0; n--) {
         if (global) {
-            d[n] = mp_get_user_path(NULL, global, s[n]);
+            d[n] = mp_get_user_path(NULL, global, bstr0(s[n]));
         } else {
             d[n] = talloc_strdup(NULL, s[n]);
         }

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -158,7 +158,7 @@ struct m_property *m_property_list_find(const struct m_property *list,
 // action: one of m_property_action
 // ctx: opaque value passed through to property implementation
 // returns: one of mp_property_return
-int m_property_do(struct mp_log *log, const struct m_property* prop_list,
+int m_property_do(struct mpv_global *global, const struct m_property* prop_list,
                   const char* property_name, int action, void* arg, void *ctx);
 
 // Given a path of the form "a/b/c", this function will set *prefix to "a",

--- a/options/options.c
+++ b/options/options.c
@@ -1013,7 +1013,6 @@ static const struct MPOpts mp_default_opts = {
     .sync_max_factor = 5,
     .load_config = true,
     .position_resume = true,
-    .watch_history_path = "~~state/watch_history.jsonl",
     .autoload_files = true,
     .demuxer_thread = true,
     .demux_termination_timeout = 0.1,

--- a/options/path.h
+++ b/options/path.h
@@ -52,7 +52,7 @@ char **mp_find_all_config_files(void *talloc_ctx, struct mpv_global *global,
 // paths starting with '~'. Used to allow the user explicitly reference a
 // file from the user's home or mpv config directory.
 char *mp_get_user_path(void *talloc_ctx, struct mpv_global *global,
-                       const char *path);
+                       struct bstr path);
 
 // Same as mp_get_user_path but also normalizes the path if it happens to be
 // relative.

--- a/player/client.c
+++ b/player/client.c
@@ -1143,13 +1143,13 @@ static int run_client_command(mpv_handle *ctx, struct mp_cmd *cmd, mpv_node *res
 
 int mpv_command(mpv_handle *ctx, const char **args)
 {
-    return run_client_command(ctx, mp_input_parse_cmd_strv(ctx->log, args), NULL);
+    return run_client_command(ctx, mp_input_parse_cmd_strv(ctx->mpctx->global, args), NULL);
 }
 
 int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result)
 {
     struct mpv_node rn = {.format = MPV_FORMAT_NONE};
-    int r = run_client_command(ctx, mp_input_parse_cmd_node(ctx->log, args), result ? &rn : NULL);
+    int r = run_client_command(ctx, mp_input_parse_cmd_node(ctx->mpctx->global, args), result ? &rn : NULL);
     if (result && r >= 0)
         *result = rn;
     return r;
@@ -1158,7 +1158,7 @@ int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result)
 int mpv_command_ret(mpv_handle *ctx, const char **args, mpv_node *result)
 {
     struct mpv_node rn = {.format = MPV_FORMAT_NONE};
-    int r = run_client_command(ctx, mp_input_parse_cmd_strv(ctx->log, args), result ? &rn : NULL);
+    int r = run_client_command(ctx, mp_input_parse_cmd_strv(ctx->mpctx->global, args), result ? &rn : NULL);
     if (result && r >= 0)
         *result = rn;
     return r;
@@ -1240,12 +1240,12 @@ static int run_async_cmd(mpv_handle *ctx, uint64_t ud, struct mp_cmd *cmd)
 
 int mpv_command_async(mpv_handle *ctx, uint64_t ud, const char **args)
 {
-    return run_async_cmd(ctx, ud, mp_input_parse_cmd_strv(ctx->log, args));
+    return run_async_cmd(ctx, ud, mp_input_parse_cmd_strv(ctx->mpctx->global, args));
 }
 
 int mpv_command_node_async(mpv_handle *ctx, uint64_t ud, mpv_node *args)
 {
-    return run_async_cmd(ctx, ud, mp_input_parse_cmd_node(ctx->log, args));
+    return run_async_cmd(ctx, ud, mp_input_parse_cmd_node(ctx->mpctx->global, args));
 }
 
 void mpv_abort_async_command(mpv_handle *ctx, uint64_t reply_userdata)

--- a/player/command.c
+++ b/player/command.c
@@ -5243,7 +5243,7 @@ static void cmd_osd_overlay(void *p)
 
 static struct track *find_track_with_url(struct MPContext *mpctx, int type, const char *url)
 {
-    char *path = mp_get_user_path(NULL, mpctx->global, url);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(url));
     struct track *t = NULL;
     for (int n = 0; n < mpctx->num_tracks; n++) {
         struct track *track = mpctx->tracks[n];
@@ -6036,7 +6036,7 @@ static void cmd_expand_path(void *p)
 
     cmd->result = (mpv_node){
         .format = MPV_FORMAT_STRING,
-        .u.string = mp_get_user_path(NULL, mpctx->global, cmd->args[0].v.s)
+        .u.string = mp_get_user_path(NULL, mpctx->global, bstr0(cmd->args[0].v.s)),
     };
 }
 
@@ -6045,7 +6045,7 @@ static void cmd_normalize_path(void *p)
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
 
-    char *path = mp_get_user_path(NULL, mpctx->global, cmd->args[0].v.s);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(cmd->args[0].v.s));
     cmd->result = (mpv_node){
         .format = MPV_FORMAT_STRING,
         .u.string = mp_normalize_path(NULL, path),
@@ -6117,7 +6117,7 @@ static void cmd_loadfile(void *p)
     if (action.type == LOAD_TYPE_REPLACE)
         playlist_clear(mpctx->playlist);
 
-    char *path = mp_get_user_path(NULL, mpctx->global, filename);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
     struct playlist_entry *entry = playlist_entry_new(path);
     talloc_free(path);
     if (cmd->args[3].v.str_list) {
@@ -6152,7 +6152,7 @@ static void cmd_loadlist(void *p)
 
     struct load_action action = get_load_action(mpctx, action_flag);
 
-    char *path = mp_get_user_path(NULL, mpctx->global, filename);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
     struct playlist *pl = playlist_parse_file(path, cmd->abort->cancel,
                                               mpctx->global);
     talloc_free(path);
@@ -6939,7 +6939,7 @@ static void cmd_load_config_file(void *p)
     struct MPContext *mpctx = cmd->mpctx;
 
     void *ctx = talloc_new(NULL);
-    char *config_file = mp_get_user_path(ctx, mpctx->global, cmd->args[0].v.s);
+    char *config_file = mp_get_user_path(ctx, mpctx->global, bstr0(cmd->args[0].v.s));
     int r = m_config_parse_config_file(mpctx->mconfig, mpctx->global,
                                        config_file, NULL, 0);
     talloc_free(ctx);
@@ -6957,7 +6957,7 @@ static void cmd_load_input_conf(void *p)
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
 
-    char *config_file = mp_get_user_path(NULL, mpctx->global, cmd->args[0].v.s);
+    char *config_file = mp_get_user_path(NULL, mpctx->global, bstr0(cmd->args[0].v.s));
     cmd->success = mp_input_load_config_file(mpctx->input, config_file);
     talloc_free(config_file);
 }
@@ -7035,7 +7035,7 @@ static void run_dump_cmd(struct mp_cmd_ctx *cmd, double start, double end,
         return;
     }
 
-    char *path = mp_get_user_path(NULL, mpctx->global, filename);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
     mp_cmd_msg(cmd, MSGL_INFO, "Cache dumping started.");
 
     if (!demux_cache_dump_set(mpctx->demuxer, start, end, path)) {

--- a/player/command.c
+++ b/player/command.c
@@ -3632,6 +3632,16 @@ static int mp_property_cwd(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
+static int mp_property_current_watch_history_path(void *ctx, struct m_property *prop,
+                                                  int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    char *path = mp_get_watch_history_path(NULL, mpctx);
+    int r = m_property_strdup_ro(action, arg, path);
+    talloc_free(path);
+    return r;
+}
+
 static int mp_property_current_watch_later_dir(void *ctx, struct m_property *prop,
                                                int action, void *arg)
 {
@@ -4519,6 +4529,7 @@ static const struct m_property mp_properties_base[] = {
     {"ambient-light", mp_property_ambient_light},
 
     {"working-directory", mp_property_cwd},
+    {"current-watch-history-path", mp_property_current_watch_history_path},
     {"current-watch-later-dir", mp_property_current_watch_later_dir},
 
     {"protocol-list", mp_property_protocols},

--- a/player/command.c
+++ b/player/command.c
@@ -4685,7 +4685,7 @@ int mp_property_do(const char *name, int action, void *val,
                    struct MPContext *ctx)
 {
     struct command_ctx *cmd = ctx->command_ctx;
-    int r = m_property_do(ctx->log, cmd->properties, name, action, val, ctx);
+    int r = m_property_do(ctx->global, cmd->properties, name, action, val, ctx);
 
     if (mp_msg_test(ctx->log, MSGL_V) && is_property_set(action, val)) {
         struct m_option option_type = {0};
@@ -4974,7 +4974,7 @@ static int edit_filters(struct MPContext *mpctx, struct mp_log *log,
     struct m_obj_settings *new_chain = NULL;
     m_option_copy(co->opt, &new_chain, co->data);
 
-    int r = m_option_parse(log, co->opt, bstr0(optname), bstr0(arg), &new_chain);
+    int r = m_option_parse(mpctx->global, log, co->opt, bstr0(optname), bstr0(arg), &new_chain);
     if (r >= 0)
         r = set_filters(mpctx, mediatype, new_chain);
 
@@ -5361,7 +5361,7 @@ static void cmd_cycle_values(void *p)
     int current = -1;
     for (int n = first; n < cmd->num_args; n++) {
         union m_option_value val = m_option_value_default;
-        if (m_option_parse(mpctx->log, &prop, bstr0(name),
+        if (m_option_parse(mpctx->global, mpctx->log, &prop, bstr0(name),
                            bstr0(cmd->args[n].v.s), &val) < 0)
             continue;
 
@@ -5772,7 +5772,7 @@ static void cmd_change_list(void *p)
     }
 
     char *optname = mp_tprintf(80, "%s-%s", name, op); // the dirty truth
-    int r = m_option_parse(mpctx->log, &prop, bstr0(optname), bstr0(value), &val);
+    int r = m_option_parse(mpctx->global, mpctx->log, &prop, bstr0(optname), bstr0(value), &val);
     if (r >= 0 && mp_property_do(name, M_PROPERTY_SET, &val, mpctx) <= 0)
         r = -1;
     m_option_free(&prop, &val);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -69,8 +69,8 @@ void mp_parse_cfgfiles(struct MPContext *mpctx)
 
     mp_mk_user_dir(mpctx->global, "home", "");
 
-    char *p1 = mp_get_user_path(NULL, mpctx->global, "~~home/");
-    char *p2 = mp_get_user_path(NULL, mpctx->global, "~~old_home/");
+    char *p1 = mp_get_user_path(NULL, mpctx->global, bstr0("~~home/"));
+    char *p2 = mp_get_user_path(NULL, mpctx->global, bstr0("~~old_home/"));
     if (strcmp(p1, p2) != 0 && mp_path_exists(p2)) {
         MP_WARN(mpctx, "Warning, two config dirs found:\n   %s (main)\n"
                 "   %s (bogus)\nYou should merge or delete the second one.\n",

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -197,6 +197,17 @@ static bool copy_mtime(const char *f1, const char *f2)
     return true;
 }
 
+char *mp_get_watch_history_path(void *talloc_ctx, struct MPContext *mpctx)
+{
+    char *history_path = mpctx->opts->watch_history_path;
+    if (history_path && history_path[0]) {
+        history_path = talloc_strdup(talloc_ctx, history_path);
+    } else {
+        history_path = mp_find_user_file(talloc_ctx, mpctx->global, "state", "watch_history.jsonl");
+    }
+    return history_path;
+}
+
 char *mp_get_playback_resume_dir(struct MPContext *mpctx)
 {
     char *wl_dir = mpctx->opts->watch_later_dir;

--- a/player/core.h
+++ b/player/core.h
@@ -513,6 +513,7 @@ void audio_start_ao(struct MPContext *mpctx);
 void mp_parse_cfgfiles(struct MPContext *mpctx);
 void mp_load_auto_profiles(struct MPContext *mpctx);
 bool mp_load_playback_resume(struct MPContext *mpctx, const char *file);
+char *mp_get_watch_history_path(void *talloc_ctx, struct MPContext *mpctx);
 char *mp_get_playback_resume_dir(struct MPContext *mpctx);
 void mp_write_watch_later_conf(struct MPContext *mpctx);
 void mp_delete_watch_later_conf(struct MPContext *mpctx, const char *file);

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -340,7 +340,7 @@ static const char *get_builtin_file(const char *name)
 // Push up to limit bytes of file fname: from builtin_files, else from the OS.
 static void af_push_file(js_State *J, const char *fname, int limit, void *af)
 {
-    char *filename = mp_get_user_path(af, jctx(J)->mpctx->global, fname);
+    char *filename = mp_get_user_path(af, jctx(J)->mpctx->global, bstr0(fname));
     MP_VERBOSE(jctx(J), "Reading file '%s'\n", filename);
     if (limit < 0)
         limit = INT_MAX - 1;
@@ -949,7 +949,7 @@ static void script__write_file(js_State *J, void *af)
     if (strstr(fname, prefix) != fname)  // simple protection for incorrect use
         js_error(J, "File name must be prefixed with '%s'", prefix);
     fname += strlen(prefix);
-    fname = mp_get_user_path(af, jctx(J)->mpctx->global, fname);
+    fname = mp_get_user_path(af, jctx(J)->mpctx->global, bstr0(fname));
     MP_VERBOSE(jctx(J), "%s file '%s'\n", opstr, fname);
 
     FILE *f = fopen(fname, append ? "ab" : "wb");

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1545,9 +1545,7 @@ static void append_to_watch_history(struct MPContext *mpctx)
         return;
 
     void *ctx = talloc_new(NULL);
-    char *history_path = mpctx->opts->watch_history_path;
-    if (!history_path || !history_path[0])
-        history_path = mp_find_user_file(ctx, mpctx->global, "state", "watch_history.jsonl");
+    char *history_path = mp_get_watch_history_path(NULL, mpctx);
     char *history_path_dir = bstrto0(ctx, mp_dirname(history_path));
     mp_mkdirp(history_path_dir);
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1546,6 +1546,8 @@ static void append_to_watch_history(struct MPContext *mpctx)
 
     void *ctx = talloc_new(NULL);
     char *history_path = mpctx->opts->watch_history_path;
+    if (!history_path || !history_path[0])
+        history_path = mp_find_user_file(ctx, mpctx->global, "state", "watch_history.jsonl");
     char *history_path_dir = bstrto0(ctx, mp_dirname(history_path));
     mp_mkdirp(history_path_dir);
 

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -437,8 +437,7 @@ local function format_history_entry(entry)
 end
 
 mp.add_key_binding(nil, "select-watch-history", function ()
-    local history_file_path = mp.command_native(
-        {"expand-path", mp.get_property("watch-history-path")})
+    local history_file_path = mp.get_property("current-watch-history-path")
     local history_file, error_message = io.open(history_file_path)
     if not history_file then
         show_warning(mp.get_property_native("save-watch-history")

--- a/player/main.c
+++ b/player/main.c
@@ -235,7 +235,7 @@ static int cfg_include(void *ctx, char *filename, int flags)
     return 1;
 #endif
     struct MPContext *mpctx = ctx;
-    char *fname = mp_get_user_path(NULL, mpctx->global, filename);
+    char *fname = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
     int r = m_config_parse_config_file(mpctx->mconfig, mpctx->global, fname, NULL, flags);
     talloc_free(fname);
     return r;

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -264,7 +264,7 @@ static char *create_fname(struct MPContext *mpctx, char *template,
 
     res = talloc_strdup_append(res, template);
     res = talloc_asprintf_append(res, ".%s", file_ext);
-    char *fname = mp_get_user_path(NULL, mpctx->global, res);
+    char *fname = mp_get_user_path(NULL, mpctx->global, bstr0(res));
     talloc_free(res);
     return fname;
 
@@ -494,7 +494,7 @@ void cmd_screenshot_to_file(void *p)
         cmd->success = false;
         return;
     }
-    char *path = mp_get_user_path(NULL, mpctx->global, filename);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
     cmd->success = write_screenshot(cmd, image, path, &opts, true);
     talloc_free(image);
     talloc_free(path);

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -494,10 +494,8 @@ void cmd_screenshot_to_file(void *p)
         cmd->success = false;
         return;
     }
-    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(filename));
-    cmd->success = write_screenshot(cmd, image, path, &opts, true);
+    cmd->success = write_screenshot(cmd, image, filename, &opts, true);
     talloc_free(image);
-    talloc_free(path);
 }
 
 void cmd_screenshot(void *p)

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -202,7 +202,7 @@ static int64_t mp_load_script(struct MPContext *mpctx, const char *fname)
 
 int64_t mp_load_user_script(struct MPContext *mpctx, const char *fname)
 {
-    char *path = mp_get_user_path(NULL, mpctx->global, fname);
+    char *path = mp_get_user_path(NULL, mpctx->global, bstr0(fname));
     int64_t ret = mp_load_script(mpctx, path);
     talloc_free(path);
     return ret;

--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -193,7 +193,7 @@ void mp_setup_av_network_options(AVDictionary **dict, const char *target_fmt,
     if (opts->cookies_enabled) {
         char *file = opts->cookies_file;
         if (file && file[0])
-            file = mp_get_user_path(temp, global, file);
+            file = mp_get_user_path(temp, global, bstr0(file));
         char *cookies = cookies_lavf(temp, global, log, file);
         if (cookies && cookies[0])
             av_dict_set(dict, "cookies", cookies, 0);

--- a/stream/stream_slice.c
+++ b/stream/stream_slice.c
@@ -112,12 +112,12 @@ static int parse_slice_range(stream_t *stream)
         .type = &m_option_type_byte_size,
     };
 
-    if (m_option_parse(stream->log, &opt, bstr0("slice_start"), start, &p->slice_start) < 0)
+    if (m_option_parse(stream->global, stream->log, &opt, bstr0("slice_start"), start, &p->slice_start) < 0)
         return STREAM_ERROR;
 
     bool max_end_is_offset = bstr_startswith0(end, "+");
     if (has_end) {
-        if (m_option_parse(stream->log, &opt, bstr0("slice_max_end"), end, &p->slice_max_end) < 0)
+        if (m_option_parse(stream->global, stream->log, &opt, bstr0("slice_max_end"), end, &p->slice_max_end) < 0)
             return STREAM_ERROR;
     }
 

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -580,7 +580,7 @@ static bool create_pass(struct gl_shader_cache *sc, struct sc_entry *entry)
 
     if (sc->cache_dir && sc->cache_dir[0]) {
         // Try to load it from a disk cache.
-        cache_dir = mp_get_user_path(tmp, sc->global, sc->cache_dir);
+        cache_dir = mp_get_user_path(tmp, sc->global, bstr0(sc->cache_dir));
 
         struct AVSHA *sha = av_sha_alloc();
         MP_HANDLE_OOM(sha);


### PR DESCRIPTION
Cleanest way to handle #16573 imo.

1. Revert https://github.com/mpv-player/mpv/commit/9b7374ea40e607b61d9c5db9dffc822d52b7df38.
2. Remove the mpv_global requirement from everything in options/path.c.
3. Assorted cleanups and fixes.
4. Expand paths in `parse_str` and `parse_str_list` directly.