### PR TITLE
command: allow metadata to be set manually

### DIFF
--- a/DOCS/interface-changes/cmd-set-metadata.txt
+++ b/DOCS/interface-changes/cmd-set-metadata.txt
@@ -1,0 +1,1 @@
+make the `metadata/by-key` property writable

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2477,7 +2477,7 @@ Property list
 
     This has a number of sub-properties:
 
-    ``metadata/by-key/<key>``
+    ``metadata/by-key/<key>`` (RW)
         Value of metadata entry ``<key>``.
 
     ``metadata/list/count``

--- a/player/command.c
+++ b/player/command.c
@@ -1329,17 +1329,21 @@ static int tag_property(int action, void *arg, struct mp_tags *tags)
         // Direct access without this prefix is allowed for compatibility.
         bstr k = bstr0(ka->key);
         bstr_eatstart0(&k, "by-key/");
-        char *meta = mp_tags_get_bstr(tags, k);
-        if (!meta)
-            return M_PROPERTY_UNKNOWN;
         switch (ka->action) {
-        case M_PROPERTY_GET:
+        case M_PROPERTY_GET: {
+            char *meta = mp_tags_get_bstr(tags, k);
+            if (!meta)
+                return M_PROPERTY_UNKNOWN;
             *(char **)ka->arg = talloc_strdup(NULL, meta);
             return M_PROPERTY_OK;
+        }
         case M_PROPERTY_GET_TYPE:
             *(struct m_option *)ka->arg = (struct m_option){
                 .type = CONF_TYPE_STRING,
             };
+            return M_PROPERTY_OK;
+        case M_PROPERTY_SET:
+            mp_tags_set_bstr(tags, k, bstr0(*(char **)ka->arg));
             return M_PROPERTY_OK;
         }
     }


### PR DESCRIPTION
If track metadata is stored in an external file, it could be read and set by a script. For example:
```lua
local function on_preloaded()
    -- ... metadata reading logic, then
    for k, v in pairs(meta) do
        mp.set_property("metadata/by-key/" .. k, v)
    end
end
```