### PR TITLE
video/filter: fix UAF in vf_gpu_vulkan and HDR reset in vf_format

### DIFF
--- a/video/filter/vf_format.c
+++ b/video/filter/vf_format.c
@@ -78,9 +78,9 @@ static void set_params(struct vf_format_opts *p, struct mp_image_params *out,
     if (p->primaries)
         out->color.primaries = p->primaries;
     if (p->gamma) {
-        enum pl_color_transfer in_gamma = p->gamma;
+        enum pl_color_transfer old_gamma = out->color.transfer;
         out->color.transfer = p->gamma;
-        if (in_gamma != out->color.transfer) {
+        if (old_gamma != out->color.transfer) {
             // When changing the gamma function explicitly, also reset stuff
             // related to the gamma function since that information will almost
             // surely be false now and have to be re-inferred

--- a/video/filter/vf_gpu_vulkan.c
+++ b/video/filter/vf_gpu_vulkan.c
@@ -70,6 +70,7 @@ static struct offscreen_ctx *vk_offscreen_ctx_create(struct mpv_global *global,
 
     struct pl_vk_inst_params pl_vk_params = {0};
     struct ra_ctx_opts *ctx_opts = mp_get_config_group(NULL, global, &ra_ctx_conf);
+    bool allow_sw = ctx_opts->allow_sw;
     pl_vk_params.debug = ctx_opts->debug;
     talloc_free(ctx_opts);
     mppl_log_set_probing(vk->pllog, true);
@@ -80,7 +81,7 @@ static struct offscreen_ctx *vk_offscreen_ctx_create(struct mpv_global *global,
 
     struct vulkan_opts *vk_opts = mp_get_config_group(NULL, global, &vulkan_conf);
     vk->vulkan = mppl_create_vulkan(vk_opts, vk->vkinst, vk->pllog, VK_NULL_HANDLE,
-                                    ctx_opts->allow_sw);
+                                    allow_sw);
     talloc_free(vk_opts);
     if (!vk->vulkan)
         goto error;


### PR DESCRIPTION
## Summary
Two bug fixes in video/filter/.

## Changes

### vf_gpu_vulkan.c: Use-after-free of ctx_opts (fixes #17975)
`ctx_opts->debug` was read, then `ctx_opts` was freed via `talloc_free`, then `ctx_opts->allow_sw` was read from freed memory. Fixed by saving `allow_sw` to a local variable before freeing.

### vf_format.c: Self-comparison prevents HDR metadata reset (fixes #17987)
`in_gamma` was set from `p->gamma`, then `out->color.transfer` was also set to `p->gamma`, making the comparison `in_gamma != out->color.transfer` always false. Fixed by saving the old gamma before overwriting.
