### PR TITLE
options/options: add several audio extentions

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -1080,7 +1080,8 @@ static const struct MPOpts mp_default_opts = {
     },
     .audio_exts = (char *[]){
         "aac", "ac3", "aiff", "ape", "au", "dts", "eac3", "flac", "m4a", "mka",
-        "mp3", "oga", "ogg", "ogm", "opus", "thd", "wav", "wma", "wv", NULL
+        "mp1", "mp2", "mp3", "mpc", "oga", "ogg", "ogm", "opus", "tak", "thd",
+        "tta", "wav", "wma", "wv", NULL
     },
     .image_exts = (char *[]){
         "avif", "bmp", "gif", "heic", "heif", "j2k", "jp2", "jpeg", "jpg",


### PR DESCRIPTION
mp1 - MPEG-1 Audio Layer I
mp2 - MPEG-1 Audio Layer II
mpc - Musepack
tak - Tom's lossless Audio Kompressor
tta - The True Audio

Fixes: https://github.com/mpv-player/mpv/issues/17289
