### PR TITLE
vo_dmabuf_wayland: request redraw on resize

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -552,6 +552,8 @@ static void resize(struct vo *vo)
     vo->target_params->rotate = (vo->params->rotate % 90) * 90;
     vo->target_params->vflip = vo->params->vflip;
     mp_mutex_unlock(&vo->params_mutex);
+
+    vo->want_redraw = true;
 }
 
 static bool draw_osd(struct vo *vo, struct mp_image *cur, double pts)


### PR DESCRIPTION
Fixes panning the video while it's paused and the OSD isn't redrawing. wayland_common since c25129339dc0ff57a21140b29357bdf181882fee requests redraw when there is a resize event so there was no issue with xdg resizing but that isn't applicable to resizing due to panscan options changing.