### PR TITLE
etc/mpv.conf: replace the --sharpen example

### DIFF
--- a/etc/mpv.conf
+++ b/etc/mpv.conf
@@ -140,4 +140,4 @@
 # The following profile can be enabled on the command line with: --profile=eye-cancer
 
 #[eye-cancer]
-#sharpen=5
+#gamma=100


### PR DESCRIPTION
While this was funny, gpu-next doesn't support --sharpen and it is now the default VO, so replace it with something that actually works.