### PR TITLE
Assorted fixes for a Win32 build from PowerShell

### DIFF
--- a/ci/build-win32.ps1
+++ b/ci/build-win32.ps1
@@ -197,11 +197,17 @@ subrandr_build = custom_target(
   ],
   console: true
 )
+python = find_program('python3')
 subrandr_lib = custom_target(
   'subrandr-copy',
   input: subrandr_build,
   output: 'subrandr.lib',
-  command: ['cp', meson.current_build_dir() / 'lib' / 'subrandr.lib', '@OUTPUT@']
+  command: [
+    python,
+    '-c',
+    'import shutil; import sys; shutil.copy2(sys.argv[1], sys.argv[2])',
+    meson.current_build_dir() / 'lib' / 'subrandr.lib', '@OUTPUT@'
+  ]
 )
 harfbuzz = dependency('harfbuzz', default_options: ['freetype=enabled'])
 dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -1748,7 +1748,7 @@ endif
 
 # Set config.h
 conf_data = configuration_data()
-conf_data.set_quoted('CONFIGURATION', meson.build_options())
+conf_data.set_quoted('CONFIGURATION', meson.build_options().strip().replace('\\', '\\\\'))
 conf_data.set_quoted('DEFAULT_OPTICAL_DEVICE', optical_device)
 
 # Loop over all features in the build, create a define and add them to config.h


### PR DESCRIPTION
Hi all,

Coming here from https://gitlab.freedesktop.org/gstreamer/meson-ports/ffmpeg/-/work_items/75, this is a MR to address the issues I found when trying to set up mpv as per the [Windows build instructions](https://github.com/mpv-player/mpv/blob/master/DOCS/compile-windows.md).

I found the following bits:

- The `libjxl_threads` override couldn't be accepted by the FFmpeg wrap because of a missing version (it checks for 0.7.0 or higher)
- subrandr uses `cp` to move a generated static library, which is not available under PowerShell (easily fixable with an inline Python script)
- lastly, the use of `meson.build_options()` which was added in https://github.com/mpv-player/mpv/pull/14907 needs one to also escape backslashes properly, otherwise they are interpreted by Clang as escape sequences.

All feedback is appreciated. Thanks in advance for the review!
