### PR TITLE
sub/draw_bmp: limit memset to available width in last slice

### DIFF
--- a/sub/draw_bmp.c
+++ b/sub/draw_bmp.c
@@ -485,9 +485,9 @@ static void clear_rgba_overlay(struct mp_draw_sub_cache *p)
         for (int sx = 0; sx < p->s_w; sx++) {
             struct slice *s = &line[sx];
 
-            // Ensure this final slice doesn't extend beyond the width of p->s_w
-            if (s->x1 == SLICE_W && sx == p->s_w - 1 && y == p->rgba_overlay->h - 1)
-                s->x1 = MPMIN(p->w - ((p->s_w - 1) * SLICE_W), s->x1);
+            // Ensure the last slice doesn't extend beyond the total width.
+            if (sx == p->s_w - 1)
+                s->x1 = MPMIN(p->w - (sx * SLICE_W), s->x1);
 
             if (s->x0 <= s->x1) {
                 memset(px + s->x0, 0, (s->x1 - s->x0) * 4);


### PR DESCRIPTION
f3c1dcf7a13c61deb6bcdeeaec9f82163ab31177 is a previous attempt at fixing a buffer overflow.
This fixes another buffer overflow on the previous line if the image is small enough. 
```
# buffer overflow at line y=62 :
mpv --no-config --vo=dmabuf-wayland  av://lavfi:testsrc=size=78x64
# works:
mpv --no-config --vo=dmabuf-wayland  av://lavfi:testsrc=size=78x63
```

What's happening is that we are just trying to set pixel to 0 by of SLICE_W(256) chunk. But width is not multiple of 256, the last chunk of each line will overflow to the next. This leads to unnecessary copies at the next iteration which overwrites the previous overflown data. 

It has bigger impact on small image. For example, a 78x64 BGRA8 image has 19968 bytes. But previous implementation would write at least ```256*63 = 63488``` bytes! (... not counting the last line for simplicity). Another way to fix the problem is to extend f3c1dcf7a13c61deb6bcdeeaec9f82163ab31177 for each line:

```diff
diff --git a/sub/draw_bmp.c b/sub/draw_bmp.c
index 4aa59976a9..02cbc1b93e 100644
--- a/sub/draw_bmp.c
+++ b/sub/draw_bmp.c
@@ -486,7 +486,7 @@ static void clear_rgba_overlay(struct mp_draw_sub_cache *p)
             struct slice *s = &line[sx];
 
             // Ensure this final slice doesn't extend beyond the width of p->s_w
-            if (s->x1 == SLICE_W && sx == p->s_w - 1 && y == p->rgba_overlay->h - 1)
+            if (s->x1 == SLICE_W && sx == p->s_w - 1)
                 s->x1 = MPMIN(p->w - ((p->s_w - 1) * SLICE_W), s->x1);
 
             if (s->x0 <= s->x1) {
```
Which to me seems like a convoluted way to just ```memset(mp_image_pixel_ptr(p->rgba_overlay, 0, 0, 0), p->rgba_overlay->stride[0] * p->rgba_overlay->h)```. 
The struct slice line info is updated somehow so I kept that. (but also nuked it: could not see any effect)

Happy to apply either.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
