### PR TITLE
cocoa-cb: re-enable `wid` (NSView) embedding on macOS for libmpv use

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3787,6 +3787,22 @@ Window
     specially, and mpv will draw on top of the desktop wallpaper and below
     desktop icons.
 
+    On macOS/Cocoa, the ID is interpreted as ``NSView*``. Pass it as value cast
+    to ``intptr_t``. mpv will create its own sub-view.
+    The following constraints apply:
+
+    - This is only supported with libmpv. Specifying a wid with mpv cli will
+      end with an error
+    - The supplied NSView pointer must be from the same process into which
+      libmpv is loaded. Since macOS does not support cross-process window
+      access, attempts trying to do so will always crash
+    - The process needs to have an NSApplication with event loop running
+      on the main thread
+    - The wid must be set after mpv_create() and before mpv_initialize()
+      and cannot be changed afterwards
+    - The only supported vo is libmpv, which will be automatically set when
+      a wid is provided
+
     On Android, the ID is interpreted as ``android.view.Surface``. Pass it as a
     value cast to ``intptr_t``. Use with ``--vo=mediacodec_embed`` and
     ``--hwdec=mediacodec`` for direct rendering using MediaCodec, or with

--- a/meson.build
+++ b/meson.build
@@ -1650,6 +1650,7 @@ features += {'macos-cocoa-cb': macos_cocoa_cb.allowed()}
 if features['macos-cocoa-cb']
     swift_sources += files('osdep/mac/libmpv_helper.swift',
                            'video/out/cocoa_cb_common.swift',
+                           'video/out/cocoa_cb_embedded.swift',
                            'video/out/mac/gl_layer.swift')
 endif
 if features['cocoa'] and features['vulkan'] and features['swift']

--- a/osdep/mac/app_bridge.h
+++ b/osdep/mac/app_bridge.h
@@ -107,6 +107,7 @@ void cocoa_uninit_media_keys(void);
 void cocoa_set_input_context(struct input_ctx *input_context);
 void cocoa_set_mpv_handle(struct mpv_handle *ctx);
 void cocoa_init_cocoa_cb(void);
+void cocoa_init_embedded_view(int64_t wid);
 // multithreaded wrapper for mpv_main
 int cocoa_main(int argc, char *argv[]);
 

--- a/osdep/mac/app_bridge.m
+++ b/osdep/mac/app_bridge.m
@@ -161,6 +161,11 @@ void cocoa_init_cocoa_cb(void)
     [[AppHub shared] initCocoaCb];
 }
 
