### PR TITLE
ytdl_hook.lua: convert metadata values to string

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -680,7 +680,7 @@ local function add_single_video(json)
 
         for json_name, mp_name in pairs(tag_list) do
             if json[json_name] then
-                metadata[mp_name] = json[json_name]
+                metadata[mp_name] = tostring(json[json_name])
             end
         end
     end


### PR DESCRIPTION
Fixes https://github.com/mpv-player/mpv/pull/17805#issuecomment-4340090625