### PR TITLE
bash-completion: don't append '=' to help and clr options

### DIFF
--- a/etc/mpv.bash-completion
+++ b/etc/mpv.bash-completion
@@ -34,6 +34,9 @@ _mpv_get_args()
     type="ShowProfile"
   elif [ "$1" = "--profile" ]; then
     type="Profile"
+  elif [ "$1" = "--help" -o "$1" = "--h" ]; then
+    # --help=<substring> filters by option name, not String values
+    type="Help"
   fi
 
   declare -a candidates
@@ -70,6 +73,13 @@ _mpv_get_args()
     ShowProfile)
       candidates=($(mpv $1= | grep -v ':' | awk '{print $1;}'))
       ;;
+    Help)
+      # Mirror zsh help-options: bare option names (no "--"),
+      # excluding no-* and *-(add|append|clr|pre|set|remove|toggle).
+      candidates=($(_mpv_options | awk '{print $1;}' | grep '^--' | \
+        grep -vE '^--no-' | grep -vE '^--.*-(add|append|clr|pre|set|remove|toggle)$' | \
+        sed 's/^--//'))
+      ;;
     *)
       # There are other categories; some of which we could do something smarter
       # about, with enough work.
@@ -81,8 +91,11 @@ _mpv_get_args()
   fi
 }
 
-# This regex detects special options where we don't want an '=' appended
-_mpv_special_regex='\s(Flag.*\[not in config files\]|Print)'
+# Options where '=' is not appended:
+#   - Print options and "not in config files" flags
+#   - list-type sub-options with no argument (e.g. --af-clr, --vo-help)
+# --help/--h are intentionally excluded (they take a substring filter).
+_mpv_special_regex='\s(Flag.*\[not in config files\]|Print)|^\s+--[[:alnum:]-]+-(clr|help)\s*$'
 _mpv_skip_regex='\sremoved \[deprecated\]'
 
 _mpv_regular_options()


### PR DESCRIPTION
The special-options regex decided which options are completed without
a trailing '=', but it only covered Print options and "not in config
files" flags. As a result, two groups of no-argument options still got
 '=' appended:
    
      (1) *-clr / *-help sub-options (e.g. --af-clr, --vo-help) which are
          mpv list-type sub-options taking no argument.
      (2) --help/--h which is String-typed in --list-options but actually
          accepts a substring filter to narrow down the option listing.
    
Extend the regex to cover (1). For (2), keep '=' appended (it does take
an argument) and route completion through a new Help branch that mirrors
the zsh help-options state: complete bare option names (no "--"
prefix), excluding no-* negations and list-type sub-options
(-add/-append/-clr/-pre/-set/-remove/-toggle). Bare names are needed
because --help=<substring> matches within the option name body.
