### PR TITLE
ci: Ensure winget is available on windows-11-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,13 @@ jobs:
           key: ${{ matrix.target }}-${{ steps.get_time.outputs.timestamp }}
           restore-keys: ${{ matrix.target }}-
 
+      - name: Install Winget on windows-11-arm
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
+          Repair-WinGetPackageManager -Latest -Force
+
       - name: Install dependencies
         run: |
           python -m pip install meson


### PR DESCRIPTION
Manually installs and repairs winget module in windows-11-arm runner to ensure it is available for following dependency step. Fixes consistently failing win32 aarch64 CI step.