### PR TITLE
sub: add sub-lines property

### DIFF
--- a/DOCS/interface-changes/sub-lines.txt
+++ b/DOCS/interface-changes/sub-lines.txt
@@ -1,0 +1,1 @@
+add `sub-lines` and `secondary-sub-lines` properties

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3278,6 +3278,29 @@ Property list
 ``secondary-sub-end``
     Same as ``sub-end``, but for the secondary subtitles.
 
+``sub-lines``
+    The list of subtitle lines in memory. Not available if the subtitle is not
+    text-based (i.e. DVD/BD subtitles).
+
+    When querying the property with the client API using ``MPV_FORMAT_NODE``,
+    or with Lua ``mp.get_property_native``, this will return a mpv_node with
+    the following contents:
+
+    ::
+
+        MPV_FORMAT_NODE_ARRAY
+            MPV_FORMAT_NODE_MAP (for each subtitle line)
+                "text"  MPV_FORMAT_STRING
+                "start" MPV_FORMAT_DOUBLE
+                "end"   MPV_FORMAT_DOUBLE
+
+    ASS tags are stripped from ``text``.
+
+    ``end`` is absent if unknown.
+
+``secondary-sub-lines``
+    Same as ``sub-lines``, but for the secondary subtitles.
+
 ``playlist-pos`` (RW)
     Current position on playlist. The first entry is on position 0. Writing to
     this property may start playback at the new position.

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -336,8 +336,7 @@ g-e
     Select an MKV edition or DVD/Blu-ray title.
 
 g-l
-    Select a subtitle line to seek to. This currently requires ``ffmpeg`` in
-    ``PATH``, or in the same folder as mpv on Windows.
+    Select a subtitle line to seek to.
 
 g-d
     Select an audio device.

--- a/DOCS/man/select.rst
+++ b/DOCS/man/select.rst
@@ -102,9 +102,6 @@ Available script bindings are:
 ``select-subtitle-line``
     Select a subtitle line to seek to. This doesn't work with image subtitles.
 
-    This currently requires ``ffmpeg`` in ``PATH``, or in the same folder as mpv
-    on Windows.
-
 ``select-audio-device``
     Select an audio device.
 

--- a/player/command.c
+++ b/player/command.c
@@ -3418,6 +3418,43 @@ static int mp_property_sub_end(void *ctx, struct m_property *prop,
     return property_time(action, arg, end);
 }
 
