### PR TITLE
audio: fix NULL deref of codec_descriptor in ad_lavc

### DIFF
--- a/audio/decode/ad_lavc.c
+++ b/audio/decode/ad_lavc.c
@@ -311,7 +311,8 @@ static struct mp_decoder *create(struct mp_filter *parent,
         return NULL;
     }
 
-    codec->codec_desc = priv->avctx->codec_descriptor->long_name;
+    codec->codec_desc = priv->avctx->codec_descriptor ?
+                        priv->avctx->codec_descriptor->long_name : NULL;
     mp_chmap_from_av_layout(&priv->codec->channels, &priv->avctx->ch_layout);
 
     return &priv->public;


### PR DESCRIPTION
## Summary
Fix NULL pointer dereference in audio decoder initialization.

## Changes

### ad_lavc.c (fixes #17990)
\priv->avctx->codec_descriptor\ can be NULL for unknown/internal libavcodec codec IDs. Added a NULL guard before accessing \->long_name\.