### PR TITLE
docs/comments: fix more doubled-word typos

### DIFF
--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1993,7 +1993,7 @@ The following hooks are currently defined:
     Ordered after ``start-file`` and before ``playback-restart``.
 
 ``on_load_fail``
-    Called after after a file has been opened, but failed to. This can be
+    Called after a file has been opened, but failed to. This can be
     used to provide a fallback in case native demuxers failed to recognize
     the file, instead of always running before the native demuxers like
     ``on_load``. Demux will only be retried if ``stream-open-filename``

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5307,7 +5307,7 @@ libavfilter, within the system audio API resampler, or any other places).
 
 ``--audio-resample-max-output-size=<length>``
     Limit maximum size of audio frames filtered at once, in ms (default: 40).
-    The output size size is limited in order to make resample speed changes
+    The output size is limited in order to make resample speed changes
     react faster. This is necessary especially if decoders or filters output
     very large frame sizes (like some lossless codecs or some DRC filters).
     This option does not affect the resampling algorithm in any way.

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1251,7 +1251,7 @@ static void pass_is_compute(struct gl_video *p, int bw, int bh, bool flexible)
 }
 
 // w/h: the width/height of the compute shader's operating domain (e.g. the
-// target target that needs to be written, or the source texture that needs to
+// target that needs to be written, or the source texture that needs to
 // be reduced)
 static void dispatch_compute(struct gl_video *p, int w, int h,
                              struct compute_info info)

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2324,7 +2324,7 @@ static void set_screensaver(struct vo_x11_state *x11, bool enabled)
         CARD16 state;
         DPMSInfo(mDisplay, &state, &onoff);
         if (!x11->dpms_touched && enabled)
-            return; // enable DPMS only we we disabled it before
+            return; // enable DPMS only if we disabled it before
         if (enabled != !!onoff) {
             MP_VERBOSE(x11, "Setting DMPS: %s.\n", enabled ? "on" : "off");
             if (enabled) {


### PR DESCRIPTION
Follow-up to #17926. After that PR merged, @garoto pointed out four more doubled-word instances that this PR addresses.

- `DOCS/man/options.rst:5310` — "output size size is limited" → "output size is limited"
- `DOCS/man/input.rst:1996` — "Called after after a file" → "Called after a file"
- `video/out/gpu/video.c:1254` — "target target that needs to be written" → "target that needs to be written"
- `video/out/x11_common.c:2327` — "enable DPMS only we we disabled it before" → "enable DPMS only if we disabled it before"

The x11_common one wasn't a pure duplicate — the first "we" was a typo for "if". The fixed comment now matches the conditional on the line above (`if (!x11->dpms_touched && enabled)`), which is what the code actually does.

cc @garoto @kasper93