### PR TITLE
ci/win32: link synchronization.lib with subrandr

### DIFF
--- a/ci/build-win32.ps1
+++ b/ci/build-win32.ps1
@@ -217,9 +217,11 @@ dep = declare_dependency(
     harfbuzz,
     # those deps are hardcoded, because parsing rustc native-static-libs, would
     # be lots of code for little benefit, those libs won't really change.
+    # Keep in sync with library/windows_link/src/lib.rs in the rust repo.
     cc.find_library('dbghelp', required: true),
     cc.find_library('kernel32', required: true),
     cc.find_library('ntdll', required: true),
+    cc.find_library('synchronization', required: true),
     cc.find_library('userenv', required: true),
     cc.find_library('ws2_32', required: true)
   ],


### PR DESCRIPTION
Rust nightly since rust-lang/rust#162270 no longer imports WaitOnAddress and WakeByAddress* through raw-dylib in std.