### PR TITLE
vo_gpu: interpolation-threshold check: allow any integer

### DIFF
--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -3574,7 +3574,7 @@ void gl_video_render_frame(struct gl_video *p, struct vo_frame *frame,
                            (p->frames_drawn || !frame->still);
         if (interpolate) {
             double ratio = frame->ideal_frame_duration / frame->vsync_interval;
-            if (fabs(ratio - 1.0) < p->opts.interpolation_threshold)
+            if (fabs(ratio - floor(ratio + 0.5)) < p->opts.interpolation_threshold)
                 interpolate = false;
         }
 


### PR DESCRIPTION
Instead of checking whether the ratio is approximately 1.0, this PR checks whether the ratio is approximately an integer. This way, any video whose fps is approximately a factor of the display Hz will pass the check. #7467 