### PR TITLE
wayland: warn when no seats are available

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -4282,6 +4282,10 @@ bool vo_wayland_init(struct vo *vo)
         goto err;
     }
 
+    if (wl_list_empty(&wl->seat_list))
+        MP_WARN(wl, "No input seats found or compositor doesn't support %s, "
+                    "input devices won't work\n", wl_seat_interface.name);
+
     /* Can't be initialized during registry due to multi-protocol dependence */
     if (create_viewports(wl))
         goto err;


### PR DESCRIPTION
We warn that scrolling won't work if wl_seat version >= 5 isn't available, so it makes sense to also warn when no seats are available or no wl_seat is available
