### PR TITLE
context_menu.lua: set user-data/mpv/context-menu/open

### DIFF
--- a/DOCS/interface-changes/menu-open.rst
+++ b/DOCS/interface-changes/menu-open.rst
@@ -1,0 +1,1 @@
+add `user-data/mpv/context-menu/open` sub-property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3874,6 +3874,9 @@ Property list
     ``user-data/mpv/console/open``
         Whether the console is open.
 
+    ``user-data/mpv/context-menu/open``
+        Whether the context menu script is open.
+
 ``menu-data`` (RW)
     This property stores the raw menu definition. See `Context Menu`_ section for details.
 

--- a/player/lua/context_menu.lua
+++ b/player/lua/context_menu.lua
@@ -648,6 +648,8 @@ close = function ()
     for key, _ in pairs(bindings) do
         mp.remove_key_binding("_context_menu_" .. key)
     end
+
+    mp.set_property_native("user-data/mpv/context-menu/open", false)
 end
 
 mp.register_script_message("open", function ()
@@ -675,6 +677,8 @@ mp.register_script_message("open", function ()
             complex = key == "ANY_UNICODE",
         })
     end
+
+    mp.set_property_native("user-data/mpv/context-menu/open", true)
 end)
 
 mp.register_script_message("select", function ()


### PR DESCRIPTION
Closes #17428.

Questions:

- Should be context-menu or context_menu?
- Should this instead be a top-level property that also shows the Windows menu status?
- Or should the Windows menu also update `user-data`?