### PR TITLE
osc.lua: fix osc-idlescreen no command not hiding logo

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -3126,6 +3126,8 @@ tick = function()
         msg.trace("idle message")
         if user_opts.idlescreen then
             render_logo()
+        else
+            render_wipe(state.logo_osd)
         end
 
         -- Hide main OSC but keep window controls functional


### PR DESCRIPTION
## Summary
- Fix the `osc-idlescreen no` script command not properly hiding the mpv logo when the player is idle

## Changes
| File | Change |
|------|--------|
| `player/lua/osc.lua` | Add `else` branch to call `render_wipe(state.logo_osd)` when `user_opts.idlescreen` is false during idle state |

## Test Plan
- [ ] `mpv --no-config --idle --force-window`
- [ ] `script-message osc-idlescreen no` — logo should disappear
- [ ] `script-message osc-idlescreen yes` — logo should reappear

Fixes #18114
