### PR TITLE
wayland: set image_description_processed when not using color mgmnt

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3486,7 +3486,7 @@ static void set_color_management(struct vo_wayland_state *wl)
 {
 #if HAVE_WAYLAND_PROTOCOLS_1_41
     if (!wl->color_surface || !wl->supports_parametric)
-        return;
+        goto nosupport;
 
     struct pl_color_space color = wl->target_params.color;
     int primaries = wl->primaries_map[color.primaries];
@@ -3497,7 +3497,7 @@ static void set_color_management(struct vo_wayland_state *wl)
         MP_VERBOSE(wl, "Compositor does not support transfer function: %s\n", m_opt_choice_str(pl_csp_trc_names, color.transfer));
     if (!primaries || !transfer) {
         wp_color_management_surface_v1_unset_image_description(wl->color_surface);
-        return;
+        goto nosupport;
     }
 
     MP_VERBOSE(wl, "Generating image creator params:\n");
@@ -3546,6 +3546,11 @@ static void set_color_management(struct vo_wayland_state *wl)
     struct wp_image_description_v1 *image_description = wp_image_description_creator_params_v1_create(image_creator_params);
     wl->image_description_processed = false;
     wp_image_description_v1_add_listener(image_description, &image_description_listener, wl);
+    return;
+
+nosupport:
+    wl->image_description_processed = true;
+    return;
 #endif
 }
 


### PR DESCRIPTION
This sets ```wl->image_description_processed``` when the compositor does not support the TF or primaries. 

Otherwise ```wl->image_description_processed``` will always be false and the window will not show.


Fixes https://github.com/mpv-player/mpv/issues/17371 
