### PR TITLE
mac: add support for force-render and fix initial black frame

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3648,7 +3648,7 @@ Window
 
 ``--force-render``
     Forces mpv to always render frames regardless of the visibility of the
-    window. Currently only affects X11 and Wayland VOs since they are the
+    window. Currently only affects X11, Wayland and macvk VOs since they are the
     only ones that have this optimization (i.e. everything else always renders
     regardless of visibility).
 

--- a/video/out/mac/common.swift
+++ b/video/out/mac/common.swift
@@ -43,6 +43,7 @@ class Common: NSObject {
     var appNotificationObservers: [NSObjectProtocol] = []
 
     var cursorVisibilityWanted: Bool = true
+    var needsInitialDraw: Bool = true
 
     var title: String = "mpv" {
         didSet { if let window = window { window.title = title } }
@@ -469,6 +470,14 @@ class Common: NSObject {
             events = 0
             return ev
         }
+    }
+
+    func windowDidMiniaturize() {
+        needsInitialDraw = false
+    }
+
+    func windowDidBecomeMain() {
+        needsInitialDraw = false
     }
 
     func windowDidEndAnimation() {}

--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -558,6 +558,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     func windowDidMiniaturize(_ notification: Notification) {
+        common.windowDidMiniaturize()
         option.setOption(minimized: true)
     }
 
@@ -571,6 +572,10 @@ class Window: NSWindow, NSWindowDelegate {
 
     func windowDidBecomeKey(_ notification: Notification) {
         common.updateCursorVisibility()
+    }
+
+    func windowDidBecomeMain(_ notification: Notification) {
+        common.windowDidBecomeMain()
     }
 
     func windowDidChangeOcclusionState(_ notification: Notification) {

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -110,7 +110,9 @@ class MacCommon: Common {
     }
 
     @objc func isVisible() -> Bool {
-        return window?.occlusionState.contains(.visible) ?? false || option.vo.force_render
+        return window?.occlusionState.contains(.visible) ?? false ||
+               option.vo.force_render ||
+               needsInitialDraw
     }
 
     override func displayLinkCallback(_ displayLink: CVDisplayLink,

--- a/video/out/mac_common.swift
+++ b/video/out/mac_common.swift
@@ -110,7 +110,7 @@ class MacCommon: Common {
     }
 
     @objc func isVisible() -> Bool {
-        return window?.occlusionState.contains(.visible) ?? false
+        return window?.occlusionState.contains(.visible) ?? false || option.vo.force_render
     }
 
     override func displayLinkCallback(_ displayLink: CVDisplayLink,


### PR DESCRIPTION
add support for the force-redraw option analogous to wayland and x11.

since commit 5010c24 the initial window always shows a black frame instead of the actual first rendered frame of the video, since the visibility for the initial render is always false. in the worst case the first shown frame wasn't the intended first rendered frame. initial always allow the first render even when the window is still hidden.

@low-batt this should fix the other issue mentioned here https://github.com/mpv-player/mpv/issues/16693#issuecomment-3195051293