### PR TITLE
un-hardcode drag and drop

### DIFF
--- a/DOCS/interface-changes/dnd.txt
+++ b/DOCS/interface-changes/dnd.txt
@@ -1,1 +1,2 @@
 add `--input-builtin-drag-and-drop` option
+add `dropped-file` property

--- a/DOCS/interface-changes/dnd.txt
+++ b/DOCS/interface-changes/dnd.txt
@@ -1,0 +1,1 @@
+add `--input-builtin-drag-and-drop` option

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3244,9 +3244,9 @@ Property list
         nanoseconds. This uses the same clock as ``mpv_get_time_ns()``.
 
     ``dropped-files/action``
-        The action of the drag-and-drop event, can be one of ``replace``,
-        ``append``, or ``insert-next``. This is affected by the
-        ``--drag-and-drop`` option.
+        The action of the drag-and-drop event. This is normally ``replace``.
+        Depending on the platform, this can also be ``append`` in some cases,
+        such as shift key being held while files are dropped.
 
     ``dropped-files/files``
         The dropped file names of the drag-and-drop event.

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3231,6 +3231,39 @@ Property list
             "pad-btns"           MPV_FORMAT_NODE_MAP
                (key and string value for each pad-btn entry)
 
+``dropped-files``
+    Information of the most recent drag-and-drop event mpv received. This
+    property is only updated when ``--input-builtin-drag-and-drop=no``.
+    A client can observe this property to detect when a drag-and-drop event
+    happens. This property is unavailable if no drag-and-drop event has
+    happened.
+
+    Has the following sub-properties:
+
+    ``dropped-files/time``
+        The timestamp of the last drag-and-drop event mpv received, in
+        nanoseconds. This uses the same clock as ``mpv_get_time_ns()``.
+
+    ``dropped-files/action``
+        The action of the drag-and-drop event, can be one of ``replace``,
+        ``append``, or ``insert-next``. This is affected by the
+        ``--drag-and-drop`` option.
+
+    ``dropped-files/files``
+        The dropped file names of the drag-and-drop event.
+
+    When querying the property with the client API using ``MPV_FORMAT_NODE``,
+    or with Lua ``mp.get_property_native``, this will return a mpv_node with
+    the following contents:
+
+    ::
+
+        MPV_FORMAT_NODE_MAP
+            "time"    MPV_FORMAT_INT64
+            "action"  MPV_FORMAT_STRING
+            "files"   MPV_FORMAT_NODE_ARRAY
+                MPV_FORMAT_STRING
+
 ``sub-ass-extradata``
     The current ASS subtitle track's extradata. There is no formatting done.
     The extradata is returned as a string as-is. This property is not

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3232,8 +3232,7 @@ Property list
                (key and string value for each pad-btn entry)
 
 ``dropped-files``
-    Information of the most recent drag-and-drop event mpv received. This
-    property is only updated when ``--input-builtin-drag-and-drop=no``.
+    Information of the most recent drag-and-drop event mpv received.
     A client can observe this property to detect when a drag-and-drop event
     happens. This property is unavailable if no drag-and-drop event has
     happened.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4454,7 +4454,8 @@ Input
 
 ``--input-builtin-drag-and-drop=<yes|no>``
     Enable the built-in drag-and-drop behavior (default: yes). Setting it to no
-    disables the built-in drag-and-drop handling.
+    disables the built-in drag-and-drop handling and enables the ``dropped-files``
+    property, which can be used to retrieve information about dropped files.
 
 ``--input-cmdlist``
     Prints all commands that can be bound to keys.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4452,6 +4452,10 @@ Input
     option, this option only affects VOs which support the ``begin-vo-dragging``
     command, and does not disable window dragging initialized with the command.
 
+``--input-builtin-drag-and-drop=<yes|no>``
+    Enable the built-in drag-and-drop behavior (default: yes). Setting it to no
+    disables the built-in drag-and-drop handling.
+
 ``--input-cmdlist``
     Prints all commands that can be bound to keys.
 

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -4454,8 +4454,7 @@ Input
 
 ``--input-builtin-drag-and-drop=<yes|no>``
     Enable the built-in drag-and-drop behavior (default: yes). Setting it to no
-    disables the built-in drag-and-drop handling and enables the ``dropped-files``
-    property, which can be used to retrieve information about dropped files.
+    disables the built-in drag-and-drop handling.
 
 ``--input-cmdlist``
     Prints all commands that can be bound to keys.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3464,13 +3464,12 @@ Window
     (Windows only) Snap the player window to screen edges.
 
 ``--drag-and-drop=<no|auto|replace|append|insert-next>``
-    Controls the default behavior of drag and drop on platforms that support
-    this. ``auto`` will obey what the underlying os/platform gives mpv.
-    Typically, holding shift during the drag and drop will append the item to
-    the playlist. Otherwise, it will completely replace it. ``replace``,
-    ``append``, and ``insert-next`` always force replacing, appending to, and
-    inserting next into the playlist respectively. ``no`` disables all drag and
-    drop behavior.
+    Controls the default built-in drag-and-drop behavior
+    (``--input-builtin-drag-and-drop``).
+    ``auto`` will obey the ``action`` value in ``dropped-files`` property.
+    ``replace``, ``append``, and ``insert-next`` always force replacing,
+    appending to, and inserting next into the playlist respectively.
+    ``no`` disables all drag and drop behavior.
 
 ``--ontop``
     Makes the player window stay on top of other windows.

