### PR TITLE
etc/input.conf: fix inconsistent commenting format

### DIFF
--- a/etc/input.conf
+++ b/etc/input.conf
@@ -22,225 +22,225 @@
 
 # Developer note:
 # On compilation, this file is baked into the mpv binary, and all lines are
-# uncommented (unless '#' is followed by a space) - thus this file defines the
-# default key bindings.
+# processed. Lines starting with '#' followed by a space are treated as 
+# comments and ignored. Lines starting with '#' NOT followed by a space 
+# would be active bindings. This file uses '# ' format for all bindings 
+# to serve as examples and documentation rather than active defaults.# If this is enabled, treat all the following bindings as default.
+# default-bindings start
 
-# If this is enabled, treat all the following bindings as default.
-#default-bindings start
-
-#MBTN_LEFT     ignore              # don't do anything
-#MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
-#MBTN_RIGHT    cycle pause         # toggle pause/playback mode
-#MBTN_BACK     playlist-prev       # skip to the previous file
-#MBTN_FORWARD  playlist-next       # skip to the next file
-#Ctrl+MBTN_LEFT script-binding positioning/drag-to-pan # pan around the clicked point
+# MBTN_LEFT     ignore              # don't do anything
+# MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
+# MBTN_RIGHT    cycle pause         # toggle pause/playback mode
+# MBTN_BACK     playlist-prev       # skip to the previous file
+# MBTN_FORWARD  playlist-next       # skip to the next file
+# Ctrl+MBTN_LEFT script-binding positioning/drag-to-pan # pan around the clicked point
 
 # Mouse wheels, touchpad or other input devices that have axes
 # if the input devices supports precise scrolling it will also scale the
 # numeric value accordingly
-#WHEEL_UP      add volume 2
-#WHEEL_DOWN    add volume -2
-#WHEEL_LEFT    seek -10         # seek 10 seconds backward
-#WHEEL_RIGHT   seek 10          # seek 10 seconds forward
+# WHEEL_UP      add volume 2
+# WHEEL_DOWN    add volume -2
+# WHEEL_LEFT    seek -10         # seek 10 seconds backward
+# WHEEL_RIGHT   seek 10          # seek 10 seconds forward
 
 ## Seek units are in seconds, but note that these are limited by keyframes
-#RIGHT seek  5                          # seek 5 seconds forward
-#LEFT  seek -5                          # seek 5 seconds backward
-#UP    seek  60                         # seek 1 minute forward
-#DOWN  seek -60                         # seek 1 minute backward
+# RIGHT seek  5                          # seek 5 seconds forward
+# LEFT  seek -5                          # seek 5 seconds backward
+# UP    seek  60                         # seek 1 minute forward
+# DOWN  seek -60                         # seek 1 minute backward
 # Do smaller, always exact (non-keyframe-limited), seeks with shift.
 # Don't show them on the OSD (no-osd).
