### PR TITLE
misc/path_utils: don't normalize -

### DIFF
--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -159,7 +159,7 @@ char *mp_normalize_path(void *talloc_ctx, const char *path)
     if (!path)
         return NULL;
 
-    if (mp_is_url(bstr0(path)))
+    if (mp_is_url(bstr0(path)) || !strcmp(path, "-"))
         return talloc_strdup(talloc_ctx, path);
 
     void *tmp = talloc_new(NULL);


### PR DESCRIPTION
misc/path_utils: don't normalize -

This fixes options like --audio-file=- and avoids returning $PWD/- as
path and stream-open-filename when playing from standard input.

It will also allow storing playlist filenames as normalized without
checking for - at the caller.

Fixes 23b57e9f7f.