### PR TITLE
vo_gpu_next: remove swdec from upload frame pass description

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1810,7 +1810,7 @@ static inline void copy_frame_info_to_mp(struct frame_info *pl,
 
     if (sw_upload_perf && sw_upload_perf->count > 0) {
         *perf++ = *sw_upload_perf;
-        snprintf(*desc, sizeof(*desc), "upload frame (swdec)");
+        snprintf(*desc, sizeof(*desc), "upload frame");
         desc++;
     }
 


### PR DESCRIPTION
Users are confused about `-copy` hwdec, which is effectively sw upload, but let's remove this suffix.

Fixes: https://github.com/mpv-player/mpv/pull/17684#issuecomment-4170637631

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
