### PR TITLE
gpu/utils: fix division by zero in gl_transform_ortho

### DIFF
--- a/video/out/gpu/utils.c
+++ b/video/out/gpu/utils.c
@@ -10,7 +10,7 @@ void gl_transform_ortho(struct gl_transform *t, float x0, float x1,
 {
     if (y1 < y0) {
         float tmp = y0;
-        y0 = tmp - y1;
+        y0 = y1;
         y1 = tmp;
     }
 


### PR DESCRIPTION
## Summary
Fix division by zero in `gl_transform_ortho` when `y1 < y0`.

## Changes

### video/out/gpu/utils.c (fixes #17997)
The swap logic for when `y1 < y0` was incorrect: `float tmp = y0; y0 = tmp - y1; y1 = tmp;` produces `y0 == y1` when `y1 < y0`, causing a division by zero. Fixed by using a simple swap: `float tmp = y0; y0 = y1; y1 = tmp;`.
