### PR TITLE
commands.lua: add quotes to file completion

### DIFF
--- a/player/lua/commands.lua
+++ b/player/lua/commands.lua
@@ -274,10 +274,24 @@ local function file_list(directory)
         directory = mp.command_native({"expand-path", directory})
     end
 
-    local files = utils.readdir(directory, "files") or {}
+    local files = {}
+
+    for i, file in pairs(utils.readdir(directory, "files")) do
+        if directory == "." and completion_append == "" and file:find("%s") then
+            files[i] = "'" .. file .. "'"
+        elseif completion_append ~= "" then
+            files[i] = file .. completion_append
+        else
+            files[i] = file
+        end
+    end
 
     for _, dir in pairs(utils.readdir(directory, "dirs") or {}) do
-        files[#files + 1] = dir .. path_separator
+        if directory == "." and completion_append == "" and dir:find("%s") then
+            files[#files + 1] = "'" .. dir .. path_separator
+        else
+            files[#files + 1] = dir .. path_separator
+        end
     end
 
     return files
@@ -289,11 +303,13 @@ local function handle_file_completion(before_cur)
 
     completion_pos = completion_pos + last_component_pos - 1
 
+    local files = file_list(directory)
+
     -- Don"t use completion_append for file completion to not add quotes after
     -- directories whose entries you may want to complete afterwards.
     completion_append = ""
 
-    return file_list(directory)
+    return files
 end
 
 local function handle_choice_completion(option, before_cur)


### PR DESCRIPTION
Automatically inserting quotes in file completion problematic, because when completing directories you want the cursor before the final quote rather than after in order to further complete the files within, and there is no system to set a cursor position before the end of the completion.

However we can add quotes automatically without this issue when:
- completing files in the current directory
- we can add only the first quote when completing directories in the current directory
- we can add the final quote after files if the user typed a quote at the beginning of the path, since there's nothing remaining to complete after regular files

This adds single quotes because they are easier to type. Filenames containing both spaces and single quotes are not supported.