### PR TITLE
player: don't mangle current playlist entry before initialization

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -6199,7 +6199,7 @@ static void cmd_loadlist(void *p)
     talloc_free(path);
 
     if (pl) {
-        prepare_playlist(mpctx, pl);
+        prepare_playlist(mpctx, pl, true);
         struct playlist_entry *new = pl->current;
         if (action.type == LOAD_TYPE_REPLACE)
             playlist_clear(mpctx->playlist);

--- a/player/core.h
+++ b/player/core.h
@@ -553,7 +553,7 @@ void update_demuxer_properties(struct MPContext *mpctx);
 void print_track_list(struct MPContext *mpctx, const char *msg);
 void reselect_demux_stream(struct MPContext *mpctx, struct track *track,
                            bool refresh_only);
-void prepare_playlist(struct MPContext *mpctx, struct playlist *pl);
+void prepare_playlist(struct MPContext *mpctx, struct playlist *pl, bool overwrite_current);
 void autoload_external_files(struct MPContext *mpctx, struct mp_cancel *cancel);
 struct track *select_default_track(struct MPContext *mpctx, int order,
                                    enum stream_type type);


### PR DESCRIPTION
Scripts and things using the client API can load up playlists in a specific order and choose what file to start playing on by using the loadfile or loadlist commands with the play argument. However if starting from idle mode, it is possible to send these commands before all scripts finish initializing. mpv's core then does a prepare_playlist call on its own for startup which will nuke the current playlist entry set by the API user and lead to an unexpected item being played. Fix this by not unconditionally setting pl->current to NULL allow callers to optionally always overwrite it by getting the first item in the playlist (e.g. if it's called after startup anywhere else in the code). Other options like --playlist-start or --shuffle are allowed to win if they happen to be set.

Just a quick rundown of the bug this is fixing: 

For testing, any playlist of videos will do e.g.
```
ffmpeg -f lavfi -i testsrc=duration=2:size=1280x720 vid1.mkv
ffmpeg -f lavfi -i testsrc=duration=2:size=1280x720 vid2.mkv
```

Write a super simple lua script:
```
mp.commandv("loadfile", "~/vid1.mkv", "append")
mp.commandv("loadfile", "~/vid2.mkv", "append+play")
```

Then run:
`mpv --no-config --script=~/.config/mpv/scripts/testing.lua --idle --force-window`

On master (unless your computer is really slow I guess), you'll start playback with `vid1.mkv`. However `vid2.mkv` is actually what's expected here per what the `play` flag is supposed to do. If you alter the script a bit to wait until the vo window shows up, e.g.:
```
function have_vo(name, value)
    if value == true then
        mp.commandv("loadfile", "~/vid1.mkv", "append")
        mp.commandv("loadfile", "~/vid2.mkv", "append+play")
    end
end
mp.observe_property("vo-configured", "bool", have_vo)
```
You'll start from `vid2.mkv` now which is expected since mpv has had enough time to fully initialize. The point here is not mangle the current playlist entry on startup unless something else is set (watch later, etc.).