### PR TITLE
options: delete the duplicated extension "wav" in --audio-exts

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -1061,7 +1061,7 @@ static const struct MPOpts mp_default_opts = {
     },
     .audio_exts = (char *[]){
         "aac", "ac3", "aiff", "ape", "au", "dts", "eac3", "flac", "m4a", "mka",
-        "mp3", "oga", "ogg", "ogm", "opus", "thd", "wav", "wav", "wma", "wv", NULL
+        "mp3", "oga", "ogg", "ogm", "opus", "thd", "wav", "wma", "wv", NULL
     },
     .image_exts = (char *[]){
         "avif", "bmp", "gif", "heic", "heif", "j2k", "jp2", "jpeg", "jpg",


### PR DESCRIPTION
fixes: 44a3a3293f268b9f2d61a2fa2dec50fb662321ac