### PR TITLE
select.lua: always observe --osd-playlist-entry

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -1015,12 +1015,13 @@ local function clamp_submenu(submenu, max, cmd)
 end
 
 local function playlist()
+    local show = get("osd-playlist-entry")
+
     if not get("playlist") then
         return
     end
 
     local items = {}
-    local show = get("osd-playlist-entry")
 
     for i, entry in ipairs(get("playlist")) do
         items[i] = {


### PR DESCRIPTION
The playlist submenu does not update in this edge case:

- Have a playlist-count > 99 on the first vo-configured. This makes playlist() return before observing --osd-playlist-entry.
- Remove playlist entries until the count is < 100
- Change --osd-playlist-entry
- Show the playlist submenu before changing the playlist