### PR TITLE
options: add --playlist-inherit-options option

### DIFF
--- a/DOCS/interface-changes/playlist-inherit-options.txt
+++ b/DOCS/interface-changes/playlist-inherit-options.txt
@@ -1,0 +1,1 @@
+add `--playlist-inherit-options` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -335,6 +335,12 @@ Playback Control
         local files, such as special protocols like ``avdevice://`` (which are
         inherently unsafe).
 
+``--playlist-inherit-options=<yes|no|current>``
+    Whether the per-file options of a playlist file are inherited by its items
+    when the playlist file is resolved and expanded (default: no). The value
+    ``current`` means that for playlists created by ``--autocreate-playlist``,
+    only the file from which the playlist is created inherits the options.
+
 ``--chapter-merge-threshold=<number>``
     Threshold for merging almost consecutive ordered chapter parts in
     milliseconds (default: 100). Some Matroska files with ordered chapters

--- a/common/playlist.c
+++ b/common/playlist.c
@@ -52,6 +52,15 @@ void playlist_entry_add_params(struct playlist_entry *e,
         playlist_entry_add_param(e, params[n].name, params[n].value);
 }
 
+void playlist_set_params(struct playlist *pl, struct playlist_param *params,
+                         int num_params)
+{
+    for (int n = 0; n < pl->num_entries; n++) {
+        pl->entries[n]->num_params = 0;
+        playlist_entry_add_params(pl->entries[n], params, num_params);
+    }
+}
+
 static void playlist_update_indexes(struct playlist *pl, int start, int end)
 {
     start = MPMAX(start, 0);

--- a/common/playlist.h
+++ b/common/playlist.h
@@ -84,6 +84,8 @@ void playlist_entry_add_param(struct playlist_entry *e, bstr name, bstr value);
 void playlist_entry_add_params(struct playlist_entry *e,
                                struct playlist_param *params,
                                int params_count);
+void playlist_set_params(struct playlist *pl, struct playlist_param *params,
+                         int num_params);
 
 struct playlist_entry *playlist_entry_new(const char *filename);
 

--- a/options/options.c
+++ b/options/options.c
@@ -615,6 +615,8 @@ static const m_option_t mp_opts[] = {
 
     {"playlist-start", OPT_CHOICE(playlist_pos, {"auto", -1}, {"no", -1}),
         M_RANGE(0, INT_MAX)},
+    {"playlist-inherit-options", OPT_CHOICE(playlist_inherit_options,
+        {"no", 0}, {"yes", 1}, {"current", 2})},
 
     {"pause", OPT_BOOL(pause)},
     {"keep-open", OPT_CHOICE(keep_open,

--- a/options/options.h
+++ b/options/options.h
@@ -283,6 +283,7 @@ typedef struct MPOpts {
     char **input_commands;
     bool consolecontrols;
     int playlist_pos;
+    int playlist_inherit_options;
     struct m_rel_time play_start;
     struct m_rel_time play_end;
     struct m_rel_time play_length;

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1142,8 +1142,10 @@ static void transfer_playlist(struct MPContext *mpctx, struct playlist *pl,
         struct playlist_entry *new = pl->current;
         struct playlist_entry *current = mpctx->playlist->current;
         *num_new_entries = pl->num_entries;
-        if (current)
+        if (current && mpctx->opts->playlist_inherit_options == 1)
             playlist_set_params(pl, current->params, current->num_params);
+        else if (current && new && mpctx->opts->playlist_inherit_options == 2)
+            playlist_entry_add_params(new, current->params, current->num_params);
         *start_id = playlist_transfer_entries(mpctx->playlist, pl);
         // current entry is replaced
         if (current)

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1133,17 +1133,21 @@ void prepare_playlist(struct MPContext *mpctx, struct playlist *pl, bool overwri
 
 // Replace the current playlist entry with playlist contents. Moves the entries
 // from the given playlist pl, so the entries don't actually need to be copied.
+// The new entries inherit the file-local options of the current entry.
 static void transfer_playlist(struct MPContext *mpctx, struct playlist *pl,
                               int64_t *start_id, int *num_new_entries)
 {
     if (pl->num_entries) {
         prepare_playlist(mpctx, pl, true);
         struct playlist_entry *new = pl->current;
+        struct playlist_entry *current = mpctx->playlist->current;
         *num_new_entries = pl->num_entries;
+        if (current)
+            playlist_set_params(pl, current->params, current->num_params);
         *start_id = playlist_transfer_entries(mpctx->playlist, pl);
         // current entry is replaced
-        if (mpctx->playlist->current)
-            playlist_remove(mpctx->playlist, mpctx->playlist->current);
+        if (current)
+            playlist_remove(mpctx->playlist, current);
         if (new)
             mpctx->playlist->current = new;
         mpctx->playlist->playlist_dir = talloc_steal(mpctx->playlist, pl->playlist_dir);


### PR DESCRIPTION
This allows controlling whether the files in a playlist inherit the per-file options of the playlist file itself. For playlists created by --autocreate-playlist, --playlist-inherit-options=current allows inheriting only for the item the playlist is created from.

Fixes: #11150
Fixes: #15381