### PR TITLE
player/command: add default-value/choices arg fields to command-list

### DIFF
--- a/DOCS/interface-changes/command-list.txt
+++ b/DOCS/interface-changes/command-list.txt
@@ -1,0 +1,1 @@
+'command-list' now also returns a default value and available choices where applicable for each command argument.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -4222,9 +4222,12 @@ Property list
                 "vararg"  MPV_FORMAT_FLAG
                 "args"    MPV_FORMAT_NODE_ARRAY
                     MPV_FORMAT_NODE_MAP
-                        "name"     MPV_FORMAT_STRING
-                        "type"     MPV_FORMAT_STRING
-                        "optional" MPV_FORMAT_FLAG
+                        "name"           MPV_FORMAT_STRING
+                        "type"           MPV_FORMAT_STRING
+                        "optional"       MPV_FORMAT_FLAG
+                        "default-value"  MPV_FORMAT_NODE (optional, value of "type")
+                        "choices"        MPV_FORMAT_NODE_ARRAY (optional)
+                            MPV_FORMAT_STRING
 
 ``input-bindings``
     The list of current input key bindings. This returns an array of maps,

--- a/player/command.c
+++ b/player/command.c
@@ -4003,6 +4003,29 @@ static int mp_property_commands(void *ctx, struct m_property *prop,
                 node_map_add_string(ae, "name", a->name);
                 node_map_add_string(ae, "type", a->type->name);
                 node_map_add_flag(ae, "optional", a->flags & MP_CMD_OPT_ARG);
+                if (a->type == &m_option_type_choice ||
+                    a->type == &m_option_type_flags) {
+                    const struct m_opt_choice_alternatives *alt = a->priv;
+                    if (alt) {
+                        if (a->defval) {
+                            const int ival = *(const int *)a->defval;
+                            const char *val = m_opt_choice_str_def(alt, ival, NULL);
+                            if (val)
+                                node_map_add_string(ae, "default-value", val);
+                        }
+                        struct mpv_node *choices =
+                            node_map_add(ae, "choices", MPV_FORMAT_NODE_ARRAY);
+                        for (int j = 0; alt[j].name; j++) {
+                           struct mpv_node *ce = node_array_add(choices, MPV_FORMAT_NONE);
+                           ce->format = MPV_FORMAT_STRING;
+                           ce->u.string = talloc_strdup(choices->u.list, alt[j].name);
+                        }
+                    }
+                } else if (a->defval) {
+                    struct mpv_node *def =
+                        node_map_add(ae, "default-value", MPV_FORMAT_NONE);
+                    m_option_get_node(a, ae->u.list, def, (void *)a->defval);
+                }
             }
 
             node_map_add_flag(entry, "vararg", cmd->vararg);


### PR DESCRIPTION
Add optional 'default-value' and 'choices' fields where appropriate for command arguments in the 'command-list' property. Update documentation to reflect the command-list schema change.

Aligns command-list schema with option-info schema.

Partial output from libmpv "command-list" property:

```json
[{
	"name": "seek",
	"args": [{
			"name": "target",
			"type": "Time",
			"optional": false
		}, {
			"name": "flags",
			"type": "Flags",
			"optional": false,
			"default-value": "relative",
			"choices": ["relative", "-", "absolute-percent", "absolute", "relative-percent", "keyframes", "exact"]
		}, {
			"name": "legacy",
			"type": "Choice",
			"optional": true,
			"choices": ["unused", "default-precise", "keyframes", "exact"]
		}
	],
	"vararg": false
}, {
	"name": "frame-step",
	"args": [{
			"name": "frames",
			"type": "Integer",
			"optional": false,
			"default-value": 1
		}, {
			"name": "flags",
			"type": "Choice",
			"optional": true,
			"choices": ["play", "seek", "mute"]
		}
	],
	"vararg": false
}]
```