### PR TITLE
wayland: do a roundtrip to give compositor time to ready image desc

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -52,6 +52,7 @@ struct vo_wayland_state {
     struct wl_surface       *video_surface;
     struct wl_surface       *callback_surface;
     struct wl_subsurface    *video_subsurface;
+    struct wl_event_queue   *cm_queue;
 
     /* Geometry */
     struct mp_rect geometry;
@@ -102,6 +103,7 @@ struct vo_wayland_state {
     void *icc_file;
     uint32_t icc_size;
     struct pl_color_space preferred_csp;
+    bool image_desc_done;
 
     /* color-representation */
     struct wp_color_representation_manager_v1 *color_representation_manager;


### PR DESCRIPTION
Alternative to https://github.com/mpv-player/mpv/pull/16844

There's no guarantee that a roundtrip is enough, but practically, it's enough on every compositor. This might be preferred over the other PR because this is a timed wait while the other PR could be indefinite if the compositor never responds, or have adverse effects for frametiming if it takes longer than the frame budget. Though #16844 is also what Mesa, so if a compositor is so buggy it would affect more than just mpv. For that reason, I don't think there's any reason to worry about it but the maintainers might feel differently.

Posting this to discuss both solutions, I'll add a commit message if this is preferred