### PR TITLE
vf_vapoursynth: revert vsscript dlclosing

### DIFF
--- a/osdep/io.c
+++ b/osdep/io.c
@@ -781,11 +781,6 @@ void *mp_dlsym(void *handle, const char *symbol)
     return (void *)addr;
 }
 
-int mp_dlclose(void *handle)
-{
-    return CloseHandle(handle);
-}
-
 char *mp_dlerror(void)
 {
     if (mp_dl_result.errcode == 0)

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -207,6 +207,7 @@ void mp_globfree(mp_glob_t *pglob);
 
 #define RTLD_NOW 0
 #define RTLD_LOCAL 0
+#define RTLD_GLOBAL 0
 #define dlopen(fn,fg) mp_dlopen((fn), (fg))
 #define dlsym(h,s) mp_dlsym((h), (s))
 #define dlerror mp_dlerror

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -138,7 +138,6 @@ off_t mp_lseek64(int fd, off_t offset, int whence);
 int mp_ftruncate64(int fd, off_t length);
 void *mp_dlopen(const char *filename, int flag);
 void *mp_dlsym(void *handle, const char *symbol);
-int mp_dlclose(void *handle);
 char *mp_dlerror(void);
 
 // mp_stat types. MSVCRT's dev_t and ino_t are way too short to be unique.
@@ -208,10 +207,8 @@ void mp_globfree(mp_glob_t *pglob);
 
 #define RTLD_NOW 0
 #define RTLD_LOCAL 0
-#define RTLD_GLOBAL 0
 #define dlopen(fn,fg) mp_dlopen((fn), (fg))
 #define dlsym(h,s) mp_dlsym((h), (s))
-#define dlclose(h) mp_dlclose((h))
 #define dlerror mp_dlerror
 
 // Affects both "stat()" and "struct stat".

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -817,7 +817,7 @@ static const m_option_t vf_opts_fields[] = {
 static int drv_vss_init(struct priv *p)
 {
     const char *vsscript_path = getenv("VSSCRIPT_PATH");
-    const int dl_mode = RTLD_NOW | RTLD_LOCAL;
+    const int dl_mode = RTLD_NOW | RTLD_GLOBAL;
     void *vsscript_lib = NULL;
 
     if (vsscript_path) {

--- a/video/filter/vf_vapoursynth.c
+++ b/video/filter/vf_vapoursynth.c
@@ -75,7 +75,6 @@ struct priv {
 
     const struct script_driver *drv;
     // drv_vss
-    void *vs_script_lib;
     const VSSCRIPTAPI *vs_script_api;
     VSScript *vs_script;
 
@@ -818,24 +817,24 @@ static const m_option_t vf_opts_fields[] = {
 static int drv_vss_init(struct priv *p)
 {
     const char *vsscript_path = getenv("VSSCRIPT_PATH");
-    const int dl_mode = RTLD_NOW | RTLD_GLOBAL;
-    p->vs_script_lib = NULL;
+    const int dl_mode = RTLD_NOW | RTLD_LOCAL;
+    void *vsscript_lib = NULL;
 
     if (vsscript_path) {
-        p->vs_script_lib = dlopen(vsscript_path, dl_mode);
+        vsscript_lib = dlopen(vsscript_path, dl_mode);
     } else {
-        for (size_t i = 0; i < MP_ARRAY_SIZE(vsscript_lib_names) && !p->vs_script_lib; ++i) {
-            p->vs_script_lib = dlopen(vsscript_lib_names[i], dl_mode);
+        for (size_t i = 0; i < MP_ARRAY_SIZE(vsscript_lib_names) && !vsscript_lib; ++i) {
+            vsscript_lib = dlopen(vsscript_lib_names[i], dl_mode);
         }
     }
 
     VS_CC const VSSCRIPTAPI *(*getVSScriptAPI_func)(int) = NULL;
     VS_CC const char *(*getVSScriptAPILastError_func)(void) = NULL;
-    const char *unknown_error_msg = "last error unknown";
+    const char *unknown_error_msg = "Last error unknown";
 
-    if (p->vs_script_lib) {
-        getVSScriptAPI_func = (void *) dlsym(p->vs_script_lib, "getVSScriptAPI");
-        getVSScriptAPILastError_func = (void *) dlsym(p->vs_script_lib, "getVSScriptAPILastError");
+    if (vsscript_lib) {
+        getVSScriptAPI_func = (void *) dlsym(vsscript_lib, "getVSScriptAPI");
+        getVSScriptAPILastError_func = (void *) dlsym(vsscript_lib, "getVSScriptAPILastError");
     }
 
     if (!getVSScriptAPI_func) {
@@ -859,11 +858,6 @@ static int drv_vss_init(struct priv *p)
 static void drv_vss_uninit(struct priv *p)
 {
     p->vs_script_api = NULL;
-
-    if (p->vs_script_lib) {
-        dlclose(p->vs_script_lib);
-        p->vs_script_lib = NULL;
-    }
 }
 
 static int drv_vss_load_core(struct priv *p)


### PR DESCRIPTION
> VSScript is not designed to support an unload + reload cycle in the same process. Dlclosing vsscript destroys only the C++ side of its state, not the Python interpreter state it registered against. Python extension modules cannot be cleanly unloaded; Py_Finalize() does not unload them either. You should treat vsscript as process-lifetime state, and just let the OS unload the library at process exit.

Fixes https://github.com/mpv-player/mpv/issues/18046
More discussion there: https://github.com/mpv-player/mpv/pull/17731