### PR TITLE
demux_cue: fix audio file lookup inside subdirectory

### DIFF
--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -92,11 +92,10 @@ static bool open_source(struct timeline *tl, char *filename)
 
     struct bstr dirname = mp_dirname(tl->demuxer->filename);
 
-    struct bstr base_filename = bstr0(mp_basename(filename));
-    if (!base_filename.len) {
+    if (!filename[0]) {
         MP_WARN(tl, "CUE: Invalid audio filename in .cue file!\n");
     } else {
-        char *fullname = mp_path_join_bstr(ctx, dirname, base_filename);
+        char *fullname = mp_path_join_bstr(ctx, dirname, bstr0(filename));
         if (try_open(tl, fullname)) {
             res = true;
             goto out;


### PR DESCRIPTION
The FILE field in a CUE sheet may contain a relative path with subdirectories. It's not clear if this usecase is intended to be supported, as none of the usual CD/DVD ripping tool generates this type of FILE field in the CUE sheet. The specification is old and abandoned, so this will likely never be clarified and it doesn't cost much to support it so might as well...