### PR TITLE
osc.lua: add boxwidth and slimbox options for box and slimbox layouts

### DIFF
--- a/DOCS/interface-changes/osc-boxwidth.txt
+++ b/DOCS/interface-changes/osc-boxwidth.txt
@@ -1,0 +1,2 @@
+add `boxwidth` script option to osc
+add `slimboxwidth` script option to osc

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -368,6 +368,16 @@ Configurable Options
     The list of visibility modes to cycle through when calling the
     osc-visibility cycle script message. Modes are separated by ``_``.
 
+``boxwidth``
+    Default: 550
+
+    Width of the ``box`` layout.
+
+``slimboxwidth``
+    Default: 660
+
+    Width of the ``slimbox`` layout.
+
 ``boxmaxchars``
     Default: 80
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -46,6 +46,8 @@ local user_opts = {
     tcspace = 100,              -- timecode spacing (compensate font size estimation)
     visibility = "auto",        -- only used at init to set visibility_mode(...)
     visibility_modes = "never_auto_always", -- visibility modes to cycle through
+    boxwidth = 550,             -- width of the box layout
+    slimboxwidth = 660,         -- width of the slimbox layout
     boxmaxchars = 80,           -- title crop threshold for box layout
     boxvideo = false,           -- apply osc_param.video_margins to video
     dynamic_margins = false,    -- update margins dynamically with OSC visibility
@@ -1575,10 +1577,10 @@ end
 layouts["box"] = function ()
 
     local osc_geo = {
-        w = 550,    -- width
-        h = 138,    -- height
-        r = 10,     -- corner-radius
-        p = 15,     -- padding
+        w = user_opts.boxwidth,    -- width
+        h = 138,                   -- height
+        r = 10,                    -- corner-radius
+        p = 15,                    -- padding
     }
 
     -- make sure the OSC actually fits into the video
@@ -1750,9 +1752,9 @@ end
 layouts["slimbox"] = function ()
 
     local osc_geo = {
-        w = 660,    -- width
-        h = 70,     -- height
-        r = 10,     -- corner-radius
+        w = user_opts.slimboxwidth,    -- width
+        h = 70,                        -- height
+        r = 10,                        -- corner-radius
     }
 
     -- make sure the OSC actually fits into the video


### PR DESCRIPTION
Closes #17830 

I have tested this lua script by putting it in the scripts folder and setting osc=no. I tested both the box layout and slimbox layout with multiple width sizes and didn't see any issues (other than setting the values to be too small or too large). I haven't done a full compilation test with mpv as I don't think there should be any differences. 

Additional Notes:
- I chose the name boxwidth as it follows the convention set by floatingwidth
- I have used the same variable for box layout and slimbox layout as I believe its unnecessary to have another variable. As a result I decided to have the default width size set to 600 as they both had different width sizes earlier (550 and 660).

AI Disclosure 
- Used to locate width parameters for box and slimbox
- Assist with writing commit message and PR description