### PR TITLE
wayland_common: handle wayland events in VOCTRL_CHECK_EVENTS

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3908,6 +3908,7 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
 
     switch (request) {
     case VOCTRL_CHECK_EVENTS: {
+        wayland_dispatch_events(wl, 1, 0);
         struct vo_wayland_seat *seat;
         wl_list_for_each(seat, &wl->seat_list, link) {
             check_fd(wl, seat->dnd_offer, true);


### PR DESCRIPTION
VOCTRL_CHECK_EVENTS is used to handle input and redraw events, so it is necessary to check the input events from the windows system when this is called. X11 already does this, and win32 does not need to do this since the input events are processed in the UI thread, not VO thread.

However, this is not done on wayland. On wayland, input events are only processed in vo_wayland_wait_frame and vo_wayland_wait_events.

If Vulkan gpu api is used, then vo_wayland_wait_frame is only called in wayland_vk_swap_buffers, and only when using the internal vsync, and not when fifo protocol is being used.

vo_wayland_wait_events is only called in wait_vo. However, unlike VOCTRL_CHECK_EVENTS which is sent on every VO render loop, wait_vo is not called when the VO has a frame to redraw immediately, which can happen often in display-sync modes. In the worst case, this is never called.

All of the above result in situations where inputs and other wayland events not being handled in time while not rendering, or rapid rendering with wayland internal vsync disabled.

Fix this by checking wayland events in VOCTRL_CHECK_EVENTS, similar to X11, to make sure these events are handled.

