### PR TITLE
autoload.lua: stop initial file from being added twice

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -372,6 +372,9 @@ local function find_and_add_entries()
         added_entries[entry.filename] = true
     end
 
+    -- stop initial file from being added twice
+    added_entries[path] = true
+
     local append = {[-1] = {}, [1] = {}}
     for direction = -1, 1, 2 do -- 2 iterations, with direction = -1 and +1
         for i = 1, MAX_ENTRIES do


### PR DESCRIPTION
this happened right after going to the next file. the playlist would be fine when staying on the first file. with logging you can see it 'prepending' the file it was just on.

traced it back to it this behaviour appearing since 5de1f5a
the fix to just throw the current file in the added_entries right away seems to work fine in all scenarios I could think and test