### PR TITLE
wayland: fix condition for setting image description

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3442,7 +3442,7 @@ static void seat_create_text_input(struct vo_wayland_seat *seat)
 static void set_color_management(struct vo_wayland_state *wl)
 {
 #if HAVE_WAYLAND_PROTOCOLS_1_41
-    if (!wl->color_surface && !wl->supports_parametric)
+    if (!wl->color_surface || !wl->supports_parametric)
         return;
 
     struct pl_color_space color = wl->target_params.color;


### PR DESCRIPTION
We need both a color surface and parametric support to attempt to apply image description, not either one.

Fixes: 0a32f988ba57 ("wayland: move initial color management setup earlier in the init")

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
