### PR TITLE
fuzzers: set fontconfig sysroot

### DIFF
--- a/fuzzers/common.h
+++ b/fuzzers/common.h
@@ -48,6 +48,13 @@ static inline bool str_startswith(const char *str, size_t str_len,
     return !memcmp(str, prefix, prefix_len);
 }
 
+static inline void set_fontconfig_sysroot(void)
+{
+#ifdef MPV_FONTCONFIG_SYSROOT
+    setenv("FONTCONFIG_SYSROOT", MPV_STRINGIFY(MPV_FONTCONFIG_SYSROOT), 1);
+#endif
+}
+
 #ifndef PLAYBACK_TIME_LIMIT
 #define PLAYBACK_TIME_LIMIT 5
 #endif

--- a/fuzzers/fuzzer_load.c
+++ b/fuzzers/fuzzer_load.c
@@ -64,6 +64,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (sprintf(filename, "fd://%d", fd) <= 5)
         exit(1);
 
+    set_fontconfig_sysroot();
+
     mpv_handle *ctx = mpv_create();
     if (!ctx)
         exit(1);

--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -39,6 +39,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
 #endif
 
+    set_fontconfig_sysroot();
+
     mpv_handle *ctx = mpv_create();
     if (!ctx)
         exit(1);

--- a/fuzzers/fuzzer_options_parser.c
+++ b/fuzzers/fuzzer_options_parser.c
@@ -56,6 +56,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
     opts[count] = NULL;
 
+    set_fontconfig_sysroot();
+
     mpv_handle *ctx = mpv_create();
     if (!ctx)
         exit(1);

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -54,6 +54,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (!name_len || name_len != size - value_len - 1)
         return 0;
 
+    set_fontconfig_sysroot();
+
     mpv_handle *ctx = mpv_create();
     if (!ctx)
         exit(1);


### PR DESCRIPTION
Allows to specify custom fontconfig sysroot. Useful for fuzzing environments where we might use specific config, font or the system wide config is not available.