### PR TITLE
demux_cue: fix incorrect dirname

### DIFF
--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -90,9 +90,9 @@ static bool open_source(struct timeline *tl, char *filename)
     void *ctx = talloc_new(NULL);
     bool res = false;
 
-    struct bstr dirname = mp_dirname(filename);
+    struct bstr dirname = mp_dirname(tl->demuxer->filename);
 
-    struct bstr base_filename = bstr0(mp_basename(filename));
+    struct bstr base_filename = bstr0(filename);
     if (!base_filename.len) {
         MP_WARN(tl, "CUE: Invalid audio filename in .cue file!\n");
     } else {

--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -90,7 +90,7 @@ static bool open_source(struct timeline *tl, char *filename)
     void *ctx = talloc_new(NULL);
     bool res = false;
 
-    struct bstr dirname = mp_dirname(tl->demuxer->filename);
+    struct bstr dirname = mp_dirname(filename);
 
     struct bstr base_filename = bstr0(mp_basename(filename));
     if (!base_filename.len) {


### PR DESCRIPTION
When opening cue files which have audio files in a subdirectory, instead of using the path from the cue file, mpv uses the path where the cue file is openend from. So, it always defaults to `./<filename>.<ext>`.

## Example
Consider the following `Test.cue`.
```
PERFORMER "Blue Deer"
TITLE "Tiny Shell"
FILE "Disc 1/Tiny Shell - Blue Deer, Nyles Lannon.mp3" MP3
  TRACK 01 AUDIO
    TITLE "Tiny Shell"
    PERFORMER "Blue Deer, Nyles Lannon"
    INDEX 01 00:00:00
```

### My directory structure
```
.
├── Disc 1
│   └── Tiny Shell - Blue Deer, Nyles Lannon.mp3
└── Test.cue
```

mpv crashes like this.
```
[file] Cannot open file './Tiny Shell - Blue Deer, Nyles Lannon.mp3': No such file or directory
Failed to open ./Tiny Shell - Blue Deer, Nyles Lannon.mp3.
Could not open source './Tiny Shell - Blue Deer, Nyles Lannon.mp3'!
CUE: No useful audio filename in .cue file found, trying with 'Test.cue' instead!
CUE: Could not open audio file!
File tags:
 Performer: Blue Deer
 Title: Tiny Shell
No video or audio streams selected.
Exiting... (Errors when loading file)
```


Audio file is from YouTube's Audio Library.