### PR TITLE
osc.lua: don't write to user-data continously while moving the mouse

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -322,6 +322,7 @@ local state = {
     last_mouseX = nil, last_mouseY = nil,   -- last mouse position, to detect significant mouse movement
     last_touchX = -1, last_touchY = -1,     -- last touch position
     mouse_in_window = false,
+    hover_sec = -1,
     fullscreen = false,
     tick_timer = nil,
     tick_last_time = 0,                     -- when the last tick() was run
@@ -1213,11 +1214,15 @@ local function render_elements(master_ass)
                     elem_ass:append(tooltiplabel)
 
                     local hover_sec = mp.get_property_number("duration", 0) * (sliderpos / 100)
-                    mp.set_property_number("user-data/osc/hover-sec", hover_sec)
+                    local changed = math.abs(hover_sec - state.hover_sec) > 0.5
+                    if changed then
+                       mp.set_property_number("user-data/osc/hover-sec", hover_sec)
+                       state.hover_sec = hover_sec
+                    end
 
                     -- thumbnail
                     local vop = mp.get_property_native("video-out-params")
-                    local draw_thumbnail = state.osd_dimensions.w > 0 and vop
+                    local draw_thumbnail = state.osd_dimensions.w > 0 and vop and changed
                     if draw_thumbnail then
                         local r_w, r_h = get_virt_scale_factor()
                         local thumb_max = math.min(user_opts.max_thumb_size,
@@ -1258,7 +1263,8 @@ local function render_elements(master_ass)
 
                         mp.set_property_native("user-data/osc/draw-preview", thumb_req)
                     end
-                else
+                elseif state.hover_sec >= 0 then
+                    state.hover_sec = -1
                     mp.set_property_native("user-data/osc/hover-sec", nil)
                     mp.set_property_native("user-data/osc/draw-preview", nil)
                 end

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -962,6 +962,16 @@ local function get_chapter(possec)
     end
 end
 
+local function disable_thumbnail()
+    if state.hover_sec == -1 then
+        return
+    end
+
+    state.hover_sec = -1
+    mp.set_property_native("user-data/osc/hover-sec", nil)
+    mp.set_property_native("user-data/osc/draw-preview", nil)
+end
+
 local function render_elements(master_ass)
     -- when the slider is dragged or hovered and we have a target chapter name
     -- then we use it instead of the normal title. we calculate it before the
@@ -1263,10 +1273,8 @@ local function render_elements(master_ass)
 
                         mp.set_property_native("user-data/osc/draw-preview", thumb_req)
                     end
-                elseif state.hover_sec >= 0 then
-                    state.hover_sec = -1
-                    mp.set_property_native("user-data/osc/hover-sec", nil)
-                    mp.set_property_native("user-data/osc/draw-preview", nil)
+                else
+                    disable_thumbnail()
                 end
             end
 
@@ -2705,6 +2713,7 @@ end
 
 local function osc_visible(visible)
     set_bar_visible("osc_visible", visible)
+    disable_thumbnail()
 end
 
 local function set_wc_visible(visible)
@@ -3256,8 +3265,7 @@ mp.register_event("file-loaded", function()
 end)
 mp.add_hook("on_unload", 50, function()
     state.file_loaded = false
-    mp.set_property_native("user-data/osc/hover-sec", nil)
-    mp.set_property_native("user-data/osc/draw-preview", nil)
+    disable_thumbnail()
     request_tick()
 end)
 


### PR DESCRIPTION
When moving the cursor in the area that shows the OSC, user-data/osc/hover-sec and user-data/osc/draw-preview get set to nil over and over, which gets logged in verbose level. Unset them only when leaving the seekbar.
