### PR TITLE
demux/ebml: Allow uint elements to have length 0

### DIFF
--- a/demux/ebml.c
+++ b/demux/ebml.c
@@ -510,7 +510,7 @@ static void ebml_parse_element(struct ebml_parse_ctx *ctx, void *target,
             else                                                        \
                 subelptr = (fieldtype *) fieldptr
             GETPTR(uintptr, uint64_t);
-            if (length < 1 || length > 8) {
+            if (length > 8) {
                 MP_ERR(ctx, "uint invalid length %"PRIu64"\n", length);
                 goto error;
             }


### PR DESCRIPTION
[Section 7.2](https://www.rfc-editor.org/info/rfc8794/#section-7.2) of the current ebml spec (rfc 8794) states that uint elements with length 0 are permitted.

There was a previous commit [ef020c1](https://github.com/mpv-player/mpv/commit/ef020c155f6e19c1657241041c4d446debe9923f) about 11 years ago that addressed this issue for several elements. The uint element was among these; functions like ebml_read_uint were changed, but it seems this particular section may have been overlooked.

Prior to this change, mkv files with 0-length uint elements were not playable by mpv. These same files were otherwise playable or parsable without issues by other applications like ffplay, vlc, mkvinfo, etc.

Thanks.