### PR TITLE
f_auto_filters: destroy deint filter immediately on format change

### DIFF
--- a/filters/f_auto_filters.c
+++ b/filters/f_auto_filters.c
@@ -63,12 +63,15 @@ static void deint_process(struct mp_filter *f)
     bool filter_needed = opts->deinterlace == 1 ||
                          (opts->deinterlace == -1 && (p->interlaced_frame || p->sub.filter));
 
-    // If the image format changed, or if we no longer need a filter,
-    // destroy any existing filter.
-    if (img->imgfmt != p->prev_imgfmt || (p->sub.filter && !filter_needed)) {
+    // If the image format changed, destroy any existing filter immediately since
+    // it may not support the new format. If we no longer need a filter, drain
+    // and destroy it gracefully.
+    if (img->imgfmt != p->prev_imgfmt) {
+        mp_subfilter_destroy(&p->sub);
+        p->prev_imgfmt = img->imgfmt;
+    } else if (p->sub.filter && !filter_needed) {
         if (!mp_subfilter_drain_destroy(&p->sub))
             return;
-        p->prev_imgfmt = img->imgfmt;
     }
 
     // If no filter is needed or if the filter is already inserted and we reach


### PR DESCRIPTION
When the image format changes (e.g. switching hwdec), immediately destroy the existing deinterlace filter instead of draining it. Draining feeds new frames through the old filter, which can cause issues. (e.g. bwdif_vulkan receiving vaapi frames).

This fixes userdeint filter failure when switching from hwdec=vulkan to hwdec=vaapi while the filter is applied via --deinterlace=auto/yes
