### PR TITLE
mp.input: use unique event handlers for input.get requests

### DIFF
--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -653,8 +653,13 @@ mp.options = { read_options: read_options };
 /**********************************************************************
 *  input
 *********************************************************************/
+var input_handle_counter = 1;
+
 function register_event_handler(t) {
-    mp.register_script_message("input-event", function (type, args) {
+    var handler_id = "input-event/" + input_handle_counter;
+    input_handle_counter += 1;
+
+    mp.register_script_message(handler_id, function (type, args) {
         if (t[type]) {
             args = args ? JSON.parse(args) : [];
             var result = t[type].apply(null, args);
@@ -666,18 +671,19 @@ function register_event_handler(t) {
         }
 
         if (type == "closed")
-            mp.unregister_script_message("input-event");
+            mp.unregister_script_message(handler_id);
     })
+
+    return handler_id;
 }
 
 mp.input = {
     get: function(t) {
-        t.has_completions = t.complete !== undefined
+        t.has_completions = t.complete !== undefined;
+        var handler_id = register_event_handler(t);
 
-        mp.commandv("script-message-to", "console", "get-input", mp.script_name,
-                    JSON.stringify(t));
-
-        register_event_handler(t)
+        mp.commandv("script-message-to", "console", "get-input",
+                    mp.script_name, handler_id, JSON.stringify(t));
     },
     terminate: function () {
         mp.commandv("script-message-to", "console", "disable");

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -17,6 +17,7 @@ License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 
 local utils = require "mp.utils"
 local input = {}
+local handle_counter = 1
 
 local function get_non_callbacks(t)
     local non_callbacks = {}
@@ -31,7 +32,10 @@ local function get_non_callbacks(t)
 end
 
 local function register_event_handler(t)
-    mp.register_script_message("input-event", function (type, args)
+    local handler_id = "input-event/"..handle_counter
+    handle_counter = handle_counter + 1
+
+    mp.register_script_message(handler_id, function (type, args)
         if t[type] then
             local completions, completion_pos, completion_append =
                 t[type](unpack(utils.parse_json(args or "") or {}))
@@ -44,18 +48,19 @@ local function register_event_handler(t)
         end
 
         if type == "closed" then
-            mp.unregister_script_message("input-event")
+            mp.unregister_script_message(handler_id)
         end
     end)
+
+    return handler_id
 end
 
 function input.get(t)
     t.has_completions = t.complete ~= nil
 
+    local handler_id = register_event_handler(t)
     mp.commandv("script-message-to", "console", "get-input",
-                mp.get_script_name(), utils.format_json(get_non_callbacks(t)))
-
-    register_event_handler(t)
+                mp.get_script_name(), handler_id, utils.format_json(get_non_callbacks(t)))
 end
 
 input.select = input.get


### PR DESCRIPTION
This makes changes to mp.input and console.lua so that every input.get
request uses a unique script-message to handle input events.

Previously, making new input.get requests shortly after the termination
of a previous request made by the same script could cause a race
condition where the input handler was closed but the new request
was still being drawn in the UI. This was caused by the `closed` event
for the previous request being received only after the new request was
registered, hence closing the event handler for the new request instead.

In addition, this commit makes the behaviour of calling input.get while
another request is active more consistent. When a new request is
received it overwrites the in-progress request, sending a `closed`
event. However, previously, the `closed` event could not be sent if both
requests came from the same script, as the new request would have
overwritten the event handler. Now, the `closed` event is called
regardless of where the new request comes from.

Edit: this PR has largely been superseded by #17256, but since that PR
requires changes to the `mp.input` interface and this one doesn't, I'll
keep this open until I find out if that PR has interest in being merged.

## Examples

```lua
mp.add_key_binding('KP1', nil, function()
    input.get({
        prompt = 'prompt1 >',
        edited = print,
        submit = function()
            input.get({
                prompt = 'prompt2 >',
                edited = print,
            })
        end
    })
end)

mp.add_key_binding('KP2', nil, function()
    input.get({
        prompt = 'prompt1 >',
        edited = print,
        submit = function()
            mp.add_timeout(0.1, function()
                input.get({
                    prompt = 'prompt2 >',
                    edited = print,
                })
            end)
        end
    })
end)
```
If you use the first keybind specified above you can see that after every
keypress the contents of the input are printed to the console.
After pressing enter, the `submit` callback is run, creating a new prompt.
However, while the new prompt is being drawn on the screen, no callbacks
are being triggered. This is because console.lua not only sent a `submit`
callback, it also sent a `closed` callback which will only be processed
by the event loop once the `submit` callback is done.
Since the `submit` callback creates a new input.get request, overriding
the event handler with the handler for the new request, `close` ends up
closing the new request instead. The second keybind above delays the new
`input.get` request by 0.1 seconds to give the `closed` callback a chance to run first,
and so should work in the current version of mpv.

The changes in this PR mean that this race condition cannot occur, and so
both keybinds behave the same (other than perhaps a small flash caused by the
timeout).

```lua
mp.add_key_binding('KP3', nil, function()
    input.select({
        prompt = 'select1',
        items = {'one', 'two'},
        submit = print,
    })
    input.terminate()
    input.select({
        prompt = 'select2',
        items = {'three', 'four'},
        submit = print,
    })
end)

mp.add_key_binding('KP4', nil, function()
    input.select({
        prompt = 'select1',
        items = {'one', 'two'},
        submit = print,
    })
    input.terminate()
    mp.add_timeout(0.1, function()
        input.select({
            prompt = 'select2',
            items = {'three', 'four'},
            submit = print,
        })
    end)
end)
```
This race condition can also occur when explicitly closing a request with `input.terminate`.
In the first of the above keybinds, the first select prompt is overridden by the second,
which is drawn to the screen. However, the `input.terminate` call triggers a `closed`
event that removes the second select request's event handler. As such, selecting an
item does not print anything to the screen. The second example again uses a timeout
to fix the behaviour on the current version of mpv.

```lua
mp.add_key_binding('KP5', nil, function()
    input.select({
        prompt = 'select1',
        items = {'one', 'two'},
        closed = function() print('select1 closed') end,
        submit = print,
    })
    input.select({
        prompt = 'select2',
        items = {'three', 'four'},
        closed = function() print('select2 closed') end,
        submit = print,
    })
end)
```
Overriding an existing request without first terminating the input does work currently,
as shown by the above keybind. However, the single event handler means that `console.lua`
cannot send a `closed` event to the first select request like it does when a request is overridden
by a request from a different script. The changes in this PR mean that the closed event is sent
for the overridden request regardless of the source.