### PR TITLE
osdep: fix multiple bugs (command injection, FreeLibrary, signal mask)

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -783,7 +783,7 @@ void *mp_dlsym(void *handle, const char *symbol)
 
 int mp_dlclose(void *handle)
 {
-    return CloseHandle(handle);
+    return FreeLibrary((HMODULE)handle) ? 0 : -1;
 }
 
 char *mp_dlerror(void)

--- a/osdep/subprocess-posix.c
+++ b/osdep/subprocess-posix.c
@@ -224,8 +224,10 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
         sigfillset(&sigmask);
         pthread_sigmask(SIG_BLOCK, &sigmask, &oldmask);
         pid_t fres = fork();
-        if (fres < 0)
+        if (fres < 0) {
+            pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
             goto done;
+        }
         if (fres == 0) {
             // child
             setsid();

--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -66,7 +66,7 @@ static void write_arg(bstr *cmdline, char *arg)
         case '"':
             // Write the argument up to the point before the quote
             bstr_xappend(NULL, cmdline, (struct bstr){arg, pos});
-            arg += pos;
+            arg += pos + 1;
             pos = 0;
 
             // Double backslashes preceding the quote


### PR DESCRIPTION
## Summary
Multiple bug fixes in the osdep/ module.

## Changes

### subprocess-win.c: Command injection via broken quoting (fixes #17981)
When an argument contains multiple `"` characters, the escaping logic corrupts the output because the `"` character is never consumed after `arg += pos; pos = 0;`. Fixed by advancing past the `"` after resetting position.

### io.c: CloseHandle on HMODULE instead of FreeLibrary (fixes #17982)
`mp_dlclose()` calls `CloseHandle(handle)` on an `HMODULE` from `LoadLibraryW`. Must use `FreeLibrary` instead. Fixed by replacing with `FreeLibrary`.

### subprocess-posix.c: Signal mask leak on fork failure (fixes #18003)
When `fork()` fails in the detach path, all signals remain blocked because there was no `pthread_sigmask` restore before `goto done`. Fixed by adding signal mask restoration.
