### PR TITLE
video/out/wayland_common: fix crash when uninit without display

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -4474,7 +4474,8 @@ void vo_wayland_uninit(struct vo *vo)
     mp_input_put_key(wl->vo->input_ctx, MP_INPUT_RELEASE_ALL);
 
     // Ensure that any in-flight vo_wayland_preferred_description_info get deallocated.
-    wl_display_roundtrip(wl->display);
+    if (wl->display)
+        wl_display_roundtrip(wl->display);
 
     if (wl->compositor)
         wl_compositor_destroy(wl->compositor);


### PR DESCRIPTION
Fixes: 39c9d1acb498b9ea5db2bd862cb0411c96979e14 ("video/out/vulkan/context_wayland: implement target_csp for wayland")