### PR TITLE
client API: add mpv_msg() and mpv_msg_va() functions

### DIFF
--- a/DOCS/client-api-changes.rst
+++ b/DOCS/client-api-changes.rst
@@ -32,6 +32,9 @@ API changes
 
 ::
 
+ --- mpv 0.41.0 ---
+ 2.6    - add functions to write log messages using the log instance of the
+          mpv_handle: mpv_msg(), mpv_msg_va(), mpv_msg_err(), ...
  --- mpv 0.40.0 ---
  2.5    - Deprecate MPV_RENDER_PARAM_AMBIENT_LIGHT. no replacement.
  --- mpv 0.39.0 ---

--- a/DOCS/man/ipc.rst
+++ b/DOCS/man/ipc.rst
@@ -316,6 +316,20 @@ extra commands can also be used as part of the protocol:
     lead to breakages with future mpv releases. Instead, make a feature request,
     and ask for a proper event that returns the information you need.
 
+``msg``
+    Write a log message using the client's log instance. The first parameter to
+    this command is the log-level and must be one of the log levels accepted by
+    the ``mp.msg.log`` Lua function. The parameters after must all be strings.
+    Spaces are inserted to separate multiple parameters. A newline is added to
+    the end.
+
+    Example:
+
+    ::
+
+        { "command": ["msg", "error", "hello", "from", "IPC", "client!"] }
+        { "error": "success" }
+
 ``enable_event``, ``disable_event``
     Enables or disables the named event. Mirrors the ``mpv_request_event`` C
     API function. If the string ``all`` is used instead of an event name, all

--- a/include/mpv/client.h
+++ b/include/mpv/client.h
@@ -23,6 +23,7 @@
 #ifndef MPV_CLIENT_API_H_
 #define MPV_CLIENT_API_H_
 
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -41,6 +42,19 @@
 #define MPV_DECLTYPE decltype
 #else
 #define MPV_DECLTYPE __typeof__
+#endif
+
+// Stolen from osdep/compiler.h
+#if defined(__GNUC__) || defined(__clang__)
+#define MPV_PRINTF_ATTRIBUTE(a1, a2) __attribute__((format(printf, a1, a2)))
+#else
+#define MPV_PRINTF_ATTRIBUTE(a1, a2)
+#endif
+
+// Broken crap with __USE_MINGW_ANSI_STDIO
+#if defined(__MINGW32__) && defined(__GNUC__) && !defined(__clang__)
+#undef MPV_PRINTF_ATTRIBUTE
+#define MPV_PRINTF_ATTRIBUTE(a1, a2) __attribute__ ((format (gnu_printf, a1, a2)))
 #endif
 
 #ifdef __cplusplus
