### PR TITLE
vo: officially deprecate vo_vaapi

### DIFF
--- a/DOCS/interface-changes/vo-deprecation.txt
+++ b/DOCS/interface-changes/vo-deprecation.txt
@@ -1,0 +1,1 @@
+deprecate `--vo=vaapi`

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -319,6 +319,8 @@ Available video output drivers are:
     This is low quality, and has issues with OSD. We strongly recommend that
     you use ``--vo=gpu`` with ``--hwdec=vaapi`` instead.
 
+    .. warning:: This VO is deprecated will be removed next release.
+
     The following global options are supported by this video output:
 
     ``--vo-vaapi-scaling=<algorithm>``

--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -826,7 +826,8 @@ static int preinit(struct vo *vo)
     vo->hwdec_devs = hwdec_devices_create();
     hwdec_devices_add(vo->hwdec_devs, &p->mpvaapi->hwctx);
 
-    MP_WARN(vo, "Warning: this compatibility VO is low quality and may "
+    MP_WARN(vo, "Warning: this VO is deprecated and will be removed next release.\n"
+                "This compatibility VO is low quality and may\n"
                 "have issues with OSD, scaling, screenshots and more.\n"
                 "vo=gpu-next is the preferred choice in any case and "
                 "includes VA-API support via hwdec=vaapi or vaapi-copy.\n");


### PR DESCRIPTION
Using vo_vaapi has already been heavily discouraged for years since years since 5c313f1f5965eb8f00c3d242d9e27e9612dc949b. More importantly, it's just fundamentally broken on most hardware, serves no real purpose, and well we shouldn't just ship broken stuff. vo_vaapi largely only ever worked correctly on some intel hardware. The VO relies on certain API calls that other vendors never implemented so things like the OSD and subtitles are just never going to work. This largely has no reason to exist either. If you're looking for efficient playback, you can use vo_gpu/vo_gpu_next in dumb mode with vaapi decoding. You can also use vo_dmabuf_wayland with vaapi as well to avoid even more GPU to CPU copies and theoretically be even more efficient.
