### PR TITLE
osc: add property to signal thumbnailer status

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -733,6 +733,10 @@ The OSC supports displaying preview thumbnails when hovering over the seekbar if
 a compatible thumbnailer script is installed. It communicates with a thumbnailer
 script via the following ``user-data`` properties:
 
+``user-data/osc/thumbnailer-enabled``
+    Boolean property set by the thumbnailer to signal that it is capable of
+    providing thumbnail for the currently playing file.
+
 ``user-data/osc/draw-preview``
     Set by the OSC to request a thumbnail within the currently playing file.
     The requested thumbnail timestamp in seconds is set in

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -365,6 +365,10 @@ local santa_hat_lines = {
 -- luacheck: pop
 
 
+local thumbnailer_enabled = false
+mp.observe_property("user-data/osc/thumbnailer-enabled", "bool",
+    function(_, val) thumbnailer_enabled = val or false end)
+
 --
 -- Helper functions
 --
@@ -1198,7 +1202,7 @@ local function render_elements(master_ass)
                     -- thumbnail
                     local vop = mp.get_property_native("video-out-params")
                     local draw_thumbnail = state.osd_dimensions.w > 0 and vop
-                    if draw_thumbnail then
+                    if draw_thumbnail and thumbnailer_enabled then
                         local r_w, r_h = get_virt_scale_factor()
                         local thumb_max = math.min(user_opts.max_thumb_size,
                             math.min(state.osd_dimensions.w, state.osd_dimensions.h) * 0.25)


### PR DESCRIPTION
this was part of the initial pull request (#17518) but was dropped after adding the `ass` field to the draw request.

however another use case for this is for UI scripts which position their elements based on whether the thumbnailer is active or not (e.g modernZ [^0]).

while the docs already mentions that multiple thumbnailer isn't supported in practice you could have two non-conflicting thumbnailer (e.g [thumbfast] for local files and [thumbyt] for network/youtube files) installed and they'd have worked fine.

an unfortunate side effect of adding an enabled field is that such configuration will no longer work (reliably) since both scripts will end up setting this field to false without synchronization.

Fixes: https://github.com/mpv-player/mpv/pull/17518#discussion_r3110263692

[^0]: https://github.com/mpv-player/mpv/pull/17518#discussion_r3114110555

[thumbfast]: https://github.com/po5/thumbfast
[thumbyt]: https://codeberg.org/NRK/mpv-toolbox/src/branch/master/thumbyt