### PR TITLE
etc/builtin.conf: change gui mode to idle=yes

### DIFF
--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1520,7 +1520,7 @@ The profile is currently defined as follows:
     [builtin-pseudo-gui]
     terminal=no
     force-window=yes
-    idle=once
+    idle=yes
     screenshot-directory=~~desktop/
 
 The ``pseudo-gui`` profile exists for compatibility. The options in the

--- a/etc/builtin.conf
+++ b/etc/builtin.conf
@@ -15,7 +15,7 @@ player-operation-mode=pseudo-gui
 [builtin-pseudo-gui]
 terminal=no
 force-window=yes
-idle=once
+idle=yes
 screenshot-dir=~~desktop/
 
 [libmpv]


### PR DESCRIPTION
It is more expected from GUI application to stay open, even after playback. Additionally this gives user a chance to inspect possible load failures, while previously mpv would disappear.