### PR TITLE
console.lua: don't error if compute_bounds doesn't return dimensions

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -342,8 +342,10 @@ local function calculate_max_item_width()
                          (font and "\\fn" .. font or "") .. "\\q2}" ..
                          ass_escape(longest_item)
     local result = width_overlay:update()
-    max_item_width = math.min(result.x1 - result.x0,
-                              osd_w - get_margin_x() * 2 - opts.padding * 2)
+    if result.x0 then
+        max_item_width = math.min(result.x1 - result.x0,
+                                  osd_w - get_margin_x() * 2 - opts.padding * 2)
+    end
 end
 
 local function should_highlight_completion(i)


### PR DESCRIPTION
compute_bounds doesn't return any field if the rectangle is empty: its docs say "If set to true, attempt to determine bounds and write them to the command's result value as x0, x1, y0, y1 rectangle (default: false). If the rectangle is empty, not known, or somehow degenerate, it is not set.". So shrinking mpv as much as possible with a menu open caused a crash.

This doesn't happen on Xorg because of these lines in video/out/x11_common.c:

```
// Set minimum height/width to 4 to avoid off-by-one errors.
hint->flags |= PMinSize;
hint->min_width = hint->min_height = 4;
```

But it happens on Wayland and Windows ~~(no idea about macOS)~~.

Fixes #16682 along with the diff posted there.