### PR TITLE
Revert "player/core: increase number of past_frames to 1000"

### DIFF
--- a/player/core.h
+++ b/player/core.h
@@ -60,7 +60,7 @@ enum {
     OSD_LEVEL_INVISIBLE = 4,
     OSD_BAR_SEEK = 256,
 
-    MAX_NUM_VO_PTS = 1000,
+    MAX_NUM_VO_PTS = 100,
 };
 
 enum seek_type {


### PR DESCRIPTION
100 is enough and avoids mistimed frames to affect long term stats. It would be good to improve vsync estimation accuracy, but increasing averaging size alone is not the best solution.

This reverts commit 4e44fe024c8b00c0da2f1c570a9601e0cb0fe641.