### PR TITLE
demux_{lavf,timeline}: add `--flatten-editions`

### DIFF
--- a/DOCS/interface-changes/program-editions.txt
+++ b/DOCS/interface-changes/program-editions.txt
@@ -1,3 +1,4 @@
 ``track-list`` is now filtered by the currently selected edition
 add ``edition-list/N/metadata`` sub-property
 add ``program_id`` support to EDL ``!track_meta`` header
+add ``--flatten-editions`` option to disable program-based edition grouping

--- a/DOCS/interface-changes/show-dependent-tracks.txt
+++ b/DOCS/interface-changes/show-dependent-tracks.txt
@@ -1,0 +1,2 @@
+``track-list`` now hides dependent tracks (e.g. tile sub-streams, IAMF audio element layers, LCEVC enhancement streams) by default
+add ``--show-dependent-tracks`` option to expose them

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -131,6 +131,14 @@ Track Selection
     flat list. Note that depending on the file, tracks from different programs
     may be completely unrelated to each other.
 
+``--show-dependent-tracks=<yes|no>``
+    Show dependent tracks in the track list (default: no). Dependent tracks
+    carry coded data that is not independently decodable. For example, the
+    tile sub-streams that make up a tiled HEIF image, the raw coded layers of
+    an IAMF audio element, or the enhancement stream in an LCEVC group. They
+    are hidden by default because exposing them would clutter the track list
+    with entries that cannot be meaningfully selected on their own.
+
 ``--track-auto-selection=<yes|no>``
     Enable the default track auto-selection (default: yes). Enabling this will
     make the player select streams according to ``--aid``, ``--alang``, and

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -120,6 +120,17 @@ Track Selection
     to ``auto`` (the default), mpv will choose the first edition declared as a
     default, or if there is no default, the first edition defined.
 
+``--flatten-editions=<yes|no>``
+    Some container formats (such as HLS or MPEG-TS with multiple programs)
+    expose multiple programs or rendition groups. By default, mpv respects the
+    format and groups tracks into editions, filtering the track list to only
+    show tracks belonging to the currently selected edition.
+
+    Setting this option to ``yes`` ignores the program structure of the file.
+    No editions are created, and all tracks from all programs are shown as a
+    flat list. Note that depending on the file, tracks from different programs
+    may be completely unrelated to each other.
+
 ``--track-auto-selection=<yes|no>``
     Enable the default track auto-selection (default: yes). Enabling this will
     make the player select streams according to ``--aid``, ``--alang``, and

--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -981,6 +981,16 @@ static void build_editions(demuxer_t *demuxer)
     if (avfc->nb_programs <= 1)
         return;
 
+    struct MPOpts *mp_opts = mp_get_config_group(NULL, demuxer->global, &mp_opt_root);
+    int hls_bitrate = mp_opts->hls_bitrate;
+    int edition_id = mp_opts->edition_id;
+    bool flatten_editions = mp_opts->flatten_editions;
+    TA_FREEP(&mp_opts);
+    if (flatten_editions) {
+        MP_VERBOSE(demuxer, "Flattening track-based editions.\n");
+        return;
+    }
+
     for (unsigned i = 0; i < avfc->nb_programs; i++) {
         AVProgram *prog = avfc->programs[i];
 
@@ -1036,11 +1046,6 @@ static void build_editions(demuxer_t *demuxer)
     }
 
     demuxer->edition_is_track_mapping = true;
-
-    struct MPOpts *mp_opts = mp_get_config_group(priv, demuxer->global, &mp_opt_root);
-    int hls_bitrate = mp_opts->hls_bitrate;
-    int edition_id = mp_opts->edition_id;
-    TA_FREEP(&mp_opts);
 
     int selected = -1;
     if (edition_id >= 0 && edition_id < demuxer->num_editions)

--- a/demux/demux_timeline.c
+++ b/demux/demux_timeline.c
@@ -653,6 +653,16 @@ static void build_editions(struct demuxer *demuxer)
     if (demuxer->num_editions > 0)
         return;
 
+    struct MPOpts *mp_opts = mp_get_config_group(NULL, demuxer->global, &mp_opt_root);
+    int hls_bitrate = mp_opts->hls_bitrate;
+    int edition_id = mp_opts->edition_id;
+    bool flatten_editions = mp_opts->flatten_editions;
+    TA_FREEP(&mp_opts);
+    if (flatten_editions) {
+        MP_VERBOSE(demuxer, "Flattening track-based editions.\n");
+        return;
+    }
+
     int num_streams = demux_get_num_stream(demuxer);
     for (int n = 0; n < num_streams; n++) {
         struct sh_stream *sh = demux_get_stream(demuxer, n);
@@ -692,11 +702,6 @@ static void build_editions(struct demuxer *demuxer)
     }
 
     demuxer->edition_is_track_mapping = true;
-
-    struct MPOpts *mp_opts = mp_get_config_group(demuxer, demuxer->global, &mp_opt_root);
-    int hls_bitrate = mp_opts->hls_bitrate;
-    int edition_id = mp_opts->edition_id;
-    TA_FREEP(&mp_opts);
 
     int selected = -1;
     if (edition_id >= 0 && edition_id < demuxer->num_editions)

