### PR TITLE
w32_common: fix Windows 10 workaround for initial window pos

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1982,6 +1982,7 @@ set_pos_done:
         // adjustment to window position based on invisible borders, on
         // Windows 11 it should be a no-op.
         w32->pending_reset_size = true;
+        w32->window_bounds_initialized = false;
         window_resize(w32);
     }
 


### PR DESCRIPTION
Restores hack from 3d4170b81bae6f714952b24682618b25782cbcf1 to work again.

Fixes: 7466a9f9f3c87a08b1f238a6e2c1d8b99526eca0