### PR TITLE
wayland: parse toplevel states before geometry_configured check

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1798,20 +1798,6 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
         width = height = 0;
     }
 
-    if (!wl->geometry_configured) {
-        /* Save initial window size if the compositor gives us a hint here. */
-        bool autofit_or_geometry = opts->geometry.wh_valid || opts->autofit.wh_valid ||
-                                   opts->autofit_larger.wh_valid || opts->autofit_smaller.wh_valid;
-        if (width && height && !autofit_or_geometry) {
-            wl->initial_size_hint = true;
-            wl->window_size = (struct mp_rect){0, 0, width, height};
-            wl->geometry = wl->window_size;
-        } else {
-            wl->override_surface_local = true;
-        }
-        return;
-    }
-
     bool is_maximized = false;
     bool is_fullscreen = false;
     bool is_activated = false;
@@ -1879,6 +1865,20 @@ static void handle_toplevel_config(void *data, struct xdg_toplevel *toplevel,
     wl->tiled = is_tiled;
 
     wl->locked_size = is_fullscreen || is_maximized || is_tiled;
+
+    if (!wl->geometry_configured) {
+        /* Save initial window size if the compositor gives us a hint here. */
+        bool autofit_or_geometry = opts->geometry.wh_valid || opts->autofit.wh_valid ||
+                                   opts->autofit_larger.wh_valid || opts->autofit_smaller.wh_valid;
+        if (width && height && !autofit_or_geometry) {
+            wl->initial_size_hint = true;
+            wl->window_size = (struct mp_rect){0, 0, width, height};
+            wl->geometry = wl->window_size;
+        } else {
+            wl->override_surface_local = true;
+        }
+        return;
+    }
 
     if (wl->requested_decoration)
         request_decoration_mode(wl, wl->requested_decoration);


### PR DESCRIPTION
Fix toplevel state being lost before geometry_configured is configured. Previously, for a KWin rule that set fullscreen (apply initially or forced) when a --geometry was also specified, mpv would render at --geometry size even though the compositor was treating it as fullscreen. This resulted in geometry-sized content anchored to the top-right without a titlebar. This mismatch of what mpv thinks and what actually is can also be seen similarly with a KWin rule that sets a maximize state.

With this change, mpv starts in fullscreen _proper_ (ie --fullscreen). Exiting fullscreen then results in a window size as specified by the --geometry.

For the other states this handles, I'm honestly not sure as I wasn't able to force them. It _should_ be fine based on what I see here and _logically_ is correct as mpv's state should always match what the compositor informs it to be.

The bug was discovered during development of https://github.com/jellyfin/jellyfin-desktop and also confirmed to exist on the mpv master branch. I tested this manually on KWin and with a build of mpv master. 

The change seems to be correct per my relatively newish understanding of the protocol specs. I acknowledge that I understand and can speak to this change I made. I disclose that an LLM (Claude) was used in tracking this down.

---

**Testing examples: KWin rule with `--geometry=1280x720`**

  | Force Maximize | Force Fullscreen |
  |:-:|:-:|
  | ![Screenshot_20260412_162305](https://github.com/user-attachments/assets/aee7c739-f89b-4db3-8fa5-3fb360bdcf8f) |  ![Screenshot_20260412_162346](https://github.com/user-attachments/assets/11624040-294f-4e4b-aafa-7f01945f2eda) 