### PR TITLE
demux/demux_mkv: fix OOB read on short segment uid

### DIFF
--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -465,11 +465,13 @@ static int demux_mkv_read_info(demuxer_t *demuxer)
     if (info.title) {
         mp_tags_set_str(demuxer->metadata, "TITLE", info.title);
     }
+    bool have_segment_uid = false;
     if (info.n_segment_uid) {
         size_t len = info.segment_uid.len;
         if (len != sizeof(demuxer->matroska_data.uid.segment)) {
             MP_INFO(demuxer, "segment uid invalid length %zu\n", len);
         } else {
+            have_segment_uid = true;
             memcpy(demuxer->matroska_data.uid.segment, info.segment_uid.start,
                    len);
             MP_DBG(demuxer, "| + segment uid");
@@ -480,7 +482,7 @@ static int demux_mkv_read_info(demuxer_t *demuxer)
         }
     }
     if (demuxer->params && demuxer->params->matroska_wanted_uids) {
-        if (info.n_segment_uid) {
+        if (have_segment_uid) {
             for (int i = 0; i < demuxer->params->matroska_num_wanted_uids; i++) {
                 struct matroska_segment_uid *uid = demuxer->params->matroska_wanted_uids + i;
                 if (!memcmp(info.segment_uid.start, uid->segment, 16)) {


### PR DESCRIPTION
demux_mkv_read_info compares a file SegmentUID against the wanted-segment UIDs with memcmp(info.segment_uid.start, uid->segment, 16), but never checks that the parsed element is 16 bytes. The bstr points into the Info element buffer, which ebml.c sizes to the element length, so a SegmentUID shorter than 16 bytes placed last inside Info reads past the allocation. It is reachable during ordered-chapters resolution: check_file_seg() opens candidate files with matroska_wanted_uids set, which is what runs this comparison.

Gate the comparison on info.segment_uid.len matching the 16-byte uid field, the same length check this field already gets before the memcpy a few lines up and in the chapter parser. A wrong-length SegmentUID can never match a valid wanted uid, so the only behavior change is that such a file is treated as not wanted instead of over-reading. ASAN before: heap-buffer-overflow READ of size 16 in demux_mkv_read_info; after: clean.