### PR TITLE
osc.lua: don't show images' duration

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2618,7 +2618,7 @@ local function osc_init()
     -- tc_right (total/remaining time)
     ne = new_element("tc_right", "button")
 
-    ne.visible = state.duration ~= nil
+    ne.visible = state.duration and state.duration > 0
     ne.content = function ()
         if state.rightTC_trem then
             local minus = user_opts.unicodeminus and UNICODE_MINUS or "-"


### PR DESCRIPTION
3183ea99 changed the visibility condition for the duration so that 0 will make it show.

However checking for 0 was not reliable because images detected by the mf demuxer have duration determined by --mf-fps (1 by default) and 1-frame gifs have duration 0.1.

Add a proper image check to hide the duration.