+static int mp_property_sub_lines(void *ctx, struct m_property *prop,
+                                 int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    int sub_index = *(int *)prop->priv;
+    struct track *track = mpctx->current_track[sub_index][STREAM_SUB];
+    struct dec_sub *sub = track ? track->d_sub : NULL;
+    if (!sub)
+        return M_PROPERTY_UNAVAILABLE;
+
+    switch (action) {
+    case M_PROPERTY_GET_TYPE:
+        *(struct m_option *)arg = (struct m_option){.type = CONF_TYPE_NODE};
+        return M_PROPERTY_OK;
+    case M_PROPERTY_GET:
+    case M_PROPERTY_GET_NODE: {
+        struct sub_lines *lines = sub_get_lines(sub);
+        if (!lines)
+            return M_PROPERTY_UNAVAILABLE;
+
+        struct mpv_node *node = arg;
+        node_init(node, MPV_FORMAT_NODE_ARRAY, NULL);
+        for (int i = 0; i < lines->num_entries; i++) {
+            struct sub_line *line = &lines->entries[i];
+            struct mpv_node *entry = node_array_add(node, MPV_FORMAT_NODE_MAP);
+            node_map_add_string(entry, "text", line->text);
+            node_map_add_double(entry, "start", line->start);
+            if (line->end != MP_NOPTS_VALUE)
+                node_map_add_double(entry, "end", line->end);
+        }
+        talloc_free(lines);
+        return M_PROPERTY_OK;
+    }
+    }
+    return M_PROPERTY_NOT_IMPLEMENTED;
+}
+
 static int mp_property_playlist_current_pos(void *ctx, struct m_property *prop,
                                             int action, void *arg)
 {
@@ -4613,6 +4650,10 @@ static const struct m_property mp_properties_base[] = {
         .priv = (void *)&(const int){0}},
     {"secondary-sub-end", mp_property_sub_end,
         .priv = (void *)&(const int){1}},
+    {"sub-lines", mp_property_sub_lines,
+        .priv = (void *)&(const int){0}},
+    {"secondary-sub-lines", mp_property_sub_lines,
+        .priv = (void *)&(const int){1}},
 
     {"vf", mp_property_vf},
     {"af", mp_property_af},
@@ -4697,8 +4738,8 @@ static const char *const *const mp_event_property_change[] = {
       "secondary-sub-text", "audio-bitrate", "video-bitrate", "sub-bitrate",
       "decoder-frame-drop-count", "frame-drop-count", "video-frame-info",
       "vf-metadata", "af-metadata", "sub-start", "sub-end", "secondary-sub-start",
-      "secondary-sub-end", "video-out-params", "video-dec-params", "video-params",
-      "deinterlace-active", "video-target-params"),
+      "secondary-sub-end", "sub-lines", "secondary-sub-lines", "video-out-params",
+      "video-dec-params", "video-params", "deinterlace-active", "video-target-params"),
     E(MP_EVENT_DURATION_UPDATE, "duration"),
     E(MPV_EVENT_VIDEO_RECONFIG, "video-out-params", "video-params",
       "video-format", "video-codec", "video-bitrate", "dwidth", "dheight",

--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -285,128 +285,39 @@ mp.add_key_binding(nil, "select-edition", function ()
 end)
 
 mp.add_key_binding(nil, "select-subtitle-line", function ()
-    local sub = mp.get_property_native("current-tracks/sub")
+    local lines = mp.get_property_native("sub-lines")
 
-    if sub == nil then
-        show_warning("No subtitle is loaded.")
+    if not lines then
+        show_warning("Subtitle lines could not be retrieved.")
         return
     end
 
-    if sub.external and sub["external-filename"]:find("^edl://") then
-        sub["external-filename"] = sub["external-filename"]:match('https?://.*')
-                                   or sub["external-filename"]
-    end
-
-    local r = mp.command_native({
-        _name = "subprocess",
-        capture_stdout = true,
-        args = sub.external
-            and {"ffmpeg", "-loglevel", "error", "-i", sub["external-filename"],
-                 "-f", "lrc", "-map_metadata", "-1", "-fflags", "+bitexact", "-"}
-            or {"ffmpeg", "-loglevel", "error", "-i", mp.get_property("path"),
-                "-map", "s:" .. sub["id"] - 1, "-f", "lrc", "-map_metadata",
-                "-1", "-fflags", "+bitexact", "-"}
-    })
-
-    if r.error_string == "init" then
-        show_error("Failed to extract subtitles: ffmpeg not found.")
-        return
-    elseif r.status ~= 0 then
-        show_error("Failed to extract subtitles.")
-        return
-    end
-
-    local sub_lines = {}
-    local sub_times = {}
+    local items = {}
     local default_item
     local delay = mp.get_property_native("sub-delay")
     local time_pos = mp.get_property_native("time-pos") - delay
     local duration = mp.get_property_native("duration", math.huge)
-    local sub_content = {}
 
-    -- Strip HTML and ASS tags and process subtitles
-    for line in r.stdout:gmatch("[^\n]+") do
-        -- Clean up tags
-        local sub_line = line:gsub("<.->", "")                -- Strip HTML tags
-                             :gsub("\\h+", " ")               -- Replace '\h' tag
-                             :gsub("{[\\=].-}", "")           -- Remove ASS formatting
-                             :gsub(".-]", "", 1)              -- Remove time info prefix
-                             :gsub("^%s*(.-)%s*$", "%1")      -- Strip whitespace
-                             :gsub("^m%s[mbl%s%-%d%.]+$", "") -- Remove graphics code
+    for i, line in ipairs(lines) do
+        items[i] = format_time(line.start, duration) .. " " .. line.text
 
-        if sub.codec == "text" or (sub_line ~= "" and sub_line:match("^%s+$") == nil) then
-            local sub_time = line:match("%d+") * 60 + line:match(":([%d%.]*)")
-            local time_seconds = math.floor(sub_time)
-            sub_content[time_seconds] = sub_content[time_seconds] or {}
-            sub_content[time_seconds][sub_line] = true
-        end
-    end
-
-    -- Process all timestamps and content into selectable subtitle list
-    for time_seconds, contents in pairs(sub_content) do
-        for sub_line in pairs(contents) do
-            sub_times[#sub_times + 1] = time_seconds
-            sub_lines[#sub_lines + 1] = format_time(time_seconds, duration) .. " " .. sub_line
-        end
-    end
-
-    -- Generate time -> subtitle mapping
-    local time_to_lines = {}
-    for i = 1, #sub_times do
-        local time = sub_times[i]
-        local line = sub_lines[i]
-
-        if not time_to_lines[time] then
-            time_to_lines[time] = {}
-        end
-        table.insert(time_to_lines[time], line)
-    end
-
-    -- Sort by timestamp
-    local sorted_sub_times = {}
-    for i = 1, #sub_times do
-        sorted_sub_times[i] = sub_times[i]
-    end
-    table.sort(sorted_sub_times)
-
-    -- Use a helper table to avoid duplicates
-    local added_times = {}
-
-    -- Rebuild sub_lines and sub_times based on the sorted timestamps
-    local sorted_sub_lines = {}
-    for _, sub_time in ipairs(sorted_sub_times) do
-        -- Iterate over all subtitle content for this timestamp
-        if not added_times[sub_time] then
-            added_times[sub_time] = true
-            for _, line in ipairs(time_to_lines[sub_time]) do
-                table.insert(sorted_sub_lines, line)
-            end
-        end
-    end
-
-    -- Use the sorted subtitle list
-    sub_lines = sorted_sub_lines
-    sub_times = sorted_sub_times
-
-    -- Get the default item (last subtitle before current time position)
-    for i, sub_time in ipairs(sub_times) do
-        if sub_time <= time_pos then
-            default_item = i
+        if line.start <= time_pos then
+            default_item = #items
         end
     end
 
     input.select({
         prompt = "Select a line to seek to:",
-        items = sub_lines,
+        items = items,
         default_item = default_item,
-        submit = function (index)
+        submit = function (i)
             -- Add an offset to seek to the correct line while paused without a
             -- video track.
             if mp.get_property_native("current-tracks/video/image") ~= false then
                 delay = delay + 0.1
             end
 
-            mp.commandv("seek", sub_times[index] + delay, "absolute")
+            mp.commandv("seek", lines[i].start + delay, "absolute")
         end,
     })
 end)

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -580,3 +580,24 @@ bool sub_is_secondary_visible(struct dec_sub *sub)
     mp_mutex_unlock(&sub->lock);
     return ret;
 }
+
+static int sub_line_cmp(const void *a, const void *b)
+{
+    const struct sub_line *la = a, *lb = b;
+    if (la->start < lb->start) return -1;
+    if (la->start > lb->start) return  1;
+    return 0;
+}
+
+struct sub_lines *sub_get_lines(struct dec_sub *sub)
+{
+    mp_mutex_lock(&sub->lock);
+    struct sub_lines *res = NULL;
+    if (sub->sd->driver->get_lines) {
+        res = sub->sd->driver->get_lines(sub->sd);
+        qsort(res->entries, res->num_entries, sizeof(res->entries[0]),
+              sub_line_cmp);
+    }
+    mp_mutex_unlock(&sub->lock);
+    return res;
+}

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -589,12 +589,46 @@ static int sub_line_cmp(const void *a, const void *b)
     return 0;
 }
 
+static void dedup_sub_lines(struct sub_lines *lines)
+{
+    int window_start = 0;
+    int window_end = 1;
+    int current_shift = 0;
+
+    while (window_end < lines->num_entries) {
+        struct sub_line next = lines->entries[window_end + current_shift];
+        for (int i = window_start; i < window_end; ++i) {
+            if (lines->entries[i].end < next.start) {
+                struct sub_line tmp = lines->entries[window_start];
+                lines->entries[window_start++] = lines->entries[i];
+                lines->entries[i] = tmp;
+                continue;
+            }
+
+            if (!strcmp(lines->entries[i].text, next.text)) {
+                lines->entries[i].end = MPMAX(next.end, lines->entries[i].end);
+                TA_FREEP(&next.text);
+                ++current_shift, --lines->num_entries;
+                goto skip;
+            }
+        }
+
+        lines->entries[window_end++] = next;
+
+    skip:;
+    }
+}
+
 struct sub_lines *sub_get_lines(struct dec_sub *sub)
 {
     mp_mutex_lock(&sub->lock);
     struct sub_lines *res = NULL;
     if (sub->sd->driver->get_lines) {
         res = sub->sd->driver->get_lines(sub->sd);
+        qsort(res->entries, res->num_entries, sizeof(res->entries[0]),
+              sub_line_cmp);
+        dedup_sub_lines(res);
+        // dedup may sometimes reorder lines to keep its window smaller
         qsort(res->entries, res->num_entries, sizeof(res->entries[0]),
               sub_line_cmp);
     }

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -39,6 +39,17 @@ struct attachment_list {
     int num_entries;
 };
 
+struct sub_line {
+    char *text;
+    double start;
+    double end;
+};
+
+struct sub_lines {
+    struct sub_line *entries;
+    int num_entries;
+};
+
 struct dec_sub *sub_create(struct mpv_global *global, struct track *track,
                            struct attachment_list *attachments, int order);
 void sub_destroy(struct dec_sub *sub);
@@ -53,6 +64,9 @@ struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
 char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type);
 char *sub_ass_get_extradata(struct dec_sub *sub);
 struct sd_times sub_get_times(struct dec_sub *sub, double pts);
+// Return subtitle lines in memory. Call talloc_free() on the return value.
+struct sub_lines *sub_get_lines(struct dec_sub *sub);
+
 void sub_reset(struct dec_sub *sub);
 void sub_select(struct dec_sub *sub, bool selected);
 void sub_set_recorder_sink(struct dec_sub *sub, struct mp_recorder_sink *sink);

--- a/sub/sd.h
+++ b/sub/sd.h
@@ -52,6 +52,7 @@ struct sd_functions {
                                        int format, double pts);
     char *(*get_text)(struct sd *sd, double pts, enum sd_text_type type);
     struct sd_times (*get_times)(struct sd *sd, double pts);
+    struct sub_lines *(*get_lines)(struct sd *sd);
 };
 
 // lavc_conv.c

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -1017,6 +1017,44 @@ static void uninit(struct sd *sd)
     talloc_free(ctx->copy_cache);
 }
 
