### PR TITLE
ci/mac: remove deprecated macOS 13 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,7 @@ jobs:
             xcode: "Xcode_15.0"
           - os: "macos-15"
             arch: "arm"
+          - os: "macos-15-intel"
           - os: "macos-26"
             arch: "arm"
           - os: "macos-26"
@@ -301,7 +302,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.arch != 'test' }}
         with:
-          name: mpv-${{ matrix.os }}-${{ matrix.arch }}
+          name: mpv-${{ matrix.os }}${{ matrix.arch != '' && format('-{0}', matrix.arch) || '' }}
           path: mpv.tar.gz
 
   linux:


### PR DESCRIPTION
the macOS 13 runners will be removed on 4th December (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)

should be merged right before or after removal.

also added newest macOS 26 runners which are still in beta but should be out of beta wenn the macOS 13 runners are removed.