### PR TITLE
vo: don't update zoom and pan while changing file

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1991,8 +1991,11 @@ terminate_playback:
                      current && current->reloading;
     if (current)
         current->reloading = false;
-    if (!reloading)
+    if (!reloading) {
+        if (mpctx->video_out)
+            vo_set_changing_file(mpctx->video_out);
         m_config_restore_backups(mpctx->mconfig);
+    }
 
     TA_FREEP(&mpctx->filter_root);
     talloc_free(mpctx->filtered_tags);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -139,6 +139,7 @@ struct vo_internal {
     bool paused;
     bool visible;
     bool wakeup_on_done;
+    bool changing_file;
     int queued_events;              // event mask for the user
     int internal_events;            // event mask for us
 
@@ -237,12 +238,25 @@ static void read_opts(struct vo *vo)
 static void update_opts(void *p)
 {
     struct vo *vo = p;
+    struct vo_internal *in = vo->in;
 
     if (m_config_cache_update(vo->opts_cache)) {
         read_opts(vo);
         vo->driver->control(vo, VOCTRL_VO_OPTS_CHANGED, NULL);
-        // "Legacy" update of video position related options.
-        // Unlike VOCTRL_VO_OPTS_CHANGED, often not propagated to backends.
+        if (!in->changing_file) {
+            // "Legacy" update of video position related options.
+            // Unlike VOCTRL_VO_OPTS_CHANGED, often not propagated to backends.
+            vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
+        }
+    }
+}
+
+static void handle_file_change(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+
+    if (in->changing_file) {
+        in->changing_file = false;
         vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
     }
 }
@@ -1012,6 +1026,8 @@ static bool render_frame(struct vo *vo)
 
         stats_time_start(in->stats, "video-flip");
 
+        handle_file_change(vo);
+
         vo->driver->flip_page(vo);
 
         struct vo_vsync_info vsync = {
@@ -1234,6 +1250,13 @@ void vo_set_paused(struct vo *vo, bool paused)
         wakeup_locked(vo);
     }
     mp_mutex_unlock(&in->lock);
+}
+
+void vo_set_changing_file(struct vo *vo)
+{
+    mp_mutex_lock(&vo->in->lock);
+    vo->in->changing_file = true;
+    mp_mutex_unlock(&vo->in->lock);
 }
 
 int64_t vo_get_drop_count(struct vo *vo)

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -240,12 +240,10 @@ static void update_opts(void *p)
 
     if (m_config_cache_update(vo->opts_cache)) {
         read_opts(vo);
-        if (vo->driver->control) {
-            vo->driver->control(vo, VOCTRL_VO_OPTS_CHANGED, NULL);
-            // "Legacy" update of video position related options.
-            // Unlike VOCTRL_VO_OPTS_CHANGED, often not propagated to backends.
-            vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
-        }
+        vo->driver->control(vo, VOCTRL_VO_OPTS_CHANGED, NULL);
+        // "Legacy" update of video position related options.
+        // Unlike VOCTRL_VO_OPTS_CHANGED, often not propagated to backends.
+        vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
     }
 }
 

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -542,6 +542,7 @@ bool vo_want_redraw(struct vo *vo);
 void vo_seek_reset(struct vo *vo);
 void vo_destroy(struct vo *vo);
 void vo_set_paused(struct vo *vo, bool paused);
+void vo_set_changing_file(struct vo *vo);
 int64_t vo_get_drop_count(struct vo *vo);
 void vo_increment_drop_count(struct vo *vo, int64_t n);
 int64_t vo_get_delayed_count(struct vo *vo);


### PR DESCRIPTION
When the current playlist entry changes, or when quitting, and file-local options values are reset, the VO re-renders the current file with the new option values before rendering the next file, if any, causing flicker.

Fix this by not making VO drivers resize while changing file until the next frame arrives.

Manually sending VOCTRL_SET_PANSCAN for the new file is only necessary when navigating between images with the same dimensions, else VOs resize automatically on reconfig.

The VO can still re-render while changing file to print new OSD messages, only resizing and panning the image is delayed.

Fixes #7293
Fixes #7675
Fixes https://github.com/Dudemanguy/mpv-manga-reader/issues/12