### PR TITLE
f_decoder_wrapper: fix decoder name/desc allocation parent

### DIFF
--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -455,8 +455,8 @@ static bool reinit_decoder(struct priv *p)
 
         p->decoder = driver->create(p->decf, p->codec, sel->decoder);
         if (p->decoder) {
-            p->codec->decoder = talloc_strdup(p, sel->decoder);
-            p->codec->decoder_desc = talloc_strdup(p, sel->desc && sel->desc[0] ? sel->desc : NULL);
+            p->codec->decoder = talloc_strdup(p->codec, sel->decoder);
+            p->codec->decoder_desc = talloc_strdup(p->codec, sel->desc && sel->desc[0] ? sel->desc : NULL);
             MP_VERBOSE(p, "Selected decoder: %s", sel->decoder);
             if (p->codec->decoder_desc)
                 MP_VERBOSE(p, " - %s", p->codec->decoder_desc);


### PR DESCRIPTION
Those strings has to be owned by mp_codec_params, not decoder wrapper priv.

Fixes, use after free in some cases, when tracks are deselected.