### PR TITLE
video/out/x11_common: fix BadAtom error when getting atom name

### DIFF
--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -174,10 +174,12 @@ static char *x11_atom_name_buf(struct vo_x11_state *x11, Atom atom,
 {
     buf[0] = '\0';
 
-    char *new_name = XGetAtomName(x11->display, atom);
-    if (new_name) {
-        snprintf(buf, buf_size, "%s", new_name);
-        XFree(new_name);
+    if (atom != None) {
+        char *new_name = XGetAtomName(x11->display, atom);
+        if (new_name) {
+            snprintf(buf, buf_size, "%s", new_name);
+            XFree(new_name);
+        }
     }
 
     return buf;


### PR DESCRIPTION
When XdndEnter advertises format without using XdndTypeList, some of the atoms in the 3 fixed items may be None, which causes error in XGetAtomName. Fix this by not resolving name when atom is None.

Fixes the following error message when dragging file on mpv window:
X11 error: BadAtom (invalid Atom parameter)

