### PR TITLE
vo_gpu_next: don't spam render queue underrun logs on frame->still

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -1380,7 +1380,8 @@ static bool draw_frame(struct vo *vo, struct vo_frame *frame)
         case PL_QUEUE_MORE:
             // This is expected to happen semi-frequently near the start and
             // end of a file, so only log it at high verbosity and move on.
-            MP_DBG(vo, "Render queue underrun.\n");
+            if (!frame->still)
+                MP_DBG(vo, "Render queue underrun.\n");
             break;
         case PL_QUEUE_OK:
             break;


### PR DESCRIPTION
If we are redrawing on a still image (e.g. ass events), then the pl queue will hit the PL_QUEUE_MORE case which is fine but there's no need to spam the log here. The information may be useful for when an actual video is being played, but when a frame is still (e.g. paused or only a single image) it's just noise.

Fixes #17840.
