### PR TITLE
.github/ISSUE_TEMPLATE: add --msg-time to log file instruction

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
@@ -94,7 +94,7 @@ body:
           attach it to the issue.
 
 
-          If you have trouble producing a log file, you can alternatively use `--gpu-debug -v -v`,
+          If you have trouble producing a log file, you can alternatively use `--gpu-debug --msg-time -v -v`,
           save the terminal output to a file, and attach it to the issue.
 
 

--- a/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
@@ -88,7 +88,7 @@ body:
           at `~/Library/Logs/mpv.log`. You can jump to that file via the `Help > Show log File…` menu.
 
 
-          If you have trouble producing a log file, you can alternatively use `--gpu-debug -v -v`,
+          If you have trouble producing a log file, you can alternatively use `--gpu-debug --msg-time -v -v`,
           save the terminal output to a file, and attach it to the issue.
 
 

--- a/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
@@ -89,7 +89,7 @@ body:
           attach it to the issue.
 
 
-          If you have trouble producing a log file, you can alternatively use `--gpu-debug -v -v`,
+          If you have trouble producing a log file, you can alternatively use `--gpu-debug --msg-time -v -v`,
           save the terminal output to a file, and attach it to the issue.
 
 

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -87,7 +87,7 @@ body:
           attach it to the issue.
 
 
-          If you have trouble producing a log file, you can alternatively use `--gpu-debug -v -v`,
+          If you have trouble producing a log file, you can alternatively use `--gpu-debug --msg-time -v -v`,
           save the terminal output to a file, and attach it to the issue.
 
 


### PR DESCRIPTION
Logs produced with the terminal output method do not have timestamps logged by default, unlike --log-file.

Add --msg-time to the instruction to retain this information.
