### PR TITLE
input: bind Ctrl+0 to pan/zoom reset

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -243,7 +243,7 @@ Alt++ and Alt+-
 Alt+KP_ADD and Alt+KP_SUBTRACT
     Change video zoom.
 
-Alt+BACKSPACE
+Alt+BACKSPACE and Ctrl+0
     Reset the pan/zoom settings.
 
 F8

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -71,6 +71,7 @@
 #Ctrl+WHEEL_UP   script-binding positioning/cursor-centric-zoom  0.1 # zoom in towards the cursor
 #Ctrl+WHEEL_DOWN script-binding positioning/cursor-centric-zoom -0.1 # zoom out towards the cursor
 #Alt+BS set video-zoom 0; no-osd set panscan 0; no-osd set video-pan-x 0; no-osd set video-pan-y 0; no-osd set video-align-x 0; no-osd set video-align-y 0 # reset zoom and pan settings
+#Ctrl+0 set video-zoom 0; no-osd set panscan 0; no-osd set video-pan-x 0; no-osd set video-pan-y 0; no-osd set video-align-x 0; no-osd set video-align-y 0 # reset zoom and pan settings
 #HOME seek 0 absolute                   # seek to the start
 #PGUP add chapter 1                     # seek to the next chapter
 #PGDWN add chapter -1                   # seek to the previous chapter


### PR DESCRIPTION
Made it the same as Alt+BS as that's usually how Ctrl+0 works in other
applications as well, resetting the zoom and the zoom-related panning.
