### PR TITLE
stream_bluray: do not demux_flush on angle change

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -8059,7 +8059,6 @@ void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *
         if (mpctx->playback_initialized && demuxer && demuxer->stream && strcmp(demuxer->stream->info->name, "bdvm/bluray")) {
             int angle = opts->stream_bluray_opts->angle - 1;
             stream_control(demuxer->stream, STREAM_CTRL_SET_ANGLE, &angle);
-            demux_flush(demuxer);
         }
     }
 #endif


### PR DESCRIPTION
A demux_flush can cause corruption and a slight A/V desync, whereas without it the angle will simply change on the next keyframe, as is intended for seamless branching. If users want an instant angle change they can still restart playback and seek to the current position through Lua.

This was an oversight from my previous PR, I took needing a demuxer flush as a given and never tested the difference.
