### PR TITLE
vd_lavc: remove Vulkan hwdec from auto-safe selection

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -266,7 +266,7 @@ struct autoprobe_info {
 // Things not included in this list will be tried last, in random order.
 const struct autoprobe_info hwdec_autoprobe_info[] = {
     {"d3d11va",         HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
-    {"vulkan",          HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
+    {"vulkan",          HWDEC_FLAG_AUTO},
     {"dxva2",           HWDEC_FLAG_AUTO},
     {"nvdec",           HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"vaapi",           HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
@@ -275,7 +275,7 @@ const struct autoprobe_info hwdec_autoprobe_info[] = {
     {"mediacodec",      HWDEC_FLAG_AUTO},
     {"videotoolbox",    HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"d3d11va-copy",    HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
-    {"vulkan-copy",     HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
+    {"vulkan-copy",     HWDEC_FLAG_AUTO},
     {"dxva2-copy",      HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"nvdec-copy",      HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},
     {"vaapi-copy",      HWDEC_FLAG_AUTO | HWDEC_FLAG_WHITELIST},


### PR DESCRIPTION
It's unstable and unfortunately the situation is not getting better over time as there are constantly new regressions introduced, which makes it unsafe for auto selection.

It is also twice as slow as d3d11va on Windows AMD.

See also:
https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/21692
https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/21704
https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/22342
https://github.com/mpv-player/mpv/issues/16782
https://github.com/mpv-player/mpv/issues/17085
https://github.com/mpv-player/mpv/issues/17175
https://github.com/mpv-player/mpv/issues/17370
https://github.com/mpv-player/mpv/issues/17517
https://github.com/mpv-player/mpv/issues/17593
https://github.com/mpv-player/mpv/issues/17688

Those are only issues from recent months, many of which are not fixed.