### PR TITLE
init fd to -1 to avoid closing not our descriptors

### DIFF
--- a/video/out/drm_common.c
+++ b/video/out/drm_common.c
@@ -1043,6 +1043,7 @@ bool vo_drm_init(struct vo *vo)
         .mode = {{0}},
         .crtc_id = -1,
         .card_no = -1,
+        .fd = -1,
     };
 
     drm->vt_switcher_active = vt_switcher_init(&drm->vt_switcher, drm->log);
@@ -1156,7 +1157,8 @@ void vo_drm_uninit(struct vo *vo)
     if (drm->atomic_context)
         drm_atomic_destroy_context(drm->atomic_context);
 
-    close(drm->fd);
+    if (drm->fd >= 0)
+        close(drm->fd);
     talloc_free(drm);
     vo->drm = NULL;
 }

--- a/video/out/opengl/context_drm_egl.c
+++ b/video/out/opengl/context_drm_egl.c
@@ -562,6 +562,8 @@ static bool drm_egl_init(struct ra_ctx *ctx)
         goto err;
 
     struct priv *p = ctx->priv = talloc_zero(ctx, struct priv);
+    p->drm_params.fd = -1;
+    p->drm_params.render_fd = -1;
     struct vo_drm_state *drm = ctx->vo->drm;
 
     if (ctx->vo->drm->opts->draw_surface_size.wh_valid) {

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -377,6 +377,10 @@ static bool display_init(struct ra_ctx *ctx)
 
     VkDisplayModePropertiesKHR *mode = NULL;
 
+#if HAVE_DRM
+    p->drm_params.fd = -1;
+    p->drm_params.render_fd = -1;
+#endif
     p->opts = mp_get_config_group(p, ctx->global, &vulkan_display_conf);
     int display_idx = p->opts->display;
     int mode_idx = p->opts->mode;


### PR DESCRIPTION
This fixes various issues that may occur when we close(0) which was the case here, as the memory is zero initialized. 0 is valid fd, so the uninit code closes it.

Specifically it fixes the libmpv-lifetime test timeout on FreeBSD, where fd 0 was closed during VO probing. stdin is unused too, so fd 0 was free and libcurl had taken it for its internal multi wakeup pipe. close(0) then broke that pipe, and curl_multi_poll() spun forever inside libcurl on the now-invalid fd, hanging shutdown.

Not sure if libcurl itself could be hardened against EBADF, but ragardless we shouldn't close fd from under it.