### PR TITLE
ci/mac: don't apply werror to the linker for the oldest target

### DIFF
--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -7,6 +7,17 @@ set -e
 MPV_INSTALL_PREFIX="${HOME}/out/mpv"
 MPV_VARIANT="${TRAVIS_OS_NAME}"
 
+objc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations"
+
+# Homebrew's libraries are built for the macOS version of the runner, so ld
+# warns for each of them when building for an older deployment target. meson
+# 1.12 passes -Wl,-fatal_warnings with werror, so only apply werror to the
+# compilers.
+if [[ -n "${MACOSX_DEPLOYMENT_TARGET}" ]]; then
+    common_args="${common_args/--werror/-Dwerror=false -Dc_args=-Werror}"
+    objc_args="-Werror ${objc_args}"
+fi
+
 if [[ -d "./build/${MPV_VARIANT}" ]] ; then
     rm -rf "./build/${MPV_VARIANT}"
 fi
@@ -14,7 +25,7 @@ fi
 PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build $common_args \
   -Dprefix="${MPV_INSTALL_PREFIX}" \
-  -Dobjc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
+  -Dobjc_args="${objc_args}" \
   -D{caca,cdda,dvdnav,gl,iconv,lcms2,libarchive,libbluray,lua,jpeg}=enabled \
   -D{plain-gl,rubberband,zimg,zlib}=enabled \
   -D{cocoa,coreaudio,gl-cocoa,videotoolbox-gl,videotoolbox-pl}=enabled \


### PR DESCRIPTION
The macOS jobs have been failing since 13 August. In the `-target arm64-apple-macosx10.15` job, `libmpv.2.dylib` and `mpv` both fail to link with `ld: fatal warning(s) induced error (-fatal_warnings)`, and the matrix's fail-fast then cancels the other macOS jobs, so the whole build workflow is red on master.

Two things combine. Homebrew's libraries are built for the macOS version of the runner, so everything under `/opt/homebrew` currently has `minos 26.0`, and building with `MACOSX_DEPLOYMENT_TARGET=10.15` (clang clamps it to 11.0 on arm64) makes ld warn once for every library it links against. That part is not new: the last green run printed 82 of those warnings and passed. What changed is meson 1.12, released three days before the first failure, which put the linker under werror:

    def get_base_link_args(target, linker, env):
        args = []
        if env.coredata.get_option_for_target(target, 'werror'):
            args.extend(linker.get_linker_fatal_warnings())

On Apple that is `-Wl,-fatal_warnings`, so the warnings that were always there became errors. In 1.11.2 the linker only got werror under b_lto.

ld offers no way to demote just this warning: `-w` hides the text but the warnings still count as fatal, and `-no_fatal_warnings` and `-no_warn_platform_mismatch` are not options in ld-1267. So this takes werror off the linker and passes `-Werror` to the compilers by hand, which is what meson did before 1.12. Only the job that sets a deployment target is affected; the other four macOS jobs keep `--werror` as it is.

Checked on macOS 26.6 with Xcode 26.6, meson 1.12.0 and current Homebrew, which is what the runner has: with the deployment target exported the build fails the same way CI does, and with this change it compiles, links and runs, with the binary still at minos 11.0 and the mismatch warnings printed but harmless. Feature detection is unaffected — the configure summary is identical apart from the option lines.

Dropping `MACOSX_DEPLOYMENT_TARGET` from the matrix entry links cleanly as well, since the Swift target is a separate flag, but it stops building the C and ObjC code for the old target, which seemed the wrong half to give up.

Written with AI assistance, and reviewed with AI tooling. I take full responsibility for the code: I understand what it changes and why, I have tested it myself, I will respond to review in my own words, and it can be submitted under the same license as the files it touches.
