### PR TITLE
vo/context_android: fix surface tearing on resize

### DIFF
--- a/video/out/opengl/context_android.c
+++ b/video/out/opengl/context_android.c
@@ -109,6 +109,13 @@ static bool android_reconfig(struct ra_ctx *ctx)
     if (!vo_android_surface_size(ctx->vo, &w, &h))
         return false;
 
+    // Update window geometry to prevent screen tearing
+    ANativeWindow *native_window = vo_android_native_window(ctx->vo);
+    if (native_window) {
+        int32_t current_format = ANativeWindow_getFormat(native_window);
+        ANativeWindow_setBuffersGeometry(native_window, w, h, current_format);
+    }
+
     ctx->vo->dwidth = w;
     ctx->vo->dheight = h;
     ra_gl_ctx_resize(ctx->swapchain, w, h, 0);

--- a/video/out/vulkan/context_android.c
+++ b/video/out/vulkan/context_android.c
@@ -77,6 +77,13 @@ static bool android_reconfig(struct ra_ctx *ctx)
     if (!vo_android_surface_size(ctx->vo, &w, &h))
         return false;
 
+    // Update window geometry to prevent screen tearing
+    ANativeWindow *native_window = vo_android_native_window(ctx->vo);
+    if (native_window) {
+        int32_t current_format = ANativeWindow_getFormat(native_window);
+        ANativeWindow_setBuffersGeometry(native_window, w, h, current_format);
+    }
+
     ra_vk_ctx_resize(ctx, w, h);
     return true;
 }


### PR DESCRIPTION
replaces #16540

@obscenelyvague this one shouldn't break the surface format.