### PR TITLE
input.conf: bind right click to context menu

### DIFF
--- a/DOCS/interface-changes/right-click-context-menu.txt
+++ b/DOCS/interface-changes/right-click-context-menu.txt
@@ -1,0 +1,1 @@
+bind right click to context menu

--- a/DOCS/man/mpv.rst
+++ b/DOCS/man/mpv.rst
@@ -393,7 +393,7 @@ Left double click
     Toggle fullscreen on/off.
 
 Right click
-    Toggle pause on/off.
+    Show the context menu (see `CONTEXT MENU`_).
 
 Forward/Back button
     Skip to next/previous entry in playlist.

--- a/etc/input.conf
+++ b/etc/input.conf
@@ -30,7 +30,7 @@
 
 #MBTN_LEFT     ignore              # don't do anything
 #MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
-#MBTN_RIGHT    cycle pause         # toggle pause/playback mode
+#MBTN_RIGHT    script-binding select/context-menu # open context menu
 #MBTN_BACK     playlist-prev       # skip to the previous file
 #MBTN_FORWARD  playlist-next       # skip to the next file
 #Ctrl+MBTN_LEFT script-binding positioning/drag-to-pan # pan around the clicked point

--- a/etc/restore-old-bindings.conf
+++ b/etc/restore-old-bindings.conf
@@ -11,6 +11,7 @@
 
 # changed in mpv 0.42.0
 
+MBTN_RIGHT          cycle pause
 MENU script-binding select/menu
 
 # changed in mpv 0.40.0


### PR DESCRIPTION
It is time. I volunteer as a sacrifice to face the inevitable fallout.

---

mpv's lack of a (easily findable) context menu is one of the biggest reasons why less experienced users still avoid mpv. Making right click show a context menu matches countless other programs and improves the first-time user experience by showing available actions and keybinds. Users that prefer right click to pause instead can configure this in their `input.conf`. They can even use the context menu to open it!