### PR TITLE
ci/mac: pin homebrew for macOS 13 runner to last working version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,7 @@ jobs:
           - os: "macos-13"
             arch: "intel"
             xcode: "Xcode_14.1"
+            homebrew: "2e821e2d8ae38540311cd6ec60f6e1b23d61d167"
           - os: "macos-14"
             arch: "arm"
             xcode: "Xcode_15.2"
@@ -263,7 +264,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update
+          if [[ -n "${{ matrix.homebrew }}" ]]; then
+            export HOMEBREW_NO_AUTO_UPDATE=1
+            cd "$(brew --repo homebrew/core)"
+            git checkout --force ${{ matrix.homebrew }}
+          else
+            brew update
+          fi
           brew install -q autoconf automake pkgconf libtool python freetype fribidi little-cms2 \
             luajit libass ffmpeg meson rust uchardet mujs libplacebo molten-vk vulkan-loader vulkan-headers
 


### PR DESCRIPTION
we did this/something similar some time ago too. this is just a quick fix for now, since it's the last intel runner and removing it now would lead to no more intel builds.

when the runner is ultimately killed by github, we need to build mpv and its dependencies for intel on the arm runner. though this needs a lot more work.