### PR TITLE
opengl/context: require swap_buffers param for FenceSync

### DIFF
--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -79,7 +79,6 @@ struct priv {
     struct mp_log *log;
     struct ra_ctx_params params;
     struct opengl_opts *opts;
-    struct ra_swapchain_fns fns;
     GLuint main_fb;
     struct ra_tex *wrapped_fb; // corresponds to main_fb
     // for debugging:
@@ -130,6 +129,7 @@ bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_ctx_params params)
     struct ra_swapchain *sw = ctx->swapchain = talloc_ptrtype(NULL, sw);
     *sw = (struct ra_swapchain) {
         .ctx = ctx,
+        .fns = &ra_gl_swapchain_fns,
     };
 
     struct priv *p = sw->priv = talloc_ptrtype(sw, p);
@@ -138,10 +138,7 @@ bool ra_gl_ctx_init(struct ra_ctx *ctx, GL *gl, struct ra_ctx_params params)
         .log    = ctx->log,
         .params = params,
         .opts   = mp_get_config_group(p, ctx->global, &opengl_conf),
-        .fns    = ra_gl_swapchain_fns,
     };
-
-    sw->fns = &p->fns;
 
     if (!gl->version && !gl->es)
         return false;


### PR DESCRIPTION
Commits 8854c742711705be1fcfcc6a5875960a3e2593dc and 5ae0e0ff9a6974453c1aba41ddc8442d12ac9264 eliminated the external swapchain API that the render backend (vo_libmpv) was previously using. However, it was missed that this was being used to skip the gl->FenceSync calls and that logic change was not properly accounted for. This meant that vo_libmpv would leak fences since ra_gl_ctx_swap_buffers is never called to clean them up.

Fix this by making sure the ra_ctx_params have swap_buffers defined before calling gl->FenceSync. All platforms are required to implement this anyway with the exception of vo_libmpv since it's a funny special case. Fixes #17217.