+static struct sub_lines *get_lines(struct sd *sd)
+{
+    struct sd_ass_priv *ctx = sd->priv;
+    ASS_Track *track = ctx->ass_track;
+    struct sub_lines *res = talloc_zero(NULL, struct sub_lines);
+
+    for (int i = 0; i < track->n_events; i++) {
+        ASS_Event *event = &track->events[i];
+        if (!event->Text)
+            continue;
+
+        char *plain = NULL;
+        bstr result = sd_ass_to_plaintext(&plain, event->Text);
+
+        // ASS subtitle lines can have many empty lines after stripping tags,
+        // but empty lines are useful in LRC.
+        if (is_whitespace_only(result)) {
+            talloc_free(plain);
+            if (!strcmp(sd->codec->codec, "ass"))
+                continue;
+            plain = talloc_strdup(res, "");
+        } else {
+            talloc_steal(res, plain);
+        }
+
+        struct sub_line line = {
+            .text  = plain,
+            .start = event->Start / 1000.0,
+            .end   = event->Duration == UNKNOWN_DURATION * 1000
+                         ? MP_NOPTS_VALUE
+                         : (event->Start + event->Duration) / 1000.0,
+        };
+        MP_TARRAY_APPEND(res, res->entries, res->num_entries, line);
+    }
+
+    return res;
+}
+
 static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
 {
     struct sd_ass_priv *ctx = sd->priv;
@@ -1072,6 +1110,7 @@ const struct sd_functions sd_ass = {
     .get_bitmaps = get_bitmaps,
     .get_text = get_text,
     .get_times = get_times,
+    .get_lines = get_lines,
     .control = control,
     .reset = reset,
     .select = enable_output,


### PR DESCRIPTION
sub: add sub-lines property

Return all subtitle lines in memory with text, start and end.

I did not name this sub-all so it cannot be misinterpreted as referring to all subtitle tracks.

Closes #12810.

Mostly generated by Claude.


select.lua: use sub-lines instead of forking to ffmpeg

This:

- Removes the dependency of ffmpeg in PATH - useful on Windows, macOS (?), Flatpak.
- Will support subrandr.
- Avoids redownloading network subtitles.
- Avoids slow demuxing of large mkvs.
- But no longer returns future lines of embedded subtitles.
- No longer returns embedded lines of regions you seeked beyond without playing them ~~(but holding the up key works)~~ this depends if you enable the cache.
- Changing sub track drops cached subtitles.