### PR TITLE
select.lua: register not yet evaluated properties to item

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -979,7 +979,9 @@ local function on_idle()
 
     for _, item in pairs(menu) do
         if item.dirty then
+            current_item = item
             item:update()
+            current_item = nil
             item.dirty = false
         end
     end


### PR DESCRIPTION
In case when during parse and initial item creation there is only single poperty evaluated, in case like `prop1 or prop2`. Only `prop1` is evaluated and added to observe that will make item dirty. However, when item is dirty, we may need to evaluate the rest of the expression, especially important to add it to observe, so we mark it dirty next time.

Fixes: #18153