### PR TITLE
mac/window: fix white lines around screen with non-native fullscreen

### DIFF
--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -238,6 +238,7 @@ class Window: NSWindow, NSWindowDelegate {
 
         if #available(macOS 11.0, *) {
             styleMask = .borderless
+            hasShadow = false
             common.titleBar?.hide(0.0)
         } else {
             styleMask.insert(.fullScreen)
@@ -256,6 +257,7 @@ class Window: NSWindow, NSWindowDelegate {
 
         if #available(macOS 11.0, *) {
             styleMask = previousStyleMask
+            hasShadow = true
             common.titleBar?.hide(0.0)
         } else {
             styleMask.remove(.fullScreen)


### PR DESCRIPTION
in macOS 11 Apple changed AppKit to disallow use of the fullscreen window style by custom full screen implementations, reserving this style for their own implementation. mpv's custom implementation had to workaround this by manually applying changes to the window to match the fullscreen window style.

in macOS 26 Apple made changes to enhance visual depth. This included making a window's shadow more pronounced. This revealed the workaround was missing code to remove the window's shadow when in full screen mode. This was especially visible when the macOS appearance was set to dark and a dark video was played with `--native-fs=no`. The window's shadow under macOS 26 was visible as a very thin white outline around the screen.

this fix will enhance the workaround in the macOS custom full screen implementation to toggle `NSWindow.hasShadow` when entering and exiting full screen mode under macOS 11+.

Fixes: #17586
