### PR TITLE
command: add sub-snap flag to the seek command

### DIFF
--- a/DOCS/interface-changes/seek-sub-snap.txt
+++ b/DOCS/interface-changes/seek-sub-snap.txt
@@ -1,0 +1,1 @@
+add a `sub-snap` flag to the `seek` command

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -315,6 +315,17 @@ Playback Control
         Always restart playback at keyframe boundaries (fast).
     exact
         Always do exact/hr/precise seeks (slow).
+    sub-snap
+        With ``relative`` seeks, seek to the start of the next or previous
+        (depending on the sign of ``<target>``) primary subtitle event instead,
+        if it is closer than ``<target>`` seconds. Otherwise, if subtitles are
+        hidden or disabled, or if the event has not been decoded yet, an
+        ordinary relative seek is done. Snapping seeks are always exact.
+        Ignored for the other seek modes and with ``--play-dir=backward``.
+        Like ``sub-seek``, this works only with events that have already been
+        displayed or are within the prefetch range, except that snapping
+        backwards also looks behind the play position while playback is
+        paused.
 
     Multiple flags can be combined, e.g.: ``absolute+keyframes``.
 

--- a/player/command.c
+++ b/player/command.c
@@ -5973,6 +5973,271 @@ void mp_cmd_msg(struct mp_cmd_ctx *cmd, int status, const char *msg, ...)
     talloc_free(s);
 }
 