@@ -248,7 +262,7 @@ extern "C" {
  * relational operators (<, >, <=, >=).
  */
 #define MPV_MAKE_VERSION(major, minor) (((major) << 16) | (minor) | 0UL)
-#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 5)
+#define MPV_CLIENT_API_VERSION MPV_MAKE_VERSION(2, 6)
 
 /**
  * The API user is allowed to "#define MPV_ENABLE_DEPRECATED 0" before
@@ -1683,6 +1697,41 @@ MPV_EXPORT int mpv_request_event(mpv_handle *ctx, mpv_event_id event, int enable
 MPV_EXPORT int mpv_request_log_messages(mpv_handle *ctx, const char *min_level);
 
 /**
+ * Write a log message using the log instance of the mpv_handle.
+ *
+ * Safe to be called from mpv render API threads.
+ *
+ * @param lev See enum mpv_log_level.
+ * @param format printf-style format string
+ */
+MPV_EXPORT void mpv_msg(mpv_handle *ctx, mpv_log_level lev, const char *format, ...)
+    MPV_PRINTF_ATTRIBUTE(3, 4);
+
+/**
+ * Same as mpv_msg but takes a va_list.
+ */
+MPV_EXPORT void mpv_msg_va(mpv_handle *ctx, mpv_log_level lev, const char *format, va_list va)
+    MPV_PRINTF_ATTRIBUTE(3, 0);
+
+/**
+ * @defgroup msg_macros Convenience macros for mpv_msg
+ *
+ * @{
+ */
+
+#define mpv_msg_fatal(ctx, ...)     mpv_msg(ctx, MPV_LOG_LEVEL_FATAL, __VA_ARGS__)
+#define mpv_msg_err(ctx, ...)       mpv_msg(ctx, MPV_LOG_LEVEL_ERROR, __VA_ARGS__)
+#define mpv_msg_warn(ctx, ...)      mpv_msg(ctx, MPV_LOG_LEVEL_WARN, __VA_ARGS__)
+#define mpv_msg_info(ctx, ...)      mpv_msg(ctx, MPV_LOG_LEVEL_INFO, __VA_ARGS__)
+#define mpv_msg_verbose(ctx, ...)   mpv_msg(ctx, MPV_LOG_LEVEL_V, __VA_ARGS__)
+#define mpv_msg_dbg(ctx, ...)       mpv_msg(ctx, MPV_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define mpv_msg_trace(ctx, ...)     mpv_msg(ctx, MPV_LOG_LEVEL_TRACE, __VA_ARGS__)
+
+/**
+ * @}
+ */
+
+/**
  * Wait for the next event, or until the timeout expires, or if another thread
  * makes a call to mpv_wakeup(). Passing 0 as timeout will never wait, and
  * is suitable for polling.
@@ -2008,6 +2057,10 @@ MPV_DEFINE_SYM_PTR(mpv_request_event)
 #define mpv_request_event pfn_mpv_request_event
 MPV_DEFINE_SYM_PTR(mpv_request_log_messages)
 #define mpv_request_log_messages pfn_mpv_request_log_messages
+MPV_DEFINE_SYM_PTR(mpv_msg)
+#define mpv_msg pfn_mpv_msg
+MPV_DEFINE_SYM_PTR(mpv_msg_va)
+#define mpv_msg_va pfn_mpv_msg_va
 MPV_DEFINE_SYM_PTR(mpv_wait_event)
 #define mpv_wait_event pfn_mpv_wait_event
 MPV_DEFINE_SYM_PTR(mpv_wakeup)

--- a/input/ipc.c
+++ b/input/ipc.c
@@ -18,6 +18,7 @@
 #include <mpv/client.h>
 
 #include "common/msg.h"
+#include "common/msg_control.h"
 #include "input/input.h"
 #include "misc/json.h"
 #include "misc/node.h"
@@ -343,6 +344,30 @@ static char *json_execute_command(struct mpv_handle *client, void *ta_parent,
             }
             rc = mpv_request_event(client, event, enable);
         }
+    } else if (cmd && !strcmp("msg", cmd)) {
+        if (cmd_node->u.list->num < 3) {
+            rc = MPV_ERROR_INVALID_PARAMETER;
+            goto error;
+        }
+
+        for (int i = 1; i < cmd_node->u.list->num; i++) {
+            if (cmd_node->u.list->values[i].format != MPV_FORMAT_STRING) {
+                rc = MPV_ERROR_INVALID_PARAMETER;
+                goto error;
+            }
+        }
+
+        int level = mp_msg_find_level(cmd_node->u.list->values[1].u.string);
+        if (level < 0) {
+            rc = MPV_ERROR_INVALID_PARAMETER;
+            goto error;
+        }
+
+        for (int i = 2; i < cmd_node->u.list->num; i++) {
+            mp_msg(log, level, (i == 2 ? "%s" : " %s"),
+                    cmd_node->u.list->values[i].u.string);
+        }
+        mp_msg(log, level, "\n");
     } else {
         mpv_node result_node = {0};
 

--- a/player/client.c
+++ b/player/client.c
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <math.h>
 #include <stdatomic.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -1927,6 +1928,43 @@ static bool gen_log_message_event(struct mpv_handle *ctx)
         }
     }
     return false;
+}
+
+static int mp_msg_level_from_mpv_level(mpv_log_level lev)
+{
+    switch (lev) {
+        case MPV_LOG_LEVEL_FATAL:
+            return MSGL_FATAL;
+        case MPV_LOG_LEVEL_ERROR:
+            return MSGL_ERR;
+        case MPV_LOG_LEVEL_WARN:
+            return MSGL_WARN;
+        case MPV_LOG_LEVEL_INFO:
+            return MSGL_INFO;
+        case MPV_LOG_LEVEL_V:
+            return MSGL_V;
+        case MPV_LOG_LEVEL_DEBUG:
+            return MSGL_DEBUG;
+        case MPV_LOG_LEVEL_TRACE:
+            return MSGL_TRACE;
+    }
+    return -1;
+}
+
+void mpv_msg_va(mpv_handle *ctx, mpv_log_level lev, const char *format, va_list va)
+{
+    int msgl = mp_msg_level_from_mpv_level(lev);
+    if (msgl < 0)
+        return;
+    mp_msg_va(ctx->log, msgl, format, va);
+}
+
+void mpv_msg(mpv_handle *ctx, mpv_log_level lev, const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    mpv_msg_va(ctx, lev, format, va);
+    va_end(va);
 }
 
 int mpv_get_wakeup_pipe(mpv_handle *ctx)

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -356,6 +356,8 @@ static void init_sym_table(struct mp_script_args *args, void *lib) {
     INIT_SYM(mpv_event_to_node);
     INIT_SYM(mpv_request_event);
     INIT_SYM(mpv_request_log_messages);
+    INIT_SYM(mpv_msg);
+    INIT_SYM(mpv_msg_va);
     INIT_SYM(mpv_wait_event);
     INIT_SYM(mpv_wakeup);
     INIT_SYM(mpv_set_wakeup_callback);


### PR DESCRIPTION
This gives C plugins (and libmpv users) the ability to write log
messages prefixed with their client name like Lua/JS scripts.

Fixes: #14551
Fixes: #16707

---

The second commit also allows JSON IPC clients to write log messages with their client name. The prefix of libmpv users will be `main` and IPC clients `ipc_x`. Maybe those users want to be able to change that to a more descriptive name or libmpv users want more access to create instances.