+void cocoa_init_embedded_view(int64_t wid)
+{
+[[AppHub shared] initCocoaCbWithView:(__bridge NSView *)(void *)wid];
+}
+
 int cocoa_main(int argc, char *argv[])
 {
     return [(Application *)[Application sharedApplication] main:argc :argv];

--- a/osdep/mac/app_hub.swift
+++ b/osdep/mac/app_hub.swift
@@ -51,10 +51,13 @@ class AppHub: NSObject {
     }
 
     @objc func initMpv(_ mpv: OpaquePointer) {
+
+        log.log = mp_log_new(nil, mp_client_get_log(mpv), "app")
+        log.verbose("AppHub: initMpv enter")
+
         event = EventHelper(self, mpv)
         if let mpv = event?.mpv {
             self.mpv = mpv
-            log.log = mp_log_new(nil, mp_client_get_log(mpv), "app")
             option = OptionHelper(UnsafeMutablePointer(mpv), mp_client_get_global(mpv))
             input.option = option
             DispatchQueue.main.sync { menu = MenuBar(self) }
@@ -76,6 +79,7 @@ class AppHub: NSObject {
     }
 
     @objc func initInput(_ input: OpaquePointer?) {
+        if !isApplication { return }
         log.verbose("Initialising Input")
         self.input.signal(input: input)
     }
@@ -86,6 +90,15 @@ class AppHub: NSObject {
         log.verbose("Initialising CocoaCB")
         DispatchQueue.main.sync {
             self.cocoaCb = self.cocoaCb ?? CocoaCB(mpv_create_client(mpv, "cocoacb"))
+        }
+#endif
+    }
+
+    @objc func initCocoaCbWithView(_ view: NSView) {
+#if HAVE_MACOS_COCOA_CB
+        log.verbose("Initialising CocoaCB (embedded view)")
+        DispatchQueue.main.sync {
+            self.cocoaCb = CocoaCBEmbedded(mpv_create_client(mpv, "cocoacb"), view)
         }
 #endif
     }

--- a/osdep/mac/event_helper.swift
+++ b/osdep/mac/event_helper.swift
@@ -71,11 +71,6 @@ class EventHelper {
     var events: [String: [Int: EventSubscriber]] = [:]
 
     init?(_ appHub: AppHub, _ mpv: OpaquePointer) {
-        if !appHub.isApplication {
-            mpv_destroy(mpv)
-            return nil
-        }
-
         self.appHub = appHub
         self.mpv = mpv
         mpv_set_wakeup_callback(mpv, wakeup, TypeHelper.bridge(obj: self))

--- a/player/main.c
+++ b/player/main.c
@@ -42,6 +42,7 @@
 #include "common/codecs.h"
 #include "common/encode.h"
 #include "options/m_config.h"
+#include "options/m_config_frontend.h"
 #include "options/m_option.h"
 #include "options/m_property.h"
 #include "common/common.h"
@@ -367,6 +368,25 @@ int mp_initialize(struct MPContext *mpctx, char **options)
             return r == M_OPT_EXIT ? 1 : -1;
     }
 
+#if HAVE_COCOA
+
+    if (mpctx->is_cli && opts->vo->WinID > 0)
+    {
+        MP_FATAL(mpctx, "On macOS, window embedding via 'wid' parameter is not supported from the CLI.\n");
+        return -1;
+    }
+
+    if (!mpctx->is_cli && opts->vo->WinID > 0)
+    {
+        MP_INFO(mpctx, "A 'wid' for window embedding is specified. Setting vo=libmpv, which is the only supported way on macOS.\n");
+
+        int r = m_config_set_option_cli(mpctx->mconfig, bstr0("vo"), bstr0("libmpv"), 0);
+        if (r < 0) {
+            MP_WARN(mpctx, "Failed to force vo=libmpv for wid embedding (err=%d)\n", r);
+        }
+    }
+#endif
+
     if (opts->operation_mode == 1) {
         m_config_set_profile(mpctx->mconfig, "builtin-pseudo-gui",
                              M_SETOPT_NO_OVERWRITE);
@@ -411,8 +431,10 @@ int mp_initialize(struct MPContext *mpctx, char **options)
     MP_STATS(mpctx, "start init");
 
 #if HAVE_COCOA
-    mpv_handle *ctx = mp_new_client(mpctx->clients, "mac");
-    cocoa_set_mpv_handle(ctx);
+    if (mpctx->is_cli || opts->vo->WinID > 0) {
+        mpv_handle *ctx = mp_new_client(mpctx->clients, "mac");
+        cocoa_set_mpv_handle(ctx);
+    }
 #endif
 
 #if HAVE_WIN32_SMTC

--- a/video/out/cocoa_cb_embedded.swift
+++ b/video/out/cocoa_cb_embedded.swift
@@ -17,29 +17,21 @@
 
 import Cocoa
 
-class CocoaCB: Common, EventSubscriber {
-    var libmpv: LibmpvHelper
-    var layer: GLLayer?
+class CocoaCBEmbedded: CocoaCB {
+    let externalView: NSView
 
-    var isShuttingDown: Bool = false
-
-    enum State {
-        case uninitialized
-        case needsInit
-        case initialized
-    }
-    var backendState: State = .uninitialized
-
-    init(_ mpv: OpaquePointer) {
-        let log = LogHelper(mp_log_new(UnsafeMutablePointer(mpv), mp_client_get_log(mpv), "cocoacb"))
-        let option = OptionHelper(UnsafeMutablePointer(mpv), mp_client_get_global(mpv))
-        libmpv = LibmpvHelper(mpv, log)
-        super.init(option, log)
-        layer = GLLayer(cocoaCB: self)
-        AppHub.shared.event?.subscribe(self, event: .init(name: "MPV_EVENT_SHUTDOWN"))
+    init(_ mpv: OpaquePointer, _ view: NSView) {
+        externalView = view
+        super.init(mpv)
+        log.verbose("Initialized in embedded mode, NSView: \(view)")
     }
 
-    func preinit(_ vo: UnsafeMutablePointer<vo>) {
+    override func getEmbeddedBackingScaleFactor() -> CGFloat {
+        return externalView.window?.backingScaleFactor ??
+               getCurrentScreen()?.backingScaleFactor ?? 1.0
+    }
+
+    override func preinit(_ vo: UnsafeMutablePointer<vo>) {
         eventsLock.withLock { self.vo = vo }
         input = InputHelper(vo.pointee.input_ctx, option)
 
@@ -51,71 +43,66 @@ class CocoaCB: Common, EventSubscriber {
                 exit(1)
             }
 
-            initView(vo, layer)
+            initEmbeddedView(layer)
             initMisc(vo)
         }
     }
 
-    func uninit() {
-        eventsLock.withLock { self.vo = nil }
-        window?.orderOut(nil)
-        window?.close()
+    func initEmbeddedView(_ layer: CALayer) {
+        log.verbose("Attaching GLLayer to external view")
+
+        view = View(frame: externalView.bounds, common: self)
+        guard let sub = view else {
+            log.error("Unable to allocate sub-view for embedded mode")
+            return
+        }
+
+        sub.autoresizingMask = [.width, .height]
+        sub.wantsLayer = true
+        sub.layer = layer
+        sub.layerContentsPlacement = .scaleProportionallyToFit
+        layer.delegate = sub
+        externalView.addSubview(sub)
+
+        externalView.postsFrameChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(hostViewFrameDidChange(_:)),
+            name: NSView.frameDidChangeNotification,
+            object: externalView)
+
+        let scale = getEmbeddedBackingScaleFactor()
+        layer.contentsScale = scale
+
+        log.verbose("Embedded view initialized with scale factor: \(scale)")
     }
 
-    func reconfig(_ vo: UnsafeMutablePointer<vo>) {
+    override func uninit() {
+        eventsLock.withLock { self.vo = nil }
+        NotificationCenter.default.removeObserver(self,
+                                                  name: NSView.frameDidChangeNotification,
+                                                  object: externalView)
+        view?.removeFromSuperview()
+    }
+
+    override func reconfig(_ vo: UnsafeMutablePointer<vo>) {
         eventsLock.withLock { self.vo = vo }
         if backendState == .needsInit {
             DispatchQueue.main.sync { self.initBackend(vo) }
         } else if option.vo.auto_window_resize {
             DispatchQueue.main.async {
-                self.updateWindowSize(vo)
                 self.layer?.update(force: true)
-                if self.option.vo.focus_on == 2 {
-                    NSApp.activate(ignoringOtherApps: true)
-                }
             }
         }
     }
 
-    func initBackend(_ vo: UnsafeMutablePointer<vo>) {
-        let previousActiveApp = getActiveApp()
-        initApp()
-        initWindow(vo, previousActiveApp)
+    override func initBackend(_ vo: UnsafeMutablePointer<vo>) {
         updateICCProfile()
-        initWindowState()
-
         backendState = .initialized
     }
 
-    func updateWindowSize(_ vo: UnsafeMutablePointer<vo>) {
-        guard let targetScreen = getTargetScreen(forFullscreen: false) ?? NSScreen.main else {
-            log.warning("Couldn't update Window size, no Screen available")
-            return
-        }
-
-        let (wr, _) = getWindowGeometry(forScreen: targetScreen, videoOut: vo)
-        if !(window?.isVisible ?? false) && !(window?.isMiniaturized ?? false) && !NSApp.isHidden {
-            window?.makeKeyAndOrderFront(nil)
-        }
-        layer?.atomicDrawingStart()
-        window?.updateSize(wr.size)
-    }
-
-    override func displayLinkCallback(_ displayLink: CVDisplayLink,
-                                      _ inNow: UnsafePointer<CVTimeStamp>,
-                                      _ inOutputTime: UnsafePointer<CVTimeStamp>,
-                                      _ flagsIn: CVOptionFlags,
-                                      _ flagsOut: UnsafeMutablePointer<CVOptionFlags>) -> CVReturn {
-        libmpv.reportRenderFlip()
-        return kCVReturnSuccess
-    }
-
-    func getEmbeddedBackingScaleFactor() -> CGFloat {
-        return window?.backingScaleFactor ?? 1.0
-    }
-
     override func updateICCProfile() {
-        guard let colorSpace = window?.screen?.colorSpace else {
+        guard let colorSpace = getCurrentScreen()?.colorSpace else {
             log.warning("Couldn't update ICC Profile, no color space available")
             return
         }
@@ -126,8 +113,8 @@ class CocoaCB: Common, EventSubscriber {
         layer?.wantsExtendedDynamicRangeContent = isEdr
     }
 
-    func getColorSpace() -> (Bool, CGColorSpace?) {
-        guard let colorSpace = window?.screen?.colorSpace?.cgColorSpace else {
+    override func getColorSpace() -> (Bool, CGColorSpace?) {
+        guard let colorSpace = getCurrentScreen()?.colorSpace?.cgColorSpace else {
             log.warning("Couldn't retrieve ICC Profile, no color space available")
             return (false, nil)
         }
@@ -182,56 +169,18 @@ class CocoaCB: Common, EventSubscriber {
         return (false, colorSpace)
     }
 
-    override func windowDidEndAnimation() {
-        layer?.update()
-        checkShutdown()
-    }
-
-    override func windowSetToFullScreen() {
-        layer?.update(force: true)
-    }
-
-    override func windowSetToWindow() {
-        layer?.update(force: true)
-    }
-
-    override func windowDidUpdateFrame() {
-        layer?.update(force: true)
-    }
-
-    override func windowDidChangeScreen() {
-        layer?.update(force: true)
-    }
-
-    override func windowDidChangeScreenProfile() {
-        layer?.needsICCUpdate = true
+    override func getCurrentScreen() -> NSScreen? {
+        return externalView.window?.screen ??
+               getTargetScreen(forFullscreen: false) ??
+               NSScreen.main
     }
 
     override func windowDidChangeBackingProperties() {
         layer?.contentsScale = getEmbeddedBackingScaleFactor()
     }
 
-    override func windowWillStartLiveResize() {
-        layer?.inLiveResize = true
-    }
-
-    override func windowDidEndLiveResize() {
-        layer?.inLiveResize = false
-    }
-
-    override func windowDidChangeOcclusionState() {
+    @objc func hostViewFrameDidChange(_ note: Notification) {
         layer?.update(force: true)
-    }
-
-    var controlCallback: mp_render_cb_control_fn = { ( v, ctx, e, request, data ) -> Int32 in
-        let ccb = unsafeBitCast(ctx, to: CocoaCB.self)
-
-        guard let vo = v, let events = e else {
-            ccb.log.warning("Unexpected nil value in Control Callback")
-            return VO_FALSE
-        }
-
-        return ccb.control(vo, events: events, request: request, data: data)
     }
 
     override func control(_ vo: UnsafeMutablePointer<vo>,
@@ -239,46 +188,47 @@ class CocoaCB: Common, EventSubscriber {
                           request: UInt32,
                           data: UnsafeMutableRawPointer?) -> Int32 {
         switch mp_voctrl(request) {
-        case VOCTRL_PREINIT:
-            DispatchQueue.main.sync { self.preinit(vo) }
+        case VOCTRL_GET_WINDOW_ID:
+            let wid = data!.assumingMemoryBound(to: Int64.self)
+            wid.pointee = unsafeBitCast(externalView, to: Int64.self)
             return VO_TRUE
-        case VOCTRL_UNINIT:
-            DispatchQueue.main.async { self.uninit() }
+        case VOCTRL_GET_HIDPI_SCALE:
+            let scaleFactor = data!.assumingMemoryBound(to: CDouble.self)
+            scaleFactor.pointee = Double(getEmbeddedBackingScaleFactor())
             return VO_TRUE
-        case VOCTRL_RECONFIG:
-            reconfig(vo)
+        case VOCTRL_GET_UNFS_WINDOW_SIZE:
+            let sizeData = data!.assumingMemoryBound(to: Int32.self)
+            let size = UnsafeMutableBufferPointer(start: sizeData, count: 2)
+            let rect = externalView.bounds
+
+            if Bool(option.vo.hidpi_window_scale) {
+                size[0] = Int32(rect.size.width)
+                size[1] = Int32(rect.size.height)
+            } else {
+                let scale = getEmbeddedBackingScaleFactor()
+                size[0] = Int32(rect.size.width * scale)
+                size[1] = Int32(rect.size.height * scale)
+            }
+            return VO_TRUE
+        case VOCTRL_SET_UNFS_WINDOW_SIZE:
+            return VO_NOTIMPL
+        case VOCTRL_VO_OPTS_CHANGED:
+            var opt: UnsafeMutableRawPointer?
+            while option.nextChangedOption(property: &opt) {
+                // Skip window-specific options in embedded mode.
+            }
             return VO_TRUE
         default:
-            break
+            return super.control(vo, events: events, request: request, data: data)
         }
-
-        return super.control(vo, events: events, request: request, data: data)
     }
 
-    func shutdown() {
-        isShuttingDown = window?.isAnimating ?? false ||
-                         window?.isInFullscreen ?? false && option.vo.native_fs
-        if window?.isInFullscreen ?? false && !(window?.isAnimating ?? false) {
-            window?.close()
-        }
-        if isShuttingDown { return }
-
+    override func shutdown() {
+        log.verbose("Shutdown")
         uninit()
         uninitCommon()
-        window = nil
-
         layer?.lockCglContext()
         libmpv.uninit()
         layer?.unlockCglContext()
-    }
-
-    func checkShutdown() {
-        if isShuttingDown {
-            shutdown()
-        }
-    }
-
-    func handle(event: EventHelper.Event) {
-        if event.name == String(describing: MPV_EVENT_SHUTDOWN) { shutdown() }
     }
 }

--- a/video/out/mac/gl_layer.swift
+++ b/video/out/mac/gl_layer.swift
@@ -210,7 +210,7 @@ class GLLayer: CAOpenGLLayer {
     }
 
     override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj {
-        contentsScale = cocoaCB.window?.backingScaleFactor ?? 1.0
+        contentsScale = cocoaCB.getEmbeddedBackingScaleFactor()
         return cglContext
     }
 

--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -711,7 +711,16 @@ static void uninit(struct vo *vo)
 static int preinit(struct vo *vo)
 {
 #if HAVE_MACOS_COCOA_CB
-    cocoa_init_cocoa_cb();
+    struct m_config_cache *opts_cache = m_config_cache_alloc(vo, vo->global, &vo_sub_opts);
+    struct mp_vo_opts *opts = opts_cache->opts;
+    MP_VERBOSE(vo, "preinit: WinID:  %" PRIu64 "\n", opts->WinID);
+
+    if (opts->WinID > 0) {
+        // External view embedding mode, WinID is a pointer to an NSView
+        cocoa_init_embedded_view(opts->WinID);
+    } else {
+        cocoa_init_cocoa_cb();
+    }
 #else
     if (vo->probing)
         return -1;


### PR DESCRIPTION
In version 0.37, support for the old cocoa backend had been dropped, which unfortunately also removed the ability of embedding mpv in native applications by specifying a wid - which is still working for all other platforms.

This PR aims to remedy that situation by leveraging the existing cocoa-cb implementation which already has just about everything that it takes and it has been merely about gluing loose ends together and omitting those parts that are specific to standalone application use, like NSApplication and NSWindow.
