### PR TITLE
wayland: account for reference luminance adjustment by the compositor

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -305,6 +305,7 @@ struct vo_wayland_preferred_description_info {
     struct pl_color_space csp;
     void *icc_file;
     uint32_t icc_size;
+    float reference_luminance;
 };
 
 static bool single_output_spanned(struct vo_wayland_state *wl);
@@ -2195,6 +2196,10 @@ static void info_tf_named(void *data, struct wp_image_description_info_v1 *image
 static void info_luminances(void *data, struct wp_image_description_info_v1 *image_description_info,
                             uint32_t min_lum, uint32_t max_lum, uint32_t reference_lum)
 {
+    struct vo_wayland_preferred_description_info *wd = data;
+    if (!wd->is_parametric)
+        return;
+    wd->reference_luminance = (float)reference_lum;
 }
 
 static void info_target_primaries(void *data, struct wp_image_description_info_v1 *image_description_info,
@@ -2221,7 +2226,7 @@ static void info_target_luminance(void *data, struct wp_image_description_info_v
     if (!wd->is_parametric)
         return;
     wd->csp.hdr.min_luma = (float)min_lum / WAYLAND_MIN_LUM_FACTOR;
-    wd->csp.hdr.max_luma = (float)max_lum;
+    wd->csp.hdr.max_luma = (float)max_lum * (203.0/wd->reference_luminance);
 }
 
 static void info_target_max_cll(void *data, struct wp_image_description_info_v1 *image_description_info,
@@ -2230,7 +2235,7 @@ static void info_target_max_cll(void *data, struct wp_image_description_info_v1 
     struct vo_wayland_preferred_description_info *wd = data;
     if (!wd->is_parametric)
         return;
-    wd->csp.hdr.max_cll = (float)max_cll;
+    wd->csp.hdr.max_cll = (float)max_cll * (203.0/wd->reference_luminance);
 }
 
 static void info_target_max_fall(void *data, struct wp_image_description_info_v1 *image_description_info,


### PR DESCRIPTION
This should make it so kwin doesn't try to apply any additional tone mapping beyond a straight brightness adjustment whenever the SDR brightness is changed in KDE settings.

I'm very unfamiliar with wayland, in C especially, so this probably needs to be redone in a less janky way.
