### PR TITLE
mac/title: fix mouse position when snapped to position from title bar

### DIFF
--- a/video/out/mac/title_bar.swift
+++ b/video/out/mac/title_bar.swift
@@ -61,6 +61,12 @@ class TitleBar: NSVisualEffectView {
         set(appearance: option.mac.macos_title_bar_appearance)
         set(material: option.mac.macos_title_bar_material)
         set(color: option.mac.macos_title_bar_color)
+
+        // workaround for mouse up events that are prevented by system events like snap to position
+        NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { (event) -> NSEvent? in
+            self.common.window?.isMoving = false
+            return event
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -87,8 +93,6 @@ class TitleBar: NSVisualEffectView {
                 window?.zoom(self)
             }
         }
-
-        common.window?.isMoving = false
     }
 
     func set(appearance: Int32) {


### PR DESCRIPTION
when the window is snapped to a position by dragging the title bar the corresponding left mouse up event is prevented by the system snap event, which leads to the window moving state not being reset and no mouse position changes being reported. which makes UI elements unresponsive.

explicitly subscribe to left mouse up events for the whole app instead of the mouse events from the title bar and reset the moving state.

Fixes #16732