### PR TITLE
lcms: avoid NaN when building BT.1886 transfer curves

### DIFF
--- a/video/out/gpu/lcms.c
+++ b/video/out/gpu/lcms.c
@@ -279,7 +279,7 @@ static cmsHPROFILE get_vid_profile(struct gl_lcms *p, cmsContext cms,
         // Build the parametric BT.1886 transfer curve, one per channel
         for (int i = 0; i < 3; i++) {
             const double gamma = 2.40;
-            double binv = pow(src_black[i], 1.0/gamma);
+            double binv = pow(MPMAX(0, src_black[i]), 1.0/gamma);
             tonecurve[i] = cmsBuildParametricToneCurve(cms, 6,
                     (double[4]){gamma, 1.0 - binv, binv, 0.0});
         }


### PR DESCRIPTION
After https://github.com/mm2/Little-CMS/commit/bb60a46e9c50e9d3d18cf6dd81869240e4ebe618 cmsDetectBlackPoint can output nonzero X and Z values, which can end up slightly negative due to rounding errors.
Bound the resulting src_black values by 0 below to ensure that raising them to the power of 1 / gamma does not result in NaN, which would result in a broken video profile.

Fixes #17439.