### PR TITLE
sub/sd_lavc: replace debug assertions with runtime bounds check for subtitle palette

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -288,8 +288,9 @@ static void read_sub_bitmaps(struct sd *sd, struct sub *sub)
         sub->src_w = MPMAX(sub->src_w, b->x + b->w);
         sub->src_h = MPMAX(sub->src_h, b->y + b->h);
 
-        mp_assert(r->nb_colors > 0);
-        mp_assert(r->nb_colors <= 256);
+        if (r->nb_colors <= 0 || r->nb_colors > 256 || !data[1])
+            continue;
+
         uint32_t pal[256] = {0};
         memcpy(pal, data[1], r->nb_colors * 4);
         convert_pal(pal, 256, opts->sub_gray);


### PR DESCRIPTION
mp_assert is compiled out in release builds, making nb_colors unbounded. A malformed subtitle with nb_colors > 256 causes memcpy to write past the end of the fixed-size stack buffer pal[256]. Replace the debug-only assertions with a runtime bounds check and skip malformed subtitle rects.