### PR TITLE
osdep/path-win: expand `~~exe_dir/` on portable mode

### DIFF
--- a/osdep/path-win.c
+++ b/osdep/path-win.c
@@ -107,12 +107,12 @@ const char *mp_get_platform_path_win(void *talloc_ctx, const char *type)
             return mp_path_join(talloc_ctx, mp_get_win_local_app_dir(talloc_ctx), "cache");
         if (strcmp(type, "state") == 0)
             return mp_get_win_local_app_dir(talloc_ctx);
-        if (strcmp(type, "exe_dir") == 0)
-            return mp_get_win_exe_dir(talloc_ctx);
         // Not really true, but serves as a way to return a lowest-priority dir.
         if (strcmp(type, "global") == 0)
             return mp_get_win_exe_subdir(talloc_ctx, "mpv");
     }
+    if (strcmp(type, "exe_dir") == 0)
+        return mp_get_win_exe_dir(talloc_ctx);
     if (strcmp(type, "desktop") == 0)
         return mp_get_win_shell_dir(talloc_ctx, &FOLDERID_Desktop);
     return NULL;


### PR DESCRIPTION
don't know why it was only expanded on non-portable mode before, but adding this should be fine.

Closes: #10009
Closes: #18429
