### PR TITLE
select.lua: fix some incorrect boolean values in the property menu

### DIFF
--- a/player/lua/select.lua
+++ b/player/lua/select.lua
@@ -637,7 +637,9 @@ mp.add_key_binding(nil, "select-binding", function (t)
 end, { complex = true })
 
 local function add_property(properties, property, value)
-    value = value or mp.get_property_native(property)
+    if value == nil then
+        value = mp.get_property_native(property)
+    end
 
     if type(value) == "table" and next(value) then
         if type(next(value)) == "number" then


### PR DESCRIPTION
`false` value in the `value or mp.get_property_native(property)` expression will trigger `mp.get_property_native`,
<details>
<summary>
but some sub-properties cannot be accessed directly, the obtained value is nil.
</summary>
<img width="426" height="136" alt="2026-08-23 155516" src="https://github.com/user-attachments/assets/1d94505b-8f01-4679-9f9d-df4a840ce330" />
</details>



