### PR TITLE
mp.input: guard and sanitise client inputs

### DIFF
--- a/player/javascript/defaults.js
+++ b/player/javascript/defaults.js
@@ -705,8 +705,13 @@ function input_request(t) {
 
 mp.input = {
     get: function(t) {
-        t.id = t.id || mp.script_name + (t.prompt || "");
+        t.prompt = String(t.prompt || "")
+        t.id = t.id || mp.script_name + t.prompt;
         latest_log_id = t.id;
+        return input_request(t);
+    },
+    select: function(t) {
+        t.args = t.args || [];
         return input_request(t);
     },
     terminate: function () {
@@ -738,7 +743,6 @@ mp.input = {
         }
     }
 }
-mp.input.select = input_request;
 
 /**********************************************************************
  *  various

--- a/player/lua/input.lua
+++ b/player/lua/input.lua
@@ -87,13 +87,19 @@ local function input_request(t)
 end
 
 function input.get(t)
+    t.prompt = tostring(t.prompt or "")
+
     -- input.select does not support log buffers, so cannot override the latest id.
-    t.id = t.id or mp.get_script_name()..(t.prompt or "")
+    t.id = t.id or mp.get_script_name() .. t.prompt
     latest_log_id = t.id
     return input_request(t)
 end
 
-input.select = input_request
+function input.select(t)
+    -- Ensures that console.lua treats this request as a select request.
+    t.items = t.items or {}
+    return input_request(t)
+end
 
 function input.terminate()
     mp.commandv("script-message-to", "console", "disable", utils.format_json({


### PR DESCRIPTION
Currently, if scripts call mp.input methods with certain missing or incorrectly typed arguments, or if a client sends script-messages to console.lua directly, then there is a very good chance that console.lua will crash, preventing any client from making any input requests.

This PR adds guard checks to console.lua script messages, converts mp.input arguments into strings or numbers as appropriate, and handles incorrectly typed tables. It also adds error or warning messages for the more important arguments.

Edit: sorry, forgot to set the title
