### PR TITLE
player/lua/stats.lua: ellipsize filename

### DIFF
--- a/player/lua/stats.lua
+++ b/player/lua/stats.lua
@@ -690,7 +690,7 @@ end
 
 local function add_file(s, print_cache, print_tags)
     append(s, "", {prefix="File:", nl="", indent=""})
-    append_property(s, "filename", {prefix_sep="", nl="", indent=""})
+    append_property(s, "filename", {prefix_sep="", nl="", indent="", max_len=32})
     if mp.get_property_osd("filename") ~= mp.get_property_osd("media-title") then
         append_property(s, "media-title", {prefix="Title:"})
     end


### PR DESCRIPTION
For the time being this is a POC to eventually fix/mitigate the display of long URLs in OSD stats, see https://github.com/mpv-player/mpv/issues/10975#issuecomment-3476747266.

This introduces a simple ellipsize function and an additional append attribute `max_len` to automagically filter the `str` argument. The hard-coded length of 32 chars was chosen for testing purposes. Ideally it can be dynamically changed depending on the available space but I haven't figured out yet if and how that can be determined. If it can't be done, providing a script option is easy enough.

In conjunction with #17021 this could be a fix for #10975.

P.S.: I chose to do this in stats.lua because it fixes the immediate issue and Lua comes some batteries included to make this easier and readable. But I am pondering, if extending the filename attribute getter is the better place to do this, i.e. a new subproperty `/short`? Anyway, for now this is an easy (partial) win.

- [x] Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md