### PR TITLE
ci/mac: add test runner for oldest macOS target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,10 +227,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cc:
-          - "clang"
-        cxx:
-          - "clang++"
         os:
           - "macos-13"
           - "macos-14"
@@ -272,8 +268,6 @@ jobs:
         run: |
           ./ci/build-macos.sh
         env:
-          CC: "${{ matrix.cc }}"
-          CXX: "${{ matrix.cxx }}"
           TRAVIS_OS_NAME: "${{ matrix.os }}"
 
       - name: Create App Bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,10 +227,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - "macos-13"
-          - "macos-14"
-          - "macos-15"
         include:
           - os: "macos-13"
             arch: "intel"
@@ -240,6 +236,10 @@ jobs:
             xcode: "Xcode_15.2"
           - os: "macos-15"
             arch: "arm"
+          - os: "macos-15"
+            arch: "test"
+            swift: "-target arm64-apple-macosx10.15"
+            target: "10.15"
     steps:
       - uses: actions/checkout@v4
 
@@ -269,8 +269,11 @@ jobs:
           ./ci/build-macos.sh
         env:
           TRAVIS_OS_NAME: "${{ matrix.os }}"
+          SWIFT_FLAGS: "${{ matrix.swift }}"
+          MACOSX_DEPLOYMENT_TARGET: "${{ matrix.target }}"
 
       - name: Create App Bundle
+        if: ${{ matrix.arch != 'test' }}
         run: |
           meson compile -C build macos-bundle
           tar -czvf mpv.tar.gz -C build mpv.app
@@ -291,6 +294,7 @@ jobs:
           cat ./build/meson-logs/testlog.txt
 
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.arch != 'test' }}
         with:
           name: mpv-${{ matrix.os }}-${{ matrix.arch }}
           path: mpv.tar.gz

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -18,7 +18,8 @@ meson setup build $common_args \
   -Dobjc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
   -D{gl,iconv,lcms2,lua,jpeg,plain-gl,zlib}=enabled \
   -D{cocoa,coreaudio,gl-cocoa,videotoolbox-gl,videotoolbox-pl}=enabled \
-  -D{swift-build,macos-cocoa-cb,macos-media-player,macos-touchbar,vulkan}=enabled
+  -D{swift-build,macos-cocoa-cb,macos-media-player,macos-touchbar,vulkan}=enabled \
+  -Dswift-flags="${SWIFT_FLAGS}"
 
 meson compile -C build -j4
 meson install -C build


### PR DESCRIPTION
depends on #16770 (see https://github.com/Akemi/mpv/pull/34 with the fixes from the PR)

this i meant to catch usages of not available features and not properly guarded features. we use the newest runner with the newest SDK und target our lowest target macOS version (atm 10.15). this should prevent broken builds on older versions. the actual build is partially unusable since the resulting binary/bundle uses libs with the wrong target version, hence why i excluded it from upload artifact step.

CC/CCX was added in https://github.com/mpv-player/mpv/pull/12431
target error example (c/obj-c) https://github.com/Akemi/mpv/actions/runs/17585388806/job/49951891735?pr=33#step:7:795
target error example swift https://github.com/Akemi/mpv/pull/33

