### PR TITLE
mp.input: deprecate log_error()

### DIFF
--- a/DOCS/interface-changes/log-error.txt
+++ b/DOCS/interface-changes/log-error.txt
@@ -1,0 +1,1 @@
+deprecate `mp.input.log_error()`

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -204,8 +204,6 @@ string/boolean/number)
 
 ``mp.input.log(message, style)``
 
-``mp.input.log_error(message)``
-
 ``mp.input.set_log(log)``
 
 ``exit()`` (global)

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -990,11 +990,6 @@ REPL.
     and ``terminal_style`` can contain escape sequences that are used
     when the console is displayed in the terminal.
 
-``input.log_error(message)``
-    Helper to add an error line to the log buffer of the latest ``input.get()``
-    request. The line is styled with the same color as the one used
-    for commands that error. Useful when the user submits invalid input.
-
 ``input.set_log(log)``
     Replace the entire log buffer of the latest ``input.get()`` request.
 

--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -715,6 +715,8 @@ mp.input = {
                    }));
     },
     log_error: function (message) {
+        mp.msg.warn("log_error is deprecated and will be removed.")
+
         mp.commandv("script-message-to", "console", "log", JSON.stringify({
                         log_id: latest_log_id,
                         text: message,

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -102,6 +102,8 @@ function input.log(message, style, terminal_style)
 end
 
 function input.log_error(message)
+    mp.msg.warn("log_error is deprecated and will be removed.")
+
     mp.commandv("script-message-to", "console", "log", utils.format_json({
                     log_id = latest_log_id,
                     text = message,


### PR DESCRIPTION
This was a mistake. It's too situational and it's not worth complicating the API and every mp.input client with it. It made some sense before I implemented input.select() because you could use input.get() to input a choice and validate it, but in general for input.get() clients it's better to show an error with input.set_log() instead of adding new lines to the log everytime. This is what e.g.
https://framagit.org/Midgard/mpv-subber/-/blob/master/subber.lua does.

So this is only marginally useful for REPL scripts that keep adding lines to the log, and the only such scripts are commands.lua and my lua-repl.lua. commands.lua never used it and I already removed it from lua-repl.lua. Cloning all scripts in the wiki reveals that **nobody** is using log_error(), confirming that it is safe to deprecate.