### PR TITLE
filters: fix multiple bugs (height comparison, dead diagnostic, wrong handler check)

### DIFF
--- a/filters/f_lavfi.c
+++ b/filters/f_lavfi.c
@@ -342,7 +342,7 @@ static bool is_aformat_ok(struct mp_aframe *a, struct mp_aframe *b)
 static bool is_vformat_ok(struct mp_image *a, struct mp_image *b)
 {
     return a->imgfmt == b->imgfmt &&
-           a->w == b->w && a->h && b->h &&
+           a->w == b->w && a->h == b->h &&
            a->params.p_w == b->params.p_w && a->params.p_h == b->params.p_h &&
            a->nominal_fps == b->nominal_fps;
 }

--- a/filters/filter.c
+++ b/filters/filter.c
@@ -485,11 +485,11 @@ static void deinit_connection(struct mp_pin *p)
         p->within_conn = p->other->within_conn = false;
         mp_assert(!p->other->data_requested); // unused for in pins
         mp_assert(!p->other->data.type); // unused for in pins
+        if (p->data_requested)
+            MP_VERBOSE(p->owner, "dropping request due to pin disconnect\n");
         p->data_requested = false;
         if (p->data.type)
             MP_VERBOSE(p->owner, "dropping frame due to pin disconnect\n");
-        if (p->data_requested)
-            MP_VERBOSE(p->owner, "dropping request due to pin disconnect\n");
         mp_frame_unref(&p->data);
         p = p->other->user_conn;
     }

--- a/filters/frame.c
+++ b/filters/frame.c
@@ -169,7 +169,7 @@ double mp_frame_get_pts(struct mp_frame frame)
 
 void mp_frame_set_pts(struct mp_frame frame, double pts)
 {
-    if (frame_handlers[frame.type].get_pts)
+    if (frame_handlers[frame.type].set_pts)
         frame_handlers[frame.type].set_pts(frame.data, pts);
 }
 


### PR DESCRIPTION
## Summary
Three bug fixes in the filters/ module.

## Changes

### f_lavfi.c (fixes #17973)
`is_vformat_ok` used `a->h && b->h` (checking both heights are non-zero) instead of `a->h == b->h` (comparing heights). Any mid-stream resolution change affecting only height was silently missed.

### filter.c (fixes #17984)
`p->data_requested` was set to `false` before the check, making the "dropping request due to pin disconnect" message dead code. Reordered so the check happens before clearing the flag.

### frame.c (fixes #17985)
`mp_frame_set_pts` checked `get_pts` handler instead of `set_pts` to decide if the setter is callable. Would call NULL if a future frame type provides only one of the two.
