### PR TITLE
hwdec_d3d11egl: fix EGL_EXT_device_query availability check

### DIFF
--- a/video/out/opengl/hwdec_d3d11egl.c
+++ b/video/out/opengl/hwdec_d3d11egl.c
@@ -101,11 +101,13 @@ static int init(struct ra_hwdec *hw)
     GL *gl = ra_gl_get(hw->ra_ctx->ra);
 
     const char *exts = eglQueryString(egl_display, EGL_EXTENSIONS);
+    const char *client_exts = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
     if (!gl_check_extension(exts, "EGL_ANGLE_d3d_share_handle_client_buffer") ||
         !gl_check_extension(exts, "EGL_ANGLE_stream_producer_d3d_texture") ||
         !(gl_check_extension(gl->extensions, "GL_OES_EGL_image_external_essl3") ||
           gl->es == 200) ||
-        !gl_check_extension(exts, "EGL_EXT_device_query") ||
+        !(gl_check_extension(exts, "EGL_EXT_device_query") ||
+          gl_check_extension(client_exts, "EGL_EXT_device_query")) ||
         !(gl->mpgl_caps & MPGL_CAP_TEX_RG))
         return -1;
 


### PR DESCRIPTION
After ANGLE commit 56663dbfa780 EGL_EXT_device_query is listed in the client extension string instead of the display one. The display string check always failed, silently disabling native d3d11va interop.

This fixes `hwdec` with `gpu-context=angle`.