### PR TITLE
command: let overlay-add declare a colorspace tag

### DIFF
--- a/DOCS/interface-changes/overlay-add-colorspace.txt
+++ b/DOCS/interface-changes/overlay-add-colorspace.txt
@@ -1,0 +1,1 @@
+add `colorspace` argument to the `overlay-add` command, taking `srgb` (the default) or `video`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -904,7 +904,7 @@ OSD Commands
     Show the progress bar, the elapsed time and the total duration of the file
     on the OSD. ``no-osd`` has no effect on this command.
 
-``overlay-add <id> <x> <y> <file> <offset> <fmt> <w> <h> <stride> <dw> <dh>``
+``overlay-add <id> <x> <y> <file> <offset> <fmt> <w> <h> <stride> <dw> <dh> [<colorspace>]``
     Add an OSD overlay sourced from raw data. This might be useful for scripts
     and applications controlling mpv, and which want to display things on top
     of the video window.
@@ -963,6 +963,13 @@ OSD Commands
     The overlay visible portion of the overlay (``w`` and ``h``) is scaled to
     in display to ``dw`` and ``dh``.  If parameters are not present, the
     values for ``w`` and ``h`` are used.
+
+    ``colorspace`` says which colorspace the bitmap is in. ``srgb`` (the
+    default) is right for images the client drew itself, such as an
+    interface or a static picture. ``video`` is for images taken from the
+    video, such as thumbnails decoded elsewhere and passed in unconverted:
+    they are then treated like the video and tone mapped with it.
+    Overlays with different colorspaces can be used at the same time.
 
     .. note::
 

--- a/input/cmd.h
+++ b/input/cmd.h
@@ -23,7 +23,7 @@
 #include "misc/bstr.h"
 #include "options/m_option.h"
 
-#define MP_CMD_DEF_MAX_ARGS 11
+#define MP_CMD_DEF_MAX_ARGS 12
 #define MP_CMD_OPT_ARG M_OPT_OPTIONAL_PARAM
 
 struct mp_log;

--- a/player/command.c
+++ b/player/command.c
@@ -145,6 +145,7 @@ struct overlay {
     struct mp_image *source;
     int x, y;
     int dw, dh;
+    int colorspace;   // enum sub_bitmap_colorspace, declared by the client
 };
 
 struct hook_handler {
@@ -5288,6 +5289,9 @@ static void recreate_overlays(struct MPContext *mpctx)
     struct sub_bitmaps *new = &cmd->overlay_osd[overlay_next];
     new->format = SUBBITMAP_BGRA;
     new->change_id = 1;
+    // Each part carries its own colorspace, so ids with different ones can
+    // be mixed.
+    new->video_color_space = false;
 
     bool valid = false;
 
@@ -5304,6 +5308,7 @@ static void recreate_overlays(struct MPContext *mpctx)
                 .x = o->x,
                 .y = o->y,
             };
+            b.colorspace = o->colorspace;
             MP_TARRAY_APPEND(cmd, new->parts, new->num_parts, b);
         }
     }
@@ -5420,6 +5425,7 @@ static void cmd_overlay_add(void *pcmd)
     char *fmt = cmd->args[5].v.s;
     int w = cmd->args[6].v.i, h = cmd->args[7].v.i, stride = cmd->args[8].v.i;
     int dw = cmd->args[9].v.i, dh = cmd->args[10].v.i;
+    int colorspace = cmd->args[11].v.i;
 
     if (dw <= 0)
         dw = w;
@@ -5443,6 +5449,7 @@ static void cmd_overlay_add(void *pcmd)
         .y = y,
         .dw = dw,
         .dh = dh,
+        .colorspace = colorspace,
     };
     if (!overlay.source)
         goto error;
