### PR TITLE
ci: harden workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ on:
       - 'README.md'
       - 'RELEASE_NOTES'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,4 +1,5 @@
 name: Pull Request Fuzzing
+
 on:
   pull_request:
     branches: [master]
@@ -12,10 +13,13 @@ on:
         - 'Copyright'
         - 'README.md'
         - 'RELEASE_NOTES'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
 permissions: {}
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   commit-msg:
     runs-on: ubuntu-latest


### PR DESCRIPTION
if you look at existing runs you can see that the default permissions are just a bit excessive:
> GITHUB_TOKEN Permissions
  Actions: write
  ArtifactMetadata: write
  Attestations: write
  Checks: write
  CodeQuality: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Models: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
  VulnerabilityAlerts: read
