### PR TITLE
commands.lua: correctly clear completions on early returns

### DIFF
--- a/player/lua/commands.lua
+++ b/player/lua/commands.lua
@@ -464,7 +464,7 @@ local function complete(before_cur, response)
     while tokens[first_useful_token_index] and
           command_prefixes[tokens[first_useful_token_index].text] do
         if first_useful_token_index == #tokens then
-            return
+            return response({}, 1)
         end
 
         first_useful_token_index = first_useful_token_index + 1


### PR DESCRIPTION
The new async completion handling code expects an empty list of completions to be returned if no completions should be shown, but there is one case where `commands.lua` returns early and does not do this.

I believe that this particular early return only occurs when typing in command prefixes. Currently on master, if you type `osd-auto ` into `commands.lua`, and then erase the final whitespace character, the command completions are dimmed but never cleared, as we're not returning an empty list of completions. This PR fixes this behaviour.
