### PR TITLE
vo: clear request_redraw in render_frame only if video is playing

### DIFF
--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -1054,13 +1054,13 @@ static bool render_frame(struct vo *vo)
     if (in->dropped_frame) {
         MP_STATS(vo, "drop-vo");
     } else {
-        // If the initial redraw request was true or mpv is still playing,
-        // then we can clear it here since we just performed a redraw, or the
-        // next loop will draw what we need. However if there initially is
+        // If the initial redraw request was true and mpv is still playing,
+        // then we can clear it here since the next loop will guarantee that
+        // we draw whatever is needed. However if there initially is
         // no redraw request, then something can change this (i.e. the OSD)
         // while the vo was unlocked. If we are paused, don't touch
-        // in->request_redraw in that case.
-        if (request_redraw || !in->paused)
+        // in->request_redraw in that case and let do_redraw do the work later.
+        if (request_redraw && !in->paused)
             in->request_redraw = false;
     }
 


### PR DESCRIPTION
27a78276eb4b68f230e441e1baedf26f3cd66fbd almost got it but it should be an and condition not an or. When we unlock VO to draw the core, the OSD can update after we flip the page and the player can also pause itself in that time. That means that we will clear the redraw request but due to the OSD update it actually needs to draw again. Because the player paused itself in that time frame, this redraw gets lost and you have the mismatch. The simplest way to avoid that case is to only clear the redraw_request while mpv is playing. The paused case will always get handled later in do_redraw so it does not get missed. The slight downside is that it's technically possible to do a redundant redraw (e.g. what if you pause before draw_frame), but this theoretical inefficiency is deemed not really relevant or important enough to add more confusing code to avoid. Fixes #17288.

@somerandoname does this fix it for you?