### PR TITLE
ytdl_hook.lua: set metadata with use_manifests=yes

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -26,6 +26,7 @@ options.read_options(o, nil, function()
 end)
 
 local chapter_list = {}
+local metadata = {}
 local playlist_cookies = {}
 local playlist_metadata = {}
 
@@ -677,6 +678,12 @@ local function add_single_video(json)
         elseif json.tbr then
             max_bitrate = json.tbr > max_bitrate and json.tbr or max_bitrate
         end
+
+        for json_name, mp_name in pairs(tag_list) do
+            if json[json_name] then
+                metadata[mp_name] = json[json_name]
+            end
+        end
     end
 
     if streamurl == ""  then
@@ -1167,8 +1174,7 @@ local function run_ytdl_hook(url)
 
     else -- probably a video
         -- add playlist metadata if any belongs to the current video
-        local metadata = playlist_metadata[mp.get_property("playlist-path")] or {}
-        for key, value in pairs(metadata) do
+        for key, value in pairs(playlist_metadata[mp.get_property("playlist-path")] or {}) do
             json[key] = value
         end
 
@@ -1208,6 +1214,11 @@ mp.add_hook("on_preloaded", 10, function ()
         mp.set_property_native("chapter-list", chapter_list)
         chapter_list = {}
     end
+
+    for key, value in pairs(metadata) do
+        mp.set_property("metadata/by-key/" .. key, value)
+    end
+    metadata = {}
 end)
 
 mp.add_hook("on_after_end_file", 50, function ()

--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -63,7 +63,6 @@ local tag_list = {
     ["is_live"]         = "ytdl_is_live",
     ["release_year"]    = "ytdl_release_year",
     ["description"]     = "ytdl_description",
-    -- "title" is handled by force-media-title
 }
 
 local safe_protos = Set {


### PR DESCRIPTION
With use_manifests=yes EDL is not used so metadata never gets set through the tags mechanism. Thankfully the metadata property was recently made writable so use that instead.

Fixes https://github.com/mpv-player/mpv/pull/17761#issuecomment-4306070651