### PR TITLE
osc.lua: fix mouse position init

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2408,7 +2408,7 @@ local function render()
 
         -- store initial mouse position
         if (state.last_mouseX == nil or state.last_mouseY == nil)
-            and not (mouseX == nil or mouseY == nil) then
+            and not (mouseX == nil or mouseY == nil or mouseX == -1 or mouseY == -1) then
 
             state.last_mouseX, state.last_mouseY = mouseX, mouseY
         end


### PR DESCRIPTION
get_virt_mouse_pos() can return dummy -1, -1 in some cases, for example when mouse is not considered "in" the area. render() is called immediately and sets the initial mouse position to -1, -1 when the first tick happens.

When starting player and mouse is already on the window but not moved, then move the mouse, the mouse_move handler thinks that the mouse moved from -1, -1 to the current position, triggering showing even when the amount moved is less than osc-minmousemove.

Fix this by not letting render() init mouse position if the position is dummy -1.
Fixes: https://github.com/mpv-player/mpv/issues/17482
