### PR TITLE
wayland: switch to PQ when necessary

### DIFF
--- a/video/out/d3d11/context.c
+++ b/video/out/d3d11/context.c
@@ -203,7 +203,8 @@ static int d3d11_color_depth(struct ra_swapchain *sw)
     return MPMIN(ra_fmt->component_depth[0], desc1.BitsPerColor);
 }
 
-static struct pl_color_space d3d11_target_color_space(struct ra_swapchain *sw)
+static struct pl_color_space d3d11_target_color_space(struct ra_swapchain *sw,
+                                                      float source_max_luma)
 {
     if (sw->ctx->opts.composition)
         return (struct pl_color_space){0};

--- a/video/out/gpu/context.h
+++ b/video/out/gpu/context.h
@@ -79,7 +79,7 @@ struct ra_ctx_params {
     int (*color_depth)(struct ra_ctx *ctx);
 
     // Preferred device color space. Optional.
-    pl_color_space_t (*preferred_csp)(struct ra_ctx *ctx);
+    pl_color_space_t (*preferred_csp)(struct ra_ctx *ctx, float source_max_luma);
 
     // See ra_swapchain_fns.get_vsync.
     void (*get_vsync)(struct ra_ctx *ctx, struct vo_vsync_info *info);
@@ -114,7 +114,7 @@ struct ra_swapchain_fns {
     int (*color_depth)(struct ra_swapchain *sw);
 
     // Target device color space. Optional.
-    pl_color_space_t (*target_csp)(struct ra_swapchain *sw);
+    pl_color_space_t (*target_csp)(struct ra_swapchain *sw, float source_max_luma);
 
     // Called when rendering starts. Returns NULL on failure. This must be
     // followed by submit_frame, to submit the rendered frame. This function

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -305,11 +305,11 @@ static void ra_gl_ctx_get_vsync(struct ra_swapchain *sw,
         p->params.get_vsync(sw->ctx, info);
 }
 
-static pl_color_space_t ra_gl_ctx_target_csp(struct ra_swapchain *sw)
+static pl_color_space_t ra_gl_ctx_target_csp(struct ra_swapchain *sw, float source_max_luma)
 {
     struct priv *p = sw->priv;
     if (p->params.preferred_csp)
-        return p->params.preferred_csp(sw->ctx);
+        return p->params.preferred_csp(sw->ctx, source_max_luma);
     return (pl_color_space_t){0};
 }
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1089,8 +1089,16 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
     bool pass_colorspace = false;
     struct pl_color_space target_csp = {0};
     // TODO: Implement this for all backends
-    if (sw->fns->target_csp)
-        target_csp = sw->fns->target_csp(sw);
+    if (sw->fns->target_csp) {
+        float source_max_luma = 0.0f;
+        if (frame->current) {
+            source_max_luma = frame->current->params.color.hdr.max_luma;
+            if (opts->tone_map.inverse)
+                // Sentinel value to use the maximum luminance supported by the display.
+                source_max_luma = INFINITY;
+        }
+        target_csp = sw->fns->target_csp(sw, source_max_luma);
+    }
     if (target_csp.primaries == PL_COLOR_PRIM_UNKNOWN)
         target_csp.primaries = get_best_prim_container(&target_csp.hdr.prim);
     if (!pl_color_transfer_is_hdr(target_csp.transfer)) {

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -518,11 +518,11 @@ static void get_vsync(struct ra_swapchain *sw,
         p->params.get_vsync(sw->ctx, info);
 }
 
-static pl_color_space_t target_csp(struct ra_swapchain *sw)
+static pl_color_space_t target_csp(struct ra_swapchain *sw, float soucre_max_luma)
 {
     struct priv *p = sw->priv;
     if (p->params.preferred_csp)
-        return p->params.preferred_csp(sw->ctx);
+        return p->params.preferred_csp(sw->ctx, soucre_max_luma);
     return (pl_color_space_t){0};
 }
 

--- a/video/out/vulkan/context_wayland.c
+++ b/video/out/vulkan/context_wayland.c
@@ -33,9 +33,9 @@ static bool wayland_vk_check_visible(struct ra_ctx *ctx)
     return vo_wayland_check_visible(ctx->vo);
 }
 
-static pl_color_space_t wayland_vk_preferred_csp(struct ra_ctx *ctx)
+static pl_color_space_t wayland_vk_preferred_csp(struct ra_ctx *ctx, float source_max_luma)
 {
-    return vo_wayland_preferred_csp(ctx->vo);
+    return vo_wayland_preferred_csp(ctx->vo, source_max_luma);
 }
 
 static void wayland_vk_swap_buffers(struct ra_ctx *ctx)

--- a/video/out/vulkan/context_win.c
+++ b/video/out/vulkan/context_win.c
@@ -52,7 +52,7 @@ static int color_depth(struct ra_ctx *ctx)
     return -1;
 }
 
-static struct pl_color_space preferred_csp(struct ra_ctx *ctx)
+static struct pl_color_space preferred_csp(struct ra_ctx *ctx, float source_max_luma)
 {
     struct priv *p = ctx->priv;
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -192,7 +192,7 @@ struct vo_wayland_state {
 };
 
 bool vo_wayland_check_visible(struct vo *vo);
-struct pl_color_space vo_wayland_preferred_csp(struct vo *vo);
+struct pl_color_space vo_wayland_preferred_csp(struct vo *vo, float source_max_luma);
 bool vo_wayland_valid_format(struct vo_wayland_state *wl, uint32_t drm_format, uint64_t modifier);
 bool vo_wayland_init(struct vo *vo);
 bool vo_wayland_reconfig(struct vo *vo);


### PR DESCRIPTION
You can test this with the following file: [test_pattern-PQ.jxl.gz](https://github.com/user-attachments/files/23690573/test_pattern-PQ.jxl.gz)

This image contains gradients that go up to 10,000 cd/m^2. If you set the paper white luminance in your compositor to 1% of its normal value, you create a lot of artificial head room. Without this patch, the entire image becomes dark. With this patch, the bright end of the gradient continues to fully light up the output.