### PR TITLE
DOCS/man/mpv: document that URLs should be percent-encoded

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -521,6 +521,13 @@ UNIX path. To avoid problems with arbitrary paths, you should be sure that
 absolute paths passed to mpv start with ``/``, and prefix relative paths with
 ``./``.
 
+URLs that are passed to mpv should be percent-encoded for it to work reliably.
+There are some heuristics in place that tries to automatically do it, but these
+heuristics are not foolproof. For example, in order to play a file literally
+named ``foo%20.mp4``, using ``http://localhost/foo%20.mp4`` without any
+percent-encoding will not work. Percent-encoding it as
+``http://localhost/foo%2520.mp4`` will work as expected.
+
 Using the ``file://`` pseudo-protocol is discouraged, because it involves
 strange URL unescaping rules.
 


### PR DESCRIPTION
most of the time not doing so will still work since ffmpeg has some heuristics in place to detect if the url is percent encoded already or not. but these heuristics are not foolproof and so document this quirk explicitly.