### PR TITLE
DOCS: remove behavior changes before version 0.38

### DIFF
--- a/DOCS/edl-mpv.rst
+++ b/DOCS/edl-mpv.rst
@@ -366,8 +366,7 @@ tracks. In this case, it's not obvious, which virtual tracks the EDL show should
 expose when being played.
 
 Currently, mpv will apply an arbitrary heuristic which tracks the EDL file
-should expose. (Before mpv 0.30.0, it always used the first source file in the
-segment list.)
+should expose.
 
 You can set the ``layout`` option to ``this`` to make a specific entry define
 the track layout.

--- a/DOCS/encoding.rst
+++ b/DOCS/encoding.rst
@@ -42,9 +42,7 @@ section::
   oacopts-add = b=96k
 
 It's also possible to define default encoding options by putting them into
-the section named ``[encoding]``. (This behavior changed after mpv 0.3.x. In
-mpv 0.3.x, config options in the default section / no section were applied
-to encoding. This is not the case anymore.)
+the section named ``[encoding]``.
 
 One can then encode using this profile using the command::
 

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -322,10 +322,6 @@ Playback Control
     and ``absolute-percent`` seeks, while ``exact`` is used for ``absolute``
     seeks.
 
-    Before mpv 0.9, the ``keyframes`` and ``exact`` flags had to be passed as
-    3rd parameter (essentially using a space instead of ``+``). The 3rd
-    parameter is still parsed, but is considered deprecated.
-
     This is a scalable command. See the documentation of ``nonscalable`` input
     command prefix in `Input Command Prefixes`_ for details.
 
@@ -940,7 +936,7 @@ OSD Commands
     by passing a memory address as integer prefixed with an ``&`` character.
     Passing the wrong thing here will crash the player. This mode might be
     useful for use with libmpv. The ``offset`` parameter is simply added to the
-    memory address (since mpv 0.8.0, ignored before).
+    memory address.
 
     ``offset`` is the byte offset of the first pixel in the source file.
 
@@ -1212,10 +1208,11 @@ Execution Commands
 ~~~~~~~~~~~~~~~~~~
 
 ``run <command> [<arg1> [<arg2> [...]]]``
-    Run the given command. Unlike in MPlayer/mplayer2 and earlier versions of
-    mpv (0.2.x and older), this doesn't call the shell. Instead, the command
-    is run directly, with each argument passed separately. Each argument is
-    expanded like in `Property Expansion`_.
+    Run the given command.
+
+    This doesn't call the shell. Instead, the command is run directly, with each
+    argument passed separately. Each argument is expanded like in `Property
+    Expansion`_.
 
     This command has a variable number of arguments, and cannot be used with
     named arguments.
@@ -1300,8 +1297,6 @@ Execution Commands
 
     ``passthrough_stdin`` (``MPV_FORMAT_FLAG``)
         If enabled, wire the new process' stdin to mpv's stdin (default: no).
-        Before mpv 0.33.0, this argument did not exist, but the behavior was as
-        if this was set to true.
 
     The command returns the following result (as ``MPV_FORMAT_NODE_MAP``):
 
@@ -1420,7 +1415,7 @@ Scripting Commands
     1. The string ``key-binding``.
     2. The name of the binding (as established above).
     3. The key state as string (see below).
-    4. The key name (since mpv 0.15.0).
+    4. The key name.
     5. The text the key would produce, or empty string if not applicable.
     6. The scale of the key, such as the ones produced by ``WHEEL_*`` keys.
        The scale is 1 if the key is nonscalable.
@@ -1502,7 +1497,7 @@ Screenshot Commands
     If you combine this command with another one using ``;``, you can use the
     ``async`` flag to make encoding/writing the image file asynchronous. For
     normal standalone commands, this is always asynchronous, and the flag has
-    no effect. (This behavior changed with mpv 0.29.0.)
+    no effect.
 
     On success, returns a ``mpv_node`` with a ``filename`` field set to the
     saved screenshot location.
