### PR TITLE
demux: fix OOB read in ITU T.35 parsing and invalid timestamp with unknown duration

### DIFF
--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -250,7 +250,9 @@ static bool d_read_packet(struct demuxer *demuxer, struct demux_packet **out_pkt
         if (fabs(p->last_dts - pkt->dts) >= DTS_RESET_THRESHOLD) {
             MP_WARN(demuxer, "PTS discontinuity: %f->%f\n", p->last_dts, pkt->dts);
             p->base_time += p->last_dts - p->base_dts;
-            p->base_dts = pkt->dts - pkt->duration;
+            p->base_dts = pkt->dts;
+            if (pkt->duration > 0)
+                p->base_dts -= pkt->duration;
         }
         p->last_dts = pkt->dts;
     }

--- a/demux/packet.c
+++ b/demux/packet.c
@@ -376,6 +376,8 @@ int demux_packet_add_blockadditional(struct demux_packet *dp, uint64_t id,
         }
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 17, 100)
         case ITU_T_T35_COUNTRY_CODE_UK: {
+            if (remaining < 1)
+                break;
             SKIP(1); // skip t35_uk_country_code_second_octet
             if (remaining < 2)
                 break;


### PR DESCRIPTION
## Summary
Two critical/major bug fixes in the demux/ module.

## Changes

### packet.c: Integer underflow leading to OOB read (fixes #17979)
In ITU T.35 UK country code parsing, `SKIP(1)` was called before the bounds check. When `remaining == 0`, the unsigned `size_t` underflows to `SIZE_MAX`, bypassing the `if (remaining < 2)` check. Fixed by adding a bounds check before SKIP.

### demux_disc.c: Invalid timestamp with unknown duration (fixes #17998)
`pkt->duration` defaults to -1. Using `pkt->dts - pkt->duration` when duration is unknown computes `base_dts = pkt->dts + 1`, shifting all subsequent timestamps by -1 second. Fixed by checking `pkt->duration > 0` before using it.
