### PR TITLE
osdep/compiler: introduce mp_isnan

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -760,7 +760,7 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
         const uint8_t *sd = mp_av_stream_get_side_data(st, AV_PKT_DATA_DISPLAYMATRIX);
         if (sd) {
             double r = av_display_rotation_get((int32_t *)sd);
-            if (!isnan(r))
+            if (!mp_isnan(r))
                 sh->codec->rotate = (((int)(-r) % 360) + 360) % 360;
         }
 

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1021,7 +1021,7 @@ done:
 static char *print_double(const m_option_t *opt, const void *val)
 {
     double f = VAL(val);
-    if (isnan(f) && (opt->flags & M_OPT_DEFAULT_NAN))
+    if (mp_isnan(f) && (opt->flags & M_OPT_DEFAULT_NAN))
         return talloc_strdup(NULL, "default");
     return talloc_asprintf(NULL, "%f", f);
 }
@@ -1029,7 +1029,7 @@ static char *print_double(const m_option_t *opt, const void *val)
 static char *pretty_print_double(const m_option_t *opt, const void *val)
 {
     double f = VAL(val);
-    if (isnan(f))
+    if (mp_isnan(f))
         return print_double(opt, val);
     return mp_format_double(NULL, f, 4, false, false, !(opt->flags & M_OPT_FIXED_LEN_PRINT));
 }
