### PR TITLE
osdep/io: use mp_fopen on all platforms

### DIFF
--- a/audio/out/ao_pcm.c
+++ b/audio/out/ao_pcm.c
@@ -34,6 +34,7 @@
 #include "internal.h"
 #include "common/msg.h"
 #include "osdep/endian.h"
+#include "osdep/io.h"
 
 #ifdef _WIN32
 // for GetFileType to detect pipes

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -105,7 +105,11 @@ FILE *mp_fopen(const char *filename, const char *mode)
         return NULL;
 
     // Add 'b' to the mode so the CRT knows the file is opened in binary mode
-    char bmode[] = { mode[0], 'b', rwmode == O_RDWR ? '+' : '\0', '\0' };
+    char bmode[] = { mode[0], '\0', '\0', '\0' };
+    int idx = 1;
+    if (rwmode == O_RDWR)
+        bmode[idx++] = '+';
+    bmode[idx++] = 'b';
     FILE *fp = fdopen(fd, bmode);
     if (!fp) {
         close(fd);

--- a/osdep/io.c
+++ b/osdep/io.c
@@ -62,6 +62,59 @@ bool mp_set_cloexec(int fd)
     return true;
 }
 
+// fopen that sets cloexec.
+FILE *mp_fopen(const char *filename, const char *mode)
+{
+    if (!mode[0]) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    int rwmode;
+    int oflags = 0;
+    switch (mode[0]) {
+    case 'r':
+        rwmode = O_RDONLY;
+        break;
+    case 'w':
+        rwmode = O_WRONLY;
+        oflags |= O_CREAT | O_TRUNC;
+        break;
+    case 'a':
+        rwmode = O_WRONLY;
+        oflags |= O_CREAT | O_APPEND;
+        break;
+    default:
+        errno = EINVAL;
+        return NULL;
+    }
+
+    // Parse extra mode flags
+    for (const char *pos = mode + 1; *pos; pos++) {
+        switch (*pos) {
+        case '+': rwmode = O_RDWR;  break;
+        case 'x': oflags |= O_EXCL; break;
+        // Ignore unknown flags (glibc does too)
+        default: break;
+        }
+    }
+
+    // Open a CRT file descriptor
+    int fd = open(filename, rwmode | oflags | O_CLOEXEC, 0600);
+    if (fd < 0)
+        return NULL;
+
+    // Add 'b' to the mode so the CRT knows the file is opened in binary mode
+    char bmode[] = { mode[0], 'b', rwmode == O_RDWR ? '+' : '\0', '\0' };
+    FILE *fp = fdopen(fd, bmode);
+    if (!fp) {
+        close(fd);
+        return NULL;
+    }
+
+    return fp;
+}
+
 #ifndef _WIN32
 int mp_dup_cloexec(int fd)
 {
@@ -506,58 +559,6 @@ int mp_rename(const char *oldpath, const char *newpath)
         return -1;
     }
     return 0;
-}
-
-FILE *mp_fopen(const char *filename, const char *mode)
-{
-    if (!mode[0]) {
-        errno = EINVAL;
-        return NULL;
-    }
-
-    int rwmode;
-    int oflags = 0;
-    switch (mode[0]) {
-    case 'r':
-        rwmode = _O_RDONLY;
-        break;
-    case 'w':
-        rwmode = _O_WRONLY;
-        oflags |= _O_CREAT | _O_TRUNC;
-        break;
-    case 'a':
-        rwmode = _O_WRONLY;
-        oflags |= _O_CREAT | _O_APPEND;
-        break;
-    default:
-        errno = EINVAL;
-        return NULL;
-    }
-
-    // Parse extra mode flags
-    for (const char *pos = mode + 1; *pos; pos++) {
-        switch (*pos) {
-        case '+': rwmode = _O_RDWR;  break;
-        case 'x': oflags |= _O_EXCL; break;
-        // Ignore unknown flags (glibc does too)
-        default: break;
-        }
-    }
-
-    // Open a CRT file descriptor
-    int fd = mp_open(filename, rwmode | oflags);
-    if (fd < 0)
-        return NULL;
-
-    // Add 'b' to the mode so the CRT knows the file is opened in binary mode
-    char bmode[] = { mode[0], 'b', rwmode == _O_RDWR ? '+' : '\0', '\0' };
-    FILE *fp = fdopen(fd, bmode);
-    if (!fp) {
-        close(fd);
-        return NULL;
-    }
-
-    return fp;
 }
 
 // Windows' MAX_PATH/PATH_MAX/FILENAME_MAX is fixed to 260, but this limit

--- a/osdep/io.h
+++ b/osdep/io.h
@@ -80,6 +80,9 @@ int mp_make_cloexec_pipe(int pipes[2]);
 int mp_make_wakeup_pipe(int pipes[2]);
 void mp_flush_wakeup_pipe(int pipe_end);
 
+FILE *mp_fopen(const char *filename, const char *mode);
+#define fopen(...) mp_fopen(__VA_ARGS__)
+
 #ifdef _WIN32
 
 #include <wchar.h>
@@ -117,7 +120,6 @@ int mp_fprintf(FILE *stream, const char *format, ...) MP_PRINTF_ATTRIBUTE(2, 3);
 int mp_open(const char *filename, int oflag, ...);
 int mp_creat(const char *filename, int mode);
 int mp_rename(const char *oldpath, const char *newpath);
-FILE *mp_fopen(const char *filename, const char *mode);
 DIR *mp_opendir(const char *path);
 struct dirent *mp_readdir(DIR *dir);
 int mp_closedir(DIR *dir);
@@ -191,7 +193,6 @@ void mp_globfree(mp_glob_t *pglob);
 #define open(...) mp_open(__VA_ARGS__)
 #define creat(...) mp_creat(__VA_ARGS__)
 #define rename(...) mp_rename(__VA_ARGS__)
-#define fopen(...) mp_fopen(__VA_ARGS__)
 #define opendir(...) mp_opendir(__VA_ARGS__)
 #define readdir(...) mp_readdir(__VA_ARGS__)
 #define closedir(...) mp_closedir(__VA_ARGS__)

--- a/osdep/path-unix.c
+++ b/osdep/path-unix.c
@@ -19,6 +19,7 @@
 
 #include "misc/bstr.h"
 #include "options/path.h"
+#include "osdep/io.h"
 #include "osdep/threads.h"
 #include "path.h"
 

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -45,6 +45,7 @@
 #include "options/options.h"
 #include "options/path.h"
 #include "stream.h"
+#include "osdep/io.h"
 #include "osdep/timer.h"
 #include "sub/osd.h"
 #include "sub/img_convert.h"

--- a/stream/stream_dvb.c
+++ b/stream/stream_dvb.c
@@ -53,6 +53,7 @@
 #include "options/m_option.h"
 #include "options/options.h"
 #include "options/path.h"
+#include "osdep/io.h"
 #include "osdep/poll_wrapper.h"
 #include "osdep/threads.h"
 

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -3,6 +3,7 @@
 #include "common/msg.h"
 #include "options/m_option.h"
 #include "options/path.h"
+#include "osdep/io.h"
 #include "osdep/subprocess.h"
 #include "osdep/terminal.h"
 #include "test_utils.h"


### PR DESCRIPTION
Currently, all fopen uses in mpv do not set cloexec flag, resulting in fd leak whenever mpv creates a process.

This makes mpv use mp_fopen on all platforms, and always set O_CLOEXEC on the opened fd. This is required because the "e" flag for fopen is nonstandard and UB in C11, and unsupported on macOS.

This had been done similarly in other projects. e.g. https://gitlab.com/graphviz/graphviz/-/merge_requests/3797