### PR TITLE
wayland: use av_gcd instead of inventing our own gcd function

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -430,3 +430,8 @@ int mp_lcm(int x, int y)
     mp_assert(x && y);
     return x * (y / av_gcd(x, y));
 }
+
+int64_t mp_gcd(int64_t x, int64_t y)
+{
+    return av_gcd(x, y);
+}

--- a/common/common.h
+++ b/common/common.h
@@ -140,6 +140,7 @@ void mp_rect_rotate(struct mp_rect *rc, int w, int h, int rotation);
 unsigned int mp_log2(uint32_t v);
 uint32_t mp_round_next_power_of_2(uint32_t v);
 int mp_lcm(int x, int y);
+int64_t mp_gcd(int64_t x, int64_t y);
 
 int mp_snprintf_cat(char *str, size_t size, const char *format, ...)
     MP_PRINTF_ATTRIBUTE(3, 4);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -303,7 +303,6 @@ static bool single_output_spanned(struct vo_wayland_state *wl);
 static int check_for_resize(struct vo_wayland_state *wl, int edge_pixels,
                             enum xdg_toplevel_resize_edge *edges);
 static int get_mods(struct vo_wayland_seat *seat);
-static int greatest_common_divisor(int a, int b);
 static int handle_round(int scale, int n);
 static int set_cursor_visibility(struct vo_wayland_seat *s, bool on);
 static int spawn_cursor(struct vo_wayland_state *wl);
@@ -3295,14 +3294,6 @@ static void get_shape_device(struct vo_wayland_state *wl, struct vo_wayland_seat
     }
 }
 
-static int greatest_common_divisor(int a, int b)
-{
-    int rem = a % b;
-    if (rem == 0)
-        return b;
-    return greatest_common_divisor(b, rem);
-}
-
 static void guess_focus(struct vo_wayland_state *wl)
 {
     // We can't actually know if the window is focused or not in wayland,
@@ -3848,7 +3839,7 @@ static void set_geometry(struct vo_wayland_state *wl, bool resize)
     vo_calc_window_geometry(vo, wl->opts, &screenrc, &screenrc, wl->scaling_factor, false, &geo, NULL);
     vo_apply_window_geometry(vo, &geo);
 
-    int gcd = greatest_common_divisor(vo->dwidth, vo->dheight);
+    int gcd = mp_gcd(vo->dwidth, vo->dheight);
     wl->reduced_width = vo->dwidth / gcd;
     wl->reduced_height = vo->dheight / gcd;
 


### PR DESCRIPTION
Adds mp_gcd wrapper for av_gcd and uses it instead.

