### PR TITLE
DOCS/man/vo: remove mentions of 'experimental' for vo_dmabuf_wayland

### DIFF
--- a/DOCS/man/vo.rst
+++ b/DOCS/man/vo.rst
@@ -293,7 +293,7 @@ Available video output drivers are:
         Instruct SDL to switch the monitor video mode when going fullscreen.
 
 ``dmabuf-wayland``
-    Experimental Wayland output driver designed for use with either drm stateless
+    Special Wayland output driver designed for use with either drm stateless
     or VA API hardware decoding. The driver is designed to avoid any GPU to CPU copies,
     and to perform scaling and color space conversion using fixed-function hardware,
     if available, rather than GPU shaders. This frees up GPU resources for other tasks.
@@ -309,8 +309,8 @@ Available video output drivers are:
 
         This driver is not required for mpv to work on Wayland. ``vo=gpu``
         and ``vo=gpu-next`` will switch to the appropriate Wayland context
-        automatically. This driver is experimental and generally lower quality
-        than ``gpu``/``gpu-next``.
+        automatically. This video output is geared towards power efficiency
+        and has generally lower quality than ``gpu``/``gpu-next``.
 
 ``vaapi``
     Intel VA API video output driver with support for hardware decoding. Note


### PR DESCRIPTION
It's fair to say that it's generally a mature and well-working VO at this point.
