### PR TITLE
command: react to --force-window changes with no file playing

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -8120,6 +8120,9 @@ void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *
     if (opt_ptr == &opts->vo->taskbar_progress)
         update_vo_playback_state(mpctx);
 
+    if (opt_ptr == &opts->force_vo)
+        handle_force_window(mpctx, false);
+
     if (opt_ptr == &opts->image_display_duration && mpctx->vo_chain
         && mpctx->vo_chain->is_sparse && !mpctx->ao_chain
         && mpctx->video_status == STATUS_DRAINING)

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1315,8 +1315,6 @@ void run_playloop(struct MPContext *mpctx)
     handle_option_callbacks(mpctx);
 
     handle_chapter_change(mpctx);
-
-    handle_force_window(mpctx, false);
 }
 
 void mp_idle(struct MPContext *mpctx)


### PR DESCRIPTION
handle_force_window() is called in play_current_file() and run_playloop(), so it is never triggered if you do mpv --idle and then change force-window at runtime. Move the playloop call to the option callbacks to fix this.

Fixes https://github.com/mpv-player/mpv/discussions/16956.

Giving the UPDATE_VO flag to --force-window would not fix this due to it having no effect if there's isn't already a window, which prevents the bug described in 544240c829. It would also reinit the VO unnecessarily when cycling between force-window yes and immediate.