### PR TITLE
clipboard-x11: request selection at init 

### DIFF
--- a/player/clipboard/clipboard-x11.c
+++ b/player/clipboard/clipboard-x11.c
@@ -88,6 +88,15 @@ static bool clipboard_x11_init(struct clipboard_x11_priv *x11, bool xwayland)
         MP_FATAL(x11, "Xfixes init failed\n");
         goto err;
     }
+
+    // XFixesSelectionNotifyEvent does not give an initial notification
+    // so request selection here
+    XConvertSelection(x11->display, XA(x11, CLIPBOARD), XA(x11, UTF8_STRING),
+                      XA(x11, MPV_CLIPBOARD), x11->window, CurrentTime);
+    XConvertSelection(x11->display, XA_PRIMARY, XA(x11, UTF8_STRING),
+                      XA(x11, MPV_PRIMARY), x11->window, CurrentTime);
+    XFlush(x11->display);
+
     return true;
 
 err:


### PR DESCRIPTION
XFixesSelectionNotifyEvent does not give an initial notification, so initial selection needs to be requested manually.

Also fixes one of the property not being set when a client sets primary and clipboard at the same time.

Fixes: https://github.com/mpv-player/mpv/issues/17097