### PR TITLE
[RFC] osxbundle: bundle KosmicKrisp vulkan loader/driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
           if brew list ffmpeg &> /dev/null; then brew unlink ffmpeg; fi
           brew install -q autoconf automake curl pkgconf libtool python freetype fribidi little-cms2 \
             luajit libass ffmpeg-full meson rust uchardet mujs libplacebo molten-vk vulkan-loader vulkan-headers \
-            libarchive libbluray libcaca libcdio-paranoia libdvdnav rubberband zimg
+            libarchive libbluray libcaca libcdio-paranoia libdvdnav rubberband zimg mesa
           brew link ffmpeg-full
 
       - name: Build with meson

--- a/TOOLS/dylib_unhell.py
+++ b/TOOLS/dylib_unhell.py
@@ -224,23 +224,25 @@ def process_vulkan_loader(binary, loader_name, loader_relative_folder, library_n
     ]
 
     loader_system_folder = ""
+    loader_system_path = ""
     for loader_system_search_folder in loader_system_search_folders:
         if os.path.exists(loader_system_search_folder):
             loader_system_folder = loader_system_search_folder
-            break
+            if os.path.exists(os.path.join(loader_system_folder, loader_name)):
+                loader_system_path = os.path.join(loader_system_folder, loader_name)
+                break
 
     if not loader_system_folder:
         print(">>> could not find loader folder " + loader_relative_folder)
         return
 
-    loader_bundle_folder = os.path.join(resources_path(binary), loader_relative_folder)
-    loader_system_path = os.path.join(loader_system_folder, loader_name)
-    loader_bundle_path = os.path.join(loader_bundle_folder, loader_name)
-    library_relative_folder = "../../../Frameworks/"
-
-    if not os.path.exists(loader_system_path):
+    if not loader_system_path:
         print(">>> could not find loader " + loader_name)
         return
+
+    loader_bundle_folder = os.path.join(resources_path(binary), loader_relative_folder)
+    loader_bundle_path = os.path.join(loader_bundle_folder, loader_name)
+    library_relative_folder = "../../../Frameworks/"
 
     if not os.path.exists(loader_bundle_folder):
         os.makedirs(loader_bundle_folder)

--- a/TOOLS/dylib_unhell.py
+++ b/TOOLS/dylib_unhell.py
@@ -294,6 +294,7 @@ def process(binary):
 
     print(">> copying and processing vulkan loader")
     process_vulkan_loader(binary, "MoltenVK_icd.json", "vulkan/icd.d", "ICD")
+    process_vulkan_loader(binary, "kosmickrisp_mesa_icd.aarch64.json", "vulkan/icd.d", "ICD")
     if check_vulkan_max_version("1.3.261.1"):
         process_vulkan_loader(
             binary,

--- a/TOOLS/dylib_unhell.py
+++ b/TOOLS/dylib_unhell.py
@@ -218,7 +218,7 @@ def process_vulkan_loader(binary, loader_name, loader_relative_folder, library_n
         os.path.join("/etc", loader_relative_folder),
         os.path.join(os.path.expanduser("~"), ".local/share", loader_relative_folder),
         os.path.join("/usr/local/share", loader_relative_folder),
-        os.path.join("/usr/share/vulkan", loader_relative_folder),
+        os.path.join("/usr/share", loader_relative_folder),
         os.path.join(get_homebrew_prefix(), "etc", loader_relative_folder),
         os.path.join(get_homebrew_prefix(), "share", loader_relative_folder), # old location
     ]

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -19,6 +19,7 @@ meson setup build $common_args \
   -D{plain-gl,rubberband,zimg,zlib}=enabled \
   -D{cocoa,coreaudio,gl-cocoa,videotoolbox-gl,videotoolbox-pl}=enabled \
   -D{swift-build,macos-cocoa-cb,macos-media-player,macos-touchbar,vulkan}=enabled \
+  -D{egl,x11-clipboard}=disabled \
   -Dswift-flags="${SWIFT_FLAGS}"
 
 meson compile -C build -j4


### PR DESCRIPTION
bundling both loaders/drivers is probably useful for testing. one can switch between both via `vulkan-device=`.

possible problems:
1. KosmicKrisp still has some problems but it might be picked by default (alphabetical sorting?)
2. mesa has a dependency to libLLVM, which is also bundled and increases the bundle size by ~165MB

does it make sense to prioritise MoltenVK over KosmicKrisp for now?

[edit]
need to look into 2. properly. we can probably prevent this, since it has nothing to do with KosmicKrisp but are mesa dependencies that are detected by our build system too and aren't necessary for macOS builds.