### PR TITLE
wayland: resize on first surface enter in case find_output guessed wrong

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1704,8 +1704,13 @@ static void surface_handle_enter(void *data, struct wl_surface *wl_surface,
             ++outputs;
     }
 
-    if (outputs == 1)
+    if (outputs == 1) {
+        if (!wl->first_enter_done)
+            set_geometry(wl, true);
         update_output_geometry(wl, old_geometry, old_output_geometry);
+    }
+
+    wl->first_enter_done = true;
 
     MP_VERBOSE(wl, "Surface entered output %s %s (%s) (0x%x), scale = %f, refresh rate = %f Hz\n",
                wl->current_output->make, wl->current_output->model, wl->current_output->name,

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -62,6 +62,7 @@ struct vo_wayland_state {
     int bounded_width;
     int reduced_height;
     int reduced_width;
+    bool first_enter_done;
 
     /* State */
     bool activated;


### PR DESCRIPTION
This prevents options like --geometry/--autofit using the dimensions of the incorrect screen in multi output setups.

By default, mpv tries to guess the output for --geometry/--autofit based on --screen/--screen-name options, while falling back to first output in list if not set. This can be incorrect very often, so force a resize the very first time mpv surface enters any output.

This casues a noticeable resize on startup, but probably better than --autofit/--geometry having incorrect behavior if mpv didn't land in the output it guessed. Ideally, the user uses compositor to set mpv size...
