### PR TITLE
ao_coreaudio: fix init failure on macOS 27

### DIFF
--- a/audio/out/ao_coreaudio.c
+++ b/audio/out/ao_coreaudio.c
@@ -136,7 +136,7 @@ static int control(struct ao *ao, enum aocontrol cmd, void *arg)
     return CONTROL_UNKNOWN;
 }
 
-static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd, AudioChannelLayout *layout, size_t layout_size);
+static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd);
 static void init_physical_format(struct ao *ao);
 static void reinit_latency(struct ao *ao);
 static bool register_hotplug_cb(struct ao *ao);
@@ -176,11 +176,8 @@ static int init(struct ao *ao)
 
     AudioStreamBasicDescription asbd;
     ca_fill_asbd(ao, &asbd);
-    size_t layout_size;
-    AudioChannelLayout *layout = ca_get_acl(ao, &layout_size);
 
-    bool r = init_audiounit(ao, asbd, layout, layout_size);
-    talloc_free(layout);
+    bool r = init_audiounit(ao, asbd);
 
     if (!r)
         goto coreaudio_error;
@@ -279,7 +276,7 @@ coreaudio_error:
     talloc_free(tmp);
 }
 
-static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd, AudioChannelLayout *layout, size_t layout_size)
+static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd)
 {
     OSStatus err;
     uint32_t size;
@@ -322,13 +319,6 @@ static bool init_audiounit(struct ao *ao, AudioStreamBasicDescription asbd, Audi
                                sizeof(p->device));
     CHECK_CA_ERROR_L(coreaudio_error_audiounit,
                      "can't link audio unit to selected device");
-
-    err = AudioUnitSetProperty(p->audio_unit,
-                               kAudioOutputUnitProperty_ChannelMap,
-                               kAudioUnitScope_Global, 0, layout, layout_size);
-
-    CHECK_CA_ERROR_L(coreaudio_error_audiounit,
-                     "unable to set the input channel layout on the audio unit");
 
     AURenderCallbackStruct render_cb = (AURenderCallbackStruct) {
         .inputProc       = render_cb_lpcm,


### PR DESCRIPTION
This is a temporary fix for #18384 that removes the problematic call added in #15622. Refer to the issue for context.