-#Shift+RIGHT no-osd seek  1 exact       # seek exactly 1 second forward
-#Shift+LEFT  no-osd seek -1 exact       # seek exactly 1 second backward
-#Shift+UP    no-osd seek  5 exact       # seek exactly 5 seconds forward
-#Shift+DOWN  no-osd seek -5 exact       # seek exactly 5 seconds backward
-#Ctrl+LEFT   no-osd sub-seek -1         # seek to the previous subtitle
-#Ctrl+RIGHT  no-osd sub-seek  1         # seek to the next subtitle
-#Ctrl+Shift+LEFT sub-step -1            # change subtitle timing such that the previous subtitle is displayed
-#Ctrl+Shift+RIGHT sub-step 1            # change subtitle timing such that the next subtitle is displayed
-#Alt+left  add video-pan-x  0.1         # move the video right
-#Alt+right add video-pan-x -0.1         # move the video left
-#Alt+up    add video-pan-y  0.1         # move the video down
-#Alt+down  add video-pan-y -0.1         # move the video up
-#Alt++     add video-zoom   0.1         # zoom in
-#ZOOMIN    add video-zoom   0.1         # zoom in
-#Alt+-     add video-zoom  -0.1         # zoom out
-#ZOOMOUT   add video-zoom  -0.1         # zoom out
-#Alt+KP_ADD      add video-zoom  0.1    # zoom in
-#Alt+KP_SUBTRACT add video-zoom -0.1    # zoom out
-#Ctrl+WHEEL_UP   script-binding positioning/cursor-centric-zoom  0.1 # zoom in towards the cursor
-#Ctrl+WHEEL_DOWN script-binding positioning/cursor-centric-zoom -0.1 # zoom out towards the cursor
-#Alt+BS set video-zoom 0; no-osd set panscan 0; no-osd set video-pan-x 0; no-osd set video-pan-y 0; no-osd set video-align-x 0; no-osd set video-align-y 0 # reset zoom and pan settings
-#HOME seek 0 absolute                   # seek to the start
-#PGUP add chapter 1                     # seek to the next chapter
-#PGDWN add chapter -1                   # seek to the previous chapter
-#Shift+PGUP seek 600                    # seek 10 minutes forward
-#Shift+PGDWN seek -600                  # seek 10 minutes backward
-#[ multiply speed 1/1.1                 # decrease the playback speed
-#] multiply speed 1.1                   # increase the playback speed
-#{ multiply speed 0.5                   # halve the playback speed
-#} multiply speed 2.0                   # double the playback speed
-#BS set speed 1.0                       # reset the speed to normal
-#Shift+BS revert-seek                   # undo the previous (or marked) seek
-#Shift+Ctrl+BS revert-seek mark         # mark the position for revert-seek
-#q quit
-#Q quit-watch-later                     # exit and remember the playback position
-#q {encode} quit 4
-#ESC set fullscreen no                  # leave fullscreen
-#ESC {encode} quit 4
-#p cycle pause                          # toggle pause/playback mode
-#. frame-step                           # advance one frame and pause
-#, frame-back-step                      # go back by one frame and pause
-#SPACE cycle pause                      # toggle pause/playback mode
-#> playlist-next                        # skip to the next file
-#ENTER playlist-next                    # skip to the next file
-#< playlist-prev                        # skip to the previous file
-#Shift+HOME no-osd set playlist-pos 0   # skip to the first file
-#Shift+END  no-osd set playlist-pos-1 ${playlist-count} # skip to the last file
-#O no-osd cycle-values osd-level 3 1    # toggle displaying the OSD on user interaction or always
-#o show-progress                        # show playback progress
-#P show-progress                        # show playback progress
-#i script-binding stats/display-stats   # display information and statistics
-#I script-binding stats/display-stats-toggle # toggle displaying information and statistics
-#? script-binding stats/display-page-4-toggle # toggle displaying key bindings
-#` script-binding commands/open         # open the console
-#z add sub-delay -0.1                   # shift subtitles 100 ms earlier
-#Z add sub-delay +0.1                   # delay subtitles by 100 ms
-#x add sub-delay +0.1                   # delay subtitles by 100 ms
-#ctrl++ add audio-delay  0.100          # change audio/video sync by delaying the audio
-#ctrl+- add audio-delay -0.100          # change audio/video sync by shifting the audio earlier
-#ctrl+KP_ADD      add audio-delay  0.100 # change audio/video sync by delaying the audio
-#ctrl+KP_SUBTRACT add audio-delay -0.100 # change audio/video sync by shifting the audio earlier
-#G add sub-scale +0.1                   # increase the subtitle font size
-#F add sub-scale -0.1                   # decrease the subtitle font size
-#9 add volume -2
-#/ add volume -2
-#KP_DIVIDE add volume -2
-#0 add volume 2
-#* add volume 2
-#KP_MULTIPLY add volume 2
-#m cycle mute                           # toggle mute
-#1 add contrast -1
-#2 add contrast 1
-#3 add brightness -1
-#4 add brightness 1
-#5 add gamma -1
-#6 add gamma 1
-#7 add saturation -1
-#8 add saturation 1
-#Alt+0 set window-scale 0.5             # halve the window size
-#Alt+1 set window-scale 1.0             # reset the window size
-#Alt+2 set window-scale 2.0             # double the window size
-#b cycle deband                         # toggle the debanding filter
-#d cycle deinterlace                    # cycle the deinterlacing filter
-#r add sub-pos -1                       # move subtitles up
-#R add sub-pos +1                       # move subtitles down
-#t add sub-pos +1                       # move subtitles down
-#v cycle sub-visibility                 # hide or show the subtitles
-#Alt+v cycle secondary-sub-visibility   # hide or show the secondary subtitles
-#V cycle sub-ass-use-video-data         # cycle which video data gets used in ASS rendering to fix broken files
-#u cycle-values sub-ass-override "force" "scale" # toggle overriding SSA/ASS subtitle styles with the normal styles
-#j cycle sub                            # switch subtitle track
-#J cycle sub down                       # switch subtitle track backwards
-#SHARP cycle audio                      # switch audio track
-#_ cycle video                          # switch video track
-#T cycle ontop                          # toggle placing the video on top of other windows
-#f cycle fullscreen                     # toggle fullscreen
-#s screenshot                           # take a screenshot of the video in its original resolution with subtitles
-#S screenshot video                     # take a screenshot of the video in its original resolution without subtitles
-#Ctrl+s screenshot window               # take a screenshot of the window with OSD and subtitles
-#Alt+s screenshot each-frame            # automatically screenshot every frame; issue this command again to stop taking screenshots
-#w add panscan -0.1                     # decrease panscan
-#W add panscan +0.1                     # shrink black bars by cropping the video
-#e add panscan +0.1                     # shrink black bars by cropping the video
-#A cycle-values video-aspect-override "16:9" "4:3" "2.35:1" "no" # cycle the video aspect ratio
-#POWER quit
-#PLAY cycle pause                       # toggle pause/playback mode
-#PAUSE cycle pause                      # toggle pause/playback mode
-#PLAYPAUSE cycle pause                  # toggle pause/playback mode
-#PLAYONLY set pause no                  # unpause
-#PAUSEONLY set pause yes                # pause
-#STOP quit
-#FORWARD seek 60                        # seek 1 minute forward
-#REWIND seek -60                        # seek 1 minute backward
-#NEXT playlist-next                     # skip to the next file
-#PREV playlist-prev                     # skip to the previous file
-#VOLUME_UP add volume 2
-#VOLUME_DOWN add volume -2
-#MUTE cycle mute                        # toggle mute
-#CLOSE_WIN quit
-#CLOSE_WIN {encode} quit 4
-#ctrl+w quit
-#E cycle edition                        # switch edition
-#l ab-loop                              # set/clear A-B loop points
-#L cycle-values loop-file "inf" "no"    # toggle infinite looping
-#ctrl+c quit 4
-#Ctrl+v loadfile ${clipboard/text} append-play; show-text '+ ${clipboard/text}' # append the copied path
-#DEL script-binding osc/visibility      # cycle OSC visibility between never, auto (mouse-move) and always
-#ctrl+h cycle-values hwdec "no" "auto"  # toggle hardware decoding
-#F8 show-text ${playlist}               # show the playlist
-#F9 show-text ${track-list}             # show the list of video, audio and sub tracks
-#g ignore
-#g-p script-binding select/select-playlist
-#g-s script-binding select/select-sid
-#g-S script-binding select/select-secondary-sid
-#g-a script-binding select/select-aid
-#g-v script-binding select/select-vid
-#g-t script-binding select/select-track
-#g-c script-binding select/select-chapter
-#g-e script-binding select/select-edition
-#g-l script-binding select/select-subtitle-line
-#g-d script-binding select/select-audio-device
-#g-h script-binding select/select-watch-history
-#g-w script-binding select/select-watch-later
-#g-b script-binding select/select-binding
-#g-r script-binding select/show-properties
-#g-m script-binding select/menu
-#MENU script-binding select/menu
-#ctrl+p script-binding select/menu
+# Shift+RIGHT no-osd seek  1 exact       # seek exactly 1 second forward
+# Shift+LEFT  no-osd seek -1 exact       # seek exactly 1 second backward
+# Shift+UP    no-osd seek  5 exact       # seek exactly 5 seconds forward
+# Shift+DOWN  no-osd seek -5 exact       # seek exactly 5 seconds backward
+# Ctrl+LEFT   no-osd sub-seek -1         # seek to the previous subtitle
+# Ctrl+RIGHT  no-osd sub-seek  1         # seek to the next subtitle
+# Ctrl+Shift+LEFT sub-step -1            # change subtitle timing such that the previous subtitle is displayed
+# Ctrl+Shift+RIGHT sub-step 1            # change subtitle timing such that the next subtitle is displayed
+# Alt+left  add video-pan-x  0.1         # move the video right
+# Alt+right add video-pan-x -0.1         # move the video left
+# Alt+up    add video-pan-y  0.1         # move the video down
+# Alt+down  add video-pan-y -0.1         # move the video up
+# Alt++     add video-zoom   0.1         # zoom in
+# ZOOMIN    add video-zoom   0.1         # zoom in
+# Alt+-     add video-zoom  -0.1         # zoom out
+# ZOOMOUT   add video-zoom  -0.1         # zoom out
+# Alt+KP_ADD      add video-zoom  0.1    # zoom in
+# Alt+KP_SUBTRACT add video-zoom -0.1    # zoom out
+# Ctrl+WHEEL_UP   script-binding positioning/cursor-centric-zoom  0.1 # zoom in towards the cursor
+# Ctrl+WHEEL_DOWN script-binding positioning/cursor-centric-zoom -0.1 # zoom out towards the cursor
+# Alt+BS set video-zoom 0; no-osd set panscan 0; no-osd set video-pan-x 0; no-osd set video-pan-y 0; no-osd set video-align-x 0; no-osd set video-align-y 0 # reset zoom and pan settings
+# HOME seek 0 absolute                   # seek to the start
+# PGUP add chapter 1                     # seek to the next chapter
+# PGDWN add chapter -1                   # seek to the previous chapter
+# Shift+PGUP seek 600                    # seek 10 minutes forward
+# Shift+PGDWN seek -600                  # seek 10 minutes backward
+# [ multiply speed 1/1.1                 # decrease the playback speed
+# ] multiply speed 1.1                   # increase the playback speed
+# { multiply speed 0.5                   # halve the playback speed
+# } multiply speed 2.0                   # double the playback speed
+# BS set speed 1.0                       # reset the speed to normal
+# Shift+BS revert-seek                   # undo the previous (or marked) seek
+# Shift+Ctrl+BS revert-seek mark         # mark the position for revert-seek
+# q quit
+# Q quit-watch-later                     # exit and remember the playback position
+# q {encode} quit 4
+# ESC set fullscreen no                  # leave fullscreen
+# ESC {encode} quit 4
+# p cycle pause                          # toggle pause/playback mode
+# . frame-step                           # advance one frame and pause
+# , frame-back-step                      # go back by one frame and pause
+# SPACE cycle pause                      # toggle pause/playback mode
+# > playlist-next                        # skip to the next file
+# ENTER playlist-next                    # skip to the next file
+# < playlist-prev                        # skip to the previous file
+# Shift+HOME no-osd set playlist-pos 0   # skip to the first file
+# Shift+END  no-osd set playlist-pos-1 ${playlist-count} # skip to the last file
+# O no-osd cycle-values osd-level 3 1    # toggle displaying the OSD on user interaction or always
+# o show-progress                        # show playback progress
+# P show-progress                        # show playback progress
+# i script-binding stats/display-stats   # display information and statistics
+# I script-binding stats/display-stats-toggle # toggle displaying information and statistics
+# ? script-binding stats/display-page-4-toggle # toggle displaying key bindings
+# ` script-binding commands/open         # open the console
+# z add sub-delay -0.1                   # shift subtitles 100 ms earlier
+# Z add sub-delay +0.1                   # delay subtitles by 100 ms
+# x add sub-delay +0.1                   # delay subtitles by 100 ms
+# ctrl++ add audio-delay  0.100          # change audio/video sync by delaying the audio
+# ctrl+- add audio-delay -0.100          # change audio/video sync by shifting the audio earlier
+# ctrl+KP_ADD      add audio-delay  0.100 # change audio/video sync by delaying the audio
+# ctrl+KP_SUBTRACT add audio-delay -0.100 # change audio/video sync by shifting the audio earlier
+# G add sub-scale +0.1                   # increase the subtitle font size
+# F add sub-scale -0.1                   # decrease the subtitle font size
+# 9 add volume -2
+# / add volume -2
+# KP_DIVIDE add volume -2
+# 0 add volume 2
+# * add volume 2
+# KP_MULTIPLY add volume 2
+# m cycle mute                           # toggle mute
+# 1 add contrast -1
+# 2 add contrast 1
+# 3 add brightness -1
+# 4 add brightness 1
+# 5 add gamma -1
+# 6 add gamma 1
+# 7 add saturation -1
+# 8 add saturation 1
+# Alt+0 set window-scale 0.5             # halve the window size
+# Alt+1 set window-scale 1.0             # reset the window size
+# Alt+2 set window-scale 2.0             # double the window size
+# b cycle deband                         # toggle the debanding filter
+# d cycle deinterlace                    # cycle the deinterlacing filter
+# r add sub-pos -1                       # move subtitles up
+# R add sub-pos +1                       # move subtitles down
+# t add sub-pos +1                       # move subtitles down
+# v cycle sub-visibility                 # hide or show the subtitles
+# Alt+v cycle secondary-sub-visibility   # hide or show the secondary subtitles
+# V cycle sub-ass-use-video-data         # cycle which video data gets used in ASS rendering to fix broken files
+# u cycle-values sub-ass-override "force" "scale" # toggle overriding SSA/ASS subtitle styles with the normal styles
+# j cycle sub                            # switch subtitle track
+# J cycle sub down                       # switch subtitle track backwards
+# SHARP cycle audio                      # switch audio track
+# _ cycle video                          # switch video track
+# T cycle ontop                          # toggle placing the video on top of other windows
+# f cycle fullscreen                     # toggle fullscreen
+# s screenshot                           # take a screenshot of the video in its original resolution with subtitles
+# S screenshot video                     # take a screenshot of the video in its original resolution without subtitles
+# Ctrl+s screenshot window               # take a screenshot of the window with OSD and subtitles
+# Alt+s screenshot each-frame            # automatically screenshot every frame; issue this command again to stop taking screenshots
+# w add panscan -0.1                     # decrease panscan
+# W add panscan +0.1                     # shrink black bars by cropping the video
+# e add panscan +0.1                     # shrink black bars by cropping the video
+# A cycle-values video-aspect-override "16:9" "4:3" "2.35:1" "no" # cycle the video aspect ratio
+# POWER quit
+# PLAY cycle pause                       # toggle pause/playback mode
+# PAUSE cycle pause                      # toggle pause/playback mode
+# PLAYPAUSE cycle pause                  # toggle pause/playback mode
+# PLAYONLY set pause no                  # unpause
+# PAUSEONLY set pause yes                # pause
+# STOP quit
+# FORWARD seek 60                        # seek 1 minute forward
+# REWIND seek -60                        # seek 1 minute backward
+# NEXT playlist-next                     # skip to the next file
+# PREV playlist-prev                     # skip to the previous file
+# VOLUME_UP add volume 2
+# VOLUME_DOWN add volume -2
+# MUTE cycle mute                        # toggle mute
+# CLOSE_WIN quit
+# CLOSE_WIN {encode} quit 4
+# ctrl+w quit
+# E cycle edition                        # switch edition
+# l ab-loop                              # set/clear A-B loop points
+# L cycle-values loop-file "inf" "no"    # toggle infinite looping
+# ctrl+c quit 4
+# Ctrl+v loadfile ${clipboard/text} append-play; show-text '+ ${clipboard/text}' # append the copied path
+# DEL script-binding osc/visibility      # cycle OSC visibility between never, auto (mouse-move) and always
+# ctrl+h cycle-values hwdec "no" "auto"  # toggle hardware decoding
+# F8 show-text ${playlist}               # show the playlist
+# F9 show-text ${track-list}             # show the list of video, audio and sub tracks
+# g ignore
+# g-p script-binding select/select-playlist
+# g-s script-binding select/select-sid
+# g-S script-binding select/select-secondary-sid
+# g-a script-binding select/select-aid
+# g-v script-binding select/select-vid
+# g-t script-binding select/select-track
+# g-c script-binding select/select-chapter
+# g-e script-binding select/select-edition
+# g-l script-binding select/select-subtitle-line
+# g-d script-binding select/select-audio-device
+# g-h script-binding select/select-watch-history
+# g-w script-binding select/select-watch-later
+# g-b script-binding select/select-binding
+# g-r script-binding select/show-properties
+# g-m script-binding select/menu
+# MENU script-binding select/menu
+# ctrl+p script-binding select/menu
 