@@ -7890,7 +7897,11 @@ const struct mp_cmd_def mp_cmds[] = {
                                         {"h", OPT_INT(v.i)},
                                         {"stride", OPT_INT(v.i)},
                                         {"dw", OPT_INT(v.i), OPTDEF_INT(0)},
-                                        {"dh", OPT_INT(v.i), OPTDEF_INT(0)}, }},
+                                        {"dh", OPT_INT(v.i), OPTDEF_INT(0)},
+                                        {"colorspace", OPT_CHOICE(v.i,
+                                            {"srgb", SUB_BITMAP_CSP_SRGB},
+                                            {"video", SUB_BITMAP_CSP_VIDEO}),
+                                            OPTDEF_INT(SUB_BITMAP_CSP_SRGB)} }},
     { "overlay-remove", cmd_overlay_remove, { {"id", OPT_INT(v.i)} } },
 
     { "osd-overlay", cmd_osd_overlay,

--- a/sub/osd.h
+++ b/sub/osd.h
@@ -35,6 +35,14 @@ enum sub_bitmap_format {
     SUBBITMAP_COUNT
 };
 
+// Colorspace a client declared for a bitmap it supplied.
+// It indexes the per-colorspace groups the VO renders in one pass.
+enum sub_bitmap_colorspace {
+    SUB_BITMAP_CSP_SRGB = 0,  // client drawn content, the default
+    SUB_BITMAP_CSP_VIDEO,     // taken from the video, treat it like the video
+    SUB_BITMAP_CSP_COUNT
+};
+
 struct sub_bitmap {
     void *bitmap;
     int stride;
@@ -48,6 +56,11 @@ struct sub_bitmap {
     // is the position within the source. (Strictly speaking this is redundant
     // with the bitmap pointer.)
     int src_x, src_y;
+
+    // enum sub_bitmap_colorspace; only meaningful for SUBBITMAP_BGRA. Placed
+    // here because it fits the existing padding and leaves the struct's size
+    // unchanged.
+    uint8_t colorspace;
 
     union {
         struct {

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -465,6 +465,9 @@ static struct sub_bitmaps *get_bitmaps(struct sd *sd, struct mp_osd_res d,
     res->packed_w = current->bound_w;
     res->packed_h = current->bound_h;
     res->format = SUBBITMAP_BGRA;
+    // Image subtitles are muxed with the video and authored in its colorspace,
+    // unlike bitmaps passed in through the overlay-add command.
+    res->video_color_space = true;
 
     double video_par = 0;
     if (priv->avctx->codec_id == AV_CODEC_ID_DVD_SUBTITLE &&

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -71,7 +71,9 @@ struct osd_entry {
 
 struct osd_state {
     struct osd_entry entries[MAX_OSD_PARTS];
-    struct pl_overlay overlays[MAX_OSD_PARTS];
+    // A bitmap object can declare several colorspaces, and each one is drawn as
+    // its own overlay over the shared texture.
+    struct pl_overlay overlays[MAX_OSD_PARTS * SUB_BITMAP_CSP_COUNT];
 };
 
 struct scaler_params {
@@ -366,26 +368,68 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
             break;
         }
 
+        // Group parts by declared colorspace into unbroken runs so overlays
+        // can point to them directly. Processing one colorspace per pass keeps
+        // it linear without sorting or extra allocations. Only client-supplied
+        // bitmaps set a per-part colorspace, image subtitles declare one
+        // globally and leave per-part fields unset, keeping them in a group.
+        const int num_csp = item->format == SUBBITMAP_BGRA &&
+                            !item->video_color_space ? SUB_BITMAP_CSP_COUNT : 1;
+        int csp_start[SUB_BITMAP_CSP_COUNT];
+        int csp_count[SUB_BITMAP_CSP_COUNT];
         entry->num_parts = 0;
-        for (int i = 0; i < item->num_parts; i++) {
-            const struct sub_bitmap *b = &item->parts[i];
-            if (b->dw == 0 || b->dh == 0)
-                continue;
-            uint32_t c = b->libass.color;
-            struct pl_overlay_part part = {
-                .src = { b->src_x, b->src_y, b->src_x + b->w, b->src_y + b->h },
-                .dst = { b->x, b->y, b->x + b->dw, b->y + b->dh },
-                .color = {
-                    (c >> 24) / 255.0f,
-                    ((c >> 16) & 0xFF) / 255.0f,
-                    ((c >> 8) & 0xFF) / 255.0f,
-                    (255 - (c & 0xFF)) / 255.0f,
+        for (int csp = 0; csp < num_csp; csp++) {
+            csp_start[csp] = entry->num_parts;
+            for (int i = 0; i < item->num_parts; i++) {
+                const struct sub_bitmap *b = &item->parts[i];
+                if (b->dw == 0 || b->dh == 0)
+                    continue;
+                if (num_csp > 1 && b->colorspace != csp)
+                    continue;
+                uint32_t c = b->libass.color;
+                struct pl_overlay_part part = {
+                    .src = { b->src_x, b->src_y, b->src_x + b->w, b->src_y + b->h },
+                    .dst = { b->x, b->y, b->x + b->dw, b->y + b->dh },
+                    .color = {
+                        (c >> 24) / 255.0f,
+                        ((c >> 16) & 0xFF) / 255.0f,
+                        ((c >> 8) & 0xFF) / 255.0f,
+                        (255 - (c & 0xFF)) / 255.0f,
+                    }
+                };
+                MP_TARRAY_APPEND(p, entry->parts, entry->num_parts, part);
+            }
+
+            // Duplicate overlay parts for each eye in stereo 3D modes. This
+            // runs while the current colorspace's group is still the tail of
+            // the array, so that the group stays one unbroken run.
+            if (div[0] > 1 || div[1] > 1) {
+                int orig_num = entry->num_parts;
+                for (int x = 0; x < div[0]; x++) {
+                    for (int y = 0; y < div[1]; y++) {
+                        if (x == 0 && y == 0)
+                            continue;
+                        float off_x = res.w * x;
+                        float off_y = res.h * y;
+                        for (int i = csp_start[csp]; i < orig_num; i++) {
+                            struct pl_overlay_part duped = entry->parts[i];
+                            duped.dst.x0 += off_x;
+                            duped.dst.x1 += off_x;
+                            duped.dst.y0 += off_y;
+                            duped.dst.y1 += off_y;
+                            MP_TARRAY_APPEND(p, entry->parts, entry->num_parts, duped);
+                        }
+                    }
                 }
-            };
-            MP_TARRAY_APPEND(p, entry->parts, entry->num_parts, part);
+            }
+
+            csp_count[csp] = entry->num_parts - csp_start[csp];
         }
 
-        struct pl_overlay *ol = &state->overlays[frame->num_overlays++];
+        // The groups share everything except which parts they cover and, for a
+        // client that asked for the video's colorspace, the colorspace itself.
+        struct pl_overlay overlay;
+        struct pl_overlay *ol = &overlay;
         *ol = (struct pl_overlay) {
             .tex = entry->tex,
             .parts = entry->parts,
@@ -443,27 +487,19 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
             break;
         }
 
-        // Duplicate overlay parts for each eye in stereo 3D modes
-        if (div[0] > 1 || div[1] > 1) {
-            int orig_num = entry->num_parts;
-            for (int x = 0; x < div[0]; x++) {
-                for (int y = 0; y < div[1]; y++) {
-                    if (x == 0 && y == 0)
-                        continue;
-                    float off_x = res.w * x;
-                    float off_y = res.h * y;
-                    for (int i = 0; i < orig_num; i++) {
-                        struct pl_overlay_part duped = entry->parts[i];
-                        duped.dst.x0 += off_x;
-                        duped.dst.x1 += off_x;
-                        duped.dst.y0 += off_y;
-                        duped.dst.y1 += off_y;
-                        MP_TARRAY_APPEND(p, entry->parts, entry->num_parts, duped);
-                    }
-                }
-            }
-            ol->parts = entry->parts;
-            ol->num_parts = entry->num_parts;
+        for (int csp = 0; csp < num_csp; csp++) {
+            if (!csp_count[csp])
+                continue;
+            struct pl_overlay *out = &state->overlays[frame->num_overlays++];
+            *out = *ol;
+            out->parts = entry->parts + csp_start[csp];
+            out->num_parts = csp_count[csp];
+            // A client that declared the video's colorspace wants its bitmap
+            // treated exactly like the video, so this takes the colorspace
+            // verbatim and skips the peak override applied above, which
+            // is there to stop image subtitles blowing out.
+            if (csp == SUB_BITMAP_CSP_VIDEO && src)
+                out->color = src->params.color;
         }
     }
 

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -398,8 +398,10 @@ static void update_overlays(struct vo *vo, struct mp_osd_res res,
         case SUBBITMAP_BGRA:
             ol->mode = PL_OVERLAY_NORMAL;
             ol->repr.alpha = PL_ALPHA_PREMULTIPLIED;
-            // Infer bitmap colorspace from source
-            if (src) {
+            // Infer bitmap colorspace from source, but only if the bitmap is
+            // actually in it. Bitmaps from overlay-add come from the client and
+            // are sRGB, so they keep the default set above.
+            if (src && item->video_color_space) {
                 ol->color = src->params.color;
                 if (pl_color_transfer_is_hdr(ol->color.transfer)) {
                     bool use_static = p->next_opts->image_subs_hdr_peak == -2;


### PR DESCRIPTION
Depends on #18392. That PR is the first commit here and is unchanged, only the second commit, `command: let overlay-add declare a colorspace`, is new for review.

### Why

#18392 settles `overlay-add` bitmaps as sRGB, which is right for a client drawing its own interface and wrong for content taken from the video. thumbfast decodes thumbnails and hands them over unconverted, expecting them to be tone mapped along with the video. The command carried no colorspace information, so one behavior had to serve both cases, depending on the situation one case is left broken.

### What

An optional twelfth argument:

```
overlay-add <id> <x> <y> <file> <offset> <fmt> <w> <h> <stride> <dw> <dh> <colorspace>
```

`srgb` is the default and keeps the behavior #18392 settles on. `video` uses the video's exact colorspace and tone maps the bitmap with it. Existing callers are unaffected.

A bitmap declared as `video` is left exactly as the video, without the `--image-subs-hdr-peak` override that keeps image subtitles from blowing out (a thumbnail has to match the video it came from) and clamping it to a different peak means it cannot.

### How

Overlay ids share one packed texture, so each part carries its own colorspace. Appending the parts one colorspace at a time leaves each group a single run of the array, which is the form pl_overlay takes, and the VO draws one overlay per group over the shared texture. Ids with different colorspaces can then be mixed.

Grouping is one pass per colorspace over the parts, so it stays linear and doesn't need a scratch buffer or sorting. `struct sub_bitmap` gains a `uint8_t`, placed so it's in the existing padding, `sizeof` is 56 before and after, verified with `gdb -ex 'ptype /o'`.

Stereo 3D duplication had to move inside the grouping loop. Leaving it where it was makes the copies land outside every group's range and they don't get drawn.

### MP_CMD_DEF_MAX_ARGS

It allowed eleven arguments, an additional one was added, raising it to twelve.

### Testing

Tested on Arch Linux, `vo=gpu-next`, Vulkan (`x11vk`), NVIDIA (`nvidia-open 610.57.04`), against a BT.2020/PQ clip and an SDR clip.

| Case | Result |
|---|---|
| `srgb`, HDR source | exact passthrough, `60,80,100,120,140,160` in and out |
| `video`, HDR source | takes the video's colorspace, `19,28,40,54,72,94` |
| omitted argument | identical to `srgb` |
| all three in one frame | each rendered with its own colorspace |
| 8 ids, alternating tags | 4/4 and 4/4 correct |
| `overlay-remove` | removes the right id, leaves the rest untouched |
| invalid value | rejected, `invalid parameter` |

`pl_color_space` was also printed where it is assigned: for an overlay tagged `video` every field matches the video exactly, the primaries, transfer and the float luminances. While an `srgb`-tagged overlay keeps BT.709/sRGB.
