### PR TITLE
input/keycodes: fix combo key handling for - key

### DIFF
--- a/input/keycodes.c
+++ b/input/keycodes.c
@@ -341,7 +341,7 @@ int mp_input_get_keys_from_string(char *name, int max_num_keys,
     n = 0;
     for (end = strchr(ptr, '-'); ; end = strchr(ptr, '-')) {
         if (end && end[1] != '\0') {
-            if (end[1] == '-')
+            if (*ptr == '-' && end[1] == '-')
                 end = &end[1];
             end[0] = '\0';
         }


### PR DESCRIPTION
The current handling tries to handle the edge case where the current key in a combo key is -, but when the current key is not - and the next key is -, it misdetects - as separator and fails to parse correctly.

Fix this by restricting the handling to situations where the current key is -.

Fixes: ce2367725e43124f8be5ef43650cd9514ae1c335
Fixes: #16784
