### PR TITLE
osc.lua: allow clicking window controls from the top

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1721,7 +1721,6 @@ local function bar_layout(direction, slim)
     }
 
     local padX = 9
-    local padY = 3
     local buttonW = 27
     local tcW = (state.tc_ms) and 170 or 110
     if user_opts.tcspace >= 50 and user_opts.tcspace <= 200 then
@@ -1763,8 +1762,8 @@ local function bar_layout(direction, slim)
         osc_param.video_margins.t = osc_geo.h / osc_param.playresy
     end
 
-    local line1 = osc_geo.y - direction * (9 + padY)
-    local line2 = osc_geo.y - direction * (36 + padY)
+    local line1 = osc_geo.y - direction * 12
+    local line2 = osc_geo.y - direction * 39
 
     osc_param.areas = {}
 
@@ -1797,7 +1796,7 @@ local function bar_layout(direction, slim)
 
 
     -- Menu
-    geo = { x = osc_geo.x + padX + 4, y = line1, an = 4, w = 18, h = 18 - padY }
+    geo = { x = osc_geo.x + padX + 4, y = line1, an = 4, w = 18, h = math.abs(line2 - line1) }
     lo = add_layout("menu")
     lo.geometry = geo
     lo.style = osc_styles.topButtonsBar
@@ -1860,7 +1859,7 @@ local function bar_layout(direction, slim)
 
     -- Playback control buttons
     geo = { x = osc_geo.x + padX + padwc_l, y = line2, an = 4,
-            w = buttonW, h = 36 - padY*2}
+            w = buttonW, h = osc_geo.h - math.abs(line2 - line1)}
     lo = add_layout("play_pause")
     lo.geometry = geo
     lo.style = osc_styles.smallButtonsBar


### PR DESCRIPTION
Allow clicking window controls buttons when the mouse is at the top of the window to make them easier to click.

The close button with the default windowcontrols_alignment=right specifically is already clickable from the rightmost part of the window.

Partial fix of #9791.
