### PR TITLE
demux_edl: support global_tags with delay_open

### DIFF
--- a/demux/demux_edl.c
+++ b/demux/demux_edl.c
@@ -560,12 +560,11 @@ static struct timeline_par *build_timeline(struct timeline *root,
     if (!tl->track_layout && !tl->delay_open)
         goto error;
     if (!root->meta)
-        root->meta = tl->track_layout;
+        root->meta = tl->track_layout ? tl->track_layout : root->demuxer;
 
     // Not very sane, since demuxer fields are supposed to be treated read-only
     // from outside, but happens to work in this case, so who cares.
-    if (root->meta)
-        mp_tags_merge(root->meta->metadata, edl_root->tags);
+    mp_tags_merge(root->meta->metadata, edl_root->tags);
 
     mp_assert(tl->num_parts == parts->num_parts);
     return tl;

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -62,7 +62,6 @@ local tag_list = {
     ["release_year"]    = "ytdl_release_year",
     ["description"]     = "ytdl_description",
     -- "title" is handled by force-media-title
-    -- tags don't work with all_formats=yes
 }
 
 local safe_protos = Set {


### PR DESCRIPTION
The delay_open mechanism used by
--script-opt=ytdl_hook-all_formats=yes breaks setting metadata with global_tags because tl->track_layout is NULL. See adcf51dccd cbb8f534b0 8ea7aa5471.

Fix this by applying tags to the EDL timeline in this case.

Tags must still be applied to tl->track_layout when available for them to work with local EDL files.