### PR TITLE
select.lua: make property list more in line with the description in the manual

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -565,11 +565,22 @@ local function add_property(property, value)
     value = value or mp.get_property_native(property)
 
     if type(value) == "table" and next(value) then
-        for key, val in pairs(value) do
-            add_property(property .. "/" .. key, val)
+        if type(next(value)) == "number" then
+            for i, val in ipairs(value) do
+                add_property(property .. "/" .. (i - 1), val)
+            end
+        else
+            for key, val in pairs(value) do
+                add_property(property .. "/" .. key, val)
+            end
         end
     else
-        properties[#properties + 1] = property .. ": " .. utils.to_string(value)
+        if type(value) == "boolean" then
+            value = value and "yes" or "no"
+        else
+            value = utils.to_string(value)
+        end
+        properties[#properties + 1] = property .. ": " .. value
     end
 end
 


### PR DESCRIPTION
1. the index of array-type properties is 0-based. ( e.g. `playlist/N` )
2. boolean values should be formatted as yes/no instead of true/false.