### PR TITLE
demux_{lavf,timeline}: consider audio only HLS when selecting edition

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1051,30 +1051,40 @@ static void build_editions(demuxer_t *demuxer)
     if (edition_id >= 0 && edition_id < demuxer->num_editions)
         selected = edition_id;
 
-    // Select initial edition by best variant bitrate
+    // Select initial edition by best variant bitrate. Prefer the program's
+    // video stream as the representative, falling back to audio for
+    // audio-only variants (e.g. HLS audio-only renditions).
     if (selected < 0 && hls_bitrate >= 0) {
         int best = -1;
         int best_bitrate = 0;
         bool best_ok = false;
         for (int n = 0; n < demuxer->num_editions; n++) {
             AVProgram *prog = avfc->programs[n];
+            struct sh_stream *rep = NULL;
             for (unsigned j = 0; j < prog->nb_stream_indexes; j++) {
                 unsigned idx = prog->stream_index[j];
                 if (idx >= priv->num_streams || !priv->streams[idx]->sh)
                     continue;
                 struct sh_stream *sh = priv->streams[idx]->sh;
-                if (sh->type != STREAM_VIDEO || sh->hls_bitrate <= 0)
+                if (sh->hls_bitrate <= 0)
                     continue;
-                bool ok = sh->hls_bitrate <= hls_bitrate;
-                if (best < 0 || (ok && !best_ok) ||
-                    (ok && best_ok && sh->hls_bitrate > best_bitrate) ||
-                    (!ok && !best_ok && sh->hls_bitrate < best_bitrate))
-                {
-                    best = n;
-                    best_bitrate = sh->hls_bitrate;
-                    best_ok = ok;
+                if (sh->type == STREAM_VIDEO) {
+                    rep = sh;
+                    break;
                 }
-                break;
+                if (sh->type == STREAM_AUDIO && !rep)
+                    rep = sh;
+            }
+            if (!rep)
+                continue;
+            bool ok = rep->hls_bitrate <= hls_bitrate;
+            if (best < 0 || (ok && !best_ok) ||
+                (ok && best_ok && rep->hls_bitrate > best_bitrate) ||
+                (!ok && !best_ok && rep->hls_bitrate < best_bitrate))
+            {
+                best = n;
+                best_bitrate = rep->hls_bitrate;
+                best_ok = ok;
             }
         }
         if (best >= 0)

--- a/demux/demux_timeline.c
+++ b/demux/demux_timeline.c
@@ -703,15 +703,19 @@ static void build_editions(struct demuxer *demuxer)
         selected = edition_id;
 
     // Select initial edition by best variant bitrate, preferring editions
-    // whose video stream is marked as default.
+    // whose video stream is marked as default. Audio streams are considered
+    // too so that audio-only variants (e.g. HLS/DASH audio-only renditions)
+    // still get picked, but video always wins over audio.
     if (selected < 0) {
         int best = -1;
         int best_bitrate = 0;
         bool best_ok = false;
         bool best_default = false;
+        bool best_video = false;
         for (int n = 0; n < num_streams; n++) {
             struct sh_stream *sh = demux_get_stream(demuxer, n);
-            if (sh->type != STREAM_VIDEO || sh->program_id < 0)
+            if ((sh->type != STREAM_VIDEO && sh->type != STREAM_AUDIO) ||
+                sh->program_id < 0)
                 continue;
             if (!sh->default_track && (hls_bitrate < 0 || sh->hls_bitrate <= 0))
                 continue;
@@ -719,9 +723,12 @@ static void build_editions(struct demuxer *demuxer)
             if (e < 0)
                 continue;
             bool ok = hls_bitrate < 0 || sh->hls_bitrate <= hls_bitrate;
+            bool is_video = sh->type == STREAM_VIDEO;
             bool better;
             if (best < 0) {
                 better = true;
+            } else if (is_video != best_video) {
+                better = is_video;
             } else if (sh->default_track != best_default) {
                 better = sh->default_track;
             } else if (ok != best_ok) {
@@ -735,6 +742,7 @@ static void build_editions(struct demuxer *demuxer)
                 best_bitrate = sh->hls_bitrate;
                 best_ok = ok;
                 best_default = sh->default_track;
+                best_video = is_video;
             }
         }
         if (best >= 0)


### PR DESCRIPTION
Fixes: #17836