### PR TITLE
ra_pl: add x2bgr10/x2rgb10 special RA formats

### DIFF
--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -103,6 +103,30 @@ struct ra *ra_create_pl(pl_gpu gpu, struct mp_log *log)
             rafmt->component_depth[c] = plfmt->component_depth[c];
         }
 
+        // Special formats for which libplacebo happens to have direct support.
+        if (strcmp(plfmt->name, "rgb10a2") == 0) {
+            rafmt->special_imgfmt = IMGFMT_X2BGR10;
+            struct ra_imgfmt_desc *desc = talloc_zero(rafmt, struct ra_imgfmt_desc);
+            rafmt->special_imgfmt_desc = desc;
+            desc->component_bits = 10;
+            desc->num_planes = 1;
+            desc->planes[0] = rafmt;
+            for (int c = 0; c < 3; c++)
+                desc->components[0][c] = c + 1;
+            desc->chroma_w = desc->chroma_h = 1;
+        }
+        if (strcmp(plfmt->name, "bgr10a2") == 0) {
+            rafmt->special_imgfmt = IMGFMT_X2RGB10;
+            struct ra_imgfmt_desc *desc = talloc_zero(rafmt, struct ra_imgfmt_desc);
+            rafmt->special_imgfmt_desc = desc;
+            desc->component_bits = 10;
+            desc->num_planes = 1;
+            desc->planes[0] = rafmt;
+            for (int c = 0; c < 3; c++)
+                desc->components[0][c] = 3 - c;
+            desc->chroma_w = desc->chroma_h = 1;
+        }
+
         MP_TARRAY_APPEND(ra, ra->formats, ra->num_formats, rafmt);
     }
 


### PR DESCRIPTION
x2bgr10/x2rgb10 are packed formats that do not automatically get mapped by the existing ra_pl logic. They are more useful than other non-byte-aligned packed formats because they show up when dealing with > 8bit RGB content, which is more common in an HDR context.

In practice, x2bgr10 is probably the only one that's going to get used, but I figured there's no harm in supporting both.

I also experimented with adding generic logic to map packed formats, but it's a bunch of un-intuitive code and the ra format constraints mean the only accepted packed formats would be x2bgr10 and x2rgb10 anyway. To add insult to injury, you'd still need special case code in `ra_gl` to provide missing metadata to make the generic mapping work.

With all that as the alternative, simply adding special formats to `ra_pl` is much easier to understand and maintain.