### PR TITLE
player/lua: fix autofree ctx leak on exit() call

### DIFF
--- a/player/lua.c
+++ b/player/lua.c
@@ -1296,6 +1296,7 @@ static int script_autofree_call(lua_State *L)
 
 static int script_autofree_trampoline(lua_State *L)
 {
+    struct script_ctx *ctx = get_ctx(L);
     // n*args
     autofree_data data = {
         .target = lua_touserdata(L, lua_upvalueindex(2)),  // fn
@@ -1307,7 +1308,7 @@ static int script_autofree_trampoline(lua_State *L)
     lua_insert(L, 1);  // autofree_call n*args
     lua_pushlightuserdata(L, &data);  // autofree_call n*args &data
 
-    data.ctx = talloc_new(NULL);
+    data.ctx = talloc_new(ctx);
     int r = lua_pcall(L, lua_gettop(L) - 1, LUA_MULTRET, 0);  // m*retvals
     talloc_free(data.ctx);
 


### PR DESCRIPTION
Fixes LSAN leak when tests call fail() and exit(1) is called. We have mpv_destroy set for atexit but data.ctx was null parented, so it had no parent to be freed by. Parent it to script_ctx instead so it gets cleaned up by mpv_destroy.

LSAN output:

Direct leak of 400 byte(s) in 5 object(s) allocated from:
    #\0 0x7f4c6c52c01f in malloc (/lib64/libasan.so.8+0x12c01f) (BuildId: db0aa5bf57ed53a5869a3a2cc49051292ceb6390)
    #\1 0x7f4c6b276388 in ta_alloc_size ../ta/ta.c:139
    #\2 0x7f4c6b2bf01f in script_autofree_trampoline ../player/lua.c:1310
    #\3 0x7f4c69373b15  (/lib64/libluajit-5.1.so.2+0xbb15) (BuildId: 182622c63dea3dd74173bbd5a810051a76bcf4d9)
