### PR TITLE
stream_file: don't report a size for pipes and sockets

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -104,8 +104,8 @@ static int64_t get_size(stream_t *s)
     struct priv *p = s->priv;
     struct stat st;
     if (fstat(p->fd, &st) == 0) {
-        if (st.st_size <= 0 && !s->seekable)
-            st.st_size = -1;
+        if (!S_ISREG(st.st_mode) && !s->seekable)
+            return -1;
         if (st.st_size >= 0)
             return st.st_size;
     }


### PR DESCRIPTION
get_size() takes the size from fstat(). The size only means something for regular files. For pipes and sockets macOS and the BSDs put the number of bytes currently buffered in st_size, so mpv reported a small value that changed with every read as the stream size. Since 20eead1813 switched from lseek(), which fails on pipes, to fstat(), the guard only handled the case where st_size is 0, which is what Linux reports.

FFmpeg 9.0.1 started[1] to bound the trun sample count by avio_size() and rejects fragments once the pipe holds fewer bytes than the sample index has entries.

Don't report a size for non regular files that are not seekable. Windows is unaffected because mp_fstat() already reports 0 for pipes, same as Linux.

[1] https://github.com/FFmpeg/FFmpeg/commit/ae0e0ba3c3df840191e7a4c9b76494372ec53202

Fixes: #18405