### PR TITLE
ci: fix comment workflow permissions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,7 +12,7 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  issues: write
+  pull-requests: write
 
 jobs:
   pr_comment:


### PR DESCRIPTION
We are commenting on pull requests.