@@ -1078,7 +1078,7 @@ static int double_get(const m_option_t *opt, void *ta_parent,
                       struct mpv_node *dst, void *src)
 {
     double f = VAL(src);
-    if (isnan(f) && (opt->flags & M_OPT_DEFAULT_NAN)) {
+    if (mp_isnan(f) && (opt->flags & M_OPT_DEFAULT_NAN)) {
         dst->format = MPV_FORMAT_STRING;
         dst->u.string = talloc_strdup(ta_parent, "default");
     } else {
@@ -1091,8 +1091,8 @@ static int double_get(const m_option_t *opt, void *ta_parent,
 static bool double_equal(const m_option_t *opt, void *a, void *b)
 {
     double fa = VAL(a), fb = VAL(b);
-    if (isnan(fa) || isnan(fb))
-        return isnan(fa) == isnan(fb);
+    if (mp_isnan(fa) || mp_isnan(fb))
+        return mp_isnan(fa) == mp_isnan(fb);
     return fa == fb;
 }
 

--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -54,6 +54,12 @@
 #define MP_ASSERT_UNREACHABLE() ((void)0)
 #endif
 
+#if __has_builtin(__builtin_isnan)
+#define mp_isnan __builtin_isnan
+#else
+#define mp_isnan isnan
+#endif
+
 #ifdef __MINGW_PRINTF_FORMAT
 #define MP_PRINTF_FORMAT __MINGW_PRINTF_FORMAT
 #elif __has_attribute(format)

--- a/video/mp_image.c
+++ b/video/mp_image.c
@@ -1124,7 +1124,7 @@ struct mp_image *mp_image_from_av_frame(struct AVFrame *src)
         int vflip = ((int64_t)matrix[0] * (int64_t)matrix[4]
                     - (int64_t)matrix[1] * (int64_t)matrix[3]) < 0;
         double r = av_display_rotation_get(matrix);
-        if (!isnan(r)) {
+        if (!mp_isnan(r)) {
             dst->params.rotate = (((int)(-r) % 360) + 360) % 360;
             dst->params.vflip = vflip;
         }

--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -797,7 +797,7 @@ static bool mode_match(const drmModeModeInfo *mode,
                        unsigned int height,
                        double refresh)
 {
-    if (isnan(refresh)) {
+    if (mp_isnan(refresh)) {
         return
             (mode->hdisplay == width) &&
             (mode->vdisplay == height);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1750,7 +1750,7 @@ static void load_shader(struct gl_video *p, struct bstr body)
 // Semantic equality
 static bool double_seq(double a, double b)
 {
-    return (isnan(a) && isnan(b)) || a == b;
+    return (mp_isnan(a) && mp_isnan(b)) || a == b;
 }
 
 static bool scaler_fun_eq(struct scaler_fun a, struct scaler_fun b)
@@ -1817,9 +1817,9 @@ static void reinit_scaler(struct gl_video *p, struct scaler *scaler,
         scaler->kernel->w = *t_window;
 
     for (int n = 0; n < 2; n++) {
-        if (!isnan(conf->kernel.params[n]))
+        if (!mp_isnan(conf->kernel.params[n]))
             scaler->kernel->f.params[n] = conf->kernel.params[n];
-        if (!isnan(conf->window.params[n]))
+        if (!mp_isnan(conf->window.params[n]))
             scaler->kernel->w.params[n] = conf->window.params[n];
     }
 
@@ -3368,7 +3368,7 @@ static void gl_video_interpolate_frame(struct gl_video *p, struct vo_frame *t,
             // position itself
             double vsync_dist = t->vsync_interval / t->ideal_frame_duration,
                    threshold = tscale->conf.kernel.params[0];
-            threshold = isnan(threshold) ? 0.0 : threshold;
+            threshold = mp_isnan(threshold) ? 0.0 : threshold;
             mix = (1 - mix) / vsync_dist;
             mix = mix <= 0 + threshold ? 0 : mix;
             mix = mix >= 1 - threshold ? 1 : mix;

--- a/video/out/gpu/video_shaders.c
+++ b/video/out/gpu/video_shaders.c
@@ -300,7 +300,7 @@ void pass_sample_oversample(struct gl_shader_cache *sc, struct scaler *scaler,
     gl_sc_uniform_vec2(sc, "output_size", (float[2]){w, h});
     GLSL(vec2 coeff = fcoord * output_size/size;)
     float threshold = scaler->conf.kernel.params[0];
-    threshold = isnan(threshold) ? 0.0 : threshold;
+    threshold = mp_isnan(threshold) ? 0.0 : threshold;
     GLSLF("coeff = (coeff - %f) * 1.0/%f;\n", threshold, 1.0 - 2 * threshold);
     GLSL(coeff = clamp(coeff, 0.0, 1.0);)
     // Compute the right blend of colors
@@ -723,12 +723,12 @@ static void pass_tone_map(struct gl_shader_cache *sc,
     float param = opts->curve_param;
     switch (curve) {
     case TONE_MAPPING_CLIP:
-        GLSLF("sig = min(%f * sig, 1.0);\n", isnan(param) ? 1.0 : param);
+        GLSLF("sig = min(%f * sig, 1.0);\n", mp_isnan(param) ? 1.0 : param);
         break;
 
     case TONE_MAPPING_MOBIUS:
         GLSLF("if (sig_peak > (1.0 + 1e-6)) {\n");
-        GLSLF("const float j = %f;\n", isnan(param) ? 0.3 : param);
+        GLSLF("const float j = %f;\n", mp_isnan(param) ? 0.3 : param);
         // solve for M(j) = j; M(sig_peak) = 1.0; M'(j) = 1.0
         // where M(x) = scale * (x+a)/(x+b)
         GLSLF("float a = -j*j * (sig_peak - 1.0) / (j*j - 2.0*j + sig_peak);\n");
@@ -742,7 +742,7 @@ static void pass_tone_map(struct gl_shader_cache *sc,
         break;
 
     case TONE_MAPPING_REINHARD: {
-        float contrast = isnan(param) ? 0.5 : param,
+        float contrast = mp_isnan(param) ? 0.5 : param,
               offset = (1.0 - contrast) / contrast;
         GLSLF("sig = sig / (sig + vec3(%f));\n", offset);
         GLSLF("float scale = (sig_peak + %f) / sig_peak;\n", offset);
@@ -765,7 +765,7 @@ static void pass_tone_map(struct gl_shader_cache *sc,
     }
 
     case TONE_MAPPING_GAMMA: {
-        float gamma = isnan(param) ? 1.8 : param;
+        float gamma = mp_isnan(param) ? 1.8 : param;
         GLSLF("const float cutoff = 0.05, gamma = 1.0/%f;\n", gamma);
         GLSL(float scale = pow(cutoff / sig_peak, gamma.x) / cutoff;)
         GLSLF("sig = mix(scale * sig,"
@@ -776,7 +776,7 @@ static void pass_tone_map(struct gl_shader_cache *sc,
     }
 
     case TONE_MAPPING_LINEAR: {
-        float coeff = isnan(param) ? 1.0 : param;
+        float coeff = mp_isnan(param) ? 1.0 : param;
         GLSLF("sig = min(%f / sig_peak, 1.0) * sig;\n", coeff);
         break;
     }

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2237,9 +2237,9 @@ static const struct pl_filter_config *map_scaler(struct priv *p,
     }
 
     for (int i = 0; i < 2; i++) {
-        if (!isnan(cfg->kernel.params[i]))
+        if (!mp_isnan(cfg->kernel.params[i]))
             par->config.params[i] = cfg->kernel.params[i];
-        if (!isnan(cfg->window.params[i]))
+        if (!mp_isnan(cfg->window.params[i]))
             par->config.wparams[i] = cfg->window.params[i];
     }
 
@@ -2574,7 +2574,7 @@ static void update_render_options(struct vo *vo)
     pars->color_map_params.tone_mapping_function = tone_map_funs[opts->tone_map.curve];
 AV_NOWARN_DEPRECATED(
     pars->color_map_params.tone_mapping_param = opts->tone_map.curve_param;
-    if (isnan(pars->color_map_params.tone_mapping_param)) // vo_gpu compatibility
+    if (mp_isnan(pars->color_map_params.tone_mapping_param)) // vo_gpu compatibility
         pars->color_map_params.tone_mapping_param = 0.0;
 )
     pars->color_map_params.inverse_tone_mapping = opts->tone_map.inverse;


### PR DESCRIPTION
Some platforms like MinGW have suboptimal isnan, so use __builtin_isnan instead if possible.

https://godbolt.org/z/snPKGPfKo
