### PR TITLE
video/out/d3d11:  add changing size support for composition mode

### DIFF
--- a/DOCS/interface-changes/vo-d3d11.txt
+++ b/DOCS/interface-changes/vo-d3d11.txt
@@ -1,1 +1,2 @@
 add `--d3d11-output-mode` enable use specific output mode for creating the D3D11 swapchain.
+add `--d3d11-composition-size=<WxH>` support for d3d11 composition mode.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6937,6 +6937,13 @@ them.
 
     Android with ``--gpu-context=android`` only.
 
+``--d3d11-composition-size=<WxH>``
+    Set size of the output for d3d11 composition mode.
+    When use composition mode, there is no window, must set the output size by
+    the embedding application.
+
+    Windows with ``--gpu-context=d3d11`` and  ``--d3d11-output-mode=composition`` only.
+
 ``--gpu-sw``
     Continue even if a software renderer is detected. This only works with
     OpenGL/Vulkan backends. For d3d11, see ``--d3d11-warp``.

--- a/options/options.c
+++ b/options/options.c
@@ -245,6 +245,9 @@ static const m_option_t mp_vo_opt_list[] = {
 #if HAVE_EGL_ANDROID
     {"android-surface-size", OPT_SIZE_BOX(android_surface_size)},
 #endif
+#if HAVE_D3D11
+    {"d3d11-composition-size", OPT_SIZE_BOX(d3d11_composition_size)},
+#endif
     {"swapchain-depth", OPT_INT(swapchain_depth), M_RANGE(1, VO_MAX_SWAPCHAIN_DEPTH)},
     {"override-display-fps", OPT_REPLACED("display-fps-override")},
     {0}

--- a/options/options.h
+++ b/options/options.h
@@ -86,6 +86,8 @@ typedef struct mp_vo_opts {
 
     struct m_geometry android_surface_size;
 
+    struct m_geometry d3d11_composition_size;
+
     int swapchain_depth;  // max number of images to render ahead
 
     struct m_geometry video_crop;

--- a/player/command.c
+++ b/player/command.c
@@ -7999,7 +7999,7 @@ void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *
             queue_seek(mpctx, MPSEEK_RELATIVE, 0.0, MPSEEK_EXACT, 0);
     }
 
-    if (opt_ptr == &opts->vo->android_surface_size) {
+    if (opt_ptr == &opts->vo->android_surface_size || opt_ptr == &opts->vo->d3d11_composition_size) {
         if (mpctx->video_out)
             vo_control(mpctx->video_out, VOCTRL_EXTERNAL_RESIZE, NULL);
     }

--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -167,8 +167,11 @@ static bool resize(struct ra_ctx *ctx)
 
 static bool d3d11_reconfig(struct ra_ctx *ctx)
 {
-    if (!ctx->opts.composition)
+    if (ctx->opts.composition) {
+        vo_w32_composition_size(ctx->vo);
+    } else {
         vo_w32_config(ctx->vo);
+    }
     return resize(ctx);
 }
 
@@ -522,6 +525,9 @@ static bool d3d11_init(struct ra_ctx *ctx)
 
     ctx->opts.composition = p->opts->output_mode == 1;
     if (!ctx->opts.composition && !vo_w32_init(ctx->vo))
+        goto error;
+
+    if (ctx->opts.composition && !vo_w32_composition_size(ctx->vo))
         goto error;
 
     if (!ctx->opts.composition && ctx->opts.want_alpha)

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -2544,6 +2544,22 @@ void vo_w32_swapchain(struct vo *vo, void *swapchain)
     vo->display_swapchain = swapchain;
 }
 
+bool vo_w32_composition_size(struct vo *vo)
+{
+    int w = vo->opts->d3d11_composition_size.w;
+    int h = vo->opts->d3d11_composition_size.h;
+
+    if (w <= 0 || h <= 0) {
+        MP_ERR(vo, "Failed to get height and width!\n");
+        return false;
+    }
+
+    vo->dwidth = w;
+    vo->dheight = h;
+
+    return true;
+}
+
 void vo_w32_run_on_thread(struct vo *vo, void (*cb)(void *ctx), void *ctx)
 {
     struct vo_w32_state *w32 = vo->w32;

--- a/video/out/w32_common.h
+++ b/video/out/w32_common.h
@@ -32,6 +32,7 @@ int vo_w32_control(struct vo *vo, int *events, int request, void *arg);
 void vo_w32_config(struct vo *vo);
 HWND vo_w32_hwnd(struct vo *vo);
 void vo_w32_swapchain(struct vo *vo, void *swapchain);
+bool vo_w32_composition_size(struct vo *vo);
 void vo_w32_run_on_thread(struct vo *vo, void (*cb)(void *ctx), void *ctx);
 void vo_w32_set_transparency(struct vo *vo, bool enable);
 


### PR DESCRIPTION
When using the composition mode, there’s no window and no way to set the output size. 
This adds changing size support for composition mode, based on the Android surface size code. 

Also, composition mode isn't limited to Win32; it can be used in UWP too.
Is it appropriate to place **vo_w32_composition_size** and **vo_w32_swapchain** in w32_common?
I'm not sure, or where they should be placed.