### PR TITLE
Revert "vo_gpu_next: use reported display contrast value also in SDR …

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1092,6 +1092,7 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
         // set in the hint. But also because setting target peak in SDR mode is
         // very specific usecase, needs proper calibration, users can set it manually.
         target_csp.hdr.max_luma = 0;
+        target_csp.hdr.min_luma = 0;
         target_csp.hdr.max_cll = 0;
         target_csp.hdr.max_fall = 0;
     }


### PR DESCRIPTION
…mode"

This reverts commit d204051d930e494868ae987ccdf1392f1914cb14.

The premise for the commit is totally incorrect. We can't use EDID information in HDR Static Metadata Data block if the monitor isn't in HDR mode.

Fixes #16933