### PR TITLE
meson: bump libcurl minimum version to 7.87.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -621,7 +621,7 @@ if darwin
     subdir(join_paths('TOOLS', 'osxbundle'))
 endif
 
-libcurl = dependency('libcurl', version: '>= 7.83.0', required: get_option('libcurl'))
+libcurl = dependency('libcurl', version: '>= 7.87.0', required: get_option('libcurl'))
 features += {'libcurl': libcurl.found()}
 if features['libcurl']
     dependencies += [libcurl]


### PR DESCRIPTION
CURL_WRITEFUNC_ERROR is only avaialble from 7.87 onwards

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
