### PR TITLE
player/command: don't refresh sub stream on UPDATE_SUB option updates

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -8247,9 +8247,6 @@ void mp_option_run_callback(struct MPContext *mpctx, struct mp_option_callback *
                 int ret = sub_control(sub, SD_CTRL_UPDATE_OPTS, &flags);
                 if (ret == CONTROL_OK && flags & (UPDATE_SUB_FILT | UPDATE_SUB_HARD)) {
                     sub_redecode_cached_packets(sub);
-                    sub_reset(sub);
-                    if (track->selected)
-                        reselect_demux_stream(mpctx, track, true);
                 }
             }
         }


### PR DESCRIPTION
Back when reselect_demux_stream call was added in this path in 700f72f, sub_redecode_cached_packets only retained the last two packets. The subtitle decoder cache was changed in 0a4b098 to retain the whole packet sequence. Therefore sub_redecode_cached_packets by itself can rebuild the new decoder state entirely from packets held in memory, and we no longer need the demuxer to refresh the track.

This fixes expensive track refresh for network streams, where changing some sub-* options during runtime of network streams would cause the cache to be dropped
