### PR TITLE
demux_playlist: only autocreate on regular file

### DIFF
--- a/DOCS/interface-changes/autocreate-playlist.txt
+++ b/DOCS/interface-changes/autocreate-playlist.txt
@@ -1,0 +1,1 @@
+make `--autocreate-playlist` only activate for regular files

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4375,8 +4375,8 @@ Demuxer
     This is a string list option. See `List Options`_ for details.
 
 ``--autocreate-playlist=<no|filter|same>``
-    When opening a local file, act as if the parent directory is opened and
-    create a playlist automatically.
+    When opening a local regular file, act as if the parent directory is opened
+    and create a playlist automatically.
 
     :no:     Load a single file (default).
     :filter: Create a playlist from the parent directory with files matching

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -538,7 +538,8 @@ static int parse_dir(struct pl_parser *p)
     struct stream *stream = p->real_stream;
     enum autocreate_mode autocreate = AUTO_NONE;
     p->pl->playlist_dir = NULL;
-    if (p->autocreate_playlist && p->real_stream->is_local_fs && !p->real_stream->is_directory) {
+    if (p->autocreate_playlist && p->real_stream->is_local_fs && p->real_stream->is_regular &&
+        !p->real_stream->is_directory) {
         bstr ext = bstr_get_ext(bstr0(p->real_stream->url));
         switch (p->autocreate_playlist) {
         case 1: // filter

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -163,6 +163,7 @@ typedef struct stream {
     bool is_network : 1; // I really don't know what this is for
     bool is_local_fs : 1; // from the filesystem
     bool is_directory : 1; // directory on the filesystem
+    bool is_regular : 1; // regular file
     bool access_references : 1; // open other streams
     bool allow_partial_read : 1; // allows partial read with stream_read_file()
     struct mp_log *log;

--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -354,6 +354,7 @@ static int open_f(stream_t *stream, const struct stream_open_args *args)
             stream->is_directory = true;
         } else if (S_ISREG(st.st_mode)) {
             p->regular_file = true;
+            stream->is_regular = true;
 #ifndef _WIN32
             // O_NONBLOCK has weird semantics on file locks; remove it.
             int val = fcntl(p->fd, F_GETFL) & ~(unsigned)O_NONBLOCK;


### PR DESCRIPTION
trying to autocreate playlist when the file is a fifo breaks playback. the bug report is a special case of `/dev/fd/*` but even for named fifos, opening and closing them can cause the other end to stop writing.

Closes: https://github.com/mpv-player/mpv/issues/17682