### PR TITLE
demux_lavf: bail on tile grid group with no resolvable members

### DIFF
--- a/demux/demux_lavf.c
+++ b/demux/demux_lavf.c
@@ -1179,6 +1179,12 @@ static void handle_tile_grid_group(demuxer_t *demuxer, AVStreamGroup *stream_gro
         graph = talloc_asprintf_append(graph, "[%d]", i);
     }
 
+    if (vsh->group->num_members < 1) {
+        MP_WARN(demuxer, "Tile grid group %u has no resolvable member "
+                "streams - ignoring.\n", stream_group->index);
+        goto error;
+    }
+
     graph = talloc_asprintf_append(graph, "xstack=inputs=%d:layout=", grid->nb_tiles);
     for (int i = 0; i < grid->nb_tiles; i++) {
         if (i > 0)


### PR DESCRIPTION
handle_tile_grid_group() builds a virtual video track from an AVStreamGroupTileGrid that libavformat produces for a grid image (AVIF/HEIF). It sizes group->members to nb_tiles and appends one member per tile, skipping any tile whose offsets[i].idx is past stream_group->nb_streams. If every tile is skipped, or nb_tiles is zero, num_members stays 0, yet members[0] is still read into primary_sh and dereferenced right after. MP_TARRAY_GROW leaves those slots uninitialized, so members[0] is a garbage pointer rather than NULL.

Bail to the existing error path once the tile loop resolved no member, before the members[0] read. The LCEVC and layered-video handlers already return without forming a group when their streams do not resolve, so this keeps the tile-grid path consistent with them. Before: a grid whose tiles all reference out-of-range stream indices dereferences uninitialized memory; after: the group is dropped and the rest of the file still loads.