### PR TITLE
vo_gpu_next: keep overlay-add bitmaps in sRGB

### DIFF
--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -465,6 +465,9 @@ static struct sub_bitmaps *get_bitmaps(struct sd *sd, struct mp_osd_res d,
     res->packed_w = current->bound_w;
     res->packed_h = current->bound_h;
     res->format = SUBBITMAP_BGRA;
+    // Image subtitles are muxed with the video and authored in its colorspace,
+    // unlike bitmaps passed in through the overlay-add command.
+    res->video_color_space = true;
 
     double video_par = 0;
     if (priv->avctx->codec_id == AV_CODEC_ID_DVD_SUBTITLE &&

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -398,8 +398,10 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
         case SUBBITMAP_BGRA:
             ol->mode = PL_OVERLAY_NORMAL;
             ol->repr.alpha = PL_ALPHA_PREMULTIPLIED;
-            // Infer bitmap colorspace from source
-            if (src) {
+            // Infer bitmap colorspace from source, but only if the bitmap is
+            // actually in it. Bitmaps from overlay-add come from the client and
+            // are sRGB, so they keep the default set above.
+            if (src && item->video_color_space) {
                 ol->color = src->params.color;
                 if (pl_color_transfer_is_hdr(ol->color.transfer)) {
                     bool use_static = p->next_opts->image_subs_hdr_peak == -2;


### PR DESCRIPTION
Bitmaps supplied through the `overlay-add` command are reinterpreted in the
video's colorspace under `vo_gpu_next`. Any client that draws its interface
as a bitmap and hands it to mpv through that command therefore gets it
mangled whenever the file is HDR. `vo_gpu` does not do this, so the two
video outputs disagree.

This affects clients generally: anything pushing a
BGRA surface through `overlay-add` is subject to it, including script-driven
thumbnail overlays. The case I ran into is Nuvio Desktop, a media player
whose entire player interface, seek bar, buttons, timestamps, title is
rendered as an HTML page, captured to a premultiplied BGRA surface, and
pushed to mpv with `overlay-add`, because the interface must composite over
the video inside a single embedded window. On HDR files the whole interface
is visibly wrong: light greys clip to white, darker greys to black, the text is fringing and artifacting and colors shift.

Measured on a BT.2020/PQ clip by pushing an sRGB overlay and reading the
rendered pixels back, with SDR output:

| input (sRGB) | output before | output after |
| --- | --- | --- |
| 192, 192, 192 | **255, 255, 255** | 192, 192, 192 |
| 128, 128, 128 | 190, 190, 190 | 128, 128, 128 |
| 255, 0, 0 | **255, 117, 37** | 255, 0, 0 |

Mean error was 36.5 of 255 before the change, and exact after it. With an
HDR target the overlay was instead passed through untouched, so sRGB white
was emitted as PQ 255, which requests 10000 nits.

`struct sub_bitmaps` already carries `video_color_space` for exactly this
question, and the `SUBBITMAP_LIBASS` branch honors it. Only the
`SUBBITMAP_BGRA` branch inferred unconditionally. The flag is now set where
image subtitles are packed and honored in the video output, so image
subtitles keep their existing behavior and only `overlay-add` changes.

**Tested on:**
- **Operating System:** Arch Linux
- **Kernel:** 7.1.8-arch1-3
- **Window manager:** Hyprland, Wayland session with the player on XWayland
- **mpv:** built from git master [`e7191f2a65`](https://github.com/mpv-player/mpv/commit/e7191f2a65d64af266c5c80793e79d2f4b92b789)
- **GPU:** GeForce RTX 3070 Laptop GPU
- **Driver:** NVIDIA proprietary driver version 610.57.04 on

using `vo_gpu_next` with the `x11vk` GPU context. Verified against an HDR10 clip with known color patches,
and in Nuvio Desktop itself on real HDR content, where the interface renders
correctly with the change applied. Image subtitles were checked separately
and are unchanged.

**Without Patch**
<img width="332" height="357" alt="without_patch" src="https://github.com/user-attachments/assets/a4ba660d-1fb0-4730-a68a-99a9af5105a4" />    <img width="319" height="349" alt="without_patch_2" src="https://github.com/user-attachments/assets/feb922d5-7a68-4c45-8da0-45607102c2e7" />

**With Patch Applied**
<img width="331" height="350" alt="with_patch" src="https://github.com/user-attachments/assets/63ca3de5-aab4-4c25-8aad-c398c45cc3b9" />    <img width="304" height="345" alt="with_patch_2" src="https://github.com/user-attachments/assets/dd71d47c-e48c-416b-a893-014122947b74" />


Marked as a request for comments for two reasons. Issue #13381 shows that
colorspace handling for subtitles and the on-screen display is still under
discussion, and issue #10678 asks for an explicit colorspace tag on the
`overlay-add` command rather than inferring sRGB. This change infers, so it
may not be the direction you want. I am happy to rework it either way.

One open question: should bitmaps from `overlay-add` also be scaled to the
reference luminance, the way the `SUBBITMAP_LIBASS` branch does? I am glad to add it if that
is the correct behavior.