### PR TITLE
player/playloop: fix OSC updates during frame stepping

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -216,14 +216,9 @@ void add_step_frame(struct MPContext *mpctx, int dir, bool use_seek)
 {
     if (!mpctx->vo_chain)
         return;
-    if (dir > 0 && !use_seek) {
-        mpctx->step_frames += dir;
-        set_pause_state(mpctx, false);
-    } else {
-        if (!mpctx->hrseek_active) {
-            queue_seek(mpctx, MPSEEK_FRAMESTEP, dir, MPSEEK_VERY_EXACT, 0);
-            set_pause_state(mpctx, true);
-        }
+    if (!mpctx->hrseek_active) {
+        queue_seek(mpctx, MPSEEK_FRAMESTEP, dir, MPSEEK_VERY_EXACT, 0);
+        set_pause_state(mpctx, true);
     }
 }
 


### PR DESCRIPTION
Disclaimer: I am not a coder and used an AI/LLM to help with this.

* Use precise seeks instead of the step counter for frame-forward stepping, avoiding temporary pause state changes that caused OSC update problems.

* As a trade-off, frame-forward stepping is now more performance intensive than the previous frame-stepping approach.

* Hold-to-play functionality remains unaffected.

Previously, stepping forward frame by frame could cause the OSC to become stuck, indicated by the pause icon remaining visible and the timecode not updating. The issue would persist until another frame action was performed or the OSC was hidden and shown again.

Steps to reproduce:

1. Show the OSC by moving the mouse pointer over the player.

2. Pause playback.

3. Press the frame-forward shortcut key once.

4. The pause icon remains visible and the timecode does not update.

5. Hide and show the OSC by moving the mouse pointer away from and back over the player.

6. The play icon is shown and the timecode is updated.

If the issue does not occur, repeat steps 3–5.
