### PR TITLE
github/workflows/docs: update package index to fix install failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Docs
         run: |
+          sudo apt-get update
           sudo apt-get install --no-install-recommends -y python3-docutils rst2pdf
           ./TOOLS/docutils-wrapper.py rst2man --strip-elements-with-class=contents --halt=2 ./DOCS/man/mpv.rst mpv.1
           ./TOOLS/docutils-wrapper.py rst2html --halt=2 ./DOCS/man/mpv.rst mpv.html


### PR DESCRIPTION
When index is outdated some files may not exist, when we try to install them.