### PR TITLE
sanitize missed escape sequences

### DIFF
--- a/common/msg.c
+++ b/common/msg.c
@@ -559,7 +559,7 @@ static void write_term_msg(struct mp_log *log, int lev, bstr text, bstr *out)
     }
 }
 
-static void sanitize(bstr *text)
+void mp_msg_sanitize(bstr *text)
 {
     for (size_t i = 0; i < text->len; i++) {
         unsigned char ch = text->start[i];
@@ -587,8 +587,19 @@ static void sanitize(bstr *text)
                 text->start[i] = '?';
         }
         // Allow only printable > 0x20 and 0x08-0x0D (backspace, tab, newline, ...)
-        else if (ch < 0x08 || (ch > 0x0D && ch < 0x20)) {
+        else if (ch < 0x08 || (ch > 0x0D && ch < 0x20) || ch == 0x7F) {
             text->start[i] = '?';
+        }
+        // Block UTF-8 encoded C1 controls (U+0080-U+009F = bytes C2 80..C2 9F).
+        // xterm interprets these as C1 control functions (CSI, OSC, DCS, ST, ...),
+        // which allows bypassing the ESC/BEL filter above.
+        else if (ch == 0xC2 && i + 1 < text->len &&
+                 (unsigned char)text->start[i + 1] >= 0x80 &&
+                 (unsigned char)text->start[i + 1] <= 0x9F)
+        {
+            text->start[i] = '?';
+            text->start[i + 1] = '?';
+            i++;
         }
     }
 }
@@ -613,7 +624,7 @@ void mp_msg_va(struct mp_log *log, int lev, const char *format, va_list va)
         bstr_xappend(root, &root->buffer, bstr0(format));
     }
 
-    sanitize(&root->buffer);
+    mp_msg_sanitize(&root->buffer);
 
     // Remember last status message and restore it to ensure that it is
     // always displayed

--- a/common/msg.h
+++ b/common/msg.h
@@ -67,6 +67,10 @@ static inline bool mp_msg_test(struct mp_log *log, int lev)
 
 void mp_msg_set_max_level(struct mp_log *log, int lev);
 
+// Sanitize text for terminal output.
+struct bstr;
+void mp_msg_sanitize(struct bstr *text);
+
 // Convenience macros.
 #define mp_fatal(log, ...)      mp_msg(log, MSGL_FATAL, __VA_ARGS__)
 #define mp_err(log, ...)        mp_msg(log, MSGL_ERR, __VA_ARGS__)

--- a/player/osd.c
+++ b/player/osd.c
@@ -108,7 +108,9 @@ static void term_osd_update_title(struct MPContext *mpctx)
         return;
 
     char *s = mp_property_expand_escaped_string(mpctx, mpctx->opts->term_title);
-    if (bstr_equals(bstr0(s), bstr0(mpctx->term_osd_title))) {
+    bstr title = bstr0(s);
+    mp_msg_sanitize(&title);
+    if (bstr_equals(title, bstr0(mpctx->term_osd_title))) {
         talloc_free(s);
         return;
     }


### PR DESCRIPTION
~~The current version of mpv prints media metadata (title tags, chapter names, etc.) to the terminal in its OSD/status line. A crafted media file with escape sequences in its metadata can inject sequences into the terminal.~~

~~The issue is related to the interpretation of OSC sequences in most terminals. This can allow attacks such as spoofing terminal content and overwriting the clipboard. Since the user is not aware of this and may expect different content in the clipboard, there is a chance they may paste this into a terminal and reach code execution.~~


~~The PR replaces any byte that could end or escape out of an OSC-0 payload. This includes the C0 range (which contains BEL 0x07, the OSC terminator, and ESC 0x1B, which can introduce further escape sequences or form the 2-byte ST terminator ESC \), and DEL 0x7F. UTF-8 continuation bytes (0x80-0xBF) and lead bytes (0xC0-0xFF) are left alone so non-ASCII titles render. Note: byte 0x9C is ST in 8-bit C1 mode but is also a legitimate UTF-8 continuation byte; mpv assumes a UTF-8 terminal, matching the rest of the codebase.~~

The sanitize function misses 0xC2 and 0x9D. On xterm, these are interpreted as C1 control characters, allowing OSC 52 clipboard injection with zero ESC or BEL bytes.