### PR TITLE
misc/codepoint_width: handle partially ill-formed UTF-8

### DIFF
--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -258,36 +258,43 @@ int bstr_parse_utf8_code_length(unsigned char b)
     return (bytes >= 2 && bytes <= 4) ? bytes : -1;
 }
 
-int bstr_decode_utf8(struct bstr s, struct bstr *out_next)
+int bstr_decode_partial_utf8(struct bstr *s)
 {
-    if (s.len == 0)
+    if (s->len == 0)
         return -1;
-    unsigned int codepoint = s.start[0];
-    s.start++; s.len--;
+    unsigned int codepoint = s->start[0];
+    s->start++; s->len--;
     if (codepoint >= 128) {
         int bytes = bstr_parse_utf8_code_length(codepoint);
-        if (bytes < 1 || s.len < bytes - 1)
-            return -1;
+        if (bytes < 1)
+            return BSTR_DECODE_OUT_OF_RANGE;
         codepoint &= 127 >> bytes;
         for (int n = 1; n < bytes; n++) {
-            int tmp = (unsigned char)s.start[0];
+            if (!s->len)
+                return BSTR_DECODE_TRUNCATED_SEQUENCE;
+            int tmp = (unsigned char)s->start[0];
             if ((tmp & 0xC0) != 0x80)
-                return -1;
+                return BSTR_DECODE_TRUNCATED_SEQUENCE;
             codepoint = (codepoint << 6) | (tmp & ~0xC0);
-            s.start++; s.len--;
+            s->start++; s->len--;
         }
         if (codepoint > 0x10FFFF || (codepoint >= 0xD800 && codepoint <= 0xDFFF))
-            return -1;
+            return BSTR_DECODE_OUT_OF_RANGE;
+
         // Overlong sequences - check taken from libavcodec.
-        // (The only reason we even bother with this is to make libavcodec's
-        //  retarded subtitle utf-8 check happy.)
         unsigned int min = bytes == 2 ? 0x80 : 1 << (5 * bytes - 4);
         if (codepoint < min)
-            return -1;
+            return BSTR_DECODE_OVERLONG_ENCODING;
     }
-    if (out_next)
-        *out_next = s;
     return codepoint;
+}
+
+int bstr_decode_utf8(struct bstr s, struct bstr *out_next)
+{
+    int res = bstr_decode_partial_utf8(&s);
+    if (res >= 0 && out_next)
+        *out_next = s;
+    return res;
 }
 
 struct bstr bstr_split_utf8(struct bstr str, struct bstr *out_next)

--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -88,11 +88,34 @@ bool bstr_in_list0(struct bstr str, char **list);
 // ignored. When successful, this allocates a new array to store the output.
 bool bstr_decode_hex(void *talloc_ctx, struct bstr hex, struct bstr *out);
 
+#define BSTR_DECODE_OUT_OF_RANGE -1
+#define BSTR_DECODE_TRUNCATED_SEQUENCE -2
+#define BSTR_DECODE_OVERLONG_ENCODING -3
+
+// Decode the UTF-8 code point at the start of the string, and return the
+// character.
+//
+// Unlike `bstr_decode_utf8`, this function will modify `str` directly
+// and will advance it even if the sequence at the start of the string
+// is ill-formed.
+//
+// On error, returns an error code depending on what type of ill-formed
+// sequence was encountered.
+// - `BSTR_DECODE_OUT_OF_RANGE` is returned if the first byte starts a
+//   five or six byte sequence or if the consumed sequence resulted in
+//   a value that is not a valid code point.
+// - `BSTR_DECODE_TRUNCATED_SEQUENCE` if an initially valid sequence
+//   was interrupted by an invalid continuation or the end of the string.
+//   Note that the consumed prefix may additionally be overlong.
+// - `BSTR_DECODE_OVERLONG_ENCODING` if a non-shortest-form sequence
+//   was fully decoded and rejected.
+int bstr_decode_partial_utf8(struct bstr *str);
+
 // Decode the UTF-8 code point at the start of the string, and return the
 // character.
 // After calling this function, *out_next will point to the next character.
 // out_next can be NULL.
-// On error, -1 is returned, and *out_next is not modified.
+// On error, a negative value is returned, and *out_next is not modified.
 int bstr_decode_utf8(struct bstr str, struct bstr *out_next);
 
 // Return the UTF-8 code point at the start of the string.

--- a/misc/codepoint_width.c
+++ b/misc/codepoint_width.c
@@ -658,6 +658,25 @@ static int ucdToCharacterWidth(const int val)
 
 #include "common/common.h"
 
