### PR TITLE
screenshot: correctly detect hardware frame

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -377,7 +377,7 @@ static struct mp_image *screenshot_get(struct MPContext *mpctx, int mode,
     }
 
     // vo_get_current_frame() can return a hardware frame, which we have to download first.
-    if (image && image->fmt.flags & MP_IMGFLAG_HWACCEL) {
+    if (image && IMGFMT_IS_HWACCEL(image->imgfmt)) {
         struct mp_image *nimage = mp_image_hw_download(image, NULL);
         talloc_free(image);
         if (!nimage)


### PR DESCRIPTION
This only ever worked by accident and relied on broken behavior that was fixed by 9b1d47ece11da8625591bb5817bbad622485074b

Fixes #17185