### PR TITLE
f_autoconvert: keep hw frames on the GPU when possible

### DIFF
--- a/filters/f_autoconvert.c
+++ b/filters/f_autoconvert.c
@@ -230,38 +230,50 @@ static bool build_image_converter(struct mp_autoconvert *c, struct mp_log *log,
             mp_err(log, "Failed to create HW uploader for format %s\n",
                    mp_imgfmt_to_name(src_fmt));
         }
-    } else if (dst_all_hw && num_fmts > 0) {
+    } else if ((dst_all_hw || !imgfmt_is_sw) && num_fmts > 0) {
+        // All targets are hw, or the source is hw and staying on the GPU may
+        // be possible, which beats downloading.
         bool upload_created = false;
         int sw_fmt = imgfmt_is_sw ? img->imgfmt : img->params.hw_subfmt;
-
         for (int i = 0; i < num_fmts; i++) {
+            if (!IMGFMT_IS_HWACCEL(fmts[i]))
+                continue;
             // We can probably use this! Very lazy and very approximate.
             struct mp_hwupload upload = mp_hwupload_create(conv, fmts[i],
                                                            sw_fmt, false);
-            if (upload.successful_init) {
-                mp_info(log, "HW-uploading to %s\n", mp_imgfmt_to_name(fmts[i]));
-                filters[2] = upload.f;
-                hwupload_fmt = upload.selected_sw_imgfmt;
-                fmts = &hwupload_fmt;
-                num_fmts = hwupload_fmt ? 1 : 0;
-                hw_to_sw = false;
-
-                // We cannot do format conversions when transferring between
-                // two hardware devices, so reject this format if that would be
-                // required.
-                if (!imgfmt_is_sw && hwupload_fmt != sw_fmt) {
-                    mp_err(log, "Format %s is not supported by %s\n",
-                           mp_imgfmt_to_name(sw_fmt),
-                           mp_imgfmt_to_name(p->imgfmts[i]));
-                    continue;
-                }
-                upload_created = true;
-                break;
+            if (!upload.successful_init)
+                continue;
+            // For a hw source this is a move between two devices, and the
+            // uploader cannot convert sw formats on the way. Whether the
+            // move works can only be tested with a real frame; do that when
+            // a sw target exists and the result decides against downloading.
+            // With only hw targets there is no alternative route, so insert
+            // the uploader untested and let the first frame decide.
+            if (!imgfmt_is_sw &&
+                (upload.selected_sw_imgfmt != sw_fmt ||
+                 (dst_have_sw && !mp_hwupload_probe_hw_to_hw(&upload, img)))) {
+                mp_verbose(log, "Cannot keep %s frames on the GPU as %s\n",
+                           mp_imgfmt_to_name(img->imgfmt),
+                           mp_imgfmt_to_name(fmts[i]));
+                talloc_free(upload.f);
+                continue;
             }
+            mp_info(log, "HW-uploading to %s\n", mp_imgfmt_to_name(fmts[i]));
+            filters[2] = upload.f;
+            hwupload_fmt = upload.selected_sw_imgfmt;
+            fmts = &hwupload_fmt;
+            num_fmts = hwupload_fmt ? 1 : 0;
+            hw_to_sw = false;
+            upload_created = true;
+            break;
         }
-        if (!upload_created) {
+        if (!upload_created && dst_all_hw) {
+            // Nothing else can produce the hw target formats. Failing here
+            // keeps the unconvertible frames away from consumers that would
+            // blindly dereference their native handles.
             mp_err(log, "Failed to create HW uploader for format %s\n",
                    mp_imgfmt_to_name(sw_fmt));
+            goto fail;
         }
     }
 
@@ -291,8 +303,8 @@ static bool build_image_converter(struct mp_autoconvert *c, struct mp_log *log,
         force_sws_params |= !mp_image_params_equal(&imgpar, &p->imgparams);
         need_sws |= force_sws_params;
     }
-    if (!imgfmt_is_sw && dst_all_hw) {
-        // This is a hw -> hw upload, so the sw format must already be
+    if (!imgfmt_is_sw && !hw_to_sw) {
+        // This is a direct hw -> hw upload, so the sw format must already be
         // mutually understood. No conversion can be done.
         need_sws = false;
     }

--- a/filters/f_hwtransfer.c
+++ b/filters/f_hwtransfer.c
@@ -68,6 +68,36 @@ static const struct hwmap_pairs hwmap_pairs[] = {
     {0}
 };
 
+bool mp_hwupload_probe_hw_to_hw(struct mp_hwupload *u, struct mp_image *src)
+{
+    if (!u->f || !src || !src->hwctx)
+        return false;
+    struct priv *p = u->f->priv;
+
+    bool map_images = false;
+    for (int n = 0; n < p->num_map_fmts; n++) {
+        if (src->imgfmt == p->map_fmts[n]) {
+            map_images = true;
+            break;
+        }
+    }
+
+    // Mirror hwupload_process(): same device, same pool parameters, same
+    // map or transfer choice, so the test cannot diverge from what the
+    // uploader will do with the real frames.
+    AVBufferRef *frames = NULL;
+    if (!mp_update_av_hw_frames_pool(&frames, p->av_device_ctx, p->hw_imgfmt,
+                                     src->params.hw_subfmt, src->w, src->h,
+                                     src->imgfmt == IMGFMT_CUDA))
+        return false;
+    struct mp_image *dst = map_images ? mp_av_pool_image_hw_map(frames, src)
+                                      : mp_av_pool_image_hw_upload(frames, src);
+    bool ok = !!dst;
+    talloc_free(dst);
+    av_buffer_unref(&frames);
+    return ok;
+}
+
 /**
  * @brief Find the closest supported format when hw uploading
  *

--- a/filters/f_hwtransfer.h
+++ b/filters/f_hwtransfer.h
@@ -18,6 +18,13 @@ struct mp_hwupload {
 struct mp_hwupload mp_hwupload_create(struct mp_filter *parent, int hw_imgfmt,
                                        int sw_imgfmt, bool src_is_same_hw);
 
+// Whether the created uploader can move the hw frame src to its hw format
+// without going through system memory, by mapping it or by a direct libavutil
+// transfer on the GPU. Support cannot be queried, so it is tested with src
+// against the uploader's own device and pool parameters. Only valid for
+// uploaders created with src_is_same_hw=false.
+bool mp_hwupload_probe_hw_to_hw(struct mp_hwupload *u, struct mp_image *src);
+
 // A filter which downloads sw frames from hw. Ignores sw frames.
 struct mp_hwdownload {
     struct mp_filter *f;

--- a/video/mp_image_pool.c
+++ b/video/mp_image_pool.c
@@ -411,6 +411,9 @@ bool mp_update_av_hw_frames_pool(struct AVBufferRef **hw_frames_ctx,
         if (format == AV_PIX_FMT_D3D11) {
             AVD3D11VAFramesContext *d3d11va_frames_ctx = hw_frames->hwctx;
             d3d11va_frames_ctx->BindFlags |= D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+            // Shareable textures are cheap and allow libavutil to transfer
+            // frames directly to another device, e.g. d3d11 -> vulkan.
+            d3d11va_frames_ctx->MiscFlags |= D3D11_RESOURCE_MISC_SHARED;
         }
 #endif
 


### PR DESCRIPTION
Converting between two hw formats in the filter chain either fails on the first frame (only hw targets, for example nvdec feeding d3d11vpp) or always leaves the GPU (mixed targets, autoconvert unconditionally downloads), because libavutil transfers between two hardware frame contexts exist only for a few device pairs and support cannot be queried, only tried.

With this change autoconvert builds the chain around the uploader for hw sources and keeps the frame on the GPU when that is actually possible:

* mp_image_pool creates shareable D3D11 textures, so libavutil can transfer them to another device directly.
* When both hw and sw targets are available, a test with the current frame (map or transfer, against the same device and pool parameters the uploader would use) decides between the direct GPU route and the plain download. When only hw targets exist there is nothing to decide, so the uploader is inserted and a failing transfer surfaces on the first frame exactly as today. Nothing is copied through system memory implicitly, and a target needing a sw format conversion on the way is rejected at setup.

With the libavutil counterpart (https://github.com/flowreen/FFmpeg/tree/d3d11-vulkan-transfer) D3D11 textures transfer directly to Vulkan in both directions, single plane formats as one image and nv12/p010 through per plane bridging, so both the default nv12 passthrough and --vf=d3d11vpp=format=x2bgr10 (RTX Video HDR and VSR) stay on the GPU under --gpu-api=vulkan. Without it, behavior matches master for every route that exists today.

Under a Vulkan VO the d3d11vpp filter itself needs #18301 before it can be created at all; the two PRs are independent otherwise.

### AI disclosure

Disclosure: this patch was written with AI assistance (Claude Code), which diagnosed the bug, wrote the change, and ran the verification on my machine. I have reviewed it and understand what it changes and why, I take responsibility for it, and review responses will be written by me. filters/f_autoconvert.c carries no licence header and so falls under the repository default of LGPLv2.1+; I submit the change under that licence.