### PR TITLE
options: add --playlist-inherit-options=auto and make it default

### DIFF
--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -357,11 +357,13 @@ Playback Control
         local files, such as special protocols like ``avdevice://`` (which are
         inherently unsafe).
 
-``--playlist-inherit-options=<yes|no|current>``
+``--playlist-inherit-options=<yes|no|current|auto>``
     Whether the per-file options of a playlist file are inherited by its items
-    when the playlist file is resolved and expanded (default: no). The value
+    when the playlist file is resolved and expanded (default: auto). The value
     ``current`` means that for playlists created by ``--autocreate-playlist``,
     only the file from which the playlist is created inherits the options.
+    The value ``auto`` behaves like ``current`` for playlists created by
+    ``--autocreate-playlist``, and behaves like ``yes`` otherwise.
 
 ``--chapter-merge-threshold=<number>``
     Threshold for merging almost consecutive ordered chapter parts in

--- a/options/options.c
+++ b/options/options.c
@@ -618,7 +618,7 @@ static const m_option_t mp_opts[] = {
     {"playlist-start", OPT_CHOICE(playlist_pos, {"auto", -1}, {"no", -1}),
         M_RANGE(0, INT_MAX)},
     {"playlist-inherit-options", OPT_CHOICE(playlist_inherit_options,
-        {"no", 0}, {"yes", 1}, {"current", 2})},
+        {"no", 0}, {"yes", 1}, {"current", 2}, {"auto", 3})},
 
     {"pause", OPT_BOOL(pause)},
     {"keep-open", OPT_CHOICE(keep_open,
@@ -1063,6 +1063,7 @@ static const struct MPOpts mp_default_opts = {
     .term_osd_bar_chars = "[-+-]",
     .consolecontrols = true,
     .playlist_pos = -1,
+    .playlist_inherit_options = 3,
     .play_frames = -1,
     .rebase_start_time = true,
     .keep_open_pause = true,

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1142,10 +1142,15 @@ static void transfer_playlist(struct MPContext *mpctx, struct playlist *pl,
         struct playlist_entry *new = pl->current;
         struct playlist_entry *current = mpctx->playlist->current;
         *num_new_entries = pl->num_entries;
-        if (current && mpctx->opts->playlist_inherit_options == 1)
+        if (current && (mpctx->opts->playlist_inherit_options == 1 ||
+                        (!new && mpctx->opts->playlist_inherit_options == 3)))
+        {
             playlist_set_params(pl, current->params, current->num_params);
-        else if (current && new && mpctx->opts->playlist_inherit_options == 2)
+        } else if (current && new && (mpctx->opts->playlist_inherit_options == 2 ||
+                                      mpctx->opts->playlist_inherit_options == 3))
+        {
             playlist_entry_add_params(new, current->params, current->num_params);
+        }
         *start_id = playlist_transfer_entries(mpctx->playlist, pl);
         // current entry is replaced
         if (current)


### PR DESCRIPTION
Should make more sense as a default to inherit file local options for ordinary playlists. Items from auto created playlists do not logically belong to the starting item so they are excluded.
