### PR TITLE
Don't allow any escapes in --term-title

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5425,11 +5425,7 @@ Terminal
     line. Expands properties. See `Property Expansion`_.
 
 ``--term-title=<string>``
-    Set the terminal title. Currently, this simply concatenates the escape
-    sequence setting the window title with the provided (property expanded)
-    string. This will mess up if the expanded string contain bytes that end the
-    escape sequence, or if the terminal does not understand the sequence. The
-    latter probably includes the regrettable win32.
+    Set the terminal title.
 
     Expands properties. See `Property Expansion`_.
 

--- a/common/msg.c
+++ b/common/msg.c
@@ -559,13 +559,13 @@ static void write_term_msg(struct mp_log *log, int lev, bstr text, bstr *out)
     }
 }
 
-void mp_msg_sanitize(bstr *text)
+void mp_msg_sanitize(bstr *text, bool allow_sgr)
 {
     for (size_t i = 0; i < text->len; i++) {
         unsigned char ch = text->start[i];
 
         // Allow SGR escape sequences only, filter anything else.
-        if (ch == 0x1B && i + 2 < text->len && text->start[i + 1] == '[') {
+        if (allow_sgr && ch == 0x1B && i + 2 < text->len && text->start[i + 1] == '[') {
             size_t j = i + 2;
             bool sgr = false;
 
@@ -625,7 +625,7 @@ void mp_msg_va(struct mp_log *log, int lev, const char *format, va_list va)
         bstr_xappend(root, &root->buffer, bstr0(format));
     }
 
-    mp_msg_sanitize(&root->buffer);
+    mp_msg_sanitize(&root->buffer, true);
 
     // Remember last status message and restore it to ensure that it is
     // always displayed

--- a/common/msg.h
+++ b/common/msg.h
@@ -69,7 +69,7 @@ void mp_msg_set_max_level(struct mp_log *log, int lev);
 
 // Sanitize text for terminal output.
 struct bstr;
-void mp_msg_sanitize(struct bstr *text);
+void mp_msg_sanitize(struct bstr *text, bool allow_sgr);
 
 // Convenience macros.
 #define mp_fatal(log, ...)      mp_msg(log, MSGL_FATAL, __VA_ARGS__)

--- a/player/osd.c
+++ b/player/osd.c
@@ -109,7 +109,7 @@ static void term_osd_update_title(struct MPContext *mpctx)
 
     char *s = mp_property_expand_escaped_string(mpctx, mpctx->opts->term_title);
     bstr title = bstr0(s);
-    mp_msg_sanitize(&title);
+    mp_msg_sanitize(&title, false);
     if (bstr_equals(title, bstr0(mpctx->term_osd_title))) {
         talloc_free(s);
         return;


### PR DESCRIPTION
Unlike --term-playing-msg, the --term-title string is printed in an escape sequence already. If we print other escapes during this sequence, it will abort the sequence and dump the rest of the title string as a visible string to the user, and possibly beep as well, since the title string can end with a bel character.
