### PR TITLE
video/out/win_state: don't move window when force-window-position=no

### DIFF
--- a/DOCS/interface-changes/geometry-position.txt
+++ b/DOCS/interface-changes/geometry-position.txt
@@ -1,0 +1,1 @@
+`--geometry` x/y position is now applied only on initial window creation, unless `--force-window-position=yes` is set.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3532,6 +3532,15 @@ Window
 
     .. note::
 
+        The geometry size and position are applied during window initialization.
+        Subsequent automatic resizes (via ``--auto-window-resize``) reapply the
+        size from ``--geometry`` but not the position, unless
+        ``--force-window-position`` is enabled. Updating ``--geometry`` during
+        playback always applies the position, regardless of the
+        ``--force-window-position`` setting.
+
+    .. note::
+
         Generally only supported by GUI VOs. Ignored for encoding.
 
     .. admonition:: Note (macOS)
@@ -3684,10 +3693,14 @@ Window
     only ones that have this optimization (i.e. everything else always renders
     regardless of visibility).
 
-``--force-window-position``
-    Forcefully move mpv's video output window to default location whenever
-    there is a change in video parameters, video stream or file. This used to
-    be the default behavior. Currently only affects Windows, X11, macvk and SDL VOs.
+``--force-window-position=<yes|no>``
+    Controls whether the window is moved back to its initial position after an
+    automatic resize due to video stream size changes (see
+    ``--auto-window-resize``). When disabled, the window preserves its current
+    position and only resizes to match the new video size. When enabled, the
+    window is repositioned to the initial location set by ``--geometry``, or
+    the center of the screen if no geometry is specified. Currently only
+    affects Windows, X11, macvk and SDL VOs. (default: no)
 
 ``--auto-window-resize=<yes|no>``
     By default, mpv will automatically resize itself if the video's size changes

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -2348,6 +2348,10 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
                 if (!w32->window_bounds_initialized)
                     return VO_TRUE;
 
+                // Force window repositioning if geometry xy is valid.
+                if (changed_option == &vo_opts->geometry)
+                    w32->window_bounds_initialized = !w32->opts->geometry.xy_valid;
+
                 if (w32->current_fs) {
                     w32->pending_resize = true;
                     w32->pending_maximize = false;

--- a/video/out/win_state.c
+++ b/video/out/win_state.c
@@ -74,9 +74,9 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 //  monitor: position of the monitor on virtual desktop (used for pixelaspect).
 //  dpi_scale: the DPI multiplier to get from virtual to real coordinates
 //             (>1 for "hidpi")
-//  force_center: force centering x/y in the middle of the given screen even if
-//                opts->force_window_position is not set. ignored if the user
-//                supplies valid x/y coordinates on their own.
+//  force_pos: force window position even if opts->force_window_position is not
+//             set. If geometry x/y is not valid, this will center the window.
+//             Useful for initial window placement.
 //  size_constraint: if non-NULL, the resulting size will be limited by the size
 //                   specified in this geometry. This applies to both autofit
 //                   and geometry options.
@@ -88,7 +88,7 @@ static void apply_autofit(int *w, int *h, int scr_w, int scr_h,
 void vo_calc_window_geometry(struct vo *vo, struct mp_vo_opts *opts,
                              const struct mp_rect *screen,
                              const struct mp_rect *monitor, double dpi_scale,
-                             bool force_center, struct vo_win_geometry *out_geo,
+                             bool force_pos, struct vo_win_geometry *out_geo,
                              struct m_geometry *size_constraint)
 {
     *out_geo = (struct vo_win_geometry){0};
@@ -130,7 +130,7 @@ void vo_calc_window_geometry(struct vo *vo, struct mp_vo_opts *opts,
     out_geo->win.x0 = (int)(scr_w - d_w) / 2;
     out_geo->win.y0 = (int)(scr_h - d_h) / 2;
 
-    bool center = (opts->force_window_position || force_center) && !opts->geometry.xy_valid;
+    bool center = (opts->force_window_position || force_pos) && !opts->geometry.xy_valid;
     m_geometry_apply(&out_geo->win.x0, &out_geo->win.y0, &d_w, &d_h,
                      scr_w, scr_h, center, &opts->geometry);
 
@@ -148,7 +148,7 @@ void vo_calc_window_geometry(struct vo *vo, struct mp_vo_opts *opts,
     out_geo->win.x1 = out_geo->win.x0 + d_w;
     out_geo->win.y1 = out_geo->win.y0 + d_h;
 
-    if (opts->geometry.xy_valid || opts->force_window_position || force_center)
+    if (opts->force_window_position || force_pos)
         out_geo->flags |= VO_WIN_FORCE_POS;
 }
 

--- a/video/out/win_state.h
+++ b/video/out/win_state.h
@@ -29,7 +29,7 @@ struct m_geometry;
 void vo_calc_window_geometry(struct vo *vo, struct mp_vo_opts *opts,
                              const struct mp_rect *screen,
                              const struct mp_rect *monitor, double dpi_scale,
-                             bool force_center, struct vo_win_geometry *out_geo,
+                             bool force_pos, struct vo_win_geometry *out_geo,
                              struct m_geometry *size_constraint);
 void vo_apply_window_geometry(struct vo *vo, const struct vo_win_geometry *geo);
 

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1810,7 +1810,7 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_apply_window_geometry(vo, &geo);
 
     struct mp_rect rc = !x11->pseudo_mapped || opts->auto_window_resize || opts->geometry.wh_valid ||
-                        opts->geometry.xy_valid ? geo.win : x11->nofsrc;
+                        (geo.flags & VO_WIN_FORCE_POS) ? geo.win : x11->nofsrc;
 
     if (x11->parent) {
         vo_x11_update_geometry(vo);
@@ -2132,6 +2132,9 @@ int vo_x11_control(struct vo *vo, int *events, int request, void *arg)
                             &x11->opts->window_maximized);
                     vo_x11_maximize(vo);
                 }
+                // Force window repositioning if geometry xy is valid.
+                if (opt == &opts->geometry)
+                    x11->pseudo_mapped = !x11->opts->geometry.xy_valid;
                 vo_x11_set_geometry(vo);
             }
         }


### PR DESCRIPTION
When force-window-position=no place window on requested position only on initially (when VO requests `force_pos`), except that keep existing position on auto resizes.

This applies to both when user provides geometry or default center position is used.

Fixes: #17588