### PR TITLE
player/playloop: handle force window in playloop

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -1315,6 +1315,8 @@ void run_playloop(struct MPContext *mpctx)
     handle_option_callbacks(mpctx);
 
     handle_chapter_change(mpctx);
+
+    handle_force_window(mpctx, false);
 }
 
 void mp_idle(struct MPContext *mpctx)


### PR DESCRIPTION
813c1123299a284261caccc035ef27a2ddcb5d24 moved force window to option callback. This happens before the loading of the file has finished (which is supposed to trigger handle_force_window) so it is too early to handle certain cases, such as loading of album art failed and therefore window will never be created because there is no video track.

Adding force window check in playloop to make sure window is always initialized after file loading is complete.

Fixes: 813c1123299a284261caccc035ef27a2ddcb5d24
Fixes: #17209