### PR TITLE
stream_curl: avoid using symbol only available in >= 7.87

### DIFF
--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -352,13 +352,17 @@ static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdat
     struct priv *p = userdata;
     size_t bytes = size * nmemb;
 
+    // Returning a value other than size*nmemb signals failure to libcurl. If
+    // size*nmemb is already 0, we must return 1 to avoid looking like success.
+    const size_t failure = bytes ? 0 : 1;
+
     // header_callback validated the response and logged any error status,
     // we don't care about error body.
     if (!p->stream_ok)
-        return CURL_WRITEFUNC_ERROR;
+        return failure;
 
     if (atomic_load_explicit(&p->aborted, memory_order_relaxed))
-        return CURL_WRITEFUNC_ERROR;
+        return failure;
 
     mp_mutex_lock(&p->mtx);
 


### PR DESCRIPTION
CURL_WRITEFUNC_ERROR is only available in 7.87, while we require 7.83 in meson. This symbol isn't critical at all though, and we can make-do without it.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
