### PR TITLE
lua: remove the deprecated error field from end-file

### DIFF
--- a/DOCS/interface-changes/end-file-error.txt
+++ b/DOCS/interface-changes/end-file-error.txt
@@ -1,0 +1,1 @@
+remove the deprecated `error` field from `end-file`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1829,8 +1829,7 @@ This list uses the event name field value, and the C API symbol in brackets:
             Playback was ended by sending the quit command.
 
         ``error``
-            An error happened. In this case, an ``error`` field is present with
-            the error string.
+            An error happened.
 
         ``redirect``
             Happens with playlists and similar. Details see
@@ -1849,10 +1848,7 @@ This list uses the event name field value, and the C API symbol in brackets:
 
     ``file_error``
         Set to mpv error string describing the approximate reason why playback
-        failed. Unset if no error known. (In Lua scripting, this value was set
-        on the ``error`` field directly. This is deprecated since mpv 0.33.0.
-        In the future, this ``error`` field will be unset for this specific
-        event.)
+        failed. Unset if no error known.
 
     ``playlist_insert_id``
         If loading ended, because the playlist entry to be played was for example

--- a/player/lua.c
+++ b/player/lua.c
@@ -558,7 +558,7 @@ static int script_get_script_directory(lua_State *L)
 
 static void pushnode(lua_State *L, mpv_node *node);
 
-static int script_raw_wait_event(lua_State *L, void *tmp)
+static int script_wait_event(lua_State *L, void *tmp)
 {
     struct script_ctx *ctx = get_ctx(L);
 
@@ -1226,7 +1226,7 @@ struct fn_entry {
 
 static const struct fn_entry main_fns[] = {
     FN_ENTRY(log),
-    AF_ENTRY(raw_wait_event),
+    AF_ENTRY(wait_event),
     FN_ENTRY(request_event),
     FN_ENTRY(find_config_file),
     FN_ENTRY(get_script_directory),

--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -502,15 +502,6 @@ _G.print = mp.msg.info
 package.loaded["mp"] = mp
 package.loaded["mp.msg"] = mp.msg
 
-function mp.wait_event(t)
-    local r = mp.raw_wait_event(t)
-    if r and r.file_error and not r.error then
-        -- compat; deprecated
-        r.error = r.file_error
-    end
-    return r
-end
-
 _G.mp_event_loop = function()
     mp.dispatch_events(true)
 end


### PR DESCRIPTION
This has been deprecated for 6 years so remove the compatibility code.

This basically reverts 37f441d61b.