### PR TITLE
player/command: fix update-clipboard text-primary

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -7155,7 +7155,7 @@ static void cmd_update_clipboard(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
     struct MPContext *mpctx = cmd->mpctx;
-    struct clipboard_access_params params = {.type = cmd->args[0].v.i};
+    struct clipboard_access_params params = {.target = cmd->args[0].v.i};
     double timeout = cmd->args[1].v.i / 1000.0;
     bool success = false;
 


### PR DESCRIPTION
It mistakenly updates text instead.

Fixes: https://github.com/mpv-player/mpv/pull/17608#issuecomment-4171321728