### PR TITLE
video/out/gpu/video: change `treat-srgb-as-power22` default to auto

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7392,7 +7392,7 @@ them.
     to ensure a consistent appearance. Depending on the platform, the sRGB EOTF
     used by the system compositor may differ.
 
-    The default is ``input``. (Only for ``--vo=gpu-next``)
+    The default is ``auto``. (Only for ``--vo=gpu-next``)
 
 ``--tone-mapping=<value>``
     Specifies the algorithm used for tone-mapping images onto the target

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -409,7 +409,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .early_flush = -1,
     .shader_cache = true,
     .hwdec_interop = "auto",
-    .treat_srgb_as_power22 = 1, // input
+    .treat_srgb_as_power22 = 1|2|4, // auto
 };
 
 static OPT_STRING_VALIDATE_FUNC(validate_error_diffusion_opt);


### PR DESCRIPTION
We want to have symmetry on the input and output. Also outputting sRGB encoded image to gamma 2.2 display is clipping blacks. 2.2 displays are more common and are reference sRGB display, which is what we should target.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