--- a/input/dnd.c
+++ b/input/dnd.c
@@ -38,9 +38,17 @@ static bool might_be_subtitle_file(mpv_node *sub_exts, char *file)
 static void handle_dnd(mpv_handle *mpv, mpv_node *files, char *action)
 {
     mpv_node sub_exts = {0};
+    mpv_node drop_type = {0};
     if (mpv_get_property(mpv, "sub-auto-exts", MPV_FORMAT_NODE, &sub_exts) != MPV_ERROR_SUCCESS ||
         sub_exts.format != MPV_FORMAT_NODE_ARRAY)
         goto end;
+    if (mpv_get_property(mpv, "drag-and-drop", MPV_FORMAT_NODE, &drop_type) != MPV_ERROR_SUCCESS ||
+        drop_type.format != MPV_FORMAT_STRING)
+        goto end;
+    if (!strcmp(drop_type.u.string, "no"))
+        goto end;
+    if (strcmp(drop_type.u.string, "auto"))
+        action = drop_type.u.string;
 
     struct mpv_node_list *list = files->u.list;
     for (int i = 0; i < list->num; i++) {
@@ -95,6 +103,7 @@ static void handle_dnd(mpv_handle *mpv, mpv_node *files, char *action)
 
 end:
     mpv_free_node_contents(&sub_exts);
+    mpv_free_node_contents(&drop_type);
 }
 
 static MP_THREAD_VOID mpv_event_loop_fn(void *arg)

--- a/input/dnd.c
+++ b/input/dnd.c
@@ -1,0 +1,141 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dnd.h"
+#include "common/msg.h"
+#include "misc/bstr.h"
+#include "misc/node.h"
+#include "misc/path_utils.h"
+#include "osdep/threads.h"
+#include "player/client.h"
+
+static bool might_be_subtitle_file(mpv_node *sub_exts, char *file)
+{
+    for (int i = 0; i < sub_exts->u.list->num; i++) {
+         mpv_node sub_ext = sub_exts->u.list->values[i];
+         if (sub_ext.format != MPV_FORMAT_STRING)
+             continue;
+         if (!bstrcasecmp0(bstr_get_ext(bstr0(file)), sub_ext.u.string))
+             return true;
+    }
+    return false;
+}
+
+static void handle_dnd(mpv_handle *mpv, mpv_node *files, char *action)
+{
+    mpv_node sub_exts = {0};
+    if (mpv_get_property(mpv, "sub-auto-exts", MPV_FORMAT_NODE, &sub_exts) != MPV_ERROR_SUCCESS ||
+        sub_exts.format != MPV_FORMAT_NODE_ARRAY)
+        goto end;
+
+    struct mpv_node_list *list = files->u.list;
+    for (int i = 0; i < list->num; i++) {
+          mpv_node file = list->values[i];
+          if (file.format != MPV_FORMAT_STRING)
+              goto end;
+    }
+
+    bool all_sub = true;
+    for (int i = 0; i < list->num; i++)
+        all_sub &= might_be_subtitle_file(&sub_exts, list->values[i].u.string);
+
+    if (all_sub) {
+        for (int i = 0; i < list->num; i++) {
+            const char *cmd[] = {
+                "osd-auto",
+                "sub-add",
+                list->values[i].u.string,
+                NULL
+            };
+            mpv_command(mpv, cmd);
+        }
+    } else if (!strcmp(action, "insert-next")) {
+        /* To insert the entries in the correct order, we iterate over them
+           backwards */
+        for (int i = list->num - 1; i >= 0; i--) {
+            const char *cmd[] = {
+                "osd-auto",
+                "loadfile",
+                list->values[i].u.string,
+                /* Since we're inserting in reverse, wait til the final item
+                   is added to start playing */
+                (i > 0) ? "insert-next" : "insert-next-play",
+                NULL
+            };
+            mpv_command(mpv, cmd);
+        }
+    } else {
+        for (int i = 0; i < list->num; i++) {
+            const char *cmd[] = {
+                "osd-auto",
+                "loadfile",
+                list->values[i].u.string,
+                /* Either start playing the dropped files right away
+                   or add them to the end of the current playlist */
+                (i == 0 && !strcmp(action, "replace")) ? "replace" : "append-play",
+                NULL
+            };
+            mpv_command(mpv, cmd);
+        }
+    }
+
+end:
+    mpv_free_node_contents(&sub_exts);
+}
+
+static MP_THREAD_VOID mpv_event_loop_fn(void *arg)
+{
+    mp_thread_set_name("dnd");
+    mpv_handle *mpv = arg;
+    bool enabled = false;
+    mpv_observe_property(mpv, 0, "dropped-files", MPV_FORMAT_NODE);
+    mpv_observe_property(mpv, 0, "input-builtin-drag-and-drop", MPV_FORMAT_FLAG);
+
+    while (1) {
+        mpv_event *event = mpv_wait_event(mpv, -1);
+        if (event->event_id == MPV_EVENT_SHUTDOWN)
+            break;
+        if (event->event_id == MPV_EVENT_PROPERTY_CHANGE) {
+            mpv_event_property *prop = event->data;
+            if (enabled && !strcmp(prop->name, "dropped-files") && prop->format == MPV_FORMAT_NODE) {
+                mpv_node *node = prop->data;
+                mpv_node *action = node_map_get(node, "action");
+                if (!action || action->format != MPV_FORMAT_STRING)
+                    continue;
+
+                mpv_node *files = node_map_get(node, "files");
+                if (!files || files->format != MPV_FORMAT_NODE_ARRAY)
+                    continue;
+                handle_dnd(mpv, files, action->u.string);
+            }
+            if (!strcmp(prop->name, "input-builtin-drag-and-drop") && prop->format == MPV_FORMAT_FLAG)
+                enabled = *(int *)prop->data;
+        }
+    }
+
+    mpv_destroy(mpv);
+    MP_THREAD_RETURN();
+}
+
+void mp_dnd_init(mpv_handle *mpv)
+{
+    mp_thread mpv_event_loop;
+    if (!mp_thread_create(&mpv_event_loop, mpv_event_loop_fn, mpv))
+        mp_thread_detach(mpv_event_loop);
+    else
+        mpv_destroy(mpv);
+}

--- a/input/dnd.h
+++ b/input/dnd.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of mpv.
+ *
+ * mpv is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * mpv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with mpv.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "player/client.h"
+
+void mp_dnd_init(mpv_handle *mpv);

--- a/input/event.c
+++ b/input/event.c
@@ -18,55 +18,6 @@
 #include "event.h"
 #include "input.h"
 #include "common/msg.h"
-#include "player/external_files.h"
-
-void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files,
-                         enum mp_dnd_action action)
-{
-    bool all_sub = true;
-    for (int i = 0; i < num_files; i++)
-        all_sub &= mp_might_be_subtitle_file(files[i]);
-
-    if (all_sub) {
-        for (int i = 0; i < num_files; i++) {
-            const char *cmd[] = {
-                "osd-auto",
-                "sub-add",
-                files[i],
-                NULL
-            };
-            mp_input_run_cmd(ictx, cmd);
-        }
-    } else if (action == DND_INSERT_NEXT) {
-        /* To insert the entries in the correct order, we iterate over them
-           backwards */
-        for (int i = num_files - 1; i >= 0; i--) {
-            const char *cmd[] = {
-                "osd-auto",
-                "loadfile",
-                files[i],
-                /* Since we're inserting in reverse, wait til the final item
-                   is added to start playing */
-                (i > 0) ? "insert-next" : "insert-next-play",
-                NULL
-            };
-            mp_input_run_cmd(ictx, cmd);
-        }
-    } else {
-        for (int i = 0; i < num_files; i++) {
-            const char *cmd[] = {
-                "osd-auto",
-                "loadfile",
-                files[i],
-                /* Either start playing the dropped files right away
-                   or add them to the end of the current playlist */
-                (i == 0 && action == DND_REPLACE) ? "replace" : "append-play",
-                NULL
-            };
-            mp_input_run_cmd(ictx, cmd);
-        }
-    }
-}
 
 int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,
                             bstr data, enum mp_dnd_action action)
