### PR TITLE
vo: wake up core when VO requests redraw

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1166,7 +1166,7 @@ static MP_THREAD_VOID vo_thread(void *ptr)
                 wakeup_core(vo);
             }
         }
-        if (vo->want_redraw && !in->want_redraw) {
+        if (vo->want_redraw) {
             in->want_redraw = true;
             wakeup_core(vo);
         }


### PR DESCRIPTION
a74a324 returned responsibility of video redraw back to playloop. The playloop is only run if something wakes up the core.

However, the logic for VO requested redraw only wakes up the core when in->want_redraw is false, which is only resetted by vo_redraw, called from the core. This creates a situation where it can never wake up the core, so redrawing never happens even when VO requests it.

efc44d0 caused the issue to surface because it also throttles VO requested redraws, and in some cases results in the above behavior.

Fix this by always waking up core when the VO requests redraw.

Fixes: #17292