### PR TITLE
ci/mac: install ffmpeg-full with homebrew when available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,9 +295,11 @@ jobs:
           else
             brew update
           fi
+          if brew list ffmpeg &> /dev/null; then brew unlink ffmpeg; fi
           brew install -q autoconf automake pkgconf libtool python freetype fribidi little-cms2 \
-            luajit libass ffmpeg meson rust uchardet mujs libplacebo molten-vk vulkan-loader vulkan-headers \
+            luajit libass ffmpeg-full meson rust uchardet mujs libplacebo molten-vk vulkan-loader vulkan-headers \
             libarchive libbluray libcaca libcdio-paranoia libdvdnav rubberband zimg
+          brew link ffmpeg-full
 
       - name: Build with meson
         id: build


### PR DESCRIPTION
homebrew slimmed down their ffmpeg formula and stripping it off some essential functionality.

~~use ffmpeg-full instead when available. this is a new formula and not available on older homebrew version.~~ additionally, this is keg only formula and not automatically symlinked system wide. make sure ffmpeg is not installed in parallel and install ffmpeg-full system wide.