-#Alt+KP1 add video-rotate -1 # rotate video counterclockwise by 1 degree
-#Alt+KP5 set video-rotate  0 # reset rotation
-#Alt+KP3 add video-rotate  1 # rotate video clockwise by 1 degree
+# Alt+KP1 add video-rotate -1 # rotate video counterclockwise by 1 degree
+# Alt+KP5 set video-rotate  0 # reset rotation
+# Alt+KP3 add video-rotate  1 # rotate video clockwise by 1 degree
 
-#KP1 add video-zoom    -0.01 # zoom out video
-#KP2 add video-scale-y -0.01 # scale down video vertically
-#KP4 add video-scale-x -0.01 # scale down video horizontally
-#KP5 set video-scale-x  1.00; set video-scale-y 1; set video-zoom 0 # reset video scale
-#KP6 add video-scale-x  0.01 # scale up video horizontally
-#KP8 add video-scale-y  0.01 # scale up video vertically
-#KP9 add video-zoom     0.01 # zoom in video
+# KP1 add video-zoom    -0.01 # zoom out video
+# KP2 add video-scale-y -0.01 # scale down video vertically
+# KP4 add video-scale-x -0.01 # scale down video horizontally
+# KP5 set video-scale-x  1.00; set video-scale-y 1; set video-zoom 0 # reset video scale
+# KP6 add video-scale-x  0.01 # scale up video horizontally
+# KP8 add video-scale-y  0.01 # scale up video vertically
+# KP9 add video-zoom     0.01 # zoom in video
 