@@ -84,7 +35,7 @@ int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,
             char *s = bstrto0(tmp, line);
             MP_TARRAY_APPEND(tmp, files, num_files, s);
         }
-        mp_event_drop_files(ictx, num_files, files, action);
+        mp_input_drop_files(ictx, num_files, files, action);
         talloc_free(tmp);
         return num_files > 0;
     } else {

--- a/input/event.h
+++ b/input/event.h
@@ -27,10 +27,6 @@ enum mp_dnd_action {
     DND_INSERT_NEXT,
 };
 
-// Enqueue files for playback after drag and drop
-void mp_event_drop_files(struct input_ctx *ictx, int num_files, char **files,
-                         enum mp_dnd_action action);
-
 // Drop data in a specific format (identified by the mimetype).
 // Returns <0 on error, ==0 if data was ok but empty, >0 on success.
 int mp_event_drop_mime_data(struct input_ctx *ictx, const char *mime_type,

--- a/input/event.h
+++ b/input/event.h
@@ -25,6 +25,7 @@ enum mp_dnd_action {
     DND_REPLACE,
     DND_APPEND,
     DND_INSERT_NEXT,
+    DND_NONE,
 };
 
 // Drop data in a specific format (identified by the mimetype).

--- a/input/input.c
+++ b/input/input.c
@@ -204,6 +204,7 @@ struct input_opts {
     bool default_bindings;
     bool builtin_bindings;
     bool builtin_dragging;
+    bool builtin_dnd;
     bool enable_mouse_movements;
     bool vo_key_input;
     bool test;
@@ -223,6 +224,7 @@ const struct m_sub_options input_config = {
         {"input-default-bindings", OPT_BOOL(default_bindings)},
         {"input-builtin-bindings", OPT_BOOL(builtin_bindings)},
         {"input-builtin-dragging", OPT_BOOL(builtin_dragging)},
+        {"input-builtin-drag-and-drop", OPT_BOOL(builtin_dnd)},
         {"input-test", OPT_BOOL(test)},
         {"input-doubleclick-time", OPT_INT(doubleclick_time),
          M_RANGE(0, 1000)},
@@ -254,6 +256,7 @@ const struct m_sub_options input_config = {
         .default_bindings = true,
         .builtin_bindings = true,
         .builtin_dragging = true,
+        .builtin_dnd = true,
         .vo_key_input = true,
         .allow_win_drag = true,
         .preprocess_wheel = true,
@@ -1281,6 +1284,12 @@ bool mp_input_test_dragging(struct input_ctx *ictx, int x, int y)
 void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                          enum mp_dnd_action action)
 {
+    input_lock(ictx);
+    if (!ictx->opts->builtin_dnd) {
+        input_unlock(ictx);
+        return;
+    }
+
     bool all_sub = true;
     for (int i = 0; i < num_files; i++)
         all_sub &= mp_might_be_subtitle_file(files[i]);
@@ -1293,7 +1302,7 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                 files[i],
                 NULL
             };
-            mp_input_run_cmd(ictx, cmd);
+            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
         }
     } else if (action == DND_INSERT_NEXT) {
         /* To insert the entries in the correct order, we iterate over them
@@ -1308,7 +1317,7 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                 (i > 0) ? "insert-next" : "insert-next-play",
                 NULL
             };
-            mp_input_run_cmd(ictx, cmd);
+            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
         }
     } else {
         for (int i = 0; i < num_files; i++) {
@@ -1321,9 +1330,10 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                 (i == 0 && action == DND_REPLACE) ? "replace" : "append-play",
                 NULL
             };
-            mp_input_run_cmd(ictx, cmd);
+            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
         }
     }
+    input_unlock(ictx);
 }
 
 unsigned int mp_input_get_mouse_event_counter(struct input_ctx *ictx)

--- a/input/input.c
+++ b/input/input.c
@@ -996,7 +996,7 @@ static int find_touch_point_index(struct input_ctx *ictx, int id)
     return -1;
 }
 
-static void notify_touch_update(struct input_ctx *ictx)
+static void notify_event_update(struct input_ctx *ictx)
 {
     // queue dummy cmd so that touch-pos can notify observers
     mp_cmd_t *cmd = mp_input_parse_cmd(ictx, bstr0("ignore"), "<internal>");
@@ -1016,7 +1016,7 @@ static void update_touch_point(struct input_ctx *ictx, int idx, int id, int x, i
     // Emulate mouse input from the primary touch point (the first one added)
     if (ictx->opts->touch_emulate_mouse && idx == 0)
         set_mouse_pos(ictx, x, y, false);
-    notify_touch_update(ictx);
+    notify_event_update(ictx);
 }
 
 void mp_input_add_touch_point(struct input_ctx *ictx, int id, int x, int y)
@@ -1037,7 +1037,7 @@ void mp_input_add_touch_point(struct input_ctx *ictx, int id, int x, int y)
             set_mouse_pos(ictx, x, y, false);
             feed_key(ictx, MP_MBTN_LEFT | MP_KEY_STATE_DOWN, 1, false);
         }
-        notify_touch_update(ictx);
+        notify_event_update(ictx);
     }
     input_unlock(ictx);
 }
@@ -1064,7 +1064,7 @@ void mp_input_remove_touch_point(struct input_ctx *ictx, int id)
         // Emulate MBTN_LEFT up if there are no touch points left
         if (ictx->opts->touch_emulate_mouse && ictx->num_touch_points == 0)
             feed_key(ictx, MP_MBTN_LEFT | MP_KEY_STATE_UP, 1, false);
-        notify_touch_update(ictx);
+        notify_event_update(ictx);
     }
     input_unlock(ictx);
 }

--- a/input/input.c
+++ b/input/input.c
@@ -210,7 +210,6 @@ struct input_opts {
     bool default_bindings;
     bool builtin_bindings;
     bool builtin_dragging;
-    bool builtin_dnd;
     bool enable_mouse_movements;
     bool vo_key_input;
     bool test;
@@ -230,7 +229,6 @@ const struct m_sub_options input_config = {
         {"input-default-bindings", OPT_BOOL(default_bindings)},
         {"input-builtin-bindings", OPT_BOOL(builtin_bindings)},
         {"input-builtin-dragging", OPT_BOOL(builtin_dragging)},
-        {"input-builtin-drag-and-drop", OPT_BOOL(builtin_dnd)},
         {"input-test", OPT_BOOL(test)},
         {"input-doubleclick-time", OPT_INT(doubleclick_time),
          M_RANGE(0, 1000)},
@@ -262,7 +260,6 @@ const struct m_sub_options input_config = {
         .default_bindings = true,
         .builtin_bindings = true,
         .builtin_dragging = true,
-        .builtin_dnd = true,
         .vo_key_input = true,
         .allow_win_drag = true,
         .preprocess_wheel = true,
@@ -1291,63 +1288,15 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                          enum mp_dnd_action action)
 {
     input_lock(ictx);
-    if (!ictx->opts->builtin_dnd) {
-        TA_FREEP(&ictx->dropped_files);
-        ictx->dropped_files = talloc_zero_array(ictx, bstr, num_files);
-        ictx->num_dropped_files = num_files;
-        ictx->dnd_ts = mp_time_ns();
-        ictx->dnd_action = action;
-        for (int i = 0; i < num_files; i++)
-            ictx->dropped_files[i] = bstrdup(ictx->dropped_files, bstr0(files[i]));
-
-        notify_event_update(ictx);
-        input_unlock(ictx);
-        return;
-    }
-
-    bool all_sub = true;
+    TA_FREEP(&ictx->dropped_files);
+    ictx->dropped_files = talloc_zero_array(ictx, bstr, num_files);
+    ictx->num_dropped_files = num_files;
+    ictx->dnd_ts = mp_time_ns();
+    ictx->dnd_action = action;
     for (int i = 0; i < num_files; i++)
-        all_sub &= mp_might_be_subtitle_file(files[i]);
+        ictx->dropped_files[i] = bstrdup(ictx->dropped_files, bstr0(files[i]));
 
-    if (all_sub) {
-        for (int i = 0; i < num_files; i++) {
-            const char *cmd[] = {
-                "osd-auto",
-                "sub-add",
-                files[i],
-                NULL
-            };
-            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
-        }
-    } else if (action == DND_INSERT_NEXT) {
-        /* To insert the entries in the correct order, we iterate over them
-           backwards */
-        for (int i = num_files - 1; i >= 0; i--) {
-            const char *cmd[] = {
-                "osd-auto",
-                "loadfile",
-                files[i],
-                /* Since we're inserting in reverse, wait til the final item
-                   is added to start playing */
-                (i > 0) ? "insert-next" : "insert-next-play",
-                NULL
-            };
-            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
-        }
-    } else {
-        for (int i = 0; i < num_files; i++) {
-            const char *cmd[] = {
-                "osd-auto",
-                "loadfile",
-                files[i],
-                /* Either start playing the dropped files right away
-                   or add them to the end of the current playlist */
-                (i == 0 && action == DND_REPLACE) ? "replace" : "append-play",
-                NULL
-            };
-            queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
-        }
-    }
+    notify_event_update(ictx);
     input_unlock(ictx);
 }
 

--- a/input/input.c
+++ b/input/input.c
@@ -33,6 +33,7 @@
 #include "osdep/io.h"
 #include "misc/rendezvous.h"
 
+#include "event.h"
 #include "input.h"
 #include "keycodes.h"
 #include "osdep/threads.h"
@@ -44,6 +45,7 @@
 #include "options/path.h"
 #include "mpv_talloc.h"
 #include "options/options.h"
+#include "player/external_files.h"
 #include "misc/bstr.h"
 #include "misc/node.h"
 #include "stream/stream.h"
@@ -1274,6 +1276,54 @@ bool mp_input_test_dragging(struct input_ctx *ictx, int x, int y)
                         test_mouse(ictx, x, y, MP_INPUT_ALLOW_VO_DRAGGING);
     input_unlock(ictx);
     return r;
+}
+
+void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
+                         enum mp_dnd_action action)
+{
+    bool all_sub = true;
+    for (int i = 0; i < num_files; i++)
+        all_sub &= mp_might_be_subtitle_file(files[i]);
+
+    if (all_sub) {
+        for (int i = 0; i < num_files; i++) {
+            const char *cmd[] = {
+                "osd-auto",
+                "sub-add",
+                files[i],
+                NULL
+            };
+            mp_input_run_cmd(ictx, cmd);
+        }
+    } else if (action == DND_INSERT_NEXT) {
+        /* To insert the entries in the correct order, we iterate over them
+           backwards */
+        for (int i = num_files - 1; i >= 0; i--) {
+            const char *cmd[] = {
+                "osd-auto",
+                "loadfile",
+                files[i],
+                /* Since we're inserting in reverse, wait til the final item
+                   is added to start playing */
+                (i > 0) ? "insert-next" : "insert-next-play",
+                NULL
+            };
+            mp_input_run_cmd(ictx, cmd);
+        }
+    } else {
+        for (int i = 0; i < num_files; i++) {
+            const char *cmd[] = {
+                "osd-auto",
+                "loadfile",
+                files[i],
+                /* Either start playing the dropped files right away
+                   or add them to the end of the current playlist */
+                (i == 0 && action == DND_REPLACE) ? "replace" : "append-play",
+                NULL
+            };
+            mp_input_run_cmd(ictx, cmd);
+        }
+    }
 }
 
 unsigned int mp_input_get_mouse_event_counter(struct input_ctx *ictx)

