### PR TITLE
build: remove -Wno-pointer-sign and fix resulting warnings

### DIFF
--- a/audio/decode/ad_lavc.c
+++ b/audio/decode/ad_lavc.c
@@ -237,7 +237,7 @@ static int receive_frame(struct mp_filter *da, struct mp_frame *out)
     AVFrameSideData *sd =
         av_frame_get_side_data(priv->avframe, AV_FRAME_DATA_SKIP_SAMPLES);
     if (sd && sd->size >= 10) {
-        char *d = sd->data;
+        uint8_t *d = sd->data;
         priv->skip_samples += AV_RL32(d + 0);
         priv->trim_samples += AV_RL32(d + 4);
     }

--- a/audio/filter/af_lavcac3enc.c
+++ b/audio/filter/af_lavcac3enc.c
@@ -254,7 +254,7 @@ static void af_lavcac3enc_process(struct mp_filter *f)
     uint8_t **planes = mp_aframe_get_data_rw(out);
     if (!planes)
         goto error;
-    char *buf = planes[0];
+    uint8_t *buf = planes[0];
     memcpy(buf, hdr, header_len);
     memcpy(buf + header_len, pkt->data, pkt->size);
     memset(buf + header_len + pkt->size, 0,

--- a/audio/filter/af_scaletempo.c
+++ b/audio/filter/af_scaletempo.c
@@ -370,7 +370,7 @@ static void af_scaletempo_process(struct mp_filter *f)
     uint8_t **out_planes = mp_aframe_get_data_rw(out);
     if (!out_planes)
         goto error;
-    int8_t *pout = out_planes[0];
+    uint8_t *pout = out_planes[0];
     int out_offset = 0;
     if (s->bytes_queued >= s->bytes_queue) {
         int ti;

--- a/audio/out/ao_alsa.c
+++ b/audio/out/ao_alsa.c
@@ -757,7 +757,7 @@ static int init_device(struct ao *ao, int mode)
 
     int num_channels = ao->channels.num;
     err = snd_pcm_hw_params_set_channels_near
-            (p->alsa, alsa_hwparams, &num_channels);
+            (p->alsa, alsa_hwparams, (unsigned int *)&num_channels);
     CHECK_ALSA_ERROR("Unable to set channels");
     dump_hw_params(ao, "HW params after channels:\n", alsa_hwparams);
 
@@ -767,7 +767,7 @@ static int init_device(struct ao *ao, int mode)
     }
 
     err = snd_pcm_hw_params_set_rate_near
-            (p->alsa, alsa_hwparams, &ao->samplerate, NULL);
+            (p->alsa, alsa_hwparams, (unsigned int *)&ao->samplerate, NULL);
     CHECK_ALSA_ERROR("Unable to set samplerate-2");
     dump_hw_params(ao, "HW params after rate-2:\n", alsa_hwparams);
 

--- a/common/common.c
+++ b/common/common.c
@@ -110,7 +110,7 @@ char *mp_format_double(void *talloc_ctx, double val, int precision,
     if (percent_sign)
         bstr_xappend(talloc_ctx, &str, bstr0("%"));
     str.start[str.len] = '\0';
-    return str.start;
+    return (char *)str.start;
 }
 
 // Set rc to the union of rc and rc2
@@ -231,7 +231,7 @@ void mp_append_utf8_bstr(void *talloc_ctx, struct bstr *buf, uint32_t codepoint)
     uint8_t tmp;
     char *output = data;
     PUT_UTF8(codepoint, tmp, *output++ = tmp;);
-    bstr_xappend(talloc_ctx, buf, (bstr){data, output - data});
+    bstr_xappend(talloc_ctx, buf, (bstr){(unsigned char *)data, output - data});
 }
 
 // Parse a C/JSON-style escape beginning at code, and append the result to *str
@@ -257,7 +257,7 @@ static bool mp_parse_escape(void *talloc_ctx, bstr *dst, bstr *code)
     case '\'': replace = '\''; break;
     }
     if (replace) {
-        bstr_xappend(talloc_ctx, dst, (bstr){&replace, 1});
+        bstr_xappend(talloc_ctx, dst, (bstr){(unsigned char *)&replace, 1});
         *code = bstr_cut(*code, 1);
         return true;
     }
@@ -266,7 +266,7 @@ static bool mp_parse_escape(void *talloc_ctx, bstr *dst, bstr *code)
         char c = bstrtoll(num, &num, 16);
         if (num.len)
             return false;
-        bstr_xappend(talloc_ctx, dst, (bstr){&c, 1});
+        bstr_xappend(talloc_ctx, dst, (bstr){(unsigned char *)&c, 1});
         *code = bstr_cut(*code, 3);
         return true;
     }

