### PR TITLE
osxbundle: make bundle category configurable and default to video

### DIFF
--- a/TOOLS/osxbundle.py
+++ b/TOOLS/osxbundle.py
@@ -35,9 +35,10 @@ def copy_bundle(binary_name, src_path):
 def copy_binary(binary_name):
     shutil.copy(binary_name, target_binary(binary_name))
 
-def apply_plist_template(plist_file, version):
+def apply_plist_template(plist_file, version, category):
+    print(">> setting bundle category to " + category)
     for line in fileinput.input(plist_file, inplace=True):
-        print(line.rstrip().replace("${VERSION}", version))
+        print(line.rstrip().replace("${VERSION}", version).replace("${CATEGORY}", category))
 
 def sign_bundle(binary_name):
     sign_directories = ["Contents/Frameworks", "Contents/MacOS"]
@@ -64,6 +65,9 @@ def main():
     parser.add_option("-s", "--skip-deps", action="store_false", dest="deps",
                       default=True,
                       help="don't bundle the dependencies")
+    parser.add_option("-c", "--category", action="store", dest="category",
+                      type="choice", choices=["video", "games"], default="video",
+                      help="sets bundle category")
 
     (options, args) = parser.parse_args()
 
@@ -82,7 +86,7 @@ def main():
     print("> copying binary")
     copy_binary(binary_name)
     print("> generating Info.plist")
-    apply_plist_template(target_plist(binary_name), version)
+    apply_plist_template(target_plist(binary_name), version, options.category)
 
     if options.deps:
         print("> bundling dependencies")

--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -133,7 +133,7 @@
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>LSApplicationCategoryType</key>
-    <string>public.app-category.games</string>
+    <string>public.app-category.${CATEGORY}</string>
     <key>LSEnvironment</key>
     <dict>
       <key>MallocNanoZone</key>

--- a/meson.build
+++ b/meson.build
@@ -1844,7 +1844,7 @@ if get_option('cplayer')
         custom_target('macos-bundle',
             output: 'mpv.app',
             depends: version_h,
-            command: [osxbundle, mpv, '@SOURCE_ROOT@'],
+            command: [osxbundle, mpv, '@SOURCE_ROOT@', '-c', get_option('macos-bundle-category')],
         )
     endif
 

--- a/meson.options
+++ b/meson.options
@@ -110,6 +110,7 @@ option('macos-12-features', type: 'feature', value: 'auto', description: 'macOS 
 option('macos-cocoa-cb', type: 'feature', value: 'auto', description: 'macOS libmpv backend')
 option('macos-media-player', type: 'feature', value: 'auto', description: 'macOS Media Player support')
 option('macos-touchbar', type: 'feature', value: 'auto', description: 'macOS Touch Bar support')
+option('macos-bundle-category', type : 'combo', choices : ['video', 'games'], value : 'video', description: 'macOS bundle category')
 option('swift-build', type: 'feature', value: 'auto', description: 'macOS Swift build tools')
 option('swift-flags', type: 'string', description: 'Optional Swift compiler flags')
 


### PR DESCRIPTION
in a13a6743633d9e0eddb2ea7befbef89f1e19788a we set the default category for the bundle to games, to get certain benefits like better rendering timing, better bluetooth latency, better threading, etc (bundle only).

though this also prevents low power modes and wrongly categories the app for spotlight search etc.

set the default category to video and add an option to set the category to games if one wishes to.
