### PR TITLE
wayland: move info_done variable to vo_wayland

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -103,6 +103,7 @@ struct vo_wayland_state {
     void *icc_file;
     uint32_t icc_size;
     struct pl_color_space preferred_csp;
+    bool image_description_info_done;
 
     /* color-representation */
     struct wp_color_representation_manager_v1 *color_representation_manager;


### PR DESCRIPTION
vo_wayland_preferred_description_info is destroyed after info_done, so obviously we can't store it here. This causes a use-after-free. Embarrassing mistake

Fixes: 7a7d871d0a6e19f5e25190709b0fe6370460d846
