### PR TITLE
vo_kitty: include leading slash in shm name payload

### DIFF
--- a/video/out/vo_kitty.c
+++ b/video/out/vo_kitty.c
@@ -420,10 +420,10 @@ static int preinit(struct vo *vo)
 #if HAVE_POSIX_SHM
     if (p->opts.use_shm) {
         p->shm_path = talloc_asprintf(vo, "/mpv-kitty-%p", vo);
-        int p_size = strlen(p->shm_path) - 1;
+        int p_size = strlen(p->shm_path);
         int b64_size = AV_BASE64_SIZE(p_size);
         p->shm_path_b64 = talloc_array(vo, char, b64_size);
-        av_base64_encode(p->shm_path_b64, b64_size, p->shm_path + 1, p_size);
+        av_base64_encode(p->shm_path_b64, b64_size, p->shm_path, p_size);
     }
 #else
     if (p->opts.use_shm) {


### PR DESCRIPTION
POSIX portable shm names start with '/'. mpv already creates the object as "/mpv-kitty-%p", but the Kitty APC payload was the base64 of shm_path+1 (slash stripped). Linux glibc shm_open() accepts both forms, macOS/Darwin does not. With q=2 the terminal hides the error, so --vo-kitty-use-shm=yes shows no image on macOS.

Encode the full shm_path, matching the protocol examples.