### PR TITLE
menu.conf: make quit-watch-later item name more user-friendly

### DIFF
--- a/etc/menu.conf
+++ b/etc/menu.conf
@@ -151,5 +151,5 @@ T&ools
 	&Online documentation	script-binding select/open-docs
 	S&upport				script-binding select/open-chat
 
-&Quit				quit
-Quit watc&h later	quit-watch-later	hidden=save_position_on_quit
+&Quit					quit
+Quit an&d save position	quit-watch-later	hidden=save_position_on_quit


### PR DESCRIPTION
The name "Quit watch later" is hard to understand for users that don't already know about the quit-watch-later command.

For what it's worth, this does also have some downsides:

1. It makes the context menu even wider, since "Quit watch later" was already the longest option.
2. ~~The option no longer has a hint (since all of the letter are already used as hints elsewhere)~~ `&d` is available.
3. The meaning of the "Open > Watch later" option may now be slightly less obvious to users. But this option does not work by default anyway, so the user will need to read the manual either way before using this option.

But all of these are fairly minor issues.
