### PR TITLE
player/command: deprecate ao-volume and ao-mute

### DIFF
--- a/DOCS/interface-changes/deprecate-ao-volume-mute.txt
+++ b/DOCS/interface-changes/deprecate-ao-volume-mute.txt
@@ -1,0 +1,2 @@
+deprecate `ao-volume`
+deprecate `ao-mute`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -2702,9 +2702,13 @@ Property list
     on a linear curve, while with PulseAudio this controls per-application volume
     on a cubic curve.
 
+    .. warning:: This property is deprecated and will be removed in the future.
+
 ``ao-mute`` (RW)
     Similar to ``ao-volume``, but controls the mute state. May be unimplemented
     even if ``ao-volume`` works.
+
+     .. warning:: This property is deprecated and will be removed in the future.
 
 ``audio-params``
     Audio format as output by the audio decoder.


### PR DESCRIPTION
These properties were mostly only useful before the removal of --softvol=no. At present, mpv has its own volume mixer and never touches the audio server volume at all. There's no reason for mpv to provide these properties, if users wish to change the audio server volume, it's trivial to do so in a Lua/Javascript script.

Moreover, ao-volume presents the audio server volume as-is, meaning without any conversion or normalization. As such, the meaning of the value changes depending on the audio server in use or the configuration of the audio server. There's no correct way for mpv to do this normalization. This kind of functionality is better suited for a Lua/Javascript script where the user can normalize the values to their preferred scale, and not bloat mpv with pointless properties that are confusing and not useful.