--- a/input/input.c
+++ b/input/input.c
@@ -160,6 +160,12 @@ struct input_ctx {
     struct touch_point *touch_points;
     int num_touch_points;
 
+    // List of last dropped files
+    int64_t dnd_ts;
+    enum mp_dnd_action dnd_action;
+    bstr *dropped_files;
+    int num_dropped_files;
+
     int tablet_x, tablet_y;
     // Indicates tablet tools in proximity / close to tablet surface
     bool tablet_tool_in_proximity;
@@ -1286,6 +1292,15 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
 {
     input_lock(ictx);
     if (!ictx->opts->builtin_dnd) {
+        TA_FREEP(&ictx->dropped_files);
+        ictx->dropped_files = talloc_zero_array(ictx, bstr, num_files);
+        ictx->num_dropped_files = num_files;
+        ictx->dnd_ts = mp_time_ns();
+        ictx->dnd_action = action;
+        for (int i = 0; i < num_files; i++)
+            ictx->dropped_files[i] = bstrdup(ictx->dropped_files, bstr0(files[i]));
+
+        notify_event_update(ictx);
         input_unlock(ictx);
         return;
     }
@@ -1333,6 +1348,23 @@ void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
             queue_cmd(ictx, mp_input_parse_cmd_strv(ictx->log, cmd));
         }
     }
