### PR TITLE
demux/demux_mkv: bound num_headers read in parse_vorbis_chmap

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -1819,10 +1819,12 @@ static void parse_vorbis_chmap(struct mp_chmap *channels, unsigned char *data,
     if (size < 4)
         return;
     uint32_t vendor_length = AV_RL32(data);
-    if (vendor_length + 4 > size) // also check for the next AV_RB32 below
+    if (vendor_length + 4 > size)
         return;
     size -= vendor_length + 4;
     data += vendor_length + 4;
+    if (size < 4)
+        return;
     uint32_t num_headers = AV_RL32(data);
     size -= 4;
     data += 4;


### PR DESCRIPTION
parse_vorbis_chmap() validates that the buffer holds the 4-byte vendor length plus the vendor string, then skips both and reads a 4-byte header count with AV_RL32. The earlier check never accounts for those last 4 bytes, so a FLAC CodecPrivate whose VorbisComment block is exactly vendor_length + 4 bytes long reads four bytes past the block.

Add the same size < 4 guard the per-header loop right below already uses, before the count read. Before, the function leaned on the vendor-string check to cover a field it never measured; after, every read stays inside the size the block reader passed in. The FLAC metadata size is known only at this layer, so the bound belongs here and not in the caller.
