### PR TITLE
screenshot: percent decode filename if it's a URI

### DIFF
--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -40,6 +40,7 @@
 #include "video/image_writer.h"
 #include "video/sws_utils.h"
 #include "sub/osd.h"
+#include "stream/stream.h"
 
 #include "video/csputils.h"
 
@@ -176,8 +177,12 @@ static char *create_fname(struct MPContext *mpctx, char *template,
         case 'f':
         case 'F': {
             char *video_file = NULL;
-            if (mpctx->filename)
-                video_file = mp_basename(mpctx->filename);
+            if (mpctx->filename) {
+                if (mp_is_url(bstr0(mpctx->filename)))
+                    video_file = mp_basename(mp_url_unescape(res, mpctx->filename));
+                else
+                    video_file = mp_basename(mpctx->filename);
+            }
 
             if (!video_file)
                 video_file = "NO_FILE";


### PR DESCRIPTION
any uri that's fed to mpv should be percent encoded already (ffmpeg will sometimes do it for you, but it's heuristic is not foolproof [^1]).

but there's no reason for us to leak uri quirks into screenshot filename, and it's generally not what users want either. so do the obvious thing and percent decode the filename if it's a uri.

[^1]: https://github.com/mpv-player/mpv/issues/17450#issuecomment-3953135707

Fixes: https://github.com/mpv-player/mpv/issues/17450
