### PR TITLE
Add --focus-on support in X11

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3488,7 +3488,7 @@ Window
     :level:   A level as integer.
 
 ``--focus-on=<never|open|all>``,
-    (macOS only)
+    (X11 and macOS only)
     Focus the video window and make it the front most window on specific events (default: open).
 
     :never: Never focus the window on open or new file load events.

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -2061,7 +2061,9 @@ static void vo_x11_minimize(struct vo *vo)
     if (x11->opts->window_minimized) {
         XIconifyWindow(x11->display, x11->window, x11->screen);
     } else {
-        long params[5] = {0};
+        long params[5] = {
+            1, // source indication: normal
+        };
         x11_send_ewmh_msg(x11, "_NET_ACTIVE_WINDOW", params);
     }
 }

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -1708,6 +1708,12 @@ static void vo_x11_map_window(struct vo *vo, struct mp_rect rc)
     if (mp_input_vo_keyboard_enabled(x11->input_ctx))
         events |= KeyPressMask | KeyReleaseMask;
     vo_x11_selectinput_witherr(vo, x11->display, x11->window, events);
+    if (!x11->opts->focus_on) { // 0 is never, if it is 1 or 2 we don't want to set this property
+        long user_time = 0;
+        XChangeProperty(x11->display, x11->window,
+                        XA(x11, _NET_WM_USER_TIME), XA_CARDINAL, 32,
+                        PropModeReplace, (unsigned char *)&user_time, 1);
+    }
     XMapWindow(x11->display, x11->window);
 
     if (x11->opts->cursor_passthrough)
@@ -1838,6 +1844,13 @@ void vo_x11_config_vo_window(struct vo *vo)
     vo_x11_update_geometry(vo);
     update_vo_size(vo);
     x11->pending_vo_events &= ~VO_EVENT_RESIZE; // implicitly done by the VO
+
+    if (opts->focus_on == 2) {
+        long data[5] = {
+            1, // source indication: normal
+        };
+        x11_send_ewmh_msg(x11, "_NET_ACTIVE_WINDOW", data);
+    }
 }
 
 static void vo_x11_sticky(struct vo *vo, bool sticky)


### PR DESCRIPTION
ref https://specifications.freedesktop.org/wm/latest-single/#id-1.6.16
"The special value of zero on a newly mapped window can be used to request that the window not be initially focused when it is mapped."