### PR TITLE
vf_d3d11vpp: create own device if the VO provides none

### DIFF
--- a/DOCS/man/vf.rst
+++ b/DOCS/man/vf.rst
@@ -718,9 +718,23 @@ Available mpv-only filters are:
             Apply high quality VDPAU scaling (needs capable hardware).
 
 ``d3d11vpp``
-    Direct3D 11 video post-processing. Requires a D3D11 context and works best
-    with hardware decoding. Software frames are automatically uploaded to hardware
+    Direct3D 11 video post-processing. Works best with a D3D11 context and
+    hardware decoding. Software frames are automatically uploaded to hardware
     for processing.
+
+    If the video output provides no D3D11 device, for example with
+    ``--gpu-api=vulkan``, the filter creates its own device. Every frame is
+    then copied between the two devices, directly on the GPU when the formats
+    involved allow it and through system memory otherwise, which costs memory
+    bandwidth and adds latency. Prefer ``--gpu-api=d3d11`` when using this
+    filter.
+
+    In that fallback mode, frames from a different hardware decoder, such as
+    the CUDA frames ``nvdec`` produces, are routed through system memory on
+    their way to the D3D11 device, which costs yet another copy.
+    ``--hwdec=d3d11va`` cannot be used at all, because the decoder picks its
+    device before this filter is created, so it falls back to software
+    decoding.
 
     ``format``
         Convert to the selected image format, e.g., nv12, p010, etc. (default: don't change).

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -777,15 +777,40 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
         if (hwctx && hwctx->av_device_ref) {
             p->av_device_ref = av_buffer_ref(hwctx->av_device_ref);
         } else {
-            const struct hwcontext_fns *fns =
-                hwdec_get_hwcontext_fns(AV_HWDEVICE_TYPE_D3D11VA);
-            if (!fns || !fns->create_dev)
-                goto fail;
-            struct hwcontext_create_dev_params dev_params = {0};
-            p->av_device_ref = fns->create_dev(f->global, f->log, &dev_params);
-            if (!p->av_device_ref)
-                goto fail;
-            MP_WARN(f, "No D3D11 video output, using a standalone device. "
+            // Prefer deriving from the VO's device, so that we land on the
+            // same adapter it is rendering on. Creating a device standalone
+            // picks whichever adapter enumerates first, which is not
+            // necessarily the same GPU on a multi-adapter system.
+            struct hwdec_imgfmt_request vk_params = {
+                .imgfmt = IMGFMT_VULKAN,
+                .probing = false,
+            };
+            hwdec_devices_request_for_img_fmt(info->hwdec_devs, &vk_params);
+            struct mp_hwdec_ctx *vkctx =
+                hwdec_devices_get_by_imgfmt_and_type(info->hwdec_devs,
+                                                     IMGFMT_VULKAN,
+                                                     AV_HWDEVICE_TYPE_VULKAN);
+            if (vkctx && vkctx->av_device_ref) {
+                int ret = av_hwdevice_ctx_create_derived(&p->av_device_ref,
+                                                         AV_HWDEVICE_TYPE_D3D11VA,
+                                                         vkctx->av_device_ref, 0);
+                if (ret < 0) {
+                    MP_VERBOSE(f, "Could not derive a D3D11 device from the "
+                                  "VO's Vulkan device: %s\n", av_err2str(ret));
+                    p->av_device_ref = NULL;
+                }
+            }
+            if (!p->av_device_ref) {
+                const struct hwcontext_fns *fns =
+                    hwdec_get_hwcontext_fns(AV_HWDEVICE_TYPE_D3D11VA);
+                if (!fns || !fns->create_dev)
+                    goto fail;
+                struct hwcontext_create_dev_params dev_params = {0};
+                p->av_device_ref = fns->create_dev(f->global, f->log, &dev_params);
+                if (!p->av_device_ref)
+                    goto fail;
+            }
+            MP_WARN(f, "No D3D11 video output, using a separate device. "
                        "Frames are copied through system memory, which is "
                        "slow. Use --gpu-api=d3d11 to avoid this.\n");
         }

--- a/video/filter/vf_d3d11vpp.c
+++ b/video/filter/vf_d3d11vpp.c
@@ -115,6 +115,10 @@ struct priv {
     AVBufferRef *av_device_ref;
     AVBufferRef *hw_pool;
 
+    // Set only if the device was created by us instead of taken from the VO.
+    struct mp_hwdec_devices *hwdec_devs;
+    struct mp_hwdec_ctx own_hwctx;
+
     struct mp_refqueue *queue;
 
     UINT num_past_views;
@@ -697,6 +701,9 @@ static void uninit(struct mp_filter *vf)
     flush_frames(vf);
     talloc_free(p->queue);
     av_buffer_unref(&p->hw_pool);
+
+    if (p->hwdec_devs)
+        hwdec_devices_remove(p->hwdec_devs, &p->own_hwctx);
     av_buffer_unref(&p->av_device_ref);
 
     if (p->video_ctx)
@@ -757,9 +764,43 @@ static struct mp_filter *vf_d3d11vpp_create(struct mp_filter *parent,
     struct mp_hwdec_ctx *hwctx =
         hwdec_devices_get_by_imgfmt_and_type(info->hwdec_devs, IMGFMT_D3D11,
                                              AV_HWDEVICE_TYPE_D3D11VA);
-    if (!hwctx || !hwctx->av_device_ref)
-        goto fail;
-    p->av_device_ref = av_buffer_ref(hwctx->av_device_ref);
+    bool from_vo = hwctx && hwctx->av_device_ref &&
+                   !(hwctx->driver_name &&
+                     !strcmp(hwctx->driver_name, vf_d3d11vpp_filter.name));
+
+    if (from_vo) {
+        p->av_device_ref = av_buffer_ref(hwctx->av_device_ref);
+    } else {
+        // The VO does not provide a D3D11 device (e.g. --gpu-api=vulkan).
+        // Share one with any other instance of this filter, so that frames
+        // stay usable across a chain of them, or create one if we are first.
+        if (hwctx && hwctx->av_device_ref) {
+            p->av_device_ref = av_buffer_ref(hwctx->av_device_ref);
+        } else {
+            const struct hwcontext_fns *fns =
+                hwdec_get_hwcontext_fns(AV_HWDEVICE_TYPE_D3D11VA);
+            if (!fns || !fns->create_dev)
+                goto fail;
+            struct hwcontext_create_dev_params dev_params = {0};
+            p->av_device_ref = fns->create_dev(f->global, f->log, &dev_params);
+            if (!p->av_device_ref)
+                goto fail;
+            MP_WARN(f, "No D3D11 video output, using a standalone device. "
+                       "Frames are copied through system memory, which is "
+                       "slow. Use --gpu-api=d3d11 to avoid this.\n");
+        }
+        // Advertise the device so that the generic upload/download filters can
+        // move frames in and out of it. Every instance registers its own entry
+        // even when sharing a device: filters are created before the old ones
+        // are destroyed, so the instance we borrowed from may go away first.
+        p->own_hwctx = (struct mp_hwdec_ctx){
+            .driver_name = vf_d3d11vpp_filter.name,
+            .av_device_ref = p->av_device_ref,
+            .hw_imgfmt = IMGFMT_D3D11,
+        };
+        p->hwdec_devs = info->hwdec_devs;
+        hwdec_devices_add(p->hwdec_devs, &p->own_hwctx);
+    }
     AVHWDeviceContext *avhwctx = (void *)p->av_device_ref->data;
     AVD3D11VADeviceContext *d3dctx = avhwctx->hwctx;
 


### PR DESCRIPTION
In short: `d3d11vpp` takes its D3D11 device from the video output, so with `--gpu-api=vulkan` it cannot initialise at all and mpv drops the video track. RTX Video HDR and RTX Video Super Resolution are therefore unreachable unless you also switch renderer. This falls back to a standalone D3D11 device when the VO has none.

### Background

People enable RTX Video HDR, get nothing, and have no way to tell why. The prompt for this was someone asking exactly that: https://www.reddit.com/r/mpv/comments/1v6msec/do_i_need_to_change_config_to_enable_rtxhdr_in_mpv/

That is a single report, not evidence of wide demand, and `--gpu-api=d3d11` remains the better answer on merit. But the current behaviour gives no signal at all: the filter fails to construct and the video track disappears, with nothing pointing at the video output as the cause. Either it should work or it should say why, and working turned out to be the smaller change.

### Problem

```
[vo/gpu-next] Loading hwdec drivers for format: 'd3d11'
[vo/gpu-next] Loading hwdec driver 'd3d11va'
[user_filter_wrapper] Creating filter 'd3d11vpp' failed.
Video: no video
```

The lazy loader does run, but `hwdec_d3d11va`'s init starts with

```c
if (!ra_is_d3d11(hw->ra_ctx->ra))
    return -1;
```

so with a Vulkan rendering abstraction it declines immediately, no D3D11 device is ever registered in `hwdec_devs`, and `vf_d3d11vpp_create()` bails. The driver loads, refuses, and leaves the list empty, which is why the log looks like it should have worked.

### Fix

The video processor does not have to run on the VO's device. When the VO provides none, create a standalone one via `hwcontext_fns_d3d11`, the same helper the copy hwdecs use, and advertise it with `hwdec_devices_add()` so the generic upload and download filters can move frames in and out of it.

This costs an upload and a download per frame, so the filter warns, and it still prefers the VO's device whenever there is one. `--gpu-api=d3d11` is unaffected.

Two details that are not obvious:

- **Every instance registers its own `mp_hwdec_ctx`, even when sharing a device.** `mp_output_chain_update_filters()` creates new filters before freeing the old ones, so an instance that merely borrowed a peer's device is left with nothing registered once that peer deregisters, and the next upload probe fails. Symptom was that any runtime `vf` change silently disabled the filter.
- **Instances share one device rather than each creating their own.** An `ID3D11VideoProcessorInputView` cannot be created from another device's texture, so a chain of two `d3d11vpp` filters breaks if they disagree on a device.

### Known limitations, documented in vf.rst

- `--hwdec=d3d11va` still cannot be used with a non-D3D11 VO, because `init_video_decoder()` runs before `recreate_video_filters()`, so the device is registered too late for the decoder. It falls back to software decoding.
- `d3d11_create_standalone()` passes a NULL DXGI adapter, so on a hybrid system the device lands on whatever enumerates first. That is the discrete GPU on my machine, but it is not guaranteed.
- Decoders that emit a *different* hardware format need #18300 as well. Without it, this patch alone works with `--hwdec=no` and with every copy-back mode (`auto-copy`, `nvdec-copy`, `d3d11va-copy`, all verified), but `--hwdec=auto` selecting nvdec fails, because its CUDA frames cannot be uploaded into D3D11.

### Testing

Windows 11, RTX 5090, driver 610.74, `--vo=gpu-next`.

RTX Video HDR and RTX VSR both engage under `--gpu-api=vulkan`, output is correctly tagged `rgb/bt.2020/pq/full`, and libplacebo picks an `HDR10_ST2084` swapchain. Pixel output matches the `--gpu-api=d3d11` reference at SSIM 1.000000 and PSNR 95 dB, against PSNR 28 dB for a no-filter control.

Also covered: playlist advance, seeking, runtime `vf` changes, two `d3d11vpp` filters chained, already-HDR sources (correctly a no-op), and 60 filter create/destroy cycles with a threaded decoder (`--vd-queue-enable=yes`) showing no failures and no handle or memory growth against a `--gpu-api=d3d11` control. Confirmed the d3d11 path still takes the VO's device and stays zero-copy.

Cost of the fallback, over 600 frames at 1080p: about +6.5 ms/frame CPU versus +3.5 ms/frame on the native d3d11 path, and roughly double the steady-state memory, 640 MB against 346 MB.

**Not tested:** non-NVIDIA hardware, so the Intel VSR path is unexercised, and hybrid systems where the integrated GPU enumerates first.

I do not know this codebase's conventions well, so if you would prefer a different approach, a narrower fix, or this split differently across commits, say so and I will rework it.

cc @kasper93

### AI disclosure

Disclosure: this patch was written with AI assistance (Claude Code), which diagnosed the bug, wrote the change, and ran the testing described above on my machine. I have reviewed it and understand what it changes and why, I take responsibility for it, and review responses will be written by me. video/filter/vf_d3d11vpp.c is LGPLv2.1+ per its header; I submit the change under that licence.
