### PR TITLE
ytdl_hook.lua: set the title in metadata

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -37,6 +37,7 @@ end
 
 -- youtube-dl JSON name to mpv tag name
 local tag_list = {
+    ["title"]           = "title",
     ["artist"]          = "artist",
     ["album"]           = "album",
     ["album_artist"]    = "album_artist",
@@ -729,10 +730,6 @@ local function add_single_video(json)
     msg.debug("streamurl: " .. streamurl)
 
     mp.set_property("stream-open-filename", streamurl:gsub("^data:", "data://", 1))
-
-    if mp.get_property("force-media-title", "") == "" then
-        mp.set_property("file-local-options/force-media-title", json.title)
-    end
 
     -- set hls-bitrate for dash track selection
     if max_bitrate > 0 and


### PR DESCRIPTION
93fe7a5526 made global_tags work with all_formats=yes, so do like suggested in 8ea7aa5471 and set the title via tags.

This makes available in ${metadata/title}, even if you set --force-media-title separately.

--force-media-title is also set when self_redirecting_url is true, but tags seem not to be set in this case and I don't know where to find such videos to test. It was originally added to close #5313, but the URL linked there no longer loads.