### PR TITLE
video/out/w32_common: add --focus-on support for Windows

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3488,8 +3488,12 @@ Window
     :level:   A level as integer.
 
 ``--focus-on=<never|open|all>``,
-    (X11 and macOS only)
+    (Windows, X11 and macOS only)
     Focus the video window and make it the front most window on specific events (default: open).
+
+    On Windows, due to the system's focus stealing prevention mechanism,
+    ``--force-window=immediate`` is recommended for ``open`` and ``all``
+    to work reliably.
 
     :never: Never focus the window on open or new file load events.
     :open:  Focus the window on creation, eg when a vo is initialised.

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -2052,8 +2052,11 @@ terminate_playback:
                      current && current->reloading;
     if (current)
         current->reloading = false;
-    if (!reloading)
+    if (!reloading) {
+        if (mpctx->video_out)
+            vo_set_changing_file(mpctx->video_out);
         m_config_restore_backups(mpctx->mconfig);
+    }
 
     TA_FREEP(&mpctx->filter_root);
     talloc_free(mpctx->filtered_tags);

--- a/video/out/vo.c
+++ b/video/out/vo.c
@@ -139,6 +139,7 @@ struct vo_internal {
     bool paused;
     bool visible;
     bool wakeup_on_done;
+    bool changing_file;
     int queued_events;              // event mask for the user
     int internal_events;            // event mask for us
 
@@ -237,15 +238,29 @@ static void read_opts(struct vo *vo)
 static void update_opts(void *p)
 {
     struct vo *vo = p;
+    struct vo_internal *in = vo->in;
 
     if (m_config_cache_update(vo->opts_cache)) {
         read_opts(vo);
-        if (vo->driver->control) {
-            vo->driver->control(vo, VOCTRL_VO_OPTS_CHANGED, NULL);
+        vo->driver->control(vo, VOCTRL_VO_OPTS_CHANGED, NULL);
+        if (!in->changing_file) {
             // "Legacy" update of video position related options.
             // Unlike VOCTRL_VO_OPTS_CHANGED, often not propagated to backends.
             vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
         }
+    }
+}
+
+static void handle_file_change(struct vo *vo)
+{
+    struct vo_internal *in = vo->in;
+
+    if (in->changing_file) {
+        in->changing_file = false;
+        vo->driver->control(vo, VOCTRL_SET_PANSCAN, NULL);
+
+        if (vo->opts->focus_on == 2)
+            vo->driver->control(vo, VOCTRL_BRING_FRONT, NULL);
     }
 }
 
@@ -1014,6 +1029,8 @@ static bool render_frame(struct vo *vo)
 
         stats_time_start(in->stats, "video-flip");
 
+        handle_file_change(vo);
+
         vo->driver->flip_page(vo);
 
         struct vo_vsync_info vsync = {
@@ -1069,6 +1086,13 @@ done:
     mp_mutex_unlock(&in->lock);
 
     return more_frames;
+}
+
+void vo_set_changing_file(struct vo *vo)
+{
+    mp_mutex_lock(&vo->in->lock);
+    vo->in->changing_file = true;
+    mp_mutex_unlock(&vo->in->lock);
 }
 
 static void do_redraw(struct vo *vo)

--- a/video/out/vo.h
+++ b/video/out/vo.h
@@ -133,6 +133,8 @@ enum mp_voctrl {
     // Clipboard
     VOCTRL_GET_CLIPBOARD,               // struct voctrl_clipboard*
     VOCTRL_SET_CLIPBOARD,
+
+    VOCTRL_BRING_FRONT,
 };
 
 // Helper to expose what kind of content is currently playing to the VO.
@@ -542,6 +544,7 @@ bool vo_want_redraw(struct vo *vo);
 void vo_seek_reset(struct vo *vo);
 void vo_destroy(struct vo *vo);
 void vo_set_paused(struct vo *vo, bool paused);
+void vo_set_changing_file(struct vo *vo);
 int64_t vo_get_drop_count(struct vo *vo);
 void vo_increment_drop_count(struct vo *vo, int64_t n);
 int64_t vo_get_delayed_count(struct vo *vo);

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -1987,6 +1987,9 @@ set_pos_done:
             ShowWindow(w32->window, SW_SHOWMINNOACTIVE);
         } else if (w32->opts->window_maximized && !w32->current_fs) {
             ShowWindow(w32->window, SW_SHOWMAXIMIZED);
+        } else if (w32->opts->focus_on == 0) {
+            ShowWindow(w32->window, SW_SHOWNOACTIVATE);
+            SetWindowPos(w32->window, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
         } else {
             ShowWindow(w32->window, SW_SHOW);
         }
@@ -2017,6 +2020,9 @@ void vo_w32_config(struct vo *vo)
 {
     struct vo_w32_state *w32 = vo->w32;
     mp_dispatch_run(w32->dispatch, gui_thread_reconfig, w32);
+
+    if (w32->opts->focus_on == 2)
+        SetForegroundWindow(w32->window);
 }
 
 static void w32_api_load(struct vo_w32_state *w32)

--- a/video/out/w32_common.c
+++ b/video/out/w32_common.c
@@ -2020,9 +2020,6 @@ void vo_w32_config(struct vo *vo)
 {
     struct vo_w32_state *w32 = vo->w32;
     mp_dispatch_run(w32->dispatch, gui_thread_reconfig, w32);
-
-    if (w32->opts->focus_on == 2)
-        SetForegroundWindow(w32->window);
 }
 
 static void w32_api_load(struct vo_w32_state *w32)
@@ -2311,6 +2308,7 @@ static bool gui_thread_control_supports(int request)
     case VOCTRL_BEGIN_DRAGGING:
     case VOCTRL_SHOW_MENU:
     case VOCTRL_UPDATE_MENU:
+    case VOCTRL_BRING_FRONT:
         return true;
     }
 
@@ -2505,12 +2503,17 @@ static int gui_thread_control(struct vo_w32_state *w32, int request, void *arg)
     case VOCTRL_SHOW_MENU:
         PostMessageW(w32->window, WM_SHOWMENU, 0, 0);
         return VO_TRUE;
-    case VOCTRL_UPDATE_MENU:;
+    case VOCTRL_UPDATE_MENU:
         const m_option_t menu_data_type = {.type = CONF_TYPE_NODE};
         m_option_free(&menu_data_type, &w32->menu_data);
         m_option_copy(&menu_data_type, &w32->menu_data, arg);
         talloc_steal(w32, node_get_alloc(&w32->menu_data));
         return VO_TRUE;
+    case VOCTRL_BRING_FRONT:
+        if (SetForegroundWindow(w32->window) != FALSE)
+            return VO_TRUE;
+
+        return VO_FALSE;
     }
 
     // Keep gui_thread_control_supports() in sync


### PR DESCRIPTION
Background: I use the pseudo GUI mode. If I give mpv a network source (like a YouTube video), ytdl_hook will take a while to resolve the video URL, and mpv doesn't show any window until the video is ready to be output, due to the default `--force-window=yes`. In the meantime, if I click any other window, when mpv's main window eventually shows, it is in background. I had to write a AutoHotkey script to wait for the mpv window to be created then bring it to foreground. Then I saw https://github.com/mpv-player/mpv/commit/c0ef68904d35f69b71163fd7deb3b5bb27ddd9a7, thought I might be able to do the same for Windows support.

Windows has focus stealing prevention mechanism. If a user launches an app, and that app doesn't immediately create a window and show it in foreground, it will lose the ability to do that by itself later. That's why many large apps (such as Visual Studio or Photoshop) that takes a while to initialize come with splash window nowadays: it secures the seat to bring the real main window foreground later.

Since mpv currently lacks a proper splash window, I think recommending `--force-window=immediate` for those who need this launch-foreground-feature is sound. It makes the main window immediately appear and give user hint "you should focus on this because something is about to happen". It serves the default `--force-window=open` case.

If user still moves to other apps when ytdl_hook resolves, to make mpv automatically foreground when playback starts, `--force-window=all` is needed. However, if I understand correctly, this value means `SetForegroundWindow` needs to be called when every new file is started. I saw in X11 and Mac implementations that they put equivalent API in the vo's "reconfig" entry point. I tried `vo_w32_config`, but it seems if the next file has the same width and height as previous, the window doesn't "reconfig", thus `vo_w32_config` is not called. There doesn't seem to be a function that is guaranteed to be called for every new file. I could try handling the `VOCTRL_UPDATE_WINDOW_TITLE` request in `vo_w32_control`, but I feel it might have false positive. Any suggestion?