### PR TITLE
vd_lavc: enable hwdec for DPX by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1834,7 +1834,7 @@ Video
     You can get the list of allowed codecs with ``mpv --vd=help``. Remove the
     prefix, e.g. instead of ``lavc:h264`` use ``h264``.
 
-    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1,prores,prores_raw,ffv1``. Note that
+    By default, this is set to ``h264,vc1,hevc,vp8,vp9,av1,prores,prores_raw,ffv1,dpx``. Note that
     the hardware acceleration special codecs like ``h264_vdpau`` are not
     relevant anymore, and in fact have been removed from FFmpeg in this form.
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -165,7 +165,7 @@ const struct m_sub_options hwdec_conf = {
     .defaults = &(const struct hwdec_opts){
         .software_fallback = 3,
         .hwdec_api = (char *[]){"no", NULL,},
-        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores,prores_raw,ffv1",
+        .hwdec_codecs = "h264,vc1,hevc,vp8,vp9,av1,prores,prores_raw,ffv1,dpx",
         // Maximum number of surfaces the player wants to buffer. This number
         // might require adjustment depending on whatever the player does;
         // for example, if vo_gpu increases the number of reference surfaces for


### PR DESCRIPTION
Another Vulkan compute codec was merged in FFmpeg, for DPX. This PR just enables it by default.