### PR TITLE
osc: add back hover_sec in draw-preview

### DIFF
--- a/DOCS/man/osc.rst
+++ b/DOCS/man/osc.rst
@@ -777,9 +777,7 @@ script via the following ``user-data`` properties:
 
 ``user-data/osc/draw-preview``
     Set by the OSC to request a thumbnail within the currently playing file.
-    The requested thumbnail timestamp in seconds is set in
-    ``user-data/osc/hover-sec``. The ``draw-preview`` property is a table with
-    the following fields:
+    The ``draw-preview`` property is a table with the following fields:
 
     ``x``, ``y``
         Top-left coordinates (positive integers) to draw the thumbnail at.
@@ -788,6 +786,9 @@ script via the following ``user-data`` properties:
         Width and height (positive non-zero integers) of the area to draw the
         thumbnail in. Note that this only specifies the drawing width and
         height, the actual backing thumbnail size may differ.
+
+    ``hover-sec``
+        Requested thumbnail timestamp in seconds.
 
     ``ass``
         Optional ASS string to render alongside the thumbnail, using OSD

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -1259,6 +1259,7 @@ local function render_elements(master_ass)
                         local thumb_req = {
                             x = math.floor(thumb_x + 0.5), y = math.floor(thumb_y + 0.5),
                             w = math.floor(thumb_w + 0.5), h = math.floor(thumb_h + 0.5),
+                            ["hover-sec"] = hover_sec,
                         }
 
                         local thumb_ass = assdraw.ass_new()


### PR DESCRIPTION
this was initially part of draw-preview but was later moved to a separate property because it was deemed useful outside of just thumbnail preview. however this causes bugs when a thumbnailer observes draw-request and the draw rectangle doesn't change (e.g due to getting clamped around the border).

add back hover_sec which makes the draw-request more self contained and removes this footgun.

Fixes: https://github.com/mpv-player/mpv/pull/17518#discussion_r3256017469
