### PR TITLE
mp.input: avoiding race conditions arising from multiple input requests

### DIFF
--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -980,16 +980,18 @@ REPL.
     requests made by other scripts.
 
 ``input.log(message, style, terminal_style)``
-    Add a line to the log buffer. ``style`` can contain additional ASS tags to
-    apply to ``message``, and ``terminal_style`` can contain escape sequences
-    that are used when the console is displayed in the terminal.
+    Add a line to the log buffer of the latest ``input.get()`` request.
+    ``style`` can contain additional ASS tags to apply to ``message``,
+    and ``terminal_style`` can contain escape sequences that are used
+    when the console is displayed in the terminal.
 
 ``input.log_error(message)``
-    Helper to add a line to the log buffer with the same color as the one used
+    Helper to add an error line to the log buffer of the latest ``input.get()``
+    request. The line is styled with the same color as the one used
     for commands that error. Useful when the user submits invalid input.
 
 ``input.set_log(log)``
-    Replace the entire log buffer.
+    Replace the entire log buffer of the latest ``input.get()`` request.
 
     ``log`` is a table of strings, or tables with ``text``, ``style`` and
     ``terminal_style`` keys.

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1710,7 +1710,7 @@ mp.register_script_message("get-input", function (args)
     else
         selectable_items = nil
         unbind_mouse()
-        id = args.id or args.client_name .. prompt
+        id = args.id
         log_offset = 0
         completion_buffer = {}
         autoselect_completion = args.autoselect_completion
@@ -1740,8 +1740,13 @@ end)
 
 -- Add a line to the log buffer
 mp.register_script_message("log", function (message)
-    local log_buffer = log_buffers[id]
-    message = utils.parse_json(message)
+    message = utils.parse_json(message or "")
+    if not message or not message.log_id then
+        return
+    end
+
+    local log_buffer = log_buffers[message.log_id]
+    if not log_buffer then return end
 
     log_buffer[#log_buffer + 1] = {
         text = message.text,
@@ -1754,7 +1759,7 @@ mp.register_script_message("log", function (message)
         table.remove(log_buffer, 1)
     end
 
-    if not open then
+    if not open or message.log_id ~= id then
         return
     end
 
@@ -1770,9 +1775,13 @@ mp.register_script_message("log", function (message)
     end
 end)
 
-mp.register_script_message("set-log", function (log)
+mp.register_script_message("set-log", function (log_id, log)
+    if not log_id or not log then
+        return
+    end
+
     log = utils.parse_json(log)
-    log_buffers[id] = {}
+    log_buffers[log_id] = {}
 
     for i = 1, #log do
         if type(log[i]) == "table" then
@@ -1789,7 +1798,9 @@ mp.register_script_message("set-log", function (log)
         end
     end
 
-    render()
+    if log_id == id then
+        render()
+    end
 end)
 
 mp.register_script_message("complete", function (message)


### PR DESCRIPTION
This PR builds on the changes proposed in #17251, I am submitting this now for comments.

The `mp.input` utilities are extremely useful, however the library currently does not provide the tools to safely use the various methods without creating code that is vulnerable to race conditions. Most of these race conditions are relatively uncommon, requiring multiple input requests to be made in close succession to each other. However, as the library becomes more popular and developers start (ab)using it more, these conditions become more likely to occur. This PR is just to point out where these data races currently occur and to present and discuss some possible solutions. @guidocella keen to hear your thoughts, especially.

I have identified three parts of the code where race conditions can occur:

1. When creating new input requests shortly after terminating an old one. This is caused by the use of a single event handler per script. I discussed this issue and presented a solution in #17251. That commit is also included in this PR as the other commits rely on it.
2. When using `input.terminate()`.
3. When sending log messages.

Edit:
4. When responding to autocomplete events.

## `input.terminate()`
### Problem
According to the discussions I've had and the examples I have seen, the primary suggested usecase for `input.terminate()` is to close the input request that a client is using once it no longer needs any further input. However, `input.terminate()` does not specify which input it closes, it just closes whatever input is open. This means that if a second client creates a new input request at approximately the same time that the first client calls terminate on their input, the terminate request from the first client may arrive after the second client has opened their input prompt, immediately terminating it. This can be rather easily tested with the following two scripts:
```lua
local input = require 'mp.input'

mp.add_key_binding('KP9', nil, function()
    input.get({
        prompt = 'prompt1',
        keep_open = true,
        submit = function()
            mp.commandv('script-message', 'test-run')
            local i = 0
            while (i < 100000) do
                i = i+1
            end
            input.terminate()
        end,
        closed = function() print('closed prompt1') end
    })
end)
```

```lua
local input = require 'mp.input'

mp.register_script_message('test-run', function()
    input.get({
        prompt = 'prompt2',
        edited = print,
        closed = function() print('closed prompt2') end
    })
end)
```
In the above examples, whether the second prompt ends up being displayed to the user depends on the length of the while loop, a race condition.

Obviously this is a very contrived example, but there are scenarios where this is viable. For example, the first script could easily be a user configured `input.select` menu of arbitrary commands (e.g., a more modern version of [this](https://github.com/jonniek/mpv-menu)), which a user has configured to trigger another input dialog.

### Solution
~An easy way to mitigate this issue is to take some queues from `mp.command_native_async()` and `mp.abort_async_command()` and use a unique `id` value for terminations. Take the below example:~
```lua
local id, timer
id = input.get({
    prompt = "Open File:\n> ",
    history_path = "~~state/open-file-history",
    opened = function()
        timer = mp.add_timeout(20, function()
            input.terminate(id)
        end)
    end,
    edited = function()
        timer:kill()
        timer:resume()
    end,
    submit = function(path)
        mp.commandv("loadfile", path)
    end
})
```
~We use an opaque `id` value returned by `input.get` or `input.select` and pass it into `input.terminate()`. The above example uses this to implement a timeout on the request. Normally, this would require significantly more guard rails to prevent `input.terminate()` from being called after this input has been closed, but with ids it's trivial.~

~I propose we add these return values for `input.get` and `input.select` and optionally allow them to be passed into `input.terminate()`, and update the documentation to propose the above approach as best practice. That way, no existing scripts break (a nil argument to `input.terminate()` still clears everything), but future scripts that follow best practice avoid causing race conditions. It's also fully backwards compatible; if a script using these ids were run on an older version of mpv, it would be akin to passing a nil value into `input.terminate()`, which means things will just work as they do now.~

This PR already does these things.

### Edit: New Solution

By caching the id of the latest input request, we can avoid these race conditions without any user facing changes.

## Logs
### Problem
The problem with the logs is basically the same as with terminate; the logs operate on whatever input happens to be open even if it's not what the client might expect. This is trivially easy to test:

```lua
mp.add_timeout(0, function()
    while(true) do
        print('hey!!!!!!')
    end
end)
```
```lua
mp.add_key_binding('Ctrl+Home', nil, function()
    input.get({
        prompt = 'prompt1'
    })
end)
```
Launch mpv, open `commands.lua` to see the spam in the console output, then use Ctrl+Home to replace `commands.lua` with our second prompt. You should see that several of the `hey!!!!!` spam makes it into the logs of the new request.

### Solution
~I imagine that the way to avoid this issue would be to explicitly specify the log id of logs rather than rely on the correct logger being active in `console.lua`. I haven't made any changes to this currently, as the log format seems a little more strictly defined and I wasn't sure about the best way to add the id information (Hence the RFC).~

This PR now caches the id of the latest ``input.get`` request and sends it to `console.lua`, ensuring that the logs are added to the correct input buffers.