### PR TITLE
vo_gpu_next: fix image subtitle hdr peak

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -2795,10 +2795,12 @@ Subtitles
     canvas size. Can be useful to test broken subtitles, which often happen
     when the video was transcoded, while attempting to keep the old subtitles.
 
-``--image-subs-hdr-peak=<sdr|video|10-10000>``
+``--image-subs-hdr-peak=<sdr|video|video-static|video-dynamic|10-10000>``
     Controls the image subtitle diffuse white level in cd/m² (nits) for HDR
-    videos (default: 1000). ``sdr`` is 203 cd/m² for standard SDR white, while
-    ``video`` uses video metadata. (``--vo=gpu-next`` only)
+    videos (default: 1000). ``sdr`` is 203 cd/m² for standard SDR white,
+    ``video`` uses all video metadata including peak detection,
+    ``video-dynamic`` uses only per-scene video metadata,
+    ``video-static`` uses only static video metadata, (``--vo=gpu-next`` only)
 
     This also affects image subtitle brightness in HDR tone mapping with
     ``--blend-subtitles=<yes|video>``.

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -194,7 +194,7 @@ const struct m_sub_options gl_next_conf = {
         {"sub-hdr-peak", OPT_CHOICE(sub_hdr_peak, {"sdr", PL_COLOR_SDR_WHITE}),
             M_RANGE(10, 10000)},
         {"image-subs-hdr-peak", OPT_CHOICE(image_subs_hdr_peak, {"sdr", PL_COLOR_SDR_WHITE},
-            {"video", -1}),  M_RANGE(10, 10000)},
+            {"video", -1}, {"video-static", -2}, {"video-dynamic", -3}),  M_RANGE(10, 10000)},
         {"allow-delayed-peak-detect", OPT_BOOL(delayed_peak)},
         {"border-background", OPT_CHOICE(border_background,
             {"none",  BACKGROUND_NONE},
@@ -388,7 +388,19 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
             if (src) {
                 ol->color = src->params.color;
                 if (pl_color_transfer_is_hdr(ol->color.transfer)) {
-                    if (p->next_opts->image_subs_hdr_peak != -1) {
+                    bool use_static = p->next_opts->image_subs_hdr_peak == -2;
+                    if (use_static || p->next_opts->image_subs_hdr_peak == -3) {
+                        float max;
+                        pl_color_space_nominal_luma_ex(pl_nominal_luma_params(
+                            .color      = &ol->color,
+                            .metadata   = use_static ? PL_HDR_METADATA_HDR10 : PL_HDR_METADATA_ANY,
+                            .scaling    = PL_HDR_NITS,
+                            .out_max    = &max,
+                        ));
+                        ol->color.hdr = (struct pl_hdr_metadata) {
+                            .max_luma = max,
+                        };
+                    } else if (p->next_opts->image_subs_hdr_peak != -1) {
                         ol->color.hdr = (struct pl_hdr_metadata) {
                             .max_luma = p->next_opts->image_subs_hdr_peak,
                         };


### PR DESCRIPTION
704afb89681bc6d7fb87cce0a389444de3fac2a0 assumed that HDR image subtitles target SDR white. However, this is incorrect according to UHD BD spec version 3.2:

> CLUTs of Presentation Graphics streams and Interactive Graphics streams
> are prepared by content author according to dynamic range property of
> the Primary video stream.
> If a Primary video stream is HDR, the Graphics streams have CLUTs
> expressed in BT.2020 color space primaries and ST2084 EOTF.
> If a Primary video stream is SDR, the Graphics streams have CLUTs
> expressed in BT.709 color space primaries and BT.1886 EOTF.

This means that PGS subtitles always have the same colorspace and HDR dynamic range as the video, so the target peak should also be the same.

This is also supported by the BD-J spec (which displays PGS graphics):

> However the BD-ROM player does not support color space conversion nor
> dynamic range conversion of Java graphics and Background plane when
> mixing with video plane.

The Graphics model spec further states:

> The composited image on the graphics plane is transformed to full color
> and transparency by the CLUT module and then overlaid on the video
> image.

These sentences indicate that BD-ROM players simply overlay the decoded graphics onto the video without any kind of conversion.

Change the default of image-subs-hdr-peak to video to fix this. If there are compatibility issues, the option can be manually set to sdr.

Fixes: 704afb89681bc6d7fb87cce0a389444de3fac2a0
Fixes: #17475
