### PR TITLE
DOCS/man/mpv: clarify how to enable EDL support in mpv url handler

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1285,6 +1285,10 @@ PROTOCOLS
     trusted source, since it disables the safety limits, basically allowing any
     protocol to be opened from the URL handler.
 
+    Example browser bookmarklet that opens the current page in mpv::
+
+        javascript:void(location='mpv://'+encodeURIComponent(location.href))
+
 ``http://...``, ``https://``, ...
 
     Many network protocols are supported, but the protocol prefix must always

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1279,7 +1279,11 @@ PROTOCOLS
 
     mpv protocol. This is used for starting mpv from URL handler. The protocol
     is stripped and the rest is passed to the player as a normal open argument.
-    Only safe network protocols are allowed to be opened this way.
+    Only safe network protocols are allowed to be opened this way. To open
+    other protocols (such as ``edl://`` URLs produced by the youtube-dl hook),
+    use ``--load-unsafe-playlists``. Only enable this when invoking mpv from a
+    trusted source, since it disables the safety limits, basically allowing any
+    protocol to be opened from the URL handler.
 
 ``http://...``, ``https://``, ...
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -395,6 +395,11 @@ Playback Control
     location. (Instead, the behavior is as if the playlist entries were provided
     directly to mpv command line or ``loadfile`` command.)
 
+    This also enables non-network protocols inside the ``mpv://`` URL handler.
+    For example, the youtube-dl hook builds ``edl://`` playlists. This
+    effectively allows crossing between network and local boundaries, bypassing
+    safety restrictions, so it should be used with caution.
+
 ``--access-references=<yes|no>``
     Follow any references in the file being opened (default: yes). Disabling
     this is helpful if the file is automatically scanned (e.g. thumbnail


### PR DESCRIPTION
This is useful for sources that require EDL for playback.