### PR TITLE
ao_pipewire: feature notify pulseaudio of mpv's pid

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -42,6 +42,7 @@
 #include "ao.h"
 #include "audio/format.h"
 #include "internal.h"
+#include "osdep/getpid.h"
 #include "osdep/timer.h"
 
 #if !PW_CHECK_VERSION(1, 0, 4)
@@ -585,6 +586,8 @@ static int init(struct ao *ao)
         PW_KEY_TARGET_OBJECT, ao->device,
         NULL
     );
+
+    pw_properties_setf(props, PW_KEY_APP_PROCESS_ID, "%d", mp_getpid());
 
     if (ao->set_media_role)
         pw_properties_set(props, PW_KEY_MEDIA_ROLE,


### PR DESCRIPTION

Goal is to link mpv's pulseaudio sink data against playerctl instance data.

Playerctl defines instances by `$PROCESS.instance$PID` by passing the pid to pulseaudio we are able to reliably generate the playerctl instance identity purely from pulseaudio information.

The ao_pipewire solution uses pipewire library functions alongside mp_getpid() to set the pulseaudio property application.process.id.