@@ -2078,8 +2073,7 @@ prefixes can be specified. They are separated by whitespace.
 ``repeatable``
     For some commands, keeping a key pressed doesn't run the command repeatedly.
     This prefix forces enabling key repeat in any case. For a list of commands:
-    the first command determines the repeatability of the whole list (up to and
-    including version 0.33 - a list was always repeatable).
+    the first command determines the repeatability of the whole list.
 ``nonrepeatable``
     For some commands, keeping a key pressed runs the command repeatedly.
     This prefix forces disabling key repeat in any case.
@@ -2132,10 +2126,6 @@ command behaves by itself. There are the following cases:
   in detached mode. This can for example happen in cases when a command does not
   have an  asynchronous implementation. The async libmpv API still never blocks
   the caller in these cases.
-
-Before mpv 0.29.0, the ``async`` prefix was only used by screenshot commands,
-and made them run the file saving code in a detached manner. This is the
-default now, and ``async`` changes behavior only in the ways mentioned above.
 
 Currently the following commands have different waiting characteristics with
 sync vs. async: sub-add, audio-add, sub-reload, audio-reload,
@@ -2292,9 +2282,6 @@ Property list
     property is unavailable. Note that the file duration is not always exactly
     known, so this is an estimate.
 
-    This replaces the ``length`` property, which was deprecated after the
-    mpv 0.9 release. (The semantics are the same.)
-
     This has a sub-property:
 
     ``duration/full``
@@ -2425,11 +2412,9 @@ Property list
 
     For Matroska files, this is the edition. For DVD/Blu-ray, this is the title.
 
-    Before mpv 0.31.0, this showed the actual edition selected at runtime, if
-    you didn't set the option or property manually. With mpv 0.31.0 and later,
-    this strictly returns the user-set option or property value, and the
-    ``current-edition`` property was added to return the runtime selected
-    edition (this matters with ``--edition=auto``, the default).
+    This strictly returns the user-set option or property value, and the
+    ``current-edition`` property returns the runtime selected edition (this
+    matters with ``--edition=auto``, the default).
 
 ``current-edition``
     Currently selected edition. This property is unavailable if no file is
@@ -2562,7 +2547,7 @@ Property list
 
     This also returns ``yes``/true if playback is restarting or if nothing is
     playing at all. In other words, it's only ``no``/false if there's actually
-    video playing. (Behavior since mpv 0.7.0.)
+    video playing.
 
 ``cache-speed``
     Current I/O read speed between the cache and the lower layer (like network).
@@ -2707,8 +2692,7 @@ Property list
 ``mixer-active``
     Whether the audio mixer is active.
 
-    This option is relatively useless. Before mpv 0.18.1, it could be used to
-    infer behavior of the ``volume`` property.
+    This option is relatively useless.
 
 ``ao-volume`` (RW)
     System volume. This property is available only if mpv audio output is
@@ -2781,9 +2765,8 @@ Property list
     seek to refresh the video properly.) You can watch the other hwdec
     properties to see whether this was successful.
 
-    Unlike in mpv 0.9.x and before, this does not return the currently active
-    hardware decoder. Since mpv 0.18.0, ``hwdec-current`` is available for
-    this purpose.
+    This does not return the currently active hardware decoder.
+    ``hwdec-current`` is available for this purpose.
 
 ``hwdec-current``
     The current hardware decoding in use. If decoding is active, return one of
@@ -3306,8 +3289,6 @@ Property list
     "current", this property returns -1. Likewise, writing -1 will put the
     player into idle mode (or exit playback if idle mode is not enabled). If an
     out of range index is written to the property, this behaves as if writing -1.
-    (Before mpv 0.33.0, instead of returning -1, this property was unavailable
-    if no playlist entry was current.)
 
     Writing the current value back to the property will have no effect.
     Use ``playlist-play-index`` to restart the playback of the current entry if
@@ -3404,7 +3385,7 @@ Property list
         MPV_FORMAT_NODE_ARRAY
             MPV_FORMAT_NODE_MAP (for each playlist entry)
                 "filename"      MPV_FORMAT_STRING
