### PR TITLE
video/out/hwdec_cuda: use mp_msg for ffnvcodec logging

### DIFF
--- a/video/out/hwdec/hwdec_cuda.c
+++ b/video/out/hwdec/hwdec_cuda.c
@@ -87,7 +87,7 @@ static int cuda_init(struct ra_hwdec *hw)
             continue;
 
         if (!initialized) {
-            ret = cuda_load_functions(&p->cu, NULL);
+            ret = cuda_load_functions(&p->cu, hw);
             if (ret != 0) {
                 MP_MSG(hw, level, "Failed to load CUDA symbols\n");
                 return -1;

--- a/video/out/hwdec/hwdec_cuda.h
+++ b/video/out/hwdec/hwdec_cuda.h
@@ -19,9 +19,16 @@
 
 #pragma once
 
-#include <ffnvcodec/dynlink_loader.h>
-
 #include "video/out/gpu/hwdec.h"
+
+#define FFNV_LOG_FUNC(logctx, ...) \
+    mp_msg(((struct ra_hwdec *)(logctx))->log, \
+           ((struct ra_hwdec *)(logctx))->probing ? MSGL_V : MSGL_ERR, \
+           __VA_ARGS__)
+#define FFNV_DEBUG_LOG_FUNC(logctx, ...) \
+    mp_msg(((struct ra_hwdec *)(logctx))->log, MSGL_DEBUG, __VA_ARGS__)
+
+#include <ffnvcodec/dynlink_loader.h>
 
 struct cuda_hw_priv {
     struct mp_hwdec_ctx hwctx;


### PR DESCRIPTION
ffnvcodec falls back to fprintf(stderr) unless FFNV_LOG_FUNC and FFNV_DEBUG_LOG_FUNC are defined by the user
(https://github.com/FFmpeg/nv-codec-headers/blob/master/include/ffnvcodec/dynlink_loader.h#L80-L84). Define these callbacks so CUDA loader messages go through mpv's normal logging instead.

Fixes https://github.com/mpv-player/mpv/issues/18223