### PR TITLE
player/loadfile: fix stack-overflow on EDL metadata track

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1051,8 +1051,12 @@ void autoload_external_files(struct MPContext *mpctx, struct mp_cancel *cancel)
     struct subfn *list = find_external_files(mpctx->global, mpctx->filename, opts);
     talloc_steal(tmp, list);
 
-    int sc[STREAM_TYPE_COUNT] = {0};
+    // demux_edl allocates metadata track with type set to STREAM_TYPE_COUNT,
+    // count this too, even though it won't have any effect on the selection.
+    int sc[STREAM_TYPE_COUNT + 1] = {0};
     for (int n = 0; n < mpctx->num_tracks; n++) {
+        mp_assert(mpctx->tracks[n]->type >= 0);
+        mp_assert(mpctx->tracks[n]->type <= STREAM_TYPE_COUNT);
         if (!mpctx->tracks[n]->attached_picture)
             sc[mpctx->tracks[n]->type]++;
     }


### PR DESCRIPTION
demux_edl allocates metadata track with type set to STREAM_TYPE_COUNT, when counting track types this was not accounted for. Make room for this "special" type of track. Add asserts while at it, just in case.

Note that other similar uses are gated behind track->selected, and metadata track will never be marked as one.

This is not exploitable, as it was overriding only one integer value past the allocated array, so worse thing that could happen is that we misbehave during track selection or crash.

Side note, OSS-Fuzz was fuzzing this for few years now, and couldn't dig into this specific case. I've validated that our fuzzer is in fact reproducing this issue when provided the testcase, which I belive was a basis for this report.

Fixes: GHSA-qpf4-42gw-f286

This vulnerability was discovered by Claude, Anthropic's AI assistant, with OSS-Fuzz fuzzing and triaged by Ada Logics manually in collaboration with Anthropic Research.