### PR TITLE
Use a wrapper script as the entrypoint in OSX bundle

### DIFF
--- a/TOOLS/osxbundle/README.md
+++ b/TOOLS/osxbundle/README.md
@@ -1,0 +1,22 @@
+# macOS Bundle
+
+This directory contains the skeleton structure for the macOS application bundle.
+
+## Wrapper Script
+
+The `mpv-wrapper` script in `mpv.app/Contents/MacOS/` serves as the entry point for the mpv application. This allows for:
+
+1. **Specifying default command line arguments**: Edit the `DEFAULT_ARGS` variable in the wrapper script to add default arguments that will be passed to mpv on every launch.
+
+2. **Maintaining compatibility**: The wrapper ensures that arguments passed when opening files (e.g., via double-click or drag-and-drop) are still properly forwarded to mpv.
+
+### Usage
+
+To customize default arguments for your mpv.app bundle:
+
+1. Before running `osxbundle.py`, edit `TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper`
+2. Set the `DEFAULT_ARGS` variable to your desired command line options
+3. Example: `DEFAULT_ARGS="--force-window --keep-open"`
+4. Run `osxbundle.py` to create the bundle with your customized wrapper
+
+The `Info.plist` is configured to use `mpv-wrapper` as the `CFBundleExecutable`, which means the wrapper script will be executed when the app is launched.

--- a/TOOLS/osxbundle/mpv.app/Contents/Info.plist
+++ b/TOOLS/osxbundle/mpv.app/Contents/Info.plist
@@ -117,7 +117,7 @@
       </dict>
     </array>
     <key>CFBundleExecutable</key>
-    <string>mpv</string>
+    <string>mpv-wrapper</string>
     <key>CFBundleIconFile</key>
     <string>icon</string>
     <key>CFBundleIconName</key>

--- a/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper
+++ b/TOOLS/osxbundle/mpv.app/Contents/MacOS/mpv-wrapper
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Wrapper script for mpv on macOS
+# This script allows for specifying default command line arguments
+# while still accepting arguments passed when opening files
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Path to the actual mpv binary
+MPV_BINARY="$SCRIPT_DIR/mpv"
+
+# Default arguments can be specified here
+# Example: DEFAULT_ARGS="--force-window --keep-open"
+DEFAULT_ARGS=""
+
+# Execute mpv with default arguments followed by any passed arguments
+# Note: DEFAULT_ARGS is intentionally unquoted to allow proper argument splitting
+if [ -n "$DEFAULT_ARGS" ]; then
+    # shellcheck disable=SC2086
+    exec "$MPV_BINARY" $DEFAULT_ARGS "$@"
+else
+    exec "$MPV_BINARY" "$@"
+fi


### PR DESCRIPTION
This pull request improves the macOS application bundle for mpv by introducing a wrapper script as the new entry point. This allows users to specify default command line arguments for mpv launches and ensures compatibility with file opening methods on macOS. The documentation has also been updated to explain how to customize the wrapper.