### PR TITLE
mac/window: respect aspect ratio on title-bar double-click zoom

### DIFF
--- a/video/out/mac/window.swift
+++ b/video/out/mac/window.swift
@@ -326,6 +326,11 @@ class Window: NSWindow, NSWindowDelegate {
         }
     }
 
+    func windowWillUseStandardFrame(_ window: NSWindow, defaultFrame: NSRect) -> NSRect {
+        guard keepAspect, !isInFullscreen else { return defaultFrame }
+        return aspectFit(rect: unfsContentFrame, in: defaultFrame)
+    }
+
     func setMaximized(_ stateWanted: Bool) {
         if isZoomed == stateWanted { return }
 


### PR DESCRIPTION
### What

  When the macOS "Double-click a window's title bar to" preference is set
  to "Zoom" (or the green title-bar button is clicked), mpv windows
  expand to the full screen rectangle, ignoring the video aspect ratio,
  even with `keepaspect-window=yes`.

  ### Why

  `MpvWindow` sets `contentAspectRatio` in the `keepAspect` setter
  (window.swift:48). AppKit honors `contentAspectRatio` for interactive
  drag-resize but not for `zoom:`. For `zoom:`, AppKit calls
  `windowWillUseStandardFrame:defaultFrame:` on the delegate to obtain
  the target frame; without that override it falls back to
  `screen.visibleFrame`, which is screen-aspect.

  ### Fix

  Implement `windowWillUseStandardFrame(_:defaultFrame:)` to aspect-fit
  `unfsContentFrame` inside the proposed default frame, reusing the
  existing `aspectFit()` helper. Pass through unchanged when
  `keepAspect` is off or the window is in fullscreen.

  ### Testing

  - Built on macOS with `gpu-api=vulkan` (MoltenVK), `keepaspect-window=yes`.
  - Title-bar double-click and green button both expand to the largest
    aspect-correct rectangle that fits the visible screen frame.
  - `f` (toggle-fullscreen), `Alt+3/4` (`current-window-scale`), and
    manual drag-resize unchanged.
  - Behavior with `keepaspect=no` / `keepaspect-window=no` unchanged
    (delegate returns `defaultFrame`).