### PR TITLE
osdep/language-win: fix use of GetUserPreferredUILanguages()

### DIFF
--- a/osdep/language-win.c
+++ b/osdep/language-win.c
@@ -39,7 +39,7 @@ char **mp_get_user_langs(void)
     char **ret = NULL;
     size_t ret_count = 0;
     wchar_t *buf = NULL;
-    ULONG size, count;
+    ULONG size = 0, count;
 
     if (!GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &count, NULL, &size))
         goto done;


### PR DESCRIPTION
Commit baf2fd2f281745140b90baf80a4c7a1af05490e5 fixed this for 2nd call to GetSystemPreferredUILanguages(), but apparently regressed the 1st call, duh.

To retrieve the size both buffer has to be NULL and size 0.

Memory has a lot of zeros, because it has been working quite consistently on CI.
