### PR TITLE
loadfile: clip long track titles

### DIFF
--- a/DOCS/interface-changes/osd-track-url-title-max-length.txt
+++ b/DOCS/interface-changes/osd-track-url-title-max-length.txt
@@ -1,0 +1,1 @@
+add `--osd-track-url-title-max-length`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4698,6 +4698,13 @@ OSD
 
     Default: ``title``.
 
+``--osd-track-url-title-max-length=<length>``
+    Truncate URL track titles to ``length`` characters. Wide unicode characters
+    count as multiple characters to make this work correctly with terminal
+    output. Set to 0 to disable.
+
+    Default: 90.
+
 ``--osd-bar-align-x=<-1-1>``
     Position of the OSD bar. -1 is far left, 0 is centered, 1 is far right.
     Fractional values (like 0.5) are allowed.

--- a/options/options.c
+++ b/options/options.c
@@ -888,6 +888,8 @@ static const m_option_t mp_opts[] = {
 
     {"osd-playlist-entry", OPT_CHOICE(playlist_entry_name,
         {"title", 0}, {"filename", 1}, {"both", 2})},
+    {"osd-track-url-title-max-length", OPT_INT(max_track_url_title_max_length),
+        M_RANGE(0, INT_MAX)},
 
     {"video-osd", OPT_BOOL(video_osd), .flags = UPDATE_OSD},
 
@@ -999,6 +1001,7 @@ static const struct MPOpts mp_default_opts = {
     .osd_level = 1,
     .osd_on_seek = 1,
     .osd_duration = 1000,
+    .max_track_url_title_max_length = 90,
 #if HAVE_LUA
     .lua_load_osc = true,
     .lua_load_ytdl = true,

--- a/options/options.h
+++ b/options/options.h
@@ -277,6 +277,7 @@ typedef struct MPOpts {
     char *osd_status_msg;
     char *osd_msg[3];
     int playlist_entry_name;
+    int max_track_url_title_max_length;
     int player_idle_mode;
     char **input_commands;
     bool consolecontrols;


### PR DESCRIPTION
When a track information is longer than the terminal width, clip it and add ellipsis. Useful for long URLs.

Fixes #10975 along with #17021.