### PR TITLE
select.lua: link to mpv's IRC channel in the menu

### DIFF
--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -138,6 +138,9 @@ Available script bindings are:
 ``open-docs``
     Open mpv's online documentation in the browser.
 
+``open-chat``
+    Open mpv's chat in the browser.
+
 ``menu``
     Show a menu with miscellaneous entries.
 

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -682,6 +682,10 @@ mp.add_key_binding(nil, "open-docs", function ()
     system_open("https://mpv.io/manual/")
 end)
 
+mp.add_key_binding(nil, "open-chat", function ()
+    system_open("https://web.libera.chat/#mpv")
+end)
+
 mp.add_key_binding(nil, "menu", function ()
     local sub_track_count = 0
     local audio_track_count = 0
@@ -727,6 +731,7 @@ mp.add_key_binding(nil, "menu", function ()
         {"Edit key bindings", "script-binding select/edit-input-conf", true},
         {"Help", "script-binding stats/display-page-4-toggle", true},
         {"Online documentation", "script-binding select/open-docs", true},
+        {"Support", "script-binding select/open-chat", true},
     }
 
     local labels = {}


### PR DESCRIPTION
Add a menu entry that opens mpv's IRC channel so users can quickly ask support questions.