### PR TITLE
vo/opengl/formats: use R8 and RG8 formats on GL2.1 and ES2 if available

### DIFF
--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -212,6 +212,26 @@ static const struct gl_functions gl_functions[] = {
         .extension = "GL_EXT_unpack_subimage",
         .provides = MPGL_CAP_ROW_LENGTH,
     },
+    // Framebuffers, alternative extension name. Some GL 2.1 drivers (e.g.
+    // Mesa lima) expose only this one. It provides a compatible subset of
+    // GL_ARB_framebuffer_object for our purposes; the entrypoints loaded
+    // here are overwritten by the ARB/core ones below if available.
+    {
+        .ver_exclude = 300,
+        .ver_es_exclude = 200, // FBOs are core in ES2
+        .extension = "GL_EXT_framebuffer_object",
+        .provides = MPGL_CAP_FB,
+        .functions = (const struct gl_function[]) {
+            DEF_FN_NAME(BindFramebuffer, "glBindFramebufferEXT"),
+            DEF_FN_NAME(GenFramebuffers, "glGenFramebuffersEXT"),
+            DEF_FN_NAME(DeleteFramebuffers, "glDeleteFramebuffersEXT"),
+            DEF_FN_NAME(CheckFramebufferStatus, "glCheckFramebufferStatusEXT"),
+            DEF_FN_NAME(FramebufferTexture2D, "glFramebufferTexture2DEXT"),
+            DEF_FN_NAME(GetFramebufferAttachmentParameteriv,
+                        "glGetFramebufferAttachmentParameterivEXT"),
+            {0}
+        },
+    },
     // Framebuffers, extension in GL 2.x, core in GL 3.x core.
     {
         .ver_core = 300,

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -186,6 +186,12 @@ int ra_gl_ctx_color_depth(struct ra_swapchain *sw)
     if ((gl->es < 300 && !gl->version) || !(gl->mpgl_caps & MPGL_CAP_FB))
         return 0;
 
+    // Querying the default framebuffer needs GL_ARB_framebuffer_object or
+    // GL 3.0+; GL_EXT_framebuffer_object does not allow it.
+    if (!p->main_fb && gl->version && gl->version < 300 &&
+        !gl_check_extension(gl->extensions, "GL_ARB_framebuffer_object"))
+        return 0;
+
     gl->BindFramebuffer(GL_FRAMEBUFFER, p->main_fb);
 
     GLenum obj = gl->version ? GL_BACK_LEFT : GL_BACK;

--- a/video/out/opengl/context.c
+++ b/video/out/opengl/context.c
@@ -193,6 +193,12 @@ int ra_gl_ctx_color_depth(struct ra_swapchain *sw)
     if ((gl->es < 300 && !gl->version) || !(gl->mpgl_caps & MPGL_CAP_FB))
         return 0;
 
+    // The *_SIZE attachment queries need GL_ARB_framebuffer_object or
+    // GL 3.0+; GL_EXT_framebuffer_object does not provide them.
+    if (gl->version && gl->version < 300 &&
+        !gl_check_extension(gl->extensions, "GL_ARB_framebuffer_object"))
+        return 0;
+
     gl->BindFramebuffer(GL_FRAMEBUFFER, p->main_fb);
 
     GLenum obj = gl->version ? GL_BACK_LEFT : GL_BACK;

--- a/video/out/opengl/formats.c
+++ b/video/out/opengl/formats.c
@@ -24,6 +24,15 @@ const struct gl_format gl_formats[] = {
     // Specifically not color-renderable.
     {"rgb16",   GL_RGB16,    GL_RGB,             T_U16, F_TF | F_EXT16},
 
+    // GL 2.1 with GL_ARB/EXT_texture_rg, but without requiring FBOs or float
+    // textures (unlike F_GL2F). Upload/filtering only.
+    {"r8",      GL_R8,       GL_RED,             T_U8,  F_TF | F_GL2RG},
+    {"rg8",     GL_RG8,      GL_RG,              T_U8,  F_TF | F_GL2RG},
+
+    // ES2 with GL_EXT_texture_rg. ES2 requires unsized internal formats.
+    {"r",       GL_RED,      GL_RED,             T_U8,  F_TF | F_ES2RG},
+    {"rg",      GL_RG,       GL_RG,              T_U8,  F_TF | F_ES2RG},
+
     // GL2 legacy. Ignores possibly present FBO extensions (no CF flag set).
     {"l8",    GL_LUMINANCE8, GL_LUMINANCE,       T_U8,  F_TF | F_GL2},
     {"la8", GL_LUMINANCE8_ALPHA8, GL_LUMINANCE_ALPHA, T_U8,  F_TF | F_GL2},
@@ -104,7 +113,7 @@ const struct gl_format gl_formats[] = {
 // Return an or-ed combination of all F_ flags that apply.
 int gl_format_feature_flags(GL *gl)
 {
-    return (gl->version == 210 ? F_GL2 : 0)
+    int flags = (gl->version == 210 ? F_GL2 : 0)
          | (gl->version >= 300 ? F_GL3 : 0)
          | (gl->es == 200 ? F_ES2 : 0)
          | (gl->es >= 300 ? F_ES3 : 0)
@@ -116,7 +125,15 @@ int gl_format_feature_flags(GL *gl)
             (gl->mpgl_caps & MPGL_CAP_ARB_FLOAT) &&
             (gl->mpgl_caps & MPGL_CAP_TEX_RG) &&
             (gl->mpgl_caps & MPGL_CAP_FB)) ? F_GL2F : 0)
+         | ((gl->version == 210 &&
+            (gl->mpgl_caps & MPGL_CAP_TEX_RG)) ? F_GL2RG : 0)
+         | ((gl->es == 200 &&
+            (gl->mpgl_caps & MPGL_CAP_TEX_RG)) ? F_ES2RG : 0)
          | (gl->mpgl_caps & MPGL_CAP_APPLE_RGB_422 ? F_APPL : 0);
+    // F_GL2RG is a subset of F_GL2F; avoid duplicate format entries.
+    if (flags & F_GL2F)
+        flags &= ~F_GL2RG;
+    return flags;
 }
 
 int gl_format_type(const struct gl_format *format)

--- a/video/out/opengl/formats.h
+++ b/video/out/opengl/formats.h
@@ -25,6 +25,8 @@ enum {
     F_EXTF16    = 1 << 6, // GL_EXT_color_buffer_half_float
     F_GL2F      = 1 << 7, // GL2.1-only with texture_rg + texture_float + FBOs
     F_APPL      = 1 << 8, // GL_APPLE_rgb_422
+    F_GL2RG     = 1 << 9, // GL2.1-only with texture_rg (no float/FBO requirement)
+    F_ES2RG     = 1 << 10, // ES2-only with GL_EXT_texture_rg
 
     // Feature flags. They are additional and signal presence of features.
     F_CR        = 1 << 16, // color-renderable


### PR DESCRIPTION
Improve vo_gpu's OpenGL backend on older/limited GL implementations (notably Mesa lima, which exposes GL 2.1 with GL_EXT_framebuffer_object and GL_EXT_texture_rg, but no GL_ARB_framebuffer_object)

- Support GL_EXT_framebuffer_object as an FBO provider: Some GL 2.1 drivers expose only the EXT variant of the FBO extension, leaving MPGL_CAP_FB unset even though FBOs work fine. mpv's FBO usage falls within the subset that EXT and ARB share, so load the EXT entrypoints as an alternative; the ARB/core entrypoints still overwrite them when available. Since querying default-framebuffer attachment parameters is an ARB/GL 3.0 addition, ra_gl_ctx_color_depth() now skips that query when only the EXT extension is present.
- Use R8/RG8 formats on GLES 2.0 and GL 2.1 with texture_rg: Previously R/RG textures were only used on GL 3.0/ES 3.0, or GL 2.1 with texture_rg + texture_float + FBOs all present. Add format classes for ES2 with GL_EXT_texture_rg (unsized internal formats) and GL 2.1 with ARB/EXT_texture_rg alone. This avoids the LUMINANCE/LUMINANCE_ALPHA swizzle hack and matches the .rg layout of dmabuf imports (DRM_FORMAT_R8/GR88, i.e. NV12 via drm-prime).