### PR TITLE
osc.lua: ignore seek ranges without positive duration

### DIFF
--- a/player/lua/osc.lua
+++ b/player/lua/osc.lua
@@ -2533,7 +2533,7 @@ local function osc_init()
         if user_opts.seekrangestyle == "none" or not cache_enabled() then
             return nil
         end
-        if state.duration == nil then
+        if state.duration == nil or state.duration == 0 then
             return nil
         end
         local nranges = {}


### PR DESCRIPTION
 `seekRangesF()` currently accepts a zero duration and produces NaN/Inf
  coordinates, which `assdraw` cannot format. Restoree the positive-duration
  guard so invalid seek-range metadata is ignored

  Tested with Lua 5.1 and 5.2 syntax checks and the full Lua lint suite.

  Fixes #18344