### PR TITLE
menu.conf: hide the Pause menu item while the player is paused

### DIFF
--- a/etc/menu.conf
+++ b/etc/menu.conf
@@ -1,5 +1,5 @@
-Pla&y	cycle pause		hidden=not pause and not idle_active	disabled=idle_active
-Pa&use	cycle pause		hidden=idle_active or pause
+Pla&y	cycle pause		hidden=not (pause or idle_active)	disabled=idle_active
+Pa&use	cycle pause		hidden=pause or idle_active
 &Stop	stop			hidden=idle ~= true						disabled=idle_active
 
 Ope&n


### PR DESCRIPTION
According to the `hidden` logic of the Play and Pause menu items defined in `menu.conf`, these two items should never appear at the same time.

But, while the player was paused, the context menu showed both Play and Pause items.

The correct behavior is to hide the Pause item while the player is paused.