### PR TITLE
osdep/compiler: don't use __has_builtin for __builtin_mul_overflow 

### DIFF
--- a/osdep/compiler.h
+++ b/osdep/compiler.h
@@ -87,7 +87,7 @@
 
 #if defined(__STDC_VERSION_STDCKDINT_H__) && __STDC_VERSION_STDCKDINT_H__ >= 202311L
 #define MP_CKD_MUL(result, a, b) ckd_mul(result, a, b)
-#elif __has_builtin(__builtin_mul_overflow)
+#else
 #define MP_CKD_MUL(result, a, b) __builtin_mul_overflow(a, b, result)
 #endif
 


### PR DESCRIPTION
The feature test macro is nonstandard and not available on older GCC version, which causes build failure despite the compiler does support __builtin_mul_overflow.

Since there are no fallback when __builtin_mul_overflow is not available, there is no need to check, so simply remove it. If __builtin_mul_overflow is not supported compilation will still fail just like currently.

