### PR TITLE
player/loadfile: save watch later consistently on playlist manipulation

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6168,11 +6168,8 @@ static void cmd_loadfile(void *p)
     node_init(res, MPV_FORMAT_NODE_MAP, NULL);
     node_map_add_int64(res, "playlist_entry_id", entry->id);
 
-    if (action.type == LOAD_TYPE_REPLACE || (action.play && !mpctx->playlist->current)) {
-        if (mpctx->opts->position_save_on_quit) // requested in issue #1148
-            mp_write_watch_later_conf(mpctx);
+    if (action.type == LOAD_TYPE_REPLACE || (action.play && !mpctx->playlist->current))
         mp_set_playlist_entry(mpctx, entry);
-    }
     mp_notify(mpctx, MP_EVENT_CHANGE_PLAYLIST, NULL);
     mp_wakeup_core(mpctx);
 }

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -2145,6 +2145,8 @@ void mp_play_files(struct MPContext *mpctx)
 void mp_set_playlist_entry(struct MPContext *mpctx, struct playlist_entry *e)
 {
     mp_assert(!e || playlist_entry_to_index(mpctx->playlist, e) >= 0);
+    if (mpctx->opts->position_save_on_quit) // requested in issue #1148
+        mp_write_watch_later_conf(mpctx);
     mpctx->playlist->current = e;
     mpctx->playlist->current_was_replaced = false;
     mp_notify(mpctx, MP_EVENT_CHANGE_PLAYLIST, NULL);


### PR DESCRIPTION
loadfile replace is not the only command that will change the current playing file and it is important to preserve watch later, when this happens.