### PR TITLE
vo_gpu_next: don't dither scRGB

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -955,6 +955,11 @@ static void apply_target_options(struct priv *p, struct pl_frame *target,
         struct ra_swapchain *sw = p->ra_ctx->swapchain;
         dither_depth = sw->fns->color_depth ? sw->fns->color_depth(sw) : 0;
     }
+#if PL_API_VER >= 362
+    // Don't dither scRGB, assume downstream will handle quantization properly.
+    if (target->color.transfer == PL_COLOR_TRC_SCRGB)
+        dither_depth = -1;
+#endif
     if (dither_depth > 0) {
         struct pl_bit_encoding *tbits = &target->repr.bits;
         tbits->color_depth += dither_depth - tbits->sample_depth;


### PR DESCRIPTION
scRGB is basically intermediary format, but we don't really know what would be the real target. And since we send floating-point buffer, we can just expect the downstream will handle dithering and quantization at some point.