### PR TITLE
vo_gpu_next: expose tone-mapping=linearlight

### DIFF
--- a/DOCS/interface-changes/add-linearlight-tone-mapping
+++ b/DOCS/interface-changes/add-linearlight-tone-mapping
@@ -1,0 +1,1 @@
+expose tone-mapping=linearlight

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -7682,6 +7682,9 @@ them.
     linear
         Linearly stretches the entire reference gamut to (a linear multiple of)
         the display.
+    linearlight
+        Like linear, but in linear light instead of perceptually linear.
+        (``--vo=gpu-next`` only)
     spline
         Perceptually linear single-pivot polynomial. (``--vo=gpu-next`` only)
     bt.2446a

--- a/video/out/gpu/video.c
+++ b/video/out/gpu/video.c
@@ -462,6 +462,7 @@ const struct m_sub_options gl_video_conf = {
             {"hable",    TONE_MAPPING_HABLE},
             {"gamma",    TONE_MAPPING_GAMMA},
             {"linear",   TONE_MAPPING_LINEAR},
+            {"linearlight", TONE_MAPPING_LINEARLIGHT},
             {"spline",   TONE_MAPPING_SPLINE},
             {"bt.2390",  TONE_MAPPING_BT_2390},
             {"bt.2446a", TONE_MAPPING_BT_2446A},

--- a/video/out/gpu/video.h
+++ b/video/out/gpu/video.h
@@ -99,6 +99,7 @@ enum tone_mapping {
     TONE_MAPPING_BT_2446A,
     TONE_MAPPING_ST2094_40,
     TONE_MAPPING_ST2094_10,
+    TONE_MAPPING_LINEARLIGHT,
 };
 
 enum gamut_mode {

--- a/video/out/vo_gpu_next.c
+++ b/video/out/vo_gpu_next.c
@@ -2790,6 +2790,7 @@ static void update_render_options(struct vo *vo)
         [TONE_MAPPING_BT_2446A] = &pl_tone_map_bt2446a,
         [TONE_MAPPING_ST2094_40] = &pl_tone_map_st2094_40,
         [TONE_MAPPING_ST2094_10] = &pl_tone_map_st2094_10,
+        [TONE_MAPPING_LINEARLIGHT] = &pl_tone_map_linear_light,
     };
 
     const struct pl_gamut_map_function * const gamut_modes[] = {


### PR DESCRIPTION
Not sure how useful it is, but it's listed in https://github.com/mpv-player/mpv/wiki/GPU-Next-vs-GPU

Added in libplacebo in https://github.com/haasn/libplacebo/commit/b7c9e9c2f0881e371be6526b55d986df57fae3c4 so no version bumps needed.
