### PR TITLE
demux_playlist: add support for 'strm' playlist files

### DIFF
--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -259,7 +259,7 @@ static int parse_m3u(struct pl_parser *p)
             int len = stream_read_peek(p->real_stream, probe, sizeof(probe));
             bstr data = {probe, len};
             if (ext && data.len >= 2 && maybe_text(data)) {
-                const char *exts[] = {"m3u", "m3u8", NULL};
+                const char *exts[] = {"m3u", "m3u8", "strm", NULL};
                 for (int n = 0; exts[n]; n++) {
                     if (strcasecmp(ext, exts[n]) == 0)
                         goto ok;
@@ -616,6 +616,7 @@ static const struct pl_format dir_formats[] = {
 static const struct pl_format playlist_formats[] = {
     {"m3u", parse_m3u,
      MIME_TYPES("audio/mpegurl", "audio/x-mpegurl", "application/x-mpegurl")},
+    {"strm", parse_m3u},
     {"ini", parse_ref_init},
     {"pls", parse_pls,
      MIME_TYPES("audio/x-scpls")},

--- a/options/options.c
+++ b/options/options.c
@@ -1091,7 +1091,7 @@ static const struct MPOpts mp_default_opts = {
         "zip", "rar", "7z", "cbz", "cbr", NULL
     },
     .playlist_exts = (char *[]){
-        "cue", "edl", "m3u", "m3u8", "pls", NULL
+        "cue", "edl", "m3u", "m3u8", "pls", "strm", NULL
     },
 
     .sub_auto_exts = (char *[]){


### PR DESCRIPTION
Spec: https://emby.media/support/articles/Strm-Files.html

The .strm format consists of a URI or local path as the sole contents of a text file, this is parsed by software like Emby or Jellyfin to treat remote streams or paths as if they are in the local filesystem. This PR adds .strm to mpv's internal list of playlist file formats, and points it to the handler for ~~.txt~~ .m3u files as they should be compatible.

~~I have not tested the code in this PR yet as I wasn't able to compile mpv locally, but will test using the artifact produced for this PR by CI.~~

-----

The initial state of this PR didn't work, but I confirmed that .m3u is the only supported playlist type that is compatible with .strm, and the latest commit switches the handler from txt to m3u. .strm doesn't need all the features of m3u/m3u8, but they do not cause issues with the relatively barebones playlist format of strm.