-                "current"       MPV_FORMAT_FLAG (might be missing; since mpv 0.7.0)
+                "current"       MPV_FORMAT_FLAG (might be missing)
                 "playing"       MPV_FORMAT_FLAG (same)
                 "title"         MPV_FORMAT_STRING (optional)
                 "id"            MPV_FORMAT_INT64
@@ -4332,8 +4313,6 @@ caveats with some properties (due to historical reasons):
     example, if you set ``aid=5``, and the currently played file contains no
     audio track with ID 5, the ``aid`` property will return ``no``.
 
-    Before mpv 0.31.0, you could set existing tracks at runtime only.
-
 ``display-fps``
     This inconsistent behavior is deprecated. Post-deprecation, the reported
     value and the option value are cleanly separated (``override-display-fps``
@@ -4344,10 +4323,6 @@ caveats with some properties (due to historical reasons):
     reinitialize, the option will be set, but the runtime filter chain does not
     change. On the other hand, the next video to be played will fail, because
     the initial filter chain cannot be created.
-
-    This behavior changed in mpv 0.31.0. Before this, the new value was rejected
-    *iff* a video (for ``vf``) or an audio (for ``af``) track was active. If
-    playback was not active, the behavior was the same as the current one.
 
 ``playlist``
     The property is read-only and returns the current internal playlist. The

--- a/DOCS/man/javascript.rst
+++ b/DOCS/man/javascript.rst
@@ -350,8 +350,6 @@ paths - like ``<script-dir>/modules`` for scripts which load from a directory).
 
 The custom-init file is ignored if mpv is invoked with ``--no-config``.
 
-Before mpv 0.34, the file name was ``.init.js`` (with dot) at the same dir.
-
 The event loop
 --------------
 

