### PR TITLE
docs/comments: fix doubled-word typos

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -852,7 +852,7 @@ Interface changes
       (such as "sub-file"), deprecated in mpv 0.26.0
     - deprecate the old command based hook API, and introduce a proper C API
       (the high level Lua API for this does not change)
-    - rename the the lua-settings/ config directory to script-opts/
+    - rename the lua-settings/ config directory to script-opts/
     - the way the player waits for scripts getting loaded changes slightly. Now
       scripts are loaded in parallel, and block the player from continuing
       playback only in the player initialization phase. It could change again in

--- a/DOCS/man/encode.rst
+++ b/DOCS/man/encode.rst
@@ -102,5 +102,5 @@ You can encode files from one format/codec to another using this facility.
     .. admonition:: Example
 
         "``--oremove-metadata=comment,genre``"
-            excludes copying of the the comment and genre tags to the output
+            excludes copying of the comment and genre tags to the output
             file.

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7008,7 +7008,7 @@ them.
 
 ``--macos-geometry-calculation=<visible|whole>``
     This changes the rectangle which is used to calculate the screen position
-    and size of the window (default: visible). ``visible`` takes the the menu
+    and size of the window (default: visible). ``visible`` takes the menu
     bar and Dock into account and the window is only positioned/sized within the
     visible screen frame rectangle, ``whole`` takes the whole screen frame
     rectangle and ignores the menu bar and Dock. Other previous restrictions

--- a/player/lua.c
+++ b/player/lua.c
@@ -362,7 +362,7 @@ static void fuck_lua(lua_State *L, const char *search_path, const char *extra)
     // Unbelievable but true: Lua loads .lua files AND dynamic libraries from
     // the working directory. This is highly security relevant.
     // Lua scripts are still supposed to load globally installed libraries, so
-    // try to get by by filtering out any relative paths.
+    // try to get by filtering out any relative paths.
     while (path.len) {
         bstr item;
         bstr_split_tok(path, ";", &item, &path);

--- a/video/out/present_sync.c
+++ b/video/out/present_sync.c
@@ -24,7 +24,7 @@
 
 /* General nonsense about this mechanism.
  *
- * This requires that that caller has access to two, related values:
+ * This requires that the caller has access to two, related values:
  * (ust, msc): clock time and incrementing counter of last vsync (this is
  *             increased continuously, even if we don't swap)
  *


### PR DESCRIPTION
Pure typo fixes in user-facing manpages, interface changelog, and source comments. No behavior change.

- `DOCS/man/encode.rst`: "copying of the the comment" → "copying of the comment"
- `DOCS/man/options.rst`: "``visible`` takes the the menu bar" → "takes the menu bar"
- `DOCS/interface-changes.rst`: "rename the the lua-settings/" → "rename the lua-settings/"
- `video/out/present_sync.c`: "requires that that caller" → "requires that the caller"
- `player/lua.c`: "try to get by by filtering" → "try to get by filtering"