### PR TITLE
options: disable system title-bar by default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3493,9 +3493,8 @@ Window
 
 ``--title-bar=<yes|no>``
     (Windows and X11 only)
-    Play video with the window title bar. Since this is on by default,
-    use ``--title-bar=no`` to hide the title bar. The ``--border`` option takes
-    precedence.
+    Play video with the window title bar. The ``--border`` option takes
+    precedence. (Default: no)
 
 ``--on-all-workspaces``
     (X11 and macOS only)

--- a/options/options.c
+++ b/options/options.c
@@ -275,7 +275,6 @@ const struct m_sub_options vo_sub_opts = {
         .taskbar_progress = true,
         .show_in_taskbar = true,
         .border = true,
-        .title_bar = true,
         .appid = "mpv",
         .WinID = -1,
         .window_scale = 1.0,


### PR DESCRIPTION
We have our own window controls and window looks cleaner without system title bar decoration.