### PR TITLE
ytdl_hook.lua: fix title detection for twitch streams

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -740,7 +740,11 @@ local function add_single_video(json)
     mp.set_property("stream-open-filename", streamurl:gsub("^data:", "data://", 1))
 
     if mp.get_property("force-media-title", "") == "" then
-        mp.set_property("file-local-options/force-media-title", json.title)
+        if json.extractor == "twitch:stream" then
+                mp.set_property("file-local-options/force-media-title", json.description)
+        else
+                mp.set_property("file-local-options/force-media-title", json.title)
+        end
     end
 
     -- set hls-bitrate for dash track selection


### PR DESCRIPTION
For some reason twitch puts the title (as its visible in the website) in the JSON property ``description`` instead of ``title``
<details>
<summary>Excerpt of the output of yt-dlp -J for a twitch stream</summary>

```json
  "id": "325146193276",
  "display_id": "shroud",
  "title": "shroud (live) 2025-07-30 15:58",
  "description": "lots of bugs, but I need to CONTINUE.",
  "uploader": "shroud",
  "uploader_id": "shroud",
  "timestamp": 1753899752,
  "view_count": null,
  "is_live": true,
  "webpage_url": "https://www.twitch.tv/shroud",
  "original_url": "https://www.twitch.tv/shroud",
  "webpage_url_basename": "shroud",
  "webpage_url_domain": "twitch.tv",
  "extractor": "twitch:stream",
  "extractor_key": "TwitchStream",
  "playlist": null,
  "playlist_index": null,
  "thumbnail": "https://static-cdn.jtvnw.net/previews-ttv/live_user_shroud-0x0.jpg",
  "fulltitle": "shroud (live)",
  "upload_date": "20250730",
  "release_year": null,
  "live_status": "is_live",
  "was_live": false,
  "requested_subtitles": null,
  "_has_drm": null,
  "epoch": 1753901939,
```
</details>

Only ``force-media-title`` in ``add_single_video`` was changed ``force-media-title`` in ``run_ytdl_hook`` was not since it works fine without it and i preferred to be conservative with changes, however please review/test

I have been running mpv with this patch since 2018 and recently started using linux more often so it would be nice if it was there by default on the next distro build

Cheers