+    input_unlock(ictx);
+}
+
+void mp_input_get_dropped_files(struct input_ctx *ictx, void *talloc_ctx,
+                                int64_t *dnd_ts,
+                                enum mp_dnd_action *dnd_action,
+                                char ***dropped_files)
+{
+    input_lock(ictx);
+    *dnd_ts = ictx->dnd_ts;
+    *dnd_action = ictx->dnd_action;
+    *dropped_files = NULL;
+    int num = 0;
+    for (int i = 0; i < ictx->num_dropped_files; i++)
+        MP_TARRAY_APPEND(talloc_ctx, *dropped_files, num,
+                         bstrto0(talloc_ctx, ictx->dropped_files[i]));
+    MP_TARRAY_APPEND(talloc_ctx, *dropped_files, num, NULL);
     input_unlock(ictx);
 }
 
@@ -1746,6 +1778,7 @@ struct input_ctx *mp_input_init(struct mpv_global *global,
         .wakeup_ctx = wakeup_ctx,
         .active_sections = talloc_array(ictx, struct active_section, 0),
         .touch_points = talloc_array(ictx, struct touch_point, 0),
+        .dnd_action = DND_NONE,
     };
 
     ictx->opts = ictx->opts_cache->opts;

--- a/input/input.h
+++ b/input/input.h
@@ -209,6 +209,11 @@ bool mp_input_test_dragging(struct input_ctx *ictx, int x, int y);
 // Enqueue files for playback after drag and drop
 void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
                          enum mp_dnd_action action);
+// Last dropped files
+void mp_input_get_dropped_files(struct input_ctx *ictx, void *talloc_ctx,
+                                int64_t *dnd_ts,
+                                enum mp_dnd_action *dnd_action,
+                                char ***dropped_files);
 
 // Initialize the input system
 struct mpv_global;

--- a/input/input.h
+++ b/input/input.h
@@ -22,6 +22,7 @@
 #include "misc/bstr.h"
 
 #include "cmd.h"
+#include "event.h"
 
 #define MP_MAX_TABLET_PAD_BUTTONS 10
 
@@ -204,6 +205,10 @@ bool mp_input_test_mouse_active(struct input_ctx *ictx, int x, int y);
 // Whether input.c wants mouse drag events at this mouse position. If this
 // returns false, some VOs will initiate window dragging.
 bool mp_input_test_dragging(struct input_ctx *ictx, int x, int y);
+
+// Enqueue files for playback after drag and drop
+void mp_input_drop_files(struct input_ctx *ictx, int num_files, char **files,
+                         enum mp_dnd_action action);
 
 // Initialize the input system
 struct mpv_global;

