### PR TITLE
osc.lua: increase deadzoneszie to 0.75

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -230,7 +230,7 @@ Configurable Options
     Set to ``no`` to disable any special mouse wheel behavior.
 
 ``deadzonesize``
-    Default: 0.5
+    Default: 0.75
 
     Size of the deadzone. The deadzone is an area that makes the mouse act
     like leaving the window. Movement there won't make the OSC show up and
@@ -239,6 +239,7 @@ Configurable Options
     of the window it will span. Values between 0.0 and 1.0, where 0 means the
     OSC will always popup with mouse movement in the window, and 1 means the
     OSC will only show up when the mouse hovers it. Default pre-0.21.0 was 0.
+    Default pre-0.42.0 was 0.5.
 
 ``minmousemove``
     Default: 0

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -25,7 +25,7 @@ local user_opts = {
                                 -- user, but internally negative is "always-on".
     fadeduration = 200,         -- duration of fade out (and fade in, if enabled) in ms, 0 = no fade
     fadein = false,             -- whether to enable fade-in effect
-    deadzonesize = 0.5,         -- size of deadzone
+    deadzonesize = 0.75,        -- size of deadzone
     minmousemove = 0,           -- minimum amount of pixels the mouse has to
                                 -- move between ticks to make the OSC show up
     layout = "bottombar",


### PR DESCRIPTION
This allows to retain deadzone in the middle of the screen when both top and bottom bars are enabled. We also doesn't have to show bars that early before moving mouse down.