### PR TITLE
vo_gpu_next: don't hint colorspace when ICC profile is used

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7045,6 +7045,9 @@ them.
     Requires a supporting driver and ``--vo=gpu-next``. (Default: ``auto``)
 
     .. note::
+        When `--icc-profile` is used colorspace hint is disabled.
+
+    .. note::
         Auto detected target colorspace metadata is not guaranteed to be always
         best choice. It depends on your compositor, driver, and display
         capabilities. However in most cases ``auto`` mode should work fine.

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1084,6 +1084,8 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
     bool target_hint = p->next_opts->target_hint == 1 ||
                        (p->next_opts->target_hint == -1 &&
                         target_csp.transfer != PL_COLOR_TRC_UNKNOWN);
+    if (p->icc_profile)
+        target_hint = false;
     // Assume HDR is supported, if target_csp() is not available
     if (target_csp.transfer == PL_COLOR_TRC_UNKNOWN) {
         target_csp = (struct pl_color_space){


### PR DESCRIPTION
We don't know which colorspace the profile were created from. We could set hint to ICC target colorspace, but it would be ambiguous, because it doesn't say which colorspace were configured in practice.

Additionally on Wayland with all the color management the client side ICC correction is not supported, because we cannot set pass-through mode.

Conceptually we should use VK_COLOR_SPACE_PASS_THROUGH_EXT to get "direct" access to display response, but while this may work on macOS, on Wayland it means "don't configure csp", instead of "configure to pass-through", which means colorspace would have to be configured externally, which is also not possible, see [1].

You can also see [2] for more discussion on the topic.

For now let's not hint any colospace and leave libplacebo in default selection. Which restores previous status quo. This can be improved in future, but for now this fixes use of ICC profiles in default mpv config.

[1] https://gitlab.freedesktop.org/pq/color-and-hdr/-/issues/27
[2] https://github.com/haasn/libplacebo/issues/324
