### PR TITLE
ci/mac: fix macOS 15 test action and cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,6 +324,7 @@ jobs:
           TRAVIS_OS_NAME: "${{ matrix.os }}"
           SWIFT_FLAGS: "${{ matrix.swift }}"
           MACOSX_DEPLOYMENT_TARGET: "${{ matrix.target }}"
+          MACOS_ARCH: "${{ matrix.arch }}"
 
       - name: Create App Bundle
         if: ${{ matrix.arch != 'test' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,7 @@ jobs:
           - os: "macos-15"
             arch: "arm"
           - os: "macos-15-intel"
+            homebrew: "956fbd2598f7b0bc3c7ef72edaa622e19415f6c9"
           - os: "macos-26"
             arch: "arm"
           - os: "macos-26"

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -4,14 +4,20 @@ set -e
 
 . ./ci/build-common.sh
 
+objc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations"
+c_args=""
 if [[ "${MACOS_ARCH}" == "test" ]]; then
     # remove -werror + tests and keep libmpv for test builds only
     common_args="-Dlibmpv=true"
+    # add back -werror for compiling only, not for linking
+    objc_args="-Werror ${objc_args}"
+    c_args="-Werror"
 fi
 
 PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build $common_args \
-  -Dobjc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
+  -Dobjc_args="${objc_args}" \
+  -Dc_args="${c_args}" \
   -D{caca,cdda,dvdnav,gl,iconv,lcms2,libarchive,libbluray,lua,jpeg}=enabled \
   -D{plain-gl,rubberband,zimg,zlib}=enabled \
   -D{cocoa,coreaudio,gl-cocoa,videotoolbox-gl,videotoolbox-pl}=enabled \

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -4,6 +4,11 @@ set -e
 
 . ./ci/build-common.sh
 
+if [[ "${MACOS_ARCH}" == "test" ]]; then
+    # remove -werror + tests and keep libmpv for test builds only
+    common_args="-Dlibmpv=true"
+fi
+
 PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build $common_args \
   -Dobjc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \

--- a/ci/build-macos.sh
+++ b/ci/build-macos.sh
@@ -4,16 +4,8 @@ set -e
 
 . ./ci/build-common.sh
 
-MPV_INSTALL_PREFIX="${HOME}/out/mpv"
-MPV_VARIANT="${TRAVIS_OS_NAME}"
-
-if [[ -d "./build/${MPV_VARIANT}" ]] ; then
-    rm -rf "./build/${MPV_VARIANT}"
-fi
-
 PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig/" CC="${CC}" CXX="${CXX}" \
 meson setup build $common_args \
-  -Dprefix="${MPV_INSTALL_PREFIX}" \
   -Dobjc_args="-Wno-error=deprecated -Wno-error=deprecated-declarations" \
   -D{caca,cdda,dvdnav,gl,iconv,lcms2,libarchive,libbluray,lua,jpeg}=enabled \
   -D{plain-gl,rubberband,zimg,zlib}=enabled \


### PR DESCRIPTION
just deactivating the "warnings as errors" for linking on the test action. the warnings are expected. also cleaned up some old stuff.

for the mujs problem see this action https://github.com/Akemi/mpv/actions/runs/33256346421/job/99117320730#step:6:226