### PR TITLE
options.lua: stop searching in lua-settings

### DIFF
--- a/DOCS/interface-changes/lua-settings.rst
+++ b/DOCS/interface-changes/lua-settings.rst
@@ -1,0 +1,1 @@
+stop searching the deprecated `lua-settings` directory for script config files

--- a/player/lua/options.lua
+++ b/player/lua/options.lua
@@ -52,14 +52,6 @@ local function read_options(options, identifier, on_update)
     -- read config file
     local conffilename = "script-opts/" .. identifier .. ".conf"
     local conffile = mp.find_config_file(conffilename)
-    if conffile == nil then
-        msg.debug(conffilename .. " not found.")
-        conffilename = "lua-settings/" .. identifier .. ".conf"
-        conffile = mp.find_config_file(conffilename)
-        if conffile then
-            msg.warn("lua-settings/ is deprecated, use directory script-opts/")
-        end
-    end
     local f = conffile and io.open(conffile,"r")
     if f == nil then
         -- config not found


### PR DESCRIPTION
This has been deprecated for 8 years, since 9eadc068fa, with a visible warning. Removing it has the benefit of not spamming every log file with lua-settings searches.