### PR TITLE
 fix minor overflow in demux_mkv.c

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1819,7 +1819,8 @@ static void parse_vorbis_chmap(struct mp_chmap *channels, unsigned char *data,
     if (size < 4)
         return;
     uint32_t vendor_length = AV_RL32(data);
-    if (vendor_length + 4 > size) // also check for the next AV_RB32 below
+    // 4 (vendor_length) + vendor string + 4 (num_headers); subtract to avoid overflow
+    if (size < 8 || vendor_length > size - 8)
         return;
     size -= vendor_length + 4;
     data += vendor_length + 4;


### PR DESCRIPTION
parse_vorbis_chmap in demux/demux_mkv.c: `vendor_length + 4 > size` overflows in 32-bit math, and reserves 4 bytes too few for the following num_headers read, letting a crafted Matroska/FLAC file over-read up to 4 bytes past a metadata block. This leads to nothing and is harmless but can easily be fixed.