### PR TITLE
osc.lua: use the cached chapter-list for chapter markers

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2485,10 +2485,9 @@ local function osc_init()
     ne.slider.markerF = function ()
         local duration = mp.get_property_number("duration")
         if duration ~= nil then
-            local chapters = mp.get_property_native("chapter-list", {})
             local markers = {}
-            for n = 1, #chapters do
-                markers[n] = (chapters[n].time / duration * 100)
+            for n = 1, #state.chapter_list do
+                markers[n] = (state.chapter_list[n].time / duration * 100)
             end
             return markers
         else


### PR DESCRIPTION
When 0197729949 added state.chapter_list this call was not updated to use the cached value, but there is no reason not to use it, especially now that more cached properties are used.