### PR TITLE
console.lua: use the default OSD margins when OSC margins are set

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -160,11 +160,27 @@ local function get_font()
 end
 
 local function get_margin_x()
-    return opts.margin_x > -1 and opts.margin_x or mp.get_property_native("osd-margin-x")
+    if opts.margin_x > -1 then
+        return opts.margin_x
+    end
+
+    if global_margins.t > 0 or global_margins.b > 0 then
+        return mp.get_property_native("option-info/osd-margin-x/default-value")
+    end
+
+    return mp.get_property_native("osd-margin-x")
 end
 
 local function get_margin_y()
-    return opts.margin_y > -1 and opts.margin_y or mp.get_property_native("osd-margin-y")
+    if opts.margin_y > -1 then
+        return opts.margin_y
+    end
+
+    if global_margins.t > 0 or global_margins.b > 0 then
+        return mp.get_property_native("option-info/osd-margin-y/default-value")
+    end
+
+    return mp.get_property_native("osd-margin-y")
 end
 
 


### PR DESCRIPTION
The OSC (with #17544) and uosc increase --osd-margin-y along with user-data/osc/margins to not overlap with OSD messages, which positions console far apart form the bottom.

Fix this by using the default --osd-margin-{x,y} when OSC margins are set.

Fixes https://github.com/mpv-player/mpv/pull/15334#issuecomment-2755892945

Alternative to #17545.
