### PR TITLE
bstr: avoid null pointer arithmetic in bstr_cut()

### DIFF
--- a/misc/bstr.h
+++ b/misc/bstr.h
@@ -232,6 +232,9 @@ static inline struct bstr bstr_cut(struct bstr str, int n)
     }
     if (((size_t)n) > str.len)
         n = str.len;
+    // Forming a pointer from NULL (e.g. NULL + 0) is undefined behavior.
+    if (!str.start)
+        return (struct bstr){NULL, str.len - n};
     return (struct bstr){str.start + n, str.len - n};
 }
 


### PR DESCRIPTION
## Summary
- `bstr_cut()` computed `(struct bstr){str.start + n, str.len - n}`. When `str.start` is `NULL` and `n == 0`, `str.start + n` is `NULL + 0`, which is undefined behavior per C11 6.5.6/8 (a null pointer does not point into any object, so adding an offset is not defined).
- This is reachable from fuzzed input: `separate_input_param()` → `get_nextsep()` → `bstr_cut(str, idx < 0 ? str.len : idx)` with an empty bstr (`bstr0(NULL)` → `{NULL, 0}`). Reported by the `fuzzer_load_config_file` harness with the "applying zero offset to null pointer" runtime error.
- The rest of `bstr.h` already treats a `NULL` start as "no string" (see the `bstrdup0()` comment and `bstrdup()`'s `{NULL, str.len}` initializer), so return a `NULL` bstr instead of producing a bogus pointer.

## Changes
| File | Change |
|------|--------|
| `misc/bstr.h` | `bstr_cut()`: return `{NULL, str.len - n}` when `str.start` is NULL, avoiding the null-pointer arithmetic. |

## Test plan
- [ ] Build the fuzzers with the clang OSS-Fuzz sanitizer (`-fsanitize=address,undefined,fuzzer`) and rerun `fuzzer_load_config_file` with the repro from #18105 — the "applying zero offset to null pointer" runtime error no longer fires.
- [ ] `meson compile -C build` and existing test suite still pass (one-line guard, no behavior change for non-NULL strings).

Fixes #18105
