### PR TITLE
hwdec_vulkan: propagate the queue creation flags to ffmpeg

### DIFF
--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -124,6 +124,12 @@ static int vulkan_init(struct ra_hwdec *hw)
     device_hwctx->enabled_dev_extensions = vk->vulkan->extensions;
     device_hwctx->nb_enabled_dev_extensions = vk->vulkan->num_extensions;
 
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(60, 32, 100) && PL_API_VER >= 365
+    // libplacebo uses the same flags for all queues, so grab them from the
+    // queue we know we'll have
+    device_hwctx->queue_flags = vk->vulkan->queue_graphics.flags;
+#endif
+
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 34, 100)
     device_hwctx->nb_qf = 0;
     device_hwctx->qf[device_hwctx->nb_qf++] = (AVVulkanDeviceQueueFamily) {


### PR DESCRIPTION
Up until now, we have not bothered to propagate queue creation flags when setting up the ffmpeg device context, but with libplacebo setting flags like VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR and newer nvidia drivers actually supporting this feature, I've now managed to run into this. If the flags aren't put into the context, ffmpeg code can end up calling vkGetDeviceQueue2 with the wrong flags, and the driver will return a NULL queue instead.

I suspect we got this far without hitting this because the only filter that can currently end up calling vkGetDeviceQueue2 is vf_libplacebo and then only with the new `inherit_device=1` where the device we set up _from_ libplacebo goes back to libplacebo. The oroborus is complete.
