### PR TITLE
options/m_option: allow /WS geometry parameter usable without XYWH

### DIFF
--- a/options/m_option.c
+++ b/options/m_option.c
@@ -2357,7 +2357,7 @@ exit:
                BSTR_P(name), BSTR_P(param));
     }
     mp_info(log,
-         "Valid format: [W[%%][xH[%%]]][{+-}X[%%]{+-}Y[%%]] | [X[%%]:Y[%%]]\n");
+         "Valid format: [W[%%][xH[%%]]][{+-}X[%%]{+-}Y[%%]][/WS] | [X[%%]:Y[%%]]\n");
     return is_help ? M_OPT_EXIT : M_OPT_INVALID;
 }
 


### PR DESCRIPTION
This allows specifying workspace while using autofit for window size or leave it as default instead of mandatory geometry in pixels.