### PR TITLE
video: automatically switch to software rendering with huge images

### DIFF
--- a/player/video.c
+++ b/player/video.c
@@ -224,14 +224,15 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
 {
     mp_assert(!mpctx->vo_chain);
 
+    struct vo_extra ex = {
+        .input_ctx = mpctx->input,
+        .osd = mpctx->osd,
+        .encode_lavc_ctx = mpctx->encode_lavc_ctx,
+        .wakeup_cb = mp_wakeup_core_cb,
+        .wakeup_ctx = mpctx,
+    };
+
     if (!mpctx->video_out) {
-        struct vo_extra ex = {
-            .input_ctx = mpctx->input,
-            .osd = mpctx->osd,
-            .encode_lavc_ctx = mpctx->encode_lavc_ctx,
-            .wakeup_cb = mp_wakeup_core_cb,
-            .wakeup_ctx = mpctx,
-        };
         mpctx->video_out = init_best_video_out(mpctx->global, &ex);
         if (!mpctx->video_out) {
             MP_FATAL(mpctx, "Error opening/initializing "
@@ -240,6 +241,15 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
             goto err_out;
         }
         mpctx->mouse_cursor_visible = true;
+    }
+
+    if (track) {
+        struct vo *vo = vo_handle_max_texture_size(mpctx->video_out, mpctx->global, &ex,
+            MPMAX(track->stream->codec->disp_w, track->stream->codec->disp_h));
+        if (vo) {
+            uninit_video_out(mpctx);
+            mpctx->video_out = vo;
+        }
     }
 
     update_window_title(mpctx, true);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -178,6 +178,9 @@ struct vo_internal {
     struct stats_ctx *stats;
 };
 
+int max_texture_size;
+char *previous_vo;
+
 extern const struct m_sub_options gl_video_conf;
 
 static void forget_frames(struct vo *vo);
@@ -331,6 +334,7 @@ struct vo *init_best_video_out(struct mpv_global *global, struct vo_extra *ex)
     struct mp_vo_opts *opts = mp_get_config_group(NULL, global, &vo_sub_opts);
     struct m_obj_settings *vo_list = opts->video_driver_list;
     struct vo *vo = NULL;
+    previous_vo = NULL;
     // first try the preferred drivers, with their optional subdevice param:
     if (vo_list && vo_list[0].name) {
         for (int n = 0; vo_list[n].name; n++) {
@@ -357,6 +361,43 @@ autoprobe:
 done:
     talloc_free(opts);
     return vo;
+}
+
+struct vo *vo_handle_max_texture_size(struct vo* vo, struct mpv_global *global,
+                                      struct vo_extra *ex, int size)
+{
+    struct vo *new_vo = NULL;
+
+    if (vo->driver->get_max_texture_size) {
+        max_texture_size = vo->driver->get_max_texture_size(vo);
+
+        if (size > max_texture_size) {
+            MP_WARN(vo,
+                    "Video dimension %d exceeds the GPU maximum texture size of %d.\n"
+                    "Attempting to use software rendering.\n",
+                    size, vo->driver->get_max_texture_size(vo));
+
+            for (int i = 0; i < MP_ARRAY_SIZE(video_out_drivers); i++) {
+                const struct vo_driver *driver = video_out_drivers[i];
+                if (!driver->is_software)
+                    continue;
+                new_vo = vo_create(true, global, ex, (char *)driver->name);
+                if (new_vo) {
+                    previous_vo = (char *)vo->driver->name;
+                    break;
+                }
+            }
+        }
+    } else if (previous_vo && size <= max_texture_size) {
+        MP_WARN(vo,
+                "Video dimension %d is within the GPU maximum texture size of %d.\n"
+                "Switching back to %s.\n",
+                size, max_texture_size, previous_vo);
+        new_vo = vo_create(false, global, ex, previous_vo);
+        previous_vo = NULL;
+    }
+
+    return new_vo;
 }
 
 static void terminate_vo(void *p)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -323,6 +323,7 @@ struct vo_driver {
 
     const char *name;
     const char *description;
+    bool is_software;
 
     /*
      *   returns: zero on successful initialization, non-zero on error.
@@ -335,6 +336,12 @@ struct vo_driver {
      * returns: 0 on not supported, otherwise 1
      */
     int (*query_format)(struct vo *vo, int format);
+
+    /*
+     * Return the maximum dimension (width or height) of a single texture that
+     * this VO can handle.
+     */
+    int (*get_max_texture_size)(struct vo *vo);
 
     /*
      * Initialize or reconfigure the display driver.
@@ -524,6 +531,8 @@ struct vo {
 
 struct mpv_global;
 struct vo *init_best_video_out(struct mpv_global *global, struct vo_extra *ex);
+struct vo *vo_handle_max_texture_size(struct vo* vo, struct mpv_global *global,
+                                      struct vo_extra *ex, int size);
 int vo_reconfig(struct vo *vo, struct mp_image_params *p);
 int vo_reconfig2(struct vo *vo, struct mp_image *img);
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1520,6 +1520,12 @@ static int query_format(struct vo *vo, int format)
     return supported;
 }
 
+static int get_max_texture_size(struct vo *vo)
+{
+    struct priv *p = vo->priv;
+    return p->gpu->limits.max_tex_2d_dim;
+}
+
 static void resize(struct vo *vo)
 {
     struct priv *p = vo->priv;
@@ -2680,6 +2686,7 @@ const struct vo_driver video_out_gpu_next = {
             0x0,
     .preinit = preinit,
     .query_format = query_format,
+    .get_max_texture_size = get_max_texture_size,
     .reconfig = reconfig,
     .control = control,
     .get_image_ts = get_image,

--- a/video/out/vo_wlshm.c
+++ b/video/out/vo_wlshm.c
@@ -320,6 +320,7 @@ static void get_vsync(struct vo *vo, struct vo_vsync_info *info)
 const struct vo_driver video_out_wlshm = {
     .description = "Wayland SHM video output (software scaling)",
     .name = "wlshm",
+    .is_software = true,
     .preinit = preinit,
     .query_format = query_format,
     .reconfig = reconfig,

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -439,6 +439,7 @@ static int control(struct vo *vo, uint32_t request, void *data)
 const struct vo_driver video_out_x11 = {
     .description = "X11 (software scaling)",
     .name = "x11",
+    .is_software = true,
     .priv_size = sizeof(struct priv),
     .preinit = preinit,
     .query_format = query_format,


### PR DESCRIPTION
When an image is larger than the max GPU texture size, enable ~~--d3d11-warp, --cocoa-cb-sw-renderer,~~ --vo=x11 or --vo=wlshm.

~~Note that VO autoprobing cannot be used for this because it only takes account of when VOs fail too create, and we need to have the first frame to know if it is too large.~~

~~Changing to a smaller image currently does not switch back the options, not sure if that is worth doing.~~

Fixes #4264.


Requested by linkmauve.

--d3d11-warp depends on https://code.videolan.org/videolan/libplacebo/-/merge_requests/819 to work.

~~Windows and macOS are untested. This changes the values of user options there for simplicity.~~

It may be possible to also get the max texture size on dmabuf-wayland, so get_max_texture_size is introduced in a way that other VOs can implement it.

Nvidia on OpenGL and Vulkan has 32k max texture size so this is most likely not needed there.