### PR TITLE
select.lua: quote and escape string arguments in menu item commands

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -962,6 +962,11 @@ local function on_idle()
     mp.set_property_native("menu-data", menu_data)
 end
 
+-- quote string and escape it in JSON-style
+local function quote(str)
+    return utils.format_json(str or "")
+end
+
 local function clamp_submenu(submenu, max, cmd)
     if #submenu <= max then
        return submenu
@@ -1111,7 +1116,7 @@ local function audio_devices()
     for i, device in ipairs(get("audio-device-list")) do
         items[i] = {
             title = format_audio_device(device):gsub("&", "&&"),
-            cmd = "set audio-device " .. device.name,
+            cmd = "set audio-device " .. quote(device.name),
         }
 
         if device.name == selected_device then
@@ -1154,8 +1159,8 @@ local function profiles()
 
     for _, profile in ipairs(user_profiles) do
         items[#items + 1] = {
-            title = profile,
-            cmd = "apply-profile " .. profile:gsub("&", "&&"),
+            title = profile:gsub("&", "&&"),
+            cmd = "apply-profile " .. quote(profile),
         }
     end
 


### PR DESCRIPTION
try to define a `[foo \ "bar"]` profile in mpv.conf, the command to apply it in context-menu is `apply-profile foo \ "bar"`, which is obviously incorrect, the correct command should be `apply-profile "foo \\ \"bar\""`.

for string arguments that may contain spaces or some special characters, we need to quote and escape them.