### PR TITLE
command: set the language of added tracks from the filename

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6401,9 +6401,11 @@ static void cmd_track_reload(void *p)
 
     struct track *t = mp_track_by_tid(mpctx, type, cmd->args[0].v.i);
     int nt_num = -1;
+    char *lang = NULL;
 
     if (t && t->is_external && t->external_filename) {
         char *filename = talloc_strdup(NULL, t->external_filename);
+        lang = talloc_steal(NULL, t->lang);
         enum track_flags flags = 0;
         flags |= t->attached_picture ? TRACK_ATTACHED_PICTURE : 0;
         flags |= t->hearing_impaired_track ? TRACK_HEARING_IMPAIRED : 0;
@@ -6418,19 +6420,16 @@ static void cmd_track_reload(void *p)
 
     if (nt_num < 0) {
         cmd->success = false;
+        talloc_free(lang);
         return;
     }
 
     struct track *nt = mpctx->tracks[nt_num];
 
-    if (!nt->lang) {
-        enum track_flags flags = 0;
-        bstr lang = mp_guess_lang_from_filename(bstr0(nt->external_filename), NULL,
-                                                &flags);
-        nt->lang = bstrto0(nt, lang);
-        nt->hearing_impaired_track = flags & TRACK_HEARING_IMPAIRED;
-        nt->forced_track = flags & TRACK_FORCED;
-        nt->default_track = flags & TRACK_DEFAULT;
+    if (nt->lang) {
+        talloc_free(lang);
+    } else {
+        nt->lang = talloc_steal(nt, lang);
     }
 
     mp_switch_track(mpctx, nt->type, nt, 0);


### PR DESCRIPTION
If you do `sub-add foo.en.srt`, it doesn't set lang=en. Like 5871ba8f3e did for the reload commands, re-extract the language from the filename, along with hearing impaired, forced and default flags.

PS: is it correct for `cmd_track_reload` to inherit flag values from before reloading? Like I noticed in the linked commit, this breaks the edge case of the flags being set within the stream and being removed before reloading.