### PR TITLE
sub/sd_sbr: pass track language to `sbr_load_text`

### DIFF
--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -75,6 +75,7 @@ struct dec_sub {
 
     struct mp_codec_params *codec;
     double start, end;
+    char *lang;
 
     double last_vo_pts;
     struct sd *sd;
@@ -171,6 +172,7 @@ static struct sd *init_decoder(struct dec_sub *sub)
             .order = sub->order,
             .attachments = sub->attachments,
             .codec = sub->codec,
+            .lang = sub->lang,
             .preload_ok = true,
         };
 
@@ -204,6 +206,7 @@ struct dec_sub *sub_create(struct mpv_global *global, struct track *track,
         .shared_opts_cache = m_config_cache_alloc(sub, global, &mp_subtitle_shared_sub_opts),
         .sh = track->stream,
         .codec = track->stream->codec,
+        .lang = track->lang,
         .attachments = talloc_steal(sub, attachments),
         .play_dir = 1,
         .order = order,

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -29,6 +29,7 @@ struct sd {
 
     struct attachment_list *attachments;
     struct mp_codec_params *codec;
+    const char *lang;
 
     // Set to false as soon as the decoder discards old subtitle events.
     // (only needed if sd_functions.accept_packets_in_advance == false)

--- a/sub/sd_sbr.c
+++ b/sub/sd_sbr.c
@@ -148,7 +148,7 @@ static void decode(struct sd *sd, struct demux_packet *packet)
         packet->buffer,
         packet->len,
         fmt,
-        NULL
+        sd->lang
     );
 
     // Since `demux_sbr` only ever sends us one packet,


### PR DESCRIPTION
The language hint is required for *correct* handling of RTL in srv3 so
provide the best-effort guess from the subtitle track.

Without this hint some RTL paragraphs are going to be wrongly assumed
LTR and reorder incorrectly. Additionally, subrandr may soon start
treating srv3 segments as `inline-block`s which means guessing is not
going to be possible anymore (at least as part of unicode bidi algorithm).

---

This will alleviate the issue from https://github.com/mpv-player/mpv/issues/12978 when using srv3 subtitles (careful wording to not close that issue in case we still want to track it for other formats). I tested it with the example subtitle line provided in that issue (manually transplanted to srv3) and it seemed to work.

Currently does nothing. With https://github.com/afishhh/subrandr/pull/139 it gets parsed as a [`LanguageIdentifier`](https://docs.rs/icu_locale/latest/icu_locale/struct.LanguageIdentifier.html) (Unicode BCP47), canonicalized, and its directionality used for base paragraph direction (`direction` CSS property on root inline box of srv3 lines).

Also: sometimes `yt-dlp` attaches weird stuff like `en-sAO4vbAqVZo` or `en-sAO4vbAqVZo` which will fail to even be detected as a language tag by mpv, not sure what to do about that (even if it did it would fail in subrandr, could probably special case in both but let's not complicate for now?).