--- a/DOCS/man/lua.rst
+++ b/DOCS/man/lua.rst
@@ -61,8 +61,7 @@ that uses the ``.foo`` file extension.
 mpv also appends the top level directory of the script to the start of Lua's
 package path so you can import scripts from there too. Be aware that this will
 shadow Lua libraries that use the same package path. (Single file scripts do not
-include mpv specific directories in the Lua package path. This was silently
-changed in mpv 0.32.0.)
+include mpv specific directories in the Lua package path.)
 
 Using a script directory is the recommended way to package a script that
 consists of multiple source files, or requires other files (you can use
@@ -100,17 +99,14 @@ The event loop will wait for events and dispatch events registered with
 ``mp.register_event``. It will also handle timers added with ``mp.add_timeout``
 and similar (by waiting with a timeout).
 
-Since mpv 0.6.0, the player will wait until the script is fully loaded before
-continuing normal operation. The player considers a script as fully loaded as
-soon as it starts waiting for mpv events (or it exits). In practice this means
-the player will more or less hang until the script returns from the main chunk
-(and ``mp_event_loop`` is called), or the script calls ``mp_event_loop`` or
+The player will wait until the script is fully loaded before continuing normal
+operation. The player considers a script as fully loaded as soon as it starts
+waiting for mpv events (or it exits). In practice this means the player will
+more or less hang until the script returns from the main chunk (and
+``mp_event_loop`` is called), or the script calls ``mp_event_loop`` or
 ``mp.dispatch_events`` directly. This is done to make it possible for a script
-to fully setup event handlers etc. before playback actually starts. In older
-mpv versions, this happened asynchronously. With mpv 0.29.0, this changes
-slightly, and it merely waits for scripts to be loaded in this manner before
-starting playback as part of the player initialization phase. Scripts run though
-initialization in parallel. This might change again.
+to fully setup event handlers etc. before playback actually starts. Scripts run
+though initialization in parallel.
 
 mp functions
 ------------

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -440,12 +440,10 @@ because ``--fs`` is a flag option that requires no parameter. If an option
 changes and its parameter becomes optional, then a command line using the
 alternative syntax will break.
 
-Until mpv 0.31.0, there was no difference whether an option started with ``--``
-or a single ``-``. Newer mpv releases strictly expect that you pass the option
-value after a ``=``. For example, before ``mpv --log-file f.txt`` would write
-a log to ``f.txt``, but now this command line fails, as ``--log-file`` expects
-an option value, and ``f.txt`` is simply considered a normal file to be played
-(as in ``mpv f.txt``).
+For options starting with ``--``, mpv expects that you pass the option value
+after a ``=``. For example, ``mpv --log-file f.txt`` will fail, as
+``--log-file`` expects an option value, and ``f.txt`` is simply considered a
+normal file to be played (as in ``mpv f.txt``).
 
 The future plan is that ``-option value`` will not work anymore, and options
 with a single ``-`` behave the same as ``--`` options.
@@ -484,9 +482,9 @@ quotes.
 
 The ``[...]`` form of quotes wraps everything between ``[`` and ``]``. It's
 useful with shells that don't interpret these characters in the middle of
-an argument (like bash). These quotes are balanced (since mpv 0.9.0): the ``[``
-and ``]`` nest, and the quote terminates on the last ``]`` that has no matching
-``[`` within the string. (For example, ``[a[b]c]`` results in ``a[b]c``.)
+an argument (like bash). These quotes are balanced: the ``[`` and ``]`` nest,
+and the quote terminates on the last ``]`` that has no matching ``[`` within the
+string. (For example, ``[a[b]c]`` results in ``a[b]c``.)
 
 The fixed-length quoting syntax is intended for use with external
 scripts and programs.
@@ -702,8 +700,6 @@ If you want to pass a value without interpreting it for escapes or ``,``, it is
 recommended to use the ``-append`` variant. When using libmpv, prefer using
 ``MPV_FORMAT_NODE_MAP``; when using a scripting backend or the JSON IPC, use an
 appropriate structured data type.
-
-Prior to mpv 0.33, ``:`` was also recognized as separator by ``-set``.
 
 Object settings list options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -293,13 +293,11 @@ Playback Control
     different demuxers and will not work with this option. They still can be
     played directly, without using this option.
 
-    You can play playlists directly, without this option. Before mpv version
-    0.31.0, this option disabled any security mechanisms that might be in
-    place, but since 0.31.0 it uses the same security mechanisms as playing a
-    playlist file directly. If you trust the playlist file, you can disable
-    any security checks with ``--load-unsafe-playlists``. Because playlists
-    can load other playlist entries, consider applying this option only to the
-    playlist itself and not its entries, using something along these lines:
+    By default, mpv doesn't play URLs from playlists which are considered
+    unsafe. If you trust the playlist file, you can disable any security checks
+    with ``--load-unsafe-playlists``. Because playlists can load other playlist
+    entries, consider applying this option only to the playlist itself and not
+    its entries, using something along these lines:
 
         ``mpv --{ --playlist=filename --load-unsafe-playlists --}``
 
@@ -1230,11 +1228,10 @@ Video
 
         This is the recommended mode, and the default.
     <decoder>
-        Old, decoder-based framedrop mode. (This is the same as ``--framedrop=yes``
-        in mpv 0.5.x and before.) This tells the decoder to skip frames (unless
-        they are needed to decode future frames). May help with slow systems,
-        but can produce unwatchable choppy output, or even freeze the display
-        completely.
+        Old, decoder-based framedrop mode. This tells the decoder to skip frames
+        (unless they are needed to decode future frames). May help with slow
+        systems, but can produce unwatchable choppy output, or even freeze the
+        display completely.
 
         This uses a heuristic which may not make sense, and in  general cannot
         achieve good results, because the decoder's frame dropping cannot be
@@ -2128,8 +2125,7 @@ Audio
     amplification. Negative values can be passed for compatibility, but are
     treated as 0.
 
-    Since mpv 0.18.1, this always controls the internal mixer (aka software
-    volume).
+    This always controls the internal mixer (aka software volume).
 
 ``--volume-max=<100.0-1000.0>``
     Set the maximum amplification level in percent (default: 130). A value of
@@ -3015,9 +3011,6 @@ Subtitles
         options) are ignored when ASS-subtitles are rendered, unless
         ``--sub-ass=no`` is specified.
 