+// Check whether a truncated UTF-8 sequence is well-formed.
+//
+// See https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G27506
+static bool is_valid_partial_sequence(struct bstr seq)
+{
+    if (seq.len < 2)
+        return true;
+
+    if (seq.start[0] == 0xE0)
+        return seq.start[1] >= 0xA0;
+    else if (seq.start[0] == 0xED)
+        return seq.start[1] <= 0x9F;
+    else if (seq.start[0] == 0xF0)
+        return seq.start[1] >= 0x90;
+    else if (seq.start[0] == 0xF4)
+        return seq.start[1] <= 0x8F;
+    return true;
+}
+
 int term_disp_width(bstr str, int max_width, const unsigned char **cut_pos)
 {
     static const int ambiguous_width = 1;
@@ -676,11 +695,25 @@ int term_disp_width(bstr str, int max_width, const unsigned char **cut_pos)
         }
 
         prev_pos = str.start;
-        int cp = bstr_decode_utf8(str, &str);
+        int cp = bstr_decode_partial_utf8(&str);
 
-        // Stop processing on any invalid input
-        if (cp < 0)
-            return 0;
+        // Assume the terminal replaces maximal ill-formed subparts with
+        // a single U+FFFD replacement character as described in
+        // https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G66453
+        if (cp < 0) {
+            struct bstr partial = {(unsigned char *)prev_pos, str.start - prev_pos};
+            if (cp == BSTR_DECODE_TRUNCATED_SEQUENCE &&
+                is_valid_partial_sequence(partial))
+            {
+                // This is a truncated but initially well-formed sequence,
+                // should be replaced with a single U+FFFD.
+                current_width = 1;
+            } else {
+                // Otherwise each byte should be replaced individually.
+                current_width = partial.len;
+            }
+            goto next;
+        }
 
         if (cp == '\r') {
             width = 0;
@@ -724,9 +757,9 @@ int term_disp_width(bstr str, int max_width, const unsigned char **cut_pos)
             // Fetch next codepoint in grapheme cluster
             bstr cluster_end;
             cp = bstr_decode_utf8(str, &cluster_end);
-            // Stop processing on any invalid input
+            // Invalid sequences end the current grapheme.
             if (cp < 0)
-                return 0;
+                break;
             int trail = ucdLookup(cp);
 
             state = ucdGraphemeJoins(state, lead, trail);

--- a/test/codepoint_width.c
+++ b/test/codepoint_width.c
@@ -58,6 +58,21 @@ int main(void) {
     assert_int_equal(W("A\nB"), 2);            // ASCII characters with newline (newline should not affect width)
     assert_int_equal(W("ABC\tDEF"), 11);       // Tab inside a string
 
+    // Single illegal character
+    assert_int_equal(W("abc" "\xFF" "def"), 7);
+    // Codepoint sequence cut off by one byte
+    assert_int_equal(W("abc"  "\xF0\x9F\x98" "def"), 7);
+
+    // Examples from https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G66453
+    // Table 3-8. U+FFFD for Non-Shortest Form Sequences
+    assert_int_equal(W("\xC0\xAF\xE0\x80\xBF\xF0\x81\x82\x41"), 9);
+    // Table 3-9. U+FFFD for Ill-Formed Sequences for Surrogates
+    assert_int_equal(W("\xED\xA0\x80\xED\xBF\xBF\xED\xAF\x41"), 9);
+    // Table 3-10. U+FFFD for Other Ill-Formed Sequences
+    assert_int_equal(W("\xF4\x91\x92\x93\xFF\x41\x80\xBF\x42"), 9);
+    // Table 3-11. U+FFFD for Truncated Sequences
+    assert_int_equal(W("\xE1\x80\xE2\xF0\x91\x92\xF1\xBF\x41"), 5);
+
     // ASCII characters with color
     assert_int_equal(W("\033[31mABC\033[0m\033[32mDEF\033[0m"), 6);
 


### PR DESCRIPTION
Previously the function just bailed on invalid input, this instead makes it count how many replacement characters would be shown by a terminal complying with the Unicode specification's recommendation here: https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G66453

Fixes https://github.com/mpv-player/mpv/pull/17773#issuecomment-4277538534

---

I wasn't sure if it's better to go through all the call sites of `bstr_decode_utf8` to adjust them to this `bstr *` change so I just split out an inner function, but there's like <10 call sites so could also change the behavior of `bstr_decode_utf8` itself.

Now whether this is correct: it seems to work and the examples from the spec pass, I also found https://hsivonen.fi/broken-utf-8/ while researching and that post links a test page that I quickly converted into assertions for the test here: https://github.com/afishhh/mpv/commit/a7d4080daf92b9caa76118503abb42fc3903c938. Those also pass but I left them out since there's a lot of them and thought it might be overkill.
My terminal (kitty) also passes these tests, don't know about others.

Can also confirm `\xff` + `aaaaaaaaaaaaaaa...` in `term-status-msg` no longer fills  the terminal with junk.