### PR TITLE
playloop: unset last_chapter_flag when queueing non-chapter seeks

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -296,8 +296,6 @@ static void mp_seek(MPContext *mpctx, struct seek_params seek)
     if (seek.type == MPSEEK_CHAPTER) {
         mpctx->last_chapter_flag = false;
         seek.type = MPSEEK_ABSOLUTE;
-    } else {
-        mpctx->last_chapter_seek = -2;
     }
 
     bool hr_seek_very_exact = seek.exact == MPSEEK_VERY_EXACT;
@@ -458,6 +456,11 @@ void queue_seek(struct MPContext *mpctx, enum seek_type type, double amount,
     struct seek_params *seek = &mpctx->seek;
 
     mp_wakeup_core(mpctx);
+
+    if (type != MPSEEK_CHAPTER) {
+        mpctx->last_chapter_flag = false;
+        mpctx->last_chapter_seek = -2;
+    }
 
     switch (type) {
     case MPSEEK_RELATIVE:


### PR DESCRIPTION
This fixes a race condition where if a non-chapter seek is queued immediately after a chapter seek is queued, the chapter property may become unavailable until a new file is loaded.

If multiple seeks are queued within the same playloop iteration, only the last seek is executed. Because the chapter seek is never executed, last_chapter_flag remains set and last_chapter_seek becomes -2, which causes get_current_chapter to return -2, which makes the chapter property unavailable.

Unset this (and also last_chapter_seek) immediately rather than wait for seek execution, like chapter seeks set these immediately.

Fixes: 233f1e46f67fef71d7a270f798f6a4e3198a1606 ("playloop: make chapter property more accurate when seeking chapters")