### PR TITLE
hwdec: fix multiple critical/major bugs (CUDA init, Vulkan unmap, GL context, VK close)

### DIFF
--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -193,8 +193,10 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
         return ret;
 
     for (int n = 0; n < desc.num_planes; n++) {
-        if (!p_owner->ext_init(mapper, desc.planes[n], n))
+        if (!p_owner->ext_init(mapper, desc.planes[n], n)) {
+            ret = -1;
             goto error;
+        }
     }
 
  error:

--- a/video/out/hwdec/hwdec_cuda_gl.c
+++ b/video/out/hwdec/hwdec_cuda_gl.c
@@ -84,7 +84,6 @@ static bool cuda_ext_gl_init(struct ra_hwdec_mapper *mapper,
     return true;
 
 error:
-    CHECK_CU(cu->cuCtxPopCurrent(&dummy));
     return false;
 }
 

--- a/video/out/hwdec/hwdec_cuda_vk.c
+++ b/video/out/hwdec/hwdec_cuda_vk.c
@@ -140,6 +140,7 @@ static bool cuda_ext_vk_init(struct ra_hwdec_mapper *mapper,
     if (ret < 0)
         goto error;
 
+    evk->sem_handle.fd = -1;
     evk->vk_sem.sem = pl_vulkan_sem_create(gpu, pl_vulkan_sem_params(
         .type = VK_SEMAPHORE_TYPE_TIMELINE,
         .export_handle = HANDLE_TYPE,

--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -225,7 +225,7 @@ static void mapper_unmap(struct ra_hwdec_mapper *mapper)
 {
     struct vulkan_hw_priv *p_owner = mapper->owner->priv;
     struct vulkan_mapper_priv *p = mapper->priv;
-    if (!mapper->src)
+    if (!mapper->src || !p->vkf)
         goto end;
 
     AVHWFramesContext *hwfc = (AVHWFramesContext *) mapper->src->hwctx->data;


### PR DESCRIPTION
## Summary
Four critical/major fixes in the hwdec subsystem.

## Changes

### hwdec_cuda.c: mapper_init returns 0 on failure (fixes #17976)
When `ext_init` fails, `ret` is still 0 (from successful `cuCtxPushCurrent`), and `goto error` does not set `ret = -1`. The framework treats the mapper as initialized. Fixed by setting `ret = -1` before `goto error`.

### hwdec_vulkan.c: NULL deref in mapper_unmap (fixes #17977)
`mapper_map` error path calls `mapper_unmap` before `p->vkf` is initialized. Added a guard to skip unmap logic when `p->vkf` is NULL.

### hwdec_cuda_gl.c: Extra cuCtxPopCurrent (fixes #17988)
Error path pops the CUDA context even though the caller already manages push/pop. Removed the extra cuCtxPopCurrent.

### hwdec_cuda_vk.c: close(0) on pl_vulkan_sem_create failure (fixes #17989)
`evk` is talloc-zeroed, so `sem_handle.fd == 0`. When pl_vulkan_sem_create fails, the error handler calls `close(0)`, closing stdin. Fixed by initializing `sem_handle.fd = -1`.
