### PR TITLE
ytdl_hook.lua: use the new request_size AVOption when needed

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -862,6 +862,18 @@ local function add_single_video(json)
         stream_opts["cookies"] = serialize_cookies_for_avformat(existing_cookies)
     end
 
+    local chunk_size = math.huge
+    if has_requested_formats then
+        for _, f in pairs(requested_formats) do
+            if f.downloader_options and f.downloader_options.http_chunk_size then
+                chunk_size = math.min(chunk_size, tonumber(f.downloader_options.http_chunk_size))
+            end
+        end
+    end
+    if chunk_size < math.huge then
+        stream_opts = append_libav_opt(stream_opts, "request_size", tostring(chunk_size))
+    end
+
     mp.set_property_native("file-local-options/stream-lavf-o", stream_opts)
 end
 


### PR DESCRIPTION
Some sites throttle requests, but throttling can be avoided with many small range requests. yt-dlp implements a "http_chunk_size" key in its -J output to inform us of the ideal size.

https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/21703 has just been merged, which allows using the http_chunk_size to greatly speed up how fast YouTube videos get loaded into the cache by mpv.

Should the FFmpeg that mpv is built against lack the request_size AVOption, then this will silently not do anything new, so no version checks are needed.

Specifying multiple_requests=1 like suggested in https://github.com/mpv-player/mpv/issues/8655#issuecomment-3872689494 does not seem necessary.

Fixes #8655.
Supersedes #15612.
