### PR TITLE
wayland: handle all outputs disappearing without segfaulting

### DIFF
--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -58,6 +58,8 @@ struct vo_wayland_state {
     struct mp_rect window_size;
     struct wl_list output_list;
     struct vo_wayland_output *current_output;
+    struct mp_rect old_geometry;
+    struct mp_rect old_output_geometry;
     int bounded_height;
     int bounded_width;
     int reduced_height;


### PR DESCRIPTION
If you switch TTYs while mpv is playing, compositors (well at least sway anyway but I imagine they all do this) will remove all outputs from the registry. This segfaults when you switch back since we try to access cleared memory. Rework this so wl->current_output is given null when appropriate and properly guarded. You still need at least one output to initially place the surface, but in general they can all disappear during runtime and it should work. Change the log to verbose because that becomes just noise in this case (switching TTYs). The surface entrance event happens later and should get all the proper parameters.
