### PR TITLE
vo_gpu_next: fix upload synchronization

### DIFF
--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -345,14 +345,21 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
             MP_ERR(vo, "Failed recreating OSD texture!\n");
             break;
         }
-        ok = pl_tex_upload(p->gpu, &(struct pl_tex_transfer_params) {
+        struct pl_tex_transfer_params upload_params = {
             .tex        = entry->tex,
             .rc         = { .x1 = item->packed_w, .y1 = item->packed_h, },
             .row_pitch  = item->packed->stride[0],
             .ptr        = item->packed->planes[0],
-        });
+        };
+        // Keep the image alive until it's fully read.
+        if (p->gpu->limits.callbacks) {
+            upload_params.callback = talloc_free;
+            upload_params.priv = mp_image_new_ref(item->packed);
+        }
+        ok = pl_tex_upload(p->gpu, &upload_params);
         if (!ok) {
             MP_ERR(vo, "Failed uploading OSD texture!\n");
+            talloc_free(upload_params.priv);
             break;
         }
 
@@ -790,8 +797,12 @@ static bool map_frame(pl_gpu gpu, pl_tex *tex, const struct pl_source_frame *src
                 data[n].buf = buf;
                 data[n].buf_offset = (uint8_t *) data[n].pixels - buf->data;
                 data[n].pixels = NULL;
-            } else if (gpu->limits.callbacks) {
+            }
+            // Keep the image alive until it's fully read.
+            if (gpu->limits.callbacks) {
+                mp_assert(!data[n].callback);
                 data[n].callback = talloc_free;
+                mp_assert(!data[n].priv);
                 data[n].priv = mp_image_new_ref(mpi);
             }
 
@@ -803,6 +814,10 @@ static bool map_frame(pl_gpu gpu, pl_tex *tex, const struct pl_source_frame *src
                 talloc_free(mpi);
                 return false;
             }
+
+            // Without async callback support, we have to poll...
+            if (!gpu->limits.callbacks && data[n].buf)
+                while (pl_buf_poll(gpu, data[n].buf, UINT64_MAX));
         }
         timer_pool_stop(p->sw_upload_timer);
         p->sw_upload_perf = timer_pool_measure(p->sw_upload_timer);
@@ -2143,6 +2158,11 @@ done:
 static void uninit(struct vo *vo)
 {
     struct priv *p = vo->priv;
+
+    // Drain any in-flight uploads.
+    if (p->gpu)
+        pl_gpu_finish(p->gpu);
+
     pl_queue_destroy(&p->queue); // destroy this first
     for (int i = 0; i < MP_ARRAY_SIZE(p->osd_state.entries); i++)
         pl_tex_destroy(p->gpu, &p->osd_state.entries[i].tex);


### PR DESCRIPTION
And make them actually async when copied from host ptr. The issue was when we used DR buf upload, which is always async, it was not synchronized in anyway.

Fixes: #13811