### PR TITLE
Revert "osc.lua: fix window controls showing in fullscreen"

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -440,12 +440,6 @@ Configurable Options
     and ``quit``. Not all platforms implement ``minimize`` and ``maximize``,
     but ``quit`` will always work.
 
-``windowcontrols_fullscreen``
-    Default: no
-
-    Whether to show window controls in fullscreen mode. Only applies when
-    ``windowcontrols`` is set to ``auto``.
-
 ``windowcontrols_independent``
     Default: yes
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -52,7 +52,6 @@ local user_opts = {
     sub_margins = false,        -- adjust sub-margin-y to not overlap with OSC
     osd_margins = true,         -- adjust osd-margin-y to not overlap with OSC
     windowcontrols = "auto",    -- whether to show window controls
-    windowcontrols_fullscreen = false, -- show window controls in fullscreen
     windowcontrols_alignment = "right", -- which side to show window controls on
     windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
     windowcontrols_independent = true, -- show window controls and bottom bar independently
@@ -720,10 +719,7 @@ end
 local function window_controls_enabled()
     local val = user_opts.windowcontrols
     if val == "auto" then
-        if state.fullscreen then
-            return user_opts.windowcontrols_fullscreen
-        end
-        return not state.border or not state.title_bar
+        return not (state.border and state.title_bar)
     else
         return val ~= "no"
     end


### PR DESCRIPTION
3b664281521bef0b2923f1fc024cd88b654d0652 changed the behavior a bit and made it so window controls aren't shown in fullscreen by default. We've since gotten several users pop into IRC and ask what happened, so clearly there is some confusion. Just default it back to 'yes' again to match the old behavior.