### PR TITLE
m_option: fix x:y mode format when printing geometry

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2269,11 +2269,15 @@ static char *print_geometry(const m_option_t *opt, const void *val)
             APPEND_PER(w, w_per);
             res = talloc_asprintf_append(res, "x");
             APPEND_PER(h, h_per);
-        }
-        if (gm->xy_valid) {
-            res = talloc_asprintf_append(res, gm->x_sign ? "-" : "+");
+            if (gm->xy_valid) {
+                res = talloc_asprintf_append(res, gm->x_sign ? "-" : "+");
+                APPEND_PER(x, x_per);
+                res = talloc_asprintf_append(res, gm->y_sign ? "-" : "+");
+                APPEND_PER(y, y_per);
+            }
+        } else {
             APPEND_PER(x, x_per);
-            res = talloc_asprintf_append(res, gm->y_sign ? "-" : "+");
+            res = talloc_asprintf_append(res, ":");
             APPEND_PER(y, y_per);
         }
         if (gm->ws > 0)


### PR DESCRIPTION
Previously, x:y mode geometry strings were incorrectly printed using the WxH+x+y format.

Fixes #17435

Tested the following:

mpv "av://lavfi:testsrc=size=1280x720:rate=1" --video-crop="150:100"
● Video  --vid=1  (wrapped_avframe 1280x720 1 fps)
VO: [gpu-next] 1280x720 rgb24
video-crop: 150:100

mpv "av://lavfi:testsrc=size=360x180:rate=1" --video-crop="+150+100"
● Video  --vid=1  (wrapped_avframe 360x180 1 fps)
VO: [gpu-next] 360x180 rgb24
video-crop: 0x0+150+100

mpv "av://lavfi:testsrc=size=1280x720:rate=1" --video-crop="50x10+150+100"
● Video  --vid=1  (wrapped_avframe 1280x720 1 fps)
VO: [gpu-next] 1280x720 rgb24
video-crop: 50x10+150+100

mpv "av://lavfi:testsrc=size=1280x720:rate=1" --video-crop="50%:50%"
● Video  --vid=1  (wrapped_avframe 1280x720 1 fps)
VO: [gpu-next] 1280x720 rgb24
video-crop: 50%:50%