### PR TITLE
command: reject negative offset for overlay-add

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5175,7 +5175,7 @@ static void cmd_overlay_add(void *pcmd)
         MP_ERR(mpctx, "overlay-add: invalid id %d\n", id);
         goto error;
     }
-    if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4)) {
+    if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4) || offset < 0) {
         MP_ERR(mpctx, "overlay-add: inconsistent parameters\n");
         goto error;
     }
@@ -5206,7 +5206,7 @@ static void cmd_overlay_add(void *pcmd)
     } else {
         fd = open(file, O_RDONLY | O_BINARY | O_CLOEXEC);
     }
-    int map_size = 0;
+    size_t map_size = 0;
     if (fd >= 0) {
         map_size = offset + h * stride;
         void *m = mmap(NULL, map_size, PROT_READ, MAP_SHARED, fd, 0);


### PR DESCRIPTION
in theory someone could have been using a negative offset with the pointer argument, but that doesn't really make sense when you can just adjust the pointer value yourself before calling.