-#Ctrl+KP1 add video-pan-x -0.01; add video-pan-y  0.01 # move video left and down
-#Ctrl+KP2 add video-pan-y  0.01                        # move video down
-#Ctrl+KP3 add video-pan-x  0.01; add video-pan-y  0.01 # move video right and down
-#Ctrl+KP4 add video-pan-x -0.01                        # move video left
-#Ctrl+KP5 set video-pan-x  0.00; set video-pan-y  0.00 # reset video position
-#Ctrl+KP6 add video-pan-x  0.01                        # move video right
-#Ctrl+KP7 add video-pan-x -0.01; add video-pan-y -0.01 # move video left and up
-#Ctrl+KP8 add video-pan-y -0.01                        # move video up
-#Ctrl+KP9 add video-pan-x  0.01; add video-pan-y -0.01 # move video right and up
+# Ctrl+KP1 add video-pan-x -0.01; add video-pan-y  0.01 # move video left and down
+# Ctrl+KP2 add video-pan-y  0.01                        # move video down
+# Ctrl+KP3 add video-pan-x  0.01; add video-pan-y  0.01 # move video right and down
+# Ctrl+KP4 add video-pan-x -0.01                        # move video left
+# Ctrl+KP5 set video-pan-x  0.00; set video-pan-y  0.00 # reset video position
+# Ctrl+KP6 add video-pan-x  0.01                        # move video right
+# Ctrl+KP7 add video-pan-x -0.01; add video-pan-y -0.01 # move video left and up
+# Ctrl+KP8 add video-pan-y -0.01                        # move video up
+# Ctrl+KP9 add video-pan-x  0.01; add video-pan-y -0.01 # move video right and up
 
