### PR TITLE
osc.lua: remove pause_state()

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2350,11 +2350,6 @@ local function hide_wc()
     hide_bar("wc", "wc_visible", "wc_anitype", set_wc_visible)
 end
 
-local function pause_state(_, enabled)
-    state.paused = enabled
-    request_tick()
-end
-
 local function cache_state(_, st)
     state.cache_state = st
     request_tick()
@@ -2867,7 +2862,7 @@ mp.add_hook("on_unload", 50, function()
 end)
 
 mp.observe_property("display-fps", "number", set_tick_delay)
-mp.observe_property("pause", "bool", pause_state)
+mp.observe_property("pause", "bool", request_tick)
 mp.observe_property("volume", "number", request_tick)
 mp.observe_property("mute", "bool", request_tick)
 mp.observe_property("demuxer-cache-state", "native", cache_state)


### PR DESCRIPTION
The function `pause_state()` doesn't need to exist. It has `state.paused = enabled` but it is never used or read anywhere.

In fact, there is no state `paused` at all and `pause_state()` was purely used for the observer, nothing else.

Use `request_tick()` directly in the observer instead.