### PR TITLE
vd_lavc: disallow hwdec for grouped streams

### DIFF
--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -1264,8 +1264,12 @@ static bool init_group_decoder(struct priv *p, struct mp_filter *public_f)
     }
 
     mp_require(!public_f->stream_info);
-    struct mp_stream_info *no_hwdec = talloc_zero(public_f, struct mp_stream_info);
-    public_f->stream_info = no_hwdec;
+    struct mp_stream_info *parent_info = mp_filter_find_stream_info(public_f);
+    struct mp_stream_info *group_info = talloc_zero(p, struct mp_stream_info);
+    if (parent_info)
+        *group_info = *parent_info;
+    group_info->force_swdec = true;
+    public_f->stream_info = group_info;
 
     enum mp_frame_type ftype;
     switch (p->header->type) {

--- a/filters/filter.h
+++ b/filters/filter.h
@@ -407,6 +407,7 @@ struct mp_stream_info {
     struct osd_state *osd;
     bool vflip;
     bool rotate90;
+    bool force_swdec;
     struct vo *dr_vo; // for calling vo_get_image()
 };
 

--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -233,6 +233,7 @@ typedef struct lavc_ctx {
     // From VO
     struct vo *vo;
     struct mp_hwdec_devices *hwdec_devs;
+    bool force_swdec;
 
     // Wrapped AVHWDeviceContext* used for decoding.
     AVBufferRef *hwdec_dev;
@@ -529,6 +530,9 @@ static void select_and_set_hwdec(struct mp_filter *vd)
         } else if (!hwdec_codec_allowed(vd, codec)) {
             MP_VERBOSE(vd, "Not trying to use hardware decoding: codec %s is not "
                     "on whitelist.\n", codec);
+            break;
+        } else if (ctx->force_swdec) {
+            MP_VERBOSE(vd, "Not trying to use hardware decoding: disallowed\n");
             break;
         } else {
             bool hwdec_name_supported = false;  // relevant only if !hwdec_auto
@@ -1482,6 +1486,7 @@ static struct mp_decoder *create(struct mp_filter *parent,
     if (info) {
         ctx->hwdec_devs = info->hwdec_devs;
         ctx->vo = info->dr_vo;
+        ctx->force_swdec = info->force_swdec;
     }
 
     reinit(vd);


### PR DESCRIPTION
44a2c3393921e tried to do this in a cute way by unsetting the hwdev to be used for hwdec, but this doesn't prevent -copy variants from being probed. Instead explicitly disallow it for grouped streams
