### PR TITLE
client: fix leak in mpv_command_{ret,node} if result argument is NULL

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -1149,7 +1149,7 @@ int mpv_command(mpv_handle *ctx, const char **args)
 int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result)
 {
     struct mpv_node rn = {.format = MPV_FORMAT_NONE};
-    int r = run_client_command(ctx, mp_input_parse_cmd_node(ctx->log, args), &rn);
+    int r = run_client_command(ctx, mp_input_parse_cmd_node(ctx->log, args), result ? &rn : NULL);
     if (result && r >= 0)
         *result = rn;
     return r;
@@ -1158,7 +1158,7 @@ int mpv_command_node(mpv_handle *ctx, mpv_node *args, mpv_node *result)
 int mpv_command_ret(mpv_handle *ctx, const char **args, mpv_node *result)
 {
     struct mpv_node rn = {.format = MPV_FORMAT_NONE};
-    int r = run_client_command(ctx, mp_input_parse_cmd_strv(ctx->log, args), &rn);
+    int r = run_client_command(ctx, mp_input_parse_cmd_strv(ctx->log, args), result ? &rn : NULL);
     if (result && r >= 0)
         *result = rn;
     return r;


### PR DESCRIPTION
See the commit message. Can be reproduced with the following program:
<details><summary>leak.c</summary><p>

```
// Build with: gcc -o leak leak.c `pkg-config --libs --cflags mpv`
// Run with: valgrind --leak-check=full --show-reachable=no ./leak /path/to/file

#include <stddef.h>
#include <stdio.h>
#include <stdlib.h>

#include <mpv/client.h>

static void die(const char *msg) {
    fprintf(stderr, "%s\n", msg);
    exit(1);
}

int main(int argc, char *argv[]) {
    if (argc != 2) {
        die("pass a single media file as argument");
    }

    mpv_handle *ctx = mpv_create();
    if (!ctx) {
        die("failed creating context");
    }

    mpv_set_option_string(ctx, "input-default-bindings", "yes");
    mpv_set_option_string(ctx, "input-terminal", "yes");
    mpv_set_option_string(ctx, "terminal", "yes");

    if (mpv_initialize(ctx) < 0) {
        die("failed to initialize mpv");
    }

    struct mpv_node cmd = {
        .format = MPV_FORMAT_NODE_MAP,
        .u.list = &(struct mpv_node_list){
            .num = 2,
            .keys = (char *[]){ "name", "url", },
            .values = (struct mpv_node[]){
                (struct mpv_node){ .format = MPV_FORMAT_STRING, .u.string = "loadfile" },
                (struct mpv_node){ .format = MPV_FORMAT_STRING, .u.string = argv[1] },
            },
        },
    };

    // This will leak:
    if (mpv_command_node(ctx, &cmd, NULL) < 0) {
        die("failed to execute command");
    }

    // This will not leak:
    //struct mpv_node dummy;
    //if (mpv_command_node(ctx, &cmd, &dummy) < 0) {
    //    die("failed to execute command");
    //} else {
    //    mpv_free_node_contents(&dummy);
    //}

    while (1) {
        mpv_event *event = mpv_wait_event(ctx, 10000);
        if (event->event_id == MPV_EVENT_SHUTDOWN) {
            break;
        }
    }

    mpv_terminate_destroy(ctx);
    return 0;
}
```

</p></details>

Running it under valgrind outputs:
```
==3178==
==3178== HEAP SUMMARY:
==3178==     in use at exit: 149,268 bytes in 984 blocks
==3178==   total heap usage: 25,704 allocs, 24,720 frees, 18,264,913 bytes allocated
==3178==
==3178== 282 (72 direct, 210 indirect) bytes in 1 blocks are definitely lost in loss record 258 of 267
==3178==    at 0x4856373: calloc (vg_replace_malloc.c:1675)
==3178==    by 0x499A7E4: ta_zalloc_size (ta.c:156)
==3178==    by 0x4901C31: node_init (node.c:31)
==3178==    by 0x4928495: cmd_loadfile (command.c:6039)
==3178==    by 0x492F2A9: run_command (command.c:5498)
==3178==    by 0x491A03F: run_client_command (client.c:1134)
==3178==    by 0x491BE9D: mpv_command_node (client.c:1152)
==3178==    by 0x400141E: main (in /home/heather/leak)
==3178==
==3178== LEAK SUMMARY:
==3178==    definitely lost: 72 bytes in 1 blocks
==3178==    indirectly lost: 210 bytes in 3 blocks
==3178==      possibly lost: 0 bytes in 0 blocks
==3178==    still reachable: 147,138 bytes in 959 blocks
==3178==         suppressed: 0 bytes in 0 blocks
==3178== Reachable blocks (those to which a pointer was found) are not shown.
==3178== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3178==
==3178== For lists of detected and suppressed errors, rerun with: -s
==3178== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
I tested with both NULL and non-NULL result in cases of both success and failure, and it seems to function correctly.