### PR TITLE
vo_libmpv: use the VO_CAP of the renderer backend instead of the VO

### DIFF
--- a/video/out/vo_libmpv.c
+++ b/video/out/vo_libmpv.c
@@ -359,7 +359,7 @@ int mpv_render_context_render(mpv_render_context *ctx, mpv_render_param *params)
 
             struct mp_rect src, dst;
             struct mp_osd_res osd;
-            mp_get_src_dst_rects(ctx->log, ctx->vo_opts, ctx->vo->driver->caps,
+            mp_get_src_dst_rects(ctx->log, ctx->vo_opts, ctx->renderer->driver_caps,
                                 &ctx->img_params, vp_w, abs(vp_h),
                                 1.0, &src, &dst, &osd);
 


### PR DESCRIPTION
The software renderer backend is not capable of using any of the VO capabilities set globally by vo_libmpv. This can lead to assertion errors when trying to render a video with 90 degree rotation metadata. Instead use the ctx->renderer->driver_caps value so the source frame doesn't have its params rotated when it's not desired.