### PR TITLE
demux_libarchive: normalize stream URL path before escaping

### DIFF
--- a/demux/demux_libarchive.c
+++ b/demux/demux_libarchive.c
@@ -76,7 +76,7 @@ static int open_file(struct demuxer *demuxer, enum demux_check check)
     struct playlist *pl = talloc_zero(demuxer, struct playlist);
     demuxer->playlist = pl;
 
-    char *prefix = mp_normalize_path(NULL, mp_url_escape(mpa, demuxer->stream->url, "~|%"));
+    char *prefix = mp_url_escape(NULL, mp_normalize_path(mpa, demuxer->stream->url), "~|%");
 
     char **files = NULL;
     int num_files = 0;


### PR DESCRIPTION
Path normalization can introduce pipe characters from the current working directory when opening relative paths, which will make the stream split the path and entry name prematurely. Escape the normalized path, not the other way around.

Fixes: 440f35a26db3fd9f25282bff0f06f4e86e8133c2 ("demux_libarchive: normalize the stream url path")