### PR TITLE
player: restart playback when eof reached

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -1474,9 +1474,7 @@ static int mp_property_eof_reached(void *ctx, struct m_property *prop,
     MPContext *mpctx = ctx;
     if (!mpctx->playback_initialized)
         return M_PROPERTY_UNAVAILABLE;
-    bool eof = mpctx->video_status == STATUS_EOF &&
-               mpctx->audio_status == STATUS_EOF;
-    return m_property_bool_ro(action, arg, eof);
+    return m_property_bool_ro(action, arg, mpctx_eof_reached(mpctx));
 }
 
 static int mp_property_seeking(void *ctx, struct m_property *prop,

--- a/player/core.h
+++ b/player/core.h
@@ -614,6 +614,7 @@ double get_relative_time(struct MPContext *mpctx);
 void reset_playback_state(struct MPContext *mpctx);
 void set_pause_state(struct MPContext *mpctx, bool user_pause);
 void update_internal_pause_state(struct MPContext *mpctx);
+bool mpctx_eof_reached(struct MPContext *mpctx);
 void update_core_idle_state(struct MPContext *mpctx);
 void add_step_frame(struct MPContext *mpctx, int dir, bool use_seek);
 void step_frame_mute(struct MPContext *mpctx, bool mute);

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -141,8 +141,7 @@ double get_relative_time(struct MPContext *mpctx)
 
 void update_core_idle_state(struct MPContext *mpctx)
 {
-    bool eof = mpctx->video_status == STATUS_EOF &&
-               mpctx->audio_status == STATUS_EOF;
+    bool eof = mpctx_eof_reached(mpctx);
     bool active = !mpctx->paused && mpctx->restart_complete &&
                   !mpctx->stop_play && mpctx->in_playloop && !eof;
 
@@ -160,12 +159,30 @@ bool get_internal_paused(struct MPContext *mpctx)
     return mpctx->opts->pause || mpctx->paused_for_cache;
 }
 
+bool mpctx_eof_reached(struct MPContext *mpctx)
+{
+    return mpctx->video_status == STATUS_EOF &&
+           mpctx->audio_status == STATUS_EOF;
+}
+
 // The value passed here is the new value for mpctx->opts->pause
 void set_pause_state(struct MPContext *mpctx, bool user_pause)
 {
     struct MPOpts *opts = mpctx->opts;
+    bool restart_from_eof = opts->keep_open && !user_pause &&
+                            mpctx->paused && !mpctx->paused_for_cache &&
+                            mpctx->playback_initialized &&
+                            mpctx_eof_reached(mpctx);
 
     opts->pause = user_pause;
+
+    if (restart_from_eof) {
+        double start = get_start_time(mpctx, mpctx->play_dir);
+
+        mpctx->stop_play = KEEP_PLAYING;
+        mark_seek(mpctx);
+        queue_seek(mpctx, MPSEEK_ABSOLUTE, start, MPSEEK_DEFAULT, 0);
+    }
 
     bool internal_paused = get_internal_paused(mpctx);
     if (internal_paused != mpctx->paused) {

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -179,7 +179,6 @@ void set_pause_state(struct MPContext *mpctx, bool user_pause)
     if (restart_from_eof) {
         double start = get_start_time(mpctx, mpctx->play_dir);
 
-        mpctx->stop_play = KEEP_PLAYING;
         mark_seek(mpctx);
         queue_seek(mpctx, MPSEEK_ABSOLUTE, start, MPSEEK_DEFAULT, 0);
     }


### PR DESCRIPTION
### Description


~~When playback reaches EOF with `--keep-open=yes` and loop file is disabled, mpv keeps the file open and sets eof-reached. Pressing Play in SMTC currently only clears pause, but does not restart playback.~~

~~This PR seeks to the beginning first if `eof-reached` is true, then unpause. Pressing Play while paused before EOF continues to behave as before.~~

When playback reaches EOF with `--keep-open=yes` and loop file is disabled, mpv keeps the file open and enters the EOF state. Since `--keep-open` normally acts like `set pause yes` on EOF, pressing Play or any other stuff that setting `pause=no` only clears the pause state, but does not restart playback.

This PR handles the EOF restart, when unpausing from a keep-open EOF state, mpv seeks back to the file start position before resuming playback.

This makes the behavior consistent across SMTC, osc display, keyboard bindings unpause.

### Testing

- Windows 11 version 25H2 (26200.8457)
- --keep-open=yes --loop-file=no --loop-playlist=no
- Windows SMTC Play
- OSC play button
- keyboard play/pause