### PR TITLE
player/command: fix repeatable frame stepping with the seek argument

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5888,8 +5888,8 @@ static void cmd_frame_step(void *p)
     if (flags == 1) {
         // frame-step command has on_updown set so it is called on both down
         // and up, but stepping should only be triggered when it matches the
-        // emit_on_up flag.
-        if (cmd->cmd->is_up == cmd->cmd->emit_on_up)
+        // emit_on_up flag or if the command is repeated.
+        if (cmd->cmd->repeated || cmd->cmd->is_up == cmd->cmd->emit_on_up)
             add_step_frame(mpctx, frames, true);
     } else {
         if (cmd->cmd->is_up) {


### PR DESCRIPTION
730062b5103f40cbd90af27f54e35705548a1cb1 fixed the problem with mouse buttons but unfortunately we forgot to include repeated commands in the condition. This effectively made any variant of "frame-step X seek" unrepeatable even though it was supposed to be. So just allow those in add_step_frame too.

Fixes #17348.
