### PR TITLE
vulkan: set pl_vulkan_swapchain_params.alpha_bits if alpha needed

### DIFF
--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -425,6 +425,9 @@ bool ra_vk_ctx_init(struct ra_ctx *ctx, struct mpvk_ctx *vk,
         .surface = vk->surface,
         .present_mode = preferred_mode,
         .swapchain_depth = ctx->vo->opts->swapchain_depth,
+#if PL_API_VER >= 359
+        .alpha_bits = ctx->opts.want_alpha ? 8 : 0,
+#endif
     };
 
     if (p->opts->swap_mode >= 0) // user override


### PR DESCRIPTION
We can try to calculate specific amount of bit required in the future, and also populate color_bits field but for now this should suffice.

Ref: https://code.videolan.org/videolan/libplacebo/-/merge_requests/767
