### PR TITLE
Draft: Send content frame rate surface hints

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -766,12 +766,16 @@ static void handle_new_stream(demuxer_t *demuxer, int i)
         sh->codec->disp_h = codec->height;
         sh->codec->bitrate = codec->bit_rate;
         sh->codec->format_name = talloc_strdup(sh->codec, av_get_pix_fmt_name(codec->format));
-        if (st->avg_frame_rate.num)
+        if (st->avg_frame_rate.num) {
             sh->codec->fps = av_q2d(st->avg_frame_rate);
+            sh->codec->fps_num = st->avg_frame_rate.num;
+            sh->codec->fps_den = st->avg_frame_rate.den;
+        }
         if (is_image(st, sh->attached_picture, priv->avif)) {
             MP_VERBOSE(demuxer, "Assuming this is an image format.\n");
             sh->image = true;
             sh->codec->fps = demuxer->opts->mf_fps;
+            sh->codec->fps_num = sh->codec->fps_den = 0;
         }
         sh->codec->par_w = st->sample_aspect_ratio.num;
         sh->codec->par_h = st->sample_aspect_ratio.den;
@@ -1218,6 +1222,8 @@ static void handle_tile_grid_group(demuxer_t *demuxer, AVStreamGroup *stream_gro
 
     struct sh_stream *primary_sh = vsh->group->members[0];
     vsh->codec->fps    = primary_sh->codec->fps;
+    vsh->codec->fps_num = primary_sh->codec->fps_num;
+    vsh->codec->fps_den = primary_sh->codec->fps_den;
     vsh->image         = primary_sh->image;
     vsh->still_image   = primary_sh->still_image;
     vsh->default_track = true;

--- a/demux/stheader.h
+++ b/demux/stheader.h
@@ -163,6 +163,9 @@ struct mp_codec_params {
     // STREAM_VIDEO
     bool avi_dts;         // use DTS timing; first frame and DTS is 0
     double fps;           // frames per second (set only if constant fps)
+    int fps_num, fps_den; // fps as exact rational (0/0 if not known); this is
+                          // set only if the container provides an exact rate,
+                          // and is always consistent with the fps field
     bool reliable_fps;    // the fps field is definitely not broken
     int par_w, par_h;     // pixel aspect ratio (0 if unknown/square)
     int disp_w, disp_h;   // display size

--- a/filters/f_decoder_wrapper.c
+++ b/filters/f_decoder_wrapper.c
@@ -197,6 +197,7 @@ struct priv {
     struct mp_image_params dec_format, last_format, fixed_format;
 
     double fps;
+    int fps_num, fps_den;
 
     double start_pts;
     double start, end;
@@ -579,6 +580,17 @@ double mp_decoder_wrapper_get_container_fps(struct mp_decoder_wrapper *d)
     double res = p->fps;
     thread_unlock(p);
     return res;
+}
+
+bool mp_decoder_wrapper_get_container_fps_rational(struct mp_decoder_wrapper *d,
+                                                   int *num, int *den)
+{
+    struct priv *p = d->f->priv;
+    thread_lock(p);
+    *num = p->fps_num;
+    *den = p->fps_den;
+    thread_unlock(p);
+    return *num > 0 && *den > 0;
 }
 
 void mp_decoder_wrapper_set_spdif_flag(struct mp_decoder_wrapper *d, bool spdif)
@@ -1288,6 +1300,8 @@ static bool init_group_decoder(struct priv *p, struct mp_filter *public_f)
 
     p->is_group = true;
     p->fps = p->header->codec->fps;
+    p->fps_num = p->header->codec->fps_num;
+    p->fps_den = p->header->codec->fps_den;
 
     // Currently only lavfi merge is supported, this can be extended if needed.
     if (g->num_members < 1 || !g->lavfi_graph) {
@@ -1387,11 +1401,14 @@ struct mp_decoder_wrapper *mp_decoder_wrapper_create(struct mp_filter *parent,
         p->log = mp_log_new(p, parent->global->log, "!vd");
 
         p->fps = src->codec->fps;
+        p->fps_num = src->codec->fps_num;
+        p->fps_den = src->codec->fps_den;
 
         MP_VERBOSE(p, "Container reported FPS: %f\n", p->fps);
 
         if (p->opts->fps_override) {
             p->fps = p->opts->fps_override;
+            p->fps_num = p->fps_den = 0;
             MP_INFO(p, "Container FPS forced to %5.3f.\n", p->fps);
             MP_INFO(p, "Use --no-correct-pts to force FPS based timing.\n");
         }

--- a/filters/f_decoder_wrapper.h
+++ b/filters/f_decoder_wrapper.h
@@ -53,6 +53,13 @@ int mp_decoder_wrapper_get_frames_dropped(struct mp_decoder_wrapper *d);
 
 double mp_decoder_wrapper_get_container_fps(struct mp_decoder_wrapper *d);
 
+// Return the container FPS as an exact rational, as provided by the demuxer.
+// Returns false and sets *num/*den to 0 if the container did not provide an
+// exact rate (in which case only the value returned by
+// mp_decoder_wrapper_get_container_fps() is known).
+bool mp_decoder_wrapper_get_container_fps_rational(struct mp_decoder_wrapper *d,
+                                                   int *num, int *den);
+
 // Whether to prefer spdif wrapper over real decoders on next reinit.
 void mp_decoder_wrapper_set_spdif_flag(struct mp_decoder_wrapper *d, bool spdif);
 

--- a/filters/f_output_chain.h
+++ b/filters/f_output_chain.h
@@ -31,6 +31,9 @@ struct mp_output_chain {
     struct mp_image_params input_params;
     struct mp_image_params output_params;
     double container_fps;
+    // container_fps as an exact rational, if the demuxer provided one (0/0 if
+    // not known).
+    int container_fps_num, container_fps_den;
     void (*update_subtitles)(void *ctx, double pts);
     void *update_subtitles_ctx;
 

--- a/player/misc.c
+++ b/player/misc.c
@@ -17,9 +17,12 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
+
+#include <libavutil/rational.h>
 
 #include "mpv_talloc.h"
 
@@ -174,6 +177,28 @@ void issue_refresh_seek(struct MPContext *mpctx, enum seek_precision min_prec)
     queue_seek(mpctx, MPSEEK_ABSOLUTE, get_current_time(mpctx), min_prec, 0);
 }
 
+static void update_content_frame_rate(struct MPContext *mpctx, struct track *track)
+{
+    struct voctrl_content_frame_rate frame_rate = {
+        .numerator = 0,
+        .denominator = 1,
+    };
+
+    if (track && track->vo_c && !track->image) {
+        double fps = track->vo_c->filter->container_fps;
+        if (fps > 0) {
+            AVRational rate = av_d2q(fps, INT_MAX);
+            if (rate.num > 0 && rate.den > 0) {
+                frame_rate.numerator = rate.num;
+                frame_rate.denominator = rate.den;
+            }
+        }
+    }
+
+    if (mpctx->video_out)
+        vo_control(mpctx->video_out, VOCTRL_CONTENT_FRAME_RATE, &frame_rate);
+}
+
 void update_content_type(struct MPContext *mpctx, struct track *track)
 {
     enum mp_content_type content_type;
@@ -186,6 +211,8 @@ void update_content_type(struct MPContext *mpctx, struct track *track)
     }
     if (mpctx->video_out)
         vo_control(mpctx->video_out, VOCTRL_CONTENT_TYPE, &content_type);
+
+    update_content_frame_rate(mpctx, track);
 }
 
 void update_vo_playback_state(struct MPContext *mpctx)

--- a/player/misc.c
+++ b/player/misc.c
@@ -21,6 +21,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include <libavutil/rational.h>
+
 #include "mpv_talloc.h"
 
 #include "osdep/io.h"
@@ -174,6 +176,59 @@ void issue_refresh_seek(struct MPContext *mpctx, enum seek_precision min_prec)
     queue_seek(mpctx, MPSEEK_ABSOLUTE, get_current_time(mpctx), min_prec, 0);
 }
 
+// Recover an exact frame rate from a container which only reports a rounded
+// one (Matroska's DefaultDuration for example gives 41708333ns instead of
+// 1001/24000s). Plain av_d2q() would turn that into 1000000000/41708333, while
+// consumers of the rate need to be able to tell x/1 and x*1000/1001 rates
+// apart (DP AdaptiveSync FAVT encodes the 1.001 divider as a single bit), so
+// prefer the nearest normative rate.
+static AVRational fps_to_rational(double fps)
+{
+    long int n = lrint(fps);
+    if (n > 0 && n <= INT_MAX / 1000) {
+        // The two families are ~0.1% apart, so this can't be ambiguous.
+        double tolerance = n * 1e-4;
+        if (fabs(fps - n) < tolerance)
+            return (AVRational){n, 1};
+        if (fabs(fps - n * 1000.0 / 1001.0) < tolerance)
+            return (AVRational){n * 1000, 1001};
+    }
+    // Not a normative rate; keep num and den small enough to stay meaningful.
+    return av_d2q(fps, 65535);
+}
+
+static void update_content_frame_rate(struct MPContext *mpctx, struct track *track)
+{
+    struct voctrl_content_frame_rate frame_rate = {
+        .numerator = 0,
+        .denominator = 1,
+    };
+
+    if (track && track->vo_c && !track->image) {
+        struct mp_output_chain *filter = track->vo_c->filter;
+        AVRational rate = {
+            filter->container_fps_num,
+            filter->container_fps_den,
+        };
+
+        // Pass the container rate through unchanged if it is known exactly.
+        // Some containers report a rate which is exact, but averaged over the
+        // whole file instead of being the authored cadence (10800000/450449
+        // instead of 24000/1001), which is of no use here either - all rates
+        // in actual use have a denominator of 1 or 1001.
+        if (rate.num <= 0 || rate.den <= 0 || rate.den > 1001)
+            rate = fps_to_rational(filter->container_fps);
+
+        if (rate.num > 0 && rate.den > 0) {
+            frame_rate.numerator = rate.num;
+            frame_rate.denominator = rate.den;
+        }
+    }
+
+    if (mpctx->video_out)
+        vo_control(mpctx->video_out, VOCTRL_CONTENT_FRAME_RATE, &frame_rate);
+}
+
 void update_content_type(struct MPContext *mpctx, struct track *track)
 {
     enum mp_content_type content_type;
@@ -186,6 +241,8 @@ void update_content_type(struct MPContext *mpctx, struct track *track)
     }
     if (mpctx->video_out)
         vo_control(mpctx->video_out, VOCTRL_CONTENT_TYPE, &content_type);
+
+    update_content_frame_rate(mpctx, track);
 }
 
 void update_vo_playback_state(struct MPContext *mpctx)

--- a/player/video.c
+++ b/player/video.c
@@ -271,6 +271,9 @@ void reinit_video_chain_src(struct MPContext *mpctx, struct track *track)
         vo_c->dec_src = track->dec->f->pins[0];
         vo_c->filter->container_fps =
             mp_decoder_wrapper_get_container_fps(track->dec);
+        mp_decoder_wrapper_get_container_fps_rational(track->dec,
+                                            &vo_c->filter->container_fps_num,
+                                            &vo_c->filter->container_fps_den);
         vo_c->is_coverart = !!track->attached_picture;
         vo_c->is_sparse = track->stream->still_image || vo_c->is_coverart;
 

--- a/video/out/meson.build
+++ b/video/out/meson.build
@@ -1,3 +1,5 @@
+fs = import('fs')
+
 wl_protocol_dir = wayland['deps'][2].get_variable(pkgconfig: 'pkgdatadir', internal: 'pkgdatadir')
 protocols = [[wl_protocol_dir, 'stable/linux-dmabuf/linux-dmabuf-v1.xml'],
              [wl_protocol_dir, 'stable/presentation-time/presentation-time.xml'],
@@ -16,6 +18,13 @@ protocols = [[wl_protocol_dir, 'stable/linux-dmabuf/linux-dmabuf-v1.xml'],
 ]
 wl_protocols_source = []
 wl_protocols_headers = []
+
+features += {'wayland-protocols-content-frame-rate': fs.is_file(join_paths(
+    wl_protocol_dir, 'staging/content-frame-rate/content-frame-rate-v1.xml'))}
+
+if features['wayland-protocols-content-frame-rate']
+    protocols += [[wl_protocol_dir, 'staging/content-frame-rate/content-frame-rate-v1.xml']]
+endif
 
 foreach v: ['1.39', '1.41', '1.44', '1.47', '1.48']
     features += {'wayland-protocols-' + v.replace('.', '-'):

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -88,6 +88,7 @@ enum mp_voctrl {
     VOCTRL_SET_CURSOR_VISIBILITY,       // bool*
 
     VOCTRL_CONTENT_TYPE,                // enum mp_content_type*
+    VOCTRL_CONTENT_FRAME_RATE,          // struct voctrl_content_frame_rate*
 
     VOCTRL_KILL_SCREENSAVER,
     VOCTRL_RESTORE_SCREENSAVER,
@@ -140,6 +141,11 @@ enum mp_content_type {
     MP_CONTENT_NONE, // used for force-window
     MP_CONTENT_IMAGE,
     MP_CONTENT_VIDEO,
+};
+
+struct voctrl_content_frame_rate {
+    uint32_t numerator;
+    uint32_t denominator;
 };
 
 #define VO_TRUE         true

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -51,6 +51,9 @@
 #include "xdg-shell.h"
 #include "viewporter.h"
 #include "content-type-v1.h"
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+#include "content-frame-rate-v1.h"
+#endif
 #include "single-pixel-buffer-v1.h"
 #include "fractional-scale-v1.h"
 #include "tablet-unstable-v2.h"
@@ -2857,6 +2860,14 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         wl->content_type_manager = wl_registry_bind(reg, id, &wp_content_type_manager_v1_interface, ver);
     }
 
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (!strcmp(interface, wp_content_frame_rate_manager_v1_interface.name) && found++) {
+        ver = 1;
+        wl->content_frame_rate_manager = wl_registry_bind(
+            reg, id, &wp_content_frame_rate_manager_v1_interface, ver);
+    }
+#endif
+
     if (!strcmp(interface, wp_single_pixel_buffer_manager_v1_interface.name) && found++) {
         ver = 1;
         wl->single_pixel_manager = wl_registry_bind(reg, id, &wp_single_pixel_buffer_manager_v1_interface, ver);
@@ -3807,6 +3818,20 @@ static void set_content_type(struct vo_wayland_state *wl)
     }
 }
 
+static void set_content_frame_rate(struct vo_wayland_state *wl)
+{
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (!wl->content_frame_rate_manager || !wl->content_frame_rate)
+        return;
+
+    uint32_t den = wl->current_content_frame_rate_den ?
+                   wl->current_content_frame_rate_den : 1;
+    wp_content_frame_rate_v1_set_frame_rate(
+        wl->content_frame_rate,
+        wl->current_content_frame_rate_num,
+        den);
+#endif
+}
 static void set_cursor(struct vo_wayland_seat *s, struct wl_surface *cursor_surface,
                        int32_t hotspot_x, int32_t hotspot_y)
 {
@@ -4277,6 +4302,13 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         set_content_type(wl);
         return VO_TRUE;
     }
+    case VOCTRL_CONTENT_FRAME_RATE: {
+        struct voctrl_content_frame_rate *content_frame_rate = arg;
+        wl->current_content_frame_rate_num = content_frame_rate->numerator;
+        wl->current_content_frame_rate_den = content_frame_rate->denominator;
+        set_content_frame_rate(wl);
+        return VO_TRUE;
+    }
     case VOCTRL_GET_FOCUSED: {
         *(bool *)arg = wl->focused;
         return VO_TRUE;
@@ -4590,6 +4622,17 @@ bool vo_wayland_init(struct vo *vo)
                    wp_content_type_manager_v1_interface.name);
     }
 
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (wl->content_frame_rate_manager) {
+        wl->content_frame_rate =
+            wp_content_frame_rate_manager_v1_get_surface_content_frame_rate(
+                wl->content_frame_rate_manager, wl->surface);
+    } else {
+        MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
+                   wp_content_frame_rate_manager_v1_interface.name);
+    }
+#endif
+
     if (!wl->single_pixel_manager) {
         MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
                    wp_single_pixel_buffer_manager_v1_interface.name);
