### PR TITLE
**TAKING VOTES** osc.lua: make windowcontrols=auto show window controls in fullscreen

### DIFF
--- a/DOCS/interface-changes/osc-wc.txt
+++ b/DOCS/interface-changes/osc-wc.txt
@@ -2,3 +2,4 @@ add `osc-windowcontrols_independent` script-opt
 change ``osc-windowcontrols=auto`` to enable window controls in fullscreen
 add ``osc-windowcontrols=auto-windowed`` to restore the previous behavior
 add ``osc-windowcontrols_deadzonesize`` script-opt
+add ``osc-windowcontrols_bar`` script-opt

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -481,6 +481,13 @@ Configurable Options
     the window controls will always popup with mouse movement in the window, and
     1 means the window controls will only show up when the mouse hovers it.
 
+``windowcontrols_bar``
+    Default: auto
+
+    Whether to draw a bar and ``windowcontrols_title`` next to the buttons. Can
+    be ``yes``, ``no``, or ``auto``. ``auto`` draws them only when the title is
+    not already printed in the rest of the OSC.
+
 ``floatingtitle``
     Default: yes
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -56,6 +56,7 @@ local user_opts = {
     windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
     windowcontrols_independent = true, -- show window controls and bottom bar independently
     windowcontrols_deadzonesize = 1,   -- size of the window controls deadzone
+    windowcontrols_bar = "auto", -- whether to draw the window controls bar
     floatingtitle = true,         -- show title in the floating layout?
     floatingwidth = 700,          -- width of the floating layout
     floatingalpha = 130,          -- alpha of the floating layout background
@@ -1294,8 +1295,10 @@ local function window_controls(topbar)
              get_hitbox_coords(controlbox_left, wc_geo.y, wc_geo.an,
                                controlbox_w, wc_geo.h))
 
-    local floating_buttons_only = user_opts.layout == "floating"
-                                  and user_opts.floatingtitle
+    local floating_buttons_only = user_opts.windowcontrols_bar == "no" or
+        (user_opts.windowcontrols_bar == "auto" and
+         (user_opts.layout ~= "slimbox" and
+          (user_opts.layout ~= "floating" or user_opts.floatingtitle)))
 
     local lo
 
@@ -1306,9 +1309,12 @@ local function window_controls(topbar)
     lo.layer = 10
     if floating_buttons_only then
         -- Compact background behind buttons only
-        lo.alpha[1] = user_opts.floatingalpha
+        lo.alpha[1] = user_opts[user_opts.layout == "floating" and "floatingalpha" or "boxalpha"]
         local blur_extend = 4
-        local r = 10
+        local r = 0
+        if user_opts.layout == "floating" or user_opts.layout == "box" then
+            r = 10
+        end
         lo.geometry = {
             x = controlbox_left - blur_extend,
             y = wc_geo.y,


### PR DESCRIPTION
This allows quickly quitting mpv in fullscreen.

~~Users with --title-bar/border who don't want them can disable them with --script-opt=osc-windowcontrols=no with no need for conditional profiles. For users who disabled --title-bar/border, nothing changes.~~

`--script-opt=osc-windowcontrols=auto-windowed` restores the previous
behavior.

Arguments for this are:

- Both of the most popular third-party OSCs (uosc and ModernZ) enable them.
- macOS adds them to all fullscreen windows automatically. This commit therefore avoids enabling then on macOS, because they would be redundant.
- Since 353e4efdef (6 years ago) they've been enabled in fullscreen with no border/title-bar without anybody every complaining about them. When we removed them, even though it only affected this non-default configuration, several users came to IRC to complain in a short time.
- It's easier to disable features than to discover that they exist.

Feel free to react with thumbs up or down depending on whether you agree with the change.