### PR TITLE
vd_lavc: add hwdec-min-height option to limit hw decoding

### DIFF
--- a/DOCS/interface-changes/hwdec-default.txt
+++ b/DOCS/interface-changes/hwdec-default.txt
@@ -1,0 +1,1 @@
+add `hwdec-min-size` and set its default to 360

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -1556,6 +1556,13 @@ Video
     older hardware. d3d11va can always use ``yuv420p``, which uses an opaque
     format, with likely no advantages.
 
+``--hwdec-min-size=<number>``
+    Minimum size in pixels for hwdec to be used. Hardware decoding will only be
+    attempted if either the height or width is equal to or greater than this
+    value. This can be used to avoid using hwdec for small videos where CPU
+    decoding may be more efficient than hardware decoding. Setting to 0 disables
+    this check. (Default: 360)
+
 ``--cuda-decode-device=<auto|0..>``
     Choose the GPU device used for decoding when using the ``cuda`` or
     ``nvdec`` hwdecs with the OpenGL GPU backend, and with the ``cuda-copy``


### PR DESCRIPTION
Set to 360 by default. Only attempt to use hardware accelerated video decoding if the video height is more than 360. This is taken from Chromium*, basically using CPU decoding should be more efficient if the video resolution is this small.

* https://github.com/chromium/chromium/blob/a2575bd8b31fb964352efd9cab974ef72db6fe55/media/filters/decoder_selector.cc#L49-L63
