### PR TITLE
autoload.lua: exit early when path is a directory

### DIFF
--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -297,6 +297,11 @@ local function find_and_add_entries()
     end
 
     local path = mp.get_property("path", "")
+    if utils.readdir(path) then
+        msg.debug("stopping: current path is a directory")
+        return
+    end
+
     local dir, filename = utils.split_path(path)
     msg.trace(("dir: %s, filename: %s"):format(dir, filename))
     if o.disabled then

--- a/TOOLS/lua/autoload.lua
+++ b/TOOLS/lua/autoload.lua
@@ -297,10 +297,6 @@ local function find_and_add_entries()
     end
 
     local path = mp.get_property("path", "")
-    if utils.readdir(path) then
-        msg.debug("stopping: current path is a directory")
-        return
-    end
 
     local dir, filename = utils.split_path(path)
     msg.trace(("dir: %s, filename: %s"):format(dir, filename))
@@ -309,6 +305,11 @@ local function find_and_add_entries()
         return
     elseif #dir == 0 then
         msg.debug("stopping: not a local path")
+        return
+    end
+    local pathinfo = utils.file_info(path)
+    if pathinfo and pathinfo.is_dir then
+        msg.debug("stopping: path is a directory")
         return
     end
 


### PR DESCRIPTION
## Description

Before this change, autoload would split a directory path into two, using the parent directory as the autoload directory. This lead to the addition of unexpected files to the playlist (i.e., all the files in the directory tree starting from the *parent* as the base).

Now, the effective behavior when a directory is given falls back to the configured mpv directory-mode. I.e. the specified directory gets expanded, and mpv decides what to do with the subdirectories.

## Testing

I have tested this change in a couple of autoload:directory_mode and mpv:directory-mode combinations. It behaves fine in most cases. The only slightly surprising ones (from a user's view):
1.) autoload:ignore + mpv:lazy - the subdirectories do get added to the playlist
2.) autoload:recursive + mpv:lazy - The subdirectories get added, but are expanded lazily. I personally expected to expand the directories always when autoload:recursive is active - however, it would require a much deeper change, and I guess it's really just a philosophical question. Having mpv handle how to expand the specified directory should be fine.

When multiple paths are passed to mpv (i.e. the initial playlist has more than 1 files / directories), the script does not autoload any adjacent files, which is the expected behavior as before.