### PR TITLE
DOCS/man/vf: fix parameter separator in EBNF

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -35,7 +35,7 @@ The exact syntax is:
 
     and the ``filter-parameter-list``:
 
-        ``<filter-parameter> | <filter-parameter> "," <filter-parameter-list>``
+        ``<filter-parameter> | <filter-parameter> ":" <filter-parameter-list>``
 
     and ``filter-parameter``:
 


### PR DESCRIPTION
The filter separator was used in the EBNF notation instead of the parameter separator.

> The parameters are separated by : (not ,, as that starts a new filter entry).

compared to

> and the `filter-parameter-list`:
>
>    `<filter-parameter> | <filter-parameter> "," <filter-parameter-list>`