### PR TITLE
vo: trigger manual redraws at most at slightly over display fps

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1187,8 +1187,17 @@ static MP_THREAD_VOID vo_thread(void *ptr)
         if (send_pause)
             vo->driver->control(vo, vo_paused ? VOCTRL_PAUSE : VOCTRL_RESUME, NULL);
         if (wait_until > now && redraw) {
-            vo->driver->control(vo, VOCTRL_REDRAW, NULL);
-            do_redraw(vo); // now is a good time
+            // Allow manual redraws at most at slightly over display fps.
+            int64_t max_interval = (MP_TIME_S_TO_NS(1) / MPMAX(in->display_fps, 10)) / 1.1;
+            // Some windowing platforms break if we submit frames too fast.
+            if (vo->previous_redraw_time + max_interval <= now) {
+                vo->driver->control(vo, VOCTRL_REDRAW, NULL);
+                do_redraw(vo); // now is a good time
+                vo->previous_redraw_time = now;
+            } else {
+                in->request_redraw = true;
+                wait_vo(vo, now + max_interval);
+            }
             continue;
         }
         if (vo->want_redraw) // might have been set by VOCTRLs

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -508,6 +508,7 @@ struct vo {
     struct m_config_cache *eq_opts_cache;
 
     bool want_redraw;   // redraw as soon as possible
+    int64_t previous_redraw_time;
 
     // current window state
     int dwidth;


### PR DESCRIPTION
This is workaround for some windowing platforms that break when they get too many present requests.