### PR TITLE
test/libmpv_lifetime: set ao and vo to null

### DIFF
--- a/test/libmpv_lifetime.c
+++ b/test/libmpv_lifetime.c
@@ -92,6 +92,7 @@ int main(void)
 
             set_option_string(ctx, "msg-level", "all=trace");
             set_option_string(ctx, "terminal", "yes");
+            set_option_string(ctx, "msg-time", "yes");
 
             check_error(initialize(ctx));
 


### PR DESCRIPTION
This isn't relevant to the test, and saves time spent probing VOs and AOs. In my case, this brings down the test from 3.64s to 1.42s. Hopefully this is enough to make the test not timeout on freebsd.

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.
