### PR TITLE
context_menu.lua: don't open disabled submenus on hover

### DIFF
--- a/player/lua/context_menu.lua
+++ b/player/lua/context_menu.lua
@@ -495,7 +495,7 @@ local function handle_mouse_move()
         open_submenu_timer = nil
     end
 
-    if item and item.data.submenu then
+    if item and item.data.submenu and not has_state(item.data, "disabled") then
         open_submenu_timer = mp.add_timeout(options.seconds_to_open_submenus, function ()
             open_submenu()
         end)


### PR DESCRIPTION
A menu item can have a non-empty submenu but still be disabled. This is the case for mkvs with a single edition. Don't open the submenu on hover in that case.