### PR TITLE
stream: fix multiple critical bugs (chapter bounds, DVDNAV buffer, lavf NULL deref)

### DIFF
--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -203,7 +203,7 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
             return STREAM_UNSUPPORTED;
         int chapter = *(double *)arg;
         double time = MP_NOPTS_VALUE;
-        if (chapter >= 0 || chapter < ti->chapter_count)
+        if (chapter >= 0 && chapter < ti->chapter_count)
             time = BD_TIME_TO_MP(ti->chapters[chapter].start);
         if (time == MP_NOPTS_VALUE)
             return STREAM_ERROR;

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -322,7 +322,7 @@ static int fill_buffer(stream_t *s, void *buf, int max_len)
         case DVDNAV_VTS_CHANGE: {
             int tit = 0, part = 0;
             dvdnav_vts_change_event_t *vts_event =
-                (dvdnav_vts_change_event_t *)s->buffer;
+                (dvdnav_vts_change_event_t *)buf;
             MP_INFO(s, "DVDNAV, switched to title: %d\n",
                    vts_event->new_vtsN);
             if (!priv->had_initial_vts) {

--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -126,9 +126,11 @@ static int control(stream_t *s, int cmd, void *arg)
             // This usually yields the URLContext (why does it even exist?),
             // which holds the name of the actual protocol implementation.
             void *child = avio->av_class->child_next(avio, NULL);
-            AVClass *cl = *(AVClass **)child;
-            if (cl && cl->item_name)
-                proto = cl->item_name(child);
+            if (child) {
+                AVClass *cl = *(AVClass **)child;
+                if (cl && cl->item_name)
+                    proto = cl->item_name(child);
+            }
         }
         static const char *const has_read_seek[] = {
             "rtmp", "rtmpt", "rtmpe", "rtmpte", "rtmps", "rtmpts", "mmsh", 0};


### PR DESCRIPTION
## Summary
Three critical bug fixes in the stream/ module.

## Changes

### stream_bluray.c (fixes #17970)
Change || to && in chapter bounds check. When chapter >= 0 (always true for valid chapters), the || short-circuits and never checks chapter < ti->chapter_count, allowing OOB array access.

### stream_dvdnav.c (fixes #17971)
VTS_CHANGE event reads from \s->buffer\ instead of \uf\. All other event handlers (\DVDNAV_CELL_CHANGE\, \DVDNAV_SPU_CLUT_CHANGE\) correctly use \uf\. The event data is written to \uf\ by \dvdnav_get_next_block\, so reading from \s->buffer\ returns garbage.

### stream_lavf.c (fixes #17972)
\vio->av_class->child_next(avio, NULL)\ can return NULL for certain AVIOContext implementations. The returned pointer was dereferenced without a NULL check. Added a guard.