### PR TITLE
video/out/bitmap_packer: replace abort with graceful fallback on invalid bitmap size

### DIFF
--- a/video/out/bitmap_packer.c
+++ b/video/out/bitmap_packer.c
@@ -135,12 +135,13 @@ int packer_pack(struct bitmap_packer *packer)
         if (in[i].x <= 0 || in[i].y <= 0) {
             in[i] = (struct pos){0, 0};
         } else {
+            if (packer->padding > 32767)
+                packer->padding = 32767;
             in[i].x += packer->padding * 2;
             in[i].y += packer->padding * 2;
         }
-        if (in[i].x < 0 || in [i].x > 65535 || in[i].y < 0 || in[i].y > 65535) {
-            fprintf(stderr, "Invalid OSD / subtitle bitmap size\n");
-            abort();
+        if (in[i].x < 0 || in[i].x > 65535 || in[i].y < 0 || in[i].y > 65535) {
+            in[i] = (struct pos){0, 0};
         }
         xmax = MPMAX(xmax, in[i].x);
         ymax = MPMAX(ymax, in[i].y);


### PR DESCRIPTION
A malformed subtitle with extreme dimensions can trigger abort(), crashing mpv. Replace it with a safe fallback to zero-sized bitmap. Also cap padding to prevent integer overflow in the padding*2 calculation, and fix a typo (in [i].x -> in[i].x).