### PR TITLE
vo_gpu_next: add timer for hwdec frame mapping

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -44,6 +44,7 @@
 #include "placebo/utils.h"
 #include "gpu/context.h"
 #include "gpu/hwdec.h"
+#include "gpu/utils.h"
 #include "gpu/video.h"
 #include "gpu/video_shaders.h"
 #include "sub/osd.h"
@@ -109,6 +110,8 @@ struct priv {
     struct gpu_ctx *context;
     struct ra_hwdec_ctx hwdec_ctx;
     struct ra_hwdec_mapper *hwdec_mapper;
+    struct timer_pool *hwdec_timer;
+    struct mp_pass_perf hwdec_perf;
 
     // Allocated DR buffers
     mp_mutex dr_lock;
@@ -526,6 +529,8 @@ static bool hwdec_reconfig(struct priv *p, struct ra_hwdec *hwdec,
             return p->hwdec_mapper;
         } else {
             ra_hwdec_mapper_free(&p->hwdec_mapper);
+            timer_pool_destroy(p->hwdec_timer);
+            p->hwdec_timer = NULL;
         }
     }
 
@@ -534,6 +539,7 @@ static bool hwdec_reconfig(struct priv *p, struct ra_hwdec *hwdec,
         MP_ERR(p, "Initializing texture for hardware decoding failed.\n");
         return NULL;
     }
+    p->hwdec_timer = timer_pool_create(p->ra_ctx->ra);
 
     return p->hwdec_mapper;
 }
@@ -588,15 +594,22 @@ static bool hwdec_acquire(pl_gpu gpu, struct pl_frame *frame)
     if (!hwdec_reconfig(p, fp->hwdec, &mpi->params))
         return false;
 
+    timer_pool_start(p->hwdec_timer);
     if (ra_hwdec_mapper_map(p->hwdec_mapper, mpi) < 0) {
         MP_ERR(p, "Mapping hardware decoded surface failed.\n");
+        timer_pool_stop(p->hwdec_timer);
         return false;
     }
 
     for (int n = 0; n < frame->num_planes; n++) {
-        if (!(frame->planes[n].texture = hwdec_get_tex(p, n)))
+        if (!(frame->planes[n].texture = hwdec_get_tex(p, n))) {
+            timer_pool_stop(p->hwdec_timer);
             return false;
+        }
     }
+
+    timer_pool_stop(p->hwdec_timer);
+    p->hwdec_perf = timer_pool_measure(p->hwdec_timer);
 
     return true;
 }
@@ -1720,27 +1733,41 @@ done:
 }
 
 static inline void copy_frame_info_to_mp(struct frame_info *pl,
-                                         struct mp_frame_perf *mp) {
+                                         struct mp_frame_perf *mp,
+                                         struct mp_pass_perf *hwdec_perf)
+{
     static_assert(MP_ARRAY_SIZE(pl->info) == MP_ARRAY_SIZE(mp->perf), "");
     mp_assert(pl->count <= VO_PASS_PERF_MAX);
-    mp->count = MPMIN(pl->count, VO_PASS_PERF_MAX);
 
-    for (int i = 0; i < mp->count; ++i) {
+    struct mp_pass_perf *perf = mp->perf;
+    char (*desc)[VO_PASS_DESC_MAX_LEN] = mp->desc;
+    struct mp_pass_perf *perf_end = perf + VO_PASS_PERF_MAX;
+
+    if (hwdec_perf && hwdec_perf->count > 0) {
+        *perf++ = *hwdec_perf;
+        snprintf(*desc, sizeof(*desc), "map frame (hwdec)");
+        desc++;
+    }
+
+    for (int i = 0; i < pl->count && perf < perf_end; ++i) {
         const struct pl_dispatch_info *pass = &pl->info[i];
 
         static_assert(VO_PERF_SAMPLE_COUNT >= MP_ARRAY_SIZE(pass->samples), "");
         mp_assert(pass->num_samples <= MP_ARRAY_SIZE(pass->samples));
 
-        struct mp_pass_perf *perf = &mp->perf[i];
         perf->count = MPMIN(pass->num_samples, VO_PERF_SAMPLE_COUNT);
         memcpy(perf->samples, pass->samples, perf->count * sizeof(pass->samples[0]));
         perf->last = pass->last;
         perf->peak = pass->peak;
         perf->avg = pass->average;
 
-        strncpy(mp->desc[i], pass->shader->description, sizeof(mp->desc[i]) - 1);
-        mp->desc[i][sizeof(mp->desc[i]) - 1] = '\0';
+        strncpy(*desc, pass->shader->description, sizeof(*desc) - 1);
+        (*desc)[sizeof(*desc) - 1] = '\0';
+        perf++;
+        desc++;
     }
+
+    mp->count = perf - mp->perf;
 }
 
 static void update_ra_ctx_options(struct vo *vo, struct ra_ctx_opts *ctx_opts)
@@ -1799,8 +1826,8 @@ static int control(struct vo *vo, uint32_t request, void *data)
 
     case VOCTRL_PERFORMANCE_DATA: {
         struct voctrl_performance_data *perf = data;
-        copy_frame_info_to_mp(&p->perf_fresh, &perf->fresh);
-        copy_frame_info_to_mp(&p->perf_redraw, &perf->redraw);
+        copy_frame_info_to_mp(&p->perf_fresh, &perf->fresh, &p->hwdec_perf);
+        copy_frame_info_to_mp(&p->perf_redraw, &perf->redraw, NULL);
         return true;
     }
 
@@ -2052,6 +2079,7 @@ static void uninit(struct vo *vo)
 
     if (vo->hwdec_devs) {
         ra_hwdec_mapper_free(&p->hwdec_mapper);
+        timer_pool_destroy(p->hwdec_timer);
         ra_hwdec_ctx_uninit(&p->hwdec_ctx);
         hwdec_devices_set_loader(vo->hwdec_devs, NULL, NULL);
         hwdec_devices_destroy(vo->hwdec_devs);


### PR DESCRIPTION
With `--d3d11va-zero-copy=no` (default), we do the GPU-GPU copy of the frame, add this time to the stats.