### PR TITLE
hwdec_vulkan: guard deprecated AVVulkanDeviceContext.lock/unlock_queue

### DIFF
--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -102,8 +102,18 @@ static int vulkan_init(struct ra_hwdec *hw)
     AVVulkanDeviceContext *device_hwctx = device_ctx->hwctx;
 
     device_ctx->user_opaque = (void *)vk->vulkan;
-    device_hwctx->lock_queue = lock_queue;
-    device_hwctx->unlock_queue = unlock_queue;
+    // libavutil deprecated AVVulkanDeviceContext.lock/unlock_queue without
+    // replacement. This prevents us from using queue locking, as those callback
+    // will be removed in lavu. Set those callbacks as long as they are still
+    // present, they will be noop in libplacebo with `VK_KHR_internally_synchronized_queues`.
+    //
+    // It's unclear what will happen to devices that do not support
+    // `VK_KHR_internally_synchronized_queues` when the lock/unlock_queue
+    // callbacks are removed.
+#if LIBAVUTIL_VERSION_MAJOR < 62
+    AV_NOWARN_DEPRECATED(device_hwctx->lock_queue = lock_queue;)
+    AV_NOWARN_DEPRECATED(device_hwctx->unlock_queue = unlock_queue;)
+#endif
     device_hwctx->get_proc_addr = vk->vkinst->get_proc_addr;
     device_hwctx->inst = vk->vkinst->instance;
     device_hwctx->phys_dev = vk->vulkan->phys_device;


### PR DESCRIPTION
libavutil deprecated AVVulkanDeviceContext.lock/unlock_queue without replacement [1]. This prevents us from using queue locking, as those callback will be removed in lavu. Set those callbacks as long as they are still present, they will be noop in libplacebo with `VK_KHR_internally_synchronized_queues`.

It's unclear what will happen to devices that do not support `VK_KHR_internally_synchronized_queues` when the lock/unlock_queue callbacks are removed.

[1] https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/c102e89448a06d9920920923a4008fee3db4ea37