### PR TITLE
osc.lua: reduce floatingalpha a little

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -473,7 +473,7 @@ Configurable Options
     Width of the ``floating`` layout.
 
 ``floatingalpha``
-    Default: 130
+    Default: 105
 
     Alpha of the ``floating`` layout background, 0 (opaque) to 255 (fully
     transparent).

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -56,7 +56,7 @@ local user_opts = {
     windowcontrols_independent = true, -- show window controls and bottom bar independently
     floatingtitle = true,         -- show title in the floating layout?
     floatingwidth = 700,          -- width of the floating layout
-    floatingalpha = 130,          -- alpha of the floating layout background
+    floatingalpha = 105,          -- alpha of the floating layout background
     tracknumberswidth = 35,       -- width for track number labels (0 = icon only)
     greenandgrumpy = false,     -- disable santa hat
     livemarkers = true,         -- update seekbar chapter markers on duration change


### PR DESCRIPTION
Alpha blending is done in gamma light of the target, when the overlay is drawn. Depending on VO and target format, the alpha value can act quite differently.

Lower it a little to avoid excessive transparency in some cases. This should be fixed or workaround in better way, but for now just adjust the value.