### PR TITLE
[RFC] mac: fix open file from finder and clean ups

### DIFF
--- a/input/dnd.c
+++ b/input/dnd.c
@@ -140,6 +140,23 @@ static MP_THREAD_VOID mpv_event_loop_fn(void *arg)
     MP_THREAD_RETURN();
 }
 
+void mp_dnd_load_file(mpv_handle *mpv, int num_files, char **files, enum mp_dnd_action action)
+{
+    mpv_node *items = talloc_zero_array(NULL, mpv_node, num_files);
+    mpv_node_list list = {.values = items, .num = num_files};
+    mpv_node node = {.format = MPV_FORMAT_NODE_ARRAY, .u = {.list = &list}};
+    for (int n = 0; n < num_files; n++) {
+        items[n] = (mpv_node){.format = MPV_FORMAT_STRING,
+                              .u = {.string = files[n]}};
+    }
+
+    char *actionstr = action == DND_REPLACE ? "replace" :
+                      action == DND_APPEND ? "append" :
+                      action == DND_INSERT_NEXT ? "insert-next" :
+                      "none";
+    handle_dnd(mpv, &node, actionstr);
+}
+
 void mp_dnd_init(mpv_handle *mpv)
 {
     mp_thread mpv_event_loop;

--- a/input/dnd.h
+++ b/input/dnd.h
@@ -18,4 +18,7 @@
 
 #include "player/client.h"
 
+#include "event.h"
+
+void mp_dnd_load_file(mpv_handle *ctx, int num_files, char **files, enum mp_dnd_action action);
 void mp_dnd_init(mpv_handle *mpv);

--- a/osdep/mac/app_bridge_objc.h
+++ b/osdep/mac/app_bridge_objc.h
@@ -28,6 +28,7 @@
 #include "common/global.h"
 #include "input/input.h"
 #include "input/event.h"
+#include "input/dnd.h"
 #include "input/keycodes.h"
 #include "video/out/win_state.h"
 

--- a/osdep/mac/app_hub.swift
+++ b/osdep/mac/app_hub.swift
@@ -39,6 +39,7 @@ class AppHub: NSObject {
     var isApplication: Bool { return NSApp is Application }
     var isBundle: Bool { return ProcessInfo.processInfo.environment["MPVBUNDLE"] == "true" }
     var openEvents: Int = 0
+    var openFiles: [String] = []
 
     private override init() {
         input = InputHelper()
@@ -113,9 +114,22 @@ class AppHub: NSObject {
             return strL.localizedStandardCompare(strR) == .orderedAscending
         }
         log.verbose("\(openEvents > 0 ? "Appending" : "Opening") dropped files: \(files)")
-        input.open(files: files, append: openEvents > 0)
-        openEvents += 1
+        DispatchQueue.main.async {
+            self.open(files: files, append: self.openEvents > 0)
+            self.openEvents += 1
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { self.openEvents -= 1 }
+
+    }
+
+    func open(files: [String], append: Bool = false) {
+        openFiles += files
+        guard let mpv = mpv else { return }
+
+        input.open(files: files, append: append) { (filesPtr, action) in
+            mp_dnd_load_file(mpv, Int32(openFiles.count), &filesPtr, action)
+        }
+        openFiles = []
     }
 
     func getIcon() -> NSImage {

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -253,16 +253,23 @@ class InputHelper: NSObject {
         lock.withLock {
             guard let input = input else { return }
 
-            var action = DND_APPEND
-            if !append {
-                action = NSEvent.modifierFlags.contains(.shift) ? DND_APPEND : DND_REPLACE
+            open(files: files, append: append) { (filesPtr, action) in
+                mp_input_drop_files(input, Int32(files.count), &filesPtr, action)
             }
-
-            let filesClean = files.map { $0.hasPrefix("file:///.file/id=") ? (URL(string: $0)?.path ?? $0) : $0 }
-            var filesPtr = filesClean.map { UnsafeMutablePointer<CChar>(strdup($0)) }
-            mp_input_drop_files(input, Int32(files.count), &filesPtr, action)
-            for charPtr in filesPtr { free(UnsafeMutablePointer(mutating: charPtr)) }
         }
+    }
+
+    func open(files: [String], append: Bool = false,
+              completion: (inout [UnsafeMutablePointer<CChar>?], mp_dnd_action) -> Void) {
+        var action = DND_APPEND
+        if !append {
+            action = NSEvent.modifierFlags.contains(.shift) ? DND_APPEND : DND_REPLACE
+        }
+
+        let filesClean = files.map { $0.hasPrefix("file:///.file/id=") ? (URL(string: $0)?.path ?? $0) : $0 }
+        var filesPtr = filesClean.map { UnsafeMutablePointer<CChar>(strdup($0)) }
+        completion(&filesPtr, action)
+        for charPtr in filesPtr { free(UnsafeMutablePointer(mutating: charPtr)) }
     }
 
     private func useAltGr() -> Bool {

--- a/osdep/mac/input_helper.swift
+++ b/osdep/mac/input_helper.swift
@@ -249,11 +249,11 @@ class InputHelper: NSObject {
         return String(utf16CodeUnits: chars, count: length)
     }
 
-    @objc func open(files: [String], append: Bool = false) {
+    @objc func handleDnd(files: [String]) {
         lock.withLock {
             guard let input = input else { return }
 
-            open(files: files, append: append) { (filesPtr, action) in
+            open(files: files) { (filesPtr, action) in
                 mp_input_drop_files(input, Int32(files.count), &filesPtr, action)
             }
         }

--- a/osdep/mac/menu_bar.swift
+++ b/osdep/mac/menu_bar.swift
@@ -334,7 +334,7 @@ class MenuBar: NSObject, EventSubscriber {
 
     @objc func openFiles() {
         guard let files = dialog.openFiles(path: currentDir) else { return }
-        appHub.input.open(files: files)
+        appHub.open(files: files)
     }
 
     @objc func openPlaylist() {
@@ -344,7 +344,7 @@ class MenuBar: NSObject, EventSubscriber {
 
     @objc func openUrl() {
         guard let file = dialog.openUrl() else { return }
-        appHub.input.open(files: [file])
+        appHub.open(files: [file])
     }
 
     @objc func command(_ menuItem: MenuItem) {

--- a/video/out/mac/view.swift
+++ b/video/out/mac/view.swift
@@ -92,7 +92,7 @@ class View: NSView, CALayerDelegate {
             }
         }
         if files.isEmpty { return false }
-        input?.open(files: files)
+        input?.handleDnd(files: files)
         return true
     }
 


### PR DESCRIPTION
this exposes the handle_dnd function. i am not sure if this is the best way to expose it and it might also cause deadlocks like this(?). @na-na-hi @kasper93 it would be nice to have your input on this, how it should be exposed and where it might reside in the end.

clean up the discrepancies between dnd and file open events. there are 4 cases that open files that use the dnd function:
- open file/url menu entry
- d'n'd various types on the window (string, urls, files, etc)
- opening via finder/open with
- d'n'd on dock icon (when already open, when still closed)

the latter two can not be distinguished since they are handled by the same internal mechanism without any reference from where the event was started. hence why the dnd on dock icon won't/can't be handled as a dnd event anymore. the menu items where moved to the new open file function and only the dnd on the window is now handled by the internal dnd function. 

consequently, all dnd options only influence the dnd on windows case from the future and how it was intended.

Fixes #17921