### PR TITLE
command: unset metadata key if string is empty

### DIFF
--- a/player/command.c
+++ b/player/command.c
@@ -1342,9 +1342,15 @@ static int tag_property(int action, void *arg, struct mp_tags *tags)
                 .type = CONF_TYPE_STRING,
             };
             return M_PROPERTY_OK;
-        case M_PROPERTY_SET:
-            mp_tags_set_bstr(tags, k, bstr0(*(char **)ka->arg));
+        case M_PROPERTY_SET: {
+            bstr v = bstr0(*(char **)ka->arg);
+            if (v.len == 0) {
+                mp_tags_remove_bstr(tags, k);
+            } else {
+                mp_tags_set_bstr(tags, k, v);
+            }
             return M_PROPERTY_OK;
+        }
         }
     }
     }


### PR DESCRIPTION
Followup to #17603

There is currently no way to completely remove a key from a metadata dictionary. This change makes it so that if a key's value is set to an empty string, the key itself will also be removed.