### PR TITLE
Fix Twitch VOD timestamps being offset by ~60 seconds

### DIFF
--- a/demux/demux_timeline.c
+++ b/demux/demux_timeline.c
@@ -59,6 +59,7 @@ struct virtual_source {
     struct timeline_par *tl;
 
     bool dash, no_clip, delay_open;
+    bool rebase;
 
     struct segment **segments;
     int num_segments;
@@ -250,6 +251,8 @@ static void switch_segment(struct demuxer *demuxer, struct virtual_source *src,
     reselect_streams(demuxer);
     if (!src->no_clip)
         demux_set_ts_offset(new->d, new->start - new->d_start);
+    else if (src->rebase)
+        demux_set_ts_offset(new->d, new->start - new->d->start_time);
     if (!src->no_clip || !init)
         demux_seek(new->d, start_pts, flags);
 
@@ -546,6 +549,7 @@ static bool add_tl(struct demuxer *demuxer, struct timeline_par *tl)
 {
     struct priv *p = demuxer->priv;
 
+    struct MPOpts *mp_opts = mp_get_config_group(NULL, demuxer->global, &mp_opt_root);
     struct virtual_source *src = talloc_ptrtype(p, src);
     *src = (struct virtual_source){
         .tl = tl,
@@ -553,7 +557,9 @@ static bool add_tl(struct demuxer *demuxer, struct timeline_par *tl)
         .delay_open = tl->delay_open,
         .no_clip = tl->no_clip || tl->dash,
         .dts = MP_NOPTS_VALUE,
+        .rebase = tl->delay_open && mp_opts->rebase_start_time,
     };
+    TA_FREEP(&mp_opts);
 
     if (!tl->num_parts)
         return false;


### PR DESCRIPTION
Fix for #14840

For the delay_open + no_clip case (ytdl_hook EDL), d_start is 0 because the stream wasn't opened yet. The added else if branch uses new->d->start_time directly, which is the actual start_time of the HLS demuxer that was just opened by reopen_lazy_segments().

Note though that even without this fix, the whole stream plays from start to finish, it's just the displayed timestamps that are incorrect. Also the problem only happens with the edl uris. If you directly mpv one of the m3u8 stream urls, it works correctly without this fix as well.

Idk if you'd want to check the rebase-start-time option here? It currently has no effect and the stream always starts at 0:00:00 with the fix, while it does work on the direct m3u8 uri.