### PR TITLE
meson: build mpv.com with -Os

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1855,7 +1855,7 @@ if get_option('cplayer')
     if win32
         if get_option('win32-subsystem') != 'console'
             wrapper_sources = 'osdep/win32-console-wrapper.c'
-            executable('mpv', wrapper_sources, c_args: ['-municode', '-fno-asynchronous-unwind-tables', '-fno-stack-protector'],
+            executable('mpv', wrapper_sources, c_args: ['-municode', '-fno-asynchronous-unwind-tables', '-fno-stack-protector', '-Os'],
                        link_args: ['-municode', '-nostartfiles', '-nodefaultlibs'],
                        override_options: ['b_sanitize=none'],
                        name_suffix: 'com', install: true)


### PR DESCRIPTION
LLVM even in freestanding build required memset/memcpy/memmove to be implemented. We don't use them directly but the calls are generated from the code, which are later optimized away. Since this suppose to be small utility application, we can always optimize it.

Fixes: #17664