--- a/options/options.c
+++ b/options/options.c
@@ -587,6 +587,7 @@ static const m_option_t mp_opts[] = {
     {"dvd", OPT_SUBSTRUCT(dvd_opts, dvd_conf)},
 #endif
     {"edition", OPT_CHOICE(edition_id, {"auto", -1}), M_RANGE(0, 8190)},
+    {"flatten-editions", OPT_BOOL(flatten_editions)},
 #if HAVE_LIBBLURAY
     {"bluray", OPT_SUBSTRUCT(stream_bluray_opts, stream_bluray_conf)},
 #endif /* HAVE_LIBBLURAY */

--- a/options/options.c
+++ b/options/options.c
@@ -588,6 +588,7 @@ static const m_option_t mp_opts[] = {
 #endif
     {"edition", OPT_CHOICE(edition_id, {"auto", -1}), M_RANGE(0, 8190)},
     {"flatten-editions", OPT_BOOL(flatten_editions)},
+    {"show-dependent-tracks", OPT_BOOL(show_dependent_tracks)},
 #if HAVE_LIBBLURAY
     {"bluray", OPT_SUBSTRUCT(stream_bluray_opts, stream_bluray_conf)},
 #endif /* HAVE_LIBBLURAY */

--- a/options/options.h
+++ b/options/options.h
@@ -255,6 +255,7 @@ typedef struct MPOpts {
     int hls_bitrate;
     int edition_id;
     bool flatten_editions;
+    bool show_dependent_tracks;
     bool initial_audio_sync;
     double sync_max_video_change;
     double sync_max_audio_change;

--- a/options/options.h
+++ b/options/options.h
@@ -254,6 +254,7 @@ typedef struct MPOpts {
     bool use_filedir_conf;
     int hls_bitrate;
     int edition_id;
+    bool flatten_editions;
     bool initial_audio_sync;
     double sync_max_video_change;
     double sync_max_audio_change;

--- a/player/command.c
+++ b/player/command.c
@@ -1979,7 +1979,7 @@ static struct track* track_next(struct MPContext *mpctx, enum stream_type type,
     bool seen = track == NULL;
     for (int n = 0; n < mpctx->num_tracks; n++) {
         struct track *cur = mpctx->tracks[n];
-        if (cur->type == type && track_in_current_edition(mpctx, cur)) {
+        if (cur->type == type && track_is_visible(mpctx, cur)) {
             if (cur == track) {
                 seen = true;
             } else if (!cur->selected) {
@@ -2237,7 +2237,7 @@ static int mp_property_list_tracks(void *ctx, struct m_property *prop,
                 struct track *track = mpctx->tracks[n];
                 if (track->type != type)
                     continue;
-                if (!track_in_current_edition(mpctx, track))
+                if (!track_is_visible(mpctx, track))
                     continue;
                 res = talloc_asprintf_append(res, "%s%s: ",
                     spacing == 2 ? "\n\n" : spacing == 1 ? "\n" : "",
@@ -2285,7 +2285,7 @@ static int mp_property_list_tracks(void *ctx, struct m_property *prop,
 
                     for (int n = 0; n < mpctx->num_tracks; n++) {
                         struct track *track = mpctx->tracks[n];
-                        if (track->type == type && track_in_current_edition(mpctx, track)) {
+                        if (track->type == type && track_is_visible(mpctx, track)) {
                             res = talloc_strdup_append(res, "\n");
                             res = append_track_info(res, track);
                         }
@@ -2302,7 +2302,7 @@ static int mp_property_list_tracks(void *ctx, struct m_property *prop,
     int *map = talloc_array(NULL, int, mpctx->num_tracks);
     int count = 0;
     for (int n = 0; n < mpctx->num_tracks; n++) {
-        if (track_in_current_edition(mpctx, mpctx->tracks[n]))
+        if (track_is_visible(mpctx, mpctx->tracks[n]))
             map[count++] = n;
     }
     struct filtered_track_ctx ft = { .mpctx = mpctx, .map = map };
@@ -2358,7 +2358,7 @@ static int mp_property_current_tracks(void *ctx, struct m_property *prop,
     int index = -1;
     int filtered_index = 0;
     for (int n = 0; n < mpctx->num_tracks; n++) {
-        if (!track_in_current_edition(mpctx, mpctx->tracks[n]))
+        if (!track_is_visible(mpctx, mpctx->tracks[n]))
             continue;
         if (mpctx->tracks[n] == t) {
             index = filtered_index;

--- a/player/core.h
+++ b/player/core.h
@@ -551,7 +551,7 @@ struct playlist_entry *mp_next_file(struct MPContext *mpctx, int direction,
 void mp_set_playlist_entry(struct MPContext *mpctx, struct playlist_entry *e);
 void mp_play_files(struct MPContext *mpctx);
 void update_demuxer_properties(struct MPContext *mpctx);
-bool track_in_current_edition(struct MPContext *mpctx, struct track *track);
+bool track_is_visible(struct MPContext *mpctx, struct track *track);
 void print_track_list(struct MPContext *mpctx, const char *msg);
 void reselect_demux_stream(struct MPContext *mpctx, struct track *track,
                            bool refresh_only);

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -607,6 +607,14 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
 {
     struct MPOpts *opts = mpctx->opts;
     int tid = opts->stream_id[order][type];
+    const struct demuxer *demuxer = mpctx->demuxer;
+    // Prefer tracks from the same program as the selected video when not using editions.
+    int preferred_program = -1;
+    if (type != STREAM_VIDEO && mpctx->current_track[0][STREAM_VIDEO] &&
+        (!demuxer || !demuxer->edition_is_track_mapping || demuxer->num_editions <= 1))
+    {
+        preferred_program = mpctx->current_track[0][STREAM_VIDEO]->program_id;
+    }
     if (tid == -2)
         return NULL;
     char **langs = process_langs(opts->stream_lang[type]);
@@ -635,6 +643,9 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
         if (track->no_auto_select)
             continue;
         if (!opts->autoload_files && track->is_external)
+            continue;
+        if (preferred_program != -1 && !track->is_external &&
+            track->program_id != -1 && track->program_id != preferred_program)
             continue;
         if (duplicate_track(mpctx, order, type, track))
             continue;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -295,7 +295,7 @@ static bool edition_has_track_of_type(struct MPContext *mpctx,
     return false;
 }
 
-bool track_in_current_edition(struct MPContext *mpctx, struct track *track)
+static bool track_in_current_edition(struct MPContext *mpctx, struct track *track)
 {
     struct demuxer *demuxer = mpctx->demuxer;
     if (!demuxer || !demuxer->edition_is_track_mapping || demuxer->num_editions <= 1)
@@ -312,6 +312,15 @@ bool track_in_current_edition(struct MPContext *mpctx, struct track *track)
     return false;
 }
 
+bool track_is_visible(struct MPContext *mpctx, struct track *track)
+{
+    if (!track_in_current_edition(mpctx, track))
+        return false;
+    if (track->dependent_track && !mpctx->opts->show_dependent_tracks)
+        return false;
+    return true;
+}
+
 void print_track_list(struct MPContext *mpctx, const char *msg)
 {
     if (msg)
@@ -319,7 +328,7 @@ void print_track_list(struct MPContext *mpctx, const char *msg)
     for (int t = 0; t < STREAM_TYPE_COUNT; t++) {
         for (int n = 0; n < mpctx->num_tracks; n++) {
             struct track *track = mpctx->tracks[n];
-            if (track->type != t || !track_in_current_edition(mpctx, track))
+            if (track->type != t || !track_is_visible(mpctx, track))
                 continue;
             // Indent tracks after messages like "Tracks switched" and
             // "Playing:".
@@ -634,7 +643,7 @@ struct track *select_default_track(struct MPContext *mpctx, int order,
         struct track *track = mpctx->tracks[n];
         if (track->type != type)
             continue;
-        if (!track_in_current_edition(mpctx, track))
+        if (!track_is_visible(mpctx, track))
             continue;
         if (track->user_tid == tid) {
             pick = track;

--- a/test/libmpv_test_track_selection.c
+++ b/test/libmpv_test_track_selection.c
@@ -374,6 +374,39 @@ static void test_track_selection(char *file, char *path)
         check_string("current-tracks/sub/lang", "jpn");
         check_string("current-tracks/sub/program-id", "2");
         check_string("current-tracks/video/program-id", "2");
+
+        // flatten-editions: all 4 tracks exposed, no edition filtering
+        set_property_string("flatten-editions", "yes");
+        set_property_string("edition", "auto");
+        set_property_string("slang", "");
+        set_property_string("subs-fallback", "no");
+        reload_file(path);
+        check_string("track-list/count", "4");
+        // no editions created
+        check_string("edition-list/count", "0");
+
+        // video from program 1 selected (first video), no sub selected
+        check_string("track-list/0/type", "video");
+        check_string("track-list/0/program-id", "1");
+        check_string("track-list/0/selected", "yes");
+        check_string("current-tracks/video/program-id", "1");
+        check_string("sid", "no");
+
+        // preferred_program: eng sub in program 1 is picked when slang=eng
+        set_property_string("slang", "eng");
+        reload_file(path);
+        check_string("track-list/0/selected", "yes");
+        check_string("current-tracks/video/program-id", "1");
+        check_string("current-tracks/sub/lang", "eng");
+        check_string("current-tracks/sub/program-id", "1");
+
+        // preferred_program: jpn sub in program 2 follows video from program 2
+        set_property_string("vid", "2");
+        set_property_string("slang", "jpn");
+        reload_file(path);
+        check_string("current-tracks/video/program-id", "2");
+        check_string("current-tracks/sub/lang", "jpn");
+        check_string("current-tracks/sub/program-id", "2");
     }
 }
 


### PR DESCRIPTION
Lavf exposes editions/programs/renditions as flat track list tagged with program_id. We respect the program_id metadata and group tracks into respective programs as unrelated tracks may be completely unrelated to each other.

This commits adds an option to flatten the editions and ignore the grouping.
