### PR TITLE
video/vaapi: mark nvidia-vaapi-driver as emulated driver

### DIFF
--- a/video/vaapi.c
+++ b/video/vaapi.c
@@ -176,7 +176,7 @@ static bool is_emulated(struct AVBufferRef *hw_device_ctx)
     AVVAAPIDeviceContext *vactx = hwctx->hwctx;
 
     const char *s = vaQueryVendorString(vactx->display);
-    return s && strstr(s, "VDPAU backend");
+    return s && (strstr(s, "VDPAU backend") || strstr(s, "NVDEC driver"));
 }
 
 


### PR DESCRIPTION
This should match the vendor string[1] provided in that project, and mpv will skip using this driver on Nvidia. nvidia-vaapi-driver segfaults when trying to decode 4:4:4 videos, and there's no reason for Nvidia users to use this layer in mpv anyway. Use nvdev or vulkan instead.

1: https://github.com/elFarto/nvidia-vaapi-driver/blob/c4e1788b6d554f29adec31f3f8aa984c143c54c1/src/vabackend.c#L2331-L2335
