### PR TITLE
osdep/language-win: remove use of GetSystemPreferredUILanguages

### DIFF
--- a/osdep/language-win.c
+++ b/osdep/language-win.c
@@ -48,14 +48,6 @@ char **mp_get_user_langs(void)
     if (GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &count, buf, &size))
         apppend_langs(&ret, &ret_count, buf, count);
 
-    size = 0;
-    if (!GetSystemPreferredUILanguages(MUI_LANGUAGE_NAME, &count, NULL, &size))
-        goto done;
-
-    MP_TARRAY_GROW(NULL, buf, size);
-    if (GetSystemPreferredUILanguages(MUI_LANGUAGE_NAME, &count, buf, &size))
-        apppend_langs(&ret, &ret_count, buf, count);
-
 done:
     if (ret_count)
         MP_TARRAY_APPEND(NULL, ret, ret_count, NULL);

--- a/test/libmpv_test_track_selection.c
+++ b/test/libmpv_test_track_selection.c
@@ -82,10 +82,6 @@ static bool have_english_locale(void)
     if (any_starts_with(buf, count, L"en"))
         return true;
 
-    size = _countof(buf);
-    if (!GetSystemPreferredUILanguages(MUI_LANGUAGE_NAME, &count, buf, &size))
-        fail("GetSystemPreferredUILanguages failed: %#lx\n", GetLastError());
-
     if (any_starts_with(buf, count, L"en"))
         return true;
 


### PR DESCRIPTION
The system preferred language is the language used during Windows install. It doesn't have much purpose except that it is the backend language for core Windows internals. All user facing dialogs and text should follow the user preferred language, as this is what the user selected and uses on daily basis.

It makes no sense to include system language in track selection.