### PR TITLE
github/workflows: fix libXpresent installation on freebsd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,7 +497,7 @@ jobs:
                 libplacebo \
                 libXinerama \
                 libxkbcommon \
-                libxpresent \
+                libXpresent \
                 libXv \
                 luajit \
                 meson \


### PR DESCRIPTION
The x is uppercase now.