### PR TITLE
ci/msys2: workaround crashing whisper.cpp after unload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -670,6 +670,8 @@ jobs:
         id: tests
         run: |
           meson test -C build
+        env:
+          GGML_NO_BACKTRACE: 1
 
       - name: Print meson test log
         if: ${{ failure() && steps.tests.outcome == 'failure' }}


### PR DESCRIPTION
When FFmpeg is built with whisper.cpp, the libmpv-lifetime test fails with `GGML_ASSERT(prev != ggml_uncaught_exception)`. Avoid this by disabling the problematic backtrace code.