### PR TITLE
meson: use `vapoursynth get-include` to get include dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -783,7 +783,10 @@ if features['uchardet']
     dependencies += uchardet
 endif
 
-vapoursynth = dependency('vapoursynth', version: '>= 56', required: get_option('vapoursynth'))
+vapoursynth = dependency('vapoursynth-script', version: '>= 56', required: false)
+if not vapoursynth.found()
+    vapoursynth = dependency('vapoursynth', version: '>= 56', required: get_option('vapoursynth'))
+endif
 features += {'vapoursynth': vapoursynth.found()}
 if features['vapoursynth']
     dependencies += vapoursynth.partial_dependency(compile_args: true, includes: true)


### PR DESCRIPTION
To build vf_vapoursynth headers are needed. With newer VS versions those are located in Python module, while for older they are installed in system. Try Python module first and fallback to pkg-config.

Note that this requires vapoursynth to be available during build time. If you use venv or similar, make sure it's activated.

Fixes: #18126