### PR TITLE
video/vdpau: throttle reinit in all cases

### DIFF
--- a/video/vdpau.c
+++ b/video/vdpau.c
@@ -146,10 +146,11 @@ static int handle_preemption(struct mp_vdpau_ctx *ctx)
     }
 
     // If preemption_callback has been called during our recovery attempt, we
-    // need to retry the recovery. This check is not strictly necessary, because
-    // we would act on the next check anyway, but it doesn't hurt.
-    if (ctx->is_preempted)
-        return -1;
+    // need to retry the recovery. Throttle next init, same as errors above.
+    if (ctx->is_preempted) {
+        ctx->last_preemption_retry_fail = mp_time_sec();
+        goto error;
+    }
 
     ctx->preemption_user_notified = false;
     ctx->last_preemption_retry_fail = 0;


### PR DESCRIPTION
If `is_preempted` flag is set during init we need to try again, but if we do it too fast, we never let the init to finish and constantly gets the flag re-set.

Fix this by throttling the same as error path. It's not perfect, because we rely on init timing, but was confirmed working and this restores the previous status quo.

Fixes: d9f27bd0f1d757ad01f4511d5bfae1c8620e13c2
Fixes: #18161
