### PR TITLE
video/out/opengl/context_wayland: cleanup vo when egl fails to init

### DIFF
--- a/video/out/opengl/context_wayland.c
+++ b/video/out/opengl/context_wayland.c
@@ -214,9 +214,10 @@ static void wayland_egl_update_render_opts(struct ra_ctx *ctx)
 
 static bool wayland_egl_init(struct ra_ctx *ctx)
 {
-    if (!vo_wayland_init(ctx->vo))
-        return false;
-    return egl_create_context(ctx);
+    if (vo_wayland_init(ctx->vo) && egl_create_context(ctx))
+        return true;
+    vo_wayland_uninit(ctx->vo);
+    return false;
 }
 
 const struct ra_ctx_fns ra_ctx_wayland_egl = {


### PR DESCRIPTION
When the "new" API for OpenGL VO backends was created 10 years ago in df97c30e0e324a7a51c3cb4a24eb27fcf30462b2, it was expected that any "driver" that fails to init to clean up themselves (the "old" API always called mpgl_uninit() to clean up on failure).

However, when switching Wayland to the "new" API, this was forgotten. Wayland VO will never be cleaned up when EGL init fails.

With commit a310a65d358eb0cc251fa05e142655065d851fb7, this issue was exposed when a leftover Wayland context pointer, which results from a successful Wayland context init but with failed EGL init, triggers an assertion in the X11 context init code, which expects the pointer to be NULL.

Fix this by uninit Wayland context when EGL init fails.

Fixes: bd87598af9c27315054814be4980806dd332f69c
Fixes: #17190 