### PR TITLE
vo_dmabuf_wayland: don't wait for image description with force-window

### DIFF
--- a/video/out/vo_dmabuf_wayland.c
+++ b/video/out/vo_dmabuf_wayland.c
@@ -627,16 +627,15 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
         wl_surface_damage_buffer(wl->video_surface, 0, 0, 1, 1);
     }
 
-    if (wl->color_surface && (!wl->image_description_processed || p->vo_is_waiting)) {
-        vo_wait_on_vo(vo, !wl->image_description_processed);
-        p->vo_is_waiting = !wl->image_description_processed;
-    }
-
     pts = frame->current ? frame->current->pts : 0;
     if (frame->current) {
         buf = buffer_get(vo, frame);
 
         if (buf && buf->frame) {
+            if (wl->color_surface && (!wl->image_description_processed || p->vo_is_waiting)) {
+                vo_wait_on_vo(vo, !wl->image_description_processed);
+                p->vo_is_waiting = !wl->image_description_processed;
+            }
             vo_wayland_handle_color(wl);
             struct mp_image *image = buf->frame->current;
             wl_surface_attach(wl->video_surface, buf->buffer, 0, 0);


### PR DESCRIPTION
Waiting for color management from the compositor doesn't make sense here and this breaks --force-window since the playloop doesn't advance. Skip the logic here. Fixes #17391.