### PR TITLE
stats.lua: use '->' instead of '➜' (U+279C)

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -1072,7 +1072,7 @@ local function add_audio(s)
     local merge = function(rr, rro, prop)
         local a = rr[prop] or rro[prop]
         local b = rro[prop] or rr[prop]
-        return (a == b or a == nil) and a or (a .. " ➜ " .. b)
+        return (a == b or a == nil) and a or (a .. " -> " .. b)
     end
 
     append(s, "", {prefix="Audio:", nl=o.nl .. o.nl, indent=""})


### PR DESCRIPTION
Use plain text `->` instead of unicode character `➜` in stats.lua to avoid osd stats render issue on HarmonyOS platform.

I'm porting mpv to HarmonyOS 5.0+, with libass support but without fontconfig support. I'm using configurations below:
```
--osd-font="HarmonyOS Sans"
--osd-fonts-dir="/system/fonts"
```
as shown below, `➜` cannot be successfully rendered, it requires `Noto Sans Symbols 2` in system fonts.

I don't know if this pull request is acceptable since it's for a not yet supported platform. If HarmonyOS related pull request is acceptable, I'm willing to create more pull request to add complete support for HarmonyOS in the future. (although I'm stuck with hardware decode now)

before patch:
![screenshot_20251028_135806](https://github.com/user-attachments/assets/4fb4dbbc-c02f-4576-85f4-9d1621c3206a)

render with `Noto Sans Symbols 2`
![screenshot_20251028_175157](https://github.com/user-attachments/assets/20b9cf95-b01d-481a-b390-ba84d91c901f)

after patch:
![screenshot_20251028_181714](https://github.com/user-attachments/assets/96b21b30-ad5a-4479-af67-59c69be25f32)
