### PR TITLE
ao_avfoundation: stop requesting media while paused

### DIFF
--- a/audio/out/ao_avfoundation.m
+++ b/audio/out/ao_avfoundation.m
@@ -140,15 +140,22 @@ finish:
     if (sample_buffer) CFRelease(sample_buffer);
 }
 
+static void request_media_data(struct ao *ao)
+{
+    struct priv *p = ao->priv;
+
+    [p->renderer requestMediaDataWhenReadyOnQueue:p->queue usingBlock:^{
+        feed(ao);
+    }];
+}
+
 static void start(struct ao *ao)
 {
     struct priv *p = ao->priv;
 
     p->end_time_av = -1;
     [p->synchronizer setRate:1];
-    [p->renderer requestMediaDataWhenReadyOnQueue:p->queue usingBlock:^{
-        feed(ao);
-    }];
+    request_media_data(ao);
 }
 
 static void stop(struct ao *ao)
@@ -167,9 +174,11 @@ static bool set_pause(struct ao *ao, bool paused)
     struct priv *p = ao->priv;
 
     if (paused) {
+        [p->renderer stopRequestingMediaData];
         [p->synchronizer setRate:0];
     } else {
         [p->synchronizer setRate:1];
+        request_media_data(ao);
     }
 
     return true;


### PR DESCRIPTION
## Summary

Stop `AVSampleBufferAudioRenderer` from requesting media data while mpv is paused, then register the request callback again when playback resumes.

## Root cause

`set_pause` set the render synchronizer rate to zero but left the media-data request active. If the renderer had no queued audio, `ao_read_data` returned no samples while paused. AVFoundation still considered the renderer ready for more data and immediately invoked the callback again, creating a busy loop on the `avfoundation event` queue.

The callback request now stops before the rate changes to zero. Resuming sets the rate back to one and registers a new callback, keeping the request and stop lifecycle balanced.

## Observed failure

A paused mpv 0.41.0 process consistently consumed one full CPU core while its playback, decoder, demuxer, video-output, and Lua threads slept. A process sample showed the active thread in this stack:

```
DispatchQueue: avfoundation event
AVMediaDataRequester::_requestMediaDataIfReady
__start_block_invoke (mpv)
```

The process-level signal stayed consistent across repeated measurements:

```
cpu=98.8% state=R
cpu=100.0% state=R
cpu=99.1% state=R
```

## Verification

- `meson compile -C build`
- `git diff --check origin/master...HEAD`
- Played the same remote E-AC-3 stream with `ao=avfoundation`, completed five pause/resume cycles, and left the player paused
- Repeated the pause/resume check with a generated 48 kHz audio source
- Sampled the patched process while paused:

```
pause_property=true
paused_cpu=0.2
hot_callback=no
```


Additional macOS 26 runtime verification:

- Built and ran the exact unpatched parent (`e7191f2a65`) and PR commit (`4df03a9b22`) on macOS 26.6.2 (25G83), arm64
- Served a locally generated 48 kHz 5.1 E-AC-3 stream over HTTP, stopped the producer to reproduce a stalled remote stream, then paused mpv
- Unpatched: `paused_cpu=77.4`; a three-second sample recorded 2,266 samples on `DispatchQueue: avfoundation event`, including 1,610 in `-[AVMediaDataRequester _requestMediaDataIfReady]`
- Patched: `paused_cpu=0.1`; `requestMediaDataIfReady` was absent from the sample; resume and re-pause measured `0.0%` CPU

This build configuration defines no automated tests. The behavior depends on the macOS AVFoundation runtime, so the verification exercises the real audio output.

## AI/LLM disclosure

OpenAI Codex with GPT-5.6 Sol (high) assisted with diagnosis, implementation, testing, and drafting this pull request. I understand the change and take full responsibility for it, including its licensing under the file's existing LGPLv2.1+ terms. I will participate in review with human-written responses.
