### PR TITLE
test/libmpv_common: wait for all clients and player to be destroyed

### DIFF
--- a/test/libmpv_common.h
+++ b/test/libmpv_common.h
@@ -54,7 +54,7 @@ static inline void fail(const char *fmt, ...)
 
 static inline void exit_cleanup(void)
 {
-    mpv_destroy(ctx);
+    mpv_terminate_destroy(ctx);
     ctx = NULL;
 }
 


### PR DESCRIPTION
mpv_destroy() only detaches the client, while leaving the player alone. Since this is exit cleanup, we should just wait and quit whole player.