### PR TITLE
video/out/gpu/video: change `sdr_adjust_gamma` default to yes

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7372,13 +7372,13 @@ them.
     ``sRGB``, ``gamma2.2`` or ``bt.1886`` will be rendered as-is. If set to
     ``yes``, it will be converted based on the available metadata.
 
-    ``auto`` (default) behaves like ``no``, except when ``--target-trc`` is
+    ``auto`` behaves like ``no``, except when ``--target-trc`` is
     explicitly set, in which case it behaves like ``yes``.
 
     Generally it's recommended to enable this option, if you can ensure that
     both source and target metadata is correct.
 
-    (Only for ``--vo=gpu-next``)
+    The default is ``yes``. (Only for ``--vo=gpu-next``)
 
 ``--treat-srgb-as-power22=<no|input|output|both|auto>``
     When enabled, sRGB is (de)linearized using a pure power 2.2 curve instead of

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -409,6 +409,7 @@ static const struct gl_video_opts gl_video_opts_def = {
     .early_flush = -1,
     .shader_cache = true,
     .hwdec_interop = "auto",
+    .sdr_adjust_gamma = 1, // yes
     .treat_srgb_as_power22 = 1|2|4, // auto
 };
 


### PR DESCRIPTION
Currently, Windows would enable SDR ACM by default on wide gamut monitors, while macOS and Wayland + Vulkan also always do color space conversion. So enable `sdr_adjust_gamma` by default to make it more suitable for most cases.