### PR TITLE
mac/vulkan: fix frame not displayed when paused

### DIFF
--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -168,4 +168,8 @@ class MacCommon: Common {
         layer?.contentsScale = window?.backingScaleFactor ?? 1
         windowDidResize()
     }
+
+    override func windowDidChangeOcclusionState() {
+        flagEvents(VO_EVENT_EXPOSE)
+    }
 }


### PR DESCRIPTION
add event handler for when window's occlusion state changes and now indicates some or all of the window is visible.

handling of the event is needed due to the addition of a visibility check for rendering that was added in commit 5010c24.

Fixes #16693
