### PR TITLE
mpv.metainfo.xml: Update screenshot URL

### DIFF
--- a/etc/mpv.metainfo.xml
+++ b/etc/mpv.metainfo.xml
@@ -18,7 +18,7 @@
     <content_rating type="oars-1.1" />
     <screenshots>
         <screenshot type="default">
-            <image>https://mpv.io/images/mpv-screenshot-34cd36ae.jpg</image>
+            <image>https://mpv.io/images/mpv-screenshot-0935decb.png</image>
             <caption>Main window</caption>
         </screenshot>
     </screenshots>


### PR DESCRIPTION
The previous URL causes a "404 - Not Found" error meanwhile.