### PR TITLE
wayland: don't send coef/range for rgb formats in color-representation

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -2327,6 +2327,10 @@ static void supported_coefficients_and_ranges(void *data, struct wp_color_repres
     struct vo_wayland_state *wl = data;
     int offset = range == WP_COLOR_REPRESENTATION_SURFACE_V1_RANGE_FULL ? 0 : PL_COLOR_SYSTEM_COUNT;
     switch (coefficients) {
+    case WP_COLOR_REPRESENTATION_SURFACE_V1_COEFFICIENTS_IDENTITY:
+        wl->coefficients_map[PL_COLOR_SYSTEM_RGB] = WP_COLOR_REPRESENTATION_SURFACE_V1_COEFFICIENTS_IDENTITY;
+        wl->range_map[PL_COLOR_SYSTEM_RGB + offset] = range;
+        break;
     case WP_COLOR_REPRESENTATION_SURFACE_V1_COEFFICIENTS_BT709:
         wl->coefficients_map[PL_COLOR_SYSTEM_BT_709] = WP_COLOR_REPRESENTATION_SURFACE_V1_COEFFICIENTS_BT709;
         wl->range_map[PL_COLOR_SYSTEM_BT_709 + offset] = range;


### PR DESCRIPTION
All (except identity) [coefficients](https://wayland.app/protocols/color-representation-v1#wp_color_representation_surface_v1:enum:coefficients) are only "Compatible with pixel formats of the YCbCr family."

is limited rgb a thing here?