@@ -4810,6 +4853,14 @@ void vo_wayland_uninit(struct vo *vo)
 
     if (wl->content_type_manager)
         wp_content_type_manager_v1_destroy(wl->content_type_manager);
+
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (wl->content_frame_rate)
+        wp_content_frame_rate_v1_destroy(wl->content_frame_rate);
+
+    if (wl->content_frame_rate_manager)
+        wp_content_frame_rate_manager_v1_destroy(wl->content_frame_rate_manager);
+#endif
 
     if (wl->devman)
         wl_data_device_manager_destroy(wl->devman);

--- a/video/out/wayland_common.c
+++ b/video/out/wayland_common.c
@@ -51,6 +51,9 @@
 #include "xdg-shell.h"
 #include "viewporter.h"
 #include "content-type-v1.h"
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+#include "content-frame-rate-v1.h"
+#endif
 #include "single-pixel-buffer-v1.h"
 #include "fractional-scale-v1.h"
 #include "tablet-unstable-v2.h"
@@ -2909,6 +2912,14 @@ static void registry_handle_add(void *data, struct wl_registry *reg, uint32_t id
         wl->content_type_manager = wl_registry_bind(reg, id, &wp_content_type_manager_v1_interface, ver);
     }
 
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (!strcmp(interface, wp_content_frame_rate_manager_v1_interface.name) && found++) {
+        ver = 1;
+        wl->content_frame_rate_manager = wl_registry_bind(
+            reg, id, &wp_content_frame_rate_manager_v1_interface, ver);
+    }
+#endif
+
     if (!strcmp(interface, wp_single_pixel_buffer_manager_v1_interface.name) && found++) {
         ver = 1;
         wl->single_pixel_manager = wl_registry_bind(reg, id, &wp_single_pixel_buffer_manager_v1_interface, ver);
@@ -3866,6 +3877,24 @@ static void set_content_type(struct vo_wayland_state *wl)
     }
 }
 
+static void set_content_frame_rate(struct vo_wayland_state *wl)
+{
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (!wl->content_frame_rate_manager || !wl->content_frame_rate)
+        return;
+
+    // A denominator of 0 is a protocol error.
+    uint32_t den = wl->current_content_frame_rate_den ?
+                   wl->current_content_frame_rate_den : 1;
+    MP_VERBOSE(wl, "Setting content frame rate to %u/%u\n",
+               wl->current_content_frame_rate_num, den);
+    wp_content_frame_rate_v1_set_frame_rate(
+        wl->content_frame_rate,
+        wl->current_content_frame_rate_num,
+        den);
+#endif
+}
+
 static void set_cursor(struct vo_wayland_seat *s, struct wl_surface *cursor_surface,
                        int32_t hotspot_x, int32_t hotspot_y)
 {
@@ -4337,6 +4366,13 @@ int vo_wayland_control(struct vo *vo, int *events, int request, void *arg)
         set_content_type(wl);
         return VO_TRUE;
     }
+    case VOCTRL_CONTENT_FRAME_RATE: {
+        struct voctrl_content_frame_rate *content_frame_rate = arg;
+        wl->current_content_frame_rate_num = content_frame_rate->numerator;
+        wl->current_content_frame_rate_den = content_frame_rate->denominator;
+        set_content_frame_rate(wl);
+        return VO_TRUE;
+    }
     case VOCTRL_GET_FOCUSED: {
         *(bool *)arg = wl->focused;
         return VO_TRUE;
@@ -4650,6 +4686,17 @@ bool vo_wayland_init(struct vo *vo)
                    wp_content_type_manager_v1_interface.name);
     }
 
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (wl->content_frame_rate_manager) {
+        wl->content_frame_rate =
+            wp_content_frame_rate_manager_v1_get_surface_content_frame_rate(
+                wl->content_frame_rate_manager, wl->surface);
+    } else {
+        MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
+                   wp_content_frame_rate_manager_v1_interface.name);
+    }
+#endif
+
     if (!wl->single_pixel_manager) {
         MP_VERBOSE(wl, "Compositor doesn't support the %s protocol!\n",
                    wp_single_pixel_buffer_manager_v1_interface.name);
@@ -4877,6 +4924,14 @@ void vo_wayland_uninit(struct vo *vo)
 
     if (wl->content_type_manager)
         wp_content_type_manager_v1_destroy(wl->content_type_manager);
+
+#if HAVE_WAYLAND_PROTOCOLS_CONTENT_FRAME_RATE
+    if (wl->content_frame_rate)
+        wp_content_frame_rate_v1_destroy(wl->content_frame_rate);
+
+    if (wl->content_frame_rate_manager)
+        wp_content_frame_rate_manager_v1_destroy(wl->content_frame_rate_manager);
+#endif
 
     if (wl->devman)
         wl_data_device_manager_destroy(wl->devman);

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -125,6 +125,12 @@ struct vo_wayland_state {
     struct wp_content_type_v1 *content_type;
     int current_content_type;
 
+    /* content-frame-rate */
+    struct wp_content_frame_rate_manager_v1 *content_frame_rate_manager;
+    struct wp_content_frame_rate_v1 *content_frame_rate;
+    uint32_t current_content_frame_rate_num;
+    uint32_t current_content_frame_rate_den;
+
     /* cursor-shape */
     struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
 

--- a/video/out/wayland_common.h
+++ b/video/out/wayland_common.h
@@ -146,6 +146,12 @@ struct vo_wayland_state {
     struct wp_content_type_v1 *content_type;
     int current_content_type;
 
+    /* content-frame-rate */
+    struct wp_content_frame_rate_manager_v1 *content_frame_rate_manager;
+    struct wp_content_frame_rate_v1 *content_frame_rate;
+    uint32_t current_content_frame_rate_num;
+    uint32_t current_content_frame_rate_den;
+
     /* cursor-shape */
     struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
 


### PR DESCRIPTION
Mpv player detects content fps via demux/decoder metadata, rationalized with FFmpeg `av_d2q()` and calls set_frame_rate(num, den) to sends the content frame rate (a rational frame rate numerator / denominator) using a new [wp-content-frame-rate-v1](https://gitlab.freedesktop.org/NaveenKumar/wayland-protocols/-/commits/test-content-frame-rate?ref_type=heads) protocol to the compositor.

A new Wayland protocol, wp_content_frame_rate_v1 is floated here https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/518

Mutter implementation can be found here https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5091