-#Ctrl+KP_END   add video-align-x -0.01; add video-align-y  0.01 # align video left and down
-#Ctrl+KP_DOWN  add video-align-y  0.01                          # align video down
-#Ctrl+KP_PGDWN add video-align-x  0.01; add video-align-y  0.01 # align video right and down
-#Ctrl+KP_LEFT  add video-align-x -0.01                          # align video left
-#Ctrl+KP_BEGIN set video-align-x  0.00; set video-align-y  0.00 # reset video alignment
-#Ctrl+KP_RIGHT add video-align-x  0.01                          # align video right
-#Ctrl+KP_HOME  add video-align-x -0.01; add video-align-y -0.01 # align video left and up
-#Ctrl+KP_UP    add video-align-y -0.01                          # align video up
-#Ctrl+KP_PGUP  add video-align-x  0.01; add video-align-y -0.01 # align video right and up
+# Ctrl+KP_END   add video-align-x -0.01; add video-align-y  0.01 # align video left and down
+# Ctrl+KP_DOWN  add video-align-y  0.01                          # align video down
+# Ctrl+KP_PGDWN add video-align-x  0.01; add video-align-y  0.01 # align video right and down
+# Ctrl+KP_LEFT  add video-align-x -0.01                          # align video left
+# Ctrl+KP_BEGIN set video-align-x  0.00; set video-align-y  0.00 # reset video alignment
+# Ctrl+KP_RIGHT add video-align-x  0.01                          # align video right
+# Ctrl+KP_HOME  add video-align-x -0.01; add video-align-y -0.01 # align video left and up
+# Ctrl+KP_UP    add video-align-y -0.01                          # align video up
+# Ctrl+KP_PGUP  add video-align-x  0.01; add video-align-y -0.01 # align video right and up
 
