### PR TITLE
vo: reset wait_on_vo if render_frame is called without current_frame

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -940,6 +940,7 @@ static bool render_frame(struct vo *vo)
                (in->current_frame->display_synced && in->current_frame->num_vsyncs < 1) ||
                !in->current_frame->display_synced)
     {
+        in->wait_on_vo = false;
         goto done;
     }
 


### PR DESCRIPTION
Fixes a deadlock when switching vo before a frame is displayed (e.g. with auto profiles) where we'd end up in a state where wait_on_vo is set to true for the first frame and then draw_frame is never called again so its value never changes even once dmabuf-wayland is ready to advance frame

Fixes: 468d34c9bd57 ("vo: allow VOs to request waiting before advancing frames")
Fixes: #17358