### PR TITLE
options/m_property: try to get constricted type in m_property_do

### DIFF
--- a/options/m_property.c
+++ b/options/m_property.c
@@ -66,6 +66,8 @@ static int m_property_multiply(struct mp_log *log,
     struct m_option opt = {0};
     int r;
 
+    if (!log)
+        return M_PROPERTY_ERROR;
     r = m_property_do(log, prop_list, property, M_PROPERTY_GET_CONSTRICTED_TYPE,
                       &opt, ctx);
     if (r != M_PROPERTY_OK)

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -66,9 +66,7 @@ static int m_property_multiply(struct mp_log *log,
     union m_option_value val = m_option_value_default;
     int r;
 
-    if (!log)
-        return M_PROPERTY_ERROR;
-
+    mp_require(log);
     if (!opt->type->multiply)
         return M_PROPERTY_NOT_IMPLEMENTED;
 
@@ -89,8 +87,7 @@ static int m_property_switch(struct mp_log *log,
     union m_option_value val = m_option_value_default;
     int r;
 
-    if (!log)
-        return M_PROPERTY_ERROR;
+    mp_require(log);
     struct m_property_switch_arg *sarg = arg;
     if ((r = do_action(prop_list, property, M_PROPERTY_SWITCH, arg, ctx)) !=
         M_PROPERTY_NOT_IMPLEMENTED)

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -138,6 +138,13 @@ int m_property_do(struct mp_log *log, const struct m_property *prop_list,
     if (r <= 0)
         return r;
     mp_assert(opt.type);
+    // Make sure dynamic range from properties with M_PROPERTY_GET_CONSTRICTED_TYPE is applied
+    struct m_option copt = {0};
+    r = do_action(prop_list, name, M_PROPERTY_GET_CONSTRICTED_TYPE, &copt, ctx);
+    if (r == M_PROPERTY_OK) {
+        opt.min = copt.min;
+        opt.max = copt.max;
+    }
 
     switch (action) {
     case M_PROPERTY_FIXED_LEN_PRINT:

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -121,16 +121,23 @@ int m_property_do(struct mp_log *log, const struct m_property *prop_list,
     int r;
 
     struct m_option opt = {0};
-    r = do_action(prop_list, name, M_PROPERTY_GET_TYPE, &opt, ctx);
-    if (r <= 0)
-        return r;
-    mp_assert(opt.type);
-    // Make sure dynamic range from properties with M_PROPERTY_GET_CONSTRICTED_TYPE is applied
-    struct m_option copt = {0};
-    r = do_action(prop_list, name, M_PROPERTY_GET_CONSTRICTED_TYPE, &copt, ctx);
-    if (r == M_PROPERTY_OK) {
-        opt.min = copt.min;
-        opt.max = copt.max;
+    bool get_opt_required[M_PROPERTY_MAX_ACTION] = {
+        [M_PROPERTY_FIXED_LEN_PRINT] = true, [M_PROPERTY_PRINT] = true, [M_PROPERTY_GET_STRING] = true,
+        [M_PROPERTY_MULTIPLY] = true, [M_PROPERTY_SWITCH] = true,
+        [M_PROPERTY_GET_NODE] = true, [M_PROPERTY_SET_NODE] = true,
+    };
+    if (get_opt_required[action]) {
+        r = do_action(prop_list, name, M_PROPERTY_GET_TYPE, &opt, ctx);
+        if (r <= 0)
+            return r;
+        mp_assert(opt.type);
+        // Make sure dynamic range from properties with M_PROPERTY_GET_CONSTRICTED_TYPE is applied
+        struct m_option copt = {0};
+        r = do_action(prop_list, name, M_PROPERTY_GET_CONSTRICTED_TYPE, &copt, ctx);
+        if (r == M_PROPERTY_OK) {
+            opt.min = copt.min;
+            opt.max = copt.max;
+        }
     }
 
     switch (action) {

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -60,38 +60,33 @@ static int do_action(const struct m_property *prop_list, const char *name,
 
 static int m_property_multiply(struct mp_log *log,
                                const struct m_property *prop_list,
-                               const char *property, double f, void *ctx)
+                               const char *property, double f, void *ctx,
+                               struct m_option *opt)
 {
     union m_option_value val = m_option_value_default;
-    struct m_option opt = {0};
     int r;
 
     if (!log)
         return M_PROPERTY_ERROR;
-    r = m_property_do(log, prop_list, property, M_PROPERTY_GET_CONSTRICTED_TYPE,
-                      &opt, ctx);
-    if (r != M_PROPERTY_OK)
-        return r;
-    mp_assert(opt.type);
 
-    if (!opt.type->multiply)
+    if (!opt->type->multiply)
         return M_PROPERTY_NOT_IMPLEMENTED;
 
     r = m_property_do(log, prop_list, property, M_PROPERTY_GET, &val, ctx);
     if (r != M_PROPERTY_OK)
         return r;
-    opt.type->multiply(&opt, &val, f);
+    opt->type->multiply(opt, &val, f);
     r = m_property_do(log, prop_list, property, M_PROPERTY_SET, &val, ctx);
-    m_option_free(&opt, &val);
+    m_option_free(opt, &val);
     return r;
 }
 
 static int m_property_switch(struct mp_log *log,
                              const struct m_property *prop_list,
-                             const char *property, void *arg, void *ctx)
+                             const char *property, void *arg, void *ctx,
+                             struct m_option *opt)
 {
     union m_option_value val = m_option_value_default;
-    struct m_option opt = {0};
     int r;
 
     if (!log)
@@ -101,18 +96,13 @@ static int m_property_switch(struct mp_log *log,
         M_PROPERTY_NOT_IMPLEMENTED)
         return r;
     // Fallback to m_option
-    r = m_property_do(log, prop_list, property, M_PROPERTY_GET_CONSTRICTED_TYPE,
-                      &opt, ctx);
-    if (r <= 0)
-        return r;
-    mp_assert(opt.type);
-    if (!opt.type->add)
+    if (!opt->type->add)
         return M_PROPERTY_NOT_IMPLEMENTED;
     if ((r = do_action(prop_list, property, M_PROPERTY_GET, &val, ctx)) <= 0)
         return r;
-    opt.type->add(&opt, &val, sarg->inc, sarg->wrap);
+    opt->type->add(opt, &val, sarg->inc, sarg->wrap);
     r = do_action(prop_list, property, M_PROPERTY_SET, &val, ctx);
-    m_option_free(&opt, &val);
+    m_option_free(opt, &val);
     return r;
 }
 
@@ -172,10 +162,10 @@ int m_property_do(struct mp_log *log, const struct m_property *prop_list,
         return m_property_do(log, prop_list, name, M_PROPERTY_SET_NODE, &node, ctx);
     }
     case M_PROPERTY_MULTIPLY: {
-        return m_property_multiply(log, prop_list, name, *(double *)arg, ctx);
+        return m_property_multiply(log, prop_list, name, *(double *)arg, ctx, &opt);
     }
     case M_PROPERTY_SWITCH: {
-        return m_property_switch(log, prop_list, name, arg, ctx);
+        return m_property_switch(log, prop_list, name, arg, ctx, &opt);
     }
     case M_PROPERTY_GET_CONSTRICTED_TYPE: {
         r = do_action(prop_list, name, action, arg, ctx);

--- a/options/m_property.c
+++ b/options/m_property.c
@@ -34,6 +34,30 @@
 #include "common/msg.h"
 #include "common/common.h"
 
+static int do_action(const struct m_property *prop_list, const char *name,
+                     int action, void *arg, void *ctx)
+{
+    struct m_property *prop;
+    struct m_property_action_arg ka;
+    const char *sep = strchr(name, '/');
+    if (sep && sep[1]) {
+        char base[128];
+        snprintf(base, sizeof(base), "%.*s", (int)(sep - name), name);
+        prop = m_property_list_find(prop_list, base);
+        ka = (struct m_property_action_arg) {
+            .key = sep + 1,
+            .action = action,
+            .arg = arg,
+        };
+        action = M_PROPERTY_KEY_ACTION;
+        arg = &ka;
+    } else
+        prop = m_property_list_find(prop_list, name);
+    if (!prop)
+        return M_PROPERTY_UNKNOWN;
+    return prop->call(ctx, prop, action, arg);
+}
+
 static int m_property_multiply(struct mp_log *log,
                                const struct m_property *prop_list,
                                const char *property, double f, void *ctx)
@@ -60,6 +84,36 @@ static int m_property_multiply(struct mp_log *log,
     return r;
 }
 
+static int m_property_switch(struct mp_log *log,
+                             const struct m_property *prop_list,
+                             const char *property, void *arg, void *ctx)
+{
+    union m_option_value val = m_option_value_default;
+    struct m_option opt = {0};
+    int r;
+
+    if (!log)
+        return M_PROPERTY_ERROR;
+    struct m_property_switch_arg *sarg = arg;
+    if ((r = do_action(prop_list, property, M_PROPERTY_SWITCH, arg, ctx)) !=
+        M_PROPERTY_NOT_IMPLEMENTED)
+        return r;
+    // Fallback to m_option
+    r = m_property_do(log, prop_list, property, M_PROPERTY_GET_CONSTRICTED_TYPE,
+                      &opt, ctx);
+    if (r <= 0)
+        return r;
+    mp_assert(opt.type);
+    if (!opt.type->add)
+        return M_PROPERTY_NOT_IMPLEMENTED;
+    if ((r = do_action(prop_list, property, M_PROPERTY_GET, &val, ctx)) <= 0)
+        return r;
+    opt.type->add(&opt, &val, sarg->inc, sarg->wrap);
+    r = do_action(prop_list, property, M_PROPERTY_SET, &val, ctx);
+    m_option_free(&opt, &val);
+    return r;
+}
+
 struct m_property *m_property_list_find(const struct m_property *list,
                                         const char *name)
 {
@@ -68,30 +122,6 @@ struct m_property *m_property_list_find(const struct m_property *list,
             return (struct m_property *)&list[n];
     }
     return NULL;
-}
-
-static int do_action(const struct m_property *prop_list, const char *name,
-                     int action, void *arg, void *ctx)
-{
-    struct m_property *prop;
-    struct m_property_action_arg ka;
-    const char *sep = strchr(name, '/');
-    if (sep && sep[1]) {
-        char base[128];
-        snprintf(base, sizeof(base), "%.*s", (int)(sep - name), name);
-        prop = m_property_list_find(prop_list, base);
-        ka = (struct m_property_action_arg) {
-            .key = sep + 1,
-            .action = action,
-            .arg = arg,
-        };
-        action = M_PROPERTY_KEY_ACTION;
-        arg = &ka;
-    } else
-        prop = m_property_list_find(prop_list, name);
-    if (!prop)
-        return M_PROPERTY_UNKNOWN;
-    return prop->call(ctx, prop, action, arg);
 }
 
 // (as a hack, log can be NULL on read-only paths)
@@ -136,26 +166,7 @@ int m_property_do(struct mp_log *log, const struct m_property *prop_list,
         return m_property_multiply(log, prop_list, name, *(double *)arg, ctx);
     }
     case M_PROPERTY_SWITCH: {
-        if (!log)
-            return M_PROPERTY_ERROR;
-        struct m_property_switch_arg *sarg = arg;
-        if ((r = do_action(prop_list, name, M_PROPERTY_SWITCH, arg, ctx)) !=
-            M_PROPERTY_NOT_IMPLEMENTED)
-            return r;
-        // Fallback to m_option
-        r = m_property_do(log, prop_list, name, M_PROPERTY_GET_CONSTRICTED_TYPE,
-                          &opt, ctx);
-        if (r <= 0)
-            return r;
-        mp_assert(opt.type);
-        if (!opt.type->add)
-            return M_PROPERTY_NOT_IMPLEMENTED;
-        if ((r = do_action(prop_list, name, M_PROPERTY_GET, &val, ctx)) <= 0)
-            return r;
-        opt.type->add(&opt, &val, sarg->inc, sarg->wrap);
-        r = do_action(prop_list, name, M_PROPERTY_SET, &val, ctx);
-        m_option_free(&opt, &val);
-        return r;
+        return m_property_switch(log, prop_list, name, arg, ctx);
     }
     case M_PROPERTY_GET_CONSTRICTED_TYPE: {
         r = do_action(prop_list, name, action, arg, ctx);

--- a/options/m_property.h
+++ b/options/m_property.h
@@ -97,6 +97,9 @@ enum mp_property_action {
     // Most properties do not implement this.
     //  arg: (ignored)
     M_PROPERTY_DELETE,
+
+    // Total number of actions.
+    M_PROPERTY_MAX_ACTION,
 };
 
 // Argument for M_PROPERTY_SWITCH


### PR DESCRIPTION
When setting properties via M_PROPERTY_SET_NODE, the property value
is limited by static declared range. However, some properties like
volume handle dynamic M_PROPERTY_GET_CONSTRICTED_TYPE requests and
return runtime determined limits. M_PROPERTY_SET_NODE in this case
does not respect that limit, and allows setting to a value out of
range.

Fix this by always trying to use M_PROPERTY_GET_CONSTRICTED_TYPE
first so that the dynamic limits will be used.