### PR TITLE
osc.lua: add seekbarmaxalpha option to control seekbar transparency

### DIFF
--- a/DOCS/interface-changes/osc-seekbarmaxalpha.txt
+++ b/DOCS/interface-changes/osc-seekbarmaxalpha.txt
@@ -1,0 +1,1 @@
+add `seekbarmaxalpha` script option to osc

--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -189,6 +189,11 @@ Configurable Options
     Size ratio of the seek handle if ``seekbarstyle`` is set to ``diamond``
     or ``knob``. This is relative to the full height of the seekbar.
 
+``seekbarmaxalpha``
+    Default: 255
+
+    Maximum alpha of the seekbar box, 0 (opaque) to 255 (fully transparent)
+
 ``seekbarkeyframes``
     Default: yes
 

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -31,6 +31,7 @@ local user_opts = {
     layout = "bottombar",
     seekbarstyle = "bar",       -- bar, diamond or knob
     seekbarhandlesize = 0.6,    -- size ratio of the diamond and knob handle
+    seekbarmaxalpha = 255,      -- maximum alpha value for seekbar
     seekrangestyle = "inverted",-- bar, line, slider, inverted or none
     seekrangeseparate = true,   -- whether the seekranges overlay on the bar-style seekbar
     seekrangealpha = 200,       -- transparency of seekranges
@@ -1811,7 +1812,7 @@ layouts["slimbox"] = function ()
     lo.geometry = {x = posX, y = posY - 1, an = 2, w = inner_w, h = ele_h}
     lo.layer = 10
     lo.style = osc_styles.box
-    lo.alpha[1] = user_opts.boxalpha
+    lo.alpha[1] = math.min(user_opts.seekbarmaxalpha, user_opts.boxalpha)
     lo.alpha[3] = 0
     if user_opts["seekbarstyle"] ~= "bar" then
         lo.box.radius = osc_geo.r
@@ -2082,7 +2083,7 @@ local function bar_layout(direction, slim)
     lo.layer = 15
     lo.style = osc_styles.timecodesBar
     lo.alpha[1] =
-        math.min(255, user_opts.boxalpha + (255 - user_opts.boxalpha)*0.8)
+        math.min(user_opts.seekbarmaxalpha, user_opts.boxalpha + (255 - user_opts.boxalpha)*0.8)
     if user_opts["seekbarstyle"] ~= "bar" then
         lo.box.radius = geo.h / 2
         lo.box.hexagon = user_opts["seekbarstyle"] == "diamond"
@@ -2224,7 +2225,8 @@ layouts["floating"] = function ()
     lo.geometry = {x = seekbar_cx, y = seekbar_pos_bar, an = 5, w = seekbar_w, h = seekH}
     lo.layer = 15
     lo.style = osc_styles.timecodes
-    lo.alpha[1] = math.min(255, user_opts.floatingalpha + (255 - user_opts.floatingalpha) * 0.75)
+    lo.alpha[1] = math.min(user_opts.seekbarmaxalpha,
+        user_opts.floatingalpha + (255 - user_opts.floatingalpha) * 0.75)
     if user_opts["seekbarstyle"] ~= "bar" then
         lo.box.radius = seekH / 2
         lo.box.hexagon = user_opts["seekbarstyle"] == "diamond"


### PR DESCRIPTION
I can't make changes for box layout because it doesn't have a separate bgbar1, the seekbar uses the box's background by default. 

I used AI to write a PoC for me to add bgbar1 to box layout but it would take a lot more for me to understand the code and do extensive testing with it compared to the simple changes in the other layouts.
```
new_element("bgbar1", "box")
lo = add_layout("bgbar1")
lo.geometry =
    {x = posX, y = posY+pos_offsetY-22, an = 2, w = pos_offsetX*2, h = 15}
lo.layer = 15
lo.style = osc_styles.timecodes
lo.alpha[1] = user_opts.seekbarmaxalpha
if user_opts["seekbarstyle"] ~= "bar" then
    lo.box.radius = 15 / 2
    lo.box.hexagon = user_opts["seekbarstyle"] == "diamond"
end
```
The above code is included for discussion purposes only as I want an opinion on whether or not I should further explore this. I have not done the testing required to make a commit change in the PR yet. 

I am also unsure if I should keep the change in line 1815 for slimbox layout considering it is functionally the same thing as box layout. A bgbar1 element would also be needed for slimbox if one is made for box layout.

One more thing, I was considering making it so you can manually set the exact alpha value and just calling it something more intuitive like seekbaralpha but I don't know how I would manage the defaults considering currently the defaults for some layouts are calculated using boxalpha. I could set the default as -1 or nil and do something like this.
```
lo.alpha[1] = user_opts.seekbaralpha >= 0 and user_opts.seekbaralpha or math.min(255, user_opts.boxalpha + (255 - user_opts.boxalpha) * 0.8)
```
but I'm unsure if there is any precedent to handle defaults like this in mpv

Another option is to change it to a static default and just do
```
lo.alpha[1] = user_opts.seekbaralpha
```
the static default would be set to 220, as that is the value produced by the formula at the default boxalpha of 80. The default floatingalpha of 105 produces 217, which is close enough.

If the above changes don't need to be made, the PR should be in a ready state according to my testing. If the values are not in the range of 0 to 255 it will default to being fully transparent. This works the same way as boxalpha.