### PR TITLE
vo: allow VOs to request waiting before advancing frames

### DIFF
--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -533,6 +533,7 @@ bool vo_is_ready_for_frame(struct vo *vo, int64_t next_pts);
 bool vo_is_visible(struct vo *vo);
 void vo_queue_frame(struct vo *vo, struct vo_frame *frame);
 void vo_wait_frame(struct vo *vo);
+void vo_wait_on_vo(struct vo *vo, bool wait);
 bool vo_still_displaying(struct vo *vo);
 void vo_request_wakeup_on_done(struct vo *vo);
 bool vo_has_frame(struct vo *vo);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2107,6 +2107,7 @@ static void image_description_failed(void *data, struct wp_image_description_v1 
     MP_VERBOSE(wl, "Image description failed: %d, %s\n", cause, msg);
     wp_color_management_surface_v1_unset_image_description(wl->color_surface);
     wp_image_description_v1_destroy(image_description);
+    wl->image_description_processed = true;
 }
 
 static void image_description_ready2(void *data, struct wp_image_description_v1 *image_description,
@@ -2117,6 +2118,7 @@ static void image_description_ready2(void *data, struct wp_image_description_v1 
                                                          WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL);
     MP_TRACE(wl, "Image description set on color surface.\n");
     wp_image_description_v1_destroy(image_description);
+    wl->image_description_processed = true;
 }
 
 static void image_description_ready(void *data, struct wp_image_description_v1 *image_description,
@@ -3530,6 +3532,7 @@ static void set_color_management(struct vo_wayland_state *wl)
         wp_image_description_creator_params_v1_set_max_fall(image_creator_params, lrintf(hdr.max_fall));
     }
     struct wp_image_description_v1 *image_description = wp_image_description_creator_params_v1_create(image_creator_params);
+    wl->image_description_processed = false;
     wp_image_description_v1_add_listener(image_description, &image_description_listener, wl);
 #endif
 }

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -95,6 +95,7 @@ struct vo_wayland_state {
     struct wp_color_management_surface_feedback_v1 *color_surface_feedback;
     struct wp_image_description_creator_icc_v1 *icc_creator;
     struct mp_image_params target_params;
+    bool image_description_processed;
     bool supports_parametric;
     bool supports_display_primaries;
     int primaries_map[PL_COLOR_PRIM_COUNT];


### PR DESCRIPTION
This is essentially for vo_dmabuf_wayland, but there is a race condition during initialization where we should wait on an event from the compositor to set the appropriate description for the image (namely for color management) before flipping the page. Previously, there was an off-by-one frame difference which resulted in the initial frame not being appropriately color managed. Fix this by telling the core render loop that it is not ready for the next frame. This keeps the frame queue from advancing and allows the backend to process events appropriately until it signals that it is ready.