### PR TITLE
osc.lua: fix typo

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2378,7 +2378,7 @@ local function osc_init()
             return icons.subtitle
         end
         local track = mp.get_property_number("sid", "-")
-        local count = state.audio_track_count
+        local count = state.sub_track_count
         return icons.subtitle .. label_style .. " " ..
                (user_opts.layout == "floating" and to_fraction(track, count)
                                                 or track .. "/" .. count)


### PR DESCRIPTION
oops...

Fixes: 6bf5a6ca7cec9c058d6ad3b637e66fecac38b3ca