+// Bit in the seek command's flags for the "sub-snap" modifier.
+#define SEEK_FLAG_SUB_SNAP 64
+
+// How long a snap waits for subtitles to decode, and how often it looks.
+#define SUB_SNAP_TIMEOUT_MS 500
+#define SUB_SNAP_POLL_S 0.005
+
+// Move *pts onto the first frame that actually shows the subtitle starting at
+// *pts: an exact seek lands on the frame at or before it, which is the last one
+// *without* the line. Without video, use the same fixed offset as
+// cmd_sub_step_seek().
+static void sub_snap_frame_nudge(struct MPContext *mpctx, double *pts)
+{
+    struct track *vtrack = mpctx->current_track[0][STREAM_VIDEO];
+    if (!vtrack || vtrack->image) {
+        *pts += SUB_SEEK_WITHOUT_VIDEO_OFFSET - SUB_SEEK_OFFSET;
+    } else {
+        double fps = vtrack->stream ? vtrack->stream->codec->fps : 0;
+        *pts += fps > 0 ? 1.0 / fps : SUB_SEEK_OFFSET;
+    }
+}
+
+// The primary subtitle decoder, if snapping to it makes sense at all.
+static struct dec_sub *sub_snap_dec(struct MPContext *mpctx)
+{
+    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    if (!track || !track->d_sub || mpctx->play_dir < 0 ||
+        !mpctx->opts->subs_shared->sub_visibility[0])
+        return NULL;
+    return track->d_sub;
+}
+
+enum sub_snap_result {
+    SUB_SNAP_FOUND,     // an event within the seek amount
+    SUB_SNAP_TOO_FAR,   // an event, but farther away than a plain seek
+    SUB_SNAP_UNKNOWN,   // nothing found; more decoded subtitles may change that
+};
+
+// Look for the adjacent primary subtitle event in the seek direction among the
+// ones the decoder has read, and store the seek target in *target. Telling
+// TOO_FAR from UNKNOWN is what keeps an ordinary seek through a stretch without
+// subtitles from waiting for events that are not going to turn up.
+static enum sub_snap_result sub_snap_step(struct MPContext *mpctx,
+                                          double refpts, double amount,
+                                          double *target)
+{
+    struct dec_sub *sub = sub_snap_dec(mpctx);
+    if (!sub || refpts == MP_NOPTS_VALUE)
+        return SUB_SNAP_UNKNOWN;
+
+    // A backward step keys off event end times (ass_step_sub semantics): from
+    // inside a line it goes to the previous line, from a gap to the one behind.
+    double a[2] = {refpts, amount < 0 ? -1 : 1};
+    if (sub_control(sub, SD_CTRL_SUB_STEP, a) <= 0)
+        return SUB_SNAP_UNKNOWN;
+
+    // Nudge first: it moves the target by up to a frame, which both checks
+    // below must account for, or a backward snap can end up seeking forward.
+    double stepped = a[0];
+    sub_snap_frame_nudge(mpctx, &a[0]);
+
+    // SD_CTRL_SUB_STEP can report success without moving: sd_lavc returns its
+    // input when it has no adjacent event decoded. Test that before nudging,
+    // which always moves forward and would hide it.
+    if (amount > 0 ? stepped <= refpts : stepped >= refpts)
+        return SUB_SNAP_UNKNOWN;
+    // The nudge can push a backward target past the play position.
+    if (amount < 0 && a[0] >= refpts)
+        return SUB_SNAP_UNKNOWN;
+    if (fabs(a[0] - refpts) >= fabs(amount))
+        return SUB_SNAP_TOO_FAR;
+
+    *target = a[0];
+    return SUB_SNAP_FOUND;
+}
+
+// Take as many of the pending steps as the decoded subtitles allow.
+static enum sub_snap_result sub_snap_advance(struct MPContext *mpctx)
+{
+    struct sub_snap_state *st = &mpctx->sub_snap;
+    enum sub_snap_result r = SUB_SNAP_FOUND;
+
+    while (st->steps > 0) {
+        double target;
+        r = sub_snap_step(mpctx, st->base, st->amount, &target);
+        if (r != SUB_SNAP_FOUND)
+            break;
+        st->base = target;
+        st->moved = true;
+        st->steps--;
+    }
+    return r;
+}
+
+// Issue the seek this chain resolved to and forget the chain. Steps that could
+// not be snapped are covered by their plain relative amount.
+static void sub_snap_finish(struct MPContext *mpctx)
+{
+    struct sub_snap_state *st = &mpctx->sub_snap;
+    double rest = st->amount * st->steps;
+
+    if (st->moved) {
+        queue_seek(mpctx, MPSEEK_ABSOLUTE, st->base + rest,
+                   st->steps ? st->precision : MPSEEK_EXACT, MPSEEK_FLAG_DELAY);
+    } else {
+        queue_seek(mpctx, MPSEEK_RELATIVE, rest, st->precision,
+                   MPSEEK_FLAG_DELAY);
+    }
+
+    *st = (struct sub_snap_state){
+        .base = st->base,
+        .moved = st->moved,
+        .queued = true,
+    };
+}
+
+// Only asked once, when the chain starts waiting: a chain already in flight
+// must not be cut short by playback state changing under it.
+static bool sub_snap_can_wait(struct MPContext *mpctx)
+{
+    // A backward chain relies on sub_snap_rewind(), which moves the demuxer,
+    // so it needs playback stopped.
+    return sub_snap_dec(mpctx) &&
+           (mpctx->sub_snap.amount > 0 || mpctx->paused);
+}
+
+// The events a backward chain needs are behind the play position and can not
+// be read ahead: move the *demuxer* (not playback) back to the start of the
+// window the pending steps span, and decode forward from there.
+static bool sub_snap_rewind(struct MPContext *mpctx, struct dec_sub *sub)
+{
+    struct sub_snap_state *st = &mpctx->sub_snap;
+    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    if (!track->demuxer ||
+        !demux_seek(track->demuxer, st->base + st->amount * st->steps, 0))
+    {
+        return false;
+    }
+    sub_reset(sub);
+    st->rewound = true;
+    return true;
+}
+
+static bool sub_snap_chain_valid(struct MPContext *mpctx)
+{
+    struct sub_snap_state *st = &mpctx->sub_snap;
+    return st->queued && mpctx->seek.type == MPSEEK_ABSOLUTE &&
+           mpctx->seek.amount == st->base;
+}
+
+// Start a chain from the position the seek queue is already heading for, so
+// that a snap composes with a pending seek instead of replacing it. False if
+// there is nothing to snap from, leaving an ordinary relative seek.
+static bool sub_snap_start(struct MPContext *mpctx)
+{
+    // Keep track of a seek this chain queued itself, so that mp_seek() knows
+    // to let the pending steps survive it.
+    bool queued = sub_snap_chain_valid(mpctx);
+    double base;
+    bool moved = true;
+
+    switch (mpctx->seek.type) {
+    case MPSEEK_NONE:
+        base = get_current_time(mpctx);
+        moved = false;
+        break;
+    case MPSEEK_ABSOLUTE:
+        base = mpctx->seek.amount;
+        break;
+    case MPSEEK_RELATIVE:
+        base = get_current_time(mpctx) + mpctx->seek.amount;
+        break;
+    default:
+        return false;
+    }
+
+    if (base == MP_NOPTS_VALUE)
+        return false;
+
+    mpctx->sub_snap = (struct sub_snap_state){
+        .base = base,
+        .moved = moved,
+        .queued = queued,
+    };
+    return true;
+}
+
+// Drive the subtitle decoder towards the events a pending snap needs, and
+// resolve the seek once they are there. Called once per playloop iteration.
+void handle_sub_snap(struct MPContext *mpctx)
+{
+    struct sub_snap_state *st = &mpctx->sub_snap;
+    if (!st->waiting)
+        return;
+
+    if (mpctx->seek.type && !sub_snap_chain_valid(mpctx)) {
+        // A seek that is not this chain's own was queued. It is the newer
+        // request, so drop the chain rather than adding the pending steps to
+        // it: queue_seek() would fold them into that seek's amount.
+        *st = (struct sub_snap_state){0};
+        return;
+    }
+
+    struct dec_sub *sub = sub_snap_dec(mpctx);
+    if (!sub) {
+        sub_snap_finish(mpctx);
+        return;
+    }
+
+    // Rewinding resets the reader state of every stream, so it has to wait for
+    // playback to settle, and for the seek this chain queued in particular:
+    // that one moves the demuxer itself and would undo the rewind. Reading
+    // before it has happened is pointless, so just poll on.
+    if (st->amount < 0 && !st->rewound) {
+        if (!mpctx->paused) {
+            // Unpaused since the wait was armed. Rewinding a demuxer shared
+            // with video and audio would pull the ground out from under them.
+            sub_snap_finish(mpctx);
+            return;
+        }
+        if (st->queued || mpctx->video_status < STATUS_READY) {
+            if (mp_time_ns() >= st->deadline)
+                sub_snap_finish(mpctx);
+            else
+                mp_set_timeout(mpctx, SUB_SNAP_POLL_S);
+            return;
+        }
+        if (!sub_snap_rewind(mpctx, sub)) {
+            sub_snap_finish(mpctx);
+            return;
+        }
+    }
+
+    // Reading the decoder's packets also asks the demuxer to go up to the far
+    // end of the window, past its usual read-ahead.
+    double window_end = st->amount > 0 ? st->base + st->amount : st->base;
+    bool packets_read = false, sub_updated = false;
+    sub_read_packets(sub, window_end, true, &packets_read, &sub_updated);
+
+    // A sparse stream reports EOF whenever nothing is queued for it, which in
+    // a stretch without subtitles says nothing about the window. What settles
+    // it is how far the demuxer itself has read, which is also what it keeps
+    // reading against on the decoder's behalf.
+    struct demux_reader_state state = {0};
+    struct track *track = mpctx->current_track[0][STREAM_SUB];
+    if (track->demuxer)
+        demux_get_reader_state(track->demuxer, &state);
+    bool read = packets_read &&
+                (state.eof || (state.ts_last != MP_NOPTS_VALUE &&
+                               state.ts_last >= window_end));
+
+    enum sub_snap_result r = sub_snap_advance(mpctx);
+    // Reading forward reaches the nearest event first, so TOO_FAR settles a
+    // forward chain as soon as it comes up. A backward chain decodes its
+    // window from the far end towards the play position, so the first event it
+    // finds is the farthest one, and nothing is settled until the window has
+    // been read.
+    bool settled = r == SUB_SNAP_TOO_FAR && st->amount > 0;
+    if (!st->steps || settled || read || mp_time_ns() >= st->deadline) {
+        sub_snap_finish(mpctx);
+    } else {
+        mp_set_timeout(mpctx, SUB_SNAP_POLL_S);
+    }
+}
+
 static void cmd_seek(void *p)
 {
     struct mp_cmd_ctx *cmd = p;
@@ -5993,7 +6258,34 @@ static void cmd_seek(void *p)
     mark_seek(mpctx);
     switch (abs) {
     case 0: { // Relative seek
-        queue_seek(mpctx, MPSEEK_RELATIVE, v, precision, MPSEEK_FLAG_DELAY);
+        struct sub_snap_state *st = &mpctx->sub_snap;
+        // Presses accumulate into one chain: input is drained in batches, so
+        // recomputing a target per press would collapse a burst into one step.
+        bool snap = cmd->args[1].v.i & SEEK_FLAG_SUB_SNAP;
+        if (snap && !st->steps && !st->waiting)
+            snap = sub_snap_start(mpctx);
+        if (snap) {
+            st->steps++;
+            st->amount = v;
+            st->precision = precision;
+
+            // TOO_FAR settles a forward chain here, but not a backward one:
+            // the events behind the play position may not be decoded yet, and
+            // the ones that are can be arbitrarily far back.
+            enum sub_snap_result r = sub_snap_advance(mpctx);
+            if (!st->steps || (r == SUB_SNAP_TOO_FAR && v > 0) ||
+                (!st->waiting && !sub_snap_can_wait(mpctx)))
+            {
+                sub_snap_finish(mpctx);
+            } else if (!st->waiting) {
+                st->waiting = true;
+                st->deadline =
+                    mp_time_ns() + MP_TIME_MS_TO_NS(SUB_SNAP_TIMEOUT_MS);
+                mp_set_timeout(mpctx, SUB_SNAP_POLL_S);
+            }
+        } else {
+            queue_seek(mpctx, MPSEEK_RELATIVE, v, precision, MPSEEK_FLAG_DELAY);
+        }
         set_osd_function(mpctx, (v > 0) ? OSD_FFW : OSD_REW);
         break;
     }
@@ -7565,7 +7857,8 @@ const struct mp_cmd_def mp_cmds[] = {
                 {"absolute", 4|2},
                 {"relative-percent", 4|3},
                 {"keyframes", 32|8},
-                {"exact", 32|16}),
+                {"exact", 32|16},
+                {"sub-snap", SEEK_FLAG_SUB_SNAP}),
                 OPTDEF_INT(4|0)},
             // backwards compatibility only
             {"legacy", OPT_CHOICE(v.i,

--- a/player/command.h
+++ b/player/command.h
@@ -93,6 +93,7 @@ void mp_notify(struct MPContext *mpctx, int event, void *arg);
 void mp_notify_property(struct MPContext *mpctx, const char *property);
 
 void handle_command_updates(struct MPContext *mpctx);
+void handle_sub_snap(struct MPContext *mpctx);
 
 int mp_get_property_id(struct MPContext *mpctx, const char *name);
 uint64_t mp_get_property_event_mask(const char *name);

--- a/player/core.h
+++ b/player/core.h
@@ -86,6 +86,20 @@ enum seek_flags {
     MPSEEK_FLAG_NOFLUSH = 1 << 1, // keeping remaining data for seamless loops
 };
 
+// State of a "sub-snap" seek in progress; see cmd_seek() and
+// handle_sub_snap().
+struct sub_snap_state {
+    int steps;                      // subtitle events still to step over
+    double base;                    // position the next step starts from
+    double amount;                  // signed seek window per step
+    enum seek_precision precision;
+    bool moved;                     // base is a target, not a play position
+    bool waiting;                   // waiting for the decoder to catch up
+    bool rewound;                   // the demuxer was moved back for this chain
+    bool queued;                    // the seek it queued has not run yet
+    int64_t deadline;
+};
+
 struct seek_params {
     enum seek_type type;
     enum seek_precision exact;
@@ -414,6 +428,8 @@ typedef struct MPContext {
     int64_t last_time;
 
     struct seek_params seek;
+
+    struct sub_snap_state sub_snap;
 
     /* Heuristic for relative chapter seeks: keep track which chapter
      * the user wanted to go to, even if we aren't exactly within the

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -1811,6 +1811,7 @@ static void play_current_file(struct MPContext *mpctx)
     mpctx->last_chapter_seek = -2;
     mpctx->last_chapter_flag = false;
     mpctx->last_chapter = -2;
+    mpctx->sub_snap = (struct sub_snap_state){0};
     mpctx->paused = false;
     mpctx->playing_msg_shown = false;
     mpctx->max_frames = -1;

--- a/player/playloop.c
+++ b/player/playloop.c
@@ -464,6 +464,17 @@ static void mp_seek(MPContext *mpctx, struct seek_params seek)
     update_ab_loop_clip(mpctx);
 
     mpctx->current_seek = seek;
+    // A sub-snap chain is built against a position, so any seek other than the
+    // one it queued itself invalidates it. Its own seek only means the target
+    // has been reached, and any steps still pending go on from there.
+    struct sub_snap_state *snap = &mpctx->sub_snap;
+    if (snap->queued && seek.type == MPSEEK_ABSOLUTE &&
+        seek.amount == snap->base)
+    {
+        snap->queued = false;
+    } else {
+        *snap = (struct sub_snap_state){0};
+    }
     redraw_subs(mpctx);
 }
 
@@ -1326,6 +1337,8 @@ void run_playloop(struct MPContext *mpctx)
     handle_sstep(mpctx);
 
     update_core_idle_state(mpctx);
+
+    handle_sub_snap(mpctx);
 
     execute_queued_seek(mpctx);
 


### PR DESCRIPTION
`seek <amount> sub-snap` is a relative seek that lands on the start of the next or previous primary subtitle event when one falls within `<amount>` seconds, and does an ordinary relative seek otherwise. It is meant to replace the plain relative seek on the arrow keys rather than to sit beside it as one more binding: because it never travels farther than the amount asked for, it does exactly what the seek it replaces would have done wherever no subtitle is in range.

Seeking back a few seconds during dialogue is nearly always an attempt to hear or read one line again. A plain `seek -5` lands mid-sentence, so the line has to come round a second time before it is heard whole, and `sub-seek -1` jumps to whatever event happens to be previous, which across a silent stretch can be a minute away — which is also why it cannot serve as the everyday seek key. With `sub-snap` bound to left and right there is nothing to decide before pressing: in dialogue it replays the line from its start, elsewhere it seeks. My own arrow keys have been bound to it since I wrote it and I have not wanted the plain seek back. Language learners are the obvious audience, since repeating individual lines is most of the activity, but this is what anyone rewinding to catch a mumbled line is reaching for.

A script can approximate this with `sub-seek` followed by a correction seek, but the correction is a second visible jump, and it cannot tell "there is no event within the amount" from "the decoder has not read that far yet". Only the latter is worth waiting for; conflating them makes holding the key down in a gap stall instead of seeking. `SD_CTRL_SUB_STEP` sees only what has been decoded, and how far that reaches is not exposed to scripts. Key repeat is the other half of it: input is drained in batches, so a script doing a property round-trip per press collapses a burst into one step.

The wait is driven from the playloop by `handle_sub_snap()` rather than blocking the core. A backward snap needs the region behind the play position, which cannot be read ahead, so the demuxer alone is rewound while playback stays put, and only while paused, since it is shared with the other streams. Repeated presses accumulate into one chain, and the chain starts from the target of a pending seek instead of the play position, so it composes with seeks issued in the same batch rather than replacing them.

The manual gives the limits. Like `sub-seek`, this only works with events already displayed or within the prefetch range, except that a backward snap also looks behind the play position while paused. It is ignored for the other seek modes and with `--play-dir=backward`. Whenever the event is not available it falls back to an ordinary relative seek, so it never blocks or waits visibly — it just stops snapping.

Tested with external SRT, embedded ASS and PGS from a Blu-ray rip: bursts of one to four presses from several start positions, forward and backward, on a short file and a ten-minute one; `--sub-delay` both signs and `--sub-speed` at 0.5 and 2; subtitles hidden, disabled, and present only as a secondary track; `--play-dir=backward`; twenty-five presses of key-repeat scrubbing through a gap, compared against a plain seek; and unrelated seeks queued in the same input batch, checked against the result without the flag.

Written with AI assistance, and reviewed with AI tooling. I take full responsibility for the code: I understand what it changes and why, I have tested it myself, I will respond to review in my own words, and it can be submitted under the same license as the files it touches.
