### PR TITLE
meson: disable swift when cocoa not available or disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1525,7 +1525,11 @@ if macos_sdk_version != '0.0'
     add_project_link_arguments(objc_link_flags, language: ['c', 'objc'])
 endif
 
-xcrun = find_program('xcrun', required: get_option('swift-build').require(darwin))
+swift = get_option('swift-build').require(
+    darwin and features['cocoa'],
+    error_message: 'cocoa was not found',
+)
+xcrun = find_program('xcrun', required: swift)
 swift_ver = '0.0'
 if xcrun.found()
     swift_prog = find_program(run_command(xcrun, '-find', 'swiftc', check: true).stdout().strip())
@@ -1543,7 +1547,7 @@ sys.stdout.write(swift_ver)
 endif
 
 swift = get_option('swift-build').require(
-    darwin and macos_sdk_version.version_compare('>= 10.15') and swift_ver.version_compare('>= 4.1'),
+    swift.allowed() and macos_sdk_version.version_compare('>= 10.15') and swift_ver.version_compare('>= 4.1'),
     error_message: 'A suitable macos sdk version or swift version could not be found!',
 )
 features += {'swift': swift.allowed()}


### PR DESCRIPTION
it doesn't make sense to build the swift parts without cocoa because the swift bridge would be missing and it's impossible to interact with the swift parts from obj-c, swift depends on cocoa/appkit/etc, and the cocoa main function/main loop is missing making anything cocoa/appkit/GUI crash on use.

like this it is possible to build mpv on macOS without cocoa, it will fallback to the unix main function and mpv can run in 'headless' mode, eg you can use it from CLI, it won't spawn any App icon/menu/etc, and you can use everything that isn't related to cocoa/appkit/GUI like audio playback. anything other will make mpv segfault, for example sdl2 and its vo, since it tries to spawn a window.

this was possible before, by disabling cocoa and swift independently. this is just some convenience i guess.

tbh i am not sure if this is a wanted outcome, though if you forcefully disable cocoa an macOS you should expect your app to crash in certain circumstances.

another concern of #16765