### PR TITLE
console.lua: do not allow typing newlines when searching for menu items

### DIFF
--- a/player/lua/console.lua
+++ b/player/lua/console.lua
@@ -1419,6 +1419,9 @@ end
 -- clipboard or the primary selection buffer is used (on X11 and Wayland only.)
 local function paste(clip)
     local text = get_clipboard(clip)
+    if selectable_items then
+        text = text:gsub("\r?\n", " ")
+    end
     local before_cur = line:sub(1, cursor - 1)
     local after_cur = line:sub(cursor)
     line = before_cur .. text .. after_cur
@@ -1536,7 +1539,7 @@ local function get_bindings()
         { "ctrl+[",      function() set_active(false) end       },
         { "enter",       submit                                 },
         { "kp_enter",    submit                                 },
-        { "shift+enter", function() handle_char_input("\n") end },
+        { "shift+enter", function() if not selectable_items then handle_char_input("\n") end end },
         { "ctrl+j",      submit                                 },
         { "ctrl+m",      submit                                 },
         { "bs",          handle_backspace                       },


### PR DESCRIPTION
newline makes no sense in such case, as there're no line breaks in the selectable items.
<details>
<summary>and it also causes a bug where the cursor may move outside the background box.</summary>

<img width="379" height="147" alt="2026-06-16 161500" src="https://github.com/user-attachments/assets/1384333d-7214-4219-9d3d-6cea14a8d917" />
</details>