### PR TITLE
demux/packet: fix version check for SMPTE 2094-50 metadata

### DIFF
--- a/demux/packet.c
+++ b/demux/packet.c
@@ -334,7 +334,7 @@ int demux_packet_add_blockadditional(struct demux_packet *dp, uint64_t id,
             }
 
             return 0;
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(60, 30, 100)
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(62, 30, 100)
         } else if (provider_code == ITU_T_T35_PROVIDER_CODE_SMPTE) {
             uint16_t provider_oriented_code = AV_RB16(p);
             p += sizeof(provider_oriented_code);


### PR DESCRIPTION
This enum was added in lavc 60.30.100 in https://github.com/ffmpeg/ffmpeg/commit/7faa6ee2aa01

Fixes build failure with older ffmpeg

Fixes: 76df24f40c4b ("demux/packet: add support for SMPTE 2094-50 metadata")

