### PR TITLE
osdep/subprocess-win: terminate environment block

### DIFF
--- a/osdep/subprocess-win.c
+++ b/osdep/subprocess-win.c
@@ -211,6 +211,7 @@ static wchar_t *convert_environ(void *ctx, char **env)
             abort();
         pos += count;
     }
+    ret[pos] = L'\0';
 
     return ret;
 }


### PR DESCRIPTION
Terminate the block of environment variables with NUL. Previously the block was left unterminated which could cause subprocess spawn failures depending on the array contents after the last item.

https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw

>An environment block consists of a null-terminated block of null-terminated strings. Each string is in the following form:  
>`name=value\0`

>[...]

>Note that an ANSI environment block is terminated by two zero bytes: one for the last string, one more to terminate the block. A Unicode environment block is terminated by four zero bytes: two for the last string, two more to terminate the block.

Space was allocated for the block-terminating NUL but it wasn't inserted.

AI-assisted while investigating [`thumbfast` issue 135](https://togithub.com/po5/thumbfast/issues/135).