### PR TITLE
player: fix leak on client-message send failure

### DIFF
--- a/player/client.c
+++ b/player/client.c
@@ -818,10 +818,12 @@ int mp_client_send_event(struct MPContext *mpctx, const char *client_name,
         r = send_event(ctx, &event_data, false);
     } else {
         r = -1;
-        talloc_free(data);
     }
 
     mp_mutex_unlock(&clients->lock);
+
+    if (r < 0)
+        talloc_free(data);
 
     return r;
 }


### PR DESCRIPTION
when there's a flood of events causing the event queue to overflow, the duplicated client-message payload gets dropped without being released. free it on failure too.

discovered while trying to trigger #10110.