### PR TITLE
path_utils: strip trailing path separators

### DIFF
--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -57,7 +57,7 @@ char *mp_basename(const char *path)
     }
 #endif
     s = strrchr(path, '/');
-    return s ? s + 1 : (char *)path;
+    return s && strlen(s) > 1 ? s + 1 : (char *)path;
 }
 
 struct bstr mp_dirname(const char *path)
@@ -80,8 +80,8 @@ static const char mp_path_separators[] = "/";
 // Mutates path and removes a trailing '/' (or '\' on Windows)
 void mp_path_strip_trailing_separator(char *path)
 {
-    size_t len = strlen(path);
-    if (len > 0 && strchr(mp_path_separators, path[len - 1]))
+    size_t len;
+    while ((len=strlen(path)) > 0 && strchr(mp_path_separators, path[len - 1]))
         path[len - 1] = '\0';
 }
 


### PR DESCRIPTION
Previous behavior results in a '\0' (nul char) being returned if 'filename' is a URL that ends with a '/', which in turn would lead to 'screenshot-dir' being ignored or overwritten, which then results screenshot-path effecitively starting with '/' in case of nesting screenshot dirs per file, e.g.:

```
$ mpv \
	--screenshot-dir='~/tmp/mpv-shots' \
	--screenshot-template='%f/%P' \
	https://example.org/video/
```
This happens with ytdl-hook on some sites, in case it matters. Since %f expands to '' and somehow mpv also forgets about screenshot-dir in the process, the effective *path* template now is '/%P', which is most certainly not writable for ordinary users, on *nix at least.

This strips trailing path separators in mp_basename before doing the reverse search for the first '/' which otherwise returns the very last index of the string + 1 which in turn points to the terminating '\0'.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

I have read the aforementioned document.