### PR TITLE
DOCS/man/lua: suggest keep_open for nested mp.input calls

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -929,7 +929,12 @@ REPL.
         the text in the console.
 
     ``keep_open``
-        Whether to keep the console open on submit. Defaults to ``false``.
+        Whether to keep the console open on submit, allowing further input.
+        Defaults to ``false``.
+
+        If calling ``input.get()`` or ``input.select()`` again from inside the
+        ``submit`` callback, setting this option to ``true`` allows a seamless
+        transition without the console closing and reopening.
 
     ``opened``
         A callback invoked when the console is shown. This can be used to
@@ -1025,7 +1030,12 @@ REPL.
         the 1-based index of the selected item.
 
     ``keep_open``
-        Whether to keep the console open on submit. Defaults to ``false``.
+        Whether to keep the console open on submit, allowing further input.
+        Defaults to ``false``.
+
+        If calling ``input.get()`` or ``input.select()`` again from inside the
+        ``submit`` callback, setting this option to ``true`` allows a seamless
+        transition without the console closing and reopening.
 
     Example:
 


### PR DESCRIPTION
Before #17251 keep_open was needed to make nested mp.input calls. Even after that change it is still better to pass it to not show console quickly closing and reopening to the user, so recommend it.

Depends on #17251.