### PR TITLE
ytdl_hook.lua: get the duration of fragmented mp4

### DIFF
--- a/player/lua/ytdl_hook.lua
+++ b/player/lua/ytdl_hook.lua
@@ -553,8 +553,11 @@ local function formats_to_edl(json, formats, use_all_formats)
                 elseif sub.media_type == "audio" then
                     props = props .. ",samplerate=" .. as_integer(track.asr)
                 end
-                hdr[#hdr + 1] = "!delay_open,media_type=" .. sub.media_type ..
-                    ",codec=" .. (sub.codec or "null") .. props
+
+                if not is_default then
+                    hdr[#hdr + 1] = "!delay_open,media_type=" .. sub.media_type ..
+                                    ",codec=" .. (sub.codec or "null") .. props
+                end
 
                 -- Add bitrate information etc. for better user selection.
                 local byterate = 0


### PR DESCRIPTION
Changing all_formats' default to true broke reporting the duration of bilibili.tv videos because fragmented MP4 files have the duration in a segment index box and not in the container header.

With all_formats=false the requested formats are opened immediately and libavformat uses HTTP range requests to probe the fragmented MP4 and reads the correct duration.

With all_formats=true every format gets !delay_open and libavformat can't seek for the sidx in that sub-demuxer context.

Fix this by not applying delay_open to the requested formats.

Fixes
https://github.com/mpv-player/mpv/pull/17762#issuecomment-4468518894.

Found by Claude.