### PR TITLE
player: fix cover-art-files overriding embedded video tracks

### DIFF
--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -524,7 +524,7 @@ static bool compare_track(struct track *t1, struct track *t2, char **langs, bool
     bool sub = t2->type == STREAM_SUB;
     bool ext1 = t1->is_external && !t1->no_default;
     bool ext2 = t2->is_external && !t2->no_default;
-    if (ext1 != ext2) {
+    if (ext1 != ext2 && t1->image == t2->image) {
         if (t1->attached_picture && t2->attached_picture
             && opts->audio_display == 1)
             return !ext1;


### PR DESCRIPTION
## Summary
- `--cover-art-files` external images were incorrectly preferred over embedded video tracks because the external-vs-internal comparison in `compare_track` did not account for the image/non-image distinction.
- Added `t1->image == t2->image` check so that external preference only applies when comparing tracks of the same image type.

Fixes #12219