### PR TITLE
context_angle: remove the D3D9 renderer

### DIFF
--- a/DOCS/interface-changes/angle-renderer-d3d9.txt
+++ b/DOCS/interface-changes/angle-renderer-d3d9.txt
@@ -1,0 +1,1 @@
+remove `--angle-renderer=d3d9`, ANGLE dropped the D3D9 backend

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -6987,15 +6987,10 @@ them.
 
     Windows with ANGLE only.
 
-``--angle-renderer=<d3d9|d3d11|auto>``
-    Forces a specific renderer when using the ANGLE backend (default: auto). In
-    auto mode this will pick D3D11 for systems that support Direct3D 11 feature
-    level 9_3 or higher, and D3D9 otherwise. This option is mainly for
-    debugging purposes. Normally there is no reason to force a specific
-    renderer, though ``--angle-renderer=d3d9`` may give slightly better
-    performance on old hardware. Note that the D3D9 renderer only supports
-    OpenGL ES 2.0, so most extended OpenGL features will not work if this
-    renderer is selected (similar to ``--gpu-dumb-mode``).
+``--angle-renderer=<d3d11|auto>``
+    Forces a specific renderer when using the ANGLE backend (default: auto).
+    This option is mainly for debugging purposes. Normally there is no reason
+    to force a specific renderer.
 
     Windows with ANGLE only.
 

--- a/video/out/opengl/context_angle.c
+++ b/video/out/opengl/context_angle.c
@@ -45,7 +45,6 @@
 
 enum {
     RENDERER_AUTO,
-    RENDERER_D3D9,
     RENDERER_D3D11,
 };
 
@@ -62,7 +61,6 @@ const struct m_sub_options angle_conf = {
     .opts = (const struct m_option[]) {
         {"angle-renderer", OPT_CHOICE(renderer,
             {"auto", RENDERER_AUTO},
-            {"d3d9", RENDERER_D3D9},
             {"d3d11", RENDERER_D3D11})},
         {"angle-d3d11-warp", OPT_CHOICE(d3d11_warp,
             {"auto", -1},
@@ -309,44 +307,6 @@ fail:
     return false;
 }
 
-static void d3d9_device_destroy(struct ra_ctx *ctx)
-{
-    struct priv *p = ctx->priv;
-
-    if (p->egl_display)
-        eglTerminate(p->egl_display);
-    p->egl_display = EGL_NO_DISPLAY;
-}
-
-static bool d3d9_device_create(struct ra_ctx *ctx)
-{
-    struct priv *p = ctx->priv;
-    struct vo *vo = ctx->vo;
-
-    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
-        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
-    if (!eglGetPlatformDisplayEXT) {
-        MP_FATAL(vo, "Missing EGL_EXT_platform_base\n");
-        return false;
-    }
-
-    EGLint display_attributes[] = {
-        EGL_PLATFORM_ANGLE_TYPE_ANGLE,
-            EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE,
-        EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE,
-            EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE,
-        EGL_NONE,
-    };
-    p->egl_display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-        EGL_DEFAULT_DISPLAY, display_attributes);
-    if (p->egl_display == EGL_NO_DISPLAY) {
-        MP_FATAL(vo, "Couldn't get display\n");
-        return false;
-    }
-
-    return true;
-}
-
 static void egl_window_surface_destroy(struct ra_ctx *ctx)
 {
     struct priv *p = ctx->priv;
@@ -452,11 +412,7 @@ static void angle_uninit(struct ra_ctx *ctx)
 
     context_destroy(ctx);
 
-    // Uninit the EGL device implementation that is being used
-    if (p->d3d11_device)
-        d3d11_device_destroy(ctx);
-    else
-        d3d9_device_destroy(ctx);
+    d3d11_device_destroy(ctx);
 
     vo_w32_uninit(ctx->vo);
 }
@@ -550,16 +506,6 @@ static bool angle_init(struct ra_ctx *ctx)
             context_ok = context_init(ctx);
             if (!context_ok)
                 d3d11_device_destroy(ctx);
-        }
-    }
-    if ((!context_ok && !o->renderer) || o->renderer == RENDERER_D3D9) {
-        context_ok = d3d9_device_create(ctx);
-        if (context_ok) {
-            MP_VERBOSE(vo, "Using Direct3D 9\n");
-
-            context_ok = context_init(ctx);
-            if (!context_ok)
-                d3d9_device_destroy(ctx);
         }
     }
     if (!context_ok)


### PR DESCRIPTION
ANGLE removed its D3D9 backend along with `EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE`, so `context_angle.c` no longer builds against current ANGLE headers.

CI does not catch it because the mingw job installs no ANGLE headers, so `egl-angle` auto-detects to disabled and the file is never built.

Also drops the `d3d9` value of `--angle-renderer` and its documentation. Verified the file still compiles with `-Degl-angle-win32=enabled` against current headers.
