### PR TITLE
sub/sd_ass: reuse PlayResX instead of hardcoding to 384

### DIFF
--- a/sub/ass_mp.c
+++ b/sub/ass_mp.c
@@ -36,7 +36,7 @@
 
 // res_y should be track->PlayResY
 // It determines scaling of font sizes and more.
-void mp_ass_set_style(ASS_Style *style, double res_y,
+void mp_ass_set_style(ASS_Style *style, double res_x, double res_y,
                       const struct osd_style_opts *opts)
 {
     if (!style)
@@ -51,20 +51,21 @@ void mp_ass_set_style(ASS_Style *style, double res_y,
 
     // libass_font_size = FontSize * (window_height / res_y)
     // scale translates parameters from PlayResY=720 to res_y
-    double scale = res_y / 720.0;
+    double scale_y = res_y / 720.0;
+    double scale_x = res_x / 1280.0;
 
-    style->FontSize = opts->font_size * scale;
+    style->FontSize = opts->font_size * scale_y;
     style->PrimaryColour = MP_ASS_COLOR(opts->color);
     style->SecondaryColour = style->PrimaryColour;
     style->OutlineColour = MP_ASS_COLOR(opts->outline_color);
     style->BackColour = MP_ASS_COLOR(opts->back_color);
     style->BorderStyle = opts->border_style;
-    style->Outline = opts->outline_size * scale;
-    style->Shadow = opts->shadow_offset * scale;
-    style->Spacing = opts->spacing * scale;
-    style->MarginL = opts->margin_x * scale;
+    style->Outline = opts->outline_size * scale_y;
+    style->Shadow = opts->shadow_offset * scale_y;
+    style->Spacing = opts->spacing * scale_y;
+    style->MarginL = lrint(opts->margin_x * scale_x);
     style->MarginR = style->MarginL;
-    style->MarginV = (opts->margin_y + opts->margin_y_offset) * scale;
+    style->MarginV = lrint((opts->margin_y + opts->margin_y_offset) * scale_y);
     style->ScaleX = 1.;
     style->ScaleY = 1.;
     style->Alignment = 1 + (opts->align_x + 1) + (opts->align_y + 2) % 3 * 4;

--- a/sub/ass_mp.h
+++ b/sub/ass_mp.h
@@ -44,7 +44,7 @@ struct osd_style_opts;
 struct mp_log;
 
 void mp_ass_flush_old_events(ASS_Track *track, long long ts);
-void mp_ass_set_style(ASS_Style *style, double res_y,
+void mp_ass_set_style(ASS_Style *style, double res_x, double res_y,
                       const struct osd_style_opts *opts);
 
 void mp_ass_configure_fonts(ASS_Renderer *priv, struct osd_style_opts *opts,

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -272,13 +272,17 @@ static ASS_Style *prepare_osd_ass(struct osd_state *osd, struct osd_object *obj)
     struct osd_style_opts font = *opts->osd_style;
     font.font_size *= opts->osd_scale;
 
+    double playresx = obj->ass.track->PlayResX;
     double playresy = obj->ass.track->PlayResY;
+
     // Compensate for libass and mp_ass_set_style scaling the font etc.
-    if (!opts->osd_scale_by_window && obj->vo_res.h)
+    if (!opts->osd_scale_by_window && obj->vo_res.h && obj->vo_res.w) {
+        playresx *= 1280.0 / obj->vo_res.w;
         playresy *= 720.0 / obj->vo_res.h;
+    }
 
     ASS_Style *style = get_style(&obj->ass, "OSD");
-    mp_ass_set_style(style, playresy, &font);
+    mp_ass_set_style(style, playresx, playresy, &font);
     return style;
 }
 
@@ -392,7 +396,7 @@ static void get_osd_bar_box(struct osd_state *osd, struct osd_object *obj,
         return;
     }
 
-    mp_ass_set_style(style, track->PlayResY, opts->osd_style);
+    mp_ass_set_style(style, track->PlayResX, track->PlayResY, opts->osd_style);
 
     // override the default osd opaque-box into plain outline. Otherwise
     // the opaque box is not aligned with the bar (even without shadow),
@@ -535,12 +539,13 @@ static void update_external(struct osd_state *osd, struct osd_object *obj,
 
     clear_ass(&ext->ass);
 
+    int resx = ext->ass.track->PlayResX;
     int resy = ext->ass.track->PlayResY;
-    mp_ass_set_style(get_style(&ext->ass, "OSD"), resy, osd->opts->osd_style);
+    mp_ass_set_style(get_style(&ext->ass, "OSD"), resx, resy, osd->opts->osd_style);
 
     // Some scripts will reference this style name with \r tags.
     const struct osd_style_opts *def = osd_style_conf.defaults;
-    mp_ass_set_style(get_style(&ext->ass, "Default"), resy, def);
+    mp_ass_set_style(get_style(&ext->ass, "Default"), resx, resy, def);
 
     while (t.len) {
         bstr line;

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -633,10 +633,9 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
         if (override_playres) {
             int vidw = dim->w - (dim->ml + dim->mr);
             int vidh = dim->h - (dim->mt + dim->mb);
-            track->PlayResX = track->PlayResY * (double)vidw / MPMAX(vidh, 1);
-            // ffmpeg and mpv use a default PlayResX of 384 when it is not known,
-            // this comes from VSFilter.
-            double fix_margins = track->PlayResX / (double)MP_ASS_FONT_PLAYRESX;
+            int old_playresx = track->PlayResX;
+            track->PlayResX = lrint(track->PlayResY * (double)vidw / MPMAX(vidh, 1));
+            double fix_margins = track->PlayResX / (double)old_playresx;
             for (int n = 0; n < track->n_styles; n++) {
                 track->styles[n].MarginL = lrint(track->styles[n].MarginL * fix_margins);
                 track->styles[n].MarginR = lrint(track->styles[n].MarginR * fix_margins);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -133,7 +133,7 @@ static void mp_ass_add_default_styles(struct sd *sd, ASS_Track *track, struct mp
         track->default_style = sid;
         ASS_Style *style = track->styles + sid;
         style->Name = strdup("Default");
-        mp_ass_set_style(style, track->PlayResY, opts->sub_style);
+        mp_ass_set_style(style, track->PlayResX, track->PlayResY, opts->sub_style);
     }
 
     if (shared_opts->ass_style_override[sd->order])
@@ -591,11 +591,11 @@ static void configure_ass(struct sd *sd, struct mp_osd_res *dim,
 #endif
     ass_set_selective_style_override_enabled(priv, set_force_flags);
     ASS_Style style = {0};
-    mp_ass_set_style(&style, MP_ASS_FONT_PLAYRESY, opts->sub_style);
+    mp_ass_set_style(&style, MP_ASS_FONT_PLAYRESX, MP_ASS_FONT_PLAYRESY, opts->sub_style);
     ass_set_selective_style_override(priv, &style);
     free(style.FontName);
     if (converted && track->default_style < track->n_styles) {
-        mp_ass_set_style(track->styles + track->default_style,
+        mp_ass_set_style(track->styles + track->default_style, track->PlayResX,
                          track->PlayResY, opts->sub_style);
     }
     ass_set_font_scale(priv, set_font_scale);


### PR DESCRIPTION
Hardcoding 384 here isn't correct, we should be using the original PlayResX after all.

The problem commit 1723f8a9d200bed5e225ba640411d06782cca8ca was trying to fix is instead fixed by rounding PlayResX instead of implicitly truncating it. Before 1723f8a9d200bed5e225ba640411d06782cca8ca, PlayResX was calculated using doubles and implicitly truncated to int, causing off by one errors (e.g. 511 vs 512) due to truncation errors.

Round to nearest integer instead to fix this.

Fixes: 1723f8a9d200bed5e225ba640411d06782cca8ca
Fixes: f862d3b6cd66abee98f2af21c36255ef7361cb80