### PR TITLE
video/out/gpu/hwdec: load native D3D RA hwdec drivers first

### DIFF
--- a/video/out/gpu/hwdec.c
+++ b/video/out/gpu/hwdec.c
@@ -40,25 +40,25 @@ extern const struct ra_hwdec_driver ra_hwdec_aimagereader;
 extern const struct ra_hwdec_driver ra_hwdec_vulkan;
 
 const struct ra_hwdec_driver *const ra_hwdec_drivers[] = {
-#if HAVE_VAAPI
-    &ra_hwdec_vaapi,
-#endif
-#if HAVE_VIDEOTOOLBOX_GL || HAVE_IOS_GL || HAVE_VIDEOTOOLBOX_PL
-    &ra_hwdec_videotoolbox,
-#endif
 #if HAVE_D3D_HWACCEL
- #if HAVE_EGL_ANGLE
-    &ra_hwdec_d3d11egl,
-  #if HAVE_D3D9_HWACCEL
-    &ra_hwdec_dxva2egl,
-  #endif
- #endif
  #if HAVE_D3D11
     &ra_hwdec_d3d11va,
   #if HAVE_D3D9_HWACCEL
     &ra_hwdec_dxva2dxgi,
   #endif
  #endif
+ #if HAVE_EGL_ANGLE
+    &ra_hwdec_d3d11egl,
+  #if HAVE_D3D9_HWACCEL
+    &ra_hwdec_dxva2egl,
+  #endif
+ #endif
+#endif
+#if HAVE_VAAPI
+    &ra_hwdec_vaapi,
+#endif
+#if HAVE_VIDEOTOOLBOX_GL || HAVE_IOS_GL || HAVE_VIDEOTOOLBOX_PL
+    &ra_hwdec_videotoolbox,
 #endif
 #if HAVE_GL_DXINTEROP_D3D9
     &ra_hwdec_dxva2gldx,


### PR DESCRIPTION
There is no reason to load EGL/VAAPI first as it would fail in default gpu context/api anyway, on Windows.