### PR TITLE
DOCS/man/options: clarify how --shuffle and --playlist work

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -285,8 +285,23 @@ Playback Control
 ``--pause``
     Start the player in paused state.
 
-``--shuffle``
+``--shuffle=<yes|no>``
     Play files in random order.
+    This works by shuffling the playlist at the following points:
+
+      1. At player startup before playback starts. The files specified on the
+         command line are shuffled. Note that the directories and
+         playlist files in these arguments are not expanded at this time, so
+         their contents are not shuffled until the situation 2 mentioned below
+         happens. To expand these lists at startup, use ``--playlist``.
+
+      2. When loading a directory or playlist file, either with ``loadlist``
+         command or by playing a playlist file in the current playlist. The
+         items in the loaded playlist are shuffled before they are added to
+         the current playlist. Other existing items are not shuffled.
+
+      3. When ``--loop-playlist`` is enabled, the player performs a shuffle
+         after looping.
 
 ``--playlist-start=<auto|index>``
     Set which file on the internal playlist to start playback with. The index

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -327,6 +327,13 @@ Playback Control
     different demuxers and will not work with this option. They still can be
     played directly, without using this option.
 
+    This option differs from specifying playlist files directly as arguments.
+    The playlists specified by ``--playlist`` are expanded at startup, while
+    playlist files specified directly as arguments are expanded only when the
+    list is being played. Note that this expansion is not recursive, except in
+    the case of ``--playlist=<directory>``, where expansion follows the
+    ``--directory-mode`` option.
+
     By default, mpv doesn't play URLs from playlists which are considered
     unsafe. If you trust the playlist file, you can disable any security checks
     with ``--load-unsafe-playlists``. Because playlists can load other playlist


### PR DESCRIPTION
There are many misconceptions about how these options work.
Make it more clear.

Closes: #18291
Closes: #7922
