### PR TITLE
DOCS/man/input: fix mouse-pos/hover documentation

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3153,8 +3153,15 @@ Property list
 
     ``mouse-pos/hover``
         Boolean - whether the mouse pointer hovers the video window. The
-        coordinates should be ignored when this value is false, because the
-        video backends update them only when the pointer hovers the window.
+        coordinates should be ignored when this value is false if no mouse
+        button is being pressed, because the video backends update them only
+        when the pointer hovers the window in this case.
+
+        If a mouse button is pressed while the pointer hovers the video window
+        and then the mouse pointer moves out of window region without releasing
+        the button, some video backends "capture" the pointer and still report
+        the coordinates. In this case, the value of this property may be true or
+        false depending on the video backend.
 
 ``touch-pos``
     Read-only - last known touch point positions, normalized to OSD dimensions.

--- a/player/command.c
+++ b/player/command.c
@@ -7001,7 +7001,6 @@ static void cmd_mouse(void *p)
         mp_input_get_mouse_pos(mpctx->input, &oldx, &oldy, &oldhover);
         struct mp_osd_res vo_res = osd_get_vo_res(mpctx->osd);
 
-        // TODO: VOs don't send outside positions. should we abort if outside?
         int hover = x >= 0 && y >= 0 && x < vo_res.w && y < vo_res.h;
 
         if (vo_res.w && vo_res.h && hover != oldhover)

--- a/player/command.c
+++ b/player/command.c
@@ -7011,8 +7011,7 @@ static void cmd_mouse(void *p)
     if (button == -1) {// no button
         if (pre_key)
             mp_input_put_key_artificial(mpctx->input, pre_key, 1);
-        if (pre_key != MP_KEY_MOUSE_LEAVE)
-            mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
+        mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
         return;
     }
     if (button < 0 || button >= MP_KEY_MOUSE_BTN_COUNT) {// invalid button
@@ -7030,10 +7029,8 @@ static void cmd_mouse(void *p)
     button += dbc ? MP_MBTN_DBL_BASE : MP_MBTN_BASE;
     if (pre_key)
         mp_input_put_key_artificial(mpctx->input, pre_key, 1);
-    if (pre_key != MP_KEY_MOUSE_LEAVE) {
-        mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
-        mp_input_put_key_artificial(mpctx->input, button, 1);
-    }
+    mp_input_set_mouse_pos_artificial(mpctx->input, x, y);
+    mp_input_put_key_artificial(mpctx->input, button, 1);
 }
 
 static void cmd_key(void *p)


### PR DESCRIPTION
The comment about video backends not updating pointer position is only true if no mouse button is being pressed. If mouse button is pressed on mpv window and then moves out of window region without releasing the button, some platforms (win32, Wayland, X11) "capture" the pointer and still report the coordinates, while some other platforms (SDL) do not.

The value of mouse-pos/hover also differs between platforms in this case. The value is true on win32 and Wayland, but false on X11.

Fix documentation to address them.