### PR TITLE
Fix #17357: autofit-larger ignored when opening audio cover art

### DIFF
--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -3802,6 +3802,16 @@ static void set_geometry(struct vo_wayland_state *wl, bool resize)
 
     struct vo_win_geometry geo;
     struct mp_rect screenrc = wl->current_output->geometry;
+
+    if (wl->opts->border && wl->opts->autofit_larger.h > 0) {
+        int reference_height = wl->current_output->geometry.y1;
+        int base_px = 43;
+
+        int border_percent = (base_px * 100 / reference_height);
+
+        wl->opts->autofit_larger.h -= border_percent;
+    }
+
     vo_calc_window_geometry(vo, wl->opts, &screenrc, &screenrc, wl->scaling_factor, false, &geo, NULL);
     vo_apply_window_geometry(vo, &geo);
 


### PR DESCRIPTION
Bug #17357 

Wayland gatekeeps border calculations so mpv can't account for them when calculating the window dimensions. Thus, the window was getting cut off in Wayland with autofit-larger=100%x100%, when it should be just 100% of the screen's height. Wayland uses KDE's KWin to calculate the border size, which uses a base px size and then uses DPI to do the calculation.

Since the border calculation, and thus this base px size, is always protected from mpv, an estimation was made, which then is converted into a percentage relative to the screen's height (the DPI conversion is covered by KWin). Then we subtract that percentage from the percentage passed through autofit-larger. This way we'll have mpv's window occupying slightly less and giving space for the border, giving us in the end the intended height. This was tested in two screens with different sizes and it worked and adapted well.