### PR TITLE
wayland: don't use presentation-time if the values are invalid

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -156,6 +156,7 @@ struct compositor_format {
 struct vo_wayland_feedback_pool {
     struct wp_presentation_feedback **fback;
     struct vo_wayland_state *wl;
+    int last_zero_copy;
     int len;
 };
 
@@ -2471,10 +2472,10 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
     struct vo_wayland_state *wl = fback_pool->wl;
 
     bool current_zero_copy = flags & WP_PRESENTATION_FEEDBACK_KIND_ZERO_COPY;
-    if (wl->last_zero_copy == -1 || wl->last_zero_copy != current_zero_copy) {
+    if (fback_pool->last_zero_copy == -1 || fback_pool->last_zero_copy != current_zero_copy) {
         MP_DBG(wl, "Presentation was done with %s.\n",
                  current_zero_copy ? "direct scanout" : "a copy");
-        wl->last_zero_copy = current_zero_copy;
+        fback_pool->last_zero_copy = current_zero_copy;
     }
 
     if (fback)
@@ -2500,8 +2501,7 @@ static void feedback_presented(void *data, struct wp_presentation_feedback *fbac
 static void feedback_discarded(void *data, struct wp_presentation_feedback *fback)
 {
     struct vo_wayland_feedback_pool *fback_pool = data;
-    struct vo_wayland_state *wl = fback_pool->wl;
-    wl->last_zero_copy = -1;
+    fback_pool->last_zero_copy = -1;
     if (fback)
         remove_feedback(fback_pool, fback);
 }
@@ -4361,7 +4361,6 @@ bool vo_wayland_init(struct vo *vo)
         .wakeup_pipe = {-1, -1},
         .display_fd = -1,
         .cursor_visible = true,
-        .last_zero_copy = -1,
         .opts_cache = m_config_cache_alloc(wl, vo->global, &vo_sub_opts),
         .preferred_csp = (struct pl_color_space) { .transfer = PL_COLOR_TRC_SRGB, .primaries = PL_COLOR_PRIM_BT_709 },
     };
@@ -4490,6 +4489,7 @@ bool vo_wayland_init(struct vo *vo)
         wl->fback_pool = talloc_zero(wl, struct vo_wayland_feedback_pool);
         wl->fback_pool->wl = wl;
         wl->fback_pool->len = VO_MAX_SWAPCHAIN_DEPTH;
+        wl->fback_pool->last_zero_copy = -1,
         wl->fback_pool->fback = talloc_zero_array(wl->fback_pool, struct wp_presentation_feedback *,
                                                   wl->fback_pool->len);
         wl->present = mp_present_initialize(wl, wl->opts, VO_MAX_SWAPCHAIN_DEPTH);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -156,7 +156,6 @@ struct vo_wayland_state {
     bool present_clock;
     bool present_v2;
     bool use_present;
-    int last_zero_copy;
 
     /* single-pixel-buffer */
     struct wp_single_pixel_buffer_manager_v1 *single_pixel_manager;


### PR DESCRIPTION
This can be the case when mpv is not being driven by an output, but rather by a screencast for example.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
