### PR TITLE
select.lua: don't set an empty prompt

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -785,7 +785,6 @@ mp.add_key_binding(nil, "menu", function ()
     end
 
     input.select({
-        prompt = "",
         items = labels,
         keep_open = true,
         submit = function (i)


### PR DESCRIPTION
Not needed since 44816ef8ff.