### PR TITLE
ci/build-msys2.sh: disable pdf-build for clangarm64

### DIFF
--- a/ci/build-msys2.sh
+++ b/ci/build-msys2.sh
@@ -12,6 +12,10 @@ args=(
   -Db_sanitize=address,undefined
 )
 
+[[ "$SYS" == "clangarm64" ]] && args+=(
+  -Dpdf-build=disabled
+)
+
 meson setup build $common_args "${args[@]}"
 meson compile -C build
 ./build/mpv.com -v --no-config


### PR DESCRIPTION
See: https://github.com/msys2/MINGW-packages/issues/26007