### PR TITLE
filters/f_decoder_wrapper: fix use-after-free

### DIFF
--- a/common/av_common.c
+++ b/common/av_common.c
@@ -418,8 +418,6 @@ void mp_codec_info_from_av(const AVCodecContext *avctx, struct mp_codec_params *
         c->codec_profile = avcodec_profile_name(avctx->codec_id, avctx->profile);
     c->codec = avctx->codec_descriptor->name;
     c->codec_desc = avctx->codec_descriptor->long_name;
-    c->decoder = avctx->codec->name;
-    c->decoder_desc = avctx->codec->long_name;
 }
 
 void mp_codec_info_from_avcodecpar(const AVCodecParameters *avcodecpar, struct mp_codec_params *c)
@@ -430,8 +428,6 @@ void mp_codec_info_from_avcodecpar(const AVCodecParameters *avcodecpar, struct m
     if (desc)
         c->codec_desc = desc->long_name;
     if (codec) {
-        c->decoder = codec->name;
-        c->decoder_desc = codec->long_name;
         c->codec_profile = av_get_profile_name(codec, avcodecpar->profile);
     }
     if (!c->codec_profile)

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -81,12 +81,6 @@ struct mp_codec_params {
     // Corresponding codec profile
     const char *_Atomic codec_profile;
 
-    // E.g. "h264" (usually corresponds to AVCodec.name)
-    const char *_Atomic decoder;
-
-    // Usually corresponds to AVCodec.long_name
-    const char *_Atomic decoder_desc;
-
     // Usually a FourCC, exact meaning depends on codec.
     unsigned int codec_tag;
 

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -227,6 +227,8 @@ struct priv {
 
     // --- Protected by cache_lock.
     char *cur_hwdec;
+    char *decoder_name;
+    char *decoder_desc;
     bool try_spdif;
     bool attached_picture;
     bool pts_reset;
@@ -373,8 +375,6 @@ static void decf_destroy(struct mp_filter *f)
         MP_DBG(f, "Uninit decoder.\n");
         talloc_free(p->decoder->f);
         p->decoder = NULL;
-        p->codec->decoder = NULL;
-        p->codec->decoder_desc = NULL;
     }
 
     decf_reset(f);
@@ -403,6 +403,13 @@ static bool reinit_decoder(struct priv *p)
 
     reset_decoder(p);
     p->has_broken_packet_pts = -10; // needs 10 packets to reach decision
+
+    mp_mutex_lock(&p->cache_lock);
+    talloc_free(p->decoder_name);
+    p->decoder_name = NULL;
+    talloc_free(p->decoder_desc);
+    p->decoder_desc = NULL;
+    mp_mutex_unlock(&p->cache_lock);
 
     const struct mp_decoder_fns *driver = NULL;
     struct mp_decoder_list *list = NULL;
@@ -455,11 +462,16 @@ static bool reinit_decoder(struct priv *p)
 
         p->decoder = driver->create(p->decf, p->codec, sel->decoder);
         if (p->decoder) {
-            p->codec->decoder = talloc_strdup(p, sel->decoder);
-            p->codec->decoder_desc = talloc_strdup(p, sel->desc && sel->desc[0] ? sel->desc : NULL);
+            const char *d = sel->desc && sel->desc[0] ? sel->desc : sel->decoder;
+
+            mp_mutex_lock(&p->cache_lock);
+            p->decoder_name = talloc_strdup(p, sel->decoder);
+            p->decoder_desc = talloc_strdup(p, d);
+            mp_mutex_unlock(&p->cache_lock);
+
             MP_VERBOSE(p, "Selected decoder: %s", sel->decoder);
-            if (p->codec->decoder_desc)
-                MP_VERBOSE(p, " - %s", p->codec->decoder_desc);
+            if (d)
+                MP_VERBOSE(p, " - %s", d);
             MP_VERBOSE(p, "\n");
             break;
         }
@@ -491,6 +503,24 @@ bool mp_decoder_wrapper_reinit(struct mp_decoder_wrapper *d)
     bool res = reinit_decoder(p);
     thread_unlock(p);
     return res;
+}
+
+void mp_decoder_wrapper_get_desc(struct mp_decoder_wrapper *d,
+                                 char *buf, size_t buf_size)
+{
+    struct priv *p = d->f->priv;
+    mp_mutex_lock(&p->cache_lock);
+    snprintf(buf, buf_size, "%s", p->decoder_desc ? p->decoder_desc : "");
+    mp_mutex_unlock(&p->cache_lock);
+}
+
+void mp_decoder_wrapper_get_name(struct mp_decoder_wrapper *d,
+                                 char *buf, size_t buf_size)
+{
+    struct priv *p = d->f->priv;
+    mp_mutex_lock(&p->cache_lock);
+    snprintf(buf, buf_size, "%s", p->decoder_name ? p->decoder_name : "");
+    mp_mutex_unlock(&p->cache_lock);
 }
 
 void mp_decoder_wrapper_set_frame_drops(struct mp_decoder_wrapper *d, int num)

--- a/filters/f_decoder_wrapper.h
+++ b/filters/f_decoder_wrapper.h
@@ -43,6 +43,12 @@ struct mp_decoder_wrapper {
 struct mp_decoder_wrapper *mp_decoder_wrapper_create(struct mp_filter *parent,
                                                      struct sh_stream *src);
 
+// For informational purposes.
+void mp_decoder_wrapper_get_name(struct mp_decoder_wrapper *d,
+                                 char *buf, size_t buf_size);
+void mp_decoder_wrapper_get_desc(struct mp_decoder_wrapper *d,
+                                 char *buf, size_t buf_size);
+
 // Legacy decoder framedrop control.
 void mp_decoder_wrapper_set_frame_drops(struct mp_decoder_wrapper *d, int num);
 int mp_decoder_wrapper_get_frames_dropped(struct mp_decoder_wrapper *d);

--- a/player/command.c
+++ b/player/command.c
@@ -2007,6 +2007,13 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
     struct mp_codec_params p =
         track->stream ? *track->stream->codec : (struct mp_codec_params){0};
 
+    char decoder_name[256] = {0};
+    char decoder_desc[256] = {0};
+    if (track->dec) {
+        mp_decoder_wrapper_get_name(track->dec, decoder_name, sizeof(decoder_name));
+        mp_decoder_wrapper_get_desc(track->dec, decoder_desc, sizeof(decoder_desc));
+    }
+
     bool has_rg = track->stream && track->stream->codec->replaygain_data;
     struct replaygain_data rg = has_rg ? *track->stream->codec->replaygain_data
                                        : (struct replaygain_data){0};
@@ -2064,10 +2071,10 @@ static int get_track_entry(int item, int action, void *arg, void *ctx)
                         .unavailable = !track->hls_bitrate},
         {"program-id",  SUB_PROP_INT(track->program_id),
                         .unavailable = track->program_id < 0},
-        {"decoder",     SUB_PROP_STR(p.decoder),
-                        .unavailable = !p.decoder},
-        {"decoder-desc", SUB_PROP_STR(p.decoder_desc),
-                        .unavailable = !p.decoder_desc},
+        {"decoder",     SUB_PROP_STR(decoder_name),
+                        .unavailable = !decoder_name[0]},
+        {"decoder-desc", SUB_PROP_STR(decoder_desc),
+                        .unavailable = !decoder_desc[0]},
         {"codec",       SUB_PROP_STR(p.codec),
                         .unavailable = !p.codec},
         {"codec-desc",  SUB_PROP_STR(p.codec_desc),


### PR DESCRIPTION
to trigger it, run any video with mutliple audio tracks and click on the audio track icon in default osc.

this used to be guarded by locks but was changed in a569c3ce0cf6251ecc8a641 with no explaination as to why. reverting back to old way fixes the UAF, so do that.

ASan stacktrace (notably, the allocation happens in one thread and the free on another):

```
==29382==ERROR: AddressSanitizer: heap-use-after-free on address 0x7ba2add5cc70 at pc 0x7f22b71f0ddf bp 0x7ffe01061990 sp 0x7ffe01061150 READ of size 5 at 0x7ba2add5cc70 thread T0
    #0 0x7f22b71f0dde  (/usr/lib/gcc/x86_64-pc-linux-gnu/15/libasan.so.8+0x88dde)
    #1 0x000000b6b875 in ta_strdup ../ta/ta_utils.c:114
    #2 0x000000b6ca63 in ta_xstrdup ../ta/ta_utils.c:285
    #3 0x00000072b39e in str_get ../options/m_option.c:1289
    #4 0x00000075240b in m_option_get_node ../options/m_option.h:604
    #5 0x0000007571d5 in m_property_read_sub ../options/m_property.c:486
    #6 0x0000007b4a76 in get_track_entry ../player/command.c:2132
    #7 0x000000758ca4 in m_property_read_list ../options/m_property.c:577
    #8 0x0000007b6001 in mp_property_list_tracks ../player/command.c:2239
    #9 0x000000752ef7 in do_action ../options/m_property.c:94
    #10 0x000000753b75 in m_property_do ../options/m_property.c:175
    #11 0x0000007d965b in mp_property_do ../player/command.c:4734
    #12 0x0000007868d2 in getproperty_fn ../player/client.c:1422
    #13 0x00000078c8ea in send_client_property_changes ../player/client.c:1699
    #14 0x00000078e364 in mp_client_send_property_changes ../player/client.c:1770
    #15 0x0000008610e1 in mp_wait_events ../player/playloop.c:56
    #16 0x000000875e39 in run_playloop ../player/playloop.c:1313
    #17 0x000000842b74 in play_current_file ../player/loadfile.c:1952
    #18 0x000000846816 in mp_play_files ../player/loadfile.c:2144
    #19 0x00000084cbde in mpv_main ../player/main.c:457
    #20 0x000000d0bb9a in main ../osdep/main-fn-unix.c:5
    #21 0x7f22b2a76038  (/lib64/libc.so.6+0x26038)
    #22 0x7f22b2a760f4 in __libc_start_main (/lib64/libc.so.6+0x260f4)
    #23 0x000000418160 in _start (/home/nrk/src/core/mpv/build-debug/mpv+0x418160)

0x7ba2add5cc70 is located 80 bytes inside of 85-byte region [0x7ba2add5cc20,0x7ba2add5cc75) freed by thread T2 here:
    #0 0x7f22b72aeaeb  (/usr/lib/gcc/x86_64-pc-linux-gnu/15/libasan.so.8+0x146aeb)
    #1 0x000000b68bca in ta_free ../ta/ta.c:246
    #2 0x000000b689ff in ta_free_children ../ta/ta.c:231
    #3 0x000000b68ba1 in ta_free ../ta/ta.c:243
    #4 0x000000b689ff in ta_free_children ../ta/ta.c:231
    #5 0x000000b68ba1 in ta_free ../ta/ta.c:243
    #6 0x000000765060 in ao_chain_uninit ../player/audio.c:275
    #7 0x000000765410 in uninit_audio_chain ../player/audio.c:290
    #8 0x000000827f7c in mp_switch_track_n ../player/loadfile.c:733
    #9 0x0000007ae477 in mp_property_switch_track ../player/command.c:1982
    #10 0x000000752ef7 in do_action ../options/m_property.c:94
    #11 0x000000753680 in m_property_do ../options/m_property.c:142
    #12 0x0000007d965b in mp_property_do ../player/command.c:4734
    #13 0x0000007cf713 in mp_property_alias ../player/command.c:3788
    #14 0x000000752ef7 in do_action ../options/m_property.c:94
    #15 0x000000753680 in m_property_do ../options/m_property.c:142
    #16 0x0000007d965b in mp_property_do ../player/command.c:4734
    #17 0x0000007e42f9 in change_property_cmd ../player/command.c:5367
    #18 0x0000007ed67e in cmd_add_cycle ../player/command.c:5870
    #19 0x0000007e9617 in run_command ../player/command.c:5643
    #20 0x000000782aa7 in run_client_command ../player/client.c:1134
    #21 0x000000783284 in mpv_command_string ../player/client.c:1169
    #22 0x000000bac63c in script_command ../player/lua.c:610
    #23 0x7f22b370945a  (/usr/lib64/libluajit-5.1.so.2+0x645a)

previously allocated by thread T0 here:
    #0 0x7f22b72afc9b in malloc (/usr/lib/gcc/x86_64-pc-linux-gnu/15/libasan.so.8+0x147c9b)
    #1 0x000000b67ee4 in ta_alloc_size ../ta/ta.c:139
    #2 0x000000b68241 in ta_realloc_size ../ta/ta.c:187
    #3 0x000000b6b5dd in strndup_append_at ../ta/ta_utils.c:93
    #4 0x000000b6b96b in ta_strndup ../ta/ta_utils.c:127
    #5 0x000000b6b892 in ta_strdup ../ta/ta_utils.c:114
    #6 0x000000b6ca63 in ta_xstrdup ../ta/ta_utils.c:285
    #7 0x000000625be3 in reinit_decoder ../filters/f_decoder_wrapper.c:458
    #8 0x000000626bf5 in mp_decoder_wrapper_reinit ../filters/f_decoder_wrapper.c:491
    #9 0x0000007698bc in init_audio_decoder ../player/audio.c:533
    #10 0x00000076a9dc in reinit_audio_chain_src ../player/audio.c:592
    #11 0x000000769c49 in reinit_audio_chain ../player/audio.c:556
    #12 0x0000008411e8 in play_current_file ../player/loadfile.c:1871
    #13 0x000000846816 in mp_play_files ../player/loadfile.c:2144
    #14 0x00000084cbde in mpv_main ../player/main.c:457
    #15 0x000000d0bb9a in main ../osdep/main-fn-unix.c:5
    #16 0x7f22b2a76038  (/lib64/libc.so.6+0x26038)

Thread T2 created by T0 here:
    #0 0x7f22b72a5efd in pthread_create (/usr/lib/gcc/x86_64-pc-linux-gnu/15/libasan.so.8+0x13defd)
    #1 0x000000881a9a in mp_load_script ../player/scripting.c:192
    #2 0x000000882827 in load_builtin_script ../player/scripting.c:252
    #3 0x000000882bd7 in mp_load_builtin_scripts ../player/scripting.c:264
    #4 0x00000080bfaf in mp_option_run_callback ../player/command.c:7989
    #5 0x000000861b4b in handle_option_callbacks ../player/playloop.c:130
    #6 0x00000084bd41 in mp_initialize ../player/main.c:389
    #7 0x00000084cbc9 in mpv_main ../player/main.c:455
    #8 0x000000d0bb9a in main ../osdep/main-fn-unix.c:5
    #9 0x7f22b2a76038  (/lib64/libc.so.6+0x26038)
```