### PR TITLE
osdep/win32/meson: use files() instead current_source_dir()

### DIFF
--- a/osdep/win32/meson.build
+++ b/osdep/win32/meson.build
@@ -4,5 +4,5 @@ cpp = meson.get_compiler('cpp')
 features += {'win32-smtc': cpp.has_header('winrt/base.h', required: get_option('win32-smtc'))}
 if features['win32-smtc']
     dependencies += cpp.find_library('runtimeobject')
-    sources += meson.current_source_dir() / 'smtc.cpp'
+    sources += files('smtc.cpp')
 endif


### PR DESCRIPTION
In reproducible builds, meson.current_source_dir() also leaks absolute paths, so it's better to use files() instead

ref: https://mesonbuild.com/Reference-manual_builtin_meson.html#mesoncurrent_source_dir

> You do not need to use this function!
> When passing files from the current source directory to a function since that is the default. Also, you can use the files() function to refer to files in the current or any other source directory instead of constructing paths manually with meson.current_source_dir().