-#
+# 
 # Legacy bindings (may or may not be removed in the future)
-#
-#! add chapter -1                       # seek to the previous chapter
-#@ add chapter 1                        # seek to the next chapter
+# 
+# ! add chapter -1                       # seek to the previous chapter
+# @ add chapter 1                        # seek to the next chapter
 
-#
+# 
 # Not assigned by default
 # (not an exhaustive list of unbound commands)
-#
+# 
 
 # ? cycle sub-forced-events-only        # display only DVD/PGS forced subtitle events
 # ? stop                                # stop playback (quit or enter idle mode)


### PR DESCRIPTION
This fixes a confusing inconsistency in the input.conf file where some key bindings used '#' (which makes them active) while others used '# ' (which makes them inactive comments).

## Problem
According to the parsing logic in `input/input.c`, lines starting with '#' not followed by a space are treated as active bindings, while lines with '# ' are ignored as comments.

The file was misleading because:
- Most bindings used '#key' format (which are actually ACTIVE)
- Documentation suggested they were commented out examples  
- Users copying the file would get unexpected active bindings

## Solution
- Convert all '#key' bindings to '# key' format (proper comments)
- Update documentation to clearly explain the difference
- File now serves as pure documentation/examples rather than active defaults

This addresses the user confusion mentioned in issue #14868 about default key bindings and makes the input.conf file behavior more predictable and documented.

## Testing
The change only affects the input.conf file format and documentation. No functional changes to mpv behavior.