### PR TITLE
DOCS/man/input: document that screenshot-raw works in scripts

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1462,9 +1462,10 @@ Screenshot Commands
     expansion as described in `Property Expansion`_.
 
 ``screenshot-raw [<flags> [<format>]]``
-    Return a screenshot in memory. This can be used only through the client
-    API. The MPV_FORMAT_NODE_MAP returned by this command has the ``w``, ``h``,
-    ``stride`` fields set to obvious contents.
+    Return a screenshot in memory. This can be used only through the client API
+    or from a script using ``mp.command_native``. The MPV_FORMAT_NODE_MAP
+    returned by this command has the ``w``, ``h``, ``stride`` fields set to
+    obvious contents.
 
     The ``format`` field is set to the format of the screenshot image data.
     This can be controlled by the ``format`` argument. The format can be one of


### PR DESCRIPTION
Use the same wording as expand-text and similar commands.

This was misleading, see https://github.com/po5/thumbfast/issues/84#issuecomment-1525746798