### PR TITLE
m_option: preserve nan value for floats

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1208,7 +1208,7 @@ static int float_set(const m_option_t *opt, void *dst, struct mpv_node *src)
 {
     double tmp;
     int r = double_set(opt, &tmp, src);
-    if (r >= 0 && clamp_double(opt, &tmp) < 0)
+    if (r >= 0 && clamp_float(opt, &tmp) < 0)
         return M_OPT_OUT_OF_RANGE;
     if (r >= 0)
         VAL(dst) = tmp;


### PR DESCRIPTION
M_OPT_DEFAULT_NAN flag uses NAN as the default param, otherwise setting special float options to "default" fails

Fixes: 0e7f9c39dca7 ("m_option: correctly clamp OPT_FLOAT values")
Fixes: #17436