### PR TITLE
DOCS/man/options: don't recommend --sub-justify=left

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3149,8 +3149,6 @@ Subtitles
     Control how multi line subs are justified irrespective of where they
     are aligned (default: ``auto`` which justifies as defined by
     ``--sub-align-x``).
-    Left justification is recommended to make the subs easier to read
-    as it is easier for the eyes.
 
 ``--sub-ass-justify=<yes|no>``
     Applies justification as defined by ``--sub-justify`` on ASS subtitles


### PR DESCRIPTION
It is unclear why this should be recommended. If it were recommended it would be the default. The consensus is that centered justification looks better.
