### PR TITLE
wayland: don't try to do anything on data_device.motion

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1343,9 +1343,6 @@ static void data_device_handle_leave(void *data, struct wl_data_device *wl_ddev)
 static void data_device_handle_motion(void *data, struct wl_data_device *wl_ddev,
                                       uint32_t time, wl_fixed_t x, wl_fixed_t y)
 {
-    struct vo_wayland_seat *s = data;
-    struct vo_wayland_data_offer *o = s->dnd_offer;
-    wl_data_offer_accept(o->offer, time, o->mime_type);
 }
 
 static void data_device_handle_drop(void *data, struct wl_data_device *wl_ddev)


### PR DESCRIPTION
The keyword here is "try". mpv attempts to accept data offer on motion, by using the time as the serial... which doesn't do anything. We already accept data offers on data_device.enter so this doesn't do anything even if we used the right serial.

Fixes: 68f9ee7e0b3fdddfa42fa11a15d9ae84460d5e19
