### PR TITLE
wayland: always override surface local coordinates on reconfig

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -4682,6 +4682,7 @@ bool vo_wayland_reconfig(struct vo *vo)
         wl->geometry_configured = true;
     }
 
+    wl->override_surface_local = true;
     wl->pending_vo_events |= VO_EVENT_RESIZE;
 
     return true;


### PR DESCRIPTION
Previous commit fixes the issue when doing state changes but I never actually tested just normal reconfigs (i.e. advancing a file in a playlist). Override it in this case too. Fixes #17755.