### PR TITLE
ao_pipewire: revert cubic volume curves, update docs

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2699,8 +2699,8 @@ Property list
     currently active, and only if the underlying implementation supports volume
     control. What this option does, or how the value is interpreted depends on
     the API. For example, on ALSA this usually changes system-wide audio volume
-    on a linear curve, while with PulseAudio this controls per-application volume
-    on a cubic curve.
+    on a linear curve, while with PipeWire and PulseAudio this controls
+    per-application volume on a cubic curve.
 
 ``ao-mute`` (RW)
     Similar to ``ao-volume``, but controls the mute state. May be unimplemented

--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -273,12 +273,13 @@ static void on_state_changed(void *userdata, enum pw_stream_state old, enum pw_s
 
 static float spa_volume_to_mp_volume(float vol)
 {
-        return vol * 100;
+        return cbrt(vol) * 100;
 }
 
 static float mp_volume_to_spa_volume(float vol)
 {
-        return vol / 100;
+        vol /= 100;
+        return vol * vol * vol;
 }
 
 static float volume_avg(float* vols, uint32_t n)


### PR DESCRIPTION
fix #11065