### PR TITLE
w32_common: clear window_minimized flag on minimize->maximize

### DIFF
--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1407,6 +1407,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             switch (wParam) {
             case SIZE_MAXIMIZED:
                 w32->opts->window_maximized = true;
+                w32->opts->window_minimized = false;
                 break;
             case SIZE_MINIMIZED:
                 w32->opts->window_minimized = true;


### PR DESCRIPTION
It doesn't send RESTORE in this case, so the state got confused.

Fixes: #17678