### PR TITLE
demux/ebml: use size_t for subelement allocation to avoid integer overflow

### DIFF
--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -391,7 +391,7 @@ static void ebml_parse_element(struct ebml_parse_ctx *ctx, void *target,
                     MP_ERR(ctx, "Too many subelements.\n");
                     num_elems[i] = max;
                 }
-                int sz = num_elems[i] * type->fields[i].desc->size;
+                size_t sz = (size_t)num_elems[i] * type->fields[i].desc->size;
                 *(generic_struct **) ptr = talloc_zero_size(ctx->talloc_ctx, sz);
                 break;
             }


### PR DESCRIPTION
The allocation size for EBML subelements was computed as an int, which can overflow when num_elems[i] * desc->size exceeds INT_MAX. Change the intermediate variable to size_t with an explicit cast to prevent truncation.