### PR TITLE
ytdl_hook.lua: add support for VP9 profile 2

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -82,6 +82,7 @@ local codec_map = {
     ["vtt"]         = "webvtt",
     ["opus"]        = "opus",
     ["vp9"]         = "vp9",
+    ["vp9%..*"]     = "vp9",
     ["avc1%..*"]    = "h264",
     ["av01%..*"]    = "av1",
     ["mp4a%..*"]    = "aac",


### PR DESCRIPTION
Youtube uses VP9.2 for HDR videos. Previously, this would result in the codec appearing as `null` in the console and track selection menu, and as H.264 in stats page 1.