### PR TITLE
command: fix signed integer overflow in overlay-add

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5431,7 +5431,9 @@ static void cmd_overlay_add(void *pcmd)
         MP_ERR(mpctx, "overlay-add: invalid id %d\n", id);
         goto error;
     }
-    if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4) || offset < 0) {
+    if (w <= 0 || h <= 0 || w > INT_MAX / 4 || stride < w * 4 ||
+        (stride % 4) || offset < 0)
+    {
         MP_ERR(mpctx, "overlay-add: inconsistent parameters\n");
         goto error;
     }


### PR DESCRIPTION
Fixes #18128.
cmd_overlay_add computed w * 4 in int arithmetic during parameter validation. A large positive w (e.g. 1073741824) passes the w <= 0 check but overflows int when computing w * 4 — undefined behavior, caught by UBSan. This adds a w > INT_MAX / 4 guard before the stride < w * 4 comparison so the multiplication can't overflow; oversized widths now take the existing "inconsistent parameters" error path.
Testing: Built with -Db_sanitize=address,undefined and ran the repro from the issue. Before: UBSan reports signed integer overflow: 1073741824 * 4 cannot be represented in type 'int' at command.c:5434 and aborts. After: mpv prints overlay-add: inconsistent parameters and exits cleanly.