### PR TITLE
meson: consider only 'v0.*' tags when computing the version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -738,7 +738,7 @@ jobs:
           }
 
           # Match the version string baked into the build (see common/meson.build).
-          version=$(git describe --abbrev=9 --tags --dirty)
+          version=$(git describe --abbrev=9 --tags --dirty --match "v0.*")
           notes=$(cat <<EOF
           Automated development build of the latest \`master\` branch.
 

--- a/common/meson.build
+++ b/common/meson.build
@@ -12,7 +12,7 @@ if not sys.argv[1]:
     sys.exit(1)
 git_cmd = [sys.argv[1], "--git-dir=" + os.path.join(sys.argv[2], ".git"),
            "--work-tree=" + sys.argv[2]]
-describe_cmd = git_cmd + ["describe", "--abbrev=9", "--tags", "--dirty"]
+describe_cmd = git_cmd + ["describe", "--abbrev=9", "--tags", "--dirty", "--match", "v0.*"]
 try:
     ver = check_output(describe_cmd, stderr=DEVNULL, encoding="UTF-8")
 except CalledProcessError:


### PR DESCRIPTION
This allow creating other tags on the repository and don't interfere with version string generated.

