### PR TITLE
command: let playlist-play-index current preserve file-local-options

### DIFF
--- a/DOCS/interface-changes/preserve-options.txt
+++ b/DOCS/interface-changes/preserve-options.txt
@@ -1,0 +1,1 @@
+add `preserve-options` flag to `playlist-play-index`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -517,7 +517,7 @@ Playlist Manipulation
     Go to the first of the previous entries on the playlist with a different
     ``playlist-path``.
 
-``playlist-play-index <integer|current|none>``
+``playlist-play-index <integer|current|none> [preserve-options]``]
     Start (or restart) playback of the given playlist index. In addition to the
     0-based playlist entry index, it supports the following values:
 
@@ -530,6 +530,9 @@ Playlist Manipulation
     <none>
         Playback is stopped. If idle mode (``--idle``) is enabled, the player
         will enter idle mode, otherwise it will exit.
+
+    Setting ``preserve-options`` (``MPV_FORMAT_FLAG``) will not reset file-local
+    options when the playback of the current playlist index is restarted.
 
     This command is similar to ``loadfile`` in that it only manipulates the
     state of what to play next, without waiting until the current file is

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -53,6 +53,9 @@ struct playlist_entry {
     bool init_failed : 1;
     // Entry was removed with playlist_remove (etc.), but not deallocated.
     bool removed : 1;
+    // Playback of the entry is restarting without resetting
+    // file-local options.
+    bool reloading : 1;
     // Additional refcount. Normally (reserved==0), the entry is owned by the
     // playlist, and this can be used to keep the entry alive.
     int reserved;

--- a/player/command.c
+++ b/player/command.c
@@ -5987,9 +5987,13 @@ static void cmd_playlist_play_index(void *p)
     struct MPContext *mpctx = cmd->mpctx;
     struct playlist *pl = mpctx->playlist;
     int pos = cmd->args[0].v.i;
+    bool preserve_options = cmd->num_args >= 2 && cmd->args[1].v.b;
 
     if (pos == -2)
         pos = playlist_entry_to_index(pl, pl->current);
+
+    if (preserve_options && pl->current && pos == pl->current->pl_index)
+        pl->current->reloading = true;
 
     mp_set_playlist_entry(mpctx, playlist_entry_from_index(pl, pos));
     if (cmd->on_osd & MP_ON_OSD_MSG)
@@ -7256,6 +7260,7 @@ const struct mp_cmd_def mp_cmds[] = {
         {
             {"index", OPT_CHOICE(v.i, {"current", -2}, {"none", -1}),
                 M_RANGE(-1, INT_MAX)},
+            {"preserve-options", OPT_BOOL(v.b), .flags = MP_CMD_OPT_ARG},
         }
     },
     { "playlist-shuffle", cmd_playlist_shuffle, },

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1985,7 +1985,13 @@ terminate_playback:
     // Possibly stop ongoing async commands.
     mp_abort_playback_async(mpctx);
 
-    m_config_restore_backups(mpctx->mconfig);
+    struct playlist_entry *current = mpctx->playlist->current;
+    bool reloading = mpctx->stop_play == PT_CURRENT_ENTRY &&
+                     current && current->reloading;
+    if (current)
+        current->reloading = false;
+    if (!reloading)
+        m_config_restore_backups(mpctx->mconfig);
 
     TA_FREEP(&mpctx->filter_root);
     talloc_free(mpctx->filtered_tags);


### PR DESCRIPTION
If you set file-local-options/foo at runtime and run playlist-play-index current or playlist-play-index $current_pos, file-local-options/foo is reset. Add a flag to make it preserve file-local-options.

The advantage of this change is that it allows binding Ctrl+r set file-local-options/start ${=time-pos}; playlist-play-index current yes to reload the current file while preserving all options, independently of --no-config, --watch-later-options or --reset-on-next-file, and without writing watch later files to disk. It also preserves file-local-options set on the CLI unlike loadfile.