### PR TITLE
playloop: update window title in handle_force_window

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1084,6 +1084,7 @@ int handle_force_window(struct MPContext *mpctx, bool force)
         if (vo_reconfig(vo, &p) < 0)
             goto err;
         struct track *track = mpctx->current_track[0][STREAM_VIDEO];
+        update_window_title(mpctx, true);
         update_content_type(mpctx, track);
         update_screensaver_state(mpctx);
         vo_set_paused(vo, true);


### PR DESCRIPTION
When restarting or changing the VO while on the idle screen and using force-window, this ensures that the new VO immediately receives a window title.