--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,7 @@ sources = files(
 
     ## Input
     'input/cmd.c',
+    'input/dnd.c',
     'input/event.c',
     'input/input.c',
     'input/ipc.c',

--- a/options/m_option.h
+++ b/options/m_option.h
@@ -453,7 +453,6 @@ char *format_file_size(int64_t size);
 #define UPDATE_HWDEC            (UINT64_C(1) << 11)  // --hwdec
 #define UPDATE_DVB_PROG         (UINT64_C(1) << 12)  // some --dvbin-...
 #define UPDATE_SUB_HARD         (UINT64_C(1) << 13)  // subtitle opts. that need full reinit
-#define UPDATE_SUB_EXTS         (UINT64_C(1) << 14)  // update internal list of sub exts
 #define UPDATE_VIDEO            (UINT64_C(1) << 15)  // force redraw if needed
 #define UPDATE_VO               (UINT64_C(1) << 16)  // reinit the VO
 #define UPDATE_CLIPBOARD        (UINT64_C(1) << 17)  // reinit the clipboard

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -226,6 +226,8 @@ struct m_sub_property {
     .type = {.type = &m_option_type_time}, .value = {.double_ = (f)}
 #define SUB_PROP_KEYVALUE_LIST(l) \
     .type = {.type = &m_option_type_keyvalue_list}, .value = {.keyvalue_list = (l)}
+#define SUB_PROP_STRING_LIST(l) \
+    .type = {.type = CONF_TYPE_STRING_LIST}, .value = {.string_list = (l)}
 // Expose a C array as a read-only array sub-property. The caller retains
 // ownership of the data pointer. It will be copied if needed. Used for
 // to expose arrays as sub-properties.

--- a/options/options.c
+++ b/options/options.c
@@ -920,6 +920,7 @@ static const m_option_t mp_opts[] = {
     {"", OPT_SUBSTRUCT(resample_opts, resample_conf)},
 
     {"", OPT_SUBSTRUCT(input_opts, input_config)},
+    {"input-builtin-drag-and-drop", OPT_BOOL(builtin_dnd)},
 
     {"clipboard", OPT_SUBSTRUCT(clipboard_opts, clipboard_conf)},
 
@@ -1076,6 +1077,7 @@ static const struct MPOpts mp_default_opts = {
     .screenshot_template = "mpv-shot%n",
     .play_dir = 1,
     .media_controls = true,
+    .builtin_dnd = true,
     .video_exts = (char *[]){
         "3g2", "3gp", "avi", "flv", "ivf", "m2ts", "m4v", "mj2", "mkv", "mov",
         "mp4", "mpeg", "mpg", "mxf", "ogv", "rmvb", "ts", "webm", "wmv", "y4m",

--- a/options/options.c
+++ b/options/options.c
@@ -731,7 +731,7 @@ static const m_option_t mp_opts[] = {
 
     {"sub-auto", OPT_CHOICE(sub_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
-    {"sub-auto-exts", OPT_STRINGLIST(sub_auto_exts), .flags = UPDATE_SUB_EXTS},
+    {"sub-auto-exts", OPT_STRINGLIST(sub_auto_exts)},
     {"audio-file-auto", OPT_CHOICE(audiofile_auto,
         {"no", -1}, {"exact", 0}, {"fuzzy", 1}, {"all", 2})},
     {"audio-exts", OPT_STRINGLIST(audio_exts)},

--- a/options/options.h
+++ b/options/options.h
@@ -390,6 +390,7 @@ typedef struct MPOpts {
     struct hwdec_opts *hwdec_opts;
 
     struct input_opts *input_opts;
+    bool builtin_dnd;
 
     struct clipboard_opts *clipboard_opts;
 

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -264,7 +264,7 @@ class InputHelper: NSObject {
 
             let filesClean = files.map { $0.hasPrefix("file:///.file/id=") ? (URL(string: $0)?.path ?? $0) : $0 }
             var filesPtr = filesClean.map { UnsafeMutablePointer<CChar>(strdup($0)) }
-            mp_event_drop_files(input, Int32(files.count), &filesPtr, action)
+            mp_input_drop_files(input, Int32(files.count), &filesPtr, action)
             for charPtr in filesPtr { free(UnsafeMutablePointer(mutating: charPtr)) }
         }
     }

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -252,14 +252,10 @@ class InputHelper: NSObject {
     @objc func open(files: [String], append: Bool = false) {
         lock.withLock {
             guard let input = input else { return }
-            if (option?.vo.drag_and_drop ?? -1) == -2 { return }
 
             var action = DND_APPEND
             if !append {
                 action = NSEvent.modifierFlags.contains(.shift) ? DND_APPEND : DND_REPLACE
-                if (option?.vo.drag_and_drop ?? -1) >= 0 {
-                    action = mp_dnd_action(UInt32(option?.vo.drag_and_drop ?? Int32(DND_REPLACE.rawValue)))
-                }
             }
 
             let filesClean = files.map { $0.hasPrefix("file:///.file/id=") ? (URL(string: $0)?.path ?? $0) : $0 }

--- a/osdep/win32/smtc.cpp
+++ b/osdep/win32/smtc.cpp
@@ -547,4 +547,6 @@ void mp_smtc_init(mpv_handle *mpv)
     mp_thread mpv_event_loop;
     if (!mp_thread_create(&mpv_event_loop, mpv_event_loop_fn, mpv))
         mp_thread_detach(mpv_event_loop);
+    else
+        mpv_destroy(mpv);
 }

--- a/player/command.c
+++ b/player/command.c
@@ -3267,6 +3267,44 @@ static int mp_property_tablet_pos(void *ctx, struct m_property *prop,
     return M_PROPERTY_NOT_IMPLEMENTED;
 }
 
+static int mp_property_dropped_files(void *ctx, struct m_property *prop,
+                                     int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+
+    int valid = m_property_read_sub_validate(ctx, prop, action, arg);
+    if (valid != M_PROPERTY_VALID)
+        return valid;
+
+    int64_t dnd_ts;
+    enum mp_dnd_action dnd_action;
+    char **dropped_files;
+    void *talloc_ctx = talloc_new(NULL);
+    mp_input_get_dropped_files(mpctx->input, talloc_ctx, &dnd_ts,
+                               &dnd_action, &dropped_files);
+    int r = M_PROPERTY_UNAVAILABLE;
+    if (dnd_action == DND_NONE)
+        goto done;
+
+    char *actionstr = dnd_action == DND_REPLACE ? "replace" :
+                      dnd_action == DND_APPEND ? "append" :
+                      dnd_action == DND_INSERT_NEXT ? "insert-next" :
+                      "none";
+
+    struct m_sub_property props[] = {
+        {"time",   SUB_PROP_INT64(dnd_ts)},
+        {"action", SUB_PROP_STR(actionstr)},
+        {"files",  SUB_PROP_STRING_LIST(dropped_files)},
+        {0}
+    };
+
+    r = m_property_read_sub(props, action, arg);
+
+done:
+    talloc_free(talloc_ctx);
+    return r;
+}
+
 /// Video fps (RO)
 static int mp_property_fps(void *ctx, struct m_property *prop,
                            int action, void *arg)
@@ -4666,6 +4704,7 @@ static const struct m_property mp_properties_base[] = {
     {"mouse-pos", mp_property_mouse_pos},
     {"touch-pos", mp_property_touch_pos},
     {"tablet-pos", mp_property_tablet_pos},
+    {"dropped-files", mp_property_dropped_files},
 
     // Subs
     {"sid", mp_property_switch_track, .priv = (void *)(const int[]){0, STREAM_SUB}},
@@ -4810,7 +4849,7 @@ static const char *const *const mp_event_property_change[] = {
     E(MP_EVENT_CHANGE_PLAYLIST, "playlist", "playlist-pos", "playlist-pos-1",
       "playlist-count", "playlist/count", "playlist-current-pos",
       "playlist-playing-pos"),
-    E(MP_EVENT_INPUT_PROCESSED, "mouse-pos", "touch-pos", "tablet-pos"),
+    E(MP_EVENT_INPUT_PROCESSED, "mouse-pos", "touch-pos", "tablet-pos", "dropped-files"),
     E(MP_EVENT_CORE_IDLE, "core-idle", "eof-reached"),
 };
 #undef E

--- a/player/command.c
+++ b/player/command.c
@@ -4054,8 +4054,8 @@ static int mp_property_option_info(void *ctx, struct m_property *prop,
              .unavailable = !(has_minmax && opt->min != DBL_MIN)},
             {"max",                     SUB_PROP_DOUBLE(opt->max),
              .unavailable = !(has_minmax && opt->max != DBL_MAX)},
-            {"choices", .type = {.type = CONF_TYPE_STRING_LIST},
-             .value = {.string_list = choices}, .unavailable = !choices},
+            {"choices",                 SUB_PROP_STRING_LIST(choices),
+             .unavailable = !choices},
             {0}
         };
 

--- a/player/command.c
+++ b/player/command.c
@@ -8237,9 +8237,6 @@ void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *
     if (flags & UPDATE_CLIPBOARD)
         reinit_clipboard(mpctx);
 
-    if (flags & UPDATE_SUB_EXTS)
-        mp_update_subtitle_exts(mpctx->opts);
-
     if (opt_ptr == &opts->ipc_path || opt_ptr == &opts->ipc_client) {
         mp_uninit_ipc(mpctx->ipc_ctx);
         mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);

--- a/player/external_files.c
+++ b/player/external_files.c
@@ -32,9 +32,6 @@
 #include "player/core.h"
 #include "external_files.h"
 
-// Needed for mp_might_be_subtitle_file
-char **sub_exts;
-
 static int test_ext(MPOpts *opts, bstr ext)
 {
     if (bstr_in_list0(ext, opts->sub_auto_exts))
@@ -51,16 +48,6 @@ static int test_cover_filename(bstr fname, char **cover_files)
     int idx = bstr_find_in_list0(fname, cover_files, false);
     // This equals to 0 if not in list (idx == -1)
     return -idx - 1;
-}
-
-bool mp_might_be_subtitle_file(const char *filename)
-{
-    return bstr_in_list0(bstr_get_ext(bstr0(filename)), sub_exts);
-}
-
-void mp_update_subtitle_exts(struct MPOpts *opts)
-{
-    sub_exts = opts->sub_auto_exts;
 }
 
 static int compare_filename(const void *a, const void *b)

--- a/player/external_files.h
+++ b/player/external_files.h
@@ -35,7 +35,4 @@ struct MPOpts;
 struct subfn *find_external_files(struct mpv_global *global, const char *fname,
                                   struct MPOpts *opts);
 
-bool mp_might_be_subtitle_file(const char *filename);
-void mp_update_subtitle_exts(struct MPOpts *opts);
-
 #endif /* MPLAYER_FINDFILES_H */

--- a/player/main.c
+++ b/player/main.c
@@ -56,6 +56,7 @@
 #include "common/playlist.h"
 #include "options/options.h"
 #include "options/path.h"
+#include "input/dnd.h"
 #include "input/input.h"
 #include "demux/packet_pool.h"
 
@@ -419,6 +420,8 @@ int mp_initialize(struct MPContext *mpctx, char **options)
     if (opts->media_controls)
         mp_smtc_init(mp_new_client(mpctx->clients, "SystemMediaTransportControls"));
 #endif
+
+    mp_dnd_init(mp_new_client(mpctx->clients, "dnd"));
 
     mpctx->ipc_ctx = mp_init_ipc(mpctx->clients, mpctx->global);
 

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -1251,7 +1251,7 @@ static void data_offer_handle_offer(void *data, struct wl_data_offer *offer,
     struct vo_wayland_state *wl = s->wl;
     struct vo_wayland_data_offer *o = s->pending_offer;
     int score = mp_event_get_mime_type_score(wl->vo->input_ctx, mime_type);
-    if (o->offer && score > o->mime_score && wl->opts->drag_and_drop != -2) {
+    if (o->offer && score > o->mime_score) {
         o->mime_score = score;
         talloc_replace(wl, o->mime_type, mime_type);
         MP_VERBOSE(wl, "Given data offer with mime type %s\n", o->mime_type);
@@ -1269,22 +1269,14 @@ static void data_offer_action(void *data, struct wl_data_offer *wl_data_offer, u
     struct vo_wayland_seat *s = data;
     struct vo_wayland_state *wl = s->wl;
     struct vo_wayland_data_offer *o = s->dnd_offer;
-    if (dnd_action && wl->opts->drag_and_drop != -2) {
-        if (wl->opts->drag_and_drop >= 0) {
-            o->action = wl->opts->drag_and_drop;
-        } else {
-            o->action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
-                            DND_REPLACE : DND_APPEND;
-        }
+    o->action = dnd_action & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY ?
+                    DND_REPLACE : DND_APPEND;
+    static const char * const dnd_action_names[] = {
+        [DND_REPLACE] = "DND_REPLACE",
+        [DND_APPEND] = "DND_APPEND",
+    };
 
-        static const char * const dnd_action_names[] = {
-            [DND_REPLACE] = "DND_REPLACE",
-            [DND_APPEND] = "DND_APPEND",
-            [DND_INSERT_NEXT] = "DND_INSERT_NEXT",
-        };
-
-        MP_VERBOSE(wl, "DND action is %s\n", dnd_action_names[o->action]);
-    }
+    MP_VERBOSE(wl, "DND action is %s\n", dnd_action_names[o->action]);
 }
 
 static const struct wl_data_offer_listener data_offer_listener = {
@@ -1323,13 +1315,11 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_ddev,
     *s->pending_offer = (struct vo_wayland_data_offer){.fd = -1};
     o = s->dnd_offer;
     o->action = action;
-    if (wl->opts->drag_and_drop != -2) {
-        wl_data_offer_set_actions(id, WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY |
-                                      WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE,
-                                      WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY);
-        wl_data_offer_accept(id, serial, o->mime_type);
-        MP_VERBOSE(wl, "Accepting DND offer with mime type %s\n", o->mime_type);
-    }
+    wl_data_offer_set_actions(id, WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY |
+                                  WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE,
+                                  WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY);
+    wl_data_offer_accept(id, serial, o->mime_type);
+    MP_VERBOSE(wl, "Accepting DND offer with mime type %s\n", o->mime_type);
 
 }
 
@@ -1346,12 +1336,10 @@ static void data_device_handle_leave(void *data, struct wl_data_device *wl_ddev)
         o->offer = NULL;
     }
 
-    if (wl->opts->drag_and_drop != -2) {
-        MP_VERBOSE(wl, "Releasing DND offer with mime type %s\n", o->mime_type);
-        if (o->mime_type)
-            TA_FREEP(&o->mime_type);
-        o->mime_score = 0;
-    }
+    MP_VERBOSE(wl, "Releasing DND offer with mime type %s\n", o->mime_type);
+    if (o->mime_type)
+        TA_FREEP(&o->mime_type);
+    o->mime_score = 0;
 }
 
 static void data_device_handle_motion(void *data, struct wl_data_device *wl_ddev,
@@ -1372,10 +1360,8 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_ddev)
         return;
     }
 
-    if (wl->opts->drag_and_drop != -2) {
-        MP_VERBOSE(wl, "Receiving DND offer with mime %s\n", o->mime_type);
-        wl_data_offer_receive(o->offer, o->mime_type, pipefd[1]);
-    }
+    MP_VERBOSE(wl, "Receiving DND offer with mime %s\n", o->mime_type);
+    wl_data_offer_receive(o->offer, o->mime_type, pipefd[1]);
 
     close(pipefd[1]);
     o->fd = pipefd[0];

--- a/video/out/win32/droptarget.c
+++ b/video/out/win32/droptarget.c
@@ -171,7 +171,7 @@ static STDMETHODIMP DropTarget_Drop(IDropTarget *self, IDataObject *pDataObj,
             }
 
             GlobalUnlock(medium.hGlobal);
-            mp_event_drop_files(t->input_ctx, recvd_files, files, action);
+            mp_input_drop_files(t->input_ctx, recvd_files, files, action);
             talloc_free(files);
         }
 

--- a/video/out/win32/droptarget.c
+++ b/video/out/win32/droptarget.c
@@ -133,18 +133,12 @@ static STDMETHODIMP DropTarget_Drop(IDropTarget *self, IDataObject *pDataObj,
     struct droptarget *t = (struct droptarget *)self;
 
     enum mp_dnd_action action;
-    if (t->opts->drag_and_drop >= 0) {
-        action = t->opts->drag_and_drop;
-    } else {
-        action = (grfKeyState & MK_SHIFT) ? DND_APPEND : DND_REPLACE;
-    }
+    action = (grfKeyState & MK_SHIFT) ? DND_APPEND : DND_REPLACE;
 
     SAFE_RELEASE(t->data_obj);
 
     STGMEDIUM medium;
-    if (t->opts->drag_and_drop == -2) {
-        t->last_effect = DROPEFFECT_NONE;
-    } else if (SUCCEEDED(IDataObject_GetData(pDataObj, &fmtetc_file, &medium))) {
+    if (SUCCEEDED(IDataObject_GetData(pDataObj, &fmtetc_file, &medium))) {
         if (GlobalLock(medium.hGlobal)) {
             HDROP drop = medium.hGlobal;
 

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1050,20 +1050,15 @@ static void vo_x11_dnd_handle_selection(struct vo *vo, XSelectionEvent *se)
 
     if (se->selection == XA(x11, XdndSelection) &&
         se->property == XAs(x11, DND_PROPERTY) &&
-        se->target == x11->dnd_requested_format &&
-        x11->opts->drag_and_drop != -2)
+        se->target == x11->dnd_requested_format)
     {
         int nitems;
         void *prop = x11_get_property(x11, x11->window, XAs(x11, DND_PROPERTY),
                                       x11->dnd_requested_format, 8, &nitems);
         if (prop) {
             enum mp_dnd_action action;
-            if (x11->opts->drag_and_drop >= 0) {
-                action = x11->opts->drag_and_drop;
-            } else {
-                action = x11->dnd_requested_action == XA(x11, XdndActionCopy) ?
-                         DND_REPLACE : DND_APPEND;
-            }
+            action = x11->dnd_requested_action == XA(x11, XdndActionCopy) ?
+                      DND_REPLACE : DND_APPEND;
 
             char *mime_type = x11_dnd_mime_type(x11, x11->dnd_requested_format);
             MP_VERBOSE(x11, "Dropping type: %s (%s)\n",


### PR DESCRIPTION
This adds `--input-builtin-drag-and-drop` option and `dropped-file` property, which disables built-in drag and drop handling and allows clients to implement custom drop file behavior. 

Fixes: #11906
Fixes: #12151
