### PR TITLE
options: add --sub-pause to pause on each subtitle's last frame

### DIFF
--- a/DOCS/interface-changes/sub-pause.txt
+++ b/DOCS/interface-changes/sub-pause.txt
@@ -1,0 +1,1 @@
+add `--sub-pause` option

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -3024,6 +3024,24 @@ Subtitles
     Can be used to disable display of secondary subtitles, but still select and
     decode them.
 
+``--sub-pause=<yes|no>``
+    Automatically pause playback on the last frame on which each primary
+    subtitle is visible (default: no). Resuming plays until the end of the next
+    subtitle, so repeatedly resuming steps through the dialogue line by line.
+    Has no effect without a primary subtitle track, while subtitles are hidden
+    (see ``--sub-visibility``), or during backward playback.
+
+    Since this needs a following video frame to pause on, it does nothing for
+    audio-only playback, for cover art and other still images, for a subtitle
+    that is still visible on the last frame of a file, and when video frame
+    lookahead is disabled (``--untimed``, ``--video-latency-hacks``, and VOs
+    that do not retain frames). It also does nothing for subtitles with an
+    unknown end time, or in formats rendered by ``subrandr``.
+
+    If several subtitles overlap, playback is paused when the last of them
+    ends. With ASS subtitles this counts signs and other non-dialogue events,
+    so tracks that use them can pause more than once per line of dialogue.
+
 ``--sub-clear-on-seek``
     (Obscure, rarely useful.) Can be used to play broken mkv files with
     duplicate ReadOrder fields. ReadOrder is the first field in a

--- a/options/options.c
+++ b/options/options.c
@@ -621,6 +621,7 @@ static const m_option_t mp_opts[] = {
         {"no", 0}, {"yes", 1}, {"current", 2})},
 
     {"pause", OPT_BOOL(pause)},
