### PR TITLE
ao_pipewire: treat init timeout as failure instead of success

### DIFF
--- a/audio/out/ao_pipewire.c
+++ b/audio/out/ao_pipewire.c
@@ -668,7 +668,7 @@ static int init(struct ao *ao)
 
     pw_thread_loop_unlock(p->loop);
 
-    if (p->init_state == INIT_STATE_ERROR)
+    if (p->init_state != INIT_STATE_SUCCESS)
         goto error;
 
     return 0;


### PR DESCRIPTION
When wait_for_init_done times out, init_state remains INIT_STATE_NONE. The original check only handled INIT_STATE_ERROR, allowing init() to return 0 (success) even though the stream was never properly initialized. This could lead to an infinite reload loop when the partially initialized stream later enters an error state.

Fix by checking for INIT_STATE_SUCCESS instead of INIT_STATE_ERROR, so that any state other than SUCCESS (including NONE due to timeout) is correctly treated as a failure.