### PR TITLE
github/issue_template: add IDs to textarea fields for URL queries

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
@@ -4,6 +4,7 @@ labels: ["os:linux"]
 type: Bug
 body:
 - type: textarea
+  id: mpv_information
   attributes:
       label: "mpv Information"
       placeholder: |
@@ -24,6 +25,7 @@ body:
   validations:
       required: false
 - type: textarea
+  id: other_information
   attributes:
       label: "Other Information"
       description: >
@@ -53,6 +55,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: reproduction_steps
   attributes:
       label: "Reproduction Steps"
       description: >
@@ -74,18 +77,21 @@ body:
   validations:
       required: true
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected Behavior"
       placeholder: "What were you expecting?"
   validations:
       required: true
 - type: textarea
+  id: actual_behavior
   attributes:
       label: "Actual Behavior"
       placeholder: "What happened instead?"
   validations:
       required: true
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       placeholder: "Drag and drop log file here (Don't paste content directly)"
@@ -109,6 +115,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: sample_files
   attributes:
       label: "Sample Files"
       placeholder: "Drag and drop sample files here"

--- a/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
@@ -4,6 +4,7 @@ labels: ["os:mac"]
 type: Bug
 body:
 - type: textarea
+  id: mpv_information
   attributes:
       label: "mpv Information"
       placeholder: |
@@ -24,6 +25,7 @@ body:
   validations:
       required: false
 - type: textarea
+  id: other_info
   attributes:
       label: "Other Information"
       description: >
@@ -46,6 +48,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: reproduction_steps
   attributes:
       label: "Reproduction Steps"
       description: >
@@ -67,18 +70,21 @@ body:
   validations:
       required: true
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected Behavior"
       placeholder: "What were you expecting?"
   validations:
       required: true
 - type: textarea
+  id: actual_behavior
   attributes:
       label: "Actual Behavior"
       placeholder: "What happened instead?"
   validations:
       required: true
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       placeholder: "Drag and drop log file here (Don't paste content directly)"
@@ -104,6 +110,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: sample_files
   attributes:
       label: "Sample Files"
       placeholder: "Drag and drop sample files here"

--- a/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
@@ -4,6 +4,7 @@ labels: ["os:win"]
 type: Bug
 body:
 - type: textarea
+  id: mpv_information
   attributes:
       label: "mpv Information"
       placeholder: |
@@ -24,6 +25,7 @@ body:
   validations:
       required: false
 - type: textarea
+  id: other_information
   attributes:
       label: "Other Information"
       description: >
@@ -48,6 +50,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: reproduction_steps
   attributes:
       label: "Reproduction Steps"
       description: >
@@ -69,18 +72,21 @@ body:
   validations:
       required: true
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected Behavior"
       placeholder: "What were you expecting?"
   validations:
       required: true
 - type: textarea
+  id: actual_behavior
   attributes:
       label: "Actual Behavior"
       placeholder: "What happened instead?"
   validations:
       required: true
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       placeholder: "Drag and drop log file here (Don't paste content directly)"
@@ -105,6 +111,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: sample_files
   attributes:
       label: "Sample Files"
       placeholder: "Drag and drop sample files here"

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -4,6 +4,7 @@ labels: []
 type: Bug
 body:
 - type: textarea
+  id: mpv_information
   attributes:
       label: "mpv Information"
       placeholder: |
@@ -24,6 +25,7 @@ body:
   validations:
       required: false
 - type: textarea
+  id: important_information
   attributes:
       label: "Important Information"
       description: >
@@ -46,6 +48,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: reproduction_steps
   attributes:
       label: "Reproduction Steps"
       description: >
@@ -67,18 +70,21 @@ body:
   validations:
       required: true
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected Behavior"
       placeholder: "What were you expecting?"
   validations:
       required: true
 - type: textarea
+  id: actual_behavior
   attributes:
       label: "Actual Behavior"
       placeholder: "What happened instead?"
   validations:
       required: true
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       placeholder: "Drag and drop log file here (Don't paste content directly)"
@@ -102,6 +108,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: sample_files
   attributes:
       label: "Sample Files"
       placeholder: "Drag and drop sample files here"

--- a/.github/ISSUE_TEMPLATE/4_bug_report_build.yml
+++ b/.github/ISSUE_TEMPLATE/4_bug_report_build.yml
@@ -4,6 +4,7 @@ labels: ["core:meson"]
 type: Bug
 body:
 - type: textarea
+  id: important_information
   attributes:
       label: "Important Information"
       description: >
@@ -21,6 +22,7 @@ body:
   validations:
       required: true
 - type: textarea
+  id: reproduction_steps
   attributes:
       label: "Reproduction Steps"
       description: >
@@ -30,18 +32,21 @@ body:
   validations:
       required: true
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected Behavior"
       placeholder: "What were you expecting?"
   validations:
       required: true
 - type: textarea
+  id: actual_behavior
   attributes:
       label: "Actual Behavior"
       placeholder: "What happened instead?"
   validations:
       required: true
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       placeholder: "Drag and drop log file here (Don't paste content directly)"

--- a/.github/ISSUE_TEMPLATE/5_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/5_feature_request.yml
@@ -4,6 +4,7 @@ labels: ["meta:feature-request"]
 type: Feature
 body:
 - type: textarea
+  id: expected_behavior
   attributes:
       label: "Expected behavior of the wanted feature"
       description: >
@@ -20,9 +21,11 @@ body:
   validations:
       required: true
 - type: textarea
+  id: alternative_behavior
   attributes:
       label: "Alternative behavior of the wanted feature"
 - type: textarea
+  id: log_file
   attributes:
       label: "Log File"
       description: >
@@ -34,6 +37,7 @@ body:
           If you have trouble producing a log file, you can alternatively use `-v -v`, save the
           terminal output to a file, and attach it to the issue.
 - type: textarea
+  id: sample_files
   attributes:
       label: "Sample Files"
       placeholder: "Drag and drop sample files here"


### PR DESCRIPTION
decided to split out this commit from #17211, because it's just a necessity for it but can be used independently of it.

this adds the possibility to pre-fill certain fields in our issue templates with a URL query via their IDs. as an example [here](https://github.com/Akemi/mpv/issues/new?template=2_bug_report_macos.yml&mpv_info=mpv%20v0.41.0-49-ge3ebeb27e-dirty%20Copyright%20©%202000-2025%20mpv%2FMPlayer%2Fmplayer2%20projects%0A%20built%20on%20Dec%2031%202025%2015%3A25%3A16%0Alibplacebo%20version%3A%20v7.357.0%20(v7.351.0-87-g9bffcaf2)%0AFFmpeg%20version%3A%208.0.1%0AFFmpeg%20library%20versions%3A%0A%20%20%20libavcodec%20%20%20%20%20%2062.11.100%0A%20%20%20libavdevice%20%20%20%20%2062.1.100%0A%20%20%20libavfilter%20%20%20%20%2011.4.100%0A%20%20%20libavformat%20%20%20%20%2062.3.100%0A%20%20%20libavutil%20%20%20%20%20%20%2060.8.100%0A%20%20%20libswresample%20%20%206.1.100%0A%20%20%20libswscale%20%20%20%20%20%209.1.100&other_info=-%20macOS%20version%3A%2015.7.2%20(Build%2024G325)%0A-%20Source%20of%20mpv%3A%0A-%20Latest%20known%20working%20version%3A%0A-%20Issue%20started%20after%20the%20following%20happened%3A), pre-fills the fields "mpv Information" and "Other Information". 

possible application, menu entries or CLI output to submit bug reports.

related to #17211
