### PR TITLE
github/issue_template: linux: clarify "tested latest mpv"

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_linux.yml
@@ -40,7 +40,9 @@ body:
            - The time when the problem started to happen (after updating mpv, system, driver, etc.)
            - Possible screenshot or video of visual glitches
 
-          If you're not using git master or the latest release, update.
+          If you're not using the git master branch or the [latest release](https://github.com/mpv-player/mpv/releases/latest), please update.
+          Older versions are not supported. If your distribution does not provide the latest version, please report the issue to them.
+
           Packages and builds can be found [here](https://mpv.io/installation/).
       value: |-
           - Linux version:
@@ -140,7 +142,7 @@ body:
   attributes:
       label: "I carefully read all instruction and confirm that I did the following:"
       options:
-          - label: "I tested with the latest mpv version to validate that the issue is not already fixed."
+          - label: "I tested and confirmed that the issue exists with the [latest release version](https://github.com/mpv-player/mpv/releases/latest) or newer."
             required: true
           - label: "I provided all required information including system and mpv version."
             required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_macos.yml
@@ -135,7 +135,7 @@ body:
   attributes:
       label: "I carefully read all instruction and confirm that I did the following:"
       options:
-          - label: "I tested with the latest mpv version to validate that the issue is not already fixed."
+          - label: "I tested and confirmed that the issue exists with the [latest release version](https://github.com/mpv-player/mpv/releases/latest) or newer."
             required: true
           - label: "I provided all required information including system and mpv version."
             required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_windows.yml
@@ -136,7 +136,7 @@ body:
   attributes:
       label: "I carefully read all instruction and confirm that I did the following:"
       options:
-          - label: "I tested with the latest mpv version to validate that the issue is not already fixed."
+          - label: "I tested and confirmed that the issue exists with the [latest release version](https://github.com/mpv-player/mpv/releases/latest) or newer."
             required: true
           - label: "I provided all required information including system and mpv version."
             required: true

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -133,7 +133,7 @@ body:
   attributes:
       label: "I carefully read all instruction and confirm that I did the following:"
       options:
-          - label: "I tested with the latest mpv version to validate that the issue is not already fixed."
+          - label: "I tested and confirmed that the issue exists with the [latest release version](https://github.com/mpv-player/mpv/releases/latest) or newer."
             required: true
           - label: "I provided all required information including system and mpv version."
             required: true

--- a/.github/ISSUE_TEMPLATE/4_bug_report_build.yml
+++ b/.github/ISSUE_TEMPLATE/4_bug_report_build.yml
@@ -60,7 +60,7 @@ body:
   attributes:
       label: "I carefully read all instruction and confirm that I did the following:"
       options:
-          - label: "I tested with the latest mpv version to validate that the issue is not already fixed."
+          - label: "I tested and confirmed that the issue exists with the [latest release version](https://github.com/mpv-player/mpv/releases/latest) or newer."
             required: true
           - label: "I provided all required information including system and mpv version."
             required: true


### PR DESCRIPTION
It's generally useless to try and address issues with older versions of mpv, and the bug report templates do require the user to mark that they tested with the latest version.

However, "latest" of some linux distributions "stable releases", for instance Debian, could be quite behind the actual mpv latest version.

Clarify that "latest" does not mean the latest at the distro, together with a link to the current mpv tags.

