### PR TITLE
meson.build: print drm for feature summary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1882,6 +1882,7 @@ if features['sdl2-audio'] or features['sdl2-gamepad'] or features['sdl2-video']
 endif
 
 summary({'d3d11': features['d3d11'],
+         'drm': features['drm'],
          'javascript': features['javascript'],
          'libmpv': get_option('libmpv'),
          'lua': features['lua'],


### PR DESCRIPTION
Similar to X11 and Wayland, it is a platform with gpu/gpu-next support and worths to mention.
