### PR TITLE
DOCS/man/options: clarify --directory-filter-types docs

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4377,9 +4377,9 @@ Demuxer
     ``--shuffle``, and like ``lazy`` otherwise.
 
 ``--directory-filter-types=<video,audio,image,archive,playlist>``
-    Media file types to filter when opening directory. If the list is empty,
-    all files are added to the playlist. (Default:
-    ``video,audio,image,archive,playlist``)
+    Media file types to filter when opening directory. To have all files added
+    to the playlist, clear the list using ``--directory-filter-types-clr``.
+    (Default: ``video,audio,image,archive,playlist``)
 
     This is a string list option. See `List Options`_ for details.
 


### PR DESCRIPTION
Using "mpv --directory-filter-types= dir" as an "empty" value doesn't work, because that will create a list where the first value is an empty string, so get_directory_filter() returns AUTO_NONE instead of AUTO_ANY.

You need to use --directory-filter-types-clr instead, to create a proper empty list.

I suppose this is kind of obvious in hindsight, but it took me quite some time and digging through the mpv source to figure this out – initially I assumed it must be a bug of some sort.

So clarify what "empty list" means.