### PR TITLE
ci/build-win32.ps1: Add missing dependencies to the wrap list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,8 @@ jobs:
           meson wrap install harfbuzz
           meson wrap install libpng
           meson wrap install zlib
+          meson wrap install lcms2
+          meson wrap install freetype2
 
       - name: Find Visual Studio
         run: |

--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -173,6 +173,8 @@ they will be automatically downloaded and built by Meson.
    meson wrap install harfbuzz
    meson wrap install libpng
    meson wrap install zlib
+   meson wrap install lcms2
+   meson wrap install freetype2
    ```
 4. Set environment variables so Meson uses the Clang/LLVM toolchain, or pass an
 equivalent `--native-file` to Meson.


### PR DESCRIPTION
Hi!

Coming here from https://gitlab.freedesktop.org/gstreamer/meson-ports/ffmpeg/-/work_items/75, during triage of that bug I found a couple missing libraries from the setup I use (the `build-win32.ps1` script).

All feedback is appreciated!