### PR TITLE
build: use --output option for rst2man

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1712,7 +1712,7 @@ if rst2man.found()
           docutils_wrapper, rst2man,
           '--record-dependencies', '@DEPFILE@',
           '--strip-elements-with-class=contents',
-          '@INPUT@', '@OUTPUT@'],
+          '--output=@OUTPUT@', '@INPUT@'],
         depfile: 'mpv.1.dep',
         install: true,
         install_tag: 'man',


### PR DESCRIPTION
Apparently, the separate destination argument was deprecated years ago and will be removed soon*. Just switch to the "new" way of specifiying the output. Fixes #18283.

https://sourceforge.net/p/docutils/feature-requests/36/#0709