### PR TITLE
player/loadfile: show OSD error before exiting in pseudo-gui mode

### DIFF
--- a/DOCS/interface-changes/pseudo-gui-error.txt
+++ b/DOCS/interface-changes/pseudo-gui-error.txt
@@ -1,0 +1,2 @@
+add `--error-message-duration` option to control how long the OSD error is
+shown after a failed load in `pseudo-gui` mode before mpv exits

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -806,7 +806,9 @@ Program Behavior
     commands. (Default: ``no``)
 
     ``once`` will only idle at start and let the player close once the
-    first playlist has finished playing back.
+    first playlist has finished playing back. In ``pseudo-gui`` mode, a
+    failed load is reported on the OSD before exiting; see
+    ``--error-message-duration``.
 
 ``--include=<configuration-file>``
     Specify configuration file to be parsed after the default ones.
@@ -3418,6 +3420,13 @@ Window
     image when encoding, you need to use ``--demuxer=lavf
     --demuxer-lavf-o=loop=1``, and use ``--length`` or ``--frames`` to stop
     after a particular time.
+
+``--error-message-duration=<seconds>``
+    When a file fails to load in ``pseudo-gui`` mode, mpv shows the error on
+    the OSD and keeps the window open for this many seconds before exiting,
+    instead of closing silently. Triggering ``quit`` (or closing the window)
+    aborts the wait and exits immediately. Set to ``0`` to disable.
+    (Default: 4)
 
 ``--force-window=<yes|no|immediate>``
     Create a video output window even if there is no video. This can be useful

--- a/options/options.c
+++ b/options/options.c
@@ -620,6 +620,8 @@ static const m_option_t mp_opts[] = {
     {"keep-open-pause", OPT_BOOL(keep_open_pause)},
     {"image-display-duration", OPT_DOUBLE(image_display_duration),
         M_RANGE(0, INFINITY)},
+    {"error-message-duration", OPT_DOUBLE(error_message_duration),
+        M_RANGE(0, INFINITY)},
 
     // select audio/video/subtitle stream
     // keep in sync with num_ptracks[] and MAX_PTRACKS
@@ -1053,6 +1055,7 @@ static const struct MPOpts mp_default_opts = {
     .rebase_start_time = true,
     .keep_open_pause = true,
     .image_display_duration = 5.0,
+    .error_message_duration = 4.0,
     .stream_id = { { [STREAM_AUDIO] = -1,
                      [STREAM_VIDEO] = -1,
                      [STREAM_SUB] = -1, },

--- a/options/options.h
+++ b/options/options.h
@@ -303,6 +303,7 @@ typedef struct MPOpts {
     int keep_open;
     bool keep_open_pause;
     double image_display_duration;
+    double error_message_duration;
     char *lavfi_complex;
     int stream_id[2][STREAM_TYPE_COUNT];
     char **stream_lang[STREAM_TYPE_COUNT];

--- a/player/core.h
+++ b/player/core.h
@@ -297,6 +297,10 @@ typedef struct MPContext {
     int files_errored;      // played, but errors happened at one point
     int files_broken;       // couldn't be played at all
 
+    // Deadline (mp_time_ns) until which the playloop holds idle to keep the
+    // post-error OSD message visible in pseudo-gui mode. 0 if not armed.
+    int64_t error_display_deadline;
+
     // Current file statistics
     int64_t shown_vframes, shown_aframes;
 

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -47,6 +47,7 @@
 #include "input/input.h"
 #include "misc/json.h"
 #include "misc/language.h"
+#include "misc/path_utils.h"
 
 #include "audio/out/ao.h"
 #include "filters/f_decoder_wrapper.h"
@@ -2062,6 +2063,17 @@ terminate_playback:
     if (end_event.error == MPV_ERROR_UNKNOWN_FORMAT)
         MP_ERR(mpctx, "Failed to recognize file format.\n");
 
+    if (end_event.error < 0 && mpctx->opts->operation_mode == 1 &&
+        mpctx->opts->error_message_duration > 0)
+    {
+        double duration = mpctx->opts->error_message_duration;
+        const char *name = mpctx->filename ? mp_basename(mpctx->filename) : "?";
+        set_osd_msg(mpctx, 1, (int)MP_TIME_NS_TO_MS(MP_TIME_S_TO_NS(duration)),
+                    "Failed to open: %s\n%s", name,
+                    mpv_error_string(end_event.error));
+        mpctx->error_display_deadline = mp_time_ns_add(mp_time_ns(), duration);
+    }
+
     if (mpctx->playing)
         playlist_entry_unref(mpctx->playing);
     mpctx->playing = NULL;
@@ -2180,8 +2192,21 @@ void mp_play_files(struct MPContext *mpctx)
         mpctx->playlist->current_was_replaced = false;
         mpctx->stop_play = new_entry ? PT_NEXT_ENTRY : PT_STOP;
 
-        if (!mpctx->playlist->current && mpctx->opts->player_idle_mode < 2)
+        if (!mpctx->playlist->current && mpctx->opts->player_idle_mode < 2) {
+            if (mpctx->error_display_deadline) {
+                handle_force_window(mpctx, true);
+                mp_wakeup_core(mpctx);
+                while (mpctx->stop_play == PT_STOP) {
+                    int64_t left = mpctx->error_display_deadline - mp_time_ns();
+                    if (left <= 0)
+                        break;
+                    mp_set_timeout(mpctx, MP_TIME_NS_TO_S(left));
+                    mp_idle(mpctx);
+                }
+                mpctx->error_display_deadline = 0;
+            }
             break;
+        }
     }
 
     cancel_open(mpctx);


### PR DESCRIPTION
When a file fails to load in pseudo-gui mode, mpv would close immediately. Since the terminal is suppressed in this mode, the user sees the window vanish with no explanation, indistinguishable from a crash.

Render the error on the OSD when end-file fires with an error and hold the window open briefly via a short idle wait before the playloop exits. The duration is controlled by the new --error-message-duration option (default 4 seconds, 0 disables); issuing quit (or closing the window) aborts the wait. Behavior outside pseudo-gui is unchanged.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md