### PR TITLE
command: fix signed integer overflow in overlay-add

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5431,7 +5431,7 @@ static void cmd_overlay_add(void *pcmd)
         MP_ERR(mpctx, "overlay-add: invalid id %d\n", id);
         goto error;
     }
-    if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4) || offset < 0) {
+    if (w <= 0 || h <= 0 || stride < (size_t)w * 4 || (stride % 4) || offset < 0) {
         MP_ERR(mpctx, "overlay-add: inconsistent parameters\n");
         goto error;
     }


### PR DESCRIPTION
## Summary
- Fix UBSan signed integer overflow in `cmd_overlay_add` when the overlay width parameter is large (e.g., 2^30 = 1073741824), which causes `w * 4` to overflow the signed `int` type.

## Changes
| File | Change |
|------|--------|
| `player/command.c` | Cast `w` to `size_t` before multiplying by 4 in stride validation check |

## Test Plan
- [ ] Build mpv with UBSan (`-fsanitize=signed-integer-integer-overflow`) and reproduce the issue using the repro from #18128

Fixes #18128
