### PR TITLE
Improve console.lua item width heuristic with `term_disp_width`

### DIFF
--- a/DOCS/interface-changes/mp-utils-terminal-display-width.txt
+++ b/DOCS/interface-changes/mp-utils-terminal-display-width.txt
@@ -1,0 +1,2 @@
+add `mp.utils.terminal_display_width()` function that measures the width of
+a string in terminal cells

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -35,6 +35,7 @@
 #include "input/input.h"
 #include "options/path.h"
 #include "misc/bstr.h"
+#include "misc/codepoint_width.h"
 #include "osdep/timer.h"
 #include "osdep/threads.h"
 #include "stream/stream.h"
@@ -1000,6 +1001,15 @@ static void script_get_env_list(js_State *J)
     }
 }
 
+// args: text
+static void script_terminal_display_width(js_State *J)
+{
+    bstr text = bstr0(js_tostring(J, 1));
+    const unsigned char *cut_pos;
+    int width = term_disp_width(text, INT_MAX, &cut_pos);
+    js_pushnumber(J, width);
+}
+
 // args: as-filename, content-string, returns the compiled result as a function
 static void script_compile_js(js_State *J)
 {
@@ -1202,6 +1212,7 @@ static const struct fn_entry utils_fns[] = {
     FN_ENTRY(split_path, 1),
     AF_ENTRY(join_path, 2),
     FN_ENTRY(get_env_list, 0),
+    FN_ENTRY(terminal_display_width, 1),
 
     FN_ENTRY(read_file, 2),
     AF_ENTRY(_write_file, 3),

--- a/player/lua.c
+++ b/player/lua.c
@@ -38,6 +38,7 @@
 #include "input/input.h"
 #include "options/path.h"
 #include "misc/bstr.h"
+#include "misc/codepoint_width.h"
 #include "misc/json.h"
 #include "osdep/subprocess.h"
 #include "osdep/timer.h"
@@ -1216,6 +1217,15 @@ static int script_get_env_list(lua_State *L)
     return 1;
 }
 
+static int script_terminal_display_width(lua_State *L)
+{
+    bstr text = bstr0(luaL_checkstring(L, 1));
+    const unsigned char *cut_pos;
+    int width = term_disp_width(text, INT_MAX, &cut_pos);
+    lua_pushnumber(L, width);
+    return 1;
+}
+
 #define FN_ENTRY(name) {#name, script_ ## name, 0}
 #define AF_ENTRY(name) {#name, 0, script_ ## name}
 struct fn_entry {
@@ -1265,6 +1275,7 @@ static const struct fn_entry utils_fns[] = {
     AF_ENTRY(parse_json),
     AF_ENTRY(format_json),
     FN_ENTRY(get_env_list),
+    FN_ENTRY(terminal_display_width),
     {0}
 };
 

--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -348,9 +348,12 @@ local function calculate_max_item_width()
     end
 
     local longest_item = prompt .. ("a"):rep(9)
+    local longest_item_width = utils.terminal_display_width(longest_item)
     for _, item in pairs(selectable_items) do
-        if #item > #longest_item then
+        local item_width = utils.terminal_display_width(item)
+        if item_width > longest_item_width then
             longest_item = item
+            longest_item_width = item_width
         end
     end
 

--- a/player/lua/context_menu.lua
+++ b/player/lua/context_menu.lua
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
 ]]
 
+local utils = require "mp.utils"
 local assdraw = require "mp.assdraw"
 
 local options = {
@@ -157,9 +158,12 @@ local function calculate_width(menu_items, osd_w, osd_h, checkbox)
     end
 
     local longest = ""
+    local longest_width = 0
     for _, title in pairs(titles) do
-        if #title > #longest then
+        local title_width = utils.terminal_display_width(title)
+        if title_width > longest_width then
             longest = title
+            longest_width = title_width
         end
     end
 


### PR DESCRIPTION
player/{lua,javascript}: add `mp.utils.terminal_display_width` function

console.lua: use `terminal_display_width` when picking longest menu item

Previously this function would just count bytes which was very easily
broken by incantations like `OK` which take up 52 bytes while being just
2 normal width characters visually.

`terminal_display_width` correctly counts `OK` as 2 visual characters.

Note: GitHub strips all these in their web UI but there are many Unicode
combining characters after each letter of the `OK`s above that produce
a "cursed" text effect.

Fixes https://github.com/mpv-player/mpv/issues/17772

---

Considerations:
- bikeshed the function's name?
- `term_disp_width` skips `ESC [` sequences and handles tabs in a particular way which probably doesn't match ASS so those may break this somewhat

Alternatives:
- Expose just grapheme segmentation instead (more effort)