+    {"sub-pause", OPT_BOOL(sub_pause)},
     {"keep-open", OPT_CHOICE(keep_open,
         {"no", 0},
         {"yes", 1},
@@ -1187,6 +1188,7 @@ static const struct MPOpts mp_default_opts = {
         "sub-pos",
         "sub-visibility",
         "sub-scale",
+        "sub-pause",
         "sub-use-margins",
         "sub-ass-force-margins",
         "sub-ass-use-video-data",

--- a/options/options.h
+++ b/options/options.h
@@ -303,6 +303,7 @@ typedef struct MPOpts {
     bool save_watch_history;
     char *watch_history_path;
     bool pause;
+    bool sub_pause;
     int keep_open;
     bool keep_open_pause;
     double image_display_duration;

--- a/player/core.h
+++ b/player/core.h
@@ -670,6 +670,7 @@ void uninit_sub(struct MPContext *mpctx, struct track *track);
 void uninit_sub_all(struct MPContext *mpctx);
 void update_osd_msg(struct MPContext *mpctx);
 bool update_subtitles(struct MPContext *mpctx, double video_pts);
+bool sub_pause_check(struct MPContext *mpctx, double cur_pts, double next_pts);
 
 // video.c
 void reset_video_state(struct MPContext *mpctx);

--- a/player/sub.c
+++ b/player/sub.c
@@ -170,6 +170,22 @@ bool update_subtitles(struct MPContext *mpctx, double video_pts)
     return ok;
 }
 
+bool sub_pause_check(struct MPContext *mpctx, double cur_pts, double next_pts)
+{
+    if (!mpctx->opts->sub_pause || mpctx->play_dir < 0)
+        return false;
+
+    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    struct dec_sub *sub = track ? track->d_sub : NULL;
+    if (!sub || !mpctx->opts->subs_shared->sub_visibility[0] ||
+        cur_pts == MP_NOPTS_VALUE || next_pts == MP_NOPTS_VALUE)
+    {
+        return false;
+    }
+
+    return sub_ends_between(sub, cur_pts, next_pts);
+}
+
 static struct attachment_list *get_all_attachments(struct MPContext *mpctx)
 {
     struct attachment_list *list = talloc_zero(NULL, struct attachment_list);

--- a/player/video.c
+++ b/player/video.c
@@ -1302,6 +1302,14 @@ void write_video(struct MPContext *mpctx)
             mpctx->max_frames--;
     }
 
+    // After the frame stepping above, which must get to clear step_frames and
+    // unmute first.
+    if (mpctx->num_next_frames >= 1 &&
+        sub_pause_check(mpctx, mpctx->video_pts, mpctx->next_frames[0]->pts))
+    {
+        set_pause_state(mpctx, true);
+    }
+
     vo_c->underrun_signaled = false;
 
     if (mpctx->video_status == STATUS_EOF || mpctx->stop_play)

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -487,6 +487,26 @@ struct sd_times sub_get_times(struct dec_sub *sub, double pts)
     return res;
 }
 
+// True if a subtitle is visible on the frame at cur_pts but not on the one at
+// next_pts (both video PTS). Compared in the subtitle timebase, so --sub-delay
+// and --sub-speed are accounted for.
+bool sub_ends_between(struct dec_sub *sub, double cur_pts, double next_pts)
+{
+    mp_mutex_lock(&sub->lock);
+    bool res = false;
+
+    if (sub->sd->driver->get_times) {
+        struct sd_times t = sub->sd->driver->get_times(sub->sd,
+                                            pts_to_subtitle(sub, cur_pts));
+        // Same epsilon as sd_lavc.c's visibility test; sd_ass rounds to ms.
+        res = t.end != MP_NOPTS_VALUE &&
+              pts_to_subtitle(sub, next_pts) + 1e-6 >= t.end;
+    }
+
+    mp_mutex_unlock(&sub->lock);
+    return res;
+}
+
 void sub_reset(struct dec_sub *sub)
 {
     mp_mutex_lock(&sub->lock);

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -64,6 +64,7 @@ struct sub_bitmaps *sub_get_bitmaps(struct dec_sub *sub, struct mp_osd_res dim,
 char *sub_get_text(struct dec_sub *sub, double pts, enum sd_text_type type);
 char *sub_ass_get_extradata(struct dec_sub *sub);
 struct sd_times sub_get_times(struct dec_sub *sub, double pts);
+bool sub_ends_between(struct dec_sub *sub, double cur_pts, double next_pts);
 // Return subtitle lines in memory. Call talloc_free() on the return value.
 struct sub_lines *sub_get_lines(struct dec_sub *sub);
 


### PR DESCRIPTION
Pauses playback on the last video frame on which each primary subtitle is still visible. Resuming plays to the end of the next subtitle, so repeated resuming steps through dialogue line by line. Off by default.

This is meant for language learners, who want to stop on each line long enough to read it, look a word up, or replay the audio. Pausing by hand always lands after the line has left the screen, so it has to be recalled rather than read, and pausing on a timer drifts as soon as the dialogue does.

It has been written as a user script several times, but those are all subtly wrong when --sub-delay is set: sub_get_times() returns subtitle-timebase values and pts_to_subtitle() is static in dec_sub.c, so a pause point computed from the sub-end property is off by exactly the delay. A script also only learns about the transition after the line is already gone. sub_ends_between() compares in the subtitle timebase, so --sub-delay and --sub-speed are accounted for.

The manual lists the cases where this does nothing, mostly for want of a following frame to pause on: audio-only playback, cover art, the last frame of a file, --untimed and --video-latency-hacks. It also does nothing for subtitles with unknown end times and for subrandr, which has no get_times, and with ASS it stops on signs too, since get_times() covers every event at that PTS.

Tested with SRT and embedded ASS, with --sub-delay both ways and --sub-speed at 0.5 and 2, and with subtitles hidden, disabled, and during backward playback.

Written with AI assistance, and reviewed with AI tooling. I take full responsibility for the code: I understand what it changes and why, I have tested it myself, I will respond to review in my own words, and it can be submitted under the same license as the files it touches.
