### PR TITLE
command: remove the deprecated time-start property

### DIFF
--- a/DOCS/interface-changes/time-start.txt
+++ b/DOCS/interface-changes/time-start.txt
@@ -1,0 +1,1 @@
+remove the deprecated `time-start` property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2342,11 +2342,6 @@ Property list
     ``time-pos/full``
         ``time-pos`` with milliseconds.
 
-``time-start``
-    Deprecated. Always returns 0. Before mpv 0.14, this used to return the start
-    time of the file (could affect e.g. transport streams). See
-    ``--rebase-start-time`` option.
-
 ``time-remaining``
     Remaining length of the file in seconds. Note that the file duration is not
     always exactly known, so this is an estimate.

--- a/player/command.c
+++ b/player/command.c
@@ -852,13 +852,6 @@ static int mp_property_percent_pos(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
-static int mp_property_time_start(void *ctx, struct m_property *prop,
-                                  int action, void *arg)
-{
-    // minor backwards-compat.
-    return property_time(action, arg, 0);
-}
-
 /// Current position in seconds (RW)
 static int mp_property_time_pos(void *ctx, struct m_property *prop,
                                 int action, void *arg)
@@ -4433,7 +4426,6 @@ static const struct m_property mp_properties_base[] = {
     {"frame-drop-count", mp_property_frame_drop_vo},
     {"vo-delayed-frame-count", mp_property_vo_delayed_frame_count},
     {"percent-pos", mp_property_percent_pos},
-    {"time-start", mp_property_time_start},
     {"time-pos", mp_property_time_pos},
     {"time-remaining", mp_property_remaining},
     {"audio-pts", mp_property_audio_pts},


### PR DESCRIPTION
This has been deprecated for 11 years since 70df1608d6 so remove it. All it does is return 0.