### PR TITLE
osc: only clear thumbnails when hiding

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2708,7 +2708,9 @@ end
 
 local function osc_visible(visible)
     set_bar_visible("osc_visible", visible)
-    disable_thumbnail()
+    if not visible then
+        disable_thumbnail()
+    end
 end
 
 local function set_wc_visible(visible)

--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2750,9 +2750,9 @@ end
 local function hide_bar(label, visible_key, anitype_key, set_visible)
     msg.trace("hide_" .. label)
     if not state.enabled then
+        set_visible(false)
         -- typically hide happens at render() from tick(), but now tick() is
         -- no-op and won't render again to remove the osc, so do that manually.
-        state[visible_key] = false
         render_wipe(state.osd)
     elseif user_opts.fadeduration > 0 then
         if state[visible_key] then


### PR DESCRIPTION
this currently disables thumbnail even on set_visible(true) calls which was causing flickering due when scrubbing through the timeline. only disable thumbnail when hiding the osc.

Fixes: 9ce79bcaa
