### PR TITLE
ci/macos: don't set MACOSX_DEPLOYMENT_TARGET to empty string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,11 +303,13 @@ jobs:
       - name: Build with meson
         id: build
         run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            export MACOSX_DEPLOYMENT_TARGET="${{ matrix.target }}"
+          fi
           ./ci/build-macos.sh
         env:
           TRAVIS_OS_NAME: "${{ matrix.os }}"
           SWIFT_FLAGS: "${{ matrix.swift }}"
-          MACOSX_DEPLOYMENT_TARGET: "${{ matrix.target }}"
 
       - name: Create App Bundle
         if: ${{ matrix.arch != 'test' }}


### PR DESCRIPTION
Fixes:
error: failed to parse deployment target specified in MACOSX_DEPLOYMENT_TARGET: cannot parse integer from empty string