### PR TITLE
bitmap_packer: return -1 instead of aborting on invalid bitmap size

### DIFF
--- a/video/out/bitmap_packer.c
+++ b/video/out/bitmap_packer.c
@@ -138,10 +138,8 @@ int packer_pack(struct bitmap_packer *packer)
             in[i].x += packer->padding * 2;
             in[i].y += packer->padding * 2;
         }
-        if (in[i].x < 0 || in [i].x > 65535 || in[i].y < 0 || in[i].y > 65535) {
-            fprintf(stderr, "Invalid OSD / subtitle bitmap size\n");
+        if (in[i].x < 0 || in [i].x > 65535 || in[i].y < 0 || in[i].y > 65535)
             return -1;
-        }
         xmax = MPMAX(xmax, in[i].x);
         ymax = MPMAX(ymax, in[i].y);
     }

--- a/video/out/bitmap_packer.c
+++ b/video/out/bitmap_packer.c
@@ -140,7 +140,7 @@ int packer_pack(struct bitmap_packer *packer)
         }
         if (in[i].x < 0 || in [i].x > 65535 || in[i].y < 0 || in[i].y > 65535) {
             fprintf(stderr, "Invalid OSD / subtitle bitmap size\n");
-            abort();
+            return -1;
         }
         xmax = MPMAX(xmax, in[i].x);
         ymax = MPMAX(ymax, in[i].y);


### PR DESCRIPTION
All current callers of this already handle the -1 case like an error, so instead of killing everything just return -1.