-        This used to support fontconfig patterns. Starting with libass 0.13.0,
-        this stopped working.
-
 ``--sub-font-size=<size>``
     Specify the sub font size. The unit is the size in scaled pixels at a
     window height of 720. The actual pixel size is scaled with the window
@@ -3391,12 +3384,11 @@ Window
         Also, if errors or unusual circumstances happen, the player can quit
         anyway.
 
-    Since mpv 0.6.0, this doesn't pause if there is a next file in the playlist,
-    or the playlist is looped. Approximately, this will pause when the player
-    would normally exit, but in practice there are corner cases in which this
-    is not the case (e.g. ``mpv --keep-open file.mkv /dev/null`` will play
-    file.mkv normally, then fail to open ``/dev/null``, then exit). (In
-    mpv 0.8.0, ``always`` was introduced, which restores the old behavior.)
+    ``yes`` doesn't pause if there is a next file in the playlist, or the
+    playlist is looped. Approximately, this will pause when the player would
+    normally exit, but in practice there are corner cases in which this is not
+    the case (e.g. ``mpv --keep-open file.mkv /dev/null`` will play file.mkv
+    normally, then fail to open ``/dev/null``, then exit).
 
 ``--keep-open-pause=<yes|no>``
     If set to ``no``, instead of pausing when ``--keep-open`` is active, just
@@ -3760,10 +3752,9 @@ Window
     possible if a video output is available (i.e. there is an open mpv window).
     This is not supported on all video outputs, platforms, or desktop environments.
 
-    Before mpv 0.33.0, the X11 backend ran ``xdg-screensaver reset`` in 10 second
-    intervals when not paused in order to support screensaver inhibition in some
-    environments. This functionality was removed in 0.33.0, but it is possible to
-    call the ``xdg-screensaver`` command line program from a user script instead.
+    On Wayland, this depends on the compositor supporting the idle inhibit
+    protocol. On compositors without support, you can periodically call
+    ``xdg-screensaver reset`` from a user script to inhibit the screensaver.
 
 ``--wid=<ID|-1>``
     This tells mpv to attach to an existing window. If a VO is selected that
@@ -5424,9 +5415,7 @@ Cache
     to involve network accesses or other slow media (this is an imperfect
     heuristic).
 
-    Before mpv 0.30.0, this used to accept a number, which specified the size
-    of the cache in kilobytes. Use e.g. ``--cache --demuxer-max-bytes=123k``
-    instead.
+    Use ``--demuxer-max-bytes`` to specify the size of the cache.
 
 ``--cache-secs=<seconds>``
     How many seconds of audio/video to prefetch if the cache is active. This
@@ -5994,7 +5983,6 @@ them.
 
     .. warning:: This requires setting the ``--video-sync`` option to one
                  of the ``display-`` modes, or it will be silently disabled.
-                 This was not required before mpv 0.14.0.
 
     This essentially attempts to interpolate the missing frames by convoluting
     the video along the temporal axis. The filter used can be controlled using
@@ -7954,11 +7942,6 @@ Video Sync
     mode will display them after the renderer has resumed (typically resulting
     in a short A/V desync and the video "catching up").
 
-    Before mpv 0.30.0, there was a fallback to ``audio`` mode on severe A/V
-    desync. This was changed for the sake of not sporadically stopping. Now,
-    ``display-desync`` does what it promises and may desync with audio by an
-    arbitrary amount, until it is manually fixed with a seek.
-
     These modes also require a vsync blocked presentation mode. For OpenGL, this
     translates to ``--opengl-swapinterval=1``. For Vulkan, it translates to
     ``--vulkan-swap-mode=fifo`` (or ``fifo-relaxed``).
@@ -7995,9 +7978,11 @@ Video Sync
     :display-adrop:     Drop or repeat audio data to compensate desyncing
                         video. This mode will cause severe audio artifacts if
                         the real monitor refresh rate is too different from
