### PR TITLE
ci/openbsd: enable sdl2 features for testing

### DIFF
--- a/ci/build-openbsd.sh
+++ b/ci/build-openbsd.sh
@@ -11,6 +11,9 @@ meson setup build $common_args \
   -Dpulse=enabled \
   -Dvulkan=enabled \
   -Ddvdnav=enabled \
-  -Dcdda=disabled
+  -Dcdda=disabled \
+  -Dsdl2-gamepad=enabled \
+  -Dsdl2-audio=enabled \
+  -Dsdl2-video=enabled
 meson compile -C build
 ./build/mpv -v --no-config


### PR DESCRIPTION
sdl2 is already installed on our openbsd job but wasn't really tested. 

related to #17183