### PR TITLE
stream_curl: don't set initial stream pos to > 0 if it's not seekable

### DIFF
--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -1001,7 +1001,14 @@ static int curl_open(stream_t *s, const struct stream_open_args *args)
     s->get_size = curl_get_size;
     s->control = curl_control;
     s->close = curl_close;
-    s->pos = p->request_start;
+    if (p->request_start > 0 && !p->seekable) {
+        MP_TRACE(p, "dropping initial transfer of %" PRIu64 " bytes from %s because the stream is not seekable\n",
+                p->request_start,
+                p->url);
+        s->pos = 0;
+    } else {
+        s->pos = p->request_start;
+    }
 
     return STREAM_OK;
 }


### PR DESCRIPTION
 Stream creation happens before calling `demux_open_url()` which calls
 `demux_open()` which goes through a demuxer list and calls
 `open_given_type()` until success.

 `open_given_type()` has an unconditional seek back to pos=0. This works
 with non-seekable streams because if we start with pos=0, these calls
 buffer the stream, and seeking back happens within the buffer.

 But if we start with pos > 0, a seek back will fail as we have no
 filled buffer yet. And to make matters worse, `open_given_type()`
 doesn't check if the seek happened/succeeded or not, and continues to
 parse with the assumption that it's at pos 0, Which leads to weird
 brokenness at best, and potential security issues at worst.