### PR TITLE
unify functions to get and strip file extensions

### DIFF
--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -108,7 +108,7 @@ static bool open_source(struct timeline *tl, char *filename)
     // are renamed.
 
     struct bstr cuefile =
-        bstr_strip_ext(bstr0(mp_basename(tl->demuxer->filename)));
+        mp_strip_ext(bstr0(mp_basename(tl->demuxer->filename)));
 
     DIR *d = opendir(bstrdup0(ctx, dirname));
     if (!d)

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -466,7 +466,7 @@ static int lavf_check_file(demuxer_t *demuxer, enum demux_check check)
 
     // HLS streams seems to be not well tagged, so matching mime type is not
     // enough. Strip URL parameters and match extension.
-    bstr ext = bstr_get_ext(bstr_split(bstr0(priv->filename), "?#", NULL));
+    bstr ext = mp_get_ext(bstr_split(bstr0(priv->filename), "?#", NULL));
     AVProbeData avpd = {
         // Disable file-extension matching with normal checks, except for HLS
         .filename = !bstrcasecmp0(ext, "m3u8") || !bstrcasecmp0(ext, "m3u") ||

--- a/demux/demux_libarchive.c
+++ b/demux/demux_libarchive.c
@@ -89,7 +89,7 @@ static int open_file(struct demuxer *demuxer, enum demux_check check)
 
     while (mp_archive_next_entry(mpa)) {
         if (filter && filter[0]) {
-            bstr ext = bstr_get_ext(bstr0(mpa->entry_filename));
+            bstr ext = mp_get_ext(bstr0(mpa->entry_filename));
             bool pass = false;
 
             if (bstr_in_list0(bstr0("video"), filter))

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -249,14 +249,14 @@ static int parse_m3u(struct pl_parser *p)
     if (p->probing && !bstr_equals0(line, "#EXTM3U")) {
         // Last resort: if the file extension is m3u, it might be headerless.
         if (p->check_level == DEMUX_CHECK_UNSAFE) {
-            char *ext = mp_splitext(p->real_stream->url, NULL);
+            bstr ext = bstr_get_ext(bstr0(p->real_stream->url));
             char probe[PROBE_SIZE];
             int len = stream_read_peek(p->real_stream, probe, sizeof(probe));
             bstr data = {probe, len};
-            if (ext && data.len >= 2 && maybe_text(data)) {
+            if (ext.len && data.len >= 2 && maybe_text(data)) {
                 const char *exts[] = {"m3u", "m3u8", "strm", NULL};
                 for (int n = 0; exts[n]; n++) {
-                    if (strcasecmp(ext, exts[n]) == 0)
+                    if (bstrcasecmp(ext, bstr0(exts[n])) == 0)
                         goto ok;
                 }
             }

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -249,7 +249,7 @@ static int parse_m3u(struct pl_parser *p)
     if (p->probing && !bstr_equals0(line, "#EXTM3U")) {
         // Last resort: if the file extension is m3u, it might be headerless.
         if (p->check_level == DEMUX_CHECK_UNSAFE) {
-            bstr ext = bstr_get_ext(bstr0(p->real_stream->url));
+            bstr ext = mp_get_ext(bstr0(p->real_stream->url));
             char probe[PROBE_SIZE];
             int len = stream_read_peek(p->real_stream, probe, sizeof(probe));
             bstr data = {probe, len};
@@ -426,7 +426,7 @@ static bool test_path(struct pl_parser *p, char *path, int autocreate)
     if (!strcmp(path, p->real_stream->path))
         return true;
 
-    bstr ext = bstr_get_ext(bstr0(path));
+    bstr ext = mp_get_ext(bstr0(path));
     if (autocreate & AUTO_VIDEO && bstr_in_list0(ext, p->mp_opts->video_exts))
         return true;
     if (autocreate & AUTO_AUDIO && bstr_in_list0(ext, p->mp_opts->audio_exts))
@@ -535,7 +535,7 @@ static int parse_dir(struct pl_parser *p)
     p->pl->playlist_dir = NULL;
     if (p->autocreate_playlist && p->real_stream->is_local_fs && p->real_stream->is_regular &&
         !p->real_stream->is_directory) {
-        bstr ext = bstr_get_ext(bstr0(p->real_stream->url));
+        bstr ext = mp_get_ext(bstr0(p->real_stream->url));
         switch (p->autocreate_playlist) {
         case 1: // filter
             autocreate = get_directory_filter(p);

--- a/input/dnd.c
+++ b/input/dnd.c
@@ -29,7 +29,7 @@ static bool might_be_subtitle_file(mpv_node *sub_exts, char *file)
          mpv_node sub_ext = sub_exts->u.list->values[i];
          if (sub_ext.format != MPV_FORMAT_STRING)
              continue;
-         if (!bstrcasecmp0(bstr_get_ext(bstr0(file)), sub_ext.u.string))
+         if (!bstrcasecmp0(mp_get_ext(bstr0(file)), sub_ext.u.string))
              return true;
     }
     return false;

--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -157,6 +157,9 @@ bool bstr_split_tok(bstr str, const char *tok, bstr *out_left, bstr *out_right)
 
 struct bstr bstr_splice(struct bstr str, int start, int end)
 {
+    if (!str.len)
+        return str;
+
     if (start < 0)
         start += str.len;
     if (end < 0)

--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -424,22 +424,6 @@ bool bstr_case_endswith(struct bstr s, struct bstr suffix)
     return end.len == suffix.len && bstrcasecmp(end, suffix) == 0;
 }
 
-struct bstr bstr_strip_ext(struct bstr str)
-{
-    int dotpos = bstrrchr(str, '.');
-    if (dotpos < 0)
-        return str;
-    return (struct bstr){str.start, dotpos};
-}
-
-struct bstr bstr_get_ext(struct bstr s)
-{
-    int dotpos = bstrrchr(s, '.');
-    if (dotpos < 0)
-        return (struct bstr){NULL, 0};
-    return bstr_splice(s, dotpos + 1, s.len);
-}
-
 static int h_to_i(unsigned char c)
 {
     if (c >= '0' && c <= '9')

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -222,8 +222,6 @@ bool bstr_eatend(struct bstr *s, struct bstr prefix);
 
 bool bstr_case_startswith(struct bstr s, struct bstr prefix);
 bool bstr_case_endswith(struct bstr s, struct bstr suffix);
-struct bstr bstr_strip_ext(struct bstr str);
-struct bstr bstr_get_ext(struct bstr s);
 
 static inline struct bstr bstr_cut(struct bstr str, int n)
 {

--- a/misc/language.c
+++ b/misc/language.c
@@ -300,7 +300,7 @@ done:
 
 bstr mp_guess_lang_from_filename(bstr name, int *lang_start, enum track_flags *flags)
 {
-    name = bstr_strip(bstr_strip_ext(name));
+    name = bstr_strip(mp_strip_ext(name));
 
     if (lang_start)
         *lang_start = -1;

--- a/misc/language.c
+++ b/misc/language.c
@@ -22,6 +22,7 @@
 
 #include "common/common.h"
 #include "misc/ctype.h"
+#include "misc/path_utils.h"
 
 #define L(s) { #s, sizeof(#s) - 1 }
 

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -106,12 +106,6 @@ char *mp_splitext(const char *path, bstr *root)
     return (char *)split + 1;
 }
 
-char *mp_strip_ext(void *talloc_ctx, const char *s)
-{
-    bstr root;
-    return mp_splitext(s, &root) ? bstrto0(talloc_ctx, root) : talloc_strdup(talloc_ctx, s);
-}
-
 /* Return the file extension, excluding the '.'. If root is not NULL, set it to
  * the part of the path without extension. So: path == root + "." + extension
  * Return NULL if there is no file extension and don't set *root in this case.

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -39,22 +39,29 @@
 #include <pathcch.h>
 #endif
 
-const char *mp_basename(const char *path)
+bstr mp_basename_bstr(bstr path)
 {
-    const char *s;
+    int separator_pos;
 
 #if HAVE_DOS_PATHS
-    if (!mp_is_url(bstr0(path))) {
-        s = strrchr(path, '\\');
-        if (s)
-            path = s + 1;
-        s = strrchr(path, ':');
-        if (s)
-            path = s + 1;
+    if (!mp_is_url(path)) {
+        separator_pos = bstrrchr(path, '\\');
+        if (separator_pos >= 0)
+            path = bstr_splice(path, separator_pos + 1, path.len);
+        separator_pos = bstrrchr(path, ':');
+        if (separator_pos >= 0)
+            path = bstr_splice(path, separator_pos + 1, path.len);
     }
 #endif
-    s = strrchr(path, '/');
-    return s ? s + 1 : path;
+    separator_pos = bstrrchr(path, '/');
+    if (separator_pos < 0)
+        return path;
+    return bstr_splice(path, separator_pos + 1, path.len);
+}
+
+const char *mp_basename(const char *path)
+{
+    return mp_basename_bstr(bstr0(path)).start;
 }
 
 struct bstr mp_dirname(const char *path)

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -89,23 +89,6 @@ void mp_path_strip_trailing_separator(char *path)
         path[len - 1] = '\0';
 }
 
-char *mp_splitext(const char *path, bstr *root)
-{
-    mp_assert(path);
-    const char *bn = mp_basename(path);
-
-    // Skip all leading dots, not just for "hidden" unix files, otherwise we
-    // end up splitting a part of the filename sans leading dot.
-    bn += strspn(bn, ".");
-
-    const char *split = strrchr(bn, '.');
-    if (!split || !split[1])
-        return NULL;
-    if (root)
-        *root = (bstr){(char *)path, split - path};
-    return (char *)split + 1;
-}
-
 /* Return the file extension, excluding the '.'. If root is not NULL, set it to
  * the part of the path without extension. So: path == root + "." + extension
  * Return NULL if there is no file extension and don't set *root in this case.

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -133,6 +133,18 @@ static bstr split_ext(bstr path, bstr *root)
     return ext;
 }
 
+bstr bstr_strip_ext(bstr path)
+{
+    bstr root = {0};
+    split_ext(path, &root);
+    return root.len ? root : path;
+}
+
+bstr bstr_get_ext(bstr path)
+{
+    return split_ext(path, NULL);
+}
+
 bool mp_path_is_absolute(struct bstr path)
 {
     if (path.len && strchr(mp_path_separators, path.start[0]))

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -112,6 +112,27 @@ char *mp_strip_ext(void *talloc_ctx, const char *s)
     return mp_splitext(s, &root) ? bstrto0(talloc_ctx, root) : talloc_strdup(talloc_ctx, s);
 }
 
+/* Return the file extension, excluding the '.'. If root is not NULL, set it to
+ * the part of the path without extension. So: path == root + "." + extension
+ * Return NULL if there is no file extension and don't set *root in this case.
+ */
+static bstr split_ext(bstr path, bstr *root)
+{
+    bstr basename = mp_basename_bstr(path);
+
+    // Skip all leading dots, not just for "hidden" unix files, otherwise we
+    // end up splitting a part of the filename sans leading dot.
+    basename = bstr_splice(basename, bstrspn(basename, "."), basename.len);
+
+    int dot_pos = bstrrchr(basename, '.');
+    if (dot_pos < 0 || dot_pos == basename.len - 1)
+        return (bstr){0};
+    bstr ext = bstr_splice(basename, dot_pos + 1, basename.len);
+    if (root)
+        *root = (bstr){path.start, ext.start - 1 - path.start};
+    return ext;
+}
+
 bool mp_path_is_absolute(struct bstr path)
 {
     if (path.len && strchr(mp_path_separators, path.start[0]))

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -110,7 +110,7 @@ static bstr split_ext(bstr path, bstr *root)
     return ext;
 }
 
-bstr bstr_strip_ext(bstr path)
+bstr mp_strip_ext(bstr path)
 {
     bstr root = {0};
     split_ext(path, &root);

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -117,7 +117,7 @@ bstr bstr_strip_ext(bstr path)
     return root.len ? root : path;
 }
 
-bstr bstr_get_ext(bstr path)
+bstr mp_get_ext(bstr path)
 {
     return split_ext(path, NULL);
 }

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -27,12 +27,6 @@
 const char *mp_basename(const char *path);
 bstr mp_basename_bstr(bstr path);
 
-/* Return file extension, excluding the '.'. If root is not NULL, set it to the
- * part of the path without extension. So: path == root + "." + extension
- * Don't consider it a file extension if the only '.' is the first character.
- * Return NULL if no extension and don't set *root in this case.
- */
-char *mp_splitext(const char *path, bstr *root);
 bstr bstr_strip_ext(bstr path);
 bstr bstr_get_ext(bstr path);
 

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -25,6 +25,7 @@
 // Return pointer to filename part of path
 
 const char *mp_basename(const char *path);
+bstr mp_basename_bstr(bstr path);
 
 /* Return file extension, excluding the '.'. If root is not NULL, set it to the
  * part of the path without extension. So: path == root + "." + extension

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -36,9 +36,6 @@ char *mp_splitext(const char *path, bstr *root);
 bstr bstr_strip_ext(bstr path);
 bstr bstr_get_ext(bstr path);
 
-// This is a shorthand to remove the extension
-char *mp_strip_ext(void *talloc_ctx, const char *s);
-
 /* Return struct bstr referencing directory part of path, or if that
  * would be empty, ".".
  */

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -33,6 +33,8 @@ bstr mp_basename_bstr(bstr path);
  * Return NULL if no extension and don't set *root in this case.
  */
 char *mp_splitext(const char *path, bstr *root);
+bstr bstr_strip_ext(bstr path);
+bstr bstr_get_ext(bstr path);
 
 // This is a shorthand to remove the extension
 char *mp_strip_ext(void *talloc_ctx, const char *s);

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -28,7 +28,7 @@ const char *mp_basename(const char *path);
 bstr mp_basename_bstr(bstr path);
 
 bstr bstr_strip_ext(bstr path);
-bstr bstr_get_ext(bstr path);
+bstr mp_get_ext(bstr path);
 
 /* Return struct bstr referencing directory part of path, or if that
  * would be empty, ".".

--- a/misc/path_utils.h
+++ b/misc/path_utils.h
@@ -27,7 +27,7 @@
 const char *mp_basename(const char *path);
 bstr mp_basename_bstr(bstr path);
 
-bstr bstr_strip_ext(bstr path);
+bstr mp_strip_ext(bstr path);
 bstr mp_get_ext(bstr path);
 
 /* Return struct bstr referencing directory part of path, or if that

--- a/player/command.c
+++ b/player/command.c
@@ -536,7 +536,7 @@ static int mp_property_filename(void *ctx, struct m_property *prop,
         if (strcmp(ka->key, "no-ext") == 0) {
             action = ka->action;
             arg = ka->arg;
-            f = mp_strip_ext(filename, f);
+            f = bstrto0(filename, bstr_strip_ext(bstr0(f)));
         }
     }
     int r = m_property_strdup_ro(action, arg, f);

--- a/player/command.c
+++ b/player/command.c
@@ -536,7 +536,7 @@ static int mp_property_filename(void *ctx, struct m_property *prop,
         if (strcmp(ka->key, "no-ext") == 0) {
             action = ka->action;
             arg = ka->arg;
-            f = bstrto0(filename, bstr_strip_ext(bstr0(f)));
+            f = bstrto0(filename, mp_strip_ext(bstr0(f)));
         }
     }
     int r = m_property_strdup_ro(action, arg, f);

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -166,7 +166,7 @@ void mp_load_auto_profiles(struct MPContext *mpctx)
     mp_auto_load_profile(mpctx, "protocol",
                          mp_split_proto(bstr0(mpctx->filename), NULL));
     mp_auto_load_profile(mpctx, "extension",
-                         bstr0(mp_splitext(mpctx->filename, NULL)));
+                         bstr_get_ext(bstr0(mpctx->filename)));
 
     mp_load_per_file_config(mpctx);
 }

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -166,7 +166,7 @@ void mp_load_auto_profiles(struct MPContext *mpctx)
     mp_auto_load_profile(mpctx, "protocol",
                          mp_split_proto(bstr0(mpctx->filename), NULL));
     mp_auto_load_profile(mpctx, "extension",
-                         bstr_get_ext(bstr0(mpctx->filename)));
+                         mp_get_ext(bstr0(mpctx->filename)));
 
     mp_load_per_file_config(mpctx);
 }

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -102,7 +102,7 @@ static void append_dir_external_files(struct mpv_global *global, struct MPOpts *
                                               "UTF-8-MAC", MP_NO_LATIN1_FALLBACK);
         // retrieve various parts of the filename
         struct bstr tmp_fname_noext = bstrdup(tmpmem2, bstr_strip_ext(dename));
-        struct bstr tmp_fname_ext = bstr_get_ext(dename);
+        struct bstr tmp_fname_ext = mp_get_ext(dename);
         struct bstr tmp_fname_trim = bstr_strip(tmp_fname_noext);
 
         if (den.start != dename.start)

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -79,7 +79,7 @@ static void append_dir_external_files(struct mpv_global *global, struct MPOpts *
     struct bstr f_fbname = bstr0(mp_basename(fname));
     struct bstr f_fname = mp_iconv_to_utf8(log, f_fbname,
                                            "UTF-8-MAC", MP_NO_LATIN1_FALLBACK);
-    struct bstr f_fname_noext = bstrdup(tmpmem, bstr_strip_ext(f_fname));
+    struct bstr f_fname_noext = bstrdup(tmpmem, mp_strip_ext(f_fname));
     struct bstr f_fname_trim = bstr_strip(f_fname_noext);
 
     if (f_fbname.start != f_fname.start)
@@ -101,7 +101,7 @@ static void append_dir_external_files(struct mpv_global *global, struct MPOpts *
         struct bstr dename = mp_iconv_to_utf8(log, den,
                                               "UTF-8-MAC", MP_NO_LATIN1_FALLBACK);
         // retrieve various parts of the filename
-        struct bstr tmp_fname_noext = bstrdup(tmpmem2, bstr_strip_ext(dename));
+        struct bstr tmp_fname_noext = bstrdup(tmpmem2, mp_strip_ext(dename));
         struct bstr tmp_fname_ext = mp_get_ext(dename);
         struct bstr tmp_fname_trim = bstr_strip(tmp_fname_noext);
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -988,7 +988,7 @@ int mp_add_external_file(struct MPContext *mpctx, char *filename,
         } else {
             bstr parent = {0};
             if (mpctx->filename)
-                parent = bstr_strip_ext(bstr0(mp_basename(mpctx->filename)));
+                parent = mp_strip_ext(bstr0(mp_basename(mpctx->filename)));
             bstr title = bstr0(mp_basename(disp_filename));
             bstr_eatstart(&title, parent);
             bstr_eatstart(&title, bstr0("."));

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -489,8 +489,7 @@ void cmd_screenshot_to_file(void *p)
     int mode = cmd->args[1].v.i;
     struct image_writer_opts opts = *mpctx->opts->screenshot_image_opts;
 
-    char *ext = mp_splitext(filename, NULL);
-    int format = image_writer_format_from_ext(ext);
+    int format = image_writer_format_from_ext(bstr_get_ext(bstr0(filename)));
     if (format)
         opts.format = format;
     bool high_depth = image_writer_high_depth(&opts);

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -181,7 +181,7 @@ static char *create_fname(struct MPContext *mpctx, char *template,
                 name = mp_url_unescape(res, name);
 
             if (fmt == 'F')
-                name = mp_strip_ext(res, name);
+                name = bstrto0(res, bstr_strip_ext(bstr0(name)));
             append_filename(&res, name);
             break;
         }

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -181,7 +181,7 @@ static char *create_fname(struct MPContext *mpctx, char *template,
                 name = mp_url_unescape(res, name);
 
             if (fmt == 'F')
-                name = bstrto0(res, bstr_strip_ext(bstr0(name)));
+                name = bstrto0(res, mp_strip_ext(bstr0(name)));
             append_filename(&res, name);
             break;
         }

--- a/player/screenshot.c
+++ b/player/screenshot.c
@@ -489,7 +489,7 @@ void cmd_screenshot_to_file(void *p)
     int mode = cmd->args[1].v.i;
     struct image_writer_opts opts = *mpctx->opts->screenshot_image_opts;
 
-    int format = image_writer_format_from_ext(bstr_get_ext(bstr0(filename)));
+    int format = image_writer_format_from_ext(mp_get_ext(bstr0(filename)));
     if (format)
         opts.format = format;
     bool high_depth = image_writer_high_depth(&opts);

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -104,8 +104,8 @@ static MP_THREAD_VOID script_thread(void *p)
 
 static int64_t mp_load_script(struct MPContext *mpctx, const char *fname)
 {
-    char *ext = mp_splitext(fname, NULL);
-    if (ext && strcasecmp(ext, "disable") == 0)
+    bstr ext = bstr_get_ext(bstr0(fname));
+    if (bstrcasecmp0(ext, "disable") == 0)
         return 0;
 
     void *tmp = talloc_new(NULL);
@@ -144,7 +144,7 @@ static int64_t mp_load_script(struct MPContext *mpctx, const char *fname)
     } else {
         for (int n = 0; scripting_backends[n]; n++) {
             const struct mp_scripting *b = scripting_backends[n];
-            if (ext && strcasecmp(ext, b->file_ext) == 0) {
+            if (bstrcasecmp0(ext, b->file_ext) == 0) {
                 backend = b;
                 break;
             }

--- a/player/scripting.c
+++ b/player/scripting.c
@@ -104,7 +104,7 @@ static MP_THREAD_VOID script_thread(void *p)
 
 static int64_t mp_load_script(struct MPContext *mpctx, const char *fname)
 {
-    bstr ext = bstr_get_ext(bstr0(fname));
+    bstr ext = mp_get_ext(bstr0(fname));
     if (bstrcasecmp0(ext, "disable") == 0)
         return 0;
 

--- a/video/image_writer.c
+++ b/video/image_writer.c
@@ -584,10 +584,10 @@ bool image_writer_flexible_csp(const struct image_writer_opts *opts)
         || opts->format == AV_CODEC_ID_PNG;
 }
 
-int image_writer_format_from_ext(const char *ext)
+int image_writer_format_from_ext(bstr ext)
 {
     for (int n = 0; mp_image_writer_formats[n].name; n++) {
-        if (ext && strcmp(mp_image_writer_formats[n].name, ext) == 0)
+        if (bstrcmp0(ext, mp_image_writer_formats[n].name) == 0)
             return mp_image_writer_formats[n].value;
     }
     return 0;

--- a/video/image_writer.h
+++ b/video/image_writer.h
@@ -52,7 +52,7 @@ bool image_writer_high_depth(const struct image_writer_opts *opts);
 bool image_writer_flexible_csp(const struct image_writer_opts *opts);
 
 // Map file extension to format ID - return 0 (which is invalid) if unknown.
-int image_writer_format_from_ext(const char *ext);
+int image_writer_format_from_ext(bstr ext);
 
 /*
  * Save the given image under the given filename. The parameters csp and opts

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2156,9 +2156,7 @@ static void update_user_shader_opts(struct gl_video *p, const char *path,
         return;
 
     const char *basename = mp_basename(path);
-    struct bstr shadername;
-    if (!mp_splitext(basename, &shadername))
-        shadername = bstr0(basename);
+    struct bstr shadername = bstr_strip_ext(bstr0(basename));
 
     for (int n = 0; p->opts.user_shader_opts[n * 2]; n++) {
         struct bstr key = bstr0(p->opts.user_shader_opts[n * 2 + 0]);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2155,8 +2155,7 @@ static void update_user_shader_opts(struct gl_video *p, const char *path,
     if (!p->opts.user_shader_opts)
         return;
 
-    const char *basename = mp_basename(path);
-    struct bstr shadername = mp_strip_ext(bstr0(basename));
+    struct bstr shadername = mp_strip_ext(mp_basename_bstr(bstr0(path)));
 
     for (int n = 0; p->opts.user_shader_opts[n * 2]; n++) {
         struct bstr key = bstr0(p->opts.user_shader_opts[n * 2 + 0]);

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2156,7 +2156,7 @@ static void update_user_shader_opts(struct gl_video *p, const char *path,
         return;
 
     const char *basename = mp_basename(path);
-    struct bstr shadername = bstr_strip_ext(bstr0(basename));
+    struct bstr shadername = mp_strip_ext(bstr0(basename));
 
     for (int n = 0; p->opts.user_shader_opts[n * 2]; n++) {
         struct bstr key = bstr0(p->opts.user_shader_opts[n * 2 + 0]);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2493,9 +2493,7 @@ static void update_hook_opts(struct priv *p, char **opts, const char *shaderpath
         return;
 
     const char *basename = mp_basename(shaderpath);
-    struct bstr shadername;
-    if (!mp_splitext(basename, &shadername))
-        shadername = bstr0(basename);
+    struct bstr shadername = bstr_strip_ext(bstr0(basename));
 
     for (int n = 0; opts[n * 2]; n++) {
         struct bstr k = bstr0(opts[n * 2 + 0]);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2493,7 +2493,7 @@ static void update_hook_opts(struct priv *p, char **opts, const char *shaderpath
         return;
 
     const char *basename = mp_basename(shaderpath);
-    struct bstr shadername = bstr_strip_ext(bstr0(basename));
+    struct bstr shadername = mp_strip_ext(bstr0(basename));
 
     for (int n = 0; opts[n * 2]; n++) {
         struct bstr k = bstr0(opts[n * 2 + 0]);

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2492,8 +2492,7 @@ static void update_hook_opts(struct priv *p, char **opts, const char *shaderpath
     if (!opts)
         return;
 
-    const char *basename = mp_basename(shaderpath);
-    struct bstr shadername = mp_strip_ext(bstr0(basename));
+    struct bstr shadername = mp_strip_ext(mp_basename_bstr(bstr0(shaderpath)));
 
     for (int n = 0; opts[n * 2]; n++) {
         struct bstr k = bstr0(opts[n * 2 + 0]);


### PR DESCRIPTION
video/out/vo_gpu_next: use bstr_strip_ext()

This is simpler and will allow making mp_splitext() static.


misc/path_utils: add mp_get_ext()

This is easier to understand than mp_splitext(s, NULL);


various: use mp_get_ext()


misc/path_utils: make mp_splitpath() static

It is no longer used anywhere. Also rename it to mp_split_path().


Fixes #17895.
