### PR TITLE
ao_wasapi: fix retry budget on DEVICE_INVALIDATED

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -1013,7 +1013,7 @@ bool wasapi_thread_init(struct ao *ao)
 {
     struct wasapi_state *state = ao->priv;
     MP_DBG(ao, "Init wasapi thread\n");
-    int64_t retry_wait = MP_TIME_US_TO_NS(1);
+    int64_t retry_wait = MP_TIME_MS_TO_NS(1);
     bool align_hack = false;
     HRESULT hr;
 
@@ -1096,14 +1096,14 @@ retry:
         goto retry;
     case AUDCLNT_E_DEVICE_IN_USE:
     case AUDCLNT_E_DEVICE_INVALIDATED:
-        if (retry_wait > MP_TIME_US_TO_NS(8)) {
+        if (retry_wait > MP_TIME_MS_TO_NS(1000)) {
             MP_FATAL(ao, "Bad device retry failed\n");
             return false;
         }
         wasapi_thread_uninit(ao);
-        MP_WARN(ao, "Retrying in %"PRId64" ns\n", retry_wait);
+        MP_WARN(ao, "Retrying in %.0f ms\n", MP_TIME_NS_TO_MS(retry_wait));
         mp_sleep_ns(retry_wait);
-        retry_wait *= 2;
+        retry_wait *= 10;
         goto retry;
     }
     return SUCCEEDED(hr);


### PR DESCRIPTION
## What

Fix the retry budget in `ao_wasapi`'s `fix_format` retry path so that `AUDCLNT_E_DEVICE_INVALIDATED` (and `AUDCLNT_E_DEVICE_IN_USE`) actually get a chance to recover, instead of being treated as fatal within ~15 microseconds.

## How it was found

A user of a downstream player reported "no sound after the system wakes from sleep, until I restart playback". Their log showed the AO had been running fine, then on a later playback attempt:

```
[cplayer] AO: [wasapi] 48000Hz stereo 2ch float
[ao/wasapi] Error initializing device: AUDCLNT_E_DEVICE_INVALIDATED (0x88890004)
[ao/wasapi] Retrying in 1000 ns
[ao/wasapi] Error activating device: AUDCLNT_E_DEVICE_INVALIDATED (0x88890004)
[ao/wasapi] Received failure from audio thread
[ao] Failed to initialize audio driver 'wasapi'
[cplayer] Could not open/initialize audio device -> no sound.
[cplayer] Audio: no audio
```

The `Retrying in 1000 ns` line is what gave the unit confusion away.

## Why

`wasapi_thread_init()` currently uses:

```c
int64_t retry_wait = MP_TIME_US_TO_NS(1);   // 1 us
...
case AUDCLNT_E_DEVICE_INVALIDATED:
    if (retry_wait > MP_TIME_US_TO_NS(8)) { // 8 us cap
        MP_FATAL(ao, "Bad device retry failed\n");
        return false;
    }
    ...
    MP_WARN(ao, "Retrying in %"PRId64" ns\n", retry_wait);
    mp_sleep_ns(retry_wait);
    retry_wait *= 2;
    goto retry;
```

So the total backoff before giving up is `1 + 2 + 4 + 8 = 15` microseconds. In practice `AUDCLNT_E_DEVICE_INVALIDATED` is most often hit right after the system resumes from sleep, or when the default endpoint changes. The audio endpoint typically needs hundreds of milliseconds (sometimes longer for Bluetooth devices) to come back. The current budget never covers that window, so the retry loop unconditionally falls through to `MP_FATAL`, the AO is torn down, and playback ends up permanently muted with `Could not open/initialize audio device -> no sound.` until the user manually restarts playback.

## Fix

Switch the unit to milliseconds:

- start the backoff at 20 ms
- cap it at 2 s (~7 retries totalling ~2.5 s of wait)
- log the wait in ms so the warning is meaningful

This is enough to cover the typical resume-from-sleep window without introducing a perceivable startup delay in the common case where the first attempt already succeeds (the retry path is only entered on `AUDCLNT_E_DEVICE_IN_USE` / `AUDCLNT_E_DEVICE_INVALIDATED`).

## Related

This may also help with the symptoms reported in #8096 and #15678 (no sound / wasapi failure after sleep / device changes). Not closing them since the underlying scenarios may be broader than just this retry budget — flagging for visibility only.
