### PR TITLE
context_menu.lua: prevent some rare crashes

### DIFF
--- a/player/lua/context_menu.lua
+++ b/player/lua/context_menu.lua
@@ -33,7 +33,7 @@ local options = {
     seconds_to_close_submenus = 0.2,
 }
 
-local open_menus
+local open_menus = {}
 local items
 local focused_level = 1
 local focused_index
@@ -181,15 +181,15 @@ local function calculate_height(menu_items)
 end
 
 local function add_menu(menu_items, x, y)
-    if not menu_items[1] then
-        return
-    end
-
     local visible_items = {}
     for _, item in ipairs(menu_items) do
         if not has_state(item, "hidden") then
             visible_items[#visible_items + 1] = item
         end
+    end
+
+    if not visible_items[1] then
+        return
     end
 
     local checkbox = has_checkbox(visible_items)
@@ -628,6 +628,10 @@ mp.register_script_message("open", function ()
 
     add_menu(mp.get_property_native("menu-data"), x, y)
 
+    if not open_menus[1] then
+        return
+    end
+
     render()
 
     for key, fn in pairs(bindings) do
@@ -638,6 +642,10 @@ mp.register_script_message("open", function ()
     end
 end)
 
-mp.register_script_message("select", activate_focused_item)
+mp.register_script_message("select", function ()
+    if open_menus[1] then
+        activate_focused_item()
+    end
+end)
 
 require "mp.options".read_options(options)


### PR DESCRIPTION
context_menu.lua: add a missing return

The space key selects the current item so it shouldn't also try to activate items with titles starting with space.

context_menu.lua: prevent some rare crashes

Fix crashes that won't happen in regular usage:

- If you open the menu with an empty menu-data and use keybindings
- If you open the menu with menu-data only containing hidden items
- If you invoke script-message-to context_menu select with the menu closed