### PR TITLE
stream_curl: set stream url to the effective one in case of a redirect

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3501,6 +3501,7 @@ static struct demuxer *demux_open(struct stream *stream,
     struct mp_log *log = mp_log_new(NULL, global->log, "!demux");
     struct demuxer *demuxer = NULL;
     char *force_format = params ? params->force_format : NULL;
+    char *s_url = stream->original_url ? stream->original_url : stream->url;
 
     struct parent_stream_info sinfo = {
         .seekable = stream->seekable,
@@ -3508,7 +3509,7 @@ static struct demuxer *demux_open(struct stream *stream,
         .is_streaming = stream->streaming,
         .stream_origin = stream->stream_origin,
         .cancel = cancel,
-        .filename = talloc_strdup(NULL, stream->url),
+        .filename = talloc_strdup(NULL, s_url),
     };
 
     if (!force_format)

--- a/stream/stream.h
+++ b/stream/stream.h
@@ -153,6 +153,7 @@ typedef struct stream {
     int stream_origin; // any STREAM_ORIGIN_*
     void *priv; // used for DVD, TV, RTSP etc
     char *url;  // filename/url (possibly including protocol prefix)
+    char *original_url; // holds original url in case a redirect happened
     char *path; // filename (url without protocol prefix)
     char *mime_type; // when HTTP streaming is used
     char *demuxer; // request demuxer to be used

--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -936,6 +936,13 @@ static int curl_open(stream_t *s, const struct stream_open_args *args)
     if (!p->stream_ok || atomic_load(&p->aborted))
         return STREAM_ERROR;
 
+    char *effective_url = NULL;
+    curl_easy_getinfo(p->curl, CURLINFO_EFFECTIVE_URL, &effective_url);
+    if (effective_url && strcmp(s->url, effective_url)) {
+        MP_DBG(p, "Redirected:\n (original) %s\n (redirect) %s\n", s->url, effective_url);
+        s->url = effective_url;
+    }
+
     char *content_type = NULL;
     curl_easy_getinfo(p->curl, CURLINFO_CONTENT_TYPE, &content_type);
     if (content_type && content_type[0])

--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -940,6 +940,7 @@ static int curl_open(stream_t *s, const struct stream_open_args *args)
     curl_easy_getinfo(p->curl, CURLINFO_EFFECTIVE_URL, &effective_url);
     if (effective_url && strcmp(s->url, effective_url)) {
         MP_DBG(p, "Redirected:\n (original) %s\n (redirect) %s\n", s->url, effective_url);
+        s->original_url = s->url;
         s->url = effective_url;
     }
 


### PR DESCRIPTION
 Without this, there are two issues I've quickly encountered:

 1. (major) HLS segment URLs are broken, because segment lines get appended to the original URL. Not only does this break playback, but it could leak query data (like auth tokens) to a third party.
 2. (medium) HLS master playlists are opened as actual playlists, with an entry per variant stream.

-----

First issue basically broke playback in almost all IPTV use-cases :face_with_open_eyes_and_hand_over_mouth: 

To test this. Here is a trivial python script:

<details>

``` py
from http.server import HTTPServer, BaseHTTPRequestHandler
from urllib.parse import urlparse, parse_qs

class RedirectHandler(BaseHTTPRequestHandler):
    
    def do_GET(self):
        """Handle GET requests."""
        parsed_path = urlparse(self.path)
        path = parsed_path.path
        query_params = parse_qs(parsed_path.query)
        
        # Extract status code from path (e.g., /301, /302)
        if path.startswith('/'):
            status_str = path.lstrip('/').split('/')[0]
            
            try:
                status_code = int(status_str)
            except ValueError:
                self.send_error(400, "Bad Request")
                return
            
            # Validate status code
            if status_code not in [301, 302, 303, 307, 308]:
                self.send_error(400, "Invalid status code")
                return
            
            # Extract target URL from query string
            if 'url' not in query_params:
                self.send_error(400, "Missing 'url' parameter")
                return
            
            target_url = query_params['url'][0]
            
            # Perform redirect
            self.send_response(status_code)
            self.send_header('Location', target_url)
            self.end_headers()
        else:
            self.send_error(404, "Not Found")
    
    def log_message(self, format, *args):
        """Suppress default logging."""
        pass

if __name__ == '__main__':
    server = HTTPServer(('localhost', 8000), RedirectHandler)
    print("Server running on http://localhost:8000")
    print("Usage: http://localhost:8000/301?url=https://example.com")
    print("       http://localhost:8000/302?url=https://example.com")
    print("Press Ctrl+C to stop")
    server.serve_forever()
```

</details>

To trigger the issues:

## First Issue

### Works

```
mpv --curl-enabled=no --tls-verify=no 'http://localhost:8000/301?url=https://live-qt-primary.global.ssl.fastly.net/qt/Channel-QT-TX-AWS-virginia-2/Source-QT-10M-2-sn9jy9-BP-07-04-vXxkCqNs5ul_live.m3u8'
```

### Broken

```
mpv  'http://localhost:8000/301?url=https://live-qt-primary.global.ssl.fastly.net/qt/Channel-QT-TX-AWS-virginia-2/Source-QT-10M-2-sn9jy9-BP-07-04-vXxkCqNs5ul_live.m3u8'
```

Segment URL's constructed are of the template:

```
http://localhost:8000/Source-QT-10M-2-sn9jy9-BP-07-04-vXxkCqNs5ul/$<n>.ts
```

## Second issue

### Opens as a stream

```
mpv --curl-enabled=no --tls-verify=no 'http://localhost:8000/301?url=https://bloomberg.com/media-manifest/streams/qt.m3u8'
```

### Opens as a playlist

```
mpv 'http://localhost:8000/301?url=https://bloomberg.com/media-manifest/streams/qt.m3u8'
```