### PR TITLE
demux_mkv: support demuxing native VC-1 streams

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1688,6 +1688,12 @@ static int demux_mkv_open_video(demuxer_t *demuxer, mkv_track_t *track)
             extradata = track->private_data;
             extradata_size = track->private_size;
         }
+    } else if (strcmp(track->codec_id, "V_VC1") == 0) {
+        if (track->private_size >= 7 && (track->private_data[0] & 0xf0) == 0xc0) {
+            extradata = track->private_data + 7;
+            extradata_size = track->private_size - 7;
+        }
+        sh_v->codec = "vc1";
     } else {
         for (int i = 0; mkv_video_tags[i][0]; i++) {
             if (!strcmp(mkv_video_tags[i][0], track->codec_id)) {


### PR DESCRIPTION
Match lavf's logic for how to parse the extradata.

---

A first-party codec mapping for VC-1 was added to Matroska in https://github.com/ietf-wg-cellar/matroska-specification/pull/1080 .

See also: https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23374
This PR does not technically *depend* on the linked FFmpeg PR, but it might still be better to delay merging it until the FFmpeg PR is merged, in case some issues with the implementation come up.