-                        the reported or forced rate. Since mpv 0.33.0, this
-                        acts on entire audio frames, instead of single samples.
+                        the reported or forced rate. This acts on entire audio
+                        frames, instead of single samples.
     :display-desync:    Sync video to display, and let audio play on its own.
+                        May desync with audio by an arbitrary amount, until it
+                        is manually fixed with a seek.
     :desync:            Sync video according to system clock, and let audio play
                         on its own.
 
@@ -8133,8 +8118,7 @@ Miscellaneous
 
     Unlike ``--sub-files`` and ``--audio-files``, this includes all tracks, and
     does not cause default stream selection over the "proper" file. This makes
-    it slightly less intrusive. (In mpv 0.28.0 and before, this was not quite
-    strictly enforced.)
+    it slightly less intrusive.
 
     This is a path list option. See `List Options`_ for details.
 

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -175,8 +175,7 @@ Configurable Options
     Default: bottombar
 
     The layout for the OSC. Currently available are: box, slimbox,
-    bottombar, topbar, slimbottombar, slimtopbar and floating. Default
-    pre-0.21.0 was 'box'.
+    bottombar, topbar, slimbottombar, slimtopbar and floating.
 
 ``seekbarstyle``
     Default: bar
@@ -238,14 +237,13 @@ Configurable Options
     at the window border opposite to the OSC and the size controls how much
     of the window it will span. Values between 0.0 and 1.0, where 0 means the
     OSC will always popup with mouse movement in the window, and 1 means the
-    OSC will only show up when the mouse hovers it. Default pre-0.21.0 was 0.
-    Default pre-0.42.0 was 0.5.
+    OSC will only show up when the mouse hovers it. Default pre-0.42.0 was 0.5.
 
 ``minmousemove``
     Default: 0
 
     Minimum amount of pixels the mouse has to move between ticks to make
-    the OSC show up. Default pre-0.21.0 was 3.
+    the OSC show up.
 
 ``showwindowed``
     Default: yes

--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -118,8 +118,7 @@ Available video output drivers are:
     Shared memory video output driver without hardware acceleration that works
     whenever X11 is present.
 
-    Since mpv 0.30.0, you may need to use ``--profile=sw-fast`` to get decent
-    performance.
+    You may need to use ``--profile=sw-fast`` to get decent performance.
 
     .. note:: This is a fallback only, and should not be normally used.
 
@@ -375,8 +374,7 @@ Available video output drivers are:
     the images at full color range, but 256-colors output is also supported (see
     below). On Windows it requires an ansi terminal such as mintty.
 
-    Since mpv 0.30.0, you may need to use ``--profile=sw-fast`` to get decent
-    performance.
+    You may need to use ``--profile=sw-fast`` to get decent performance.
 
     Note: the TCT image output is not synchronized with other terminal output
     from mpv, which can lead to broken images. The options ``--terminal=no`` or
@@ -631,8 +629,7 @@ Available video output drivers are:
     environment (e.g. no X). Does not support hardware acceleration (if you
     need this, check the ``drm`` backend for ``gpu`` VO).
 
-    Since mpv 0.30.0, you may need to use ``--profile=sw-fast`` to get decent
-    performance.
+    You may need to use ``--profile=sw-fast`` to get decent performance.
 
     The following global options are supported by this video output:
 
@@ -741,7 +738,6 @@ Available video output drivers are:
     Shared memory video output driver without hardware acceleration that works
     whenever Wayland is present.
 
-    Since mpv 0.30.0, you may need to use ``--profile=sw-fast`` to get decent
-    performance.
+    You may need to use ``--profile=sw-fast`` to get decent performance.
 
     .. note:: This is a fallback only, and should not be normally used.


### PR DESCRIPTION
These are ancient and not useful anymore.

The version notices are kept under:
overlay-add: handled by #17520
end-file's file_error: the notice should be removed when updating error field like suggested there
time-start: this should just be removed
~/.mpv/: needed to understand why this is used
--aid: needed to understand the following paragraphs