--- a/common/encode_lavc.c
+++ b/common/encode_lavc.c
@@ -800,7 +800,7 @@ static void encoder_2pass_prepare(struct encoder_context *p)
         if (s) {
             struct bstr content = stream_read_complete(s, p, 1000000000);
             if (content.start) {
-                p->encoder->stats_in = content.start;
+                p->encoder->stats_in = (char *)content.start;
             } else {
                 MP_WARN(p, "could not read '%s', "
                         "disabling 2-pass encoding at pass 1\n", filename);

--- a/demux/demux.c
+++ b/demux/demux.c
@@ -4801,7 +4801,7 @@ static void visit_convert(void *ctx, void *ta, char **s)
     bstr conv = mp_iconv_to_utf8(in->log, data, in->meta_charset,
                                  MP_ICONV_VERBOSE);
     if (conv.start && conv.start != data.start) {
-        char *ns = conv.start; // 0-termination is guaranteed
+        char *ns = (char *)conv.start; // 0-termination is guaranteed
         // (The old string might not be an alloc, but if it is, it's a talloc
         // child, and will not leak, even if it stays allocated uselessly.)
         *s = ns;

--- a/demux/demux_cue.c
+++ b/demux/demux_cue.c
@@ -253,7 +253,7 @@ static int try_open_file(struct demuxer *demuxer, enum demux_check check)
     if (check >= DEMUX_CHECK_UNSAFE) {
         char probe[PROBE_SIZE];
         int len = stream_read_peek(s, probe, sizeof(probe));
-        if (len < 1 || !mp_probe_cue((bstr){probe, len}))
+        if (len < 1 || !mp_probe_cue((bstr){(unsigned char *)probe, len}))
             return -1;
     }
     struct priv *p = talloc_zero(demuxer, struct priv);

--- a/demux/demux_disc.c
+++ b/demux/demux_disc.c
@@ -112,7 +112,7 @@ static void add_dvd_streams(demuxer_t *demuxer)
             }
             s = talloc_asprintf_append(s, "\n");
 
-            sh->codec->extradata = s;
+            sh->codec->extradata = (unsigned char *)s;
             sh->codec->extradata_size = strlen(s);
 
             demux_add_sh_stream(demuxer, sh);

--- a/demux/demux_mf.c
+++ b/demux/demux_mf.c
@@ -73,7 +73,7 @@ static mf_t *open_mf_pattern(void *talloc_ctx, struct demuxer *d, char *filename
                 int len = stream_read_peek(s, buf, sizeof(buf));
                 if (!len)
                     break;
-                bstr data = (bstr){buf, len};
+                bstr data = (bstr){(unsigned char *)buf, len};
                 int pos = bstrchr(data, '\n');
                 data = bstr_splice(data, 0, pos < 0 ? data.len : pos + 1);
                 bstr fname = bstr_strip(data);

--- a/demux/demux_mkv.c
+++ b/demux/demux_mkv.c
@@ -2131,7 +2131,7 @@ static int demux_mkv_open_audio(demuxer_t *demuxer, mkv_track_t *track, int idx)
         if (track->private_size) {
             extradata_len = track->private_size + 12;
             extradata = talloc_size(sh_a, extradata_len);
-            char *data = extradata;
+            char *data = (char *)extradata;
             AV_WB32(data + 0, extradata_len);
             memcpy(data + 4, "alac", 4);
             AV_WB32(data + 8, 0);
@@ -2142,7 +2142,7 @@ static int demux_mkv_open_audio(demuxer_t *demuxer, mkv_track_t *track, int idx)
         extradata = talloc_zero_size(sh_a, extradata_len);
         if (!extradata)
             goto error;
-        char *data = extradata;
+        char *data = (char *)extradata;
         memcpy(data + 0, "TTA1", 4);
         AV_WL16(data + 4, 1);
         AV_WL16(data + 6, sh_a->channels.num);

--- a/demux/demux_playlist.c
+++ b/demux/demux_playlist.c
@@ -160,7 +160,7 @@ static char *read_line(stream_t *s, char *mem, int max, int utf16)
     int read = 0;
     while (1) {
         // Reserve 1 byte of ptr for terminating \0.
-        int l = read_characters(s, &mem[read], max - read - 1, utf16);
+        int l = read_characters(s, (uint8_t *)&mem[read], max - read - 1, utf16);
         if (l < 0 || memchr(&mem[read], '\0', l)) {
             MP_WARN(s, "error reading line\n");
             return NULL;
@@ -252,7 +252,7 @@ static int parse_m3u(struct pl_parser *p)
             bstr ext = mp_get_ext(bstr0(p->real_stream->url));
             char probe[PROBE_SIZE];
             int len = stream_read_peek(p->real_stream, probe, sizeof(probe));
-            bstr data = {probe, len};
+            bstr data = {(unsigned char *)probe, len};
             if (ext.len && data.len >= 2 && maybe_text(data)) {
                 const char *exts[] = {"m3u", "m3u8", "strm", NULL};
                 for (int n = 0; exts[n]; n++) {

--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -417,7 +417,7 @@ static void ebml_parse_element(struct ebml_parse_ctx *ctx, void *target,
                                                           num_elems[i]);
                 break;
             case EBML_TYPE_EBML_ID:
-                *(int32_t **) ptr = talloc_zero_array(ctx->talloc_ctx,
+                *(int32_t **) ptr = (int32_t *)talloc_zero_array(ctx->talloc_ctx,
                                                       uint32_t, num_elems[i]);
                 break;
             default:

--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -547,7 +547,7 @@ static void ebml_parse_element(struct ebml_parse_ctx *ctx, void *target,
             }
             char **strptr;
             GETPTR(strptr, char *);
-            *strptr = talloc_strndup(ctx->talloc_ctx, data, length);
+            *strptr = talloc_strndup(ctx->talloc_ctx, (char *)data, length);
             MP_TRACE(ctx, "string \"%s\"\n", *strptr);
             break;
 

--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -35,7 +35,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
 
 #ifdef MPV_PROTO
-    if (!str_startswith(data, size - 1, MPV_STRINGIFY(MPV_PROTO) "://", sizeof(MPV_STRINGIFY(MPV_PROTO) "://") - 1))
+    if (!str_startswith((const char *)data, size - 1, MPV_STRINGIFY(MPV_PROTO) "://", sizeof(MPV_STRINGIFY(MPV_PROTO) "://") - 1))
         return 0;
 #endif
 

--- a/fuzzers/fuzzer_loadfile_direct.c
+++ b/fuzzers/fuzzer_loadfile_direct.c
@@ -31,7 +31,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
 
     // Exclude data with null bytes inside
-    if (strlen(data) != size - 1)
+    if (strlen((const char *)data) != size - 1)
         return 0;
 
 #ifdef MPV_PROTO
@@ -55,7 +55,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     check_error(mpv_initialize(ctx));
 
-    const char *cmd[] = {"loadfile", data, NULL};
+    const char *cmd[] = {"loadfile", (const char *)data, NULL};
     check_error(mpv_command(ctx, cmd));
 
     player_loop(ctx);

--- a/fuzzers/fuzzer_set_property.c
+++ b/fuzzers/fuzzer_set_property.c
@@ -26,7 +26,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     switch (MPV_FORMAT)
     {
     case MPV_FORMAT_STRING:
-        value_len = strnlen(data, size);
+        value_len = strnlen((const char *)data, size);
         if (!value_len || value_len == size)
             return 0;
         value_len += 1;

--- a/input/cmd.c
+++ b/input/cmd.c
@@ -356,7 +356,7 @@ static int pctx_read_token(struct parse_ctx *ctx, bstr *out)
     if (ctx->start.len > 1 && bstr_eatstart0(&ctx->str, "`")) {
         char endquote[2] = {ctx->str.start[0], '`'};
         ctx->str = bstr_cut(ctx->str, 1);
-        int next = bstr_find(ctx->str, (bstr){endquote, 2});
+        int next = bstr_find(ctx->str, (bstr){(unsigned char *)endquote, 2});
         if (next < 0) {
             MP_ERR(ctx, "Unterminated custom quote: ...>%.*s<.\n", BSTR_P(start));
             return -1;

--- a/input/input.c
+++ b/input/input.c
@@ -542,7 +542,7 @@ static mp_cmd_t *get_cmd_from_keys(struct input_ctx *ictx, bstr force_section,
         if (MP_KEY_IS_UNICODE(code)) {
             bstr text = {0};
             mp_append_utf8_bstr(ret, &text, code);
-            ret->key_text = text.start;
+            ret->key_text = (char *)text.start;
         }
         ret->is_mouse_button = code & MP_KEY_EMIT_ON_UP;
     } else {

--- a/input/ipc-unix.c
+++ b/input/ipc-unix.c
@@ -100,7 +100,7 @@ static MP_THREAD_VOID client_thread(void *p)
     int rc;
 
     struct client_arg *arg = p;
-    bstr client_msg = { talloc_strdup(NULL, ""), 0 };
+    bstr client_msg = { (unsigned char *)talloc_strdup(NULL, ""), 0 };
 
     char *tname = talloc_asprintf(NULL, "ipc/%s", arg->client_name);
     mp_thread_set_name(tname);
@@ -163,7 +163,7 @@ static MP_THREAD_VOID client_thread(void *p)
         if (fds[1].revents & (POLLIN | POLLHUP | POLLNVAL)) {
             while (1) {
                 char buf[128];
-                bstr append = { buf, 0 };
+                bstr append = { (unsigned char *)buf, 0 };
 
                 ssize_t bytes = read(arg->client_fd, buf, sizeof(buf));
                 if (bytes < 0) {

--- a/input/ipc-win.c
+++ b/input/ipc-win.c
@@ -205,7 +205,7 @@ static MP_THREAD_VOID client_thread(void *p)
     char buf[4096];
     HANDLE wakeup_event = CreateEventW(NULL, TRUE, FALSE, NULL);
     OVERLAPPED ol = { .hEvent = CreateEventW(NULL, TRUE, TRUE, NULL) };
-    bstr client_msg = { talloc_strdup(NULL, ""), 0 };
+    bstr client_msg = { (unsigned char *)talloc_strdup(NULL, ""), 0 };
     DWORD ioerr = 0;
     DWORD r;
 
@@ -269,7 +269,7 @@ static MP_THREAD_VOID client_thread(void *p)
                 goto done;
             }
 
-            bstr_xappend(NULL, &client_msg, (bstr){buf, r});
+            bstr_xappend(NULL, &client_msg, (bstr){(unsigned char *)buf, r});
             while (bstrchr(client_msg, '\n') != -1) {
                 char *reply_msg = mp_ipc_consume_next_command(arg->client,
                     NULL, &client_msg);

--- a/input/keycodes.c
+++ b/input/keycodes.c
@@ -250,7 +250,7 @@ int mp_input_get_key_from_name(const char *name)
     while ((p = strchr(name, '+'))) {
         for (const struct key_name *m = modifier_names; m->name; m++)
             if (!bstrcasecmp(bstr0(m->name),
-                             (struct bstr){(char *)name, p - name})) {
+                             (struct bstr){(unsigned char *)name, p - name})) {
                 modifiers |= m->key;
                 goto found;
             }
@@ -315,7 +315,7 @@ char *mp_input_get_key_name(int key)
 {
     bstr dst = {0};
     mp_input_append_key_name(&dst, key);
-    return dst.start;
+    return (char *)dst.start;
 }
 
 char *mp_input_get_key_combo_name(const int *keys, int max)

--- a/input/keycodes.c
+++ b/input/keycodes.c
@@ -328,7 +328,7 @@ char *mp_input_get_key_combo_name(const int *keys, int max)
         else
             break;
     }
-    return dst.start;
+    return (char *)dst.start;
 }
 
 int mp_input_get_keys_from_string(char *name, int max_num_keys,

--- a/meson.build
+++ b/meson.build
@@ -307,8 +307,7 @@ test_flags = ['-Wdisabled-optimization',
 
 test_flags_c = ['-Wmissing-prototypes',
                 '-Wstrict-prototypes',
-                '-Werror=implicit-function-declaration',
-                '-Wno-pointer-sign']
+                '-Werror=implicit-function-declaration']
 
 flags += cc.get_supported_arguments(test_flags)
 flags_c += cc.get_supported_arguments(test_flags_c)

--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -481,13 +481,13 @@ bool bstr_in_list0(struct bstr str, char **list)
 
 int bstr_to_wchar(void *talloc_ctx, struct bstr s, wchar_t **ret)
 {
-    int count = MultiByteToWideChar(CP_UTF8, 0, s.start, s.len, NULL, 0);
+    int count = MultiByteToWideChar(CP_UTF8, 0, (const char *)s.start, s.len, NULL, 0);
     if (count <= 0)
         abort();
     wchar_t *wbuf = *ret;
     if (!wbuf || ta_get_size(wbuf) < (count + 1) * sizeof(wchar_t))
         wbuf = talloc_realloc(talloc_ctx, wbuf, wchar_t, count + 1);
-    MultiByteToWideChar(CP_UTF8, 0, s.start, s.len, wbuf, count);
+    MultiByteToWideChar(CP_UTF8, 0, (const char *)s.start, s.len, wbuf, count);
     wbuf[count] = L'\0';
     *ret = wbuf;
     return count;

--- a/misc/bstr.c
+++ b/misc/bstr.c
@@ -48,7 +48,7 @@ int bstrcasecmp(struct bstr str1, struct bstr str2)
 {
     int ret = 0;
     if (str1.len && str2.len)
-        ret = strncasecmp(str1.start, str2.start, MPMIN(str1.len, str2.len));
+        ret = strncasecmp((char *)str1.start, (char *)str2.start, MPMIN(str1.len, str2.len));
 
     if (!ret) {
         if (str1.len == str2.len)
@@ -397,7 +397,7 @@ int bstr_xappend_vasprintf(void *talloc_ctx, bstr *s, const char *fmt,
     va_list copy;
     va_copy(copy, ap);
     size_t avail = talloc_get_size(s->start) - s->len;
-    char *dest = s->start ? s->start + s->len : NULL;
+    char *dest = s->start ? (char *)(s->start + s->len) : NULL;
     size = vsnprintf(dest, avail, fmt, copy);
     va_end(copy);
 
@@ -406,7 +406,7 @@ int bstr_xappend_vasprintf(void *talloc_ctx, bstr *s, const char *fmt,
 
     if (avail < 1 || size + 1 > avail) {
         resize_append(talloc_ctx, s, size + 1);
-        vsnprintf(s->start + s->len, size + 1, fmt, ap);
+        vsnprintf((char *)(s->start + s->len), size + 1, fmt, ap);
     }
     s->len += size;
     return size;
@@ -457,7 +457,7 @@ bool bstr_decode_hex(void *talloc_ctx, struct bstr hex, struct bstr *out)
         arr[len++] = (a << 4) | b;
     }
 
-    *out = (struct bstr){ .start = arr, .len = len };
+    *out = (struct bstr){ .start = (unsigned char *)arr, .len = len };
     return true;
 }
 

--- a/misc/charset_conv.c
+++ b/misc/charset_conv.c
@@ -69,7 +69,7 @@ static const char *mp_uchardet(void *talloc_ctx, struct mp_log *log, bstr buf)
     uchardet_t det = uchardet_new();
     if (!det)
         return NULL;
-    if (uchardet_handle_data(det, buf.start, buf.len) != 0) {
+    if (uchardet_handle_data(det, (char *)buf.start, buf.len) != 0) {
         uchardet_delete(det);
         return NULL;
     }
@@ -180,7 +180,7 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
     size_t oleft = size - 1;
 
     char *outbuf = talloc_size(NULL, osize);
-    char *ip = buf.start;
+    char *ip = (char *)buf.start;
     char *op = outbuf;
 
     while (1) {
@@ -222,7 +222,7 @@ bstr mp_iconv_to_utf8(struct mp_log *log, bstr buf, const char *cp, int flags)
     iconv_close(icdsc);
 
     outbuf[osize - oleft - 1] = 0;
-    return (bstr){outbuf, osize - oleft - 1};
+    return (bstr){(unsigned char *)outbuf, osize - oleft - 1};
 
 failure:
 #endif

--- a/misc/json.c
+++ b/misc/json.c
@@ -125,7 +125,7 @@ static int read_str(void *ta_parent, struct mpv_node *dst, char **src)
         bstr r = bstr0(str);
         if (!mp_append_escaped_string(ta_parent, &unescaped, &r))
             return -1; // broken escapes
-        str = unescaped.start; // the function guarantees null-termination
+        str = (char *)unescaped.start; // the function guarantees null-termination
     }
     dst->format = MPV_FORMAT_STRING;
     dst->u.string = str;
@@ -268,9 +268,9 @@ static void write_json_str(bstr *b, unsigned char *str)
             break;
         bstr_xappend(NULL, b, (bstr){str, cur - str});
         if (cur[0] == '\"') {
-            bstr_xappend(NULL, b, (bstr){"\\\"", 2});
+            bstr_xappend(NULL, b, (bstr){(unsigned char *)"\\\"", 2});
         } else if (cur[0] == '\\') {
-            bstr_xappend(NULL, b, (bstr){"\\\\", 2});
+            bstr_xappend(NULL, b, (bstr){(unsigned char *)"\\\\", 2});
         } else if (cur[0] < sizeof(special_escape) && special_escape[cur[0]]) {
             bstr_xappend_asprintf(NULL, b, "\\%c", special_escape[cur[0]]);
         } else {
@@ -278,7 +278,7 @@ static void write_json_str(bstr *b, unsigned char *str)
         }
         str = cur + 1;
     }
-    APPEND(b, str);
+    APPEND(b, (char *)str);
     APPEND(b, "\"");
 }
 
@@ -312,7 +312,7 @@ int json_append(bstr *b, const struct mpv_node *src, int indent)
         if (indent == 0)
             APPEND(b, src->u.string);
         else
-            write_json_str(b, src->u.string);
+            write_json_str(b, (unsigned char *)(src->u.string));
         return 0;
     case MPV_FORMAT_NODE_ARRAY:
     case MPV_FORMAT_NODE_MAP: {
@@ -325,7 +325,7 @@ int json_append(bstr *b, const struct mpv_node *src, int indent)
                 APPEND(b, ",");
             add_indent(b, next_indent);
             if (is_obj) {
-                write_json_str(b, list->keys[n]);
+                write_json_str(b, (unsigned char *)list->keys[n]);
                 APPEND(b, ":");
             }
             json_append(b, &list->values[n], next_indent);
@@ -342,7 +342,7 @@ static int json_append_str(char **dst, struct mpv_node *src, int indent)
 {
     bstr buffer = bstr0(*dst);
     int r = json_append(&buffer, src, indent);
-    *dst = buffer.start;
+    *dst = (char *) buffer.start;
     return r;
 }
 

--- a/misc/path_utils.c
+++ b/misc/path_utils.c
@@ -61,7 +61,7 @@ bstr mp_basename_bstr(bstr path)
 
 const char *mp_basename(const char *path)
 {
-    return mp_basename_bstr(bstr0(path)).start;
+    return (char *)mp_basename_bstr(bstr0(path)).start;
 }
 
 struct bstr mp_dirname(const char *path)

--- a/options/m_config_frontend.c
+++ b/options/m_config_frontend.c
@@ -110,7 +110,7 @@ static int show_profile(struct m_config *config, bstr param, int depth)
                 int l = e - list;
                 if (!l)
                     continue;
-                show_profile(config, (bstr){list, e - list}, depth);
+                show_profile(config, (bstr){(unsigned char *)list, e - list}, depth);
                 list = e + 1;
             }
             if (list[0] != '\0')

--- a/options/m_option.c
+++ b/options/m_option.c
@@ -1418,7 +1418,7 @@ static char **separate_input_param(const m_option_t *opt, bstr param,
 
     char **list = talloc_array(NULL, char *, n + 2);
     str = bstrdup(NULL, param);
-    char *ptr = str.start;
+    char *ptr = (char *)str.start;
     n = 0;
 
     while (1) {

--- a/options/path.c
+++ b/options/path.c
@@ -191,7 +191,7 @@ char *mp_get_user_path(void *talloc_ctx, struct mpv_global *global,
         // parse to "~" <prefix> "/" <rest>
         bstr prefix, rest;
         if (bstr_split_tok(bpath, "/", &prefix, &rest)) {
-            const char *rest0 = rest.start; // ok in this case
+            const char *rest0 = (char *)rest.start; // ok in this case
             if (bstr_equals0(prefix, "~")) {
                 res = mp_find_config_file(talloc_ctx, global, rest0);
                 if (!res) {

--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -65,7 +65,7 @@ static void write_arg(bstr *cmdline, char *arg)
             break;
         case '"':
             // Write the argument up to the point before the quote
-            bstr_xappend(NULL, cmdline, (struct bstr){arg, pos});
+            bstr_xappend(NULL, cmdline, (struct bstr){(unsigned char *)arg, pos});
             arg += pos;
             pos = 0;
 
@@ -107,7 +107,7 @@ static wchar_t *write_cmdline(void *ctx, char *argv0, char **args)
         }
     }
 
-    wchar_t *wcmdline = mp_from_utf8(ctx, cmdline.start);
+    wchar_t *wcmdline = mp_from_utf8(ctx, (char *)cmdline.start);
     talloc_free(cmdline.start);
     return wcmdline;
 }
@@ -382,7 +382,7 @@ void mp_subprocess2(struct mp_subprocess_opts *opts,
     // https://www.catch22.net/tuts/undocumented-createprocess>
     si.StartupInfo.cbReserved2 = sizeof(int) + crt_fd_count * (1 + sizeof(intptr_t));
     si.StartupInfo.lpReserved2 = talloc_size(tmp, si.StartupInfo.cbReserved2);
-    char *crt_buf_flags = si.StartupInfo.lpReserved2 + sizeof(int);
+    char *crt_buf_flags = (char *)si.StartupInfo.lpReserved2 + sizeof(int);
     char *crt_buf_hndls = crt_buf_flags + crt_fd_count;
 
     memcpy(si.StartupInfo.lpReserved2, &crt_fd_count, sizeof(int));

--- a/player/clipboard/clipboard-x11.c
+++ b/player/clipboard/clipboard-x11.c
@@ -165,13 +165,13 @@ static void clipboard_x11_handle_selection_notify(struct clipboard_x11_priv *x11
     if (actual_type == XA(x11, UTF8_STRING) && selection == XA(x11, CLIPBOARD)) {
         mp_mutex_lock(&x11->lock);
         talloc_free(x11->selection_text.start);
-        x11->selection_text = bstrdup(x11, bstr0(data));
+        x11->selection_text = bstrdup(x11, bstr0((char *)data));
         x11->data_changed = true;
         mp_mutex_unlock(&x11->lock);
     } else if (actual_type == XA(x11, UTF8_STRING) && selection == XA_PRIMARY) {
         mp_mutex_lock(&x11->lock);
         talloc_free(x11->primary_selection_text.start);
-        x11->primary_selection_text = bstrdup(x11, bstr0(data));
+        x11->primary_selection_text = bstrdup(x11, bstr0((char *)data));
         x11->data_changed = true;
         mp_mutex_unlock(&x11->lock);
     }

--- a/player/command.c
+++ b/player/command.c
@@ -559,7 +559,7 @@ static int mp_property_env(void *ctx, struct m_property *prop,
             char *sep = strchr(*env, '=');
             if (!sep)
                 continue;
-            bstr key = { .start = *env, .len = sep - *env };
+            bstr key = { .start = (unsigned char *)*env, .len = sep - *env };
             struct mpv_node *np = node_map_badd(&node, key, MPV_FORMAT_NONE);
             np->format = MPV_FORMAT_STRING;
             np->u.string = talloc_strdup(node.u.list, sep + 1);
@@ -5010,7 +5010,7 @@ char *mp_property_expand_escaped_string(struct MPContext *mpctx, const char *str
             break;
         bstr_xappend(tmp, &dst, bstr0("\""));
     }
-    char *r = mp_property_expand_string(mpctx, dst.start);
+    char *r = mp_property_expand_string(mpctx, (char *)dst.start);
     talloc_free(tmp);
     return r;
 }
@@ -6802,7 +6802,7 @@ static void subprocess_read(void *p, char *data, size_t size)
     struct subprocess_fd_ctx *ctx = p;
     if (ctx->capture) {
         if (ctx->output.len < ctx->max_size)
-            bstr_xappend(ctx->talloc_ctx, &ctx->output, (bstr){data, size});
+            bstr_xappend(ctx->talloc_ctx, &ctx->output, (bstr){(unsigned char *)data, size});
     } else {
         mp_msg(ctx->log, ctx->msgl, "%.*s", (int)size, data);
     }

--- a/player/configfiles.c
+++ b/player/configfiles.c
@@ -219,7 +219,7 @@ static char *mp_get_playback_resume_config_filename(struct MPContext *mpctx,
     if (opts->ignore_path_in_watch_later_config && !mp_is_url(bstr0(path)))
         path = mp_basename(path);
 
-    bstr hashstr = mp_hash_to_bstr(tmp, path, strlen(path), "MD5");
+    bstr hashstr = mp_hash_to_bstr(tmp, (const uint8_t *)path, strlen(path), "MD5");
     char *wl_dir = mp_get_playback_resume_dir(mpctx);
     if (wl_dir && wl_dir[0])
         res = mp_path_join_bstr(NULL, bstr0(wl_dir), hashstr);

--- a/player/javascript.c
+++ b/player/javascript.c
@@ -362,7 +362,7 @@ static void af_push_file(js_State *J, const char *fname, int limit, void *af)
     bstr data = stream_read_file2(filename, af, flags,
                                   jctx(J)->mpctx->global, limit);
     if (data.start) {
-        js_pushlstring(J, data.start, data.len);
+        js_pushlstring(J, (char *)data.start, data.len);
     } else {
         js_error(J, "cannot open file: '%s'", filename);
     }
@@ -942,7 +942,7 @@ static void script_split_path(js_State *J)
     const char *p = js_tostring(J, 1);
     bstr fname = mp_dirname(p);
     js_newarray(J);
-    js_pushlstring(J, fname.start, fname.len);
+    js_pushlstring(J, (char *)fname.start, fname.len);
     js_setindex(J, -2, 0);
     js_pushstring(J, mp_basename(p));
     js_setindex(J, -2, 1);

--- a/player/lua.c
+++ b/player/lua.c
@@ -268,7 +268,7 @@ static void load_file(lua_State *L, const char *fname)
     struct bstr s = stream_read_file(fname, tmp, ctx->mpctx->global, 100000000);
     if (!s.start)
         luaL_error(L, "Could not read file.\n");
-    if (luaL_loadbuffer(L, s.start, s.len, dispname))
+    if (luaL_loadbuffer(L, (char *)s.start, s.len, dispname))
         lua_error(L);
     lua_call(L, 0, 1);
     talloc_free(tmp);
@@ -1156,7 +1156,7 @@ static int script_split_path(lua_State *L)
 {
     const char *p = luaL_checkstring(L, 1);
     bstr fname = mp_dirname(p);
-    lua_pushlstring(L, fname.start, fname.len);
+    lua_pushlstring(L, (char *)fname.start, fname.len);
     lua_pushstring(L, mp_basename(p));
     return 2;
 }

--- a/stream/cookies.c
+++ b/stream/cookies.c
@@ -89,8 +89,8 @@ static struct cookie_list_type *load_cookies_from(void *ctx,
         return NULL;
     }
 
-    bstr_xappend(ctx, &data, (struct bstr){"", 1}); // null-terminate
-    char *ptr = data.start;
+    bstr_xappend(ctx, &data, (struct bstr){(unsigned char *)"", 1}); // null-terminate
+    char *ptr = (char *)data.start;
 
     struct cookie_list_type *list = NULL;
     while (*ptr) {

--- a/stream/stream.c
+++ b/stream/stream.c
@@ -808,7 +808,7 @@ int stream_skip_bom(struct stream *s)
 {
     char buf[4];
     int len = stream_read_peek(s, buf, sizeof(buf));
-    bstr data = {buf, len};
+    bstr data = {(unsigned char *)buf, len};
     for (int n = 0; n < 3; n++) {
         if (bstr_startswith0(data, bom[n])) {
             stream_seek_skip(s, stream_tell(s) + strlen(bom[n]));
@@ -868,7 +868,7 @@ struct bstr stream_read_complete(struct stream *s, void *talloc_ctx,
     }
     buf = talloc_realloc_size(talloc_ctx, buf, total_read + padding);
     memset(&buf[total_read], 0, padding);
-    return (struct bstr){buf, total_read};
+    return (struct bstr){(unsigned char *)buf, total_read};
 }
 
 struct bstr stream_read_file(const char *filename, void *talloc_ctx,

--- a/stream/stream_bluray.c
+++ b/stream/stream_bluray.c
@@ -578,7 +578,7 @@ static bool check_bdmv(const char *path)
     bool ret = false;
 
     if (fread(data, 50, 1, temp) == 1) {
-        bstr bdata = {data, 50};
+        bstr bdata = {(unsigned char *)data, 50};
         ret = bstr_startswith0(bdata, "MOBJ0100") || // AVCHD
               bstr_startswith0(bdata, "MOBJ0200") || // Blu-ray
               bstr_startswith0(bdata, "MOBJ0300");   // UHD BD

--- a/stream/stream_curl.c
+++ b/stream/stream_curl.c
@@ -561,7 +561,7 @@ static size_t header_callback(char *buffer, size_t size, size_t nitems, void *us
     if (p->probed)
         return bytes;
 
-    struct bstr line = bstr_strip_linebreaks((bstr){buffer, bytes});
+    struct bstr line = bstr_strip_linebreaks((bstr){(unsigned char *)buffer, bytes});
     switch (p->scheme->proto) {
     case MP_CURL_PROTO_HTTP:
         probe_http(p, line);
@@ -587,7 +587,7 @@ static int debug_callback(CURL *handle, curl_infotype type, char *data, size_t s
     case CURLINFO_HEADER_OUT: prefix = "> "; break;
     default:                  return 0;
     }
-    bstr msg = bstr_strip_linebreaks((bstr){data, size});
+    bstr msg = bstr_strip_linebreaks((bstr){(unsigned char *)data, size});
     MP_TRACE(p, "%s%.*s\n", prefix, BSTR_P(msg));
     return 0;
 }
@@ -1100,11 +1100,11 @@ static bool is_protocol_allowed(struct mp_log *log, bstr scheme,
     // `scheme` is required to be wrapped null-terminated string literal.
     // This is UB otherwise, see curl_schemes.
     mp_assert(scheme.len && scheme.start[scheme.len] == '\0');
-    if (whitelist && av_match_list(scheme.start, whitelist, ',') <= 0) {
+    if (whitelist && av_match_list((char *)scheme.start, whitelist, ',') <= 0) {
         mp_err(log, "Protocol '%.*s' not on whitelist '%s'!\n", BSTR_P(scheme), whitelist);
         return false;
     }
-    if (blacklist && av_match_list(scheme.start, blacklist, ',') > 0) {
+    if (blacklist && av_match_list((char *)scheme.start, blacklist, ',') > 0) {
         mp_err(log, "Protocol '%.*s' on blacklist '%s'!\n", BSTR_P(scheme), blacklist);
         return false;
     }
@@ -1324,7 +1324,7 @@ int mp_curl_avio_open(struct demuxer *demuxer, AVIOContext **pb_out,
     if (bstr_eatstart0(&rest, "crypto+") || bstr_eatstart0(&rest, "crypto:")) {
         if (!is_protocol_allowed(demuxer->log, (bstr)bstr0_lit("crypto"), whitelist, blacklist))
             return AVERROR(EINVAL);
-        return open_curl_crypto(demuxer, pb_out, cookie_out, rest.start,
+        return open_curl_crypto(demuxer, pb_out, cookie_out, (char *)rest.start,
                                 flags, options, whitelist, blacklist);
     }
 

--- a/stream/stream_dvdnav.c
+++ b/stream/stream_dvdnav.c
@@ -475,14 +475,14 @@ static int control(stream_t *stream, int cmd, void *arg)
     }
     case STREAM_CTRL_GET_NUM_ANGLES: {
         uint32_t curr, angles;
-        if (dvdnav_get_angle_info(dvdnav, &curr, &angles) != DVDNAV_STATUS_OK)
+        if (dvdnav_get_angle_info(dvdnav, (int32_t *)&curr, (int32_t *)&angles) != DVDNAV_STATUS_OK)
             break;
         *(int *)arg = angles;
         return STREAM_OK;
     }
     case STREAM_CTRL_GET_ANGLE: {
         uint32_t curr, angles;
-        if (dvdnav_get_angle_info(dvdnav, &curr, &angles) != DVDNAV_STATUS_OK)
+        if (dvdnav_get_angle_info(dvdnav, (int32_t *)&curr, (int32_t *)&angles) != DVDNAV_STATUS_OK)
             break;
         *(int *)arg = curr;
         return STREAM_OK;
@@ -490,7 +490,7 @@ static int control(stream_t *stream, int cmd, void *arg)
     case STREAM_CTRL_SET_ANGLE: {
         uint32_t curr, angles;
         int new_angle = *(int *)arg;
-        if (dvdnav_get_angle_info(dvdnav, &curr, &angles) != DVDNAV_STATUS_OK)
+        if (dvdnav_get_angle_info(dvdnav, (int32_t *)&curr, (int32_t *)&angles) != DVDNAV_STATUS_OK)
             break;
         if (new_angle > angles || new_angle < 1)
             break;

--- a/stream/stream_lavf.c
+++ b/stream/stream_lavf.c
@@ -408,7 +408,7 @@ static int open_f(stream_t *stream)
     if (avio->av_class) {
         uint8_t *mt = NULL;
         if (av_opt_get(avio, "mime_type", AV_OPT_SEARCH_CHILDREN, &mt) >= 0) {
-            stream->mime_type = talloc_strdup(stream, mt);
+            stream->mime_type = talloc_strdup(stream, (char *)mt);
             av_free(mt);
         }
     }
@@ -454,9 +454,9 @@ static struct mp_tags *read_icy(stream_t *s)
     // To detect new packages, set the icy_metadata_packet to "-" once we've
     // read it (a bit hacky, but works).
     struct mp_tags *res = NULL;
-    bstr packet = bstr0(icy_packet);
+    bstr packet = bstr0((char *)icy_packet);
     if (!bstr_equals0(packet, "-"))
-        res = mp_parse_icy_metadata(s, bstr0(icy_header), packet);
+        res = mp_parse_icy_metadata(s, bstr0((char *)icy_header), packet);
 
     if (res)
         av_opt_set(avio, "icy_metadata_packet", "-", AV_OPT_SEARCH_CHILDREN);

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -462,7 +462,7 @@ char *sub_ass_get_extradata(struct dec_sub *sub)
     mp_mutex_lock(&sub->lock);
     if (strcmp(sub->sd->codec->codec, "ass") != 0)
         goto done;
-    char *extradata = sub->sd->codec->extradata;
+    char *extradata = (char *)sub->sd->codec->extradata;
     int extradata_size = sub->sd->codec->extradata_size;
     data = talloc_strndup(NULL, extradata, extradata_size);
 done:

--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -465,7 +465,7 @@ static struct demux_packet *sdh_filter(struct sd_filter *ft,
     char *line = filter_SDH(ft, (char *)pkt->buffer, (int)pkt->len, toff);
     if (!line)
         return NULL;
-    if (0 == bstrcmp0((bstr){(char *)pkt->buffer, pkt->len}, line)) {
+    if (0 == bstrcmp0((bstr){(unsigned char *)pkt->buffer, pkt->len}, line)) {
         talloc_free(line);
         return pkt;  // unmodified, no need to allocate new packet
     }

--- a/sub/lavc_conv.c
+++ b/sub/lavc_conv.c
@@ -101,7 +101,7 @@ struct lavc_conv *lavc_conv_create(struct sd *sd)
     avctx->pkt_timebase = avctx->time_base;
     avctx->sub_charenc_mode = FF_SUB_CHARENC_MODE_IGNORE;
     priv->avctx = avctx;
-    priv->extradata = talloc_strndup(priv, avctx->subtitle_header,
+    priv->extradata = talloc_strndup(priv, (char *)avctx->subtitle_header,
                                      avctx->subtitle_header_size);
     mp_codec_info_from_av(avctx, sd->codec);
     // Keep original codec name, which get_lavc_format() may have transformed

--- a/sub/osd_libass.c
+++ b/sub/osd_libass.c
@@ -245,7 +245,7 @@ void osd_mangle_ass(bstr *dst, const char *in, bool replace_newlines)
             in += 1;
             continue;
         }
-        bstr_xappend(NULL, dst, (bstr){(char *)in, 1});
+        bstr_xappend(NULL, dst, (bstr){(unsigned char *)in, 1});
         // Break ASS escapes with U+2060 WORD JOINER
         if (escape_ass && *in == '\\')
             mp_append_utf8_bstr(NULL, dst, 0x2060);

--- a/sub/sd_ass.c
+++ b/sub/sd_ass.c
@@ -267,7 +267,7 @@ static void assobjects_init(struct sd *sd)
     ctx->shadow_track->PlayResY = MP_ASS_FONT_PLAYRESY;
     mp_ass_add_default_styles(sd, ctx->shadow_track, opts, shared_opts);
 
-    char *extradata = sd->codec->extradata;
+    char *extradata = (char *)sd->codec->extradata;
     int extradata_size = sd->codec->extradata_size;
     if (ctx->converter) {
         extradata = lavc_conv_get_extradata(ctx->converter);
@@ -384,7 +384,7 @@ static void filter_and_add(struct sd *sd, struct demux_packet *pkt)
             return;
     }
 
-    ass_process_chunk(ctx->ass_track, pkt->buffer, pkt->len,
+    ass_process_chunk(ctx->ass_track, (char *)pkt->buffer, pkt->len,
                       floor(pkt->pts * 1000 + 1e-6),
                       floor(pkt->duration * 1000 + 1e-6));
 
@@ -477,7 +477,7 @@ static void decode(struct sd *sd, struct demux_packet *packet)
             struct demux_packet pkt2 = {
                 .pts = sub_pts,
                 .duration = sub_duration,
-                .buffer = r[n],
+                .buffer = (unsigned char *)r[n],
                 .len = strlen(r[n]),
             };
             filter_and_add(sd, &pkt2);
@@ -796,7 +796,7 @@ done:
 
 static void append(bstr *b, char c)
 {
-    bstr_xappend(NULL, b, (bstr){&c, 1});
+    bstr_xappend(NULL, b, (bstr){(unsigned char *)&c, 1});
 }
 
 static void ass_to_plaintext(bstr *b, const char *in)
@@ -987,7 +987,7 @@ static void fill_plaintext(struct sd *sd, double pts)
     event->Start = 0;
     event->Duration = INT_MAX;
     event->Style = track->default_style;
-    event->Text = strdup(dst.start);
+    event->Text = strdup((char *)dst.start);
 
     talloc_free(dst.start);
 }
@@ -1238,7 +1238,7 @@ int sd_ass_fmt_offset(const char *evt_fmt)
 bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset)
 {
     // e.g. pkt->buffer ("4" is ReadOrder): "4,0,Default,,0,0,0,,fifth line"
-    bstr txt = {(char *)pkt->buffer, pkt->len}, t0 = txt;
+    bstr txt = {(unsigned char *)pkt->buffer, pkt->len}, t0 = txt;
     while (offset-- > 0) {
         int n = bstrchr(txt, ',');
         if (n < 0) {  // shouldn't happen
@@ -1252,8 +1252,8 @@ bstr sd_ass_pkt_text(struct sd_filter *ft, struct demux_packet *pkt, int offset)
 
 bstr sd_ass_to_plaintext(char **out, const char *in)
 {
-    bstr b = {*out};
+    bstr b = {(unsigned char *)*out};
     ass_to_plaintext(&b, in);
-    *out = b.start;
+    *out = (char *)b.start;
     return b;
 }

--- a/sub/sd_sbr.c
+++ b/sub/sd_sbr.c
@@ -150,7 +150,7 @@ static void decode(struct sd *sd, struct demux_packet *packet)
 
     ctx->sbr_subtitles = sbr_load_text(
         ctx->sbr_library,
-        packet->buffer,
+        (char *)packet->buffer,
         packet->len,
         fmt,
         sd->lang

--- a/test/paths.c
+++ b/test/paths.c
@@ -88,7 +88,7 @@ int main(void)
         p++;
     }
 #endif
-    TEST_NORMALIZE(dst.start, "foo");
+    TEST_NORMALIZE((char *)dst.start, "foo");
     talloc_free(ctx);
 
 #if HAVE_DOS_PATHS

--- a/test/paths.c
+++ b/test/paths.c
@@ -82,7 +82,7 @@ int main(void)
     bstr dst = bstr0(mp_getcwd(ctx));
     bstr_xappend(ctx, &dst, bstr0("/foo"));
 #if HAVE_DOS_PATHS
-    char *p = dst.start;
+    char *p = (char *)dst.start;
     while (*p) {
         *p = *p == '/' ? '\\' : *p;
         p++;

--- a/video/filter/vf_vavpp.c
+++ b/video/filter/vf_vavpp.c
@@ -370,7 +370,7 @@ static bool initialize(struct mp_filter *vf)
 
     VAProcFilterType filters[VAProcFilterCount];
     int num_filters = VAProcFilterCount;
-    status = vaQueryVideoProcFilters(p->display, p->context, filters, &num_filters);
+    status = vaQueryVideoProcFilters(p->display, p->context, filters, (unsigned int *)&num_filters);
     if (!CHECK_VA_STATUS(vf, "vaQueryVideoProcFilters()"))
         return false;
 

--- a/video/out/d3d11/ra_d3d11.c
+++ b/video/out/d3d11/ra_d3d11.c
@@ -1614,7 +1614,7 @@ static void save_cached_program(struct ra *ra, struct ra_renderpass *pass,
     strncpy(header.compiler, spirv->name, sizeof(header.compiler));
 
     struct bstr *prog = &pass->params.cached_program;
-    bstr_xappend(pass, prog, (bstr){ (char *) &header, sizeof(header) });
+    bstr_xappend(pass, prog, (bstr){ (unsigned char *) &header, sizeof(header) });
     bstr_xappend(pass, prog, vert_bc);
     bstr_xappend(pass, prog, frag_bc);
     bstr_xappend(pass, prog, comp_bc);
@@ -1825,7 +1825,7 @@ static void renderpass_run_raster(struct ra *ra,
 
     ID3D11DeviceContext_IASetInputLayout(p->ctx, pass_p->layout);
     ID3D11DeviceContext_IASetVertexBuffers(p->ctx, 0, 1, &p->vbuf,
-        &pass->params.vertex_stride, &vbuf_offset);
+    (const unsigned int *)&pass->params.vertex_stride, &vbuf_offset);
     ID3D11DeviceContext_IASetPrimitiveTopology(p->ctx,
         D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 

--- a/video/out/gpu/shader_cache.c
+++ b/video/out/gpu/shader_cache.c
@@ -893,17 +893,17 @@ static void gl_sc_generate(struct gl_shader_cache *sc,
 
     if (frag) {
         ADD_BSTR(hash_total, *frag);
-        sc->params.frag_shader = frag->start;
+        sc->params.frag_shader = (char *)frag->start;
     }
     ADD(hash_total, "\n");
     if (vert) {
         ADD_BSTR(hash_total, *vert);
-        sc->params.vertex_shader = vert->start;
+        sc->params.vertex_shader = (char *)vert->start;
     }
     ADD(hash_total, "\n");
     if (comp) {
         ADD_BSTR(hash_total, *comp);
-        sc->params.compute_shader = comp->start;
+        sc->params.compute_shader = (char *)comp->start;
     }
     ADD(hash_total, "\n");
 

--- a/video/out/gpu/spirv_shaderc.c
+++ b/video/out/gpu/spirv_shaderc.c
@@ -36,7 +36,7 @@ static bool shaderc_init(struct ra_ctx *ctx)
     if (ctx->opts.debug)
         shaderc_compile_options_set_generate_debug_info(p->opts);
 
-    int ver, rev;
+    unsigned int ver, rev;
     shaderc_get_spv_version(&ver, &rev);
     ctx->spirv->compiler_version = ver * 100 + rev; // forwards compatibility
     ctx->spirv->glsl_version = 450; // impossible to query?

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -2328,7 +2328,7 @@ static void pass_read_video(struct gl_video *p)
             continue;
 
         int first = n;
-        int num = 0;
+        unsigned int num = 0;
 
         for (int i = 0; i < n; i++) {
             if (image_equiv(img[n], img[i]) &&
@@ -2519,7 +2519,7 @@ static void pass_read_video(struct gl_video *p)
 
     // All planes are of the same size and properly aligned at this point
     pass_describe(p, "combining planes");
-    int coord = 0;
+    unsigned int coord = 0;
     for (int i = 0; i < 4; i++) {
         if (img[i].type != PLANE_NONE)
             copy_image(p, &coord, img[i]);
@@ -3163,7 +3163,7 @@ static void pass_render_frame_dumb(struct gl_video *p)
     struct gl_transform transform;
     compute_src_transform(p, &transform);
 
-    int index = 0;
+    unsigned int index = 0;
     for (int i = 0; i < p->plane_count; i++) {
         int cw = img[i].type == PLANE_CHROMA ? p->ra_format.chroma_w : 1;
         int ch = img[i].type == PLANE_CHROMA ? p->ra_format.chroma_h : 1;

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -1727,7 +1727,7 @@ found: ;
     finish_pass_tex(p, tex, p->texture_w, p->texture_h);
     struct image img = image_wrap(*tex, PLANE_RGB, p->components);
     img = pass_hook(p, name, img, tex_trans, 4);
-    copy_image(p, &(int){0}, img);
+    copy_image(p, &(unsigned int){0}, img);
     p->texture_w = img.w;
     p->texture_h = img.h;
     p->components = img.components;
@@ -2356,7 +2356,7 @@ static void pass_read_video(struct gl_video *p)
     for (int n = 0; n < 4; n++) {
         if (img[n].tex && img[n].tex->params.format->ctype == RA_CTYPE_UINT) {
             GLSLF("// use_integer fix for plane %d\n", n);
-            copy_image(p, &(int){0}, img[n]);
+            copy_image(p, &(unsigned int){0}, img[n]);
             pass_describe(p, "use_integer fix");
             finish_pass_tex(p, &p->integer_tex[n], img[n].w, img[n].h);
             img[n] = image_wrap(p->integer_tex[n], img[n].type,
@@ -2413,7 +2413,7 @@ static void pass_read_video(struct gl_video *p)
             p->ra_format.chroma_w != 1)
         {
             GLSLF("// chroma fix for rotated plane %d\n", n);
-            copy_image(p, &(int){0}, img[n]);
+            copy_image(p, &(unsigned int){0}, img[n]);
             pass_describe(p, "chroma fix for rotated plane");
             finish_pass_tex(p, &p->chroma_tex[n], img[n].w, img[n].h);
             img[n] = image_wrap(p->chroma_tex[n], img[n].type,
@@ -2532,7 +2532,7 @@ static void pass_read_video(struct gl_video *p)
 static void pass_read_tex(struct gl_video *p, struct ra_tex *tex)
 {
     struct image img = image_wrap(tex, PLANE_RGB, p->components);
-    copy_image(p, &(int){0}, img);
+    copy_image(p, &(unsigned int){0}, img);
 }
 
 // yuv conversion, and any other conversions before main up/down-scaling
@@ -3008,7 +3008,7 @@ static void pass_dither(struct gl_video *p, const struct ra_fbo *fbo)
             finish_pass_tex(p, &p->error_diffusion_tex[1], o_w, o_h);
 
             img = image_wrap(p->error_diffusion_tex[1], PLANE_RGB, p->components);
-            copy_image(p, &(int){0}, img);
+            copy_image(p, &(unsigned int){0}, img);
 
             return;
         }
@@ -3300,7 +3300,7 @@ static void pass_draw_to_screen(struct gl_video *p, const struct ra_fbo *fbo, in
             o_h = p->dst_rect.y1 - p->dst_rect.y0;
         finish_pass_tex(p, &p->screen_tex, o_w, o_h);
         struct image tmp = image_wrap(p->screen_tex, PLANE_RGB, p->components);
-        copy_image(p, &(int){0}, tmp);
+        copy_image(p, &(unsigned int){0}, tmp);
     }
 
     if (p->has_alpha) {
@@ -3824,7 +3824,7 @@ static void frame_perf_data(struct pass_info pass[], struct mp_frame_perf *out)
         if (!pass[i].desc.len)
             break;
         out->perf[out->count] = pass[i].perf;
-        strncpy(out->desc[out->count], pass[i].desc.start,
+        strncpy(out->desc[out->count], (char *)pass[i].desc.start,
                 sizeof(out->desc[out->count]) - 1);
         out->desc[out->count][sizeof(out->desc[out->count]) - 1] = '\0';
         out->count++;

--- a/video/out/opengl/common.c
+++ b/video/out/opengl/common.c
@@ -36,7 +36,7 @@
 // This guesses if the current GL context is a suspected software renderer.
 static bool is_software_gl(GL *gl)
 {
-    const char *renderer = gl->GetString(GL_RENDERER);
+    const char *renderer = (const char *)gl->GetString(GL_RENDERER);
     // Note we don't attempt to blacklist Microsoft's fallback implementation.
     // It only provides OpenGL 1.1 and will be skipped anyway.
     return !renderer ||
@@ -50,7 +50,7 @@ static bool is_software_gl(GL *gl)
 // This guesses whether our DR path is fast or slow
 static bool is_fast_dr(GL *gl)
 {
-    const char *vendor = gl->GetString(GL_VENDOR);
+    const char *vendor = (const char *)gl->GetString(GL_VENDOR);
     if (!vendor)
         return false;
 
@@ -527,7 +527,7 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
     }
 
     int major = 0, minor = 0;
-    const char *version_string = gl->GetString(GL_VERSION);
+    const char *version_string = (const char *)gl->GetString(GL_VERSION);
     if (!version_string) {
         mp_fatal(log, "glGetString(GL_VERSION) returned NULL.\n");
         goto error;
@@ -554,7 +554,7 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
 
     mp_verbose(log, "GL_VENDOR='%s'\n",   gl->GetString(GL_VENDOR));
     mp_verbose(log, "GL_RENDERER='%s'\n", gl->GetString(GL_RENDERER));
-    const char *shader = gl->GetString(GL_SHADING_LANGUAGE_VERSION);
+    const char *shader = (const char *)gl->GetString(GL_SHADING_LANGUAGE_VERSION);
     if (shader)
         mp_verbose(log, "GL_SHADING_LANGUAGE_VERSION='%s'\n", shader);
 
@@ -568,7 +568,7 @@ void mpgl_load_functions2(GL *gl, void *(*get_fn)(void *ctx, const char *n),
         GLint exts;
         gl->GetIntegerv(GL_NUM_EXTENSIONS, &exts);
         for (int n = 0; n < exts; n++) {
-            const char *ext = gl->GetStringi(GL_EXTENSIONS, n);
+            const char *ext = (const char *)gl->GetStringi(GL_EXTENSIONS, n);
             gl->extensions = talloc_asprintf_append(gl->extensions, " %s", ext);
         }
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2544,7 +2544,7 @@ static const struct pl_hook *load_hook(struct priv *p, const char *path)
 
     const struct pl_hook *hook = NULL;
     if (shader.len)
-        hook = pl_mpv_user_shader_parse(p->gpu, shader.start, shader.len);
+        hook = pl_mpv_user_shader_parse(p->gpu, (char *)shader.start, shader.len);
 
     MP_TARRAY_APPEND(p, p->user_hooks, p->num_user_hooks, (struct user_hook) {
         .path = talloc_strdup(p, path),
@@ -2617,7 +2617,7 @@ static void update_lut(struct priv *p, struct user_lut *lut)
         MP_ERR(p, "Failed to read LUT data from %s, make sure it's a valid file "
                   "and smaller or equal to %d bytes\n", fname, lut_max_size);
     } else {
-        lut->lut = pl_lut_parse_cube(p->pllog, lutdata.start, lutdata.len);
+        lut->lut = pl_lut_parse_cube(p->pllog, (char *)lutdata.start, lutdata.len);
     }
     talloc_free(fname);
     talloc_free(lutdata.start);

--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -74,7 +74,7 @@ static inline void write_bstr(bstr bs)
 
 static inline void write_str(unsigned char* s)
 {
-    write_bstr(bstr0(s));
+    write_bstr(bstr0((char *)s));
 }
 
 #define KITTY_ESC_IMG        "\033_Ga=T,f=24,s=%d,v=%d,C=1,q=2,m=1;"
@@ -226,7 +226,7 @@ static int reconfig(struct vo *vo, struct mp_image_params *params)
     write_bstr_passthrough(p, KITTY_ESC_END);
 
     if (p->opts.config_clear)
-        write_str(TERM_ESC_CLEAR_SCREEN);
+        write_str((unsigned char *)TERM_ESC_CLEAR_SCREEN);
 
     get_win_size(vo, &p->rows, &p->cols, &vo->dwidth, &vo->dheight);
     set_out_params(vo);
@@ -371,7 +371,7 @@ static void flip_page(struct vo *vo)
                                             offset + chunk < output_size);
 
             // Append at max chunk bytes
-            bstr_xappend(p, &p->cmd, (bstr){p->output + offset, chunk});
+            bstr_xappend(p, &p->cmd, (bstr){(unsigned char *)p->output + offset, chunk});
             append_passthrough(p, &p->cmd, KITTY_ESC_END);
             offset += chunk;
         }
@@ -423,7 +423,7 @@ static int preinit(struct vo *vo)
         int p_size = strlen(p->shm_path) - 1;
         int b64_size = AV_BASE64_SIZE(p_size);
         p->shm_path_b64 = talloc_array(vo, char, b64_size);
-        av_base64_encode(p->shm_path_b64, b64_size, p->shm_path + 1, p_size);
+        av_base64_encode(p->shm_path_b64, b64_size, (uint8_t *)p->shm_path + 1, p_size);
     }
 #else
     if (p->opts.use_shm) {
@@ -443,10 +443,10 @@ static int preinit(struct vo *vo)
             p->dcs_suffix = DCS_SUFFIX;
     }
 
-    write_str(TERM_ESC_HIDE_CURSOR);
+    write_str((unsigned char *)TERM_ESC_HIDE_CURSOR);
     terminal_set_mouse_input(true);
     if (p->opts.alt_screen)
-        write_str(TERM_ESC_ALT_SCREEN);
+        write_str((unsigned char *)TERM_ESC_ALT_SCREEN);
 
     return 0;
 }
@@ -474,14 +474,14 @@ static void uninit(struct vo *vo)
     write_bstr_passthrough(p, KITTY_ESC_DELETE_ALL);
     write_bstr_passthrough(p, KITTY_ESC_END);
 
-    write_str(TERM_ESC_RESTORE_CURSOR);
+    write_str((unsigned char *)TERM_ESC_RESTORE_CURSOR);
     terminal_set_mouse_input(false);
 
     if (p->opts.alt_screen) {
-        write_str(TERM_ESC_NORMAL_SCREEN);
+        write_str((unsigned char *)TERM_ESC_NORMAL_SCREEN);
     } else {
         char *cmd = talloc_asprintf(vo, TERM_ESC_GOTO_YX, p->cols, 0);
-        write_str(cmd);
+        write_str((unsigned char *)cmd);
     }
 
     free_bufs(vo);

--- a/video/out/vo_tct.c
+++ b/video/out/vo_tct.c
@@ -115,16 +115,16 @@ static void print_seq3(bstr *frame, struct lut_item *lut, bstr prefix,
                        uint8_t r, uint8_t g, uint8_t b)
 {
     bstr_xappend(NULL, frame, prefix);
-    bstr_xappend(NULL, frame, (bstr){ lut[r].str, lut[r].width });
-    bstr_xappend(NULL, frame, (bstr){ lut[g].str, lut[g].width });
-    bstr_xappend(NULL, frame, (bstr){ lut[b].str, lut[b].width });
+    bstr_xappend(NULL, frame, (bstr){ (unsigned char *)lut[r].str, lut[r].width });
+    bstr_xappend(NULL, frame, (bstr){ (unsigned char *)lut[g].str, lut[g].width });
+    bstr_xappend(NULL, frame, (bstr){ (unsigned char *)lut[b].str, lut[b].width });
     bstr_xappend0(NULL, frame, "m");
 }
 
 static void print_seq1(bstr *frame, struct lut_item *lut, bstr prefix, uint8_t c)
 {
     bstr_xappend(NULL, frame, prefix);
-    bstr_xappend(NULL, frame, (bstr){ lut[c].str, lut[c].width });
+    bstr_xappend(NULL, frame, (bstr){ (unsigned char *)lut[c].str, lut[c].width });
     bstr_xappend0(NULL, frame, "m");
 }
 

--- a/video/out/vo_vaapi.c
+++ b/video/out/vo_vaapi.c
@@ -787,7 +787,7 @@ static int preinit(struct vo *vo)
     status = vaQuerySubpictureFormats(p->display,
                                       p->va_subpic_formats,
                                       p->va_subpic_flags,
-                                      &p->va_num_subpic_formats);
+                                      (unsigned int *)&p->va_num_subpic_formats);
     if (!CHECK_VA_STATUS(p, "vaQuerySubpictureFormats()"))
         p->va_num_subpic_formats = 0;
     MP_VERBOSE(vo, "%d subpicture formats available:\n",

--- a/video/out/vo_x11.c
+++ b/video/out/vo_x11.c
@@ -247,7 +247,7 @@ static bool resize(struct vo *vo)
         *img = (struct mp_image){0};
         mp_image_setfmt(img, mpfmt);
         mp_image_set_size(img, p->image_width, p->image_height);
-        img->planes[0] = p->myximage[i]->data;
+        img->planes[0] = (uint8_t *)p->myximage[i]->data;
         img->stride[0] = p->myximage[i]->bytes_per_line;
 
         mp_image_params_guess_csp(&img->params);

--- a/video/out/vo_xv.c
+++ b/video/out/vo_xv.c
@@ -652,7 +652,7 @@ static struct mp_image get_xv_buffer(struct vo *vo, int buf_index)
     bool swapuv = ctx->xv_format == MP_FOURCC_YV12;
     for (int n = 0; n < img.num_planes; n++) {
         int sn = n > 0 &&  swapuv ? (n == 1 ? 2 : 1) : n;
-        img.planes[n] = xv_image->data + xv_image->offsets[sn];
+        img.planes[n] = (uint8_t *)xv_image->data + xv_image->offsets[sn];
         img.stride[n] = xv_image->pitches[sn];
     }
 

--- a/video/out/vulkan/context_display.c
+++ b/video/out/vulkan/context_display.c
@@ -69,7 +69,7 @@ static bool walk_display_properties(struct mp_log *log,
 
     // Count displays. This must be done before enumerating planes with the
     // Intel driver, or it will not enumerate any planes. WTF.
-    int num_displays = 0;
+    uint32_t num_displays = 0;
     vkGetPhysicalDeviceDisplayPropertiesKHR(device, &num_displays, NULL);
     if (!num_displays) {
         mp_msg(log, msgl_info, "    No available displays for device.\n");
@@ -82,7 +82,7 @@ static bool walk_display_properties(struct mp_log *log,
     }
 
     // Enumerate Planes
-    int num_planes = 0;
+    uint32_t num_planes = 0;
     vkGetPhysicalDeviceDisplayPlanePropertiesKHR(device, &num_planes, NULL);
     if (!num_planes) {
         mp_msg(log, msgl_info, "    No available planes for device.\n");
@@ -107,7 +107,7 @@ static bool walk_display_properties(struct mp_log *log,
     VkDisplayKHR **planes_to_displays =
         talloc_zero_array(tmp, VkDisplayKHR *, num_planes);
     for (int j = 0; j < num_planes; j++) {
-        int num_displays_for_plane = 0;
+        uint32_t num_displays_for_plane = 0;
         vkGetDisplayPlaneSupportedDisplaysKHR(device, j,
                                               &num_displays_for_plane, NULL);
         if (!num_displays_for_plane)
@@ -150,7 +150,7 @@ static bool walk_display_properties(struct mp_log *log,
 
         mp_msg(log, msgl_info, "    Modes:\n");
 
-        int num_modes = 0;
+        uint32_t num_modes = 0;
         vkGetDisplayModePropertiesKHR(device, display, &num_modes, NULL);
         if (!num_modes) {
             mp_msg(log, msgl_info, "      No available modes for display.\n");

--- a/video/out/x11_common.c
+++ b/video/out/x11_common.c
@@ -133,7 +133,7 @@ static const char x11_icon_128[] =
 #include "etc/mpv-icon-8bit-128x128.png.inc"
 ;
 
-#define ICON_ENTRY(var) { (char *)var, sizeof(var) }
+#define ICON_ENTRY(var) { (unsigned char *)var, sizeof(var) }
 static const struct bstr x11_icons[] = {
     ICON_ENTRY(x11_icon_16),
     ICON_ENTRY(x11_icon_32),
@@ -1279,7 +1279,7 @@ void vo_x11_check_events(struct vo *vo)
                 if (mpkey) {
                     mp_input_put_key(x11->input_ctx, mpkey | modifiers);
                 } else if (status == XLookupChars || status == XLookupBoth) {
-                    struct bstr t = { buf, len };
+                    struct bstr t = { (unsigned char *)buf, len };
                     mp_input_put_key_utf8(x11->input_ctx, modifiers, t);
                 }
             } else {
@@ -1475,7 +1475,7 @@ static void vo_x11_set_property_utf8(struct vo *vo, Atom name, const char *t)
     struct vo_x11_state *x11 = vo->x11;
 
     XChangeProperty(x11->display, x11->window, name, XA(x11, UTF8_STRING), 8,
-                    PropModeReplace, t, strlen(t));
+                    PropModeReplace, (const unsigned char *)t, strlen(t));
 }
 
 // set a X text property that expects a STRING or COMPOUND_TEXT type
@@ -1522,7 +1522,7 @@ static void vo_x11_xembed_update(struct vo_x11_state *x11, int flags)
     long xembed_info[] = {XEMBED_VERSION, flags};
     Atom name = XA(x11, _XEMBED_INFO);
     XChangeProperty(x11->display, x11->window, name, name, 32,
-                    PropModeReplace, (char *)xembed_info, 2);
+                    PropModeReplace, (unsigned char *)xembed_info, 2);
 }
 
 static void vo_x11_xembed_handle_message(struct vo *vo, XClientMessageEvent *ce)
@@ -1934,7 +1934,7 @@ static void vo_x11_update_geometry(struct vo *vo)
     x11->winrc = (struct mp_rect){0, 0, 0, 0};
     if (win) {
         XGetGeometry(x11->display, win, &dummy_win, &dummy_int, &dummy_int,
-                     &w, &h, &dummy_int, &dummy_uint);
+                     &w, &h, (unsigned int *)&dummy_int, &dummy_uint);
         if (w > INT_MAX || h > INT_MAX)
             w = h = 0;
         XTranslateCoordinates(x11->display, win, x11->rootwin, 0, 0,

--- a/video/vdpau.c
+++ b/video/vdpau.c
@@ -512,7 +512,7 @@ struct mp_image *mp_vdpau_upload_video_surface(struct mp_vdpau_ctx *ctx,
         if (src->imgfmt == IMGFMT_NV12)
             destdata[1] = destdata[2];
         vdp_st = vdp->video_surface_put_bits_y_cb_cr(surface,
-            ycbcr, destdata, src->stride);
+            ycbcr, destdata, (const uint32_t *)src->stride);
     } else {
         VdpOutputSurface rgb_surface = (intptr_t)hwmpi->planes[3];
         vdp_st = vdp->output_surface_put_bits_native(rgb_surface,


### PR DESCRIPTION
Relates to #13608

Removes `-Wno-pointer-sign` from `meson.build` and resolves all pointer sign compiler warnings across C source files.