### PR TITLE
ao_pulse: fix subscribe_cb using wrong bitmask for event type

### DIFF
--- a/audio/out/ao_pulse.c
+++ b/audio/out/ao_pulse.c
@@ -80,7 +80,7 @@ static void subscribe_cb(pa_context *c, pa_subscription_event_type_t t,
                          uint32_t idx, void *userdata)
 {
     struct ao *ao = userdata;
-    int type = t & PA_SUBSCRIPTION_MASK_SINK;
+    int type = t & PA_SUBSCRIPTION_EVENT_TYPE_MASK;
     int fac = t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
     if ((type == PA_SUBSCRIPTION_EVENT_NEW || type == PA_SUBSCRIPTION_EVENT_REMOVE)
         && fac == PA_SUBSCRIPTION_EVENT_SINK)


### PR DESCRIPTION
PA_SUBSCRIPTION_MASK_SINK is a pa_subscription_mask constant used when registering with pa_context_subscribe(), not a
pa_subscription_event_type mask. Masking the event type with it would never match PA_SUBSCRIPTION_EVENT_NEW or PA_SUBSCRIPTION_EVENT_REMOVE, causing hotplug events to be silently dropped.

Fixes: e01750020dcc9d49e6f32d513f1b40cd30148d91