### PR TITLE
stream/bluray: fix off-by-one in angle count bounds check

### DIFF
--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -260,7 +260,7 @@ static int bluray_stream_control(stream_t *s, int cmd, void *arg)
         if (!ti)
             return STREAM_UNSUPPORTED;
         int angle = *((int *) arg);
-        if (angle < 0 || angle > ti->angle_count)
+        if (angle < 0 || angle >= ti->angle_count)
             return STREAM_UNSUPPORTED;
         b->current_angle = angle;
         bd_seamless_angle_change(b->bd, angle);


### PR DESCRIPTION
angle_count is the total number of angles. Since angles are 0-indexed, the valid range is [0, angle_count-1]. The check used > instead of >=, allowing an out-of-bounds angle index to reach bd_seamless_angle_change.