### PR TITLE
console.lua: take position indicator into account when calculating width

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -348,6 +348,10 @@ local function calculate_max_item_width()
     end
 
     local longest_item = prompt .. ("a"):rep(9)
+    if #selectable_items > calculate_max_lines() then
+        local digits = math.floor(math.log(#selectable_items, 10)) + 1
+        longest_item = longest_item .. ("0"):rep(digits) .. "/" .. ("0"):rep(digits)
+    end
     local longest_item_width = utils.terminal_display_width(longest_item)
     for _, item in pairs(selectable_items) do
         local item_width = utils.terminal_display_width(item)
@@ -669,7 +673,7 @@ local function print_to_terminal()
     local counter = ""
     if selectable_items then
         if #selectable_items > calculate_max_lines() then
-            local digits = math.ceil(math.log(#selectable_items, 10))
+            local digits = math.floor(math.log(#selectable_items, 10)) + 1
             counter = terminal_styles.disabled ..
                       "[" .. string.format("%0" .. digits .. "d", focused_match) ..
                       "/" .. string.format("%0" .. digits .. "d", #matches) ..


### PR DESCRIPTION
sometimes the position indicator takes up a large portion of the input area, leaving almost no space for input.

- Before:
  <img width="349" height="129" alt="2026-06-02 120913" src="https://github.com/user-attachments/assets/dc451762-7656-4998-9b8b-7e808e9e6972" />
- After:
  <img width="459" height="128" alt="2026-06-02 121427" src="https://github.com/user-attachments/assets/e19518f4-d307-4c1d-a897-fe5a6b4477b8" />
