### PR TITLE
mac: various build fixes for older systems and build toolchains

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,7 @@ jobs:
         include:
           - os: "macos-13"
             arch: "intel"
+            xcode: "Xcode_14.1"
           - os: "macos-14"
             arch: "arm"
             xcode: "Xcode_15.2"

--- a/meson.build
+++ b/meson.build
@@ -406,13 +406,18 @@ add_project_link_arguments(link_flags, language: ['c', 'cpp', 'objc'])
 
 
 # osdep
+if darwin
+    path_source = files('osdep/path-darwin.c')
+    timer_source = files('osdep/timer-darwin.c')
+endif
+
 cocoa = dependency('appleframeworks', modules: ['Cocoa', 'IOKit', 'QuartzCore'],
                    required: get_option('cocoa'))
 features += {'cocoa': cocoa.found()}
 if features['cocoa']
     dependencies += cocoa
+    path_source += files('osdep/path-mac.m')
     sources += files('osdep/language-mac.c',
-                     'osdep/path-mac.m',
                      'osdep/utils-mac.c',
                      'osdep/mac/app_bridge.m',
                      'player/clipboard/clipboard-mac.m')
@@ -420,7 +425,6 @@ if features['cocoa']
 endif
 
 if posix
-    path_source = files('osdep/path-unix.c')
     if not get_option('fuzzers') and cc.has_function('fork', prefix : '#include <unistd.h>')
         sources += files('osdep/subprocess-posix.c')
     else
@@ -437,12 +441,8 @@ if posix and not features['cocoa']
     main_fn_source = files('osdep/main-fn-unix.c')
 endif
 
-if darwin
-    path_source = files('osdep/path-darwin.c')
-    timer_source = files('osdep/timer-darwin.c')
-endif
-
 if posix and not darwin
+    path_source = files('osdep/path-unix.c')
     timer_source = files('osdep/timer-linux.c')
 endif
 

--- a/osdep/mac/meson.build
+++ b/osdep/mac/meson.build
@@ -5,6 +5,14 @@ module = join_paths(build_root, 'osdep/mac/swift.swiftmodule')
 swift_flags = ['-c', '-emit-library', '-static', '-sdk', macos_sdk_path,
                '-emit-objc-header', '-parse-as-library']
 
+# fallback to old swift frontend build
+if swift_ver.version_compare('<5.8')
+    message('Falling back to old swift frontend build')
+    swift_prog = find_program(run_command(xcrun, '-find', 'swift', check: true).stdout().strip())
+    swift_flags = ['-frontend', '-c', '-sdk', macos_sdk_path,
+                   '-enable-objc-interop', '-emit-objc-header', '-parse-as-library']
+endif
+
 if swift_ver.version_compare('>=6.0')
     swift_flags += ['-swift-version', '5']
 endif

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -16,7 +16,7 @@
  */
 
 #if !swift(>=5.7)
-extension NSCondition {
+extension NSLocking {
     func withLock<R>(_ body: () throws -> R) rethrows -> R {
         self.lock()
         defer { self.unlock() }

--- a/osdep/mac/swift_compat.swift
+++ b/osdep/mac/swift_compat.swift
@@ -51,3 +51,18 @@ extension CGColorSpace {
     static let itur_2100_PQ: CFString = kCGColorSpaceITUR_2100_PQ
 }
 #endif
+
+#if !HAVE_MACOS_11_FEATURES
+@available(macOS 11.0, *)
+public struct UTType: Sendable {
+    public init?(filenameExtension: String) {}
+}
+
+extension NSSavePanel {
+    @available(macOS 11.0, *)
+    public var allowedContentTypes: [UTType] {
+        get { return [] }
+        set { _ = newValue }
+    }
+}
+#endif

--- a/player/command.c
+++ b/player/command.c
@@ -326,11 +326,11 @@ static char *append_selected_style(struct MPContext *mpctx, char *str)
                mpctx->video_out->osd->opts->osd_selected_color.b,
                mpctx->video_out->osd->opts->osd_selected_color.g,
                mpctx->video_out->osd->opts->osd_selected_color.r,
-               255 - mpctx->video_out->osd->opts->osd_selected_color.a,
+               (uint8_t)(255 - mpctx->video_out->osd->opts->osd_selected_color.a),
                mpctx->video_out->osd->opts->osd_selected_outline_color.b,
                mpctx->video_out->osd->opts->osd_selected_outline_color.g,
                mpctx->video_out->osd->opts->osd_selected_outline_color.r,
-               255 - mpctx->video_out->osd->opts->osd_selected_outline_color.a,
+               (uint8_t)(255 - mpctx->video_out->osd->opts->osd_selected_outline_color.a),
                OSD_ASS_1);
 }
 


### PR DESCRIPTION
fixes various things mentioned in #16765

some additional info why some fixes are needed and what errors they causd:
`command: fix type mismatch` fixes https://github.com/Akemi/mpv/actions/runs/17528518682/job/49782276161?pr=32#step:7:449

`osdep/mac/meson.build: fallback to swift build for old swift versions` fixes https://github.com/Akemi/mpv/actions/runs/17528658752/job/49782581357?pr=32#step:7:553 see also #15591 and #15594

`meson: properly add path-mac.c to path_source and don't overwrite it` https://github.com/Akemi/mpv/actions/runs/17531954401/job/49790052456?pr=32#step:11:164