### PR TITLE
player/command: fix playlist-remove argument requirement

### DIFF
--- a/DOCS/interface-changes/playlist-remove.rst
+++ b/DOCS/interface-changes/playlist-remove.rst
@@ -1,0 +1,1 @@
+remove undocumented optional argument usage for `playlist-remove` command

--- a/player/command.c
+++ b/player/command.c
@@ -7438,7 +7438,7 @@ const struct mp_cmd_def mp_cmds[] = {
     { "playlist-clear", cmd_playlist_clear },
     { "playlist-remove", cmd_playlist_remove, {
         {"index", OPT_CHOICE(v.i, {"current", -1}),
-            .flags = MP_CMD_OPT_ARG, M_RANGE(0, INT_MAX)}, }},
+            M_RANGE(0, INT_MAX)}, }},
     { "playlist-move", cmd_playlist_move,  { {"index1", OPT_INT(v.i)},
                                              {"index2", OPT_INT(v.i)}, }},
     { "run", cmd_run, { {"command", OPT_STRING(v.s)},


### PR DESCRIPTION
playlist-remove has a required index argument, as indicated by the documentation. However, in 332907e1d7225ae39565d462aac5c45c3a5cad97 MP_CMD_OPT_ARG was mistakenly added, making it optional. The effect of not specifying the argument is defaulting the index to 0 and always removing the first element in the playlist, which is not expected.

Fix this by making the argument required.

Fixes: 332907e1d7225ae39565d462aac5c45c3a5cad97

