### PR TITLE
options: add --status-msg-update-rate/--status-msg-update-rate-forced

### DIFF
--- a/DOCS/interface-changes/status-msg-update-rate.txt
+++ b/DOCS/interface-changes/status-msg-update-rate.txt
@@ -1,0 +1,1 @@
+add `--status-msg-update-rate` and `--status-msg-update-rate-forced options`

--- a/DOCS/man/options.rst
+++ b/DOCS/man/options.rst
@@ -5489,6 +5489,19 @@ Terminal
 
     See `Property Expansion`_.
 
+``--status-msg-update-rate=<updates_per_sec>``
+    Maximum update rate of both ``--osd-status-msg`` and ``--term-status-msg``.
+
+    Only a hard limit when ``--status-msg-update-rate-forced`` is set to ``yes``
+    (default: ``20.0``).
+
+``--status-msg-update-rate-forced=<no|yes>``
+    Updates to status messages are forced on each frame update. Setting this option
+    to ``yes`` makes sure ``--status-msg-update-rate`` serves as a hard limit instead.
+
+    Forced updates still happen when pausing/frame-stepping, to make sure up-to-date info
+    is displayed immediately (default: ``no``).
+
 ``--term-status-msg=<string>``
     Print out a custom string during playback instead of the standard status
     line. Expands properties. See `Property Expansion`_.

--- a/options/options.c
+++ b/options/options.c
@@ -900,6 +900,8 @@ static const m_option_t mp_opts[] = {
     {"osd-playing-msg", OPT_STRING(osd_playing_msg)},
     {"osd-playing-msg-duration", OPT_INT(osd_playing_msg_duration),
         M_RANGE(0, 3600000)},
+    {"status-msg-update-rate", OPT_DOUBLE(status_msg_update_rate), M_RANGE(1.0, 100.0), .flags = UPDATE_OSD},
+    {"status-msg-update-rate-forced", OPT_BOOL(status_msg_update_rate_forced), .flags = UPDATE_OSD},
     {"term-status-msg", OPT_STRING(status_msg), .flags = UPDATE_OSD},
     {"osd-status-msg", OPT_STRING(osd_status_msg), .flags = UPDATE_OSD},
     {"osd-msg1", OPT_STRING(osd_msg[0]), .flags = UPDATE_OSD},
@@ -1010,6 +1012,8 @@ static const m_option_t mp_opts[] = {
 
 static const struct MPOpts mp_default_opts = {
     .use_terminal = true,
+    .status_msg_update_rate = 20.0,
+    .status_msg_update_rate_forced = false,
     .msg_color = true,
     .softvol_max = 130,
     .softvol_volume = 100,

--- a/options/options.h
+++ b/options/options.h
@@ -281,6 +281,8 @@ typedef struct MPOpts {
     char *playing_msg;
     char *osd_playing_msg;
     int osd_playing_msg_duration;
+    double status_msg_update_rate;
+    bool status_msg_update_rate_forced;
     char *status_msg;
     char *osd_status_msg;
     char *osd_msg[3];

--- a/player/osd.c
+++ b/player/osd.c
@@ -505,19 +505,25 @@ void update_osd_msg(struct MPContext *mpctx)
     struct osd_state *osd = mpctx->osd;
 
     double now = mp_time_sec();
+    // update the OSD and term at most this often
+    double delay = 1.0 / opts->status_msg_update_rate;
+    bool force_delay = opts->status_msg_update_rate_forced;
 
-    if (!mpctx->osd_force_update) {
+    // still force update when pausing/frame stepping
+    if (!(mpctx->osd_force_update && (mpctx->paused || !force_delay))) {
         // Assume nothing is going on at all.
         if (!mpctx->osd_idle_update)
             return;
 
-        double delay = 0.050; // update the OSD at most this often
         double diff = now - mpctx->osd_last_update;
         if (diff < delay) {
             mp_set_timeout(mpctx, delay - diff);
             return;
         }
+    } else {
+        MP_TRACE(mpctx, "Forcing OSD/term update\n");
     }
+
     mpctx->osd_force_update = false;
     mpctx->osd_idle_update = false;
     mpctx->osd_last_update = now;


### PR DESCRIPTION
 On high fps and/or high speed playback scenarios, status message
 updates from both osd and term can incur a GPU load that is not
 insignificant, as updates are forced on each frame update.

 This commit introduces two options that control the update rate.

 `--status-msg-update-rate` defaults to 20, which matches the 0.05 delay
 that already existed when there were no forced updates.

 `--status-msg-update-rate-forced` is set to `no` by default, also to
 retain old behavior by default. But setting this option to `yes` turns
 the update rate to a hard limit, unless frame updates happen while
 paused (e.g. when frame stepping), as getting immediate updated info
 in that case is the expected behavior.