### PR TITLE
sub: report image subtitle timings in sub-lines

### DIFF
--- a/DOCS/interface-changes/sub-lines-image.txt
+++ b/DOCS/interface-changes/sub-lines-image.txt
@@ -1,0 +1,1 @@
+`sub-lines` and `secondary-sub-lines` now also list image subtitles, with empty `text`

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -3387,8 +3387,7 @@ Property list
     Same as ``sub-end``, but for the secondary subtitles.
 
 ``sub-lines``
-    The list of subtitle lines in memory. Not available if the subtitle is not
-    text-based (i.e. DVD/BD subtitles).
+    The list of subtitle lines in memory.
 
     When querying the property with the client API using ``MPV_FORMAT_NODE``,
     or with Lua ``mp.get_property_native``, this will return a mpv_node with
@@ -3403,6 +3402,10 @@ Property list
                 "end"   MPV_FORMAT_DOUBLE
 
     ASS tags are stripped from ``text``.
+
+    ``text`` is empty for image subtitles (i.e. DVD/BD subtitles), which have
+    no text. Only the lines decoded so far are listed for them, the same ones
+    ``sub-seek`` can reach.
 
     ``end`` is absent if unknown.
 

--- a/player/command.c
+++ b/player/command.c
@@ -363,7 +363,7 @@ static char *skip_n_lines(char *text, int lines)
 
 static int count_lines(char *text)
 {
-    if (!text[0])
+    if (!text || !text[0])
         return 0;
 
     int count = 0;
@@ -3569,7 +3569,7 @@ static int mp_property_sub_lines(void *ctx, struct m_property *prop,
         for (int i = 0; i < lines->num_entries; i++) {
             struct sub_line *line = &lines->entries[i];
             struct mpv_node *entry = node_array_add(node, MPV_FORMAT_NODE_MAP);
-            node_map_add_string(entry, "text", line->text);
+            node_map_add_string(entry, "text", line->text ? line->text : "");
             node_map_add_double(entry, "start", line->start);
             if (line->end != MP_NOPTS_VALUE)
                 node_map_add_double(entry, "end", line->end);
@@ -3595,7 +3595,9 @@ static int mp_property_sub_lines(void *ctx, struct m_property *prop,
                 reset = get_style_reset(mpctx);
             }
 
-            res = talloc_asprintf_append(res, "%s%s\n", line->text, reset);
+            // Image subtitles have no text; they list as empty lines.
+            res = talloc_asprintf_append(res, "%s%s\n",
+                                         line->text ? line->text : "", reset);
 
             if (line->start <= time_pos && i)
                 pos += count_lines(lines->entries[i - 1].text);

--- a/sub/dec_sub.c
+++ b/sub/dec_sub.c
@@ -605,7 +605,11 @@ static void dedup_sub_lines(struct sub_lines *lines)
                 continue;
             }
 
-            if (!strcmp(lines->entries[i].text, next.text)) {
+            // Image subtitles have no text to compare, and the decoder does
+            // not report one twice anyway.
+            if (lines->entries[i].text && next.text &&
+                !strcmp(lines->entries[i].text, next.text))
+            {
                 lines->entries[i].end = MPMAX(next.end, lines->entries[i].end);
                 TA_FREEP(&next.text);
                 ++current_shift, --lines->num_entries;

--- a/sub/dec_sub.h
+++ b/sub/dec_sub.h
@@ -42,7 +42,7 @@ struct attachment_list {
 };
 
 struct sub_line {
-    char *text;
+    char *text; // NULL for image subtitles
     double start;
     double end;
 };

--- a/sub/sd_lavc.c
+++ b/sub/sd_lavc.c
@@ -744,6 +744,23 @@ static double step_sub(struct sd *sd, double now, int movement)
     return best < 0 ? now : priv->seekpoints[best].pts;
 }
 
+static struct sub_lines *get_lines(struct sd *sd)
+{
+    struct sd_lavc_priv *priv = sd->priv;
+    struct sub_lines *res = talloc_zero(NULL, struct sub_lines);
+
+    // The seekpoints hold the timings of every subtitle decoded so far.
+    for (int n = 0; n < priv->num_seekpoints; n++) {
+        struct sub_line line = {
+            .start = priv->seekpoints[n].pts,
+            .end   = priv->seekpoints[n].endpts,
+        };
+        MP_TARRAY_APPEND(res, res->entries, res->num_entries, line);
+    }
+
+    return res;
+}
+
 static int control(struct sd *sd, enum sd_ctrl cmd, void *arg)
 {
     struct sd_lavc_priv *priv = sd->priv;
@@ -791,4 +808,5 @@ const struct sd_functions sd_lavc = {
     .control = control,
     .reset = reset,
     .uninit = uninit,
+    .get_lines = get_lines,
 };


### PR DESCRIPTION
`sub-lines` is where a script gets subtitle timings from, but it is text-only, so with DVD/BD subtitles there is nothing to work from. sd_lavc already keeps the timings of every subtitle it has decoded, to serve `sub-seek`, so this reports those through the property, with empty `text`. It comes out of #18409, where @na-na-hi pointed out that a script can already work out an exact seek target from `sub-lines`, and that what is missing is image subtitles.

For image subtitles the list covers what the decoder has been handed: everything seen so far behind the play position, and up to four events ahead of it, bounded by `--demuxer-readahead-secs`. That is the same reach `sub-seek` has.

Empty `text` rather than no `text` keeps the node as documented, and `select.lua` then lists those lines by time through the branch it already has for empty ones. It still leaves "Subtitle lines" out of its menu for image subtitles; whether a list of bare timestamps belongs there seemed a separate question, and the binding works when invoked directly.

Lines carrying no text of their own are left out of the deduplication in `sub_get_lines()`, which merges entries with equal text that have not ended before the next one starts. With nothing to compare, two image subtitles where one ends exactly where the next begins would be merged into one.

Tested with the three PGS tracks of a Blu-ray rip and with an external SRT: the timings match the file, `select-subtitle-line` works on either kind, the OSD list of a text track is unchanged, and `meson test` passes.

Written with AI assistance, and reviewed with AI tooling. I take full responsibility for the code: I understand what it changes and why, I have tested it myself, I will respond to review in my own words, and it can be submitted under the same license as the files it touches.
