### PR TITLE
options: make player-operation-mode readable as a property

### DIFF
--- a/DOCS/interface-changes/player-operation-mode.rst
+++ b/DOCS/interface-changes/player-operation-mode.rst
@@ -1,0 +1,1 @@
+make `player-operation-mode` readable as a property

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -4386,6 +4386,11 @@ Property list
     A string containing the currently active clipboard backend.
     See ``--clipboard-backends`` option for the list of available backends.
 
+``player-operation-mode``
+    A read-only string of the current player operation mode, mirroring the
+    ``--player-operation-mode`` option. To set operation mode, set the option
+    at startup instead.
+
 ``clock``
     The current local time in hour:minutes format.
 

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -1536,10 +1536,15 @@ works like in older mpv releases:
 .. warning::
 
     Currently, you can extend the ``pseudo-gui`` profile in the config file the
-    normal way. This is deprecated. In future mpv releases, the behavior might
-    change, and not apply your additional settings, and/or use a different
-    profile name.
+    normal way. This is deprecated and will be removed in future mpv releases.
 
+    As an alternative, a conditional autoprofile can be used instead:
+
+        ::
+
+            [gui]
+            profile-cond=p["player-operation-mode"]=="pseudo-gui"
+            idle=once
 
 .. include:: options.rst
 

--- a/player/command.c
+++ b/player/command.c
@@ -3166,6 +3166,14 @@ static int mp_property_term_size(void *ctx, struct m_property *prop,
     return m_property_read_sub(props, action, arg);
 }
 
+static int mp_property_player_operation_mode(void *ctx, struct m_property *prop,
+                                             int action, void *arg)
+{
+    MPContext *mpctx = ctx;
+    const struct m_opt_choice_alternatives mode_names[] = {{"cplayer", 0}, {"pseudo-gui", 1}};
+    return m_property_strdup_ro(action, arg, m_opt_choice_str(mode_names, mpctx->opts->operation_mode));
+}
+
 static int mp_property_mouse_pos(void *ctx, struct m_property *prop,
                                     int action, void *arg)
 {
@@ -4633,6 +4641,7 @@ static const struct m_property mp_properties_base[] = {
     {"idle-active", mp_property_idle},
     {"window-id", mp_property_window_id},
     {"display-swapchain", mp_property_vo_display_swapchain},
+    {"player-operation-mode", mp_property_player_operation_mode},
 
     {"chapter-list", mp_property_list_chapters},
     {"track-list", mp_property_list_tracks},


### PR DESCRIPTION
Make it readable as a property so that scripts and conditional autoprofiles can customize behavior depending if player is launched as pseudo gui mode.