### PR TITLE
mp.input: allow clients to override console.lua script-opts

### DIFF
--- a/DOCS/interface-changes/mp-input-console-opts.txt
+++ b/DOCS/interface-changes/mp-input-console-opts.txt
@@ -1,0 +1,1 @@
+add `console_opt_overrides` argument to `mp.input.get()` and `mp.input.select()`

--- a/DOCS/man/console.rst
+++ b/DOCS/man/console.rst
@@ -130,6 +130,8 @@ This script can be customized through a config file ``script-opts/console.conf``
 placed in mpv's user directory and through the ``--script-opts`` command-line
 option. The configuration syntax is described in `mp.options functions`_.
 
+Note that ``mp.input`` clients can selectively override these options.
+
 Configurable Options
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -987,6 +987,11 @@ REPL.
         among the ones stored for ``input.get()`` calls. Defaults to the calling
         script name with ``prompt`` appended.
 
+    ``console_opt_overrides``
+        A table containing configuration overrides for the console script.
+        Can be used to change the visual style of the text input, among other things.
+        See `CONSOLE`_ for the full list of options.
+
 ``input.terminate()``
     Closes any currently active input request. This will not close
     requests made by other scripts.
@@ -1057,6 +1062,11 @@ REPL.
 
     ``cursor_position``
         The initial cursor position, starting from 1.
+
+    ``console_opt_overrides``
+        A table containing configuration overrides for the console script.
+        Can be used to change the visual style of the select window, among other things.
+        See `CONSOLE`_ for the full list of options.
 
     Example:
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -29,7 +29,7 @@ end
 local platform = detect_platform()
 
 -- Default options
-local opts = {
+local script_opts = {
     monospace_font = "",
     font_size = 24,
     border_size = 1.65,
@@ -50,6 +50,7 @@ local opts = {
     history_dedup = true,
     font_hw_ratio = "auto",
 }
+local opts = script_opts
 
 local styles = {
     error = "{\\1c&H7a77f2&}",
@@ -1730,6 +1731,20 @@ mp.register_script_message("get-input", function (args)
         cursor = line:len() + 1
     end
 
+    -- Allows clients to override script-opts, but first ensures the overrides are the same type.
+    if type(args.console_opt_overrides) == "table" then
+        for k, v in pairs(args.console_opt_overrides) do
+            if type(v) ~= type(script_opts[k]) then
+                args.console_opt_overrides[k] = nil
+                msg.warn(("mp.input (%s): ignoring console_opt_overrides.%s - must be of type %s"
+                         ):format(input_caller, k, type(script_opts[k])))
+            end
+        end
+        opts = setmetatable(args.console_opt_overrides, {__index = script_opts})
+    else
+        opts = script_opts
+    end
+
     enable_completions()
 
     if args.items then
@@ -1971,6 +1986,6 @@ mp.register_script_message("type", function (...)
     mp.commandv("script-message-to", "commands", "type", ...)
 end)
 
-require "mp.options".read_options(opts, nil, render)
+require "mp.options".read_options(script_opts, nil, render)
 
 collectgarbage()


### PR DESCRIPTION
Currently, all input requests are styled the same no matter the source of the request. Users can change style settings using script-opts, but these changes will still apply to requests from all clients. The problem with this approach, is that not all scripts request the same kind of input, so not all will necessarily benefit from the same kind of styling, and some scripts which draw their own UI elements may want console.lua styling to better match their own.

This commit allows a table of script-opt overrides to be passed to `mp.input.get()` and `mp.input.select()` under the `console_opt_overrides` key, which console.lua will use instead of the its own. To minimise required changes, metatables are used to allow console.lua to seamlessly fall back on the original script-opts if the client does not provide an override. I have also required that incoming opts have the same type as the existing script-opts, which should prevent any crashes caused by mismatched types.

From looking through the code, I don't believe there are any stateful or cached values based on opts that need to be specially updated, the opts appear to be re-queried any time the console is rendered or a keybind is pressed and any crashes/bugs that might be caused by invalid inputs of the right type would presumably also happen if the user sets script-opts normally. However, I would appreciate a second opinion from someone familiar with console.lua.