### PR TITLE
video/out/d3d11: return unknown color space when use d3d11 composition mode

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -202,6 +202,9 @@ static int d3d11_color_depth(struct ra_swapchain *sw)
 
 static struct pl_color_space d3d11_target_color_space(struct ra_swapchain *sw)
 {
+    if (sw->ctx->opts.composition)
+        return (struct pl_color_space){0};
+
     struct priv *p = sw->priv;
 
     DXGI_OUTPUT_DESC1 desc;


### PR DESCRIPTION

fix  https://github.com/mpv-player/mpv/issues/16773

It not easy to get the target display when using composition mode 

just return and set color space outside