### PR TITLE
demux: don't set DEMUX_EVENT_ALL on open

### DIFF
--- a/demux/demux.c
+++ b/demux/demux.c
@@ -3558,7 +3558,7 @@ static struct demuxer *open_given_type(struct mpv_global *global,
         .access_references = opts->access_references,
         .opts = opts,
         .opts_cache = opts_cache,
-        .events = DEMUX_EVENT_ALL,
+        .events = DEMUX_EVENT_INIT | DEMUX_EVENT_DURATION | DEMUX_EVENT_METADATA | DEMUX_EVENT_STREAMS,
         .duration = -1,
         .depth = params ? params->depth : 0,
     };
@@ -3619,7 +3619,7 @@ static struct demuxer *open_given_type(struct mpv_global *global,
         demux_copy(in->d_user, in->d_thread);
         in->duration = in->d_thread->duration;
         demuxer_sort_chapters(demuxer);
-        in->events = DEMUX_EVENT_ALL;
+        in->events = DEMUX_EVENT_INIT | DEMUX_EVENT_DURATION | DEMUX_EVENT_METADATA | DEMUX_EVENT_STREAMS;
 
         struct demuxer *sub = NULL;
         if (!(params && params->disable_timeline)) {

--- a/player/loadfile.c
+++ b/player/loadfile.c
@@ -429,19 +429,22 @@ void update_demuxer_properties(struct MPContext *mpctx)
         mp_notify(mpctx, MP_EVENT_DURATION_UPDATE, NULL);
     if (events & DEMUX_EVENT_LISTS) {
         // Demuxer just published a new chapter / edition list at runtime.
-        TA_FREEP(&mpctx->chapters);
-        mpctx->num_chapters = demuxer->num_chapters;
-        if (demuxer->num_chapters > 0) {
-            mpctx->chapters = demux_copy_chapter_data(demuxer->chapters,
-                                                     demuxer->num_chapters);
-            if (mpctx->opts->rebase_start_time) {
-                for (int n = 0; n < mpctx->num_chapters; n++)
-                    mpctx->chapters[n].pts -= demuxer->start_time;
+        char *chapter_file = mpctx->opts->chapter_file;
+        if (!chapter_file || !chapter_file[0]) {
+            TA_FREEP(&mpctx->chapters);
+            mpctx->num_chapters = demuxer->num_chapters;
+            if (demuxer->num_chapters > 0) {
+                mpctx->chapters = demux_copy_chapter_data(demuxer->chapters,
+                                                         demuxer->num_chapters);
+                if (mpctx->opts->rebase_start_time) {
+                    for (int n = 0; n < mpctx->num_chapters; n++)
+                        mpctx->chapters[n].pts -= demuxer->start_time;
+                }
             }
+            mp_notify(mpctx, MP_EVENT_CHAPTER_CHANGE, NULL);
+            mp_notify_property(mpctx, "chapter-list");
+            mp_notify_property(mpctx, "chapters");
         }
-        mp_notify(mpctx, MP_EVENT_CHAPTER_CHANGE, NULL);
-        mp_notify_property(mpctx, "chapter-list");
-        mp_notify_property(mpctx, "chapters");
         mp_notify_property(mpctx, "edition");
         mp_notify_property(mpctx, "edition-list");
         mp_notify_property(mpctx, "current-edition");


### PR DESCRIPTION
Both sites that initialize demuxer->events used DEMUX_EVENT_ALL, which now also sets DEMUX_EVENT_LISTS after
5713c301603fec36352a49505e113bec1e568985. This made every demuxer report a chapter list change, even though nothing changed, and as a response update_demuxer_properties would end up freeing the chapter list on initial open.

List them explicitly, without EVENT_LISTS. That event is only set for actual runtime changes, which demux_lists_changed will set where appropriate.

Fixes: 5713c301603fec36352a49505e113bec1e568985
Fixes: https://github.com/mpv-player/mpv/issues/18459