### PR TITLE
vo_opengl/angle_dynamic: accept EGL_-prefixed exports

### DIFF
--- a/video/out/opengl/angle_dynamic.c
+++ b/video/out/opengl/angle_dynamic.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <windows.h>
 
 #include "angle_dynamic.h"
@@ -18,6 +19,28 @@ ANGLE_FNS(ANGLE_DECL)
 static bool angle_loaded;
 static mp_once angle_load_once = MP_STATIC_ONCE_INITIALIZER;
 
+// Some ANGLE builds export the EGL entry points under the EGL_-prefixed names used by Chromium
+// (EGL_QueryString rather than eglQueryString). Applications that embed such a build inherit it.
+// Without this fallback angle_load() fails, and every ANGLE-based hwdec is refused at its second
+// gate, before any device, capability or extension is examined.
+//
+// One extra GetProcAddress() per entry point on builds that export the plain names; none on the
+// builds that need it.
+static void *mp_angle_get_proc(HANDLE dll, const char *name)
+{
+    void *fn = (void *)GetProcAddress(dll, name);
+    if (fn)
+        return fn;
+    if (name[0] != 'e' || name[1] != 'g' || name[2] != 'l')
+        return NULL;
+    char buf[128] = "EGL_";
+    size_t n = strlen(name + 3);
+    if (n + 5 > sizeof(buf))
+        return NULL;
+    memcpy(buf + 4, name + 3, n + 1);
+    return (void *)GetProcAddress(dll, buf);
+}
+
 static void angle_do_load(void)
 {
     // Note: we let this handle "leak", as the functions remain valid forever.
@@ -25,7 +48,7 @@ static void angle_do_load(void)
     if (!angle_dll)
         return;
 #define ANGLE_LOAD_ENTRY(NAME, VAR) \
-    NAME = (void *)GetProcAddress(angle_dll, #NAME); \
+    NAME = (void *)mp_angle_get_proc(angle_dll, #NAME); \
     if (!NAME) return;
     ANGLE_FNS(ANGLE_LOAD_ENTRY)
     angle_loaded = true;


### PR DESCRIPTION
`angle_load()` resolves the EGL entry points with `GetProcAddress()` using their unprefixed names, and gives up on the first one that is missing:

```c
#define ANGLE_LOAD_ENTRY(NAME, VAR) \
    NAME = (void *)GetProcAddress(angle_dll, #NAME); \
    if (!NAME) return;
```

Some ANGLE builds export those entry points under the `EGL_`-prefixed spelling instead — `EGL_QueryString` rather than `eglQueryString` — which is what Chromium uses, and which applications embedding such a build inherit.

On those builds `angle_load()` returns false, so **every ANGLE-based hwdec is refused at its second gate**, before any device, capability or extension is examined. `hwdec_d3d11egl.c` and `hwdec_dxva2egl.c` both start with:

```c
if (!ra_is_gl(hw->ra_ctx->ra))
    return -1;
if (!angle_load())          // <- here
    return -1;
```

Because every gate in those functions is a bare `return -1`, mpv logs only:

```
Loading hwdec driver 'd3d11-egl'
Loading failed.
```

which is hard to tell apart from a machine that genuinely lacks the interop. That is what made this expensive to diagnose — it took a local build with a log line at each gate to find out which one it was.

### How it was found

Embedding libmpv in an [Avalonia](https://avaloniaui.net) application on Windows. Avalonia ships ANGLE as a single combined binary that exports only the prefixed names, so `eglGetCurrentDisplay`, `eglGetCurrentContext` and `eglQueryString` are all absent under the names `angle_load()` looks up, while `EGL_GetCurrentDisplay`, `EGL_GetCurrentContext` and `EGL_QueryString` are present.

Measured on ANGLE 2.1.1 (git `1c89805903c1`), Windows 11, RTX 3080, with libmpv's OpenGL render API on an ES 3.0 context.

### Result

With this change, plus the `EGL_EXT_device_query` fix from #10212 (that extension is a *client* extension queried against `EGL_NO_DISPLAY`, and `hwdec_d3d11egl.c` tests the display string), `d3d11-egl` initialises and `hwdec` goes from `d3d11va-copy` to `d3d11va` on that setup. Frame render time in the host dropped from ~14–19 ms to ~0.7 ms at 4K HEVC, since the per-frame GPU→RAM→GPU round trip is gone.

**The two are independent and both are needed** — either alone still ends in `d3d11va-copy`. This PR is only the `angle_load()` half, since #10212 already has [#11142](https://github.com/mpv-player/mpv/pull/11142) open against it.

### Cost

One extra `GetProcAddress()` per entry point on builds that export the plain names, once per process, and nothing at all on the builds that need it. Behaviour is unchanged wherever the plain names resolve.

`<string.h>` is added explicitly for `strlen`/`memcpy` — it currently arrives only transitively via `windows.h` on MinGW.

Compile-tested on MSYS2 MINGW64 (gcc 16.1.0, meson 1.11.2) and runtime-tested as described above.
