### PR TITLE
path-unix: support ~~desktop path expansion

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -590,7 +590,7 @@ Name             Meaning
 ``~~global/``    The global config path (such as ``/etc/mpv``), if available
                  (not on win32).
 ``~~osxbundle/`` The macOS bundle resource path (macOS only).
-``~~desktop/``   The path to the desktop (win32, macOS).
+``~~desktop/``   The path to the desktop.
 ``~~exe_dir/``   The path to the directory containing ``mpv.exe`` (for config
                  file purposes, ``$MPV_HOME`` will override this) (win32 only).
 ``~~cache/``     The path to application cache data (``~/.cache/mpv/``).


### PR DESCRIPTION
xdg-user-dirs is basically the standard for defining user desktop directories on linux/bsd. To account for locales and languages, we basically have to parse the config file (~/.config/user-dirs.dirs) directly. That or call xdg-user-dir. Either way, it's a little more complicated than the others, but still doable enough.
