### PR TITLE
wayland: don't use surface local coordinates if we haven't received them 

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1936,7 +1936,7 @@ resize:
                mp_rect_w(wl->geometry), mp_rect_h(wl->geometry));
 
     wl->pending_vo_events |= VO_EVENT_RESIZE;
-    wl->override_surface_local = false;
+    wl->override_surface_local = width == 0 || height == 0;
     wl->toplevel_configured = true;
 }
 


### PR DESCRIPTION
`vo_wayland_handle_scale` might be called from VO side even before mpv receives the first toplevel_config, in which case we'll try to use surface local coordinates but they're still 0.

This could be fixed by initializing override_surface_local as true during init, but probably cleaner to invert the condition instead.

Fixes: https://github.com/mpv-player/mpv/issues/17661