### PR TITLE
osdep/compiler: make MP_ASSERT_UNREACHABLE no return

### DIFF
--- a/filters/f_swresample.c
+++ b/filters/f_swresample.c
@@ -279,7 +279,8 @@ static bool reorder_planes(struct mp_aframe *mpa, int *reorder,
     if (num_planes && !planes)
         return false;
     uint8_t *old_planes[MP_NUM_CHANNELS];
-    mp_assert(num_planes <= MP_NUM_CHANNELS);
+    mp_require(num_planes <= MP_NUM_CHANNELS);
+    num_planes = MPMIN(num_planes, MP_NUM_CHANNELS);
     for (int n = 0; n < num_planes; n++)
         old_planes[n] = planes[n];
 

--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef NDEBUG
-#define MP_ASSERT_UNREACHABLE() assert(!"unreachable")
+#define MP_ASSERT_UNREACHABLE() (assert(!"unreachable"), abort())
 #elif __has_builtin(__builtin_unreachable)
 #define MP_ASSERT_UNREACHABLE() __builtin_unreachable()
 #elif defined(_MSC_VER)


### PR DESCRIPTION
On some platforms assert is continuable, we don't want that, so abort() just after.