### PR TITLE
ao_pipewire: fix copy paste error in channel mapping

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -150,7 +150,7 @@ static enum spa_audio_channel mp_speaker_id_to_spa(struct ao *ao, enum mp_speake
     case MP_SPEAKER_ID_WL:   return SPA_AUDIO_CHANNEL_FL;
     case MP_SPEAKER_ID_WR:   return SPA_AUDIO_CHANNEL_FR;
     case MP_SPEAKER_ID_SDL:  return SPA_AUDIO_CHANNEL_SL;
-    case MP_SPEAKER_ID_SDR:  return SPA_AUDIO_CHANNEL_SL;
+    case MP_SPEAKER_ID_SDR:  return SPA_AUDIO_CHANNEL_SR;
     case MP_SPEAKER_ID_LFE2: return SPA_AUDIO_CHANNEL_LFE2;
     case MP_SPEAKER_ID_TSL:  return SPA_AUDIO_CHANNEL_TSL;
     case MP_SPEAKER_ID_TSR:  return SPA_AUDIO_CHANNEL_TSR;


### PR DESCRIPTION
MP_SPEAKER_ID_SDR (surround direct right) should not map to a left channel.

Seems to be a copy paste error from the line above in the initial commit from 2022.