### PR TITLE
Remove negatives in front of 0 for subtitle seeking

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5774,7 +5774,7 @@ static void cmd_seek(void *p)
     switch (abs) {
     case 0: { // Relative seek
         queue_seek(mpctx, MPSEEK_RELATIVE, v, precision, MPSEEK_FLAG_DELAY);
-        set_osd_function(mpctx, (v > 0) ? OSD_FFW : OSD_REW);
+        set_osd_function(mpctx, (v >= 0) ? OSD_FFW : OSD_REW);
         break;
     }
     case 1: { // Absolute seek by percentage
@@ -5796,14 +5796,14 @@ static void cmd_seek(void *p)
         }
         queue_seek(mpctx, MPSEEK_ABSOLUTE, v, precision, MPSEEK_FLAG_DELAY);
         set_osd_function(mpctx,
-                         v > get_current_time(mpctx) ? OSD_FFW : OSD_REW);
+                         v >= get_current_time(mpctx) ? OSD_FFW : OSD_REW);
         break;
     }
     case 3: { // Relative seek by percentage
         queue_seek(mpctx, MPSEEK_FACTOR,
                    get_current_pos_ratio(mpctx, false) + v / 100.0,
                    precision, MPSEEK_FLAG_DELAY);
-        set_osd_function(mpctx, v > 0 ? OSD_FFW : OSD_REW);
+        set_osd_function(mpctx, v >= 0 ? OSD_FFW : OSD_REW);
         break;
     }}
     if (cmd->seek_bar_osd)
@@ -6135,7 +6135,7 @@ static void cmd_sub_step_seek(void *p)
                 mark_seek(mpctx);
                 queue_seek(mpctx, MPSEEK_ABSOLUTE, a[0], MPSEEK_EXACT,
                            MPSEEK_FLAG_DELAY);
-                set_osd_function(mpctx, (a[0] > refpts) ? OSD_FFW : OSD_REW);
+                set_osd_function(mpctx, (a[0] >= refpts) ? OSD_FFW : OSD_REW);
                 if (cmd->seek_bar_osd)
                     mpctx->add_osd_seek_info |= OSD_SEEK_INFO_BAR;
                 if (cmd->seek_msg_osd)


### PR DESCRIPTION
If you seek to a subtitle delay of 0, the message has a negative in front of it, which you typically don't write in front of 0.

<img width="301" height="75" alt="image" src="https://github.com/user-attachments/assets/c200061d-d11d-4777-a159-a894c7d9172b" />