### PR TITLE
stream_curl: require libcurl 7.88.0

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5757,7 +5757,6 @@ TLS/connection diagnostics), set ``--msg-level=curl=trace``.
 
 ``--curl-http-version=<auto|1.0|1.1|2|2tls|2-prior-knowledge|3|3only>``
     Select the maximum HTTP protocol version libcurl is allowed to negotiate.
-    If libcurl was built without HTTP/3 support, it will fallback to ``auto``.
     (default: ``auto``, i.e. let libcurl pick)
 
 ``--curl-max-redirects=<0-100>``

--- a/meson.build
+++ b/meson.build
@@ -623,7 +623,7 @@ if darwin
     subdir(join_paths('TOOLS', 'osxbundle'))
 endif
 
-libcurl = dependency('libcurl', version: '>= 7.87.0', required: get_option('libcurl'))
+libcurl = dependency('libcurl', version: '>= 7.88.0', required: get_option('libcurl'))
 features += {'libcurl': libcurl.found()}
 if features['libcurl']
     dependencies += [libcurl]

--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -84,14 +84,6 @@ struct curl_opts {
     int64_t max_request_size;
 };
 
-#ifndef CURL_HTTP_VERSION_3
-#define CURL_HTTP_VERSION_3 CURL_HTTP_VERSION_NONE
-#endif
-
-#ifndef CURL_HTTP_VERSION_3ONLY
-#define CURL_HTTP_VERSION_3ONLY CURL_HTTP_VERSION_NONE
-#endif
-
 // Older lavf has a bug with nested IO cleanup, so don't enable curl by default.
 // <https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23082>
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(62, 15, 101)


### PR DESCRIPTION
To avoid those awkward definitions. Initially much lower version was required, but after changes it landed at 7.87.0, so we might as well bump it one up.