### PR TITLE
sub/packer: correctly offset instance bitmap pointer in `pack_subrandr`

### DIFF
--- a/sub/packer.c
+++ b/sub/packer.c
@@ -369,7 +369,9 @@ static bool pack_subrandr(struct mp_sub_packer *p, struct sub_bitmaps *res,
             .w = instance->src_width,  .h = instance->src_height,
             .src_x = image_b->src_x + instance->src_off_x,
             .src_y = image_b->src_y + instance->src_off_y,
-            .bitmap = image_b->bitmap, .stride = byte_stride,
+            .bitmap = (sbr_bgra8 *)image_b->bitmap
+                      + pixel_stride * instance->src_off_y + instance->src_off_x,
+            .stride = byte_stride,
         };
         res->num_parts++;
     }


### PR DESCRIPTION
The software scaling code expects this pointer to already be offset by `src_x` and `src_y` but this function copied a pointer only offset by the image offset, forgetting about instance offset.

---

It appears I neglected poor `vo=x11` in my testing here and didn't notice this is wrong.