### PR TITLE
osc.lua: don't retrieve display-fps at startup

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -3050,7 +3050,7 @@ end)
 validate_user_opts()
 set_osc_styles()
 set_time_styles(true, true)
-set_tick_delay("display_fps", mp.get_property_number("display_fps"))
+set_tick_delay()
 visibility_mode(user_opts.visibility, true)
 update_duration_watch()
 


### PR DESCRIPTION
There is no advantage since is it never available at startup, so speed up the startup by not retrieving it.