### PR TITLE
vo_gpu[_next]/vulkan: enable extensions required for vf_fruc_vulkan filter

### DIFF
--- a/video/out/hwdec/hwdec_vulkan.c
+++ b/video/out/hwdec/hwdec_vulkan.c
@@ -157,6 +157,17 @@ static int vulkan_init(struct ra_hwdec *hw)
             };
         }
     }
+#ifdef VK_NV_optical_flow
+    for (int i = 0; i < num_qf; i++) {
+        if ((qf[i].queueFamilyProperties.queueFlags) & VK_QUEUE_OPTICAL_FLOW_BIT_NV) {
+            device_hwctx->qf[device_hwctx->nb_qf++] = (AVVulkanDeviceQueueFamily) {
+                .idx = i,
+                .num = qf[i].queueFamilyProperties.queueCount,
+                .flags = VK_QUEUE_OPTICAL_FLOW_BIT_NV,
+            };
+        }
+    }
+#endif
 #else
     int decode_index = -1;
     for (int i = 0; i < num_qf; i++) {

--- a/video/out/vulkan/context.c
+++ b/video/out/vulkan/context.c
@@ -206,6 +206,7 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
         VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME,
         VK_KHR_VIDEO_QUEUE_EXTENSION_NAME,
         VK_KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_EXTENSION_NAME,
+        VK_NV_OPTICAL_FLOW_EXTENSION_NAME,
         /*
          * Extensions below this point are newer than our minimum required Vulkan
          * headers and so we only activate them if the build time headers contain
@@ -240,6 +241,9 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
 #ifdef VK_KHR_video_decode_vp9
         VK_KHR_VIDEO_DECODE_VP9_EXTENSION_NAME, /* 1.4.317 */
 #endif
+#ifdef VK_KHR_maintenance9
+        VK_KHR_MAINTENANCE_9_EXTENSION_NAME, /* 1.4.317 */
+#endif
     };
 
     /*
@@ -248,9 +252,19 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
      * the next extension that chains on to it will also be present.
      */
 
+#ifdef VK_KHR_maintenance9
+    VkPhysicalDeviceMaintenance9FeaturesKHR maintenance_9_feature = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR,
+        .maintenance9 = true,
+    };
+#endif
+
 #ifdef VK_KHR_video_decode_vp9
      VkPhysicalDeviceVideoDecodeVP9FeaturesKHR video_decode_vp9_feature = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_DECODE_VP9_FEATURES_KHR,
+#ifdef VK_KHR_maintenance9
+        .pNext = &maintenance_9_feature,
+#endif
         .videoDecodeVP9 = true,
     };
 #endif
@@ -333,9 +347,15 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
        .shaderZeroInitializeWorkgroupMemory = true,
     };
 
+    VkPhysicalDeviceOpticalFlowFeaturesNV optical_flow_feature = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV,
+        .pNext = &zero_init_feature,
+        .opticalFlow = true,
+    };
+
     VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_feature = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR,
-        .pNext = &zero_init_feature,
+        .pNext = &optical_flow_feature,
        .dynamicRendering = true,
     };
 
@@ -394,6 +414,13 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
     bool is_uuid = opts->device &&
                    av_uuid_parse(opts->device, param_uuid) == 0;
 
+    /*
+     * Request extra queue families opportunistically. These will only be
+     * enabled if present.
+     */
+    VkQueueFlags extra_queues = VK_QUEUE_VIDEO_DECODE_BIT_KHR |
+                                VK_QUEUE_OPTICAL_FLOW_BIT_NV;
+
     mp_assert(pllog);
     mp_assert(vkinst);
     struct pl_vulkan_params device_params = {
@@ -404,7 +431,7 @@ pl_vulkan mppl_create_vulkan(struct vulkan_opts *opts,
         .async_transfer = opts->async_transfer,
         .async_compute = opts->async_compute,
         .queue_count = opts->queue_count,
-        .extra_queues = VK_QUEUE_VIDEO_DECODE_BIT_KHR,
+        .extra_queues = extra_queues,
         .opt_extensions = opt_extensions,
         .num_opt_extensions = MP_ARRAY_SIZE(opt_extensions),
         .features = &features,


### PR DESCRIPTION
ffmpeg's new vf_fruc_vulkan filter uses VK_NV_optical_flow to provide hardware accelerated optical flow for doing framerate up-conversion. For this filter to work, we must do three things:
* Enable the VK_NV_optical_flow extension and matching feature
* Request the optical flow queue family
* Enable the VK_KHR_maintenance9 extension and matching feature

This last item is important because the filter relies on implicit image sharing across queues which is a feature it provides.