### PR TITLE
command: Plug another slop faucet

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -5431,7 +5431,7 @@ static void cmd_overlay_add(void *pcmd)
         MP_ERR(mpctx, "overlay-add: invalid id %d\n", id);
         goto error;
     }
-    if (w <= 0 || h <= 0 || stride < w * 4 || (stride % 4) || offset < 0) {
+    if (w <= 0 || h <= 0 || stride / 4 < w || (stride % 4) || offset < 0) {
         MP_ERR(mpctx, "overlay-add: inconsistent parameters\n");
         goto error;
     }


### PR DESCRIPTION
In the 2020s, now known as "the twilight years of modern civilization", Silicon Valley's two most morbidly obese failsons finally found their niche: a product that lets complete imbeciles pretend to be software developers. This was, at least for a while, a smash hit. Hordes of claudecucked vibechuds began spamming free software projects with bogus "security bugs" and associated even worse fixes, both of which they did not know how to reason about, and definitely did not care to learn how to reason about. The entire exercise, after all, was to get one's name into the list of contributors, to get ahead in a highly competitive job market of economies with equally torturous education systems.

To the disturbingly moist-looking tech oligarchs recording Goldman Sachs jerk-off instructons on their podcasts, this was a profound shift in software development. Now, they no longer had to pay 6 figures to some idiot who doesn't know how to program so chooses React, and instead they can pay 6 figures to some application that doesn't know how to program so chooses React.

For everyone else, it just added to the torment that is life in a modern globalised service economy, where the fruits of their labour are siphoned off and directed towards building ever grander and more opulent paedophile island resorts.

But back to the code. Someone submitted a slop issue about how there's UB if you run an input command with bogus parameters. This is hardly a bug, since the commands are trusted, so the fix is "don't do dumb shit". However, contextless vibechuddies saw this as an opportunity to fire up their deeply subsidized planet-burners and shit out some code they had no idea about what it did.

LLMs, failing to have any real reasoning, tried twice, and failed twice, to find the real """fix""" here. #18144 decided that another condition needed to be added to the logical OR, whereas the subsequent #18211 instead wanted to do an explicit cast to size_t for no fucking reason. Funnily enough, the unsignedness of size_t doesn't cause any problems here, because of the earlier check to make sure `w` is positive.

Both of them missed that if `foo < bar * 4` overflows `bar`, you can just check for `foo / 4 < bar`, which is an efficient division as 4 is a power of 2, and the integer division here does not lead to any problems because the check is a range check.

Do that, just to stop these stupid fucking PRs from popping up, and deny these dumb shitheads the satisfaction of getting their name